### PR TITLE
Add option to pass a URL for repo-setup config

### DIFF
--- a/ci_framework/roles/repo_setup/README.md
+++ b/ci_framework/roles/repo_setup/README.md
@@ -10,5 +10,6 @@ which defaults to `~/ci-framework`
 * `cifmw_repo_setup_promotion`: Promotion line you want to deploy. Defaults to `current-podified`
 * `cifmw_repo_setup_branch`: Branch/release you want to deploy. Defaults to `zed`
 * `cifmw_repo_setup_dlrn_uri`: DLRN base URI. Defaults to https://trunk.rdoproject.org/
+* `cifmw_repo_setup_rdo_mirror`: Server from which to install RDO packages. Defaults to DLRN URI.
 * `cifmw_repo_setup_os_release`: Operating system release. Defaults to `ansible_distribution|lower`
 * `cifmw_repo_setup_src`: repo-setup repository location

--- a/ci_framework/roles/repo_setup/defaults/main.yml
+++ b/ci_framework/roles/repo_setup/defaults/main.yml
@@ -24,6 +24,7 @@ cifmw_repo_setup_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-fr
 cifmw_repo_setup_promotion: "podified-ci-testing"
 cifmw_repo_setup_branch: "zed"
 cifmw_repo_setup_dlrn_uri: "https://trunk.rdoproject.org/"
+cifmw_repo_setup_rdo_mirror: "{{ cifmw_repo_setup_dlrn_uri }}"
 cifmw_repo_setup_os_release: "{{ ansible_distribution|lower }}"
 cifmw_repo_setup_dist_major_version: "{{ ansible_distribution_major_version }}"
 cifmw_repo_setup_src: "https://github.com/openstack-k8s-operators/repo-setup"

--- a/ci_framework/roles/repo_setup/tasks/configure.yml
+++ b/ci_framework/roles/repo_setup/tasks/configure.yml
@@ -6,4 +6,5 @@
       {{ cifmw_repo_setup_promotion }}
       -d {{ cifmw_repo_setup_os_release }}{{ cifmw_repo_setup_dist_major_version }}
       -b {{ cifmw_repo_setup_branch }}
+      --rdo-mirror {{ cifmw_repo_setup_rdo_mirror }}
       -o {{ cifmw_repo_setup_basedir }}/artifacts/repositories


### PR DESCRIPTION
plugins/module_utils/repo_setup/main.py#L246
offers an option to define the URL for the
mirror from which to install the openstack
packages. This review add the option to the
config call.

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [X ] Appropriate documentation (README in the role, main README is up-to-date)
