### PR TITLE
Consolidate run_hook "playbook" tasks

### DIFF
--- a/ci_framework/roles/run_hook/README.md
+++ b/ci_framework/roles/run_hook/README.md
@@ -13,20 +13,18 @@ play has a great chance of failure.
 ### Hooks expected format
 #### Playbook
 In such a case, the following data can be provided to the hook:
-* `type`: Type of the hook. In this case, set it to `playbook`.
-* `source`: Source of the playbook. If it's a filename, the playbook is
-expected in ci_framwork/hooks/playbooks. It can be an absolute path.
+* `config_file`: Ansible configuration file. Defaults to `ansible_config_file`.
+* `connection`: Refer to the `--connection` option for `ansible-playbook`. Defaults to `local`.
+* `creates`: Refer to the `ansible.builtin.command` "creates" parameter. Defaults to `omit`.
+* `inventory`: Refer to the `--inventory` option for `ansible-playbook`. Defaults to `localhost,`.
 * `name`: Describe the hook.
-* `inventory`: Refer to the `--inventory` option for `ansible-playbook`.
-Defaults to `localhost,`.
-* `connection`: Refer to the `--connection` option for `ansible-playbook`.
-Defaults to `local`.
+* `source`: Source of the playbook. If it's a filename, the playbook is expected in ci_framwork/hooks/playbooks. It can be an absolute path.
+* `type`: Type of the hook. In this case, set it to `playbook`.
 
 #### CRD
 In such a case, the following data can be provided to the hook:
 * `type`: Type of the hook. In this case, set it to `crd`.
-* `source`: Source of the CRD. If it's a filename, the CRD is expected in
-ci_framwork/hooks/crds. It can be an absolute path.
+* `source`: Source of the CRD. If it's a filename, the CRD is expected in ci_framwork/hooks/crds. It can be an absolute path.
 * `host`: Cluster API endpoint. Defaults to `https://api.crc.testing:6443`.
 * `username`: Username for authentication against the cluster. Defaults to `kubeadmin`.
 * `password`: Password for authentication against the cluster. Defaults to `12345678`.

--- a/ci_framework/roles/run_hook/tasks/playbook.yml
+++ b/ci_framework/roles/run_hook/tasks/playbook.yml
@@ -12,18 +12,23 @@
 # even less from a task. So the way to run a playbook from within a playbook
 # is to call a command. Though we may lose some of the data passed to the
 # "main" play.
-- name: "Run {{ playbook_path }} playbook"
-  register: play_output
-  ansible.builtin.command:
-    cmd: >-
-      ansible-playbook -i {{ hook.inventory | default('localhost,') }}
-      -c {{ hook.connection | default('local') }}
-      {{ playbook_path }}
+- name: Ensure we get the logs even in case of failure
+  block:
+    - name: "Run {{ playbook_path }} playbook"
+      register: play_output
+      environment:
+        ANSIBLE_CONFIG: "{{ hook.config_file | default(ansible_config_file) }}"
+      ansible.builtin.command:
+        cmd: >-
+          ansible-playbook -i {{ hook.inventory | default('localhost,') }}
+          -c {{ hook.connection | default('local') }}
+          {{ playbook_path }}
+        create: "{{ hook.creates | default(omit) }}"
+  always:
+    - name: Output play stderr
+      ansible.builtin.debug:
+        var: play_output.stderr_lines
 
-- name: Output play stderr
-  ansible.builtin.debug:
-    var: play_output.stderr
-
-- name: Output play stdout
-  ansible.builtin.debug:
-    var: play_output.stdout
+    - name: Output play stdout
+      ansible.builtin.debug:
+        var: play_output.stdout_lines


### PR DESCRIPTION
Until now, there was no way to avoid a playbook hook to run all the
time.

This patch also allows to pass custom Ansible configuration file. By
default, it will use the one located at the root of the project,
allowing hooks to know about our custom roles and plugins.

There was also a risk we'd miss the proper outputs in case of a
crash - so now we should get the logs even if the hook fails, presented
in the proper way.

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
