### PR TITLE
Ensure correct path for action plugins in molecule

### DIFF
--- a/scripts/run_molecule
+++ b/scripts/run_molecule
@@ -38,7 +38,7 @@ if [ ${TEST_ALL_ROLES} == 'yes' ]; then
     ROLES_LIST=$(ls -1)
 fi
 
-export ANSIBLE_ACTION_PLUGINS=~/.ansible/plugins/action:/usr/share/ansible/plugins/actions
+export ANSIBLE_ACTION_PLUGINS="~/.ansible/plugins/action:/usr/share/ansible/plugins/actions:$(find /usr/local/ -type d -name action)"
 for rolepath in ${ROLES_LIST}; do
     role=$(echo $rolepath|sed "s|${local_roledir}||" | cut -f1 -d /)
     test -d ${role} || continue


### PR DESCRIPTION
Molecule was acting weirdly because it didn't find its action plugins. This seems to make it defaults to the `ci_make`, although it was NOT in any location molecule should have been able to know about...