### PR TITLE
Provides our own CI container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 ROLE_LIST := ./ci_framework/roles/*
+USE_VENV ?= ${USE_VENV:-yes}
 
 .PHONY: help
 help: ## Display this help.
@@ -26,11 +27,18 @@ pre_commit: setup_tests pre_commit_nodeps ## Runs pre-commit tests with dependen
 
 .PHONY: pre_commit_nodeps
 pre_commit_nodeps: ## Run pre-commit tests without installing dependencies
-	${HOME}/test-python/bin/pip3 install pre-commit
-	${HOME}/test-python/bin/pre-commit run
+	if [ "x$(USE_VENV)" ==  'xyes' ]; then \
+		${HOME}/test-python/bin/pre-commit run ; \
+	else \
+		pre-commit run ; \
+	fi
 
 .PHONY: tests
 tests: pre_commit molecule ## Run all tests with dependencies install
 
 .PHONY: tests_nodeps
 tests_nodeps: pre_commit_nodeps molecule_nodeps ## Run all tests without installing dependencies
+
+.PHONY: ci_ctx
+ci_ctx: ## Build CI container with buildah
+	buildah bud -t cfwm:latest -f containerfiles/Containerfile.ci

--- a/containerfiles/Containerfile.ci
+++ b/containerfiles/Containerfile.ci
@@ -1,0 +1,10 @@
+FROM registry.access.redhat.com/ubi9/ubi-init:latest
+ENV USE_VENV=no
+
+RUN dnf update -y && dnf install -y git python3-pip make gcc sudo && yum clean all
+
+COPY ../ /opt/sources
+WORKDIR /opt/sources
+RUN ls -l
+RUN /usr/bin/make setup_molecule USE_VENV=${USE_VENV}
+CMD /usr/bin/make help

--- a/scripts/setup_env
+++ b/scripts/setup_env
@@ -25,13 +25,7 @@ export PROJECT_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))/../"
 #                  system ansible may be installed.
 export ANSIBLE_SKIP_CONFLICT_CHECK=1
 
-function run_pip {
-    "${HOME}/test-python/bin/pip" install \
-                                  -c "${PROJECT_DIR}ansible-requirements.txt" \
-                                  -r "${PROJECT_DIR}requirements.txt" \
-                                  -r "${PROJECT_DIR}test-requirements.txt" \
-                                  -r "${PROJECT_DIR}molecule-requirements.txt" ${@:-}
-}
+USE_VENV=${USE_VENV:-'yes'}
 
 ## Main ----------------------------------------------------------------------
 # Source distribution information
@@ -41,44 +35,56 @@ PYTHON_EXEC=$(command -v python3 || command -v python)
 
 # Install the requirements we need to run local tests
 command -v gcc || sudo dnf -y install gcc
-VENV_MOD=venv
-case "${ID,,}" in
-    amzn|fedora)
+
+PIP='pip'
+case ${USE_VENV} in
+    'y|yes|true')
+        PIP="${HOME}/test-python/bin/pip"
+        USE_VENV='yes'
         ${PYTHON_EXEC} -m venv -h 2>&1>/dev/null || sudo "${RHT_PKG_MGR}" install -y python*-virtualenv
+        echo
+        echo ### USING VIRTUALENV
+        echo
         ;;
-    rhel|centos)
-      # venv module is usually present in python39 directly. Let's not do any other tasks.
+    'n|no|false')
+        PIP="pip"
+        USE_VENV='no'
+        echo
+        echo ### NO VENV - may break your system!
+        echo
         ;;
 esac
 
 # Kill all sudo in the current shell
 sudo -k
 
+function run_pip {
+    "${PIP}" install \
+             -c "${PROJECT_DIR}ansible-requirements.txt" \
+             -r "${PROJECT_DIR}requirements.txt" \
+             -r "${PROJECT_DIR}test-requirements.txt" \
+             -r "${PROJECT_DIR}molecule-requirements.txt" ${@:-}
+}
+
 # Ensure the required ci file is presnet
 mkdir -p ${HOME}/ci/yum.repos.d
 cp /etc/ci/mirror_info.sh ${HOME}/ci || touch ${HOME}/ci/mirror_info.sh
 cp -r /opt/yum.repos.d/* ${HOME}/ci/yum.repos.d || cp -r /etc/yum.repos.d/* ${HOME}/ci/yum.repos.d
 
-# Create a virtual env
-"${PYTHON_EXEC}" -m ${VENV_MOD} --upgrade-deps "${HOME}/test-python"
+if [ ${USE_VENV} == 'yes' ]; then
+    # Create a virtual env
+    "${PYTHON_EXEC}" -m venv --upgrade-deps "${HOME}/test-python"
+    if [[ -d "${HOME}/.cache/pip/wheels" ]]; then
+        rm -rf "${HOME}/.cache/pip/wheels"
+    fi
+fi
 
 # Run bindep
-"${HOME}/test-python/bin/pip" install pip setuptools bindep --upgrade
+"${PIP}" install pip setuptools bindep --upgrade
 "${PROJECT_DIR}/scripts/bindep-install"
 
 # Install local requirements
-if [[ -d "${HOME}/.cache/pip/wheels" ]]; then
-    rm -rf "${HOME}/.cache/pip/wheels"
-fi
 run_pip
 
-# NOTE(cloudnull): In some cases ansible will not be installed due to wheel
-#                  building issues, caused by pip. If this happens we
-#                  re-install the packages with the force flag, which will
-#                  ensure everything is rebuilt and installed correctly.
-if [ ! -f "${HOME}/test-python/bin/ansible" ]; then
-    run_pip --force
-fi
-
 # Display list of installed packages with versions (debugging failures)
-"${HOME}/test-python/bin/pip" freeze
+"${PIP}" freeze

--- a/scripts/setup_molecule
+++ b/scripts/setup_molecule
@@ -24,7 +24,20 @@ export PROJECT_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))/../"
 # NOTE(cloudnull): Disable ansible compat check, caters to the case where
 #                  system ansible may be installed.
 export ANSIBLE_SKIP_CONFLICT_CHECK=1
-"${HOME}/test-python/bin/pip" install \
-                              -c "${PROJECT_DIR}ansible-requirements.txt" \
-                              -r "${PROJECT_DIR}molecule-requirements.txt" ${@:-}
-"${HOME}/test-python/bin/ansible-galaxy" collection install -r "${PROJECT_DIR}requirements.yml"
+PIP='pip'
+case ${USE_VENV} in
+    'y|yes|true')
+        PIP="${HOME}/test-python/bin/pip"
+        USE_VENV='yes'
+        ${PYTHON_EXEC} -m venv -h 2>&1>/dev/null || sudo "${RHT_PKG_MGR}" install -y python*-virtualenv
+        ;;
+    'n|no|false')
+        PIP="pip"
+        USE_VENV='no'
+        ;;
+esac
+
+"${PIP}" install \
+         -c "${PROJECT_DIR}ansible-requirements.txt" \
+         -r "${PROJECT_DIR}molecule-requirements.txt" ${@:-}
+ansible-galaxy collection install --timeout=120 -r "${PROJECT_DIR}requirements.yml"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,2 @@
-#pre-commit # MIT
+pre-commit # MIT
 mock

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ deps =
 commands =
 # ansible-core 2.13.6 installed with py38 does not provide a way to set
 # timeout with ansible-galaxy command.
-   ansible-galaxy install -fr {toxinidir}/requirements.yml
+   ansible-galaxy install --timeout=120 -fr {toxinidir}/requirements.yml
    stestr run {posargs}
 allowlist_externals =
    bash
@@ -49,5 +49,5 @@ deps =
    virtualenv
 commands =
    bash -c "ANSIBLE_ROLES_PATH='{toxinidir}/ci_framework/roles.galaxy' \
-          ansible-galaxy install -fr {toxinidir}/requirements.yml"
+          ansible-galaxy install --timeout=120 -fr {toxinidir}/requirements.yml"
    python -m pre_commit run -a


### PR DESCRIPTION
In order to ensure we have all the needed pieces in the container for Prow, we provide our own container, with everything installed directly from the Containerfile.ci

In openshift-ci, the container may be built using one of the parameters pointing to the Containerfile directly, and we should be good.

The container did successfuly build locally, and running some "make" command was also working fine.