### PR TITLE
Correct generated "command" in dry_run

### DIFF
--- a/ci_framework/plugins/action/ci_make.py
+++ b/ci_framework/plugins/action/ci_make.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import glob
+import json
 import os
 import re
 
@@ -69,8 +70,7 @@ class ActionModule(ActionBase):
                                          module_args=module_args,
                                          task_vars=task_vars, tmp=tmp)
         else:
-            command = [k + ': ' + v for k, v in module_args.items()]
-            m_ret = {'command': ' '.join(command)}
+            m_ret = {'command': json.dumps(module_args)}
 
         # This isn't needed anymore, let's free some resources
         del tmp

--- a/ci_framework/tests/integration/targets/make/tasks/main.yml
+++ b/ci_framework/tests/integration/targets/make/tasks/main.yml
@@ -64,6 +64,8 @@
   ci_make:
     chdir: /tmp/project_makefile
     output_dir: /tmp/artifacts
+    params:
+      FOO_BAR: startrek
     dry_run: true
 
 - name: Check dry_run generated file
@@ -84,7 +86,12 @@
       ansible.builtin.slurp:
         path: "/tmp/artifacts/ci_make_2_try_dry_run_parameter.sh"
 
+    - name: Decode content
+      ansible.builtin.set_fact:
+        dry_run_decode: "{{ dry_run_content['content'] | b64decode }}"
+
     - name: Assert file content
       ansible.builtin.assert:
         that:
-          - (dry_run_content['content'] | b64decode) == "#!/bin/sh\nchdir: /tmp/project_makefile\n"
+          - "dry_run_decode == '#!/bin/sh\n{\"chdir\": \"/tmp/project_makefile\", \"params\": {\"FOO_BAR\": \"startrek\"}}\n'"
+        msg: "File content: {{ dry_run_decode }}"


### PR DESCRIPTION
Test didn't set any "params", leading to an uncaught issue with the last modification (#57).

This patch fixes it - we now have the parameters as a json, directly pushed to the file.

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
