### PR TITLE
Operator build plugin now outputs a results dictionary

### DIFF
--- a/ci_framework/roles/operator_build/molecule/default/converge.yml
+++ b/ci_framework/roles/operator_build/molecule/default/converge.yml
@@ -29,3 +29,19 @@
         cifmw_operator_build_operators:
           - name: "mariadb-operator"
             src: "{{ ansible_user_dir }}/mariadb-operator"
+
+    - name: Ensure that role output dict contains the expected values
+      ansible.builtin.assert:
+        that:
+          # Check the explicit build operator
+          - cifmw_operator_build_output['operators']['mariadb-operator']['commit_hash'] is defined
+          - cifmw_operator_build_output['operators']['mariadb-operator']['image'] is defined
+          - cifmw_operator_build_output['operators']['mariadb-operator']['image_bundle'] is defined
+          - cifmw_operator_build_output['operators']['mariadb-operator']['image_storage_bundle'] is defined
+          - cifmw_operator_build_output['operators']['mariadb-operator']['image_catalog'] is defined
+          # Check the meta operator build output
+          - cifmw_operator_build_output['operators']['openstack-operator']['commit_hash'] is defined
+          - cifmw_operator_build_output['operators']['openstack-operator']['image'] is defined
+          - cifmw_operator_build_output['operators']['openstack-operator']['image_bundle'] is defined
+          - cifmw_operator_build_output['operators']['openstack-operator']['image_storage_bundle'] is defined
+          - cifmw_operator_build_output['operators']['openstack-operator']['image_catalog'] is defined

--- a/ci_framework/roles/operator_build/tasks/build.yml
+++ b/ci_framework/roles/operator_build/tasks/build.yml
@@ -84,6 +84,16 @@
     operator_bundles: []
     cacheable: true
 
+- name: "{{ operator.name }} - Set operator build output"
+  ansible.builtin.set_fact:
+      cifmw_operator_build_output: >-
+        {{ cifmw_operator_build_output|combine({'operators': { operator.name: {
+          'image': operator_img,
+          'image_bundle': operator_img_bundle,
+          'image_storage_bundle': operator_img_storage_bundle,
+          'image_catalog': operator_img_catalog,
+        }}}, recursive=True)}}
+
 - name: "{{ operator.name }} - Call manifests"
   ci_make:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"

--- a/ci_framework/roles/operator_build/tasks/clone.yml
+++ b/ci_framework/roles/operator_build/tasks/clone.yml
@@ -24,3 +24,16 @@
     repo: "https://github.com/{{ cifmw_operator_build_org }}/{{ operator.name }}.git"
     dest: "{{ operator.src }}"
   when: not stat_op_src.stat.exists
+
+- name: "{{ operator.name }} - Fetch operator src commit"
+  ansible.builtin.command:
+    cmd: "git rev-parse HEAD"
+  register: operator_src_hash
+  when: operator.pr_sha is not defined
+
+- name: "{{ operator.name }} - Save operator src hash"
+  ansible.builtin.set_fact:
+    cifmw_operator_build_output: >-
+        {{ cifmw_operator_build_output|combine({'operators': { operator.name: {
+          'commit_hash': operator_src_hash.stdout if operator_src_hash is defined else operator.pr_sha
+        }}}, recursive=True)}}

--- a/ci_framework/roles/operator_build/tasks/main.yml
+++ b/ci_framework/roles/operator_build/tasks/main.yml
@@ -60,3 +60,9 @@
     operator: "{{ item }}"
   ansible.builtin.include_tasks: build.yml
   loop: "{{ meta_operator }}"
+
+- name: Gather role output
+  ansible.builtin.copy:
+    dest: "{{ cifmw_operator_build_basedir }}/artifacts/custom-operators.yml"
+    content: "{{ cifmw_operator_build_output | to_nice_yaml }}"
+    mode: 0644

--- a/ci_framework/roles/operator_build/vars/main.yml
+++ b/ci_framework/roles/operator_build/vars/main.yml
@@ -1,0 +1,26 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# While options found within the vars/ path can be overridden using extra
+# vars, items within this path are considered part of the role and not
+# intended to be modified.
+
+# All variables within this role should have a prefix of "cifmw_rhol_crc"
+
+# https://access.redhat.com/documentation/en-us/red_hat_openshift_local/2.14/html/getting_started_guide/installation_gsg#required-software-packages_gsg
+cifmw_operator_build_output:
+  operators: {}


### PR DESCRIPTION
To be able to fecth the operators build in the operators build step the role should pass to the next steps, mainly the deploy one, the images that were build.

As this role can add useful information for further usage like the git hash of each build operator the dictionary can be used for other fields in the future.

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
