### PR TITLE
Inject new role path in ansible

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -28,6 +28,14 @@ are shared among multiple roles:
 * `cifmw_use_libvirt`: (Bool) toggle libvirt support
 * `cifmw_use_crc`: (Bool) toggle rhol/crc usage
 
+#### Words of caution
+If you want to output the content in another location than `~/ci-framework`
+(namely set the `cifmw_basedir` to some other location), you will have to update
+the `ansible.cfg`, updating the value of `roles_path` so that it includes
+this new location.
+
+We cannot do this change runtime unfortunately.
+
 ### Role level parameters
 Please refer to the README located within the various roles.
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,7 @@
 [defaults]
 action_plugins = ./plugins/action:~/plugins/action:/usr/share/ansible/plugins/action
 library = ./plugins/modules:~/plugins/modules:/usr/share/ansible/plugins/modules
-roles_path = ./ci_framework/roles:/usr/share/ansible/roles:/etc/ansible/roles:~/.ansible/roles
+roles_path = ~/ci-framwork/artifacts/roles:./ci_framework/roles:/usr/share/ansible/roles:/etc/ansible/roles:~/.ansible/roles
 #log_path = ansible.log
 # We may consider ansible.builtin.junit
 callbacks_enabled = ansible.posix.profile_tasks

--- a/ci_framework/roles/use_install_yamls/defaults/main.yml
+++ b/ci_framework/roles/use_install_yamls/defaults/main.yml
@@ -17,7 +17,7 @@
 
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_use_install_yamls"
-cifmw_use_install_yamls_envfile: "install_yamls"
+cifmw_use_install_yamls_envfile: "install_yamls.sh"
 cifmw_use_install_yamls_out_dir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}/artifacts"
 # A list of Install_yamls makefile vars that needs to be exported
 # cifmw_use_install_yamls_vars:
@@ -25,4 +25,4 @@ cifmw_use_install_yamls_out_dir: "{{ cifmw_basedir | default(ansible_user_dir ~ 
 #   NAMESPACE: openstack
 cifmw_use_install_yamls_repo: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
 cifmw_use_install_yamls_dryrun: true
-cifmw_use_install_yamls_tasks_out: "{{ cifmw_use_install_yamls_out_dir }}/installyamls_makes/tasks"
+cifmw_use_install_yamls_tasks_out: "{{ cifmw_use_install_yamls_out_dir }}/roles/install_yamls_makes/tasks"


### PR DESCRIPTION
The use_install_yamls role and related modules primary task is to
generate task files embedding the `ci_make` calls matching install_yamls
Makefiles targets.

In order to be able to consume those tasks, we have to ensure Ansible
knows about them. We generate the whole content in a dedicated location
nested in the `cifmw_basedir/artifacts/roles` in order to keep it clean
while allowing to get this generated content in the logs.

We also add some new documentation about the implication of this current
change, especially if the operator wants to output the content somewhere
else in the tree.
