### PR TITLE
Add support for Zuul jobs in operator_build role

### DIFF
--- a/ci_framework/roles/operator_build/README.md
+++ b/ci_framework/roles/operator_build/README.md
@@ -19,10 +19,8 @@ you want to build meta-operator too, so the role can properly replace api refere
 * `cifmw_operator_build_meta_image_base`: (String) Name of the service added to be added to meta-operator build. Still limited to a sindle service (and operator). Default to **""**
 
 ## TODO
-* Include PR Owner and PR SHA for meta-operator
-* Include tasks to get PR Owner and PR SHA info from **zuul** dict.
 * Include tasks to get PR Owner and PR SHA info from **Prow** environment.
-* Add molecule tests.
+* Support build in dev environment (build with gowork without GitHub)
 
 ## Examples
 ### 1 - Building mariadb-operator checked-out from a PR and meta-operator

--- a/ci_framework/roles/operator_build/molecule/default/converge.yml
+++ b/ci_framework/roles/operator_build/molecule/default/converge.yml
@@ -21,27 +21,49 @@
     cifmw_operator_build_dryrun: true
     cifmw_operator_build_push_ct: false
   tasks:
-    - name: Build mariadb-operator
+    - name: Build keystone-operator
       include_role:
         name: operator_build
       vars:
         cifmw_operator_build_meta_build: true
         cifmw_operator_build_operators:
-          - name: "mariadb-operator"
-            src: "{{ ansible_user_dir }}/mariadb-operator"
+          - name: "keystone-operator"
+            src: "{{ ansible_user_dir }}/keystone-operator"
 
     - name: Ensure that role output dict contains the expected values
       ansible.builtin.assert:
         that:
           # Check the explicit build operator
-          - cifmw_operator_build_output['operators']['mariadb-operator']['commit_hash'] is defined
-          - cifmw_operator_build_output['operators']['mariadb-operator']['image'] is defined
-          - cifmw_operator_build_output['operators']['mariadb-operator']['image_bundle'] is defined
-          - cifmw_operator_build_output['operators']['mariadb-operator']['image_storage_bundle'] is defined
-          - cifmw_operator_build_output['operators']['mariadb-operator']['image_catalog'] is defined
+          - cifmw_operator_build_output['operators']['keystone-operator']['commit_hash'] is defined
+          - cifmw_operator_build_output['operators']['keystone-operator']['image'] is defined
+          - cifmw_operator_build_output['operators']['keystone-operator']['image_bundle'] is defined
+          - cifmw_operator_build_output['operators']['keystone-operator']['image_storage_bundle'] is defined
+          - cifmw_operator_build_output['operators']['keystone-operator']['image_catalog'] is defined
           # Check the meta operator build output
           - cifmw_operator_build_output['operators']['openstack-operator']['commit_hash'] is defined
           - cifmw_operator_build_output['operators']['openstack-operator']['image'] is defined
           - cifmw_operator_build_output['operators']['openstack-operator']['image_bundle'] is defined
           - cifmw_operator_build_output['operators']['openstack-operator']['image_storage_bundle'] is defined
           - cifmw_operator_build_output['operators']['openstack-operator']['image_catalog'] is defined
+
+    - name: Build mariadb-operator from Zuul job
+      include_role:
+        name: operator_build
+      vars:
+        cifmw_operator_build_meta_build: false
+        cifmw_operator_build_operators:
+          # to be replaced with zuul info
+          - name: "mariadb-operator"
+            src: "{{ ansible_user_dir }}/mariadb-operator"
+        zuul:
+          items:
+            - branch: master
+              change: '100'
+              change_url: https://github.com/openstack-k8s-operators/mariadb-operator/pull/100
+              patchset: 912229102d02c43cead640ad9bf863e090444ab6
+              project:
+                canonical_hostname: github.com
+                canonical_name: github.com/openstack-k8s-operators/mariadb-operator
+                name: openstack-k8s-operators/mariadb-operator
+                short_name: mariadb-operator
+                src_dir: src/github.com/openstack-k8s-operators/mariadb-operator

--- a/ci_framework/roles/operator_build/tasks/build.yml
+++ b/ci_framework/roles/operator_build/tasks/build.yml
@@ -61,7 +61,6 @@
   when:
     - cifmw_operator_build_meta_build
     - operator.name != cifmw_operator_build_meta_name
-    - pr_sha is defined
     - operator.pr_owner is not defined
 
 - name: Get container image
@@ -77,7 +76,7 @@
         pull: true
     - name: Override image
       ansible.builtin.set_fact:
-        cifmw_operator_build_golang_ct: "{{ cifmw_operator_build_golang_alt_ct }}"
+        cifmw_operator_build_golang_ct: "{{ cifmw_operator_build_golang_alt_ct }}"
 
 
 - name: "{{ operator.name }} - Set operator image tag"
@@ -99,6 +98,7 @@
   ansible.builtin.set_fact:
       cifmw_operator_build_output: >-
         {{ cifmw_operator_build_output|combine({'operators': { operator.name: {
+          'commit_hash': pr_sha,
           'image': operator_img,
           'image_bundle': operator_img_bundle,
           'image_storage_bundle': operator_img_storage_bundle,

--- a/ci_framework/roles/operator_build/tasks/clone.yml
+++ b/ci_framework/roles/operator_build/tasks/clone.yml
@@ -24,16 +24,3 @@
     repo: "https://github.com/{{ cifmw_operator_build_org }}/{{ operator.name }}.git"
     dest: "{{ operator.src }}"
   when: not stat_op_src.stat.exists
-
-- name: "{{ operator.name }} - Fetch operator src commit"
-  ansible.builtin.command:
-    cmd: "git rev-parse HEAD"
-  register: operator_src_hash
-  when: operator.pr_sha is not defined
-
-- name: "{{ operator.name }} - Save operator src hash"
-  ansible.builtin.set_fact:
-    cifmw_operator_build_output: >-
-        {{ cifmw_operator_build_output|combine({'operators': { operator.name: {
-          'commit_hash': operator_src_hash.stdout if operator_src_hash is defined else operator.pr_sha
-        }}}, recursive=True)}}

--- a/ci_framework/roles/operator_build/tasks/main.yml
+++ b/ci_framework/roles/operator_build/tasks/main.yml
@@ -14,52 +14,66 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Ensure output directory exists
+- name: Ensure mandatory directories exist
   ansible.builtin.file:
-    path: "{{ cifmw_operator_build_basedir }}/artifacts"
+    path: "{{ cifmw_operator_build_basedir }}/{{ item }}"
     state: directory
+  with_items:
+    - artifacts
+    - logs
 
-- name: Ensure log directory ecists
-  ansible.builtin.file:
-    path: "{{ cifmw_operator_build_basedir }}/logs"
-    state: directory
+- name: Populate operators list with zuul info
+  when:
+    - zuul is defined
+  vars:
+    item: "{{ item }}"
+  ansible.builtin.include_tasks: zuul_info.yml
+  loop: "{{ zuul['items'] }}"
 
-- name: Set meta-operator info
+- name: Merge lists of operators
+  ansible.builtin.set_fact:
+    operators_list: "{{ [cifmw_operator_build_operators, zuul_info_operators | default([])] \
+                    | community.general.lists_mergeby('name') }}"
+
+- name: Get meta_operator src dir from operators_list
+  ansible.builtin.set_fact:
+    cifmw_operator_build_meta_src: "{{ (operators_list \
+                                   | selectattr('name', 'eq', cifmw_operator_build_meta_name) | map(attribute='src') \
+                                   | first ) | default(cifmw_operator_build_meta_src, true) }}"
+
+- name: Adds meta-operator to the list
   when:
     - cifmw_operator_build_meta_build is true
-  block:
-    - name: Set meta-operator info
-      ansible.builtin.set_fact:
-        meta_operator:
-          - name: "{{ cifmw_operator_build_meta_name }}"
-            src: "{{ cifmw_operator_build_meta_src }}"
-            base_image: "{{ cifmw_operator_build_meta_image_base | default('') }}"
+  vars:
+    meta_operator_info:
+      - name: "{{ cifmw_operator_build_meta_name }}"
+        src: "{{ cifmw_operator_build_meta_src }}"
+  ansible.builtin.set_fact:
+    operators_list: "{{ [operators_list, meta_operator_info] \
+                    | community.general.lists_mergeby('name') }}"
 
-    - name: Meta-operator - Clone operator's code when needed
-      vars:
-        operator: "{{ item }}"
-      ansible.builtin.include_tasks: clone.yml
-      loop: "{{ meta_operator }}"
-
-- name: Clone operator's code when needed
+- name: Clone operator's code when src dir is empty
   vars:
     operator: "{{ item }}"
   ansible.builtin.include_tasks: clone.yml
-  loop: "{{ cifmw_operator_build_operators }}"
+  loop: "{{ operators_list }}"
 
-- name: Building operators list
+- name: Building operators
+  when:
+    - "item.name != cifmw_operator_build_meta_name"
   vars:
     operator: "{{ item }}"
   ansible.builtin.include_tasks: build.yml
-  loop: "{{ cifmw_operator_build_operators }}"
+  loop: "{{ operators_list }}"
 
 - name: Building meta operator
   when:
     - cifmw_operator_build_meta_build is true
+    - "item.name == cifmw_operator_build_meta_name"
   vars:
     operator: "{{ item }}"
   ansible.builtin.include_tasks: build.yml
-  loop: "{{ meta_operator }}"
+  loop: "{{ operators_list }}"
 
 - name: Gather role output
   ansible.builtin.copy:

--- a/ci_framework/roles/operator_build/tasks/zuul_info.yml
+++ b/ci_framework/roles/operator_build/tasks/zuul_info.yml
@@ -1,0 +1,40 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Populate operators from zuul info
+  block:
+    - name: Get the PR owner using github api
+      ansible.builtin.uri:
+        url: "https://api.github.com/repos/{{ item.project.name }}/pulls/{{ item.change }}"
+        return_content: true
+        headers:
+          Content-Type: "application/json"
+          Accept: "application/vnd.github+json"
+          X-GitHub-Api-Version: "2022-11-28"
+      register: result
+
+    - name: Add operator info with new content
+      ansible.builtin.set_fact:
+        zuul_info_operators: "{{ zuul_info_operators|default([]) + operator_info }}"
+      vars:
+        operator_info:
+          - name: "{{ item.project.short_name }}"
+            src: "{{ ansible_user_dir }}/{{ item.project.src_dir }}"
+            pr_sha: "{{ item.patchset }}"
+            pr_owner: "{{ result.json.head.repo.full_name }}"
+  when:
+    - "'change_url' in item"
+    - "'operator' in item.project.short_name"

--- a/scenarios/centos-9/ci.yml
+++ b/scenarios/centos-9/ci.yml
@@ -7,7 +7,8 @@ cifmw_use_crc: true
 cifmw_operator_build_push_registry: "default-route-openshift-image-registry.apps-crc.testing"
 cifmw_operator_build_push_org: "default"
 cifmw_operator_build_meta_build: true
-cifmw_operator_build_meta_src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/openstack-operator"
 cifmw_operator_build_operators:
   - name: mariadb-operator
     src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/mariadb-operator"
+  - name: openstack-operator
+    src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/openstack-operator"


### PR DESCRIPTION
This patch adds the processing of zuul information to retrieve PR information and add to operator_build list. Update molecule to simulate data from zuul.
Combine operators and meta-operator within the same list

This PR has:
- [x] Appropriate testing (molecule, python unit tests)
- [x] Appropriate documentation (README in the role, main README is up-to-date)
