### PR TITLE
Expose custom plugins to the env for molecule

### DIFF
--- a/scripts/run_molecule
+++ b/scripts/run_molecule
@@ -38,6 +38,7 @@ if [ ${TEST_ALL_ROLES} == 'yes' ]; then
     ROLES_LIST=$(ls -1)
 fi
 
+export ANSIBLE_ACTION_PLUGINS=~/.ansible/plugins/action:/usr/share/ansible/plugins/actions
 for rolepath in ${ROLES_LIST}; do
     role=$(echo $rolepath|sed "s|${local_roledir}||" | cut -f1 -d /)
     test -d ${role} || continue
@@ -48,7 +49,7 @@ for rolepath in ${ROLES_LIST}; do
             ${HOME}/test-python/bin/molecule -c "${PROJECT_DIR}${MOLECULE_CONFIG}" test
             ;;
         *)
-            molecule -c "${PROJECT_DIR}${MOLECULE_CONFIG}" test
+            molecule -c "${PROJECT_DIR}${MOLECULE_CONFIG}" --debug test
             ;;
     esac
     popd

--- a/scripts/setup_molecule
+++ b/scripts/setup_molecule
@@ -49,3 +49,5 @@ ${PIP} install \
 ${GALAXY} collection install --timeout=120 \
         -p "${COLLECTION_PATH}" \
         -r "${PROJECT_DIR}requirements.yml"
+mkdir -p ${HOME}/.ansible/plugins
+cp -a ${PROJECT_DIR}plugins/* ${HOME}/.ansible/plugins/


### PR DESCRIPTION
Molecule has to know about the custom plugins we may inject - ensure we copy the content of "plugins" in a known location, and consume them in molecule tests.