### PR TITLE
Add environment exports to ci_make reproducer

### DIFF
--- a/ci_framework/tests/integration/targets/make/tasks/main.yml
+++ b/ci_framework/tests/integration/targets/make/tasks/main.yml
@@ -54,21 +54,36 @@
       FOO_BAR: startrek
     dry_run: true
 
+- name: Test with environment parameters
+  environment:
+    MY_ENV_VAR: startrek
+    SOME_OTHER: jar-jar-binks
+  ci_make:
+    chdir: /tmp/project_makefile
+    output_dir: /tmp/artifacts
+    target: help
+    params:
+      FOO_BAR: "${MY_ENV_VAR}"
+
 - name: Check generated files
   block:
     - name: Set files attributes
       ansible.builtin.set_fact:
         files_to_check:
           "/tmp/artifacts/ci_make_0_run_ci_make_without_any_params.sh":
-            851df380c076eed2e5f40842157b4c72d12638db
+            e6ec8bc41f8aa58ef72fb1d8e336dc9c8115d0e4
           "/tmp/artifacts/ci_make_1_run_ci_make_with_a_param.sh":
-            59cc6818417dd1ff1f0cced3377eed416cf5f889
+            79fe696cf7e0f3001e99fed22f5a2674f1f8c493
           "/tmp/artifacts/ci_make_2_try_dry_run_parameter.sh":
-            f5d4eb7c8ddcae82b6ecaa6181224efe9399a783
+            4909f854ee1fc8e17c608ea0a7a2adb40101c825
+          "/tmp/artifacts/ci_make_3_test_with_environment_parameters.sh":
+            4ca6f838a71ab336f91f8775d684c3d8ccc0a89a
           "/tmp/logs/ci_make_0_run_ci_make_without_any_params.log":
             8dcc15e2dd273dda4f7120efc059274bd8d50a89
           "/tmp/logs/ci_make_1_run_ci_make_with_a_param.log":
             fa1fd735445ca641270e630a00303b5816bafff3
+          "/tmp/logs/ci_make_3_test_with_environment_parameters.log":
+            3384b44a202d4f841781dff704276e0ae44484e7
     - name: Gather files
       register: reproducer_scripts
       ansible.builtin.stat:


### PR DESCRIPTION
Until now, all of the environment was discarded from the reproducer
scripts. This would lead to errors when people want to re-run the make
command using the script, since they'd miss most of the important
content.

This patch ensures we properly export the environment passed to the
ci_make task.

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
