### PR TITLE
Implement ansible-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,13 @@ pre_commit_nodeps: ## Run pre-commit tests without installing dependencies
 		pre-commit run --all-files ; \
 	fi
 
+.PHONY: ansible_test
+ansible_test: setup_tests ansible_tests_nodeps ## Runs ansible-test with dependencies install
+
+.PHONY: ansible_test_nodeps
+ansible_test_nodeps: ## Run ansible-test without installing dependencies
+	bash scripts/run_ansible_test
+
 .PHONY: tests
 tests: pre_commit molecule ## Run all tests with dependencies install
 
@@ -85,4 +92,14 @@ run_ctx_molecule: ci_ctx ## Run molecule check in a container
 		podman run --rm -e MOLECULE_CONFIG=$(MOLECULE_CONFIG) \
 			--security-opt label=disable -v .:/opt/sources cfwm:latest \
 			bash -c "make molecule_nodeps MOLECULE_CONFIG=$(MOLECULE_CONFIG)" ; \
+	fi
+
+.PHONY: run_ctx_ansible_test
+run_ctx_ansible_test: ci_ctx ## Run molecule check in a container
+	if [ "x$(BUILD_VENV_CTX)" == 'xyes' ]; then \
+		podman run --rm  cfwm:latest \
+			bash -c "make ansible_test_nodeps" ; \
+	else \
+		podman run --rm --security-opt label=disable -v .:/opt/sources \
+			cfwm:latest bash -c "make ansible_test_nodeps" ; \
 	fi

--- a/scripts/run_ansible_test
+++ b/scripts/run_ansible_test
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+## Shell Opts ----------------------------------------------------------------
+
+set -o pipefail
+set -xeuo
+
+## Vars ----------------------------------------------------------------------
+PROJECT_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))/../"
+USE_VENV=${USE_VENV:-yes}
+HOME=${HOME:-/tmp}
+
+ansible_test='ansible-test'
+collection_path='/usr/share/ansible/collections'
+case ${USE_VENV} in
+    y|yes|true):
+        ansible_test="${HOME}/test-python/bin/ansible-test"
+        collection_path="${HOME}.ansible/collections/ansible_collections"
+        ;;
+esac
+
+mkdir -p ${HOME}/code/ansible_collections/cifmw/general
+cp -ra ${PROJECT_DIR}ci_framework/* ${HOME}/code/ansible_collections/cifmw/general/
+ln -s ${collection_path}/* ${HOME}/code/ansible_collections/
+
+pushd ${HOME}/code/ansible_collections/cifmw/general
+${ansible_test} sanity --skip-test action-plugin-docs --color=yes
+if [ -d tests/integration ]; then
+    ${ansible_test} integration --color=yes
+fi
+if [ -d tests/units ]; then
+    ${ansible_test} units --color=yes
+fi


### PR DESCRIPTION
While molecule and pre-commit already provide a nice covering, ansible-test makes some more "ansible-centric" checks, and allows to leverage some more tests in a convenient way.

Note that ansible-test is expecting a proper collection, with code located at a specific place. This is why we have to copy (and not just link) the project directory content. We take advantage of the already deployed collections by just linking them in the test path, avoiding yet another collection deploy.

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
