### PR TITLE
Retry base image download

### DIFF
--- a/ci_framework/roles/libvirt_manager/tasks/deploy_edpm_compute.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/deploy_edpm_compute.yml
@@ -37,10 +37,14 @@
     - name: Download base image
       when:
         - not disk_file_name_status.stat.exists
+      register: download_base_img
       ansible.builtin.get_url:
         url: "{{ compute_config.image_url }}"
         dest: "{{ compute_config.image_local_dir }}/{{ compute_config.disk_file_name }}"
         checksum: "sha256:{{ compute_config.sha256_image_name }}"
+      until: download_base_img.status_code == 200
+      retries: 30
+      delay: 5
 
 - name: Create EDPM compute VMs
   vars:


### PR DESCRIPTION
It may happen the remote server is either slow to answer, or a bit
overloaded.

This change should allow to pass through tiny glitches.
