### PR TITLE
Ansible: import test_deps from edpm-ansible

### DIFF
--- a/.zuul.d/prepare.yml
+++ b/.zuul.d/prepare.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: primary
   gather_facts: false
   tasks:
     - name: Prepare workspace
@@ -9,10 +9,9 @@
       become: true
       ansible.builtin.package:
         name:
-          - python3-pip
+          - buildah
           - make
-          - gcc
-          - sudo
-    - name: Install ansible requirements
+          - podman
+    - name: Build container
       ansible.builtin.command: |
-        make -C "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}" setup_molecule
+        make -C "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}" ci_ctx

--- a/.zuul.d/test-molecule.yml
+++ b/.zuul.d/test-molecule.yml
@@ -1,8 +1,11 @@
 ---
-- hosts: all
+- hosts: primary
   gather_facts: false
   tasks:
     - name: Run molecule in container
       community.general.make:
         chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
-        target: molecule
+        target: run_ctx_molecule
+        params:
+          BUILD_VENV_CTX: no
+          MOLECULE_CONFIG: .config/molecule/config_local.yml

--- a/README.md
+++ b/README.md
@@ -21,14 +21,6 @@ tests:
     export ANSIBLE_LOCAL_TMP=/tmp
     export ANSIBLE_REMOTE_TMP=/tmp
     make -C ../ci-framework pre_commit_nodeps BASEDIR ./
-- as: molecule
-  from: cifwm
-  clone: true
-  commands: |
-    export HOME=/tmp
-    export ANSIBLE_LOCAL_TMP=/tmp
-    export ANSIBLE_REMOTE_TMP=/tmp
-    make -C ../ci-framework molecule_nodeps ROLE_DIR=../your-project/
 ```
 Please refer to the `make` manpage for more fun! Please refer to the
 [openshift CI doc](https://docs.ci.openshift.org/docs/getting-started/examples/#how-do-i-write-a-simple-execute-this-command-in-a-container-test)

--- a/ci_framework/roles/test_deps/README.md
+++ b/ci_framework/roles/test_deps/README.md
@@ -1,0 +1,5 @@
+## Role: test_deps
+Ensure test environment (molecule) has proper repositories and dependencies.
+
+### Parameters
+* `test_deps_extra_packages`: List of extra packages you need to install for molecule

--- a/ci_framework/roles/test_deps/defaults/main.yml
+++ b/ci_framework/roles/test_deps/defaults/main.yml
@@ -1,0 +1,23 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+test_deps_extra_packages: []
+test_deps_setup_cifmw: false
+test_deps_repo_version: "{{ ansible_facts['distribution'] | lower }}{{ ansible_facts['distribution_major_version'] }}-master"
+test_deps_mirrors_file_path: /etc/ci/mirror_info.sh
+test_deps_setup_stream: true
+test_deps_setup_ceph: false

--- a/ci_framework/roles/test_deps/meta/main.yml
+++ b/ci_framework/roles/test_deps/meta/main.yml
@@ -1,0 +1,43 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  namespace: openstack
+  author: OpenStack
+  description:  CI Framework Role -- test_deps
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: '2.9'
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: 'EL'
+      versions:
+        - '8'
+        - '9'
+
+  galaxy_tags:
+    - cifmw
+
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/ci_framework/roles/test_deps/molecule/default/converge.yml
+++ b/ci_framework/roles/test_deps/molecule/default/converge.yml
@@ -1,0 +1,24 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  vars:
+    cifmw_become: false
+    cifmw_installroot: '/tmp/chroot/'
+  roles:
+    - role: "test_deps"

--- a/ci_framework/roles/test_deps/molecule/default/molecule.yml
+++ b/ci_framework/roles/test_deps/molecule/default/molecule.yml
@@ -1,0 +1,8 @@
+---
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/test_deps/molecule/default/prepare.yml
+++ b/ci_framework/roles/test_deps/molecule/default/prepare.yml
@@ -1,0 +1,24 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  vars:
+    cifmw_become: false
+    cifmw_installroot: '/tmp/chroot'
+  roles:
+    - role: test_deps

--- a/ci_framework/roles/test_deps/tasks/main.yml
+++ b/ci_framework/roles/test_deps/tasks/main.yml
@@ -1,0 +1,152 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Gather facts if they don't exist
+  ansible.builtin.setup:
+    gather_subset: min
+  when: "'distribution' not in ansible_facts"
+  tags:
+    - always
+
+# "{{ role_name }}" will search for and load any operating system variable file
+# found within the "vars/" path. If no OS files are found the task will skip.
+- name: Gather variables for each operating system
+  ansible.builtin.include_vars: "{{ item }}"
+  with_first_found:
+    - skip: true
+      files:
+        - "{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_version'] | lower }}.yml"
+        - "{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_major_version'] | lower }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}-{{ ansible_facts['distribution_major_version'] | lower }}.yml"
+        - "{{ ansible_facts['distribution'] | lower }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}-{{ ansible_facts['distribution_version'].split('.')[0] }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}.yml"
+  tags:
+    - always
+
+- name: Detect mirrors file
+  ansible.builtin.stat:
+    path: "{{ test_deps_mirrors_file_path }}"
+  register: mirrors_file
+
+- name: RHEL Block
+  become: true
+  when:
+    - (ansible_facts['os_family'] | lower) == 'redhat'
+    - mirrors_file.stat.exists | bool
+  block:
+    - name: Disable ubi host subscription-manager integration
+      ansible.builtin.file:
+        path: /etc/rhsm-host
+        state: absent
+
+    - name: Disable ubi 9 repos
+      when:
+        - ansible_facts['distribution_major_version'] is version(9, '>=')
+      ansible.builtin.yum_repository:
+        name: "{{ item }}"
+        state: absent
+        keepcache: false
+        reposdir: etc/yum.repos.d
+      with_items:
+        - ubi-9-appstream
+        - ubi-9-baseos
+        - ubi-9-codeready-builder
+
+- name: Block for tripleo-repos
+  when:
+    - (ansible_facts['os_family'] | lower) == 'redhat'
+  block:
+    - name: Fetch latest repo version
+      ansible.builtin.uri:
+        url: https://trunk.rdoproject.org/centos{{ ansible_facts['distribution_major_version'] }}/current/delorean.repo
+        return_content: true
+      register: cifmw_packages
+
+    - name: Create default repo file
+      become: true
+      ansible.builtin.copy:
+        content: "{{ cifmw_packages.content }}"
+        dest: /etc/yum.repos.d/delorean.repo
+        mode: 0644
+
+- name: Install tripleo-repos package
+  become: true
+  ansible.builtin.package:
+    name: "python*tripleo-repos"
+    state: present
+
+- name: Tripleo setup block
+  become: true
+  when:
+    - (ansible_facts['os_family'] | lower) == 'redhat'
+    - test_deps_setup_cifmw | bool
+  block:
+    - name: Create tripleo repos
+      ansible.builtin.command: tripleo-repos -d ubi9 \
+        {{ test_deps_setup_stream | ternary('--stream', '--no-stream', omit) }} \
+        -b master current-tripleo {{ test_deps_setup_ceph | ternary('ceph', '', omit) }}
+
+    - name: Look for redhat-release rpm
+      ansible.builtin.command: "rpm -qe redhat-release"
+      register: rpm_found
+      ignore_errors: true
+
+    - name: Workaround of redhat-release binary on ubi9
+      when:
+        - rpm_found.rc == 0
+      block:
+        - name: Remove redhat-release
+          ansible.builtin.command: "rpm -e --nodeps redhat-release"
+
+        - name: Install centos-stream-release
+          ansible.builtin.package:
+            name: "centos-stream-release"
+            state: latest
+            releasever: "{{ ansible_facts['distribution_major_version'] }}"
+
+    - name: Install additional packages
+      ansible.builtin.package:
+        name: "{{ test_deps_cifmw_packages }}"
+        state: present
+        releasever: "{{ ansible_facts['distribution_major_version'] }}"
+
+- name: Package block
+  become: true
+  block:
+    - name: Install selinux python libs
+      ansible.builtin.package:
+        name: "{{ test_deps_selinux_packages }}"
+        state: present
+        releasever: "{{ ansible_facts['distribution_major_version'] }}"
+      when:
+        - (ansible_facts['os_family'] | lower) == 'redhat'
+
+    - name: Install python yaml libs
+      ansible.builtin.package:
+        name: "{{ test_deps_yaml_packages }}"
+        state: present
+        releasever: "{{ ansible_facts['distribution_major_version'] }}"
+      when:
+        - (ansible_facts['os_family'] | lower) == 'redhat'
+
+    - name: Install extra packages
+      ansible.builtin.package:
+        name: "{{ test_deps_extra_packages }}"
+        state: present
+        releasever: "{{ ansible_facts['distribution_major_version'] }}"
+      when:
+        - (test_deps_extra_packages | length) > 0

--- a/ci_framework/roles/test_deps/vars/centos-8.yml
+++ b/ci_framework/roles/test_deps/vars/centos-8.yml
@@ -1,0 +1,24 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+test_deps_repo: https://trunk.rdoproject.org/centos8-master/current
+test_deps_yaml_packages:
+  - python3-pyyaml
+test_deps_selinux_packages:
+  - python3-libselinux
+test_deps_cifmw_packages:
+  - python3-openstacksdk

--- a/ci_framework/roles/test_deps/vars/centos-9.yml
+++ b/ci_framework/roles/test_deps/vars/centos-9.yml
@@ -1,0 +1,23 @@
+---
+# Copyright 2022 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+test_deps_repo: https://trunk.rdoproject.org/centos9-master/current
+test_deps_yaml_packages:
+  - python3-pyyaml
+test_deps_selinux_packages:
+  - python3-libselinux
+test_deps_cifmw_packages:
+  - python3-openstacksdk
+  - openssh

--- a/ci_framework/roles/test_deps/vars/fedora.yml
+++ b/ci_framework/roles/test_deps/vars/fedora.yml
@@ -1,0 +1,23 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+test_deps_repo: https://trunk.rdoproject.org/fedora/current
+test_deps_selinux_packages:
+  - python3-libselinux
+  - python2-libselinux
+test_deps_cifmw_packages:
+  - python3-openstacksdk

--- a/ci_framework/roles/test_deps/vars/redhat-8.yml
+++ b/ci_framework/roles/test_deps/vars/redhat-8.yml
@@ -1,0 +1,24 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+test_deps_repo: https://trunk.rdoproject.org/redhat8-master/current
+test_deps_yaml_packages:
+  - python3-pyyaml
+test_deps_selinux_packages:
+  - python3-libselinux
+test_deps_cifmw_packages:
+  - python3-openstacksdk

--- a/ci_framework/roles/test_deps/vars/redhat-9.yml
+++ b/ci_framework/roles/test_deps/vars/redhat-9.yml
@@ -1,0 +1,24 @@
+---
+# Copyright 2022 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+test_deps_repo: https://trunk.rdoproject.org/centos9-master/current
+test_deps_yaml_packages:
+  - python3-pyyaml
+test_deps_selinux_packages:
+  - python3-libselinux
+test_deps_cifmw_packages:
+  - python3-openstacksdk
+  - centos-stream-release
+  - openssh

--- a/scripts/run_molecule
+++ b/scripts/run_molecule
@@ -24,6 +24,7 @@ set -xeuo
 PROJECT_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))/../"
 ROLE_DIR=$1
 USE_VENV=${USE_VENV:-yes}
+MOLECULE_CONFIG=${MOLECULE_CONFIG:-.config/molecule/config_podman.yml}
 TEST_ALL_ROLES=${TEST_ALL_ROLES:-no}
 # Run local test
 (test -d ${ROLE_DIR} || (echo 'No such directory: ${ROLE_DIR}' && exit 1) ) || exit 1


### PR DESCRIPTION
This helper will be used mostly in the molecule tests, allowing to set repositories and install some packages during the "prepare" step.