### PR TITLE
Implement hooks in ci-framework

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -63,6 +63,11 @@ pre_infra:
       source: foo.yml
     - name: My glorious CRD
       type: crd
+      host: https://my.openshift.cluster
+      username: foo
+      password: bar
+      wait_condition:
+        type: pod
       source: /path/to/my/glorious.crd
 ```
 In the above example, the `foo.yml` is located in

--- a/ci_framework/hooks/playbooks/noop.yml
+++ b/ci_framework/hooks/playbooks/noop.yml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: This is a noop hook
+      ansible.builtin.debug:
+        msg: 'This is a noop hook'

--- a/ci_framework/roles/run_hook/README.md
+++ b/ci_framework/roles/run_hook/README.md
@@ -1,0 +1,39 @@
+## Role: run_hook
+Run hooks during a playbook. Hooks may be in the form of a playbook, or a
+plain CRD.
+
+### Privilege escalation
+None from the module, but a hooked playbook may require privilege escalation.
+Note that, in such a case, the password prompt will be masked, and the overall
+play has a great chance of failure.
+
+### Parameters
+* `hooks`: A list of hooks
+
+### Hooks expected format
+#### Playbook
+In such a case, the following data can be provided to the hook:
+* `type`: Type of the hook. In this case, set it to `playbook`.
+* `source`: Source of the playbook. If it's a filename, the playbook is
+expected in ci_framwork/hooks/playbooks. It can be an absolute path.
+* `name`: Describe the hook.
+* `inventory`: Refer to the `--inventory` option for `ansible-playbook`.
+Defaults to `localhost,`.
+* `connection`: Refer to the `--connection` option for `ansible-playbook`.
+Defaults to `local`.
+
+#### CRD
+In such a case, the following data can be provided to the hook:
+* `type`: Type of the hook. In this case, set it to `crd`.
+* `source`: Source of the CRD. If it's a filename, the CRD is expected in
+ci_framwork/hooks/crds. It can be an absolute path.
+* `host`: Cluster API endpoint. Defaults to `https://api.crc.testing:6443`.
+* `username`: Username for authentication against the cluster. Defaults to `kubeadmin`.
+* `password`: Password for authentication against the cluster. Defaults to `12345678`.
+* `state`: State of the service. Can be `present` or `absent`. Defaults to `present`.
+* `validate_certs`: Whether to validate or not the cluster certificates.
+* `wait_condition`: Wait condition for the service
+
+Note that the `wait_condition` must match the format used by the
+`kubernetes.core.k8s` module. More information here:
+https://docs.ansible.com/ansible/latest/collections/kubernetes/core/k8s_module.html

--- a/ci_framework/roles/run_hook/defaults/main.yml
+++ b/ci_framework/roles/run_hook/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_run_hook"
+cifmw_run_hook_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"

--- a/ci_framework/roles/run_hook/handlers/main.yml
+++ b/ci_framework/roles/run_hook/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.

--- a/ci_framework/roles/run_hook/meta/main.yml
+++ b/ci_framework/roles/run_hook/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- run_hook
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: edpm
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - edpm
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/ci_framework/roles/run_hook/molecule/default/converge.yml
+++ b/ci_framework/roles/run_hook/molecule/default/converge.yml
@@ -1,0 +1,36 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Hook in dummy playbook
+      vars:
+        hooks:
+          - name: Dummy playbook
+            source: /tmp/dummy.yml
+            type: playbook
+      ansible.builtin.include_role:
+        name: run_hook
+    - name: Hook project provided noop.yml
+      vars:
+        hooks:
+          - name: Default noop hook
+            source: noop.yml
+            type: playbook
+      ansible.builtin.include_role:
+        name: run_hook

--- a/ci_framework/roles/run_hook/molecule/default/molecule.yml
+++ b/ci_framework/roles/run_hook/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/run_hook/molecule/default/prepare.yml
+++ b/ci_framework/roles/run_hook/molecule/default/prepare.yml
@@ -1,0 +1,33 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps
+
+  tasks:
+    - name: Create dummy playbook
+      ansible.builtin.copy:
+        dest: /tmp/dummy.yml
+        content: |
+          - hosts: localhost
+            gather_facts: true
+            tasks:
+              - name: Hello world
+                ansible.builtin.debug:
+                  msg: 'Hello world!'

--- a/ci_framework/roles/run_hook/tasks/cleanup.yml
+++ b/ci_framework/roles/run_hook/tasks/cleanup.yml
@@ -1,0 +1,19 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Cleaning the World
+  debug:
+    msg: "So here run_hook should clean things up!"

--- a/ci_framework/roles/run_hook/tasks/crd.yml
+++ b/ci_framework/roles/run_hook/tasks/crd.yml
@@ -1,0 +1,21 @@
+---
+- name: "Set CRD {{ hook.name }} path"
+  set_fact:
+    crd_path: >-
+      {%- if hook.source is not ansible.builtin.abs -%}
+      {{ role_path }}/../../hooks/crds/{{ hook.src }}
+      {%- else -%}
+      {{ hook.source }}
+      {%- endif -%}
+
+- name: "Load and run {{ crd_path }} CRD"
+  kubernetes.core.k8s:
+    host: "{{ hook.host | default('https://api.crc.testing:6443') }}"
+    username: "{{ hook.username | default('kubeadmin') }}"
+    password: "{{ hook.password | default('12345678') }}"
+    state: "{{ hook.state | default(present) }}"
+    src: "{{ hook.source }}"
+    validate:
+      fail_on_error: true
+    validate_certs: "{{ hook.validate_certs | default(omit) }}"
+    wait_condition: "{{ hook.wait_condition | default(omit) }}"

--- a/ci_framework/roles/run_hook/tasks/main.yml
+++ b/ci_framework/roles/run_hook/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Loop on the passed hooks and call correct action
+  vars:
+    hook: "{{ item }}"
+  ansible.builtin.include_tasks: "{{ item.type }}.yml"
+  loop: "{{ hooks }}"

--- a/ci_framework/roles/run_hook/tasks/playbook.yml
+++ b/ci_framework/roles/run_hook/tasks/playbook.yml
@@ -1,0 +1,29 @@
+---
+- name: "Set playbook {{ hook.name }} path"
+  set_fact:
+    playbook_path: >-
+      {%- if hook.source is not ansible.builtin.abs -%}
+      {{ role_path }}/../../hooks/playbooks/{{ hook.source }}
+      {%- else -%}
+      {{ hook.source }}
+      {%- endif -%}
+
+# We cannot call ansible.builtin.import_playbook from within a play,
+# even less from a task. So the way to run a playbook from within a playbook
+# is to call a command. Though we may lose some of the data passed to the
+# "main" play.
+- name: "Run {{ playbook_path }} playbook"
+  register: play_output
+  ansible.builtin.command:
+    cmd: >-
+      ansible-playbook -i {{ hook.inventory | default('localhost,') }}
+      -c {{ hook.connection | default('local') }}
+      {{ playbook_path }}
+
+- name: Output play stderr
+  ansible.builtin.debug:
+    var: play_output.stderr
+
+- name: Output play stdout
+  ansible.builtin.debug:
+    var: play_output.stdout

--- a/ci_framework/roles/run_hook/vars/main.yml
+++ b/ci_framework/roles/run_hook/vars/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# While options found within the vars/ path can be overridden using extra
+# vars, items within this path are considered part of the role and not
+# intended to be modified.
+
+# All variables within this role should have a prefix of "cifmw_run_hook"

--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -12,8 +12,70 @@
     - name: ci_setup
     - name: repo_setup
   tasks:
-    - name: "That's all folks"
-      debug:
-        msg: "For now at least"
-    # TODO: add role inclusion with some conditional, such as "if we get
-    # that specific setting, then include that role".
+    - name: Pre-infra hook
+      when:
+        - pre_infra is defined
+      vars:
+        hooks: "{{ pre_infra }}"
+      ansible.builtin.include_role:
+        name: run_hook
+    - name: Prepare CRC
+      when:
+        - cifmw_use_crc is defined
+        - cifmw_use_crc | bool
+      ansible.builtin.include_role:
+        name: rhol_crc
+    # TODO: libvirt
+    - name: Post-infra hook
+      when:
+        - post_infra is defined
+      vars:
+        hooks: "{{ post_infra }}"
+      ansible.builtin.include_role:
+        name: run_hook
+    - name: Pre-package build hook
+      when:
+        - pre_package_build is defined
+      vars:
+        hooks: "{{ pre_package_build }}"
+      ansible.builtin.include_role:
+        name: run_hook
+    # TODO: build packages
+    - name: Post-package build hook
+      when:
+        - post_package_build is defined
+      vars:
+        hooks: "{{ post_package_build }}"
+      ansible.builtin.include_role:
+        name: run_hook
+    - name: Pre-container build hook
+      when:
+        - pre_container_build is defined
+      vars:
+        hooks: "{{ pre_container_build }}"
+      ansible.builtin.include_role:
+        name: run_hook
+    # TODO: build containers
+    - name: Post-container build hook
+      when:
+        - post_container_build is defined
+      vars:
+        hooks: "{{ post_container_build }}"
+      ansible.builtin.include_role:
+        name: run_hook
+    - name: Pre-deploy hook
+      when:
+        - pre_deploy is defined
+      vars:
+        hooks: "{{ pre_deploy }}"
+      ansible.builtin.include_role:
+        name: run_hook
+    # TODO: deploy EDPM
+    - name: Post-deploy hook
+      when:
+        - post_deploy is defined
+      vars:
+        hooks: "{{ post_deploy }}"
+      ansible.builtin.include_role:
+        name: run_hook
+    # TODO: consider if we get a "formal" test step, or if hooks are sufficiant


### PR DESCRIPTION
Hooks are needed in order to allow users to side-load content in the deployment process.

The `deploy-edpm.yml` playbook has now a first structure, allowing to understand better how hooks may be leveraged.

Of course, some pre/post hooks are kind of "the same", since they are following each others without any other tasks in-between, but getting a clean name allows to know a bit more about the actual purpose of the hook in question.

The USAGE.md file has been updated in order to show a bit more the potentials for hooks.

This PR has:
- [x] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
