### PR TITLE
Add git pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,6 @@
+#!/usr/bin/sh
+
+set -e
+
+make run_ctx_pre_commit
+make run_ctx_ansible_test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,12 +19,21 @@ new scenarios if needed.
 Then, you can run the following command in order to run tests locally:
 ```Bash
 $ make run_ctx_pre_commit
+$ make run_ctx_ansible_test
 $ make run_ctx_molecule MOLECULE_CONFIG=.config/molecule/config_local.yml
 ```
 
 This will create a container, and run tests in it (pre-commit, and molecule).
 
 Note that `podman` as well as `buildah` are needed for this step.
+
+One can also run:
+```Bash
+$ make enable-git-hooks
+```
+
+in order to configure automatic run of pre-commit tests in a local repository before
+pushing changing to any branch (see .githooks/pre-push)
 
 ### Adding new script
 If you want/need to add a new script (python, bash, perl, ...), please provide

--- a/Makefile
+++ b/Makefile
@@ -126,3 +126,8 @@ run_ctx_ansible_test: ci_ctx ## Run molecule check in a container
 		-e ANSIBLE_LOCAL_TMP=/tmp \
 		-e ANSIBLE_REMOTE_TMP=/tmp \
 		${CI_CTX_NAME} bash -c "make ansible_test_nodeps" ;
+
+.PHONY: enable-git-hooks
+enable-git-hooks:
+	git config core.hooksPath "./.githooks"
+	$(warning REMEMBER, YOU MUST HAVE REVIEWED THE CUSTOM HOOKS in .githooks!)


### PR DESCRIPTION
Adding hooks into .git/hooks is not reflected
in a commit history. Creating git_hooks folder
and configuring git to use hooks from there using:
  git config core.hooksPath path_to_git_hooks

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
