### PR TITLE
Skip operator_build role if no operator list is provided

### DIFF
--- a/ci_framework/playbooks/05-build-operators.yml
+++ b/ci_framework/playbooks/05-build-operators.yml
@@ -17,6 +17,9 @@
         oc registry login --insecure=true
 
     - name: Build operator and meta-operator
+      when:
+        - cifmw_operator_build_operators is defined
+        - cifmw_operator_build_operators | length > 0
       ansible.builtin.include_role:
         name: operator_build
 


### PR DESCRIPTION
This PR has:
- [x] Appropriate testing (molecule, python unit tests)
- [x] Appropriate documentation (README in the role, main README is up-to-date)
