### PR TITLE
Modify container related actions

### DIFF
--- a/containerfiles/Containerfile.tests
+++ b/containerfiles/Containerfile.tests
@@ -1,4 +1,4 @@
-FROM localhost/cfwm-build:latest
+FROM localhost/cifmw-build:latest
 USER root
 ENV USE_VENV=no
 ENV MOLECULE_CONFIG=.config/molecule/config_local.yml


### PR DESCRIPTION
First, build the container using podman instead of buildah
since we don't actually leverage buildah power.

Second, use complete name for the container in order to avoid
potential issues, especially when running on MacOS and
`podman machine` environment.

This PR has:
- [x] Appropriate testing (molecule, python unit tests)
- [x] Appropriate documentation (README in the role, main README is up-to-date)
