### PR TITLE
Set minimal required version for ansible

### DIFF
--- a/ansible-requirements.txt
+++ b/ansible-requirements.txt
@@ -1,3 +1,3 @@
-ansible
+ansible>=7.0.0
 importlib-metadata
 jsonschema  # MIT


### PR DESCRIPTION
Some plugins need ansible-core>=2.14, so we need to set ansible to >=7.0.0

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
