### PR TITLE
Update CS9 cloud image url

### DIFF
--- a/ci_framework/roles/libvirt_manager/defaults/main.yml
+++ b/ci_framework/roles/libvirt_manager/defaults/main.yml
@@ -29,8 +29,8 @@ cifmw_libvirt_manager_configuration:
   vms:
     compute:
       amount: 1
-      image_url: "{{ cifmw_libvirt_manager_images_url }}/CentOS-Stream-GenericCloud-9-20210830.0.x86_64.qcow2"
-      sha256_image_name: 99df867be3300ba5292e274acd149dac1dc784f9db4c30bdf8e3c89abd639976
+      image_url: "{{ cifmw_libvirt_manager_images_url }}/CentOS-Stream-GenericCloud-9-20230410.0.x86_64.qcow2"
+      sha256_image_name: 8a5abbf8b0dda3e4e49b5112ffae3fff022bf97a5f53b868adbfb80c75c313fe
       image_local_dir: "{{ cifmw_libvirt_manager_basedir }}/images/"
       disk_file_name: "centos-9-stream.qcow2"
       # GB


### PR DESCRIPTION
The existing image url is giving 404 which broke molecule and end to end job. 
It needs to be updated with latest image.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/213

This PR has:
- [x] Appropriate testing (molecule, python unit tests)
- [x] Appropriate documentation (README in the role, main README is up-to-date)
