### PR TITLE
Change Containerfile.ci image base

### DIFF
--- a/containerfiles/Containerfile.ci
+++ b/containerfiles/Containerfile.ci
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-init:latest
+FROM quay.io/centos/centos:stream9
 LABEL summary="Provides root image for openstack-k8s-operators projects in Prow" maintainer="CI Framework"
 
 USER root


### PR DESCRIPTION
Change image from ubi to centos stream. At this way we can have access to some repositories and being able to install python3-libvirt and dependencies

This PR has:
- [x] Appropriate testing (molecule, python unit tests)
- [x] Appropriate documentation (README in the role, main README is up-to-date)
