### PR TITLE
Enable artifacts generation and gathering

### DIFF
--- a/ci_framework/playbooks/logs.yml
+++ b/ci_framework/playbooks/logs.yml
@@ -1,6 +1,10 @@
 - hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
+    - name: Generate artifacts
+      ansible.builtin.include_role:
+        name: artifacts
+
     - name: Ensure ansible.log is at the expected location
       register: ansible_log_state
       ansible.builtin.stat:

--- a/ci_framework/roles/artifacts/tasks/main.yml
+++ b/ci_framework/roles/artifacts/tasks/main.yml
@@ -29,3 +29,8 @@
   tags:
     - always
   ansible.builtin.import_tasks: environment.yml
+
+- name: Gather packages information
+  tags:
+    - always
+  ansible.builtin.import_tasks: packages.yml


### PR DESCRIPTION
The artifacts role allows to gather information about the environment.

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
