### PR TITLE
Adds initial implementation of operator_build role

### DIFF
--- a/ci_framework/roles/operator_build/README.md
+++ b/ci_framework/roles/operator_build/README.md
@@ -1,0 +1,58 @@
+## Role: operator_build
+Builds OpenStack k8s operators and push them to a registry.
+When building an operator from a Pull Request, it is mandatory to provide the PR Owner and the PR SHA *only* if
+you want to build meta-operator too, so the role can properly replace api references in meta-operator.
+
+## Parameters
+* `cifmw_operator_build_org`: (String) Operator's organization on GitHub. Defaults to **openstack-k8s-operators**.
+* `cifmw_operator_build_push_registry`: (String) Registry used to push images. Defaults to **quay.rdoproject.org**.
+* `cifmw_operator_build_push_org`: (String) Registry's organization to push image to. Defaults to **openstack-k8s-operators**.
+* `cifmw_operator_build_operators`: (List) List of operators to build (it should not include meta-operator). Defaults to **[]**.
+* `cifmw_operator_build_meta_name`: (String) Meta operator's name. Defaults to **openstack-operator**.
+* `cifmw_operator_build_meta_src`: (String) Directory with src code for meta operator. Defaults to **"{{ ansible_user_dir }}/src/github.com/{{ cifmw_operator_build_org }}/{{ cifmw_operator_build_meta_name }}"**
+* `cifmw_operator_build_meta_build`: (Boolean) When set to **true** updates meta-operator's go.mod when build operators and builds meta-operator in the end. Default to **true**.
+
+## TODO
+* Include PR Owner and PR SHA for meta-operator
+* Include tasks to get PR Owner and PR SHA info from **zuul** dict.
+* Include tasks to get PR Owner and PR SHA info from **Prow** environment.
+* Add molecule tests.
+
+## Examples
+### 1 - Building mariadb-operator checked-out from a PR and meta-operator
+  ```yaml
+- hosts: all
+  tasks:
+    - name: Builds mariadb-operator and meta-operator
+      include_role:
+        name: operator_build
+      vars:
+        cifmw_operator_build_push_registry: "quay.io"
+        cifmw_operator_build_push_org: "myorg"
+        cifmw_operator_build_meta_build: true
+        cifmw_operator_build_meta_src: "/home/user/openstack-operator"
+        cifmw_operator_build_operators:
+          - name: "mariadb-operator"
+            src: "/home/user/mariadb-operator"
+            pr_owner: "ci-framework/openstack-operator"
+            pr_sha: "ea971d4a445e524b9fa55e3a0f99d11a2f118cb9"
+  ```
+
+### 2 - Building mariadb-operator and keystone-operator. Skip meta-operator build.
+  ```yaml
+- hosts: all
+  tasks:
+    - name: Building mariadb-operator and keystone-operator
+      include_role:
+        name: operator_build
+      vars:
+        cifmw_operator_build_push_registry: "quay.io"
+        cifmw_operator_build_push_org: "myorg"
+        cifmw_operator_build_meta_build: false
+        cifmw_operator_build_operators:
+          - name: "mariadb-operator"
+            src: "/home/user/mariadb-operator"
+            pr_owner:
+          - name: "mariadb-operator"
+            src: "/home/user/mariadb-operator"
+  ```

--- a/ci_framework/roles/operator_build/defaults/main.yml
+++ b/ci_framework/roles/operator_build/defaults/main.yml
@@ -1,0 +1,32 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+cifmw_operator_build_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}"
+cifmw_operator_build_dryrun: false
+# Operator's Organization
+cifmw_operator_build_org: "openstack-k8s-operators"
+# Push registry info
+cifmw_operator_build_push_registry: "quay.rdoproject.org"
+cifmw_operator_build_push_org: "openstack-k8s-operators"
+# List of operators to build (doesn't include meta-operator)
+cifmw_operator_build_operators: []
+
+# Updates meta-operator's go.mod when build operators and builds meta-operator in the end.
+cifmw_operator_build_meta_build: true
+# Meta operator's name
+cifmw_operator_build_meta_name: "openstack-operator"
+# Directory with src code for meta operator
+cifmw_operator_build_meta_src: "{{ ansible_user_dir }}/src/github.com/{{ cifmw_operator_build_org }}/{{ cifmw_operator_build_meta_name }}"

--- a/ci_framework/roles/operator_build/handlers/main.yml
+++ b/ci_framework/roles/operator_build/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.

--- a/ci_framework/roles/operator_build/meta/main.yml
+++ b/ci_framework/roles/operator_build/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- operator_build
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: edpm
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - edpm
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/ci_framework/roles/operator_build/molecule/default/converge.yml
+++ b/ci_framework/roles/operator_build/molecule/default/converge.yml
@@ -1,0 +1,35 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  vars:
+    cifmw_operator_build_dryrun: true
+  tasks:
+    - name: Clone an operator to be built
+      ansible.builtin.git:
+        repo: https://github.com/openstack-k8s-operators/mariadb-operator.git
+        dest: "{{ ansible_user_dir }}/mariadb-operator"
+
+    - name: Build mariadb-operator
+      include_role:
+        name: operator_build
+      vars:
+        cifmw_operator_build_meta_build: false
+        cifmw_operator_build_operators:
+          - name: "mariadb-operator"
+            src: "{{ ansible_user_dir }}/mariadb-operator"

--- a/ci_framework/roles/operator_build/molecule/default/molecule.yml
+++ b/ci_framework/roles/operator_build/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/operator_build/molecule/default/prepare.yml
+++ b/ci_framework/roles/operator_build/molecule/default/prepare.yml
@@ -1,0 +1,21 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps

--- a/ci_framework/roles/operator_build/tasks/build.yml
+++ b/ci_framework/roles/operator_build/tasks/build.yml
@@ -1,0 +1,140 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Set default api path for {{ operator.name }}
+  ansible.builtin.set_fact:
+    operator_api_path: "github.com/{{ cifmw_operator_build_org }}/{{ operator.name }}/api"
+
+- name: Update the go.mod file in meta operator for provided PR_SHA
+  ansible.builtin.shell: |
+    go mod edit -replace {{ operator_api_path }}=github.com/{{ operator.pr_owner }}/api@{{ operator.pr_sha }}
+    go mod tidy
+  args:
+    chdir: "{{ cifmw_operator_build_meta_src }}"
+  when:
+    - cifmw_operator_build_meta_build
+    - operator.name != cifmw_operator_build_meta_name
+    - operator.pr_owner is defined
+    - operator.pr_sha is defined
+
+- name: Get the {{ operator.name }} latest commit when no PR is provided
+  ansible.builtin.command:
+    cmd: git show-ref --head --hash head
+    chdir: "{{ operator.src }}"
+  register: git_head_out
+  when:
+    - operator.pr_sha is not defined
+
+- name: Set pr_sha to be used as image tag
+  ansible.builtin.set_fact:
+    pr_sha: "{{ operator.pr_sha | default(git_head_out.stdout | trim) }}"
+
+- name: Update the go.mod file using latest commit if no PR is provided
+  ansible.builtin.shell: |
+    go mod edit -replace {{ operator_api_path }}={{ operator_api_path }}@{{ pr_sha }}
+    go mod tidy
+  args:
+    chdir: "{{ cifmw_operator_build_meta_src }}"
+  when:
+    - cifmw_operator_build_meta_build
+    - operator.name != cifmw_operator_build_meta_name
+    - pr_sha is defined
+    - operator.pr_owner is not defined
+
+- name: Get golang container image
+  containers.podman.podman_image:
+    name: docker.io/library/golang:1.19
+
+- name: Set operator image names and tags
+  ansible.builtin.set_fact:
+    operator_img_tag: "{{ pr_sha }}"
+    operator_registry_prefix: "{{ cifmw_operator_build_push_registry }}/{{ cifmw_operator_build_push_org }}/{{ operator.name }}"
+    cacheable: true
+
+- name: Create artifact directory
+  ansible.builtin.file:
+    path: /tmp/artifacts
+    state: directory
+
+- name: Call manifests
+  ci_make:
+    dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
+    chdir: "{{ operator.src }}"
+    output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
+    target: manifests
+
+- name: Call docker-build
+  ci_make:
+    dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
+    chdir: "{{ operator.src }}"
+    output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
+    target: docker-build
+    params:
+      IMG: "{{ operator_registry_prefix }}:{{ operator_img_tag }}"
+
+- name: Call docker-push
+  ci_make:
+    dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
+    chdir: "{{ operator.src }}"
+    output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
+    target: docker-push
+    params:
+      IMG: "{{ operator_registry_prefix }}:{{ operator_img_tag }}"
+
+- name: Call bundle
+  ci_make:
+    dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
+    chdir: "{{ operator.src }}"
+    output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
+    target: bundle
+    params:
+      IMG: "{{ operator_registry_prefix }}:{{ operator_img_tag }}"
+
+- name: Call bundle-build
+  ci_make:
+    dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
+    chdir: "{{ operator.src }}"
+    output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
+    target: bundle-build
+    params:
+      BUNDLE_IMG: "{{ operator_registry_prefix }}-bundle:{{ operator_img_tag }}"
+
+- name: Push bundle image
+  containers.podman.podman_image:
+    name: "{{ operator_registry_prefix }}-bundle:{{ operator_img_tag }}"
+    pull: false
+    push: true
+  tags:
+    - push
+
+- name: Call catalog-build
+  ci_make:
+    dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
+    chdir: "{{ operator.src }}"
+    output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
+    target: catalog-build
+    params:
+      CATALOG_IMG: "{{ operator_registry_prefix }}-index:{{ operator_img_tag }}"
+      BUNDLE_IMGS: "{{ operator_registry_prefix }}-bundle:{{ operator_img_tag }}"
+
+- name: Call catalog-push
+  ci_make:
+    dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
+    chdir: "{{ operator.src }}"
+    output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
+    target: catalog-push
+    params:
+      CATALOG_IMG: "{{ operator_registry_prefix }}-index:{{ operator_img_tag }}"

--- a/ci_framework/roles/operator_build/tasks/main.yml
+++ b/ci_framework/roles/operator_build/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure output directory exists
+  ansible.builtin.file:
+    path: "{{ cifmw_operator_build_basedir }}/artifacts"
+    state: directory
+
+- name: Building operators list
+  vars:
+    operator: "{{ item }}"
+  ansible.builtin.include_tasks: build.yml
+  loop: "{{ cifmw_operator_build_operators }}"
+
+- name: Set meta-operator info
+  ansible.builtin.set_fact:
+    meta_operator:
+      - name: "{{ cifmw_operator_build_meta_name }}"
+        src: "{{ cifmw_operator_build_meta_src }}"
+
+- name: Building meta operator
+  when:
+    - cifmw_operator_build_meta_build is true
+  vars:
+    operator: "{{ item }}"
+  ansible.builtin.include_tasks: build.yml
+  loop: "{{ meta_operator }}"

--- a/ci_framework/roles/operator_build/vars/main.yml
+++ b/ci_framework/roles/operator_build/vars/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# While options found within the vars/ path can be overridden using extra
+# vars, items within this path are considered part of the role and not
+# intended to be modified.
+
+# All variables within this role should have a prefix of "cifmw_operator_build"


### PR DESCRIPTION
This patch adds initial implementation of a role to build OpenStack operators.
The role can build multiple operators, when provided their 'name' and 'src' code directory.
When testing from a pull request, in order to properly build the meta-operator, the user needs to provide the PR owner and SHA, to be used on meta-operator go.mod.

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
