### PR TITLE
Better handling of the chmod

### DIFF
--- a/containerfiles/Containerfile.ci
+++ b/containerfiles/Containerfile.ci
@@ -5,7 +5,9 @@ ENV USE_VENV=no
 RUN dnf update -y && dnf install -y git python3-pip make gcc sudo && yum clean all
 
 COPY ../ /opt/sources
-RUN chmod -R 0775 /opt/sources
+RUN find /opt/sources -type d -exec chmod g+rwx {} \;
+RUN find /opt/sources -type f -exec chmod g+rw {} \;
 WORKDIR /opt/sources
+RUN git config core.fileMode false
 RUN /usr/bin/make setup_molecule USE_VENV=${USE_VENV}
 CMD /usr/bin/make help


### PR DESCRIPTION
Instead of a blind chmod -R 0775 on files and directories, let's associate the right mode to the right content type.

Also, in order to prevent pre-commit to crash due to files being edited, let's tell git to not care about file mode changes.