### PR TITLE
Ensure we can re-run the script multiple times

### DIFF
--- a/scripts/run_ansible_test
+++ b/scripts/run_ansible_test
@@ -40,7 +40,7 @@ esac
 
 mkdir -p ${HOME}/code/ansible_collections/cifmw/general
 cp -ra ${PROJECT_DIR}ci_framework/* ${HOME}/code/ansible_collections/cifmw/general/
-ln -s ${collection_path}/* ${HOME}/code/ansible_collections/
+ln -fs ${collection_path}/* ${HOME}/code/ansible_collections/
 
 pushd ${HOME}/code/ansible_collections/cifmw/general
 ${ansible_test} sanity --skip-test action-plugin-docs --color=yes -vv


### PR DESCRIPTION
Until now, we had to trash and recreate the container if we wanted to
iterate on ansible-test runs.

This patch corrects this issue, and we can now run the following without
any issue:
```
podman run --rm -ti \
        --security-opt label=disable \
        -v .:/opt/sources --user root cifmw:latest bash
./scripts/run_ansible_test
./scripts/run_ansible_test
```
It makes the whole process faster and easier for developers.

This PR has:
- [x] Appropriate testing (molecule, python unit tests)
- [x] Appropriate documentation (README in the role, main README is up-to-date)
