### PR TITLE
Correct how molecule loops on modified roles

### DIFF
--- a/scripts/run_molecule
+++ b/scripts/run_molecule
@@ -32,13 +32,14 @@ pushd "${ROLE_DIR}"
 local_roledir=$(echo $ROLE_DIR | sed 's|\.\?\./||g')
 
 # Find what roles were modified
-ROLES_LIST=$(git diff --name-only HEAD^..HEAD .)
+ROLES_LIST=$(git diff --dirstat=files,0,cumulative HEAD^..HEAD | sed "s|^[ 0-9.]\+% \(${local_roledir}\)\?||g" | cut -d/ -f1 | sort -u )
 if [ ${TEST_ALL_ROLES} == 'yes' ]; then
     ROLES_LIST=$(ls -1 ${local_roledir})
 fi
 
 for rolepath in ${ROLES_LIST}; do
     role=$(echo $rolepath|sed "s|${local_roledir}||" | cut -f1 -d /)
+    test -d ${role} || continue
     echo "Running molecule against: ${role}"
     pushd $role
     case ${USE_VENV} in


### PR DESCRIPTION
Until now, it was looping on all modified files in a role due to the (wrong) way we detected the modifications.

The new one-liner is now stronger, and should ensure we don't test the same role twice, while ensuring we test only roles.