### PR TITLE
New role: operator_deploy

### DIFF
--- a/ci_framework/roles/operator_deploy/README.md
+++ b/ci_framework/roles/operator_deploy/README.md
@@ -1,0 +1,29 @@
+## Role: operator_deploy
+Deploy only selected operator(s) on OpenShift
+
+### Privilege escalation
+None
+
+### Parameters
+* `cifmw_operator_deploy_basedir`: Directory where we will have the RHOL/CRC binary and the configuration (e.g. artifacts/.rhol_crc_pull_secret.txt). Default to `cifmw_basedir` which defaults to ~/ci-framework.
+* `cifmw_operator_deploy_installyamls`: install_yamls root location. Defaults to `cifmw_installyamls_repos` which defaults to `../..`
+* `cifmw_operator_deploy_list`: List of the operators to deploy. It must match a proper target in install_yamls Makefile.
+
+### Example
+#### Deploy specific operator
+```YAML
+cifmw_operator_deploy_list:
+    - name: keystone_deploy
+      params:
+        KEYSTONE_REPO: https://github.com/me/my-keystone
+        KEYSTONE_BRANCH: feature/it-is-a-test
+    - name: rabbitmq
+      params:
+        RABBITMQ_IMG: local.registry:5000/features/rabbitmq:my-own-tag
+```
+#### Remove specific operator
+```YAML
+cifmw_operator_deploy_list:
+    - name: keystone_deploy_cleanup # remove only service instance without affecting operator
+    - name: rabbitmq_cleanup
+```

--- a/ci_framework/roles/operator_deploy/defaults/main.yml
+++ b/ci_framework/roles/operator_deploy/defaults/main.yml
@@ -1,0 +1,26 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_operator_deploy"
+
+# output base directory
+cifmw_operator_deploy_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}"
+# List of operators you want to deploy
+cifmw_operator_deploy_list: []
+# install_yamls repository location
+cifmw_operator_deploy_installyamls: "{{ cifmw_installyamls_repos | default('../..') }}"

--- a/ci_framework/roles/operator_deploy/meta/main.yml
+++ b/ci_framework/roles/operator_deploy/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- operator_deploy
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: edpm
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - edpm
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/ci_framework/roles/operator_deploy/molecule/default/converge.yml
+++ b/ci_framework/roles/operator_deploy/molecule/default/converge.yml
@@ -1,0 +1,30 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  environment:
+    KUBECONFIG: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+  vars:
+    cifmw_installyamls_repos: "/tmp/install_yamls"
+    cifmw_operator_deploy_list:
+      - name: keystone
+      - name: rabbitmq
+        params:
+          RABBITMQ_IMG: "quay.io/openstack-k8s-operators/rabbitmq-cluster-operator-index:latest"
+  roles:
+    - role: "operator_deploy"

--- a/ci_framework/roles/operator_deploy/molecule/default/molecule.yml
+++ b/ci_framework/roles/operator_deploy/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/operator_deploy/molecule/default/prepare.yml
+++ b/ci_framework/roles/operator_deploy/molecule/default/prepare.yml
@@ -1,0 +1,31 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps
+    - role: ci_setup
+  tasks:
+    - name: Ensure CRC is started
+      ansible.builtin.command:
+        cmd: crc start
+    - name: Fetch install_yamls repository
+      ansible.builtin.git:
+        accept_hostkey: true
+        dest: "/tmp/install_yamls"
+        repo: https://github.com/openstack-k8s-operators/install_yamls

--- a/ci_framework/roles/operator_deploy/tasks/main.yml
+++ b/ci_framework/roles/operator_deploy/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Deploy selected operators
+  ci_make:
+    output_dir: "{{ cifmw_operator_deploy_basedir }}/artifacts"
+    chdir: "{{ cifmw_operator_deploy_installyamls }}"
+    target: "{{ item.name }}"
+    params: "{{ item.params | default(omit) }}"
+  loop: "{{ cifmw_operator_deploy_list }}"


### PR DESCRIPTION
It will leverage the install_yamls Makefile targets to deploy the wanted
operators only.

It allows to pass down the needed parameters so that it will consume the
wanted image.

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
