### PR TITLE
Removing unnecessary conversion to list

### DIFF
--- a/ci_framework/plugins/action/ci_make.py
+++ b/ci_framework/plugins/action/ci_make.py
@@ -85,7 +85,7 @@ class ActionModule(ActionBase):
         # Generate file using the community.general.make "command" output value
         # First get directory content and count files matching the fixed
         # pattern
-        fnum = len(list(glob.glob('%s/ci_make_*' % output_dir)))
+        fnum = len(glob.glob('%s/ci_make_*' % output_dir))
 
         # Replace non-ASCII and spaces in ansible task name, and lower the
         # string


### PR DESCRIPTION
Glob already returns a list, either empty or with items. There is no need to cast the output to list again.

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
