### PR TITLE
Ensure root group can write in the location

### DIFF
--- a/containerfiles/Containerfile.ci
+++ b/containerfiles/Containerfile.ci
@@ -1,10 +1,11 @@
 FROM registry.access.redhat.com/ubi9/ubi-init:latest
+USER root
 ENV USE_VENV=no
 
 RUN dnf update -y && dnf install -y git python3-pip make gcc sudo && yum clean all
 
 COPY ../ /opt/sources
+RUN chmod -R 0775 /opt/sources
 WORKDIR /opt/sources
-RUN ls -l
 RUN /usr/bin/make setup_molecule USE_VENV=${USE_VENV}
 CMD /usr/bin/make help


### PR DESCRIPTION
In the openshift-ci project, rights are dropped at some point, leading to some issues. The user in use is apparently part of the "root" group, meaning it should be just fine to allow root group to access the location with write rights.