### PR TITLE
Correct condition

### DIFF
--- a/ci_framework/roles/rhol_crc/tasks/main.yml
+++ b/ci_framework/roles/rhol_crc/tasks/main.yml
@@ -52,14 +52,12 @@
 - name: Configure RHOL/CRC using install_yamls
   when:
     - cifmw_rhol_crc_use_installyamls|bool
-    - not cifmw_rhol_crc_reuse |bool
     - "'crc' not in vm_domains.list_vms"
   ansible.builtin.include_tasks: install_yamls.yml
 
 - name: Manually configure RHOL/CRC
   when:
     - not cifmw_rhol_crc_use_installyamls|bool
-    - not cifmw_rhol_crc_reuse |bool
     - "'crc' not in vm_domains.list_vms"
   block:
     - name: Set RHOL/CRC configuration options


### PR DESCRIPTION
Last patch[1] introduced an error where RHOL wasn't deployed if not present.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/77
