### PR TITLE
Cosmetic changes to the operator_build role

### DIFF
--- a/ci_framework/roles/operator_build/tasks/build.yml
+++ b/ci_framework/roles/operator_build/tasks/build.yml
@@ -14,11 +14,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Set default api path for {{ operator.name }}
+- name: "{{ operator.name }} - Set default api path"
   ansible.builtin.set_fact:
     operator_api_path: "github.com/{{ cifmw_operator_build_org }}/{{ operator.name }}/api"
 
-- name: Update the go.mod file in meta operator for provided PR_SHA
+- name: "{{ operator.name }} - Update the go.mod file in meta operator for provided PR_SHA"
   ansible.builtin.shell: |
     go mod edit -replace {{ operator_api_path }}=github.com/{{ operator.pr_owner }}/api@{{ operator.pr_sha }}
     go mod tidy
@@ -36,17 +36,17 @@
     - operator.pr_owner is defined
     - operator.pr_sha is defined
 
-- name: Get the {{ operator.name }} latest commit when no PR is provided
+- name: "{{ operator.name }} - Get latest commit when no PR is provided"
   ansible.builtin.command:
     cmd: git show-ref --head --hash head
     chdir: "{{ operator.src }}"
   register: git_head_out
 
-- name: Set pr_sha to be used as image tag
+- name: "{{ operator.name }} - Set pr_sha to be used as image tag"
   ansible.builtin.set_fact:
     pr_sha: "{{ operator.pr_sha | default(git_head_out.stdout | trim) }}"
 
-- name: Update the go.mod file using latest commit if no PR is provided
+- name: "{{ operator.name }} - Update the go.mod file using latest commit if no PR is provided"
   ansible.builtin.shell: |
     go mod edit -replace {{ operator_api_path }}={{ operator_api_path }}@{{ pr_sha }}
     go mod tidy
@@ -64,18 +64,18 @@
     - pr_sha is defined
     - operator.pr_owner is not defined
 
-- name: Get golang container image
+- name: "{{ operator.name }} - Get golang container image"
   containers.podman.podman_image:
     name: "{{ cifmw_operator_build_golang_ct }}"
     pull: true
 
-- name: Set operator image tag
+- name: "{{ operator.name }} - Set operator image tag"
   ansible.builtin.set_fact:
     operator_tag: "{{ pr_sha }}"
     operator_registry_prefix: "{{ cifmw_operator_build_push_registry }}/{{ cifmw_operator_build_push_org }}/{{ operator.name }}"
     cacheable: true
 
-- name: Set operator image names
+- name: "{{ operator.name }} - Set operator image names"
   ansible.builtin.set_fact:
     operator_img: "{{ operator_registry_prefix }}:{{ operator_tag }}"
     operator_img_bundle: "{{ operator_registry_prefix }}-bundle:{{ operator_tag }}"
@@ -84,24 +84,14 @@
     operator_bundles: []
     cacheable: true
 
-- name: Create artifact directory
-  ansible.builtin.file:
-    path: "{{ cifmw_operator_build_basedir }}/artifacts"
-    state: directory
-
-- name: Create logs directory
-  ansible.builtin.file:
-    path: "{{ cifmw_operator_build_basedir }}/logs"
-    state: directory
-
-- name: Call manifests
+- name: "{{ operator.name }} - Call manifests"
   ci_make:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
     chdir: "{{ operator.src }}"
     output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
     target: manifests
 
-- name: Call docker-build
+- name: "{{ operator.name }} - Call docker-build"
   ci_make:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
     chdir: "{{ operator.src }}"
@@ -110,7 +100,7 @@
     params:
       IMG: "{{ operator_img }}"
 
-- name: Call docker-push
+- name: "{{ operator.name }} - Call docker-push"
   when:
     - cifmw_operator_build_push_ct|bool
   ci_make:
@@ -121,7 +111,7 @@
     params:
       IMG: "{{ operator_img }}"
 
-- name: Call bundle
+- name: "{{ operator.name }} - Call bundle"
   ci_make:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
     chdir: "{{ operator.src }}"
@@ -133,7 +123,7 @@
       IMAGEREGISTRY: "{{ cifmw_operator_build_push_registry }}"
       IMAGEBASE: "{{ operator.image_base | default('') }}"
 
-- name: Builds storage-bundle for meta-operator
+- name: "{{ operator.name }} - Builds storage-bundle for meta-operator"
   when:
     - operator.name == cifmw_operator_build_meta_name
   block:
@@ -154,7 +144,7 @@
       set_fact:
         operator_bundles: "{{ operator_bundles + [operator_img_storage_bundle] }}"
 
-- name: Call bundle-build
+- name: "{{ operator.name }} - Call bundle-build"
   ci_make:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
     chdir: "{{ operator.src }}"
@@ -164,11 +154,11 @@
       BUNDLE_IMG: "{{ operator_img_bundle }}"
       BUNDLE_STORAGE_IMG: "{{ operator_img_storage_bundle }}"
 
-- name: Add bundle to bundle list
+- name: "{{ operator.name }} - Add bundle to bundle list"
   set_fact:
     operator_bundles: "{{ operator_bundles + [operator_img_bundle] }}"
 
-- name: Push bundle image
+- name: "{{ operator.name }} - Push bundle image"
   when:
     - cifmw_operator_build_push_ct|bool
   containers.podman.podman_image:
@@ -176,7 +166,7 @@
     pull: false
     push: true
 
-- name: Call catalog-build
+- name: "{{ operator.name }} - Call catalog-build"
   ci_make:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
     chdir: "{{ operator.src }}"
@@ -186,7 +176,7 @@
       CATALOG_IMG: "{{ operator_img_catalog }}"
       BUNDLE_IMGS: "{{ operator_bundles | join(',')}}"
 
-- name: Call catalog-push
+- name: "{{ operator.name }} - Call catalog-push"
   when:
     - cifmw_operator_build_push_ct|bool
   ci_make:

--- a/ci_framework/roles/operator_build/tasks/main.yml
+++ b/ci_framework/roles/operator_build/tasks/main.yml
@@ -19,6 +19,11 @@
     path: "{{ cifmw_operator_build_basedir }}/artifacts"
     state: directory
 
+- name: Ensure log directory ecists
+  ansible.builtin.file:
+    path: "{{ cifmw_operator_build_basedir }}/logs"
+    state: directory
+
 - name: Building operators list
   vars:
     operator: "{{ item }}"


### PR DESCRIPTION
Ensure we are able to follow the tasks related to each operator by the
name directly, and avoid a couple of identical tasks to run for each
operator.

This will ensure we:
- can follow the tasks
- generate proper per-operator reproducers with an easy to find name
- generate proper per-operator `make` log with an easy to find name.
- avoid duplicated tasks, meaning a slightly faster run at scale

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
