### PR TITLE
Add support for passing -d in repo-setup role

### DIFF
--- a/ci_framework/roles/repo_setup/tasks/configure.yml
+++ b/ci_framework/roles/repo_setup/tasks/configure.yml
@@ -4,5 +4,6 @@
     cmd: >-
       {{ cifmw_repo_setup_basedir }}/venv/bin/repo-setup
       {{ cifmw_repo_setup_promotion }}
+      -d {{ cifmw_repo_setup_os_release }}{{ cifmw_repo_setup_dist_major_version }}
       -b {{ cifmw_repo_setup_branch }}
       -o {{ cifmw_repo_setup_basedir }}/artifacts/repositories


### PR DESCRIPTION
repo-setup cli provides -d option to pass distro name and version to generate repos for specific RPM based distros.

It adds the support for the same.

This PR has:
- [x] Appropriate testing (molecule, python unit tests)
- [x] Appropriate documentation (README in the role, main README is up-to-date)
