### PR TITLE
Correct how EDPM environment is configured

### DIFF
--- a/ci_framework/roles/edpm_deploy/defaults/main.yml
+++ b/ci_framework/roles/edpm_deploy/defaults/main.yml
@@ -29,3 +29,5 @@ cifmw_edpm_deploy_inventory: "{{ cifmw_edpm_deploy_basedir }}/artifacts/libvirt-
 cifmw_edpm_deploy_oc: "{{ cifmw_oc | default(ansible_user_dir ~ '/.crc/bin/oc/') }}"
 # Allow to toggle ci_make dry_run parameter
 cifmw_edpm_deploy_make_dryrun: false
+# kubeconfig path
+cifmw_edpm_deploy_kubeconfig: "{{ cifmw_kubeconfig | default(ansible_user_dir ~ '/.crc/machines/crc/kubeconfig') }}"

--- a/ci_framework/roles/edpm_deploy/tasks/deploy.yml
+++ b/ci_framework/roles/edpm_deploy/tasks/deploy.yml
@@ -3,6 +3,7 @@
   environment:
     OUTPUT_DIR: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
     PATH: "{{ cifmw_edpm_deploy_oc }}:${PATH}:/usr/bin"
+    KUBECONFIG: "{{ cifmw_edpm_deploy_kubeconfig }}"
   ci_make:
     dry_run: "{{ cifmw_edpm_deploy_make_dryrun }}"
     chdir: "{{ cifmw_edpm_deploy_installyamls }}/devsetup"

--- a/ci_framework/roles/edpm_deploy/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy/tasks/main.yml
@@ -14,6 +14,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Prepare controlplane
+  ansible.builtin.include_tasks: prepare.yml
+
 - name: Configure EDPM
   ansible.builtin.include_tasks: configure.yml
 

--- a/ci_framework/roles/edpm_deploy/tasks/prepare.yml
+++ b/ci_framework/roles/edpm_deploy/tasks/prepare.yml
@@ -1,0 +1,102 @@
+---
+# Follow steps as described on:
+# https://github.com/openstack-k8s-operators/install_yamls/pull/127
+- name: Install nmstate operator
+  environment:
+    KUBECONFIG: "{{ cifmw_edpm_deploy_kubeconfig }}"
+  ci_make:
+    dry_run: "{{ cifmw_edpm_deploy_make_dryrun }}"
+    output_dir: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
+    chdir: "{{ cifmw_edpm_deploy_installyamls }}"
+    target: "nmstate"
+    params:
+      OUT: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
+
+- name: Configure CRC interface
+  environment:
+    KUBECONFIG: "{{ cifmw_edpm_deploy_kubeconfig }}"
+  ci_make:
+    dry_run: "{{ cifmw_edpm_deploy_make_dryrun }}"
+    output_dir: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
+    chdir: "{{ cifmw_edpm_deploy_installyamls }}"
+    target: "nncp"
+    params:
+      OUT: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
+
+- name: Create network-attachment-definitions for internalapi, storage and tenant
+  environment:
+    KUBECONFIG: "{{ cifmw_edpm_deploy_kubeconfig }}"
+  ci_make:
+    dry_run: "{{ cifmw_edpm_deploy_make_dryrun }}"
+    output_dir: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
+    chdir: "{{ cifmw_edpm_deploy_installyamls }}"
+    target: "netattach"
+    params:
+      OUT: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
+
+- name: Install metallb operator
+  environment:
+    KUBECONFIG: "{{ cifmw_edpm_deploy_kubeconfig }}"
+  ci_make:
+    dry_run: "{{ cifmw_edpm_deploy_make_dryrun }}"
+    output_dir: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
+    chdir: "{{ cifmw_edpm_deploy_installyamls }}"
+    target: "metallb"
+    params:
+      OUT: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
+
+- name: Create ipaddresspools and l2advertisement resources
+  environment:
+    KUBECONFIG: "{{ cifmw_edpm_deploy_kubeconfig }}"
+  ci_make:
+    dry_run: "{{ cifmw_edpm_deploy_make_dryrun }}"
+    output_dir: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
+    chdir: "{{ cifmw_edpm_deploy_installyamls }}"
+    target: "metallb_config"
+    params:
+      OUT: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
+
+- name: Create CRC storage
+  environment:
+    KUBECONFIG: "{{ cifmw_edpm_deploy_kubeconfig }}"
+  ci_make:
+    dry_run: "{{ cifmw_edpm_deploy_make_dryrun }}"
+    output_dir: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
+    chdir: "{{ cifmw_edpm_deploy_installyamls }}"
+    target: "crc_storage"
+    params:
+      OUT: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
+
+- name: Create input
+  environment:
+    KUBECONFIG: "{{ cifmw_edpm_deploy_kubeconfig }}"
+  ci_make:
+    dry_run: "{{ cifmw_edpm_deploy_make_dryrun }}"
+    output_dir: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
+    chdir: "{{ cifmw_edpm_deploy_installyamls }}"
+    target: "input"
+    params:
+      OUT: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
+
+- name: Install opentack-operator
+  environment:
+    KUBECONFIG: "{{ cifmw_edpm_deploy_kubeconfig }}"
+  ci_make:
+    dry_run: "{{ cifmw_edpm_deploy_make_dryrun }}"
+    output_dir: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
+    chdir: "{{ cifmw_edpm_deploy_installyamls }}"
+    target: "openstack"
+    params:
+      OUT: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
+
+- name: Deploy OpenStack
+  environment:
+    KUBECONFIG: "{{ cifmw_edpm_deploy_kubeconfig }}"
+    OPENSTACK_CTLPLANE: config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
+  ci_make:
+    dry_run: "{{ cifmw_edpm_deploy_make_dryrun }}"
+    output_dir: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
+    chdir: "{{ cifmw_edpm_deploy_installyamls }}"
+    target: "openstack_deploy"
+    params:
+      OUT: "{{ cifmw_edpm_deploy_basedir }}/artifacts"

--- a/ci_framework/roles/rhol_crc/defaults/main.yml
+++ b/ci_framework/roles/rhol_crc/defaults/main.yml
@@ -43,5 +43,5 @@ cifmw_rhol_crc_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
 cifmw_rhos_crc_config: {}
 
 # crc kubeconfig file
-cifmw_rhol_crc_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+cifmw_rhol_crc_kubeconfig: "{{ cifmw_kubeconfig | default(ansible_user_dir ~ '/.crc/machines/crc/kubeconfig') }}"
 cifmw_rhol_crc_creds: false

--- a/ci_framework/roles/rhol_crc/tasks/add_crc_creds.yml
+++ b/ci_framework/roles/rhol_crc/tasks/add_crc_creds.yml
@@ -13,7 +13,7 @@
         create: true
         block: |-
           eval $(crc oc-env)
-          export KUBECONFIG="{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+          export KUBECONFIG={{ cifmw_rhol_crc_kubeconfig }}
 
     - name: Source bashrc and confirm crc login
       ansible.builtin.shell: |


### PR DESCRIPTION
Based on the latest features, we now deploy EDPM with network isolation.

This patch also affects the rhol_crc role in order to get a more common
way to define the kubeconfig file.
