### PR TITLE
Add a new parameter to `ci_make`: dry_run

### DIFF
--- a/ci_framework/plugins/README.md
+++ b/ci_framework/plugins/README.md
@@ -3,6 +3,8 @@
 ## action_plugins/ci_make
 This wraps `community.general.make` module, mostly. It requires an additional
 parameter, `output_dir`, in order to output the `make` generated command.
+It also adds a new optional parameter, `dry_run`, allowing to NOT run
+`community.general.make` module, but get a file with the passed parameters.
 
 It requires a pull-request to merge in the community.general collection:
 https://github.com/ansible-collections/community.general/pull/6160

--- a/ci_framework/tests/integration/targets/make/tasks/main.yml
+++ b/ci_framework/tests/integration/targets/make/tasks/main.yml
@@ -57,5 +57,34 @@
       ansible.builtin.assert:
         that:
           - item.stat.exists is defined
-          - item.stat.exists
+          - item.stat.exists|bool
       loop: "{{ reproducer_scripts.results }}"
+
+- name: Try dry_run parameter
+  ci_make:
+    chdir: /tmp/project_makefile
+    output_dir: /tmp/artifacts
+    dry_run: true
+
+- name: Check dry_run generated file
+  block:
+    - name: Get file state
+      register: dry_run_state
+      ansible.builtin.stat:
+        path: "/tmp/artifacts/ci_make_2_try_dry_run_parameter.sh"
+
+    - name: Ensure dry_run reproducer exists
+      ansible.builtin.assert:
+        that:
+          - dry_run_state.stat.exists is defined
+          - dry_run_state.stat.exists|bool
+
+    - name: Get file content
+      register: dry_run_content
+      ansible.builtin.slurp:
+        path: "/tmp/artifacts/ci_make_2_try_dry_run_parameter.sh"
+
+    - name: Assert file content
+      ansible.builtin.assert:
+        that:
+          - (dry_run_content['content'] | b64decode) == "#!/bin/sh\nchdir: /tmp/project_makefile\n"


### PR DESCRIPTION
This will allow to get some better testing in molecule and related, since we'll generate a file, but not run the actual make command.

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
