### PR TITLE
Allow to pass extra variables/parameters to playbook hooks

### DIFF
--- a/ci_framework/roles/run_hook/README.md
+++ b/ci_framework/roles/run_hook/README.md
@@ -20,6 +20,18 @@ In such a case, the following data can be provided to the hook:
 * `name`: Describe the hook.
 * `source`: Source of the playbook. If it's a filename, the playbook is expected in ci_framwork/hooks/playbooks. It can be an absolute path.
 * `type`: Type of the hook. In this case, set it to `playbook`.
+* `extra_vars`: Dictionary listing the extra variables you want to pass down
+
+##### Example
+```YAML
+pre_deploy:
+    - name: My hook
+      source: ceph-deploy.yml
+      type: playbook
+      extra_vars:
+        UUID: <some generated UUID>
+```
+
 
 #### CRD
 In such a case, the following data can be provided to the hook:

--- a/ci_framework/roles/run_hook/molecule/default/converge.yml
+++ b/ci_framework/roles/run_hook/molecule/default/converge.yml
@@ -17,20 +17,20 @@
 
 - name: Converge
   hosts: all
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
   tasks:
-    - name: Hook in dummy playbook
-      vars:
-        hooks:
-          - name: Dummy playbook
-            source: /tmp/dummy.yml
-            type: playbook
-      ansible.builtin.include_role:
-        name: run_hook
     - name: Hook project provided noop.yml
       vars:
         hooks:
           - name: Default noop hook
             source: noop.yml
             type: playbook
+          - name: With extra-vars
+            source: /tmp/dummy.yml
+            type: playbook
+            extra_vars:
+              foo: bar
+              file: '/tmp/dummy-env.yml'
       ansible.builtin.include_role:
         name: run_hook

--- a/ci_framework/roles/run_hook/molecule/default/prepare.yml
+++ b/ci_framework/roles/run_hook/molecule/default/prepare.yml
@@ -17,17 +17,30 @@
 
 - name: Prepare
   hosts: all
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
   roles:
     - role: test_deps
 
   tasks:
+    - name: Create dummy env file
+      ansible.builtin.copy:
+        dest: /tmp/dummy-env.yml
+        content: |
+          star: wars
+          other_star: trek
     - name: Create dummy playbook
       ansible.builtin.copy:
         dest: /tmp/dummy.yml
-        content: |
+        content: |-
           - hosts: localhost
             gather_facts: true
             tasks:
+          {% raw %}
               - name: Hello world
                 ansible.builtin.debug:
-                  msg: 'Hello world!'
+                  msg: 'Hello {{ foo }}'
+              - name: Debug some vars from file
+                ansible.builtin.debug:
+                  msg: "{{ star }} and {{ other_star }} are on a boat..."
+          {% endraw %}

--- a/ci_framework/roles/run_hook/tasks/main.yml
+++ b/ci_framework/roles/run_hook/tasks/main.yml
@@ -15,7 +15,7 @@
 # under the License.
 
 - name: Loop on the passed hooks and call correct action
-  vars:
-    hook: "{{ item }}"
-  ansible.builtin.include_tasks: "{{ item.type }}.yml"
+  ansible.builtin.include_tasks: "{{ hook.type }}.yml"
   loop: "{{ hooks }}"
+  loop_control:
+    loop_var: 'hook'

--- a/ci_framework/roles/run_hook/tasks/playbook.yml
+++ b/ci_framework/roles/run_hook/tasks/playbook.yml
@@ -7,6 +7,34 @@
       {%- else -%}
       {{ hook.source }}
       {%- endif -%}
+    extra_vars: >-
+      {%- if hook.extra_vars is defined and hook.extra_vars|length > 0 -%}
+      {% for key,value in hook.extra_vars.items() -%}
+      {%- if key == 'file' %}
+      -e "@{{ value }}"
+      {%- else %}
+      -e "{{ key }}={{ value }}"
+      {%- endif %}
+      {%- endfor %}
+      {%- endif %}
+
+- name: Debug extra_vars
+  when:
+    - hook.extra_vars is defined
+  ansible.builtin.debug:
+    var: hook.extra_vars
+
+- name: Ensure file exists
+  block:
+    - name: Get file stat
+      register: playbook_stat
+      ansible.builtin.stat:
+        path: "{{ playbook_path }}"
+    - name: Fail if playbook doesn't exist
+      when:
+        - not playbook_stat.stat.exists
+      ansible.builtin.fail:
+        msg: "Playbook {{ playbook_path }} doesn't seem to exist."
 
 # We cannot call ansible.builtin.import_playbook from within a play,
 # even less from a task. So the way to run a playbook from within a playbook
@@ -22,9 +50,14 @@
         cmd: >-
           ansible-playbook -i {{ hook.inventory | default('localhost,') }}
           -c {{ hook.connection | default('local') }}
+          {{ extra_vars }}
           {{ playbook_path }}
         create: "{{ hook.creates | default(omit) }}"
   always:
+    - name: Output hook command
+      ansible.builtin.debug:
+        var: play_output.cmd
+
     - name: Output play stderr
       ansible.builtin.debug:
         var: play_output.stderr_lines


### PR DESCRIPTION
Until now, we weren't able to pass any extra parameters to the playbook
we want to run as hooks.

This patch now corrects this limitation, and adds support for "inline
parameters" as well as "environment file". This means that "-e foo=bar"
as well as "-e @my-file.yml" are supported.

In order to leverage this, you'll need to add the following entry in the
hook dict:
```YAML
extra_vars:
  foo: bar
  file: /path/to/my/file
```

It will then be converted to proper parameters for the
`ansible-playbook` command.

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
