### PR TITLE
Ensure our container is able to mimic Prow env

### DIFF
--- a/containerfiles/Containerfile.tests
+++ b/containerfiles/Containerfile.tests
@@ -3,10 +3,14 @@ USER root
 ENV USE_VENV=no
 ENV MOLECULE_CONFIG=.config/molecule/config_local.yml
 
+RUN adduser -d / -M prow
+
 COPY ../ /opt/sources
 RUN find /opt/sources -type d -exec chmod g+rwx {} \;
 RUN find /opt/sources -type f -exec chmod g+rw {} \;
 WORKDIR /opt/sources
 RUN git config core.fileMode false
 RUN /usr/bin/make setup_molecule USE_VENV=${USE_VENV}
+
+USER prow
 CMD /usr/bin/make help

--- a/scripts/run_ansible_test
+++ b/scripts/run_ansible_test
@@ -25,8 +25,12 @@ PROJECT_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))/../"
 USE_VENV=${USE_VENV:-yes}
 HOME=${HOME:-/tmp}
 
+export HOME=${HOME}
+export ANSIBLE_LOCAL_TMP=${HOME}
+export ANSIBLE_REMOTE_TMP=${HOME}
+
 ansible_test='ansible-test'
-collection_path='/usr/share/ansible/collections'
+collection_path='/usr/share/ansible/collections/ansible_collections'
 case ${USE_VENV} in
     y|yes|true):
         ansible_test="${HOME}/test-python/bin/ansible-test"
@@ -39,10 +43,10 @@ cp -ra ${PROJECT_DIR}ci_framework/* ${HOME}/code/ansible_collections/cifmw/gener
 ln -s ${collection_path}/* ${HOME}/code/ansible_collections/
 
 pushd ${HOME}/code/ansible_collections/cifmw/general
-${ansible_test} sanity --skip-test action-plugin-docs --color=yes
+${ansible_test} sanity --skip-test action-plugin-docs --color=yes -vv
 if [ -d tests/integration ]; then
-    ${ansible_test} integration --color=yes
+    ${ansible_test} integration --color=yes -vv
 fi
 if [ -d tests/units ]; then
-    ${ansible_test} units --color=yes
+    ${ansible_test} units --color=yes -vv
 fi

--- a/scripts/run_molecule
+++ b/scripts/run_molecule
@@ -35,7 +35,7 @@ local_roledir=$(echo $ROLE_DIR | sed 's|\.\?\./||g')
 # Find what roles were modified
 ROLES_LIST=$(git diff --dirstat=files,0,cumulative HEAD^..HEAD | sed "s|^[ 0-9.]\+% \(${local_roledir}\)\?||g" | cut -d/ -f1 | sort -u )
 if [ ${TEST_ALL_ROLES} == 'yes' ]; then
-    ROLES_LIST=$(ls -1 ${local_roledir})
+    ROLES_LIST=$(ls -1)
 fi
 
 for rolepath in ${ROLES_LIST}; do


### PR DESCRIPTION
Container running in Prow CI aren't providing root access. We therefore need to 100% mimic their usage.

In order to do so, the Containerfile.test is now creating a "prow" user with its home located in / (like in prow), and without any privileges.

Note that molecule isn't running on Prow for the very reason of missing privileges escalation. For that specific use, we're therefore passing "--user root" in order to keep the full accesses we need.

This patch also corrects some issues introduced in the past that weren't properly raised, and sets some more verbosity for the ansible-test runs.

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
