### PR TITLE
Add operator src directory for usage in future deploy stages.

### DIFF
--- a/ci_framework/roles/operator_build/molecule/default/validate_outputs.yml
+++ b/ci_framework/roles/operator_build/molecule/default/validate_outputs.yml
@@ -35,7 +35,8 @@
 - name: "{{ operator.name }} - Ensure that role output dict contains the expected values"
   ansible.builtin.assert:
     that:
-      - cifmw_operator_build_output['operators'][operator.name]['commit_hash'] == op_tag
+      - cifmw_operator_build_output['operators'][operator.name]['git_src_dir'] == operator.src
+      - cifmw_operator_build_output['operators'][operator.name]['git_commit_hash'] == op_tag
       - cifmw_operator_build_output['operators'][operator.name]['image'] == op_img
       - cifmw_operator_build_output['operators'][operator.name]['image_bundle'] == op_img_bundle
       - cifmw_operator_build_output['operators'][operator.name]['image_storage_bundle'] == op_img_storage_bundle

--- a/ci_framework/roles/operator_build/tasks/build.yml
+++ b/ci_framework/roles/operator_build/tasks/build.yml
@@ -98,7 +98,8 @@
   ansible.builtin.set_fact:
       cifmw_operator_build_output: >-
         {{ cifmw_operator_build_output|combine({'operators': { operator.name: {
-          'commit_hash': pr_sha,
+          'git_commit_hash': pr_sha,
+          'git_src_dir': operator.src,
           'image': operator_img,
           'image_bundle': operator_img_bundle,
           'image_storage_bundle': operator_img_storage_bundle,


### PR DESCRIPTION
Since the edpm_prepare role needs the actual build src instead of a checkout of a branch (as src can be from a PR and not only the HEAD of a branch) the source path used during operator build should be passed along to make edpm_prepare clone its copy from that path.
Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/230