### PR TITLE
Added playbook to dump zuul vars

### DIFF
--- a/.zuul.d/collect-logs.yml
+++ b/.zuul.d/collect-logs.yml
@@ -37,6 +37,18 @@
                   cp -ra {{ ansible_user_dir }}/ci-framework/logs . ;
                   cp -ra {{ ansible_user_dir }}/ci-framework/artifacts . ;
 
+            - name: Check for Zuul inventory file
+              ansible.builtin.stat:
+                path: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/scenarios/centos-9/zuul_inventory.yml"
+              register: cifmw_zuul_state
+
+            - name: Copy Zuul inventory file
+              when: cifmw_zuul_state.stat.exists | bool
+              ansible.builtin.copy:
+                remote_src: true
+                dest: "{{ ansible_user_dir }}/ci-framework/logs"
+                src: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/scenarios/centos-9/zuul_inventory.yml"
+
         - name: Get some env related data
           ansible.builtin.shell:
             chdir: "{{ ansible_user_dir }}/zuul-output/logs/"

--- a/.zuul.d/dump_zuul_vars.yml
+++ b/.zuul.d/dump_zuul_vars.yml
@@ -1,0 +1,19 @@
+---
+- hosts: controller
+  gather_facts: true
+  tasks:
+    - name: Slurp Zuul inventory
+      ansible.builtin.slurp:
+        path: "{{ zuul.executor.log_root }}/zuul-info/inventory.yaml"
+      register: _inventory_yaml
+      delegate_to: localhost
+
+    - name: Extract inventory
+      ansible.builtin.set_fact:
+        _zuul_vars: "{{ _inventory_yaml['content'] | b64decode | from_yaml }}"
+
+    - name: Create the Zuul inventory file
+      ansible.builtin.copy:
+        mode: 0644
+        content: '{{ _zuul_vars.all.vars | to_nice_yaml }}'
+        dest: '{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/scenarios/centos-9/zuul_inventory.yml'

--- a/.zuul.d/e2e-run.yml
+++ b/.zuul.d/e2e-run.yml
@@ -12,3 +12,4 @@
           -e @scenarios/centos-9/base.yml
           -e @scenarios/centos-9/install_yamls.yml
           -e @scenarios/centos-9/ci.yml
+          -e @scenarios/centos-9/zuul_inventory.yml

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -23,7 +23,9 @@
       crc_parameters: "--memory 16000 --disk-size 120 --cpus 6"
     parent: base-crc
     pre-run: .zuul.d/e2e-prepare.yml
-    run: .zuul.d/e2e-run.yml
+    run:
+      - .zuul.d/dump_zuul_vars.yml
+      - .zuul.d/e2e-run.yml
     post-run: .zuul.d/collect-logs.yml
 
 - project:


### PR DESCRIPTION
In end-to-end job, we run nestd ansible-playbook in zuul jobs.

Developers defined the vars in Zuul job definition and it needs to be passed to nested plays so that we can run the tasks based on Zuul job vars.

dump_zuul_vars.yml playbook dumps all the vars in the zuul_inventory.yml file. It will be consumed in the nested playbook.

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
