### PR TITLE
Ensure we have ansible log in known location

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,7 +2,7 @@
 action_plugins = ./plugins/action:~/plugins/action:/usr/share/ansible/plugins/action
 library = ./plugins/modules:~/plugins/modules:/usr/share/ansible/plugins/modules
 roles_path = ~/ci-framework/artifacts/roles:./ci_framework/roles:/usr/share/ansible/roles:/etc/ansible/roles:~/.ansible/roles
-#log_path = ansible.log
+log_path = ~/ansible.log
 # We may consider ansible.builtin.junit
 callbacks_enabled = ansible.posix.profile_tasks
 display_args_to_stdout = True


### PR DESCRIPTION
This location is then used in order to gather the log file in
cifmw_basedir/logs/ for future reference.
