### PR TITLE
Make current-podified the default container tag

### DIFF
--- a/ci_framework/roles/copy_container/files/copy-quay/README.rst
+++ b/ci_framework/roles/copy_container/files/copy-quay/README.rst
@@ -10,7 +10,7 @@ The functionality is as follow:
 * Pull it from the source registry
 * If it is a new container, create the repository as public in quay
 * Push it to quay
-* Tag the container with both current-tripleo and build id
+* Tag the container with both current-podified and build id
 
 Building
 --------

--- a/ci_framework/roles/copy_container/files/copy-quay/tag.go
+++ b/ci_framework/roles/copy_container/files/copy-quay/tag.go
@@ -25,7 +25,7 @@ func tagCmd(global *globalOptions) *cobra.Command {
         Short: "Tag images",
         RunE: optsTag.run,
     }
-    cmd.Flags().StringVar(&optsTag.tag, "tag", "current-tripleo", "Image tag name")
+    cmd.Flags().StringVar(&optsTag.tag, "tag", "current-podified", "Image tag name")
     cmd.Flags().StringVar(&optsTag.hash, "force-hash", "", "Force an specific hash, overwriting delorean api")
     cmd.Flags().StringVar(&optsTag.htmlOutput, "html", "", "HTML output report file")
     return cmd


### PR DESCRIPTION
This PR removes current-tripleo and
replaces it with current-podified as the default
tag for copy containers.

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [x ] Appropriate documentation (README in the role, main README is up-to-date)
