### PR TITLE
Modify ci_make wrapper

### DIFF
--- a/ci_framework/plugins/action/ci_make.py
+++ b/ci_framework/plugins/action/ci_make.py
@@ -19,6 +19,7 @@ from ansible.utils.display import Display
 ERR_UPDATE_COLLECTION = '''"command" not found in community.general.make.
 Please update collection. The expected reproducer file will NOT be generated!
 '''
+TMPL_REPRODUCER = "#!/bin/bash\npushd %s\n%s\npopd\n"
 
 
 class OutputException(Exception):
@@ -57,6 +58,8 @@ class ActionModule(ActionBase):
         # module
         output_dir = module_args.pop('output_dir')
 
+        log_dir = os.path.join(output_dir, '../logs')
+
         # Ensure we're able to write in the output_dir. If this first check
         # fails, the actual OutputException will do some more tests to check
         # what is actually wrong with the output_dir (missing, not a directory,
@@ -64,23 +67,8 @@ class ActionModule(ActionBase):
         if not os.access(output_dir, os.W_OK):
             raise OutputException(output_dir)
 
-        # Run module only if all conditions are here for file creation
-        if not dry_run:
-            m_ret = self._execute_module(module_name='community.general.make',
-                                         module_args=module_args,
-                                         task_vars=task_vars, tmp=tmp)
-        else:
-            m_ret = {'command': json.dumps(module_args)}
-
-        # This isn't needed anymore, let's free some resources
-        del tmp
-
-        # We can only check the "command" availability now, once the module
-        # has been called, unfortunately.
-        # TODO: consider if we can remove this check later
-        if 'command' not in m_ret:
-            Display().warning(ERR_UPDATE_COLLECTION)
-            return m_ret
+        if not os.access(log_dir, os.W_OK):
+            raise OutputException(log_dir)
 
         # Generate file using the community.general.make "command" output value
         # First get directory content and count files matching the fixed
@@ -92,10 +80,43 @@ class ActionModule(ActionBase):
         t_name = re.sub(r'([^\x00-\x7F]|\s)+', '_', self._task._name).lower()
         fname = 'ci_make_%i_%s.sh' % (fnum, t_name)
 
+        # Run module only if all conditions are here for file creation
+        if not dry_run:
+            m_ret = self._execute_module(module_name='community.general.make',
+                                         module_args=module_args,
+                                         task_vars=task_vars, tmp=tmp)
+            # Log in plain file
+            log_name = 'ci_make_%i_%s.log' % (fnum, t_name)
+            f_log = os.path.join(log_dir, log_name)
+            with open(f_log, 'w') as fh:
+                fh.write('### STDOUT\n')
+                fh.write(m_ret['stdout'])
+                fh.write('\n### STDERR\n')
+                fh.write(m_ret['stderr'])
+        else:
+            m_ret = {'command': json.dumps(module_args)}
+
+        # This isn't needed anymore, let's free some resources
+        del tmp
+
+        # We can only check the "command" availability now, once the module
+        # has been called, unfortunately.
+        # TODO: consider if we can remove this check later
+        scriptable = True
+        if 'command' not in m_ret:
+            Display().warning(ERR_UPDATE_COLLECTION)
+            m_ret['command'] = json.dumps(module_args)
+            scriptable = False
+
         # Write the reproducer script
         with open(os.path.join(output_dir, fname), 'w') as fh:
-            fh.write('#!/bin/sh\n' + m_ret['command'] + '\n')
-        os.chmod(os.path.join(output_dir, fname), 0o755)
+            if scriptable:
+                fh.write(TMPL_REPRODUCER % (module_args['chdir'],
+                                            m_ret['command']))
+            else:
+                fh.write(m_ret['command'])
+        if scriptable:
+            os.chmod(os.path.join(output_dir, fname), 0o755)
 
         # Return original module state
         return m_ret

--- a/ci_framework/tests/integration/targets/make/tasks/main.yml
+++ b/ci_framework/tests/integration/targets/make/tasks/main.yml
@@ -5,6 +5,7 @@
     state: directory
   loop:
     - artifacts
+    - logs
     - project_makefile
 
 - name: Inject dummy Makefile
@@ -20,6 +21,7 @@
 - name: Run ci_make without any params
   register: no_params
   ci_make:
+    target: help
     chdir: /tmp/project_makefile
     output_dir: /tmp/artifacts
 
@@ -32,6 +34,7 @@
 - name: Run ci_make with a param
   register: with_params
   ci_make:
+    target: help
     chdir: /tmp/project_makefile
     output_dir: /tmp/artifacts
     params:
@@ -43,23 +46,6 @@
       - no_params.stdout == 'This is the help thing showing toto'
       - with_params.stdout == 'This is the help thing showing starwars'
 
-- name: Check generated files
-  block:
-    - name: Gather files
-      register: reproducer_scripts
-      ansible.builtin.stat:
-        path: "/tmp/artifacts/{{ item }}"
-      loop:
-        - 'ci_make_0_run_ci_make_without_any_params.sh'
-        - 'ci_make_1_run_ci_make_with_a_param.sh'
-
-    - name: Assert file status
-      ansible.builtin.assert:
-        that:
-          - item.stat.exists is defined
-          - item.stat.exists|bool
-      loop: "{{ reproducer_scripts.results }}"
-
 - name: Try dry_run parameter
   ci_make:
     chdir: /tmp/project_makefile
@@ -68,30 +54,31 @@
       FOO_BAR: startrek
     dry_run: true
 
-- name: Check dry_run generated file
+- name: Check generated files
   block:
-    - name: Get file state
-      register: dry_run_state
-      ansible.builtin.stat:
-        path: "/tmp/artifacts/ci_make_2_try_dry_run_parameter.sh"
-
-    - name: Ensure dry_run reproducer exists
-      ansible.builtin.assert:
-        that:
-          - dry_run_state.stat.exists is defined
-          - dry_run_state.stat.exists|bool
-
-    - name: Get file content
-      register: dry_run_content
-      ansible.builtin.slurp:
-        path: "/tmp/artifacts/ci_make_2_try_dry_run_parameter.sh"
-
-    - name: Decode content
+    - name: Set files attributes
       ansible.builtin.set_fact:
-        dry_run_decode: "{{ dry_run_content['content'] | b64decode }}"
+        files_to_check:
+          "/tmp/artifacts/ci_make_0_run_ci_make_without_any_params.sh":
+            851df380c076eed2e5f40842157b4c72d12638db
+          "/tmp/artifacts/ci_make_1_run_ci_make_with_a_param.sh":
+            59cc6818417dd1ff1f0cced3377eed416cf5f889
+          "/tmp/artifacts/ci_make_2_try_dry_run_parameter.sh":
+            f5d4eb7c8ddcae82b6ecaa6181224efe9399a783
+          "/tmp/logs/ci_make_0_run_ci_make_without_any_params.log":
+            8dcc15e2dd273dda4f7120efc059274bd8d50a89
+          "/tmp/logs/ci_make_1_run_ci_make_with_a_param.log":
+            fa1fd735445ca641270e630a00303b5816bafff3
+    - name: Gather files
+      register: reproducer_scripts
+      ansible.builtin.stat:
+        path: "{{ item.key }}"
+      loop: "{{ files_to_check|dict2items }}"
 
-    - name: Assert file content
+    - name: Assert file status
       ansible.builtin.assert:
         that:
-          - "dry_run_decode == '#!/bin/sh\n{\"chdir\": \"/tmp/project_makefile\", \"params\": {\"FOO_BAR\": \"startrek\"}}\n'"
-        msg: "File content: {{ dry_run_decode }}"
+          - item.stat.exists is defined
+          - item.stat.exists|bool
+          - item.stat.checksum == files_to_check[item.stat.path]
+      loop: "{{ reproducer_scripts.results }}"


### PR DESCRIPTION
1. Generate the reproducer under any conditions
Until now, the reproducer script was generated if and only if the
"command" entry was available in the community.general.make output.
This patch allows to generate the reproducer as a plain JSON file
listing the parameters that were passed to the community.general.make
module.
Note that this should be temporary, until the collection has a new
release embedding the needed change.

2. Generate logs
Until now, no log were available, unless there was a failure. In this
condition, the log was "lost" in ansible logging.
This patch corrects this issue, by ensuring a proper logging file is
created with the same name as the reproducer script, in the "logs"
directory we create from the ci_setup role.

This PR has:
- [x] Appropriate testing (molecule, python unit tests)
- [x] Appropriate documentation (README in the role, main README is up-to-date)
