### PR TITLE
Modify how container is built

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ tests_nodeps: pre_commit_nodeps molecule_nodeps ## Run all tests without install
 .PHONY: ci_ctx
 ci_ctx: ## Build CI container with buildah
 	if [ "x$(BUILD_VENV_CTX)" == 'xyes' ]; then \
-		buildah bud -t cfwm:latest -f containerfiles/Containerfile.ci ; \
+		buildah bud -t localhost/cfwm-build:latest -f containerfiles/Containerfile.ci ; \
+		buildah bud -t localhost/cfwm:latest -f containerfiles/Containerfile.tests ; \
 	fi
 
 .PHONY: run_ctx_pre_commit

--- a/containerfiles/Containerfile.ci
+++ b/containerfiles/Containerfile.ci
@@ -1,14 +1,5 @@
 FROM registry.access.redhat.com/ubi9/ubi-init:latest
+LABEL summary="Provides root image for openstack-k8s-operators projects in Prow" maintainer="CI Framework"
+
 USER root
-ENV USE_VENV=no
-ENV MOLECULE_CONFIG=.config/molecule/config_local.yml
-
 RUN dnf update -y && dnf install -y git python3-pip make gcc sudo && yum clean all
-
-COPY ../ /opt/sources
-RUN find /opt/sources -type d -exec chmod g+rwx {} \;
-RUN find /opt/sources -type f -exec chmod g+rw {} \;
-WORKDIR /opt/sources
-RUN git config core.fileMode false
-RUN /usr/bin/make setup_molecule USE_VENV=${USE_VENV}
-CMD /usr/bin/make help

--- a/containerfiles/Containerfile.tests
+++ b/containerfiles/Containerfile.tests
@@ -1,0 +1,12 @@
+FROM localhost/cfwm-build:latest
+USER root
+ENV USE_VENV=no
+ENV MOLECULE_CONFIG=.config/molecule/config_local.yml
+
+COPY ../ /opt/sources
+RUN find /opt/sources -type d -exec chmod g+rwx {} \;
+RUN find /opt/sources -type f -exec chmod g+rw {} \;
+WORKDIR /opt/sources
+RUN git config core.fileMode false
+RUN /usr/bin/make setup_molecule USE_VENV=${USE_VENV}
+CMD /usr/bin/make help


### PR DESCRIPTION
In order to make Prow job faster, let's provide a simple root image with only the basic tools (git, make, etc).

In Prow, we have a step where we deploy the dependencies (calling `make setup_molecule`) against the pull request content, so there's no need to pre-deploy things at this point, especially since it's done when we build the root_image.

For the local testing though, we still need to get the appropriate tools and dependencies.
In order to still be able to consume a locally built container, a new Containerfile is created and used by the `make ci_ctx` target. The target will now build 2 images - the base one, listed as `localhost/cifwm-build:latest`, using Containerfile.ci, and `localhost/cfwm:latest` built against Containerfile.tests.

Since the name of the "loaded" image doesn't change, it's transparent to the user.