### PR TITLE
Stop relying on galaxy.ansible.com service

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -15,6 +15,9 @@
 # under the License.
 
 collections:
-  - ansible.posix
-  - community.general
-  - containers.podman
+  - name: https://github.com/ansible-collections/ansible.posix
+    type: git
+  - name: https://github.com/ansible-collections/community.general
+    type: git
+  - name: https://github.com/containers/ansible-podman-collections
+    type: git


### PR DESCRIPTION
With the amount of failures of the service, we can't realy rely on it anymore. Using plain git as sources for
`ansible-galaxy collection install` should make molecule runs more stable.

If needed, we may also pin a collection to a specific version, just by adding "version: foo" to the entry.