### PR TITLE
Introduce hook callback

### DIFF
--- a/ci_framework/playbooks/02-infra.yml
+++ b/ci_framework/playbooks/02-infra.yml
@@ -1,6 +1,7 @@
 - name: Run pre_infra hooks
   vars:
     hooks: "{{ pre_infra | default([]) }}"
+    step: pre_infra
   ansible.builtin.import_playbook: ./hooks.yml
 
 - hosts: "{{ cifmw_target_host | default('localhost') }}"
@@ -25,4 +26,5 @@
 - name: Run post_infra hooks
   vars:
     hooks: "{{ post_infra | default([]) }}"
+    step: post_infra
   ansible.builtin.import_playbook: ./hooks.yml

--- a/ci_framework/playbooks/03-build-packages.yml
+++ b/ci_framework/playbooks/03-build-packages.yml
@@ -1,6 +1,7 @@
 - name: Run pre_package_build hooks
   vars:
     hooks: "{{ pre_package_build | default([]) }}"
+    step: pre_package_build
   ansible.builtin.import_playbook: ./hooks.yml
 
 - hosts: "{{ cifmw_target_host | default('localhost') }}"
@@ -17,4 +18,5 @@
 - name: Run post_package_build hooks
   vars:
     hooks: "{{ post_package_build | default([]) }}"
+    step: post_package_build
   ansible.builtin.import_playbook: ./hooks.yml

--- a/ci_framework/playbooks/04-build-containers.yml
+++ b/ci_framework/playbooks/04-build-containers.yml
@@ -1,6 +1,7 @@
 - name: Run pre_container_build hooks
   vars:
     hooks: "{{ pre_container_build | default([]) }}"
+    step: pre_container_build
   ansible.builtin.import_playbook: ./hooks.yml
 
 - hosts: "{{ cifmw_target_host | default('localhost') }}"
@@ -13,4 +14,5 @@
 - name: Run post_container_build hooks
   vars:
     hooks: "{{ post_container_build | default([]) }}"
+    step: post_container_build
   ansible.builtin.import_playbook: ./hooks.yml

--- a/ci_framework/playbooks/05-build-operators.yml
+++ b/ci_framework/playbooks/05-build-operators.yml
@@ -1,6 +1,7 @@
 - name: Run pre_operator_build hooks
   vars:
     hooks: "{{ pre_operator_build | default([]) }}"
+    step: pre_operator_build
   ansible.builtin.import_playbook: ./hooks.yml
 
 - hosts: "{{ cifmw_target_host | default('localhost') }}"
@@ -22,4 +23,5 @@
 - name: Run post_operator_build hooks
   vars:
     hooks: "{{ post_operator_build | default([]) }}"
+    step: post_operator_build
   ansible.builtin.import_playbook: ./hooks.yml

--- a/ci_framework/playbooks/06-deploy-edpm.yml
+++ b/ci_framework/playbooks/06-deploy-edpm.yml
@@ -1,6 +1,7 @@
 - name: Run pre_deploy hooks
   vars:
     hooks: "{{ pre_deploy | default([]) }}"
+    step: pre_deploy
   ansible.builtin.import_playbook: ./hooks.yml
 
 - hosts: "{{ cifmw_target_host | default('localhost') }}"
@@ -14,4 +15,5 @@
 - name: Run post_deploy hooks
   vars:
     hooks: "{{ post_deploy | default([]) }}"
+    step: post_deploy
   ansible.builtin.import_playbook: ./hooks.yml

--- a/ci_framework/roles/run_hook/README.md
+++ b/ci_framework/roles/run_hook/README.md
@@ -14,13 +14,34 @@ play has a great chance of failure.
 #### Playbook
 In such a case, the following data can be provided to the hook:
 * `config_file`: Ansible configuration file. Defaults to `ansible_config_file`.
-* `connection`: Refer to the `--connection` option for `ansible-playbook`. Defaults to `local`.
 * `creates`: Refer to the `ansible.builtin.command` "creates" parameter. Defaults to `omit`.
-* `inventory`: Refer to the `--inventory` option for `ansible-playbook`. Defaults to `localhost,`.
+* `inventory`: Refer to the `--inventory` option for `ansible-playbook`. Defaults to `inventory_file`.
 * `name`: Describe the hook.
 * `source`: Source of the playbook. If it's a filename, the playbook is expected in ci_framwork/hooks/playbooks. It can be an absolute path.
 * `type`: Type of the hook. In this case, set it to `playbook`.
 * `extra_vars`: Dictionary listing the extra variables you want to pass down
+
+##### Hook callback
+A hook may generate new parameters that will be fed into the main play. In order
+to do so, the hook playbook has to create a YAML file as follow:
+```YAML
+- name: Feed generated content to main play
+  ansible.builtin.copy:
+    dest: "{{ cifmw_basedir }}/artifacts/{{ step }}_{{ hook_name }}.yml"
+    content: |
+      foo: bar
+      star: {{ my_favorit }}
+```
+The location and name are fixed. Both `cifmw_basedir`, `step` and `hook_name` are passed
+down to the hook playbook. Note that the value of `cifmw_basedir` will default
+to `~/ci-framework` if you don't pass it.
+
+In the same way, hooks may be able to consume data from a previous hook by loading
+the generated fil using `ansible.builtin.include_vars`, using the mentioned path.
+
+Note that `step` is fixed in the main playbooks, and are following the name of
+the various hook "timing" (`pre_infra`, `post_infra`, etc). The `hook_name` is
+a cleaned version of the `name` parameter you pass down in the hook description.
 
 ##### Example
 ```YAML

--- a/ci_framework/roles/run_hook/molecule/default/converge.yml
+++ b/ci_framework/roles/run_hook/molecule/default/converge.yml
@@ -19,18 +19,23 @@
   hosts: all
   vars:
     ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    step: molecule
+    hooks:
+      - name: Default noop hook
+        source: noop.yml
+        type: playbook
+      - name: With extra-vars
+        source: /tmp/dummy.yml
+        type: playbook
+        extra_vars:
+          foo: bar
+          file: '/tmp/dummy-env.yml'
   tasks:
     - name: Hook project provided noop.yml
-      vars:
-        hooks:
-          - name: Default noop hook
-            source: noop.yml
-            type: playbook
-          - name: With extra-vars
-            source: /tmp/dummy.yml
-            type: playbook
-            extra_vars:
-              foo: bar
-              file: '/tmp/dummy-env.yml'
       ansible.builtin.include_role:
         name: run_hook
+
+    - name: Ensure we have the ceph_uuid variable now
+      ansible.builtin.assert:
+        that:
+          - ceph_uuid is defined

--- a/ci_framework/roles/run_hook/molecule/default/prepare.yml
+++ b/ci_framework/roles/run_hook/molecule/default/prepare.yml
@@ -43,4 +43,9 @@
               - name: Debug some vars from file
                 ansible.builtin.debug:
                   msg: "{{ star }} and {{ other_star }} are on a boat..."
+              - name: Generate some output file
+                ansible.builtin.copy:
+                  dest: "{{ cifmw_basedir }}/artifacts/{{ step }}_{{ hook_name }}.yml"
+                  content: |
+                    ceph_uuid: 2107eea0-2344-43bf-9013-3d7ca67fc71e
           {% endraw %}

--- a/ci_framework/roles/run_hook/tasks/playbook.yml
+++ b/ci_framework/roles/run_hook/tasks/playbook.yml
@@ -1,6 +1,8 @@
 ---
 - name: "Set playbook {{ hook.name }} path"
   set_fact:
+    cifmw_basedir: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework') }}"
+    hook_name: "{{ hook.name | regex_replace('([^\x00-\x7F]|\\s|`)+', '_') |lower }}"
     playbook_path: >-
       {%- if hook.source is not ansible.builtin.abs -%}
       {{ role_path }}/../../hooks/playbooks/{{ hook.source }}
@@ -48,11 +50,26 @@
         ANSIBLE_CONFIG: "{{ hook.config_file | default(ansible_config_file) }}"
       ansible.builtin.command:
         cmd: >-
-          ansible-playbook -i {{ hook.inventory | default('localhost,') }}
-          -c {{ hook.connection | default('local') }}
+          ansible-playbook -i {{ hook.inventory | default(inventory_file) }}
           {{ extra_vars }}
+          -e "cifmw_basedir={{ cifmw_basedir }}"
+          -e "step={{ step }}"
+          -e "hook_name={{ hook_name }}"
           {{ playbook_path }}
         create: "{{ hook.creates | default(omit) }}"
+
+    - name: Load generated content if any
+      block:
+        - name: Check if we have a file
+          register: hook_callback
+          ansible.builtin.stat:
+            path: "{{ cifmw_basedir }}/artifacts/{{ step }}_{{ hook_name }}.yml"
+        - name: Load generated content in main playbook
+          when:
+            hook_callback.stat.exists
+          ansible.builtin.include_vars:
+            file: "{{ cifmw_basedir }}/artifacts/{{ step }}_{{ hook_name }}.yml"
+
   always:
     - name: Output hook command
       ansible.builtin.debug:


### PR DESCRIPTION
Introduce hook callback

If a hook creates a file such as
`{{ cifmw_basedir }}/artifacts/{{ step }}_{{ hook_name }}.yml`
the run_hook role will load it after the actual run.

`cifmw_basedir`, `hook_name` and `step` parameters are passed down from the
`run_hook` role directly, inheriting them from the main environment.

The generated file will then be loaded using the
ansible.builtin.include_vars, and they will then be available as
top-level parameters inside the main play.

This is especially interesting for hooks generating random content that
need to be feeded back in some other parts of the run. We may also
leverage this in order to pass data between hooks, since we may load the
data from within the hook playbook as well (location is known, nothing
would prevent this).

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
