### PR TITLE
Use repo-setup-get-hash tool to get dlrn md5

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -37,3 +37,6 @@ gzip
 
 # Required to build language docs
 gettext
+
+# Required for community.general.json_query usage
+python3-jmespath  [platform:rpm]

--- a/ci_framework/roles/repo_setup/defaults/main.yml
+++ b/ci_framework/roles/repo_setup/defaults/main.yml
@@ -17,6 +17,9 @@
 
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_setup_repos"
+# To get dlrn md5 hash for components [baremetal,cinder,clients,cloudops,common,
+# compute,glance,manila,network,octavia,security,swift,tempest,podified,ui,validation]
+# cifwm_repo_setup_component: <component name>
 cifmw_repo_setup_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}"
 cifmw_repo_setup_promotion: "podified-ci-testing"
 cifmw_repo_setup_branch: "zed"

--- a/ci_framework/roles/repo_setup/tasks/artifacts.yml
+++ b/ci_framework/roles/repo_setup/tasks/artifacts.yml
@@ -1,5 +1,19 @@
 ---
-- name: Get DLRN hash
-  ansible.builtin.get_url:
-    url: "{{ cifwm_repo_setup_dlrn_uri }}{{ cifmw_repo_setup_os_release }}{{ cifmw_repo_setup_dist_major_version }}-{{ cifmw_repo_setup_branch }}/{{ cifmw_repo_setup_promotion }}/delorean.repo.md5"
+- name: Run repo-setup=get-hash
+  ansible.builtin.shell: |
+    {{ cifmw_repo_setup_basedir }}/venv/bin/repo-setup-get-hash \
+      --dlrn-url {{ cifwm_repo_setup_dlrn_uri[:-1] }} \
+      --os-version {{ cifmw_repo_setup_os_release }}{{ cifmw_repo_setup_dist_major_version }} \
+      --tag {{cifmw_repo_setup_promotion }} \
+      --release {{ cifmw_repo_setup_branch }} \
+    {% if cifwm_repo_setup_component is defined %}
+      --component {{ cifmw_repo_setup_component }} \
+    {% endif %}
+      --json
+  register: _get_hash
+
+- name: Dump full hash in delorean.repo.md5 file
+  ansible.builtin.copy:
+    content: |
+      "{{ _get_hash.stdout | from_json | community.general.json_query('full_hash') }}"
     dest: "{{ cifmw_repo_setup_basedir }}/artifacts/repositories/delorean.repo.md5"


### PR DESCRIPTION
repo-setup tool provides repo-setup-get-hash[1] utility to get the dlrn md5 hash for components and dlrn tags.

Let's use the same instead of fetching the url.

[1]. https://github.com/openstack-k8s-operators/repo-setup/blob/main/setup.cfg#L36
Signed-off-by: Chandan Kumar <raukadah@gmail.com>

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [x] Appropriate documentation (README in the role, main README is up-to-date)
