### PR TITLE
Pad index in filenames

### DIFF
--- a/ci_framework/plugins/action/ci_make.py
+++ b/ci_framework/plugins/action/ci_make.py
@@ -98,7 +98,7 @@ class ActionModule(ActionBase):
         # Replace non-ASCII and spaces in ansible task name, and lower the
         # string
         t_name = re.sub(r'([^\x00-\x7F]|\s)+', '_', self._task._name).lower()
-        fname = 'ci_make_%i_%s.sh' % (fnum, t_name)
+        fname = f'ci_make_{fnum:03}_{t_name}.sh'
 
         # Run module only if all conditions are here for file creation
         if not dry_run:
@@ -106,7 +106,7 @@ class ActionModule(ActionBase):
                                          module_args=module_args,
                                          task_vars=task_vars, tmp=tmp)
             # Log in plain file
-            log_name = 'ci_make_%i_%s.log' % (fnum, t_name)
+            log_name = f'ci_make_{fnum:03}_{t_name}.log'
             f_log = os.path.join(log_dir, log_name)
             with open(f_log, 'w') as fh:
                 fh.write('### STDOUT\n')

--- a/ci_framework/tests/integration/targets/make/tasks/main.yml
+++ b/ci_framework/tests/integration/targets/make/tasks/main.yml
@@ -84,23 +84,23 @@
     - name: Set files attributes
       ansible.builtin.set_fact:
         files_to_check:
-          "/tmp/artifacts/ci_make_0_run_ci_make_without_any_params.sh":
+          "/tmp/artifacts/ci_make_000_run_ci_make_without_any_params.sh":
             e6ec8bc41f8aa58ef72fb1d8e336dc9c8115d0e4
-          "/tmp/artifacts/ci_make_1_run_ci_make_with_a_param.sh":
+          "/tmp/artifacts/ci_make_001_run_ci_make_with_a_param.sh":
             79fe696cf7e0f3001e99fed22f5a2674f1f8c493
-          "/tmp/artifacts/ci_make_2_try_dry_run_parameter.sh":
+          "/tmp/artifacts/ci_make_002_try_dry_run_parameter.sh":
             4909f854ee1fc8e17c608ea0a7a2adb40101c825
-          "/tmp/artifacts/ci_make_3_test_with_environment_parameters.sh":
+          "/tmp/artifacts/ci_make_003_test_with_environment_parameters.sh":
             4ca6f838a71ab336f91f8775d684c3d8ccc0a89a
-          "/tmp/artifacts/ci_make_4_run_ci_make_with_custom_env_variable.sh":
+          "/tmp/artifacts/ci_make_004_run_ci_make_with_custom_env_variable.sh":
             2447a25f97c34a25c0ab3a6e67baf1d2c8817c78
-          "/tmp/logs/ci_make_0_run_ci_make_without_any_params.log":
+          "/tmp/logs/ci_make_000_run_ci_make_without_any_params.log":
             8dcc15e2dd273dda4f7120efc059274bd8d50a89
-          "/tmp/logs/ci_make_1_run_ci_make_with_a_param.log":
+          "/tmp/logs/ci_make_001_run_ci_make_with_a_param.log":
             fa1fd735445ca641270e630a00303b5816bafff3
-          "/tmp/logs/ci_make_3_test_with_environment_parameters.log":
+          "/tmp/logs/ci_make_003_test_with_environment_parameters.log":
             3384b44a202d4f841781dff704276e0ae44484e7
-          "/tmp/logs/ci_make_4_run_ci_make_with_custom_env_variable.log":
+          "/tmp/logs/ci_make_004_run_ci_make_with_custom_env_variable.log":
             f17389a98ce38f871c3b69f1ad8b9956b7f95958
     - name: Gather files
       register: reproducer_scripts


### PR DESCRIPTION
That way, an `ls` will display the content in the correct order.

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
