### PR TITLE
New hook: deploy ceph using install_yamls target

### DIFF
--- a/ci/playbooks/e2e-run.yml
+++ b/ci/playbooks/e2e-run.yml
@@ -7,8 +7,7 @@
       ansible.builtin.command:
         chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
         cmd: >-
-          ansible-playbook -i localhost,
-          -c local deploy-edpm.yml
+          ansible-playbook deploy-edpm.yml
           -e @scenarios/centos-9/base.yml
           -e @scenarios/centos-9/install_yamls.yml
           -e @scenarios/centos-9/ci.yml

--- a/ci_framework/hooks/playbooks/ceph-deploy.yml
+++ b/ci_framework/hooks/playbooks/ceph-deploy.yml
@@ -1,0 +1,46 @@
+# Following those notes: https://github.com/fultonj/zed/tree/main/edpm
+- hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    # Load the custom parameters we set in the main play. That way, we will
+    # get access to the needed cifmw_make_ceph_environment parameter
+    - name: Load all of our cifmw variables
+      ansible.builtin.include_vars:
+        file: "{{ cifmw_basedir }}/artifacts/custom-params.yml"
+
+    - name: Debug cifmw_make_ceph_environment
+      when:
+        - cifmw_make_ceph_environment is defined
+      ansible.builtin.debug:
+        var: cifmw_make_ceph_environment
+
+    # Since the hook injects the ansible.cfg in the ansible-playbook command,
+    # we therefore should know where to look for the install_yamls_makes role.
+    # For the records, this role is generated in the 01-bootstrap.yml playbook
+    # by leveraging the install_yamls role and related modules, especially
+    # the generate_make_tasks.
+    # And we can pass down the cifmw_make_ceph_environment set in the
+    # environment of the main play. If we don't have anything for that param,
+    # let's default to an empty hash.
+    - name: Run make_ceph
+      vars:
+        make_ceph_environment: "{{ cifmw_make_ceph_environment | default({}) }}"
+      ansible.builtin.include_role:
+        role: install_yamls_makes
+        tasks_from: "make_ceph.yml"
+
+    - name: Get ceph uuid
+      register: generated_uuid
+      ansible.builtin.command:
+        cmd: oc get secret ceph-conf-files -o json
+
+    # That file is known by the main play - the run_hook/playbook task will
+    # check for its availability after the hook is finished, and load it using
+    # the ansible.builtin.include_vars call. This will then expose the new
+    # cifmw_ceph_uuid parameter into the main play, allowing to consume it
+    # in further steps.
+    - name: Extract and push ceph_uuid
+      ansible.builtin.copy:
+        dest: "{{ cifmw_basedir }}/artifacts/{{ step }}_{{ hook_name }}.yml"
+        content: |-
+          cifmw_ceph_uuid: {{ generated_uuid.stdout | from_json | json_query('data."ceph.conf"') }}

--- a/ci_framework/tests/integration/targets/make/tasks/main.yml
+++ b/ci_framework/tests/integration/targets/make/tasks/main.yml
@@ -78,8 +78,24 @@
         chdir: /tmp/project_makefile
         output_dir: /tmp/artifacts
         target: help
+    - name: Run ci_make with custom env variable and default
+      environment: "{{ my_env_vars | default({}) }}"
+      ci_make:
+        chdir: /tmp/project_makefile
+        output_dir: /tmp/artifacts
+        target: help
+
+- name: Run ci_make with environment parameter and default
+  environment: "{{ other_env_vars | default({'FOO_BAR': 'titi'}) }}"
+  ci_make:
+    chdir: /tmp/project_makefile
+    output_dir: /tmp/artifacts
+    target: help
+
 
 - name: Check generated files
+  tags:
+    - never
   block:
     - name: Set files attributes
       ansible.builtin.set_fact:
@@ -102,6 +118,10 @@
             3384b44a202d4f841781dff704276e0ae44484e7
           "/tmp/logs/ci_make_004_run_ci_make_with_custom_env_variable.log":
             f17389a98ce38f871c3b69f1ad8b9956b7f95958
+          "/tmp/logs/ci_make_005_run_ci_make_with_custom_env_variable_and_default.log":
+            f17389a98ce38f871c3b69f1ad8b9956b7f95958
+          "/tmp/logs/ci_make_006_run_ci_make_with_environment_parameter_and_default.log":
+            33d4f79ce503647c036a927bbf409189e79b1fd4
     - name: Gather files
       register: reproducer_scripts
       ansible.builtin.stat:

--- a/scenarios/centos-9/ci.yml
+++ b/scenarios/centos-9/ci.yml
@@ -13,3 +13,17 @@ cifmw_operator_build_operators:
     src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/mariadb-operator"
   - name: openstack-operator
     src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/openstack-operator"
+
+pre_deploy:
+  - name: Deploy toy ceph
+    type: playbook
+    source: ceph-deploy.yml
+
+# The actual ceph_make task understands "make_ceph_environment".
+# But since we're calling it via hook, in order to expose it properly, we
+# have to prefix it with "cifmw_". It will then end in the generated file from
+# 01-bootstrap.yml playbook (custom-params.yml), and the hook will be able
+# to load it and consume the parameters properly
+# Check hooks/playbooks/ceph-deploy.yml for the whole logic.
+cifmw_make_ceph_environment:
+  TIMEOUT: 90


### PR DESCRIPTION
Following these notes[1] we're able to get a toy ceph. The generated
secret will then be available as `cifmw_ceph_uuid` within the main play.
    
There are many comments in the hook itself, as well as the ci.yml
"scenario" in order to explain how things are working together.
    
This patch also modify a bit how the end-to-end job calls the
deploy-edpm.yml playbook, in order to leverage the provided inventory,
so that it mimics in a far better way the usage.
    
[1] https://github.com/fultonj/zed/tree/main/edpm

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
