### PR TITLE
New role: edpm_prepare

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -25,6 +25,8 @@ are shared among multiple roles:
 * `cifmw_basedir`: The base directory for all of the artifacts. Defaults to
 `~/ci-framework`
 * `cifmw_installyamls_repos`: install_yamls repository location. Defaults to `../..`
+* `cifmw_manifests`: Directory where k8s related manifests will be places. Defaults to
+`{{ cifmw_basedir }}/manifests`
 * `cifmw_path`: customized PATH. Defaults to `~/.crc/bin:~/.crc/bin/oc:~/bin:${PATH}`
 * `cifmw_use_libvirt`: (Bool) toggle libvirt support
 * `cifmw_use_crc`: (Bool) toggle rhol/crc usage

--- a/ci_framework/playbooks/06-deploy-edpm.yml
+++ b/ci_framework/playbooks/06-deploy-edpm.yml
@@ -12,6 +12,10 @@
         name: libvirt_manager
         tasks_from: deploy_edpm_compute.yml
 
+    - name: Call predeploy
+      ansible.builtin.include_role:
+        name: edpm_prepare
+
 - name: Run post_deploy hooks
   vars:
     hooks: "{{ post_deploy | default([]) }}"

--- a/ci_framework/roles/ci_setup/tasks/directories.yml
+++ b/ci_framework/roles/ci_setup/tasks/directories.yml
@@ -3,12 +3,13 @@
   tags:
     - always
   ansible.builtin.file:
-    path: "{{ cifmw_ci_setup_basedir }}/{{ item }}"
+    path: "{{ item }}"
     state: "{{ directory_state }}"
   loop:
-    - "artifacts/{{ cifmw_install_yamls_defaults['NAMESPACE'] }}/cr"
-    - logs
-    - tmp
-    - volumes
+    - "{{ cifmw_manifests | default(cifmw_ci_setup_basedir ~ '/artifacts/manifests') }}/\
+    {{ cifmw_install_yamls_defaults['NAMESPACE'] | default('openstack') }}/cr"
+    - "{{ cifmw_ci_setup_basedir }}/logs"
+    - "{{ cifmw_ci_setup_basedir }}/tmp"
+    - "{{ cifmw_ci_setup_basedir }}/volumes"
   loop_control:
     label: "{{ cifmw_ci_setup_basedir }}/{{ item }}"

--- a/ci_framework/roles/edpm_prepare/README.md
+++ b/ci_framework/roles/edpm_prepare/README.md
@@ -1,0 +1,12 @@
+## Role: edpm_prepare
+Prepares the environment to deploy OpenStack control plane and compute nodes.
+
+### Privilege escalation
+This role doesn't need privilege scalation.
+
+### Parameters
+* `cifmw_edpm_prepare_basedir`: (String) Base directory. Defaults to `cifmw_basedir` which defaults to **~/ci-framework**.
+* `cifmw_edpm_prepare_dry_run`: (Boolean) Skips resources installations and waits. Defaults to false.
+* `cifmw_edpm_prepare_manifests_dir`: String) Directory in where install_yamls output manifests will be placed. Defaults to **"{{ cifmw_edpm_prepare_basedir }}/artifacts/manifests"**
+* `cifmw_edpm_skip_openstack_operator:`: (Boolean) Intentionally skips the deployment of the OpenStack metaoperator. Defaults to false.
+* `cifmw_edpm_prepare_wait_subscription_retries`: (Integer) Number of retries, with 5 seconds delays, waiting for the OpenStack subscription to come up. Defaults to 5.

--- a/ci_framework/roles/edpm_prepare/defaults/main.yml
+++ b/ci_framework/roles/edpm_prepare/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_edpm_prepare"
+cifmw_edpm_prepare_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}"
+cifmw_edpm_prepare_manifests_dir: "{{ cifmw_manifests | default(cifmw_edpm_prepare_basedir ~ '/artifacts/manifests') }}"
+cifmw_edpm_skip_openstack_operator: false
+cifmw_edpm_prepare_wait_subscription_retries: 30
+cifmw_edpm_prepare_dry_run: false

--- a/ci_framework/roles/edpm_prepare/meta/main.yml
+++ b/ci_framework/roles/edpm_prepare/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- edpm_prepare
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: edpm
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - edpm
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/ci_framework/roles/edpm_prepare/molecule/default/converge.yml
+++ b/ci_framework/roles/edpm_prepare/molecule/default/converge.yml
@@ -1,0 +1,25 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  vars:
+    cifmw_use_crc: true
+    cifmw_operator_build_meta_name: openstack
+    cifmw_edpm_prepare_dry_run: true
+  roles:
+    - role: "edpm_prepare"

--- a/ci_framework/roles/edpm_prepare/molecule/default/molecule.yml
+++ b/ci_framework/roles/edpm_prepare/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/edpm_prepare/molecule/default/prepare.yml
+++ b/ci_framework/roles/edpm_prepare/molecule/default/prepare.yml
@@ -1,0 +1,30 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_basedir: "{{ ansible_user_dir }}/ci-framework"
+    cifmw_install_yamls_tasks_out: "{{ ansible_user_dir }}/zuul-jobs/roles/install_yamls_makes/tasks"
+    cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
+    cifmw_install_yamls_defaults:
+      NAMESPACE: openstack
+  roles:
+    - role: test_deps
+    - role: ci_setup
+    - role: install_yamls

--- a/ci_framework/roles/edpm_prepare/tasks/cleanup.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/cleanup.yml
@@ -1,0 +1,19 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Cleaning the World
+  debug:
+    msg: "So here edpm_prepare should clean things up!"

--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -1,0 +1,102 @@
+- name: Prepare storage in CRC
+  vars:
+    make_crc_storage_dryrun: "{{ cifmw_edpm_prepare_dry_run }}"
+  when:
+    - cifmw_use_crc is defined
+    - cifmw_use_crc | bool
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_crc_storage'
+
+- name: Set install_yamls Makefile environment variables
+  vars:
+    operators_build_output: "{{ (cifmw_operator_build_output | default({'operators':{}})).operators }}"
+  ansible.builtin.set_fact:
+    cifmw_edpm_prepare_common_env:
+      OUT: "{{ cifmw_edpm_prepare_manifests_dir }}"
+    cifmw_edpm_prepare_make_openstack_env: |
+      {% if cifmw_operator_build_meta_name in operators_build_output %}
+      OPENSTACK_IMG: {{ operators_build_output[cifmw_operator_build_meta_name].image }}
+      {% endif %}
+    cifmw_edpm_prepare_make_openstack_deploy_env: |
+      {% if cifmw_operator_build_meta_name in operators_build_output %}
+      OPENSTACK_BRANCH: ""
+      GIT_CLONE_OPTS: "-l"
+      OPENSTACK_REPO: operators_build_output[cifmw_operator_build_meta_name].git_src_dir
+      {% endif %}
+
+- name: Prepare inputs
+  vars:
+    make_input_env: "{{ cifmw_edpm_prepare_common_env }}"
+    make_input_dryrun: "{{ cifmw_edpm_prepare_dry_run }}"
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_input'
+
+# TODO: Prepare a proper operator list that dictates what operators to deploy instead of relaying on a simple flag
+- name: OpenStack meta-operator installation
+  when: not cifmw_edpm_skip_openstack_operator
+  block:
+  - name: Install OpenStack operator
+    vars:
+      make_openstack_env: "{{ cifmw_edpm_prepare_common_env |
+        combine(cifmw_edpm_prepare_make_openstack_env | from_yaml)}}"
+      make_openstack_dryrun: "{{ cifmw_edpm_prepare_dry_run }}"
+    ansible.builtin.include_role:
+      name: 'install_yamls_makes'
+      tasks_from: 'make_openstack'
+
+- name: Wait for OpenStack control plane to be installed
+  block:
+    - name: Wait for OpenStack subscription creation
+      ansible.builtin.command:
+        cmd: oc get sub openstack-operator --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }} -o=jsonpath='{.status.installplan.name}'
+      until: cifmw_edpm_prepare_wait_installplan_out.rc == 0 and cifmw_edpm_prepare_wait_installplan_out.stdout != ""
+      register: cifmw_edpm_prepare_wait_installplan_out
+      retries: "{{ cifmw_edpm_prepare_wait_subscription_retries }}"
+      delay: 5
+
+    - name: Wait for OpenStack operator to get installed
+      ansible.builtin.command:
+        cmd: >
+          oc wait InstallPlan {{ cifmw_edpm_prepare_wait_installplan_out.stdout }}
+          --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }} --for=jsonpath='{.status.phase}'=Complete --timeout=20m
+  when: not cifmw_edpm_prepare_dry_run
+
+- name: Install OpenStack service
+  vars:
+    make_openstack_deploy_env: "{{ cifmw_edpm_prepare_common_env |
+      combine(cifmw_edpm_prepare_make_openstack_deploy_env | from_yaml)}}"
+    make_openstack_deploy_dryrun: "{{ cifmw_edpm_prepare_dry_run }}"
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_openstack_deploy'
+
+- name: Wait for OpenStack control plane to be installed
+  block:
+    - name: Find the OpenStack CR manifest
+      ansible.builtin.find:
+        paths: "{{ cifmw_edpm_prepare_intall_yamls_output_dir }}/{{ cifmw_install_yamls_defaults['NAMESPACE'] }}/openstack/cr"
+        contains: "kind: OpenStackControlPlane"
+        patterns: "*.yaml"
+      register: cifmw_edpm_prepare_openstack_cr_manifest_paths
+
+    - name: Ensure manifest exists
+      ansible.builtin.assert:
+        that: cifmw_edpm_prepare_openstack_cr_manifest_paths.matched == 1
+        quiet: true
+        msg: "Cannot determine OpenStackControlPlane deployment manifest"
+
+    - name: Find files out
+      ansible.builtin.slurp:
+        src: "{{ cifmw_edpm_prepare_openstack_cr_manifest_paths.files[0].path }}"
+      register: cifmw_edpm_prepare_ctrlplane_cr_slurp
+
+    - name: Wait for OpenStack controlplane to be deployed
+      ansible.builtin.command:
+        cmd: >-
+          oc wait OpenStackControlPlane {{ (cifmw_edpm_prepare_ctrlplane_cr_slurp['content'] | b64decode | from_yaml).metadata.name }}
+          --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+          --for=condition=ready
+          --timeout=30m
+  when: not cifmw_edpm_prepare_dry_run

--- a/ci_framework/roles/operator_build/tasks/main.yml
+++ b/ci_framework/roles/operator_build/tasks/main.yml
@@ -22,6 +22,11 @@
     - artifacts
     - logs
 
+- name: Initialize role output
+  ansible.builtin.set_fact:
+    cifmw_operator_build_output: "{{ cifmw_operator_build_output }}"
+    cifmw_operator_build_meta_name: "{{ cifmw_operator_build_meta_name }}"
+
 - name: Populate operators list with zuul info
   when:
     - zuul is defined

--- a/scenarios/centos-9/ci.yml
+++ b/scenarios/centos-9/ci.yml
@@ -18,3 +18,5 @@ pre_deploy:
 # Check hooks/playbooks/ceph-deploy.yml for the whole logic.
 cifmw_make_ceph_environment:
   TIMEOUT: 90
+
+cifmw_edpm_prepare_dry_run: true

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -68,6 +68,16 @@
       - ^ci_framework/roles/edpm_deploy/(?!meta).*
       - ^ci/playbooks/molecule.*
 - job:
+    name: cifmw-molecule-edpm_prepare
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: edpm_prepare
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/edpm_prepare/(?!meta).*
+      - ^ci/playbooks/molecule.*
+- job:
     name: cifmw-molecule-install_yamls
     parent: cifmw-molecule-base
     vars:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -9,6 +9,7 @@
         - cifmw-molecule-copy_container
         - cifmw-molecule-discover_latest_image
         - cifmw-molecule-edpm_deploy
+        - cifmw-molecule-edpm_prepare
         - cifmw-molecule-install_yamls
         - cifmw-molecule-libvirt_manager
         - cifmw-molecule-operator_build


### PR DESCRIPTION
This role wraps all of the preparation steps/make targets in order to
get the dataplane ready for the actual EDPM deployment.

The goal here is to make a modular role, calling the install_yamls_makes
tasks in a way we may toggle various switches, or even inject operators
early in the game.

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
