### PR TITLE
Added support for rhos-release in repo-setup role

### DIFF
--- a/ci_framework/roles/repo_setup/defaults/main.yml
+++ b/ci_framework/roles/repo_setup/defaults/main.yml
@@ -27,3 +27,9 @@ cifwm_repo_setup_dlrn_uri: "https://trunk.rdoproject.org/"
 cifmw_repo_setup_os_release: "{{ ansible_distribution|lower }}"
 cifmw_repo_setup_dist_major_version: "{{ ansible_distribution_major_version }}"
 cifmw_repo_setup_src: "https://github.com/openstack-k8s-operators/repo-setup"
+
+# Variables related to rhos-release tools
+# rhos-release is used in downstream to populate downstream base os repos
+# cifmw_repo_setup_rhos_release_rpm: <full url of rhos-release rpm>
+# cifmw_repo_setup_rhos_release_args: <arguments for rhos-release utility>
+cifmw_repo_setup_enable_rhos_release: false

--- a/ci_framework/roles/repo_setup/tasks/main.yml
+++ b/ci_framework/roles/repo_setup/tasks/main.yml
@@ -20,3 +20,6 @@
   ansible.builtin.include_tasks: configure.yml
 - name: Generate additional artifacts
   ansible.builtin.include_tasks: artifacts.yml
+- name: Generate downstream base os repos
+  ansible.builtin.include_tasks: rhos_release.yml
+  when: cifmw_repo_setup_enable_rhos_release | bool

--- a/ci_framework/roles/repo_setup/tasks/rhos_release.yml
+++ b/ci_framework/roles/repo_setup/tasks/rhos_release.yml
@@ -1,0 +1,21 @@
+---
+- name: Install RHOS Release tool
+  ansible.builtin.package:
+    name: "{{ cifmw_repo_setup_rhos_release_rpm }}"
+    state: present
+
+- name: Get rhos-release tool version
+  become: true
+  ansible.builtin.command: rhos-release --version
+  register: rr_version
+
+- name: Print rhos-release tool version
+  debug:
+    msg: "{{ rr_version.stdout }}"
+
+- name: "Generate repos using rhos-release {{ cifmw_repo_setup_rhos_release_args }}"
+  become: true
+  ansible.builtin.command:
+    cmd: >-
+      rhos-release {{ cifmw_repo_setup_rhos_release_args }} \
+        -t {{ cifmw_repo_setup_basedir }}/artifacts/repositories


### PR DESCRIPTION
rhos-release tool is used in downstream to lay down
RHEL base os repos. repo-setup tool will be used
to generate dlrn repos.
    
Integrating rhos-release with in repo-setup role
provides a single role to deal with all the repos
 in downstream.
    
Signed-off-by: Chandan Kumar <raukadah@gmail.com>


This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [x] Appropriate documentation (README in the role, main README is up-to-date)
