### PR TITLE
Add a var to not run cron  - copy_container

### DIFF
--- a/ci_framework/roles/copy_container/defaults/main.yml
+++ b/ci_framework/roles/copy_container/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 enable_cron: true
+enable_cron_c9: true

--- a/ci_framework/roles/copy_container/tasks/main.yml
+++ b/ci_framework/roles/copy_container/tasks/main.yml
@@ -61,7 +61,7 @@
   when: enable_cron|default(true)|bool and ansible_distribution == 'CentOS' and ansible_distribution_version < '9'
 
 - become: true
-  when: ansible_distribution == 'CentOS' and ansible_distribution_version >= '9'
+  when: enable_cron_c9|default(true)|bool and ansible_distribution == 'CentOS' and ansible_distribution_version >= '9'
   block:
   - name: Create cron job to copy containers
     cron:


### PR DESCRIPTION
This PR adds a var to not run the CentOS 9
cron tasks in
ci_framework/roles/copy_container/tasks/main.yml
and just run the install.

By default the behaviour remain unchanged.
The var is set to true in the defaults.

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
