### PR TITLE
Switch test_deps to repo_setup role

### DIFF
--- a/ci_framework/roles/repo_setup/README.md
+++ b/ci_framework/roles/repo_setup/README.md
@@ -13,3 +13,5 @@ which defaults to `~/ci-framework`
 * `cifmw_repo_setup_rdo_mirror`: Server from which to install RDO packages. Defaults to DLRN URI.
 * `cifmw_repo_setup_os_release`: Operating system release. Defaults to `ansible_distribution|lower`
 * `cifmw_repo_setup_src`: repo-setup repository location
+* `cifmw_repo_setup_output`: Repository files output. Defaults to `{{ cifmw_repo_setup_basedir }}/artifacts/repositories`
+* `cifmw_repo_setup_opts`: Additional options we may to pass to repo_setup. Defaults to `''`

--- a/ci_framework/roles/repo_setup/defaults/main.yml
+++ b/ci_framework/roles/repo_setup/defaults/main.yml
@@ -28,6 +28,8 @@ cifmw_repo_setup_rdo_mirror: "{{ cifmw_repo_setup_dlrn_uri }}"
 cifmw_repo_setup_os_release: "{{ ansible_distribution|lower }}"
 cifmw_repo_setup_dist_major_version: "{{ ansible_distribution_major_version }}"
 cifmw_repo_setup_src: "https://github.com/openstack-k8s-operators/repo-setup"
+cifmw_repo_setup_output: "{{ cifmw_repo_setup_basedir }}/artifacts/repositories"
+cifmw_repo_setup_opts: ''
 
 # Variables related to rhos-release tools
 # rhos-release is used in downstream to populate downstream base os repos

--- a/ci_framework/roles/repo_setup/tasks/configure.yml
+++ b/ci_framework/roles/repo_setup/tasks/configure.yml
@@ -1,5 +1,6 @@
 ---
 - name: Run repo-setup
+  become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"
   ansible.builtin.command:
     cmd: >-
       {{ cifmw_repo_setup_basedir }}/venv/bin/repo-setup
@@ -7,4 +8,5 @@
       -d {{ cifmw_repo_setup_os_release }}{{ cifmw_repo_setup_dist_major_version }}
       -b {{ cifmw_repo_setup_branch }}
       --rdo-mirror {{ cifmw_repo_setup_rdo_mirror }}
-      -o {{ cifmw_repo_setup_basedir }}/artifacts/repositories
+      -o {{ cifmw_repo_setup_output }}
+      {{ cifmw_repo_setup_opts }}

--- a/ci_framework/roles/repo_setup/tasks/install.yml
+++ b/ci_framework/roles/repo_setup/tasks/install.yml
@@ -24,8 +24,3 @@
     cmd: "{{ cifmw_repo_setup_basedir }}/venv/bin/python setup.py install"
     chdir: "{{ cifmw_repo_setup_basedir }}/tmp/repo-setup"
     creates: "{{ cifmw_repo_setup_basedir }}/venv/bin/repo-setup"
-
-- name: Create repository output directory
-  ansible.builtin.file:
-    path: "{{ cifmw_repo_setup_basedir }}/artifacts/repositories"
-    state: directory

--- a/ci_framework/roles/repo_setup/tasks/rhos_release.yml
+++ b/ci_framework/roles/repo_setup/tasks/rhos_release.yml
@@ -19,4 +19,4 @@
   ansible.builtin.command:
     cmd: >-
       rhos-release {{ cifmw_repo_setup_rhos_release_args }} \
-        -t {{ cifmw_repo_setup_basedir }}/artifacts/repositories
+        -t {{ cifmw_repo_setup_output }}

--- a/ci_framework/roles/test_deps/tasks/main.yml
+++ b/ci_framework/roles/test_deps/tasks/main.yml
@@ -66,28 +66,14 @@
         - ubi-9-baseos
         - ubi-9-codeready-builder
 
-- name: Block for tripleo-repos
-  when:
-    - (ansible_facts['os_family'] | lower) == 'redhat'
-  block:
-    - name: Fetch latest repo version
-      ansible.builtin.uri:
-        url: https://trunk.rdoproject.org/centos{{ ansible_facts['distribution_major_version'] }}/current/delorean.repo
-        return_content: true
-      register: cifmw_packages
-
-    - name: Create default repo file
-      become: true
-      ansible.builtin.copy:
-        content: "{{ cifmw_packages.content }}"
-        dest: /etc/yum.repos.d/delorean.repo
-        mode: 0644
-
-- name: Install tripleo-repos package
-  become: true
-  ansible.builtin.package:
-    name: "python*tripleo-repos"
-    state: present
+- name: Deploy repo-setup
+  vars:
+    cifmw_repo_setup_output: "/etc/yum.repos.d"
+    cifmw_repo_setup_branch: "master"
+    cifmw_repo_setup_promotion: "current-podified"
+    cifmw_repo_setup_opts: "{{ test_deps_setup_ceph | ternary('ceph', '', omit) }}"
+  ansible.builtin.include_role:
+    name: "repo_setup"
 
 - name: Tripleo setup block
   become: true
@@ -95,11 +81,6 @@
     - (ansible_facts['os_family'] | lower) == 'redhat'
     - test_deps_setup_cifmw | bool
   block:
-    - name: Create tripleo repos
-      ansible.builtin.command: tripleo-repos -d ubi9 \
-        {{ test_deps_setup_stream | ternary('--stream', '--no-stream', omit) }} \
-        -b master current-tripleo {{ test_deps_setup_ceph | ternary('ceph', '', omit) }}
-
     - name: Look for redhat-release rpm
       ansible.builtin.command: "rpm -qe redhat-release"
       register: rpm_found


### PR DESCRIPTION
tripleo-repo shouldn't be used anymore in there. Let's switch to the
newer setup tooling.

This patch also adds some more parameters to the repo_setup role in
order to match the previous features.

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
