### PR TITLE
Better splitting of the mighty edpm-deploy.yml playbook

### DIFF
--- a/.zuul.d/collect-logs.yml
+++ b/.zuul.d/collect-logs.yml
@@ -15,6 +15,21 @@
             chdir: "{{ ansible_user_dir }}/zuul-output/logs"
             cmd: cp /tmp/report.html .
 
+    - name: Check if we get ci-framework basedir
+      register: cifmw_state
+      ansible.builtin.stat:
+        path: "{{ ansible_user_dir }}/ci-framework"
+
+    - name: Copy ci-framework interesting files
+      when:
+        - cifmw_state.stat.exists | bool
+      ansible.builtin.shell:
+        chdir: "{{ ansible_user_dir }}/zuul-output/logs/"
+        cmd: |
+          mkdir ci-framework; pushd ci-framework
+          cp -ra {{ ansible_user_dir }}/ci-framework/logs . ;
+          cp -ra {{ ansible_user_dir }}/ci-framework/artifacts . ;
+
     - name: Get some env related data
       ansible.builtin.shell: |
         rpm -qa | sort > {{ ansible_user_dir }}/zuul-output/logs/installed-pkgs.log;
@@ -22,6 +37,7 @@
         pip3 --version >> {{ ansible_user_dir }}/zuul-output/logs/python.log;
         ansible --version >> {{ ansible_user_dir }}/zuul-output/logs/python.log;
         pip3 freeze >> {{ ansible_user_dir }}/zuul-output/logs/python.log;
+        cp {{ ansible_user_dir }}/*.log {{ ansible_user_dir }}/zuul-output/logs/;
 
     - name: Copy files from workspace on node
       vars:

--- a/USAGE.md
+++ b/USAGE.md
@@ -25,6 +25,8 @@ are shared among multiple roles:
 * `cifmw_basedir`: The base directory for all of the artifacts. Defaults to
 `~/ci-framework`
 * `cifmw_installyamls_repos`: install_yamls repository location. Defaults to `../..`
+* `cifmw_use_libvirt`: (Bool) toggle libvirt support
+* `cifmw_use_crc`: (Bool) toggle rhol/crc usage
 
 ### Role level parameters
 Please refer to the README located within the various roles.

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 action_plugins = ./plugins:~/plugins/modules:/usr/share/ansible/plugins/modules
+roles_path = ./ci_framework/roles:/usr/share/ansible/roles:/etc/ansible/roles:~/.ansible/roles
 #log_path = ansible.log
 # We may consider ansible.builtin.junit
 callbacks_enabled = ansible.posix.profile_tasks

--- a/ci_framework/playbooks/build-containers.yml
+++ b/ci_framework/playbooks/build-containers.yml
@@ -1,0 +1,6 @@
+- hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Nothing to do yet
+      ansible.builtin.debug:
+        msg: "No support for that step yet"

--- a/ci_framework/playbooks/build-packages.yml
+++ b/ci_framework/playbooks/build-packages.yml
@@ -1,0 +1,6 @@
+- hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Nothing to do yet
+      ansible.builtin.debug:
+        msg: "No support for that step yet"

--- a/ci_framework/playbooks/deploy-edpm.yml
+++ b/ci_framework/playbooks/deploy-edpm.yml
@@ -1,0 +1,6 @@
+- hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Nothing to do yet
+      ansible.builtin.debug:
+        msg: "No support for that step yet"

--- a/ci_framework/playbooks/hooks.yml
+++ b/ci_framework/playbooks/hooks.yml
@@ -1,0 +1,9 @@
+- hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Run hook
+      when:
+        - hooks is defined
+        - hooks | length > 0
+      ansible.builtin.include_role:
+        name: run_hook

--- a/ci_framework/playbooks/infra-entry.yml
+++ b/ci_framework/playbooks/infra-entry.yml
@@ -1,0 +1,16 @@
+- hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Ensure libvirt is present/configured
+      when:
+        - cifmw_use_libvirt is defined
+        - cifmw_use_libvirt | bool
+      ansible.builtin.include_role:
+        name: libvirt_manager
+    - name: Prepare CRC
+      when:
+        - cifmw_use_crc is defined
+        - cifmw_use_crc | bool
+      ansible.builtin.include_role:
+        name: rhol_crc
+# TODO: vms, build-pkg-container

--- a/ci_framework/playbooks/logs.yml
+++ b/ci_framework/playbooks/logs.yml
@@ -1,0 +1,28 @@
+- hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Ensure ansible.log is at the expected location
+      register: ansible_log_state
+      ansible.builtin.stat:
+        path: "{{ ansible_user_dir }}/ansible.log"
+
+    - name: Copy ansible log if exists
+      when:
+        - ansible_log_state.stat.exists is defined
+        - ansible_log_state.stat.exists | bool
+      block:
+        - name: Generate log file name date
+          register: filename_date
+          ansible.builtin.command:
+            cmd: date +%F-%R
+
+        - name: Copy ansible log to proper location
+          ansible.builtin.copy:
+            src: "{{ ansible_user_dir }}/ansible.log"
+            dest: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework') }}/logs/ansible.log-{{ filename_date.stdout|trim }}"
+            remote_src: true
+
+        - name: Remove original log from home directory
+          ansible.builtin.file:
+            path: "{{ ansible_user_dir }}/ansible.log"
+            state: absent

--- a/ci_framework/roles/rhol_crc/tasks/main.yml
+++ b/ci_framework/roles/rhol_crc/tasks/main.yml
@@ -23,22 +23,28 @@
     - bin
 
 - name: Get VM domains through Virt
-  environment:
-    VIRSH_DEFAULT_CONNECT_URI: "qemu:///system"
   community.libvirt.virt:
     command: list_vms
+    uri: "qemu:///system"
   register: vm_domains
+
+# The way ansible/jinja2 wants to match a string is horrible - so we must rely
+# on some terrible "if true then true else false" pattern...
+- name: Set VM status
+  ansible.builtin.set_fact:
+    crc_present: >-
+      {%- if 'crc' in vm_domains.list_vms -%}{{ true }}{%- else -%}{{ false }}{%- endif -%}
 
 - name: Fail if crc domain is already defined
   ansible.builtin.fail:
     msg: "The crc domain already exist. Set cifmw_rhol_crc_force_cleanup to true to force the cleanup. Interrupting tasks..."
   when:
-    - "'crc' in vm_domains.list_vms"
+    - crc_present|bool
     - not cifmw_rhol_crc_force_cleanup|bool
     - not cifmw_rhol_crc_reuse | bool
 
 - name: Manage RHOL/CRC if not existing
-  when: (cifmw_rhol_crc_force_cleanup|bool) or "'crc' not in vm_domains.list_vms"
+  when: (cifmw_rhol_crc_force_cleanup|bool) or not crc_present|bool
   block:
     - name: Check RHOL/CRC binary exists
       ansible.builtin.stat:
@@ -54,7 +60,7 @@
 
     - name: Clean RHOL/CRC if wanted
       when:
-        - "'crc' in vm_domains.list_vms"
+        - crc_present|bool
         - cifmw_rhol_crc_force_cleanup | bool
       ansible.builtin.include_tasks: cleanup.yml
 

--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -6,76 +6,76 @@
 # openstack-k8s-operators/install_yaml repository in order to leverage its
 # own methods.
 
-- hosts: localhost
+- hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: true
   roles:
     - name: ci_setup
-    - name: repo_setup
   tasks:
-    - name: Pre-infra hook
-      when:
-        - pre_infra is defined
-      vars:
-        hooks: "{{ pre_infra }}"
+    - name: get customized parameters
+      ansible.builtin.set_fact:
+        ci_framework_params: >-
+          {{ hostvars[inventory_hostname] | dict2items | selectattr("key", "match", "^cifmw_")|list|items2dict }}
+
+    - name: Create artifacts with custom params
+      ansible.builtin.copy:
+        dest: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework') }}/artifacts/custom-params.yml"
+        content: "{{ ci_framework_params | to_nice_yaml }}"
+
+    - name: Run repo_setup
       ansible.builtin.include_role:
-        name: run_hook
-    - name: Prepare CRC
-      when:
-        - cifmw_use_crc is defined
-        - cifmw_use_crc | bool
-      ansible.builtin.include_role:
-        name: rhol_crc
-    # TODO: libvirt
-    - name: Post-infra hook
-      when:
-        - post_infra is defined
-      vars:
-        hooks: "{{ post_infra }}"
-      ansible.builtin.include_role:
-        name: run_hook
-    - name: Pre-package build hook
-      when:
-        - pre_package_build is defined
-      vars:
-        hooks: "{{ pre_package_build }}"
-      ansible.builtin.include_role:
-        name: run_hook
-    # TODO: build packages
-    - name: Post-package build hook
-      when:
-        - post_package_build is defined
-      vars:
-        hooks: "{{ post_package_build }}"
-      ansible.builtin.include_role:
-        name: run_hook
-    - name: Pre-container build hook
-      when:
-        - pre_container_build is defined
-      vars:
-        hooks: "{{ pre_container_build }}"
-      ansible.builtin.include_role:
-        name: run_hook
-    # TODO: build containers
-    - name: Post-container build hook
-      when:
-        - post_container_build is defined
-      vars:
-        hooks: "{{ post_container_build }}"
-      ansible.builtin.include_role:
-        name: run_hook
-    - name: Pre-deploy hook
-      when:
-        - pre_deploy is defined
-      vars:
-        hooks: "{{ pre_deploy }}"
-      ansible.builtin.include_role:
-        name: run_hook
-    # TODO: deploy EDPM
-    - name: Post-deploy hook
-      when:
-        - post_deploy is defined
-      vars:
-        hooks: "{{ post_deploy }}"
-      ansible.builtin.include_role:
-        name: run_hook
-    # TODO: consider if we get a "formal" test step, or if hooks are sufficiant
+        name: repo_setup
+
+- name: Run pre_infra hooks
+  vars:
+    hooks: "{{ pre_infra | default([]) }}"
+  ansible.builtin.import_playbook: ci_framework/playbooks/hooks.yml
+
+- name: Import infra entrypoint playbook
+  ansible.builtin.import_playbook: ci_framework/playbooks/infra-entry.yml
+
+- name: Run post_infra hooks
+  vars:
+    hooks: "{{ post_infra | default([]) }}"
+  ansible.builtin.import_playbook: ci_framework/playbooks/hooks.yml
+
+- name: Run pre_package_build hooks
+  vars:
+    hooks: "{{ pre_package_build | default([]) }}"
+  ansible.builtin.import_playbook: ci_framework/playbooks/hooks.yml
+
+- name: Import package build playbook
+  ansible.builtin.import_playbook: ci_framework/playbooks/build-packages.yml
+
+- name: Run post_package_build hooks
+  vars:
+    hooks: "{{ post_package_build | default([]) }}"
+  ansible.builtin.import_playbook: ci_framework/playbooks/hooks.yml
+
+- name: Run pre_container_build hooks
+  vars:
+    hooks: "{{ pre_container_build | default([]) }}"
+  ansible.builtin.import_playbook: ci_framework/playbooks/hooks.yml
+
+- name: Import package build playbook
+  ansible.builtin.import_playbook: ci_framework/playbooks/build-containers.yml
+
+- name: Run post_container_build hooks
+  vars:
+    hooks: "{{ post_container_build | default([]) }}"
+  ansible.builtin.import_playbook: ci_framework/playbooks/hooks.yml
+
+- name: Run pre_deploy hooks
+  vars:
+    hooks: "{{ pre_deploy | default([]) }}"
+  ansible.builtin.import_playbook: ci_framework/playbooks/hooks.yml
+
+- name: Import package build playbook
+  ansible.builtin.import_playbook: ci_framework/playbooks/deploy-edpm.yml
+
+- name: Run post_deploy hooks
+  vars:
+    hooks: "{{ post_deploy | default([]) }}"
+  ansible.builtin.import_playbook: ci_framework/playbooks/hooks.yml
+
+- name: Run log related tasks
+  ansible.builtin.import_playbook: ci_framework/playbooks/logs.yml

--- a/scenarios/centos-9/ci.yml
+++ b/scenarios/centos-9/ci.yml
@@ -1,2 +1,5 @@
 ---
-cifmw_installyamls_repos: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/install_yamls'].src_dir }}"
+cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
+
+#cifmw_use_libvirt: true
+cifmw_use_crc: true


### PR DESCRIPTION
Splitting it like that would allow to get a cleaner overview of the file
content, allowing an easier maintenance later.

This patch also introduces some more top-level parameters, allowing to
activate or not RHOL/CRC and Libvirt supports.
