### PR TITLE
Molecule fix avoiding 'failed to create tmp dir' error

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -30,6 +30,7 @@ provisioner:
     defaults:
       fact_caching: jsonfile
       fact_caching_connection: /tmp/molecule/facts
+      remote_tmp: /tmp
   log: true
   env:
     ANSIBLE_STDOUT_CALLBACK: yaml

--- a/.config/molecule/config_local.yml
+++ b/.config/molecule/config_local.yml
@@ -20,6 +20,7 @@ provisioner:
     defaults:
       fact_caching: jsonfile
       fact_caching_connection: /tmp/molecule/facts
+      remote_tmp: /tmp
   log: true
   env:
     ANSIBLE_STDOUT_CALLBACK: yaml

--- a/.config/molecule/config_podman.yml
+++ b/.config/molecule/config_podman.yml
@@ -35,6 +35,9 @@ provisioner:
     ANSIBLE_ROLES_PATH: "${ANSIBLE_ROLES_PATH}:${HOME}/zuul-jobs/roles"
     ANSIBLE_LIBRARY: "${ANSIBLE_LIBRARY:-/usr/share/ansible/plugins/modules}"
     ANSIBLE_FILTER_PLUGINS: "${ANSIBLE_FILTER_PLUGINS:-/usr/share/ansible/plugins/filter}"
+  config_options:
+    defaults:
+      remote_tmp: /tmp
 
 scenario:
   test_sequence:


### PR DESCRIPTION
Molecule produces it's own ansible configuration file under:

/home/<user>/.cache/molecule/<role>/<scenario>/ansible.cfg

This fix is modifying the provisionner environment in molecule.yml
files in order to instruct molecule to generate correct per role/secnario
ansible.cfg.

See: https://stackoverflow.com/questions/74393035/molecule-test-seems-to-ignore-ansible-cfgs-remote-tmp-setting

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
