### PR TITLE
Add discover_latest_image role

### DIFF
--- a/ci_framework/roles/discover_latest_image/README.md
+++ b/ci_framework/roles/discover_latest_image/README.md
@@ -1,0 +1,21 @@
+## Role: discover_latest_image
+
+An Ansible role to discover latest Centos image.
+
+### Requirements
+
+This role is currently written for Centos-9.
+
+### Role Variables
+
+* cifmw_discover_latest_image_base_url: <https://cloud.centos.org/centos/{{ ansible_distribution_major_version }}-stream/x86_64/images/> Base Url from where we can pull the Centos Image.
+* cifmw_discover_latest_image_qcow_prefix: <CentOS-Stream-GenericCloud-> Qcow2 image prefix on base_url which will be used as a filter to find latest Centos Image.
+
+
+### Example Playbook
+
+  1. Sample playbook to call the role
+
+    - name: Discover latest CentOS qcow2 image
+      include_role:
+        name: discover-latest-image

--- a/ci_framework/roles/discover_latest_image/defaults/main.yml
+++ b/ci_framework/roles/discover_latest_image/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_discover_latest_image"
+cifmw_discover_latest_image_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
+cifmw_discover_latest_image_base_url: https://cloud.centos.org/centos/{{ ansible_distribution_major_version }}-stream/x86_64/images/
+cifmw_discover_latest_image_qcow_prefix: CentOS-Stream-GenericCloud-

--- a/ci_framework/roles/discover_latest_image/molecule/default/converge.yml
+++ b/ci_framework/roles/discover_latest_image/molecule/default/converge.yml
@@ -1,0 +1,27 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  vars:
+    cifmw_repo_setup_os_release: centos
+  roles:
+    - role: "discover_latest_image"
+  tasks:
+    - name: Print discover_latest_image variables
+      ansible.builtin.debug:
+        msg: "{{ cifmw_discovered_image_name, cifmw_discovered_image_url, cifmw_discovered_sha256 }}"

--- a/ci_framework/roles/discover_latest_image/molecule/default/molecule.yml
+++ b/ci_framework/roles/discover_latest_image/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/discover_latest_image/molecule/default/prepare.yml
+++ b/ci_framework/roles/discover_latest_image/molecule/default/prepare.yml
@@ -1,0 +1,21 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps

--- a/ci_framework/roles/discover_latest_image/tasks/main.yml
+++ b/ci_framework/roles/discover_latest_image/tasks/main.yml
@@ -1,0 +1,61 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Create a temporary file
+  tempfile:
+    state: file
+  register: tempfile
+
+- name: Remove the file at temporary file path.
+  file:
+    path: "{{ tempfile.path }}"
+    state: absent
+
+- name: Fetch publication page
+  get_url:
+    url: "{{ cifmw_discover_latest_image_base_url }}?C=M;O=A"
+    dest: "{{ tempfile.path }}"
+
+- name: Find qcow2 url
+  shell: |
+    sed -n "/qcow2/ s/.*href=\"\({{ cifmw_discover_latest_image_qcow_prefix }}.*.qcow2\)\">.*/\1/p" {{ tempfile.path }} | tail -1
+  register: get_qcow_image_name
+
+- name: Remove the file at temporary file path.
+  file:
+    path: "{{ tempfile.path }}"
+    state: absent
+
+- name: Fetch SHA256SUM file
+  get_url:
+    url: "{{ cifmw_discover_latest_image_base_url }}/{{ get_qcow_image_name.stdout }}.SHA256SUM"
+    dest: "{{ tempfile.path }}"
+
+- name: Find SHA256SUM value
+  command: "awk -F ' = ' '/SHA256/ {print $2}' {{ tempfile.path }}"
+  register: get_sha256_value
+
+- name: Remove the file at temporary file path.
+  file:
+    path: "{{ tempfile.path }}"
+    state: absent
+
+- name: "Set expected facts Image: {{ cifmw_discover_latest_image_base_url }}{{ get_qcow_image_name.stdout }} sha256sum: {{ get_sha256_value.stdout }} "
+  set_fact:
+    cifmw_discovered_image_name: "{{ get_qcow_image_name.stdout }}"
+    cifmw_discovered_image_url: "{{ cifmw_discover_latest_image_base_url }}{{ get_qcow_image_name.stdout }}"
+    cifmw_discovered_sha256: "{{ get_sha256_value.stdout }}"
+    cacheable: true

--- a/ci_framework/roles/libvirt_manager/defaults/main.yml
+++ b/ci_framework/roles/libvirt_manager/defaults/main.yml
@@ -29,8 +29,8 @@ cifmw_libvirt_manager_configuration:
   vms:
     compute:
       amount: 1
-      image_url: "{{ cifmw_libvirt_manager_images_url }}/CentOS-Stream-GenericCloud-9-20230410.0.x86_64.qcow2"
-      sha256_image_name: 8a5abbf8b0dda3e4e49b5112ffae3fff022bf97a5f53b868adbfb80c75c313fe
+      image_url: "{{ cifmw_discovered_image_url | default('{{ cifmw_libvirt_manager_images_url }}/CentOS-Stream-GenericCloud-9-20230410.0.x86_64.qcow2') }}"
+      sha256_image_name: "{{ cifmw_discovered_sha256 | default('8a5abbf8b0dda3e4e49b5112ffae3fff022bf97a5f53b868adbfb80c75c313fe') }}"
       image_local_dir: "{{ cifmw_libvirt_manager_basedir }}/images/"
       disk_file_name: "centos-9-stream.qcow2"
       # GB

--- a/ci_framework/roles/libvirt_manager/meta/main.yml
+++ b/ci_framework/roles/libvirt_manager/meta/main.yml
@@ -38,4 +38,5 @@ galaxy_info:
 
 # List your role dependencies here, one per line. Be sure to remove the '[]' above,
 # if you add dependencies to this list.
-dependencies: []
+dependencies:
+  - discover_latest_image

--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -10,6 +10,7 @@
   gather_facts: true
   roles:
     - name: ci_setup
+    - name: discover_latest_image
   tasks:
     - name: get customized parameters
       ansible.builtin.set_fact:


### PR DESCRIPTION
This role is used to discover the latest cs9 qcow2 image url.
It will help the user to avoid adding the cs9 qcow2 image url
manually.
    
This role is also integrated with libvirt_manager role
and also called in deploy edpm workflow.

This PR has:
- [x] Appropriate testing (molecule, python unit tests)
- [x] Appropriate documentation (README in the role, main README is up-to-date)
