### PR TITLE
Modify how molecule is launched

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -20,6 +20,9 @@ log: true
 
 platforms:
   - name: instance
+    environment: &env
+      http_proxy: "{{ lookup('env', 'http_proxy') }}"
+      https_proxy: "{{ lookup('env', 'https_proxy') }}"
 
 provisioner:
   name: ansible

--- a/.config/molecule/config_local.yml
+++ b/.config/molecule/config_local.yml
@@ -10,6 +10,9 @@ log: true
 
 platforms:
   - name: instance
+    environment: &env
+      http_proxy: "{{ lookup('env', 'http_proxy') }}"
+      https_proxy: "{{ lookup('env', 'https_proxy') }}"
 
 provisioner:
   name: ansible

--- a/.zuul.d/collect-logs.yml
+++ b/.zuul.d/collect-logs.yml
@@ -1,0 +1,35 @@
+---
+- hosts: primary
+  gather_facts: true
+  tasks:
+    - name: Ensure file is present
+      register: molecule_report
+      ansible.builtin.stat:
+        path: /tmp/report.html
+    - name: Manage molecule report file
+      when:
+        - molecule_report.stat.exists
+      block:
+        - name: Collect logs
+          ansible.builtin.command:
+            chdir: "{{ ansible_user_dir }}/zuul-output/logs"
+            cmd: cp /tmp/report.html .
+
+    - name: Copy files from workspace on node
+      vars:
+        work_dir: "{{ ansible_user_dir }}/workspace"
+      ansible.builtin.include_role:
+        name: fetch-output
+
+    - name: Return artifact to Zuul
+      when:
+        - not skip_report | default(false)
+        - molecule_report.stat.exists
+      zuul_return:
+        data:
+          zuul:
+            artifacts:
+              - name: "Molecule report"
+                url: "report.html"
+                metadata:
+                  type: html_report

--- a/.zuul.d/prepare.yml
+++ b/.zuul.d/prepare.yml
@@ -1,17 +1,26 @@
 ---
 - hosts: primary
-  gather_facts: false
+  gather_facts: true
   tasks:
+    - name: Debug some content
+      ansible.builtin.debug:
+        var: ansible_user
     - name: Prepare workspace
       ansible.builtin.include_role:
         name: prepare-workspace
+    - name: Create zuul-output directory
+      ansible.builtin.file:
+        path: "{{ ansible_user_dir }}/zuul-output/logs"
+        state: directory
+        mode: 0755
     - name: Install required packages
       become: true
       ansible.builtin.package:
         name:
-          - buildah
           - make
           - podman
-    - name: Build container
-      ansible.builtin.command: |
-        make -C "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}" ci_ctx
+          - python3
+    - name: Install venv
+      community.general.make:
+        chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
+        target: setup_molecule

--- a/.zuul.d/test-molecule.yml
+++ b/.zuul.d/test-molecule.yml
@@ -1,11 +1,12 @@
 ---
 - hosts: primary
-  gather_facts: false
+  gather_facts: true
   tasks:
-    - name: Run molecule in container
-      community.general.make:
+    - name: Run molecule
+      environment:
+        ANSIBLE_LOG_PATH: "{{ ansible_user_dir }}/zuul-output/logs/ansible-execution.log"
+        MOLECULE_CONFIG: ".config/molecule/config_local.yml"
+        MOLECULE_REPORT: "/tmp/report.html"
+      ansible.builtin.command:
         chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
-        target: run_ctx_molecule
-        params:
-          BUILD_VENV_CTX: no
-          MOLECULE_CONFIG: .config/molecule/config_local.yml
+        cmd: ./scripts/run_molecule "ci_framework/roles/"

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -4,10 +4,14 @@
     nodeset:
       nodes:
         name: primary
-        label: ansible-cloud-centos-9-stream-tiny
+        label: cloud-centos-9-stream-vexxhost
     parent: base-minimal
+    vars:
+      LC_ALL: en_US.utf8
+      LANG: en_US.utf8
     pre-run: .zuul.d/prepare.yml
     run: .zuul.d/test-molecule.yml
+    post-run: .zuul.d/collect-logs.yml
 
 - project:
     name: openstack-k8s-operators/ci-framework


### PR DESCRIPTION
Running from within a container is nice, but we then lack the molecule logs. So instead of running in the container, let's leverage the virtualenv and related so that we can properly run on the host.