### PR TITLE
Ensure we create the compute once we get RHOL/CRC

### DIFF
--- a/ci_framework/playbooks/deploy-edpm.yml
+++ b/ci_framework/playbooks/deploy-edpm.yml
@@ -1,6 +1,7 @@
 - hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
-    - name: Nothing to do yet
-      ansible.builtin.debug:
-        msg: "No support for that step yet"
+    - name: Create and provision external computes
+      ansible.builtin.include_role:
+        name: libvirt_manager
+        tasks_from: deploy_edpm_compute.yml

--- a/ci_framework/roles/libvirt_manager/tasks/main.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/main.yml
@@ -30,6 +30,3 @@
 
 - name: Check Virsh usage
   ansible.builtin.include_tasks: virsh_checks.yml
-
-- name: Deploy EDPM Computes
-  ansible.builtin.include_tasks: deploy_edpm_compute.yml


### PR DESCRIPTION
Until now, the external nodes were created during the libvirt bootstrap,
before we ensure RHOL is up'n'running.

This patch corrects this issue, ensuring the nodes are created only once
the whole infra underneath is OK.

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
