### PR TITLE
Added support for content provider job

### DIFF
--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -39,7 +39,7 @@
 
             - name: Check for Zuul inventory file
               ansible.builtin.stat:
-                path: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/scenarios/centos-9/zuul_inventory.yml"
+                path: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/scenarios/centos-9/zuul_inventory.yml"
               register: cifmw_zuul_state
 
             - name: Copy Zuul inventory file
@@ -47,7 +47,7 @@
               ansible.builtin.copy:
                 remote_src: true
                 dest: "{{ ansible_user_dir }}/ci-framework/logs"
-                src: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/scenarios/centos-9/zuul_inventory.yml"
+                src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/scenarios/centos-9/zuul_inventory.yml"
 
         - name: Get some env related data
           ansible.builtin.shell:

--- a/ci/playbooks/content_provider/content_provider.yml
+++ b/ci/playbooks/content_provider/content_provider.yml
@@ -1,0 +1,32 @@
+---
+- name: Bootstrap step
+  ansible.builtin.import_playbook: "{{ cifmw_project_root }}/ci_framework/playbooks/01-bootstrap.yml"
+
+- hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: true
+  tasks:
+    - name: Install necessary dependencies
+      ansible.builtin.include_role:
+        name: 'install_yamls_makes'
+        tasks_from: 'make_download_tools'
+
+    - name: Deploy content provider registry
+      ansible.builtin.include_role:
+        name: registry_deploy
+
+    - name: Build Operators
+      ansible.builtin.include_role:
+        name: operator_build
+
+    - name: Get the containers list from container registry
+      ansible.builtin.command: curl -X GET localhost:5001/v2/_catalog
+      register: cp_imgs
+
+    - name: Add the container list to file
+      ansible.builtin.copy:
+        mode: 0644
+        content: "{{ cp_imgs.stdout }}"
+        dest: "{{ ansible_user_dir }}/local_registry.log"
+
+- name: Run log related tasks
+  ansible.builtin.import_playbook: "{{ cifmw_project_root }}/ci_framework/playbooks/99-logs.yml"

--- a/ci/playbooks/content_provider/pre.yml
+++ b/ci/playbooks/content_provider/pre.yml
@@ -1,0 +1,12 @@
+---
+- hosts: all
+  tasks:
+    - name: Clone repos in the job workspace
+      include_role:
+        name: prepare-workspace
+
+    - name: Install ansible-core
+      become: true
+      package:
+        name: ansible-core
+        state: present

--- a/ci/playbooks/content_provider/run.yml
+++ b/ci/playbooks/content_provider/run.yml
@@ -1,0 +1,33 @@
+---
+- hosts: all
+  gather_facts: true
+  tasks:
+    - name: Deploy content provider
+      ansible.builtin.command:
+        chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
+        cmd: >-
+          ansible-playbook -i localhost,
+          -c local ci/playbooks/content_provider/content_provider.yml
+          -e @scenarios/centos-9/base.yml
+          -e @scenarios/centos-9/content_provider.yml
+          -e @scenarios/centos-9/zuul_inventory.yml
+
+    - name: Discover an IPv4 for provider job
+      ansible.builtin.set_fact:
+        content_provider_ip: >-
+          {{ hostvars[groups.all[0]].ansible_host if hostvars[groups.all[0]].ansible_host
+          is match("[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+")
+          else hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}
+
+    - name: Return Zuul Data
+      ansible.builtin.debug:
+        msg: >-
+          Running Content provider registry on
+          {{ content_provider_ip | default('nowhere') }}
+
+    - name: Set up content registry IP address
+      zuul_return:
+        data:
+          zuul:
+            pause: true
+          content_provider_registry_ip: "{{ content_provider_ip | default('nowhere') }}"

--- a/ci/playbooks/dump_zuul_vars.yml
+++ b/ci/playbooks/dump_zuul_vars.yml
@@ -16,4 +16,4 @@
       ansible.builtin.copy:
         mode: 0644
         content: '{{ _zuul_vars.all.vars | to_nice_yaml }}'
-        dest: '{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/scenarios/centos-9/zuul_inventory.yml'
+        dest: '{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/scenarios/centos-9/zuul_inventory.yml'

--- a/ci/playbooks/e2e-prepare.yml
+++ b/ci/playbooks/e2e-prepare.yml
@@ -21,5 +21,5 @@
 
     - name: Install requirements
       community.general.make:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
+        chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
         target: setup_molecule

--- a/ci_framework/roles/operator_build/defaults/main.yml
+++ b/ci_framework/roles/operator_build/defaults/main.yml
@@ -35,3 +35,5 @@ cifmw_operator_build_meta_name: "openstack-operator"
 cifmw_operator_build_meta_src: "{{ ansible_user_dir }}/src/github.com/{{ cifmw_operator_build_org }}/{{ cifmw_operator_build_meta_name }}"
 # Default base image name, used to build meta operator bundle
 cifmw_operator_build_meta_image_base: ""
+# Set vars for Local Registry
+cifmw_operator_build_local_registry: 0

--- a/ci_framework/roles/operator_build/tasks/build.yml
+++ b/ci_framework/roles/operator_build/tasks/build.yml
@@ -143,6 +143,7 @@
       IMAGENAMESPACE: "{{ cifmw_operator_build_push_org }}"
       IMAGEREGISTRY: "{{ cifmw_operator_build_push_registry }}"
       IMAGEBASE: "{{ operator.image_base | default('') }}"
+      LOCAL_REGISTRY: "{{ cifmw_operator_build_local_registry | default ('') }}"
 
 - name: "{{ operator.name }} - Builds storage-bundle for meta-operator"
   when:
@@ -160,6 +161,7 @@
           IMAGENAMESPACE: "{{ cifmw_operator_build_push_org }}"
           IMAGEREGISTRY: "{{ cifmw_operator_build_push_registry }}"
           IMAGEBASE: "{{ operator.image_base | default('') }}"
+          LOCAL_REGISTRY: "{{ cifmw_operator_build_local_registry | default ('') }}"
 
     - name: Add bundle to bundle list
       set_fact:
@@ -174,6 +176,10 @@
     params:
       BUNDLE_IMG: "{{ operator_img_bundle }}"
       BUNDLE_STORAGE_IMG: "{{ operator_img_storage_bundle }}"
+      IMAGENAMESPACE: "{{ cifmw_operator_build_push_org }}"
+      IMAGEREGISTRY: "{{ cifmw_operator_build_push_registry }}"
+      IMAGEBASE: "{{ operator.image_base | default('') }}"
+      LOCAL_REGISTRY: "{{ cifmw_operator_build_local_registry | default ('') }}"
 
 - name: "{{ operator.name }} - Add bundle to bundle list"
   set_fact:

--- a/ci_framework/roles/registry_deploy/tasks/main.yml
+++ b/ci_framework/roles/registry_deploy/tasks/main.yml
@@ -49,8 +49,10 @@
 
 - name: Add the local registry to unqualified-search-registries
   become: true
-  ansible.builtin.copy:
-    dest: /etc/containers/registries.conf.d/myregistry.conf
+  ansible.builtin.blockinfile:
+    state: present
+    insertafter: EOF
+    dest: /etc/containers/registries.conf
     content: |-
       [[registry]]
       location = "localhost:{{ cifmw_rp_registry_port }}"

--- a/scenarios/centos-9/ci.yml
+++ b/scenarios/centos-9/ci.yml
@@ -1,4 +1,5 @@
 ---
+ansible_user_dir: "{{ lookup('env', 'HOME') }}"
 cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
 
 cifmw_use_libvirt: true

--- a/scenarios/centos-9/content_provider.yml
+++ b/scenarios/centos-9/content_provider.yml
@@ -1,0 +1,9 @@
+---
+ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+cifmw_project_root: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
+cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
+cifmw_operator_build_push_registry: "localhost:5001"
+cifmw_operator_build_push_org: "openstack-k8s-operators"
+cifmw_operator_build_org: "openstack-k8s-operators"
+cifmw_operator_build_meta_build: true
+cifmw_operator_build_local_registry: 1

--- a/zuul.d/content_provider.yaml
+++ b/zuul.d/content_provider.yaml
@@ -1,0 +1,32 @@
+---
+- job:
+    name: content-provider-base
+    parent: base-ci-framework
+    nodeset: centos-stream-9
+    required-projects:
+      - opendev.org/zuul/zuul-jobs
+      - openstack-k8s-operators/install_yamls
+      - openstack-k8s-operators/openstack-operator
+      - name: github.com/openstack-k8s-operators/ci-framework
+        override-checkout: main
+      - name: github.com/openstack-k8s-operators/repo-setup
+        override-checkout: main
+      - name: openstack-k8s-operators/openstack-ansibleee-operator
+        override-checkout: main
+      - name: openstack-k8s-operators/keystone-operator
+        override-checkout: main
+      - name: openstack-k8s-operators/nova-operator
+        override-checkout: main
+      - name: openstack-k8s-operators/mariadb-operator
+        override-checkout: main
+      - name: openstack-k8s-operators/dataplane-operator
+        override-checkout: main
+      - name: openstack-k8s-operators/placement-operator
+        override-checkout: main
+    pre-run:
+      - ci/playbooks/content_provider/pre.yml
+    run:
+      - ci/playbooks/e2e-prepare.yml
+      - ci/playbooks/dump_zuul_vars.yml
+      - ci/playbooks/content_provider/run.yml
+    post-run: ci/playbooks/collect-logs.yml

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -10,3 +10,15 @@
     nodes:
       - name: controller
         label: centos-9-stream-crc-xxl
+
+- nodeset:
+    name: centos-stream-9
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-vexxhost
+    groups:
+      - name: switch
+        nodes:
+          - controller
+      - name: peers
+        nodes: []


### PR DESCRIPTION
It will be used to build operator images and push it to the
local registry.

The content provider job will be paused to serve as registry
and the dependent job will recieve the content provider
registry ip address and from that we can pull the image.

This PR has:
- [x] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
