### PR TITLE
Some more changes in the way container is built

### DIFF
--- a/containerfiles/Containerfile.tests
+++ b/containerfiles/Containerfile.tests
@@ -6,11 +6,12 @@ ENV MOLECULE_CONFIG=.config/molecule/config_local.yml
 RUN adduser -d / -M prow
 
 COPY ../ /opt/sources
-RUN find /opt/sources -type d -exec chmod g+rwx {} \;
-RUN find /opt/sources -type f -exec chmod g+rw {} \;
+RUN chown -R prow: /opt/sources
 WORKDIR /opt/sources
-RUN git config core.fileMode false
+RUN find . -type d -exec chmod g+rwx {} \;
+RUN find . -type f -exec chmod g+rw {} \;
 RUN /usr/bin/make setup_molecule USE_VENV=${USE_VENV}
 
 USER prow
+RUN git config core.fileMode false
 CMD /usr/bin/make help


### PR DESCRIPTION
It seems buildah is doing things in a different way with regards to the "COPY" path related. podman wasn't pushing the whole content, it was stuck in the "containerfiles" directory.

The Containerfile.test also has some changes in order to correct some of the order - mostly ensuring we're in the right location before doing anything.

Those changes are needed for at least pre-commit check - for some reasons, it failed with the last modifications done to that whole process.

This PR has:
- [x] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
