### PR TITLE
Run molecule only against modified role(s)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 SHELL := /bin/bash
-ROLE_LIST ?= ./ci_framework/roles/*
+ROLE_DIR ?= ci_framework/roles/
 USE_VENV ?= ${USE_VENV:-yes}
 BUILD_VENV_CTX ?= yes
 MOLECULE_CONFIG ?= ${MOLECULE_CONFIG:-.config/molecule/config_podman.yml}
 
 # target vars for generic operator install info 1: target name , 2: operator name
 define vars
-${1}: export ROLE_LIST=${ROLE_LIST}
+${1}: export ROLE_DIR=${ROLE_DIR}
 ${1}: export USE_VENV=${USE_VENV}
 ${1}: export BUILD_VENV_CTX=${BUILD_VENV_CTX}
 ${1}: export MOLECULE_CONFIG=${MOLECULE_CONFIG}
@@ -29,10 +29,7 @@ molecule: setup_molecule molecule_nodeps ## Run molecule tests with dependencies
 
 .PHONY: molecule_nodeps
 molecule_nodeps: ## Run molecule without installing dependencies
-	export MOLECULE_CONFIG=$(MOLECULE_CONFIG)
-	for role in ${ROLE_LIST}; do \
-		bash scripts/run_molecule "$$(basename $${role})" ; \
-	done
+	bash scripts/run_molecule $(ROLE_DIR)
 
 .PHONY: pre_commit
 pre_commit: setup_tests pre_commit_nodeps ## Runs pre-commit tests with dependencies install

--- a/README.md
+++ b/README.md
@@ -2,6 +2,37 @@
 
 Still under heavy development - more info coming soon.
 
+## Use Makefile for your own CI
+### Targets of interest
+#### ci_ctx
+That one will build you a container in order to run the checks
+#### run_ctx_pre_commit
+That one will run the pre-commit check in a container.
+#### run_ctx_molecule
+That one will run molecule against the role. Note That, if needed, you can
+pass different parameters:
+```Bash
+$ make run_ctx_molecule BUILD_VENV_CTX=yes MOLECULE_CONFIG=.config/molecule/config_local.yml
+```
+Run molecule in a freshly built container, using the "config_local.yml" file. Note that
+this configuration file is *mandatory* for running molecule from within the container
+#### molecule_nodeps
+```Bash
+$ make molecule_nodeps BUILD_VENV_CTX=no \
+    MOLECULE_CONFIG=.config/molecule/config_local.yml \
+    ROLE_DIR=../my-repo/roles
+```
+This one is a bit more tricky: it means you are in a deployed env (for instance
+a container built using ```make ci_ctx```) with a 3rd-party repository
+available in /opt/my-repo. You can get this by running the following:
+```Bash
+$ podman run --rm -ti --security-opt label=disable \
+    -v .:/opt/sources \
+    -v ../my-repo:/opt/my-repo \
+    cfwm:latest bash
+```
+Then, just run the ```make``` command with the right parameters.
+
 ## Contribute
 ### Add a new Ansible role
 Run the following command to get your new role in:

--- a/scripts/run_molecule
+++ b/scripts/run_molecule
@@ -21,20 +21,28 @@ set -o pipefail
 set -xeuo
 
 ## Vars ----------------------------------------------------------------------
-
-export PROJECT_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))/../"
-export ROLE_NAME="${ROLE_NAME:-$1}"
+PROJECT_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))/../"
+ROLE_DIR=$1
 
 # Run local test
-(test -d ${PROJECT_DIR}ci_framework/roles/ || (echo 'No such directory: ${PROJECT_DIR}ci_framework/roles/' && exit 1) ) || exit 1
-(test -d "${PROJECT_DIR}ci_framework/roles/${ROLE_NAME}" || (echo "No such role: ${ROLE_NAME}" && exit 1)) || exit 1
-pushd "${PROJECT_DIR}ci_framework/roles/${ROLE_NAME}"
-case ${USE_VENV:-yes} in
-    'y|yes|true')
-        ${HOME}/test-python/bin/molecule -c "${PROJECT_DIR}${MOLECULE_CONFIG}" test
-        ;;
-    *)
-        molecule -c "${PROJECT_DIR}${MOLECULE_CONFIG}" test
-        ;;
-esac
+(test -d ${ROLE_DIR} || (echo 'No such directory: ${ROLE_DIR}' && exit 1) ) || exit 1
+
+pushd "${ROLE_DIR}"
+# Find what roles were modified
+git diff --name-only HEAD^..HEAD .
+local_roledir=$(echo $ROLE_DIR | sed 's|\.\?\./||g')
+for rolepath in $(git diff --name-only HEAD^..HEAD .); do
+    role=$(echo $rolepath|sed "s|${local_roledir}||" | cut -f1 -d /)
+    echo "Running molecule against: ${role}"
+    pushd $role
+    case ${USE_VENV:-yes} in
+        'y|yes|true')
+            ${HOME}/test-python/bin/molecule -c "${PROJECT_DIR}${MOLECULE_CONFIG}" test
+            ;;
+        *)
+            molecule -c "${PROJECT_DIR}${MOLECULE_CONFIG}" test
+            ;;
+    esac
+    popd
+done
 popd

--- a/scripts/setup_molecule
+++ b/scripts/setup_molecule
@@ -25,19 +25,24 @@ export PROJECT_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))/../"
 #                  system ansible may be installed.
 export ANSIBLE_SKIP_CONFLICT_CHECK=1
 PIP='pip'
+GALAXY="ansible-galaxy"
+COLLECTION_PATH="/usr/share/ansible/collections"
 case ${USE_VENV} in
     'y|yes|true')
         PIP="${HOME}/test-python/bin/pip"
         USE_VENV='yes'
+        GALAXY="${HOME}/test-python/bin/ansible-galaxy"
+        COLLECTION_PATH="${HOME}/.ansible/collections/ansible_collections/"
         ${PYTHON_EXEC} -m venv -h 2>&1>/dev/null || sudo "${RHT_PKG_MGR}" install -y python*-virtualenv
         ;;
     'n|no|false')
-        PIP="pip"
         USE_VENV='no'
         ;;
 esac
 
-"${PIP}" install \
+${PIP} install \
          -c "${PROJECT_DIR}ansible-requirements.txt" \
          -r "${PROJECT_DIR}molecule-requirements.txt" ${@:-}
-ansible-galaxy collection install --timeout=120 -r "${PROJECT_DIR}requirements.yml"
+${GALAXY} collection install --timeout=120 \
+  -p "${COLLECTION_PATH}" \
+  -r "${PROJECT_DIR}requirements.yml"


### PR DESCRIPTION
Using some trick, we may be able to know what role(s) were modified in the PR. This patch enables this automated filtering.

It also open a wide door for external reuse of the Makefile and scripts: if you have your own repository, you should be able to clone this one in some nearby path, and then run the following:
```Bash
make run_ctx_molecule \
        MOLECULE_CONFIG=.config/molecule/config_local.yml \
        ROLE_DIR=../my_repo/roles
```

Note: relative path must be used (for now).