### PR TITLE
Ansible: repo_setup role

### DIFF
--- a/ci_framework/roles/repo_setup/README.md
+++ b/ci_framework/roles/repo_setup/README.md
@@ -1,0 +1,13 @@
+## Role: repo_setup
+Please explain the role purpose.
+
+### Privilege escalation
+If apply, please explain the privilege escalation done in this role.
+
+### Parameters
+* `cifmw_repo_setup_basedir`: Installation basedirectory. Defaults to `cifwm_basedir`
+which defaults to `~/ci-framework`
+* `cifmw_repo_setup_promotion`: Promotion line you want to deploy. Defaults to `current-podified`
+* `cifmw_repo_setup_branch`: Branch/release you want to deploy. Defaults to `zed`
+* `cifwm_repo_setup_dlrn_uri`: DLRN base URI. Defaults to https://trunk.rdoproject.org/
+* `cifmw_repo_setup_os_release`: Operatinf system release. Defaults to `ansible_distribution|lower`

--- a/ci_framework/roles/repo_setup/defaults/main.yml
+++ b/ci_framework/roles/repo_setup/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_setup_repos"
+cifmw_repo_setup_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}"
+cifmw_repo_setup_promotion: podified-ci-testing
+cifmw_repo_setup_branch: zed
+cifwm_repo_setup_dlrn_uri: https://trunk.rdoproject.org/
+cifmw_repo_setup_os_release: "{{ ansible_distribution|lower }}"

--- a/ci_framework/roles/repo_setup/meta/main.yml
+++ b/ci_framework/roles/repo_setup/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- repo_setup
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: edpm
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - edpm
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/ci_framework/roles/repo_setup/molecule/default/converge.yml
+++ b/ci_framework/roles/repo_setup/molecule/default/converge.yml
@@ -1,0 +1,60 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  vars:
+    cifmw_repo_setup_os_release: centos
+  roles:
+    - role: "repo_setup"
+
+  tasks:
+    - name: Ensure proper locations are created
+      block:
+        - name: Stat some files
+          register: file_stats
+          ansible.builtin.stat:
+            path: "{{ ansible_user_dir }}/ci-framework/{{ item }}"
+          loop:
+            - 'artifacts/repositories/delorean.repo.md5'
+        - name: Assert file status
+          assert:
+            that:
+              - item.stat.exists is defined
+              - item.stat.exists
+          loop: "{{ file_stats.results }}"
+    - name: Cleanup env
+      ansible.builtin.include_role:
+        name: repo_setup
+        tasks_from: cleanup.yml
+
+    - name: Ensure cleanup removed proper files
+      block:
+        - name: Stat some files
+          register: file_stats
+          ansible.builtin.stat:
+            path: "{{ ansible_user_dir }}/ci-framework/{{ item }}"
+          loop:
+            - 'artifacts/repositories/delorean.repo.md5'
+            - 'venv'
+            - 'artifacts/repositories'
+        - name: Assert file status
+          assert:
+            that:
+              - item.stat.exists is defined
+              - not item.stat.exists
+          loop: "{{ file_stats.results }}"

--- a/ci_framework/roles/repo_setup/molecule/default/molecule.yml
+++ b/ci_framework/roles/repo_setup/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/repo_setup/tasks/artifacts.yml
+++ b/ci_framework/roles/repo_setup/tasks/artifacts.yml
@@ -1,0 +1,5 @@
+---
+- name: Get DLRN hash
+  ansible.builtin.get_url:
+    url: "{{ cifwm_repo_setup_dlrn_uri }}/{{ cifmw_repo_setup_os_release }}{{ ansible_distribution_major_version }}-{{ cifmw_repo_setup_branch }}/{{ cifmw_repo_setup_promotion }}/delorean.repo.md5"
+    dest: "{{ cifmw_repo_setup_basedir }}/artifacts/repositories/delorean.repo.md5"

--- a/ci_framework/roles/repo_setup/tasks/cleanup.yml
+++ b/ci_framework/roles/repo_setup/tasks/cleanup.yml
@@ -1,0 +1,25 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Remove virtualenv
+  ansible.builtin.file:
+    path: "{{ cifmw_repo_setup_basedir }}/venv"
+    state: absent
+
+- name: Remove repositories
+  ansible.builtin.file:
+    path: "{{ cifmw_repo_setup_basedir }}/artifacts/repositories"
+    state: absent

--- a/ci_framework/roles/repo_setup/tasks/configure.yml
+++ b/ci_framework/roles/repo_setup/tasks/configure.yml
@@ -1,0 +1,8 @@
+---
+- name: Run repo-setup
+  ansible.builtin.command:
+    cmd: >-
+      {{ cifmw_repo_setup_basedir }}/venv/bin/repo-setup
+      {{ cifmw_repo_setup_promotion }}
+      -b {{ cifmw_repo_setup_branch }}
+      -o {{ cifmw_repo_setup_basedir }}/artifacts/repositories

--- a/ci_framework/roles/repo_setup/tasks/install.yml
+++ b/ci_framework/roles/repo_setup/tasks/install.yml
@@ -1,0 +1,22 @@
+---
+- name: Get repo-setup repository
+  ansible.builtin.git:
+    accept_hostkey: true
+    dest: "{{ cifmw_repo_setup_basedir }}/repo-setup"
+    repo: "https://github.com/ci-framework/repo-setup"
+
+- name: Initialize python venv and install requirements
+  ansible.builtin.pip:
+    virtualenv: "{{ cifmw_repo_setup_basedir }}/venv"
+    requirements: "{{ cifmw_repo_setup_basedir }}/repo-setup/requirements.txt"
+
+- name: Install repo-setup package
+  ansible.builtin.command:
+    cmd: "{{ cifmw_repo_setup_basedir }}/venv/bin/python setup.py install"
+    chdir: "{{ cifmw_repo_setup_basedir }}/repo-setup"
+    creates: "{{ cifmw_repo_setup_basedir }}/venv/bin/repo-setup"
+
+- name: Create repository output directory
+  ansible.builtin.file:
+    path: "{{ cifmw_repo_setup_basedir }}/artifacts/repositories"
+    state: directory

--- a/ci_framework/roles/repo_setup/tasks/main.yml
+++ b/ci_framework/roles/repo_setup/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Install repo-setup
+  ansible.builtin.include_tasks: install.yml
+- name: Configure repo-setup
+  ansible.builtin.include_tasks: configure.yml
+- name: Generate additional artifacts
+  ansible.builtin.include_tasks: artifacts.yml

--- a/ci_framework/roles/repo_setup/vars/main.yml
+++ b/ci_framework/roles/repo_setup/vars/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# While options found within the vars/ path can be overridden using extra
+# vars, items within this path are considered part of the role and not
+# intended to be modified.
+
+# All variables within this role should have a prefix of "cifmw_setup_repos"


### PR DESCRIPTION
This role allows to install repo-setup in a venv, and generate the needed repository files for later use.

It also adds the delorean hash to the artifacts

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
