### PR TITLE
Revert "Bump golang version to avoid security alerts"

### DIFF
--- a/ci_framework/roles/copy_container/files/copy-quay/go.mod
+++ b/ci_framework/roles/copy_container/files/copy-quay/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3
-	golang.org/x/net v0.8.0 // indirect
+	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect


### PR DESCRIPTION
Reverts openstack-k8s-operators/ci-framework#33

We need to test it first.