### PR TITLE
Remove "`" from task name

### DIFF
--- a/ci_framework/plugins/modules/generate_make_tasks.py
+++ b/ci_framework/plugins/modules/generate_make_tasks.py
@@ -70,7 +70,7 @@ MAKE_TMPL = '''---
   when: make_%(target)s_params is defined
   ansible.builtin.debug:
     var: make_%(target)s_params
-- name: Run `make %(target)s`
+- name: Run %(target)s
   ci_make:
     output_dir: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework') }}/artifacts"
     chdir: "%(chdir)s"


### PR DESCRIPTION
Apparently the regexp used in ci_make action doesn't strip those chars.
Let's just remove them from the generated tasks, they don't really bring
much value anyway.

From now on, the filename generated will be as simple as:
ci_make_INDEX_run_TARGET.sh

The associated logfile will also match that pattern.
