### PR TITLE
Ensure we're using python3 venv module

### DIFF
--- a/ci_framework/roles/repo_setup/tasks/install.yml
+++ b/ci_framework/roles/repo_setup/tasks/install.yml
@@ -17,6 +17,7 @@
   ansible.builtin.pip:
     virtualenv: "{{ cifmw_repo_setup_basedir }}/venv"
     requirements: "{{ cifmw_repo_setup_basedir }}/tmp/repo-setup/requirements.txt"
+    virtualenv_command: "python3 -m venv"
 
 - name: Install repo-setup package
   ansible.builtin.command:


### PR DESCRIPTION
By default, ansible.builtin.pip will use the `virtualenv` command, which
isn't available on cs9 - or, at least, it's strongly advised to use
`python3 -m venv` instead.

This PR has:
- [x] Appropriate testing (molecule, python unit tests)
- [x] Appropriate documentation (README in the role, main README is up-to-date)
