### PR TITLE
Allow to pass an alternative image for golang

### DIFF
--- a/ci_framework/roles/operator_build/README.md
+++ b/ci_framework/roles/operator_build/README.md
@@ -7,6 +7,7 @@ you want to build meta-operator too, so the role can properly replace api refere
 * `cifmw_operator_build_basedir`: Base directory. Defaults to `cifmw_basedir` which defaults to **~/ci-framework**.
 * `cifmw_operator_build_dryrun`: (Boolean) Toggle `ci_make` `dry_run` flag. Defaults to **False**.
 * `cifmw_operator_build_golang_ct`: (String) Reference to the golang container. Defaults to **docker.io/library/golang:1.19**.
+* `cifmw_operator_build_golang_alt_ct`: (String) Reference to an alternative golang container. Defaults to **quay.io/projectquay/golang:1.19**.
 * `cifmw_operator_build_org`: (String) Operator's organization on GitHub. Defaults to **openstack-k8s-operators**.
 * `cifmw_operator_build_push_registry`: (String) Registry used to push images. Defaults to **quay.rdoproject.org**.
 * `cifmw_operator_build_push_org`: (String) Registry's organization to push image to. Defaults to **openstack-k8s-operators**.

--- a/ci_framework/roles/operator_build/defaults/main.yml
+++ b/ci_framework/roles/operator_build/defaults/main.yml
@@ -17,6 +17,7 @@
 cifmw_operator_build_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}"
 cifmw_operator_build_dryrun: false
 cifmw_operator_build_golang_ct: "docker.io/library/golang:1.19"
+cifmw_operator_build_golang_alt_ct: "quay.io/projectquay/golang:1.19"
 cifmw_operator_build_push_ct: true
 # Operator's Organization
 cifmw_operator_build_org: "openstack-k8s-operators"

--- a/ci_framework/roles/operator_build/tasks/build.yml
+++ b/ci_framework/roles/operator_build/tasks/build.yml
@@ -64,10 +64,21 @@
     - pr_sha is defined
     - operator.pr_owner is not defined
 
-- name: "{{ operator.name }} - Get golang container image"
-  containers.podman.podman_image:
-    name: "{{ cifmw_operator_build_golang_ct }}"
-    pull: true
+- name: Get container image
+  block:
+    - name: "{{ operator.name }} - Get golang container image"
+      containers.podman.podman_image:
+        name: "{{ cifmw_operator_build_golang_ct }}"
+        pull: true
+  rescue:
+    - name: "{{ operator.name }} - Get alternative golang container image"
+      containers.podman.podman_image:
+        name: "{{ cifmw_operator_build_golang_alt_ct }}"
+        pull: true
+    - name: Override image
+      ansible.builtin.set_fact:
+        cifmw_operator_build_golang_ct: "{{ cifmw_operator_build_golang_alt_ct }}"
+
 
 - name: "{{ operator.name }} - Set operator image tag"
   ansible.builtin.set_fact:


### PR DESCRIPTION
With the limitations of docker hub registry, it may be good to provide
an alternative image.

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
