### PR TITLE
Workaround gnupg2 issue

### DIFF
--- a/containerfiles/Containerfile.ci
+++ b/containerfiles/Containerfile.ci
@@ -2,4 +2,6 @@ FROM quay.io/centos/centos:stream9
 LABEL summary="Provides root image for openstack-k8s-operators projects in Prow" maintainer="CI Framework"
 
 USER root
+# workaround for RHBZ#2184640
+RUN sed -i 's/gpgcheck=1/gpgcheck=0/' /etc/yum.repos.d/*.repo
 RUN dnf update -y && dnf install -y git python3-pip make gcc sudo && yum clean all


### PR DESCRIPTION
Latest gnupg2 (gnupg2-2.3.3-3) markes SHA-1 as weak, breaking
effectively the whole signature system on CentOS.

This patch ensures we'll be at least able to build the container in CI,
and should be reverted as soon as the issue is corrected on CentOS.

More information:
https://bugzilla.redhat.com/show_bug.cgi?id=2184640
