### PR TITLE
Keep RHOL/CRC

### DIFF
--- a/.zuul.d/prepare.yml
+++ b/.zuul.d/prepare.yml
@@ -17,9 +17,6 @@
           - make
           - podman
           - python3
-    - name: Cleanup CRC
-      ansible.builtin.command:
-        cmd: crc cleanup
     - name: Install venv
       community.general.make:
         chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"


### PR DESCRIPTION
Since we're consuming OpenShift with various roles in this project,
let's just keep it.
The only place needing to get a cleanup up OpenShift Local is in the
rhol_crc role - and there, the molecule tests are already cleaning it
up.
