### PR TITLE
Correct some wrong/bad behavior

### DIFF
--- a/ci_framework/plugins/modules/generate_make_tasks.py
+++ b/ci_framework/plugins/modules/generate_make_tasks.py
@@ -59,12 +59,24 @@ import os
 
 
 MAKE_TMPL = '''---
+- name: Set environment fact
+  ansible.builtin.set_fact:
+    make_%(target)s_environment: "{{ edpm_env | combine(make_%(target)s_env|default({})) }}"
+    cacheable: true
+- name: Debug make_%(target)s_environment
+  ansible.builtin.debug:
+    var: make_%(target)s_environment
+- name: Debug make_%(target)s_params
+  when: make_%(target)s_params is defined
+  ansible.builtin.debug:
+    var: make_%(target)s_params
 - name: Run `make %(target)s`
   ci_make:
-    output_directory: "{{ cifmw_install_yamls_basedir }}/artifacts"
+    output_dir: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework') }}/artifacts"
     chdir: "%(chdir)s"
     target: %(target)s
-    dry_run: "{{ cifmw_install_yamls_dryrun|bool }}"
+    dry_run: "{{ make_%(target)s_dryrun|default(false)|bool }}"
+    params: "{{ make_%(target)s_params|default(omit) }}"
   environment: "{{ edpm_env }}"
 '''
 

--- a/ci_framework/roles/install_yamls/README.md
+++ b/ci_framework/roles/install_yamls/README.md
@@ -17,4 +17,3 @@ It generate the task files under install_yamls role directory.
 * cifmw_install_yamls_out_dir: Install_yamls output directory to store generated output. Defaults to "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}/artifacts"
 * cifmw_install_yamls_vars: A dict containing Makefile overrides.
 * cifmw_install_yamls_repo: Install_yamls repo path. Defaults to  "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
-* cifmw_install_yamls_dryrun: Dry run of install_yaml role. Defaults "True"

--- a/ci_framework/roles/install_yamls/defaults/main.yml
+++ b/ci_framework/roles/install_yamls/defaults/main.yml
@@ -23,6 +23,5 @@ cifmw_install_yamls_out_dir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci
 # cifmw_install_yamls_vars:
 #   MICROSHIFT: 1
 #   NAMESPACE: openstack
-cifmw_install_yamls_repo: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
-cifmw_install_yamls_dryrun: true
+cifmw_install_yamls_repo: "{{ cifmw_installyamls_repos | default(ansible_user_dir ~ '/src/github.com/openstack-k8s-operators/install_yamls') }}"
 cifmw_install_yamls_tasks_out: "{{ cifmw_install_yamls_out_dir }}/roles/install_yamls_makes/tasks"

--- a/ci_framework/tests/integration/targets/make/tasks/main.yml
+++ b/ci_framework/tests/integration/targets/make/tasks/main.yml
@@ -65,6 +65,20 @@
     params:
       FOO_BAR: "${MY_ENV_VAR}"
 
+- name: Test with environment parameters passed as ansible variables
+  block:
+    - name: Set env var
+      ansible.builtin.set_fact:
+        my_env_vars:
+          FOO_BAR: Muad-Dib
+          SOME_OTHER: Dune
+    - name: Run ci_make with custom env variable
+      environment: "{{ my_env_vars }}"
+      ci_make:
+        chdir: /tmp/project_makefile
+        output_dir: /tmp/artifacts
+        target: help
+
 - name: Check generated files
   block:
     - name: Set files attributes
@@ -78,12 +92,16 @@
             4909f854ee1fc8e17c608ea0a7a2adb40101c825
           "/tmp/artifacts/ci_make_3_test_with_environment_parameters.sh":
             4ca6f838a71ab336f91f8775d684c3d8ccc0a89a
+          "/tmp/artifacts/ci_make_4_run_ci_make_with_custom_env_variable.sh":
+            2447a25f97c34a25c0ab3a6e67baf1d2c8817c78
           "/tmp/logs/ci_make_0_run_ci_make_without_any_params.log":
             8dcc15e2dd273dda4f7120efc059274bd8d50a89
           "/tmp/logs/ci_make_1_run_ci_make_with_a_param.log":
             fa1fd735445ca641270e630a00303b5816bafff3
           "/tmp/logs/ci_make_3_test_with_environment_parameters.log":
             3384b44a202d4f841781dff704276e0ae44484e7
+          "/tmp/logs/ci_make_4_run_ci_make_with_custom_env_variable.log":
+            f17389a98ce38f871c3b69f1ad8b9956b7f95958
     - name: Gather files
       register: reproducer_scripts
       ansible.builtin.stat:


### PR DESCRIPTION
- ci_make had an issue preventing it to properly generat the reproducer
  script when we pass environments as an ansible parameter. At this
  stage, it seems the parameter isn't translated to proper value,
  leading to python issue.
  This patch allows now the action plugin to properly understand the
  environment and interpret it in order to get a correct output in the
  reproducer script.
  We also add a test to ensure we're catching any related regression.

- generate_make_tasks needs some changes in order to expose a better
  environment to ci_make.
  We also take the opportunity to add some more debugging, as well as
  adding a parameter:
  - params, allowing to pass per-task parameters down to ci_make (and,
    therefore, community.general.make)
  We also correct some of the already existing parameters to match the
  overall syntax with top-level parameters in the framework.

- install_yamls had some issues related to the top level parameters,
  since it didn't know about them.
  This patch ensures we're following the rest of the framework content,
  while removing a now useless parameter (_dryrun).

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
