### PR TITLE
Allow to just reuse RHOL/CRC if detected

### DIFF
--- a/ci_framework/roles/rhol_crc/README.md
+++ b/ci_framework/roles/rhol_crc/README.md
@@ -20,6 +20,7 @@ Become - required for the tasks in `sudoers_grant.yml` and `sudoers_revoke.yml` 
 * `cifmw_rhol_crc_binary_folder`: Folder that will be used to store the RHOL/CRC binary. Default: `bin` folder under the `cifmw_rhol_crc_basedir`.
 * `cifmw_rhol_crc_binary`: Path of the RHOL/CRC downloaded binary for executing the commands. Default: `bin/crc` binary file under the `cifmw_rhol_crc_basedir`.
 * `cifmw_rhol_crc_force_cleanup`: In case this variable is `true` it will delete if exists the actual crc instance, domain and linked resources and recreate it with the new configuration. Default: `false`
+* `cifmw_rhol_crc_reuse`: In case RHOL/CRC is detected, just reuse it. Defaults: `true`
 * `cifmw_rhol_crc_kubeconfig`: Path to crc kubeconfig file. Default to `~/.crc/machines/crc/kubeconfig`
 * `cifmw_rhol_crc_creds`: Add crc creds to bashrc. Default to `False`
 

--- a/ci_framework/roles/rhol_crc/defaults/main.yml
+++ b/ci_framework/roles/rhol_crc/defaults/main.yml
@@ -37,6 +37,7 @@ cifmw_rhol_crc_basedir: "{{ cifmw_basedir | default( ansible_user_dir ~ '/ci-fra
 cifmw_rhol_crc_binary_folder: "{{ cifmw_rhol_crc_basedir }}/bin"
 cifmw_rhol_crc_binary: "{{ cifmw_rhol_crc_basedir }}/bin/crc"
 cifmw_rhol_crc_force_cleanup: false
+cifmw_rhol_crc_reuse: true
 cifmw_rhol_crc_user_home: "{{ ansible_user_dir | default(lookup('env', 'HOME')) }}"
 cifmw_rhol_crc_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
 # Check the default values in vars

--- a/ci_framework/roles/rhol_crc/tasks/main.yml
+++ b/ci_framework/roles/rhol_crc/tasks/main.yml
@@ -44,6 +44,7 @@
   when:
     - "'crc' in vm_domains.list_vms"
     - not cifmw_rhol_crc_force_cleanup|bool
+    - not cifmw_rhol_crc_reuse | bool
 
 - name: Setup sudoers file for sudo commands in RHOL/CRC setup
   ansible.builtin.include_tasks: sudoers_grant.yml
@@ -51,11 +52,15 @@
 - name: Configure RHOL/CRC using install_yamls
   when:
     - cifmw_rhol_crc_use_installyamls|bool
+    - not cifmw_rhol_crc_reuse |bool
+    - "'crc' not in vm_domains.list_vms"
   ansible.builtin.include_tasks: install_yamls.yml
 
 - name: Manually configure RHOL/CRC
   when:
     - not cifmw_rhol_crc_use_installyamls|bool
+    - not cifmw_rhol_crc_reuse |bool
+    - "'crc' not in vm_domains.list_vms"
   block:
     - name: Set RHOL/CRC configuration options
       ansible.builtin.include_tasks: configuration.yml


### PR DESCRIPTION
Since RHOL/CRC takes a long time to bootstrap, it may be good to just
reuse the existing instance.
