### PR TITLE
Consume new nodeset label

### DIFF
--- a/.zuul.d/prepare.yml
+++ b/.zuul.d/prepare.yml
@@ -17,6 +17,7 @@
       become: true
       ansible.builtin.package:
         name:
+          - bash
           - make
           - podman
           - python3

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -4,7 +4,7 @@
     nodeset:
       nodes:
         name: primary
-        label: cloud-centos-9-stream-vexxhost
+        label: cloud-centos-8-stream-xl
     parent: base-minimal
     vars:
       LC_ALL: en_US.utf8

--- a/ci_framework/roles/operator_build/README.md
+++ b/ci_framework/roles/operator_build/README.md
@@ -60,3 +60,4 @@ you want to build meta-operator too, so the role can properly replace api refere
           - name: "mariadb-operator"
             src: "/home/user/mariadb-operator"
   ```
+

--- a/molecule-requirements.txt
+++ b/molecule-requirements.txt
@@ -8,7 +8,6 @@ pytest-testinfra
 pytest-xdist
 mock
 molecule>=3.3.4
-molecule-plugins[podman]
 ruamel.yaml
 netaddr
 jinja2

--- a/scripts/bindep-install
+++ b/scripts/bindep-install
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # Copyright Red Hat, Inc.
 # All Rights Reserved.
 #

--- a/scripts/run_ansible_test
+++ b/scripts/run_ansible_test
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # Copyright Red Hat, Inc.
 # All Rights Reserved.
 #

--- a/scripts/run_molecule
+++ b/scripts/run_molecule
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # Copyright Red Hat, Inc.
 # All Rights Reserved.
 #

--- a/scripts/setup_env
+++ b/scripts/setup_env
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # Copyright Red Hat, Inc.
 # All Rights Reserved.
 #
@@ -36,10 +36,9 @@ PYTHON_EXEC=$(command -v python3 || command -v python)
 # Install the requirements we need to run local tests
 command -v gcc || sudo dnf -y install gcc
 
-PIP='pip'
+export PATH="${HOME}/test-python/bin/:${PATH}"
 case ${USE_VENV} in
     'y|yes|true')
-        PIP="${HOME}/test-python/bin/pip"
         USE_VENV='yes'
         ${PYTHON_EXEC} -m venv -h 2>&1>/dev/null || sudo "${RHT_PKG_MGR}" install -y python*-virtualenv
         echo
@@ -47,7 +46,7 @@ case ${USE_VENV} in
         echo
         ;;
     'n|no|false')
-        PIP="pip"
+        command -v pip || sudo dnf install -y python3-pip
         USE_VENV='no'
         echo
         echo ### NO VENV - may break your system!
@@ -59,7 +58,7 @@ esac
 sudo -k
 
 function run_pip {
-    "${PIP}" install \
+    pip install \
              -c "${PROJECT_DIR}ansible-requirements.txt" \
              -r "${PROJECT_DIR}requirements.txt" \
              -r "${PROJECT_DIR}test-requirements.txt" \
@@ -73,18 +72,18 @@ cp -r /opt/yum.repos.d/* ${HOME}/ci/yum.repos.d || cp -r /etc/yum.repos.d/* ${HO
 
 if [ ${USE_VENV} == 'yes' ]; then
     # Create a virtual env
-    "${PYTHON_EXEC}" -m venv --upgrade-deps "${HOME}/test-python"
+    "${PYTHON_EXEC}" -m venv "${HOME}/test-python"
     if [[ -d "${HOME}/.cache/pip/wheels" ]]; then
         rm -rf "${HOME}/.cache/pip/wheels"
     fi
 fi
 
 # Run bindep
-"${PIP}" install pip setuptools bindep --upgrade
+pip install pip setuptools bindep --upgrade
 "${PROJECT_DIR}/scripts/bindep-install"
 
 # Install local requirements
 run_pip
 
 # Display list of installed packages with versions (debugging failures)
-"${PIP}" freeze
+pip freeze

--- a/scripts/setup_molecule
+++ b/scripts/setup_molecule
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # Copyright Red Hat, Inc.
 # All Rights Reserved.
 #
@@ -24,17 +24,14 @@ export PROJECT_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))/../"
 # NOTE(cloudnull): Disable ansible compat check, caters to the case where
 #                  system ansible may be installed.
 export ANSIBLE_SKIP_CONFLICT_CHECK=1
-PIP='pip'
-GALAXY="ansible-galaxy"
 COLLECTION_PATH="/usr/share/ansible/collections"
 USE_VENV=${USE_VENV:-yes}
 PYTHON_EXEC=$(command -v python3 || command -v python)
 
+export PATH="${HOME}/test-python/bin/:${PATH}"
 case ${USE_VENV} in
     y|yes|true)
-        PIP="${HOME}/test-python/bin/pip"
         USE_VENV='yes'
-        GALAXY="${HOME}/test-python/bin/ansible-galaxy"
         COLLECTION_PATH="${HOME}/.ansible/collections/ansible_collections/"
         ${PYTHON_EXEC} -m venv -h 2>&1>/dev/null || sudo "${RHT_PKG_MGR}" install -y python*-virtualenv
         ;;
@@ -43,11 +40,11 @@ case ${USE_VENV} in
         ;;
 esac
 
-${PIP} install \
-        -c "${PROJECT_DIR}ansible-requirements.txt" \
-        -r "${PROJECT_DIR}molecule-requirements.txt" ${@:-}
-${GALAXY} collection install --timeout=120 \
-        -p "${COLLECTION_PATH}" \
-        -r "${PROJECT_DIR}requirements.yml"
+pip install \
+    -c "${PROJECT_DIR}ansible-requirements.txt" \
+    -r "${PROJECT_DIR}molecule-requirements.txt" ${@:-}
+ansible-galaxy collection install \
+    -p "${COLLECTION_PATH}" \
+    -r "${PROJECT_DIR}requirements.yml"
 mkdir -p ${HOME}/.ansible/plugins
 cp -a ${PROJECT_DIR}plugins/* ${HOME}/.ansible/plugins/


### PR DESCRIPTION
This should allow to make some better e2e testing, since those resources
should allow to deploy CRC.

Note:
we're still on cs8, apparently there's a nested virt issue on AMD CPU on
cs9, preventing CRC to properly start.
