### PR TITLE
Remove problematic lines in _skeleton_

### DIFF
--- a/_skeleton_role_/defaults/main.yml.j2
+++ b/_skeleton_role_/defaults/main.yml.j2
@@ -17,5 +17,3 @@
 
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_{{ role_name | replace('cifmw_', '') }}"
-cifmw_{{ role_name | replace('cifmw_', '') }}_debug: {% raw %}"{{ (ansible_verbosity | int) >= 2 | bool }}"{% endraw %}
-cifmw_{{ role_name | replace('cifmw_', '') }}_hide_sensitive_logs: true


### PR DESCRIPTION
The removed lines are mostly never used, and there's a syntax issue preventing the role to work as-is.