### PR TITLE
Revert patches related to molecule output

### DIFF
--- a/scripts/run_molecule
+++ b/scripts/run_molecule
@@ -27,7 +27,6 @@ USE_VENV=${USE_VENV:-yes}
 MOLECULE_CONFIG=${MOLECULE_CONFIG:-.config/molecule/config_podman.yml}
 TEST_ALL_ROLES=${TEST_ALL_ROLES:-no}
 TEST_VERBOSITY=${TEST_VERBOSITY:-'--debug'}
-MOLECULE_FAILURES=""
 # Run local test
 (test -d ${ROLE_DIR} || (echo 'No such directory: ${ROLE_DIR}' && exit 1) ) || exit 1
 
@@ -46,26 +45,14 @@ for rolepath in ${ROLES_LIST}; do
     test -d ${role} || continue
     echo "Running molecule against: ${role}"
     pushd $role
-    MOLECULE_RESULTS=$(\
-        case ${USE_VENV} in
-                y|yes|true)
-                    ${HOME}/test-python/bin/molecule -c "${PROJECT_DIR}${MOLECULE_CONFIG}" ${TEST_VERBOSITY} test --all
-                    ;;
-                *)
-                    molecule -c "${PROJECT_DIR}${MOLECULE_CONFIG}" ${TEST_VERBOSITY} test --all
-                    ;;
-        esac ) || true
-        if [[ $MOLECULE_RESULTS =~ failed=[1-9] ]]; then
-            MOLECULE_FAILURES="${MOLECULE_FAILURES}${role}\n"
-        fi
+    case ${USE_VENV} in
+        y|yes|true)
+            ${HOME}/test-python/bin/molecule -c "${PROJECT_DIR}${MOLECULE_CONFIG}" ${TEST_VERBOSITY} test --all
+            ;;
+        *)
+            molecule -c "${PROJECT_DIR}${MOLECULE_CONFIG}" ${TEST_VERBOSITY} test --all
+            ;;
+    esac
     popd
 done
 popd
-
-if [ ${#MOLECULE_FAILURES} -gt 0 ]; then
-    echo "Molecule tests of following roles have failed"
-    echo "==============================="
-    echo -e $MOLECULE_FAILURES
-    echo "==============================="
-    exit 1
-fi


### PR DESCRIPTION
This reverts both patches:
9b113e17c8e9360871227c7f8124aa9d64c115b8
90c4fd19570eb4e2d0ddd6a0e1c5a1a4344fef1d

They introduced issues in how molecule was reporting and need some more
work.
