### PR TITLE
Rework Zuul layout for molecule

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -42,8 +42,6 @@ scenario:
   test_sequence:
     - prepare
     - converge
-    - check
-    - verify
     - cleanup
 
 verifier:

--- a/.config/molecule/config_local.yml
+++ b/.config/molecule/config_local.yml
@@ -32,6 +32,7 @@ scenario:
   test_sequence:
     - prepare
     - converge
+    - cleanup
 
 verifier:
   name: ansible

--- a/.config/molecule/config_podman.yml
+++ b/.config/molecule/config_podman.yml
@@ -43,6 +43,4 @@ scenario:
   test_sequence:
     - prepare
     - converge
-    - check
-    - verify
     - cleanup

--- a/ci/playbooks/molecule-test.yml
+++ b/ci/playbooks/molecule-test.yml
@@ -5,8 +5,9 @@
     - name: Run molecule
       environment:
         ANSIBLE_LOG_PATH: "{{ ansible_user_dir }}/zuul-output/logs/ansible-execution.log"
-        MOLECULE_CONFIG: ".config/molecule/config_local.yml"
         MOLECULE_REPORT: "/tmp/report.html"
+        LC_ALL: en_US.utf8
+        LANG: en_US.utf8
       ansible.builtin.command:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
-        cmd: ./scripts/run_molecule "ci_framework/roles/"
+        chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/ci_framework/roles/{{ TEST_RUN }}"
+        cmd: "molecule -c {{ ansible_user_dir }}/{{ zuul.project.src_dir }}/.config/molecule/config_local.yml test --all"

--- a/ci/templates/jobs-init.yaml
+++ b/ci/templates/jobs-init.yaml
@@ -1,0 +1,21 @@
+- job:
+    name: cifmw-molecule-base
+    nodeset: centos-9-crc-xl
+    parent: base-minimal
+    pre-run: ci/playbooks/molecule-prepare.yml
+    run: ci/playbooks/molecule-test.yml
+    post-run: ci/playbooks/collect-logs.yml
+    required-projects:
+      - github.com/openstack-k8s-operators/install_yamls
+
+- job:
+    name: cifmw-end-to-end
+    nodeset: centos-9-crc-xxl
+    vars:
+      crc_parameters: "--memory 16000 --disk-size 120 --cpus 6"
+    parent: base-crc
+    pre-run: ci/playbooks/e2e-prepare.yml
+    run:
+      - ci/playbooks/dump_zuul_vars.yml
+      - ci/playbooks/e2e-run.yml
+    post-run: ci/playbooks/collect-logs.yml

--- a/ci/templates/jobs.yaml
+++ b/ci/templates/jobs.yaml
@@ -1,0 +1,10 @@
+- job:
+    name: cifmw-molecule-ROLE
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: ROLE
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/ROLE/(?!meta).*
+      - ^ci/playbooks/molecule.*

--- a/ci/templates/projects.yaml
+++ b/ci/templates/projects.yaml
@@ -1,0 +1,5 @@
+- project:
+    name: openstack-k8s-operators/ci-framework
+    github-check:
+      jobs:
+        - cifmw-end-to-end

--- a/ci_framework/playbooks/03-build-packages.yml
+++ b/ci_framework/playbooks/03-build-packages.yml
@@ -12,7 +12,7 @@
         - cifmw_pkg_build_list | length > 0
       ansible.builtin.include_role:
         name: pkg_build
-        tasks_from: build
+        tasks_from: build.yml
 
 - name: Run post_package_build hooks
   vars:

--- a/ci_framework/roles/ci_setup/molecule/default/converge.yml
+++ b/ci_framework/roles/ci_setup/molecule/default/converge.yml
@@ -52,3 +52,7 @@
             that:
               - dir_stat.stat.exists is defined
               - not dir_stat.stat.exists
+
+    - name: Recreate the full thing for proper log collection
+      ansible.builtin.import_role:
+        name: ci_setup

--- a/ci_framework/roles/install_yamls/molecule/default/converge.yml
+++ b/ci_framework/roles/install_yamls/molecule/default/converge.yml
@@ -22,7 +22,6 @@
       namespace: foobar
     ansible_user_dir: "{{ lookup('env', 'HOME') }}"
     cifmw_install_yamls_repo: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
-
   roles:
     - role: "install_yamls"
 
@@ -31,3 +30,20 @@
       ansible.builtin.assert:
         that:
           - ansible_facts['edpm_env'] is defined
+
+    - name: Gather some file data
+      register: make_files
+      ansible.builtin.stat:
+        path: "{{ ansible_user_dir }}/ci-framework/artifacts/roles/install_yamls_makes/tasks/{{ item }}.yml"
+      loop:
+        - make_all
+        - make_crc
+        - make_edpm_deploy
+        - make_infra
+
+    - name: Assert files do exist
+      ansible.builtin.assert:
+        that:
+          - item.stat.exists is defined
+          - item.stat.exists | bool
+      loop: "{{ make_files.results }}"

--- a/ci_framework/roles/install_yamls/tasks/main.yml
+++ b/ci_framework/roles/install_yamls/tasks/main.yml
@@ -52,6 +52,11 @@
     state: directory
 
 - name: "Generate make targets"
+  register: cifmw_generate_makes
   generate_make_tasks:
     install_yamls_path: "{{ cifmw_install_yamls_repo }}"
     output_directory: "{{ cifmw_install_yamls_tasks_out }}"
+
+- name: Debug generate_make module
+  ansible.builtin.debug:
+    var: cifmw_generate_makes

--- a/ci_framework/roles/libvirt_manager/tasks/deploy_edpm_compute.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/deploy_edpm_compute.yml
@@ -60,7 +60,7 @@
       DISK_FILEPATH: "{{ cifmw_libvirt_manager_basedir }}/workload/edpm-compute-{{ item }}.qcow2"
   ansible.builtin.include_role:
     name: 'install_yamls_makes'
-    tasks_from: 'make_edpm_compute'
+    tasks_from: 'make_edpm_compute.yml'
   with_sequence: start=0 end={{ compute_config.amount - 1 }}
 
 - name: Wait for EDPM computes to be ready
@@ -92,5 +92,5 @@
       CMDS_FILE: "{{ cifmw_libvirt_manager_basedir }}/artifacts/edpm_compute/compute_repo-{{ item }}.sh"
   ansible.builtin.include_role:
     name: 'install_yamls_makes'
-    tasks_from: 'make_edpm_compute_repos'
+    tasks_from: 'make_edpm_compute_repos.yml'
   with_sequence: start=0 end={{ compute_config.amount - 1 }}

--- a/ci_framework/roles/pkg_build/README.md
+++ b/ci_framework/roles/pkg_build/README.md
@@ -33,5 +33,5 @@ None
     - name: Build package
       ansible.builtin.include_role:
         name: "pkg_build"
-        tasks_from: "build"
+        tasks_from: "build.yml"
 ```

--- a/ci_framework/roles/pkg_build/molecule/default/converge.yml
+++ b/ci_framework/roles/pkg_build/molecule/default/converge.yml
@@ -32,4 +32,4 @@
     - name: Build package
       ansible.builtin.include_role:
         name: "pkg_build"
-        tasks_from: "build"
+        tasks_from: "build.yml"

--- a/ci_framework/roles/rhol_crc/molecule/add_crc_creds/cleanup.yml
+++ b/ci_framework/roles/rhol_crc/molecule/add_crc_creds/cleanup.yml
@@ -17,21 +17,8 @@
 
 - name: Prepare
   hosts: all
-  vars:
-    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
-    cifmw_basedir: "{{ ansible_user_dir }}/ci-framework"
-    cifmw_install_yamls_tasks_out: "{{ ansible_user_dir }}/.ansible/roles/install_yamls_makes/tasks"
-    cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
-  roles:
-    - role: test_deps
-    - role: ci_setup
-    - role: install_yamls
+
   tasks:
-    - name: Create crc_pull_secrets.txt
-      ansible.builtin.copy:
-        dest: "{{ cifmw_basedir }}/artifacts/.rhol_crc_pull_secret.txt"
-        content: |
-          {}
-    - name: Get rid of CRC
+    - name: Cleanup RHOL/CRC after tests
       ansible.builtin.command:
         cmd: crc cleanup

--- a/ci_framework/roles/rhol_crc/molecule/add_crc_creds/converge.yml
+++ b/ci_framework/roles/rhol_crc/molecule/add_crc_creds/converge.yml
@@ -21,4 +21,4 @@
     - name: Verify crc creds playbook
       ansible.builtin.include_role:
         name: rhol_crc
-        tasks_from: add_crc_creds
+        tasks_from: add_crc_creds.yml

--- a/ci_framework/roles/rhol_crc/molecule/add_crc_creds/prepare.yml
+++ b/ci_framework/roles/rhol_crc/molecule/add_crc_creds/prepare.yml
@@ -20,3 +20,7 @@
   roles:
     - role: test_deps
     - role: ci_setup
+  tasks:
+    - name: Start RHOL/CRC
+      ansible.builtin.command:
+        cmd: crc start

--- a/ci_framework/roles/rhol_crc/molecule/default/cleanup.yml
+++ b/ci_framework/roles/rhol_crc/molecule/default/cleanup.yml
@@ -17,21 +17,8 @@
 
 - name: Prepare
   hosts: all
-  vars:
-    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
-    cifmw_basedir: "{{ ansible_user_dir }}/ci-framework"
-    cifmw_install_yamls_tasks_out: "{{ ansible_user_dir }}/.ansible/roles/install_yamls_makes/tasks"
-    cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
-  roles:
-    - role: test_deps
-    - role: ci_setup
-    - role: install_yamls
+
   tasks:
-    - name: Create crc_pull_secrets.txt
-      ansible.builtin.copy:
-        dest: "{{ cifmw_basedir }}/artifacts/.rhol_crc_pull_secret.txt"
-        content: |
-          {}
-    - name: Get rid of CRC
+    - name: Cleanup RHOL/CRC after tests
       ansible.builtin.command:
         cmd: crc cleanup

--- a/ci_framework/roles/rhol_crc/molecule/install_yamls/cleanup.yml
+++ b/ci_framework/roles/rhol_crc/molecule/install_yamls/cleanup.yml
@@ -17,21 +17,8 @@
 
 - name: Prepare
   hosts: all
-  vars:
-    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
-    cifmw_basedir: "{{ ansible_user_dir }}/ci-framework"
-    cifmw_install_yamls_tasks_out: "{{ ansible_user_dir }}/.ansible/roles/install_yamls_makes/tasks"
-    cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
-  roles:
-    - role: test_deps
-    - role: ci_setup
-    - role: install_yamls
+
   tasks:
-    - name: Create crc_pull_secrets.txt
-      ansible.builtin.copy:
-        dest: "{{ cifmw_basedir }}/artifacts/.rhol_crc_pull_secret.txt"
-        content: |
-          {}
-    - name: Get rid of CRC
+    - name: Cleanup RHOL/CRC after tests
       ansible.builtin.command:
         cmd: crc cleanup

--- a/ci_framework/roles/rhol_crc/tasks/install_yamls.yml
+++ b/ci_framework/roles/rhol_crc/tasks/install_yamls.yml
@@ -14,7 +14,7 @@
       PATH: "{{ cifmw_path }}"
   ansible.builtin.include_role:
     name: "install_yamls_makes"
-    tasks_from: "make_crc_cleanup"
+    tasks_from: "make_crc_cleanup.yml"
 
 - name: Configure crc
   vars:
@@ -30,7 +30,7 @@
       PULL_SECRET: "{{ crc_configuration['pull-secret-file'] }}"
   ansible.builtin.include_role:
     name: "install_yamls_makes"
-    tasks_from: "make_crc"
+    tasks_from: "make_crc.yml"
 
 - name: Attach default network to CRC
   vars:
@@ -39,4 +39,4 @@
       PATH: "{{ cifmw_path }}"
   ansible.builtin.include_role:
     name: "install_yamls_makes"
-    tasks_from: "make_crc_attach_default_interface"
+    tasks_from: "make_crc_attach_default_interface.yml"

--- a/scripts/create_role_molecule
+++ b/scripts/create_role_molecule
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -xe
+
+PROJECT_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))/../"
+cp ${PROJECT_DIR}/ci/templates/jobs-init.yaml ${PROJECT_DIR}/zuul.d/jobs.yaml; \
+cp ${PROJECT_DIR}/ci/templates/projects.yaml ${PROJECT_DIR}/zuul.d/projects.yaml; \
+for role in ${PROJECT_DIR}/ci_framework/roles/* ; do \
+    role=`basename ${role}`; \
+    sed "s/ROLE/${role}/" ${PROJECT_DIR}/ci/templates/jobs.yaml >> ${PROJECT_DIR}/zuul.d/jobs.yaml; \
+    echo "        - cifmw-molecule-${role}" >> ${PROJECT_DIR}/zuul.d/projects.yaml; \
+done

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,17 +1,15 @@
----
 - job:
-    name: molecule
+    name: cifmw-molecule-base
     nodeset: centos-9-crc-xl
-    parent: base-crc
-    vars:
-      LC_ALL: en_US.utf8
-      LANG: en_US.utf8
+    parent: base-minimal
     pre-run: ci/playbooks/molecule-prepare.yml
     run: ci/playbooks/molecule-test.yml
     post-run: ci/playbooks/collect-logs.yml
+    required-projects:
+      - github.com/openstack-k8s-operators/install_yamls
 
 - job:
-    name: end-to-end
+    name: cifmw-end-to-end
     nodeset: centos-9-crc-xxl
     vars:
       crc_parameters: "--memory 16000 --disk-size 120 --cpus 6"
@@ -21,3 +19,163 @@
       - ci/playbooks/dump_zuul_vars.yml
       - ci/playbooks/e2e-run.yml
     post-run: ci/playbooks/collect-logs.yml
+- job:
+    name: cifmw-molecule-artifacts
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: artifacts
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/artifacts/(?!meta).*
+      - ^ci/playbooks/molecule.*
+- job:
+    name: cifmw-molecule-build_openstack_packages
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: build_openstack_packages
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/build_openstack_packages/(?!meta).*
+      - ^ci/playbooks/molecule.*
+- job:
+    name: cifmw-molecule-ci_setup
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: ci_setup
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/ci_setup/(?!meta).*
+      - ^ci/playbooks/molecule.*
+- job:
+    name: cifmw-molecule-copy_container
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: copy_container
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/copy_container/(?!meta).*
+      - ^ci/playbooks/molecule.*
+- job:
+    name: cifmw-molecule-discover_latest_image
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: discover_latest_image
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/discover_latest_image/(?!meta).*
+      - ^ci/playbooks/molecule.*
+- job:
+    name: cifmw-molecule-edpm_deploy
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: edpm_deploy
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/edpm_deploy/(?!meta).*
+      - ^ci/playbooks/molecule.*
+- job:
+    name: cifmw-molecule-install_yamls
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: install_yamls
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/install_yamls/(?!meta).*
+      - ^ci/playbooks/molecule.*
+- job:
+    name: cifmw-molecule-libvirt_manager
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: libvirt_manager
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/libvirt_manager/(?!meta).*
+      - ^ci/playbooks/molecule.*
+- job:
+    name: cifmw-molecule-operator_build
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: operator_build
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/operator_build/(?!meta).*
+      - ^ci/playbooks/molecule.*
+- job:
+    name: cifmw-molecule-operator_deploy
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: operator_deploy
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/operator_deploy/(?!meta).*
+      - ^ci/playbooks/molecule.*
+- job:
+    name: cifmw-molecule-pkg_build
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: pkg_build
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/pkg_build/(?!meta).*
+      - ^ci/playbooks/molecule.*
+- job:
+    name: cifmw-molecule-registry_deploy
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: registry_deploy
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/registry_deploy/(?!meta).*
+      - ^ci/playbooks/molecule.*
+- job:
+    name: cifmw-molecule-repo_setup
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: repo_setup
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/repo_setup/(?!meta).*
+      - ^ci/playbooks/molecule.*
+- job:
+    name: cifmw-molecule-rhol_crc
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: rhol_crc
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/rhol_crc/(?!meta).*
+      - ^ci/playbooks/molecule.*
+- job:
+    name: cifmw-molecule-run_hook
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: run_hook
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/run_hook/(?!meta).*
+      - ^ci/playbooks/molecule.*
+- job:
+    name: cifmw-molecule-test_deps
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: test_deps
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/test_deps/(?!meta).*
+      - ^ci/playbooks/molecule.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,7 +1,21 @@
----
 - project:
     name: openstack-k8s-operators/ci-framework
     github-check:
       jobs:
-        - molecule
-        - end-to-end
+        - cifmw-end-to-end
+        - cifmw-molecule-artifacts
+        - cifmw-molecule-build_openstack_packages
+        - cifmw-molecule-ci_setup
+        - cifmw-molecule-copy_container
+        - cifmw-molecule-discover_latest_image
+        - cifmw-molecule-edpm_deploy
+        - cifmw-molecule-install_yamls
+        - cifmw-molecule-libvirt_manager
+        - cifmw-molecule-operator_build
+        - cifmw-molecule-operator_deploy
+        - cifmw-molecule-pkg_build
+        - cifmw-molecule-registry_deploy
+        - cifmw-molecule-repo_setup
+        - cifmw-molecule-rhol_crc
+        - cifmw-molecule-run_hook
+        - cifmw-molecule-test_deps


### PR DESCRIPTION
From now on, we get on molecule job per role, relying on zuul's change
detection instead of some weird/terrible script.

We also take the opportunity to prefix jobs with "cifmw-", matching the
standard prefix related to the CI Framework parameters.

This patch also correct some inconsistencies and issues in the existing
ansible code:
- ensure we pass the ".yml" extension on "tasks_from"
- ensure generated tasks from Makefile have ".yml" instead of ".yaml"
- better error reporting/handling in generate_make_tasks module
- new debug data in generate_make_tasks module
- creates new parent job for molecule for common parts
- ensure "cleanup" step is called in molecule
- ensure "crc start" is called when needed in molecule "prepare" step
- some on-the-spot corrections needed under some roles that weren't
  caught

This PR has:
- [x] Appropriate testing (molecule, python unit tests)
- [x] Appropriate documentation (README in the role, main README is up-to-date)
