### PR TITLE
Add some new targets to Makefile, add README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# CI-Framework
+
+Still under heavy development - more info coming soon.
+
+## Contribute
+### Add a new Ansible role
+Run the following command to get your new role in:
+```Bash
+$ ansible-galaxy role init \
+    --init-path ci_framework/roles \
+    --role-skeleton _skeleton_role_ \
+    YOUR_ROLE_NAME
+```
+
+
+### Run tests
+#### Makefile
+Run ```make help``` to list the available targets. Usually, you'll want to run
+```make run_ctx_pre_commit``` or ```make run_ctx_molecule``` to run the tests
+in a local container.
+
+
+## License
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/scripts/run_molecule
+++ b/scripts/run_molecule
@@ -26,6 +26,8 @@ export PROJECT_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))/../"
 export ROLE_NAME="${ROLE_NAME:-$1}"
 
 # Run local test
+(test -d ${PROJECT_DIR}ci_framework/roles/ || (echo 'No such directory: ${PROJECT_DIR}ci_framework/roles/' && exit 1) ) || exit 1
+(test -d "${PROJECT_DIR}ci_framework/roles/${ROLE_NAME}" || (echo "No such role: ${ROLE_NAME}" && exit 1)) || exit 1
 pushd "${PROJECT_DIR}ci_framework/roles/${ROLE_NAME}"
 case ${USE_VENV:-yes} in
     'y|yes|true')


### PR DESCRIPTION
The README is still incomplete, but provides some hints as to how to contribute.

The Makefile targets are mostly for the devs, since they allow to run the tests in a container.

Note that, at this point, molecule tests aren't working. We need a first role to validate the whole chain.