### PR TITLE
Correct variable used for gating_repo location

### DIFF
--- a/ci_framework/roles/build_openstack_packages/tasks/create_repo.yml
+++ b/ci_framework/roles/build_openstack_packages/tasks/create_repo.yml
@@ -30,9 +30,9 @@
 - name: Run createrepo on generated rpms
   command: createrepo gating_repo
   args:
-    chdir: '{{ cifmw_bop_build_repo_dir }}'
+    chdir: '{{ cifmw_bop_gating_repo | ansible.builtin.dirname }}'
 
 - name: Compress the repo
   command: 'tar czf {{ cifmw_bop_gating_repo }}.tar.gz gating_repo'
   args:
-    chdir: '{{ cifmw_bop_build_repo_dir }}'
+    chdir: '{{ cifmw_bop_gating_repo | ansible.builtin.dirname }}'


### PR DESCRIPTION
If we decide to pass down a different "gating_repo" value using
cifmw_bop_gating_repo, we hit an issue when hitting the create_repo step

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
