### PR TITLE
First role: ci_make

### DIFF
--- a/.config/molecule/config_local.yml
+++ b/.config/molecule/config_local.yml
@@ -28,9 +28,6 @@ scenario:
   test_sequence:
     - prepare
     - converge
-    - check
-    - verify
-    - cleanup
 
 verifier:
   name: ansible

--- a/.config/molecule/config_podman.yml
+++ b/.config/molecule/config_podman.yml
@@ -35,3 +35,11 @@ provisioner:
     ANSIBLE_ROLES_PATH: "${ANSIBLE_ROLES_PATH}:${HOME}/zuul-jobs/roles"
     ANSIBLE_LIBRARY: "${ANSIBLE_LIBRARY:-/usr/share/ansible/plugins/modules}"
     ANSIBLE_FILTER_PLUGINS: "${ANSIBLE_FILTER_PLUGINS:-/usr/share/ansible/plugins/filter}"
+
+scenario:
+  test_sequence:
+    - prepare
+    - converge
+    - check
+    - verify
+    - cleanup

--- a/_skeleton_role_/molecule/default/molecule.yml
+++ b/_skeleton_role_/molecule/default/molecule.yml
@@ -1,4 +1,7 @@
 ---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
 log: true
 
 provisioner:
@@ -6,16 +9,3 @@ provisioner:
   log: true
   env:
     ANSIBLE_STDOUT_CALLBACK: yaml
-
-scenario:
-  test_sequence:
-    - destroy
-    - create
-    - prepare
-    - converge
-    - check
-    - verify
-    - destroy
-
-verifier:
-  name: testinfra

--- a/ci_framework/roles/ci_make/README.md
+++ b/ci_framework/roles/ci_make/README.md
@@ -1,0 +1,13 @@
+## Role: ci_make
+Wrap community.general.make module and provides ordered playbook for each
+call.
+
+### Parameters
+* `cifmw_ci_make_outputdir`: Output directory for the generated playbooks. Defaults
+to "{{ ansible_user_dir }}/ci_output"
+* `chdir`: community.general.make `chdir` (mandatory)
+* `file`: community.general.make `file` (optional)
+* `jobs`: community.general.make `jobs` (optional)
+* `make`: community.general.make `make` (optional)
+* `params`: community.general.make `params` (optional)
+* `target`: community.general.make `target` (optional)

--- a/ci_framework/roles/ci_make/defaults/main.yml
+++ b/ci_framework/roles/ci_make/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_ci_make"
+cifmw_ci_make_outputdir: "{{ ansible_user_dir }}/ci_output"
+cifmw_ci_make_run: true

--- a/ci_framework/roles/ci_make/meta/main.yml
+++ b/ci_framework/roles/ci_make/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- ci_make
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: edpm
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - edpm
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/ci_framework/roles/ci_make/molecule/default/converge.yml
+++ b/ci_framework/roles/ci_make/molecule/default/converge.yml
@@ -1,0 +1,43 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  gather_facts: true
+  vars:
+    ansible_user_dir: "/tmp"
+  tasks:
+    - name: Default role with chdir
+      vars:
+        chdir: "/tmp/foo"
+      include_role:
+        name: ci_make
+    - name: Validate make output
+      ansible.builtin.assert:
+        that:
+          - "'This is the help thing showing toto' in ci_make_output.stdout"
+    - name: Role with specific parameter
+      vars:
+        chdir: "/tmp/foo"
+        params:
+          FOO_BAR: "starwars"
+      include_role:
+        name: ci_make
+    - name: Validate make output
+      ansible.builtin.assert:
+        that:
+          - "'This is the help thing showing starwars' in ci_make_output.stdout"

--- a/ci_framework/roles/ci_make/molecule/default/molecule.yml
+++ b/ci_framework/roles/ci_make/molecule/default/molecule.yml
@@ -1,0 +1,8 @@
+---
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/ci_make/molecule/default/prepare.yml
+++ b/ci_framework/roles/ci_make/molecule/default/prepare.yml
@@ -1,0 +1,34 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Create lame directory
+      ansible.builtin.file:
+        path: /tmp/foo
+        state: directory
+    - name: Push dummy Makefile
+      ansible.builtin.copy:
+        dest: /tmp/foo/Makefile
+        content: |
+          .DEFAULT_GOAL := help
+          .RECIPEPREFIX := >
+          FOO_BAR ?= "toto"
+          help:
+          > echo "This is the help thing showing ${FOO_BAR}"

--- a/ci_framework/roles/ci_make/tasks/main.yml
+++ b/ci_framework/roles/ci_make/tasks/main.yml
@@ -1,0 +1,66 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Validate we get at least chdir param
+  when:
+    - chdir is not defined
+  fail:
+    msg: "Please provide 'chdir' parameter at least"
+
+- name: Ensure output directory exists
+  become: true
+  tags:
+    - always
+  ansible.builtin.file:
+    path: "{{ cifmw_ci_make_outputdir }}"
+    state: directory
+    mode: 0750
+    owner: "{{ ansible_user_id }}"
+
+- name: Get current amount of playbooks
+  register: _existing_makes
+  ansible.builtin.find:
+    paths: "{{ cifmw_ci_make_outputdir }}"
+    recurse: false
+    file_type: "file"
+    patterns: "*_make_*.yml"
+
+- name: Create filename fact
+  ansible.builtin.set_fact:
+    _make_filename: "{{ '%02d' | format(_existing_makes.matched) }}_make_{{ target|default('') }}.yml"
+    cacheable: false
+
+- name: Create new make call using index and target
+  ansible.builtin.template:
+    dest: "{{ (cifmw_ci_make_outputdir, _make_filename) | ansible.builtin.path_join }}"
+    src: make_script.j2
+    mode: 0640
+
+- name: Call make module if wanted
+  when:
+    - cifmw_ci_make_run|bool
+  register: call_output
+  community.general.make:
+    chdir: "{{ chdir }}"
+    file: "{{ file|default(omit) }}"
+    jobs: "{{ jobs|default(omit) }}"
+    make: "{{ make|default(omit) }}"
+    params: "{{ params|default(omit) }}"
+    target: "{{ target|default(omit) }}"
+
+- name: Expose make output
+  set_fact:
+    ci_make_output: "{{ call_output }}"

--- a/ci_framework/roles/ci_make/templates/make_script.j2
+++ b/ci_framework/roles/ci_make/templates/make_script.j2
@@ -1,0 +1,24 @@
+---
+# Generated using ci_make from the CI Framework
+# https://github.com/openstack-k8s-operators/ci-framework
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Run make
+      community.general.make:
+        chdir: {{ chdir }}
+{% if file is defined %}
+        file: {{ file }}
+{% endif -%}
+{% if jobs is defined %}
+        jobs: {{ jobs }}
+{% endif -%}
+{% if make is defined %}
+        make: {{ make }}
+{% endif -%}
+{% if params is defined %}
+        params: {{ params }}
+{% endif -%}
+{% if target is defined %}
+        target: {{ target }}
+{% endif -%}


### PR DESCRIPTION
This role purpose is to generate indexed playbooks running "make" commands in a specific location.

That way, we will be able to reproduce the various "make" runs in a convenient, ordered way.