### PR TITLE
Don't call non-existing role

### DIFF
--- a/_skeleton_role_/molecule/default/prepare.yml
+++ b/_skeleton_role_/molecule/default/prepare.yml
@@ -19,4 +19,3 @@
   hosts: all
   roles:
     - role: test_deps
-    - role: env_data


### PR DESCRIPTION
For now, we'll work without the env_data role (must be imported from edpm-ansible project).

Roles are probably not needing this one for debugging. May reconsider later.

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
