### PR TITLE
Correct some tests paths

### DIFF
--- a/scripts/bindep-install
+++ b/scripts/bindep-install
@@ -34,7 +34,15 @@ RHT_PKG_MGR=$(command -v dnf || command -v yum)
 
 # NOTE(cloudnull): Get a list of packages to install with bindep. If packages
 #                  need to be installed, bindep exits with an exit code of 1.
-BINDEP_PKGS=$(${HOME}/test-python/bin/bindep -b -f "${BINDEP_FILE}" test || true)
+BINDEP_PKGS=''
+case ${USE_VENV:-yes} in
+    'y|yes|true')
+        BINDEP_PKGS=$(${HOME}/test-python/bin/bindep -b -f "${BINDEP_FILE}" test || true)
+        ;;
+    *)
+        BINDEP_PKGS=$(bindep -b -f "${BINDEP_FILE}" test || true)
+        ;;
+esac
 
 if [[ ${#BINDEP_PKGS} > 0 ]]; then
     case "${ID,,}" in

--- a/scripts/run-local-test
+++ b/scripts/run-local-test
@@ -27,5 +27,12 @@ export ROLE_NAME="${ROLE_NAME:-$1}"
 
 # Run local test
 pushd "${PROJECT_DIR}ci_framework/roles/${ROLE_NAME}"
-${HOME}/test-python/bin/molecule -c "${PROJECT_DIR}.config/molecule/config_podman.yaml" test
+case ${USE_VENV:-yes} in
+    'y|yes|true')
+        ${HOME}/test-python/bin/molecule -c "${PROJECT_DIR}.config/molecule/config_podman.yaml" test
+        ;;
+    *)
+        molecule -c "${PROJECT_DIR}.config/molecule/config_podman.yaml" test
+        ;;
+esac
 popd


### PR DESCRIPTION
Some of the calls to python scripts were still hard-coded to the venv, even if we don't use it.

This patch ensures everything is now taking the USE_VENV parameter.