### PR TITLE
Pin ansible-compat in order to work around known issue

### DIFF
--- a/ci_framework/roles/edpm_deploy/molecule/default/prepare.yml
+++ b/ci_framework/roles/edpm_deploy/molecule/default/prepare.yml
@@ -19,6 +19,8 @@
   hosts: all
   vars:
     cifmw_basedir: "/tmp/ci-framework"
+    cifmw_install_yamls_defaults:
+      NAMESPACE: openstack
   roles:
     - role: test_deps
     - role: ci_setup

--- a/molecule-requirements.txt
+++ b/molecule-requirements.txt
@@ -17,3 +17,6 @@ ansible-core
 
 # Allows to unpin cryptography
 pyOpenSSL>=22.1.0
+
+# Work around https://github.com/ansible-community/molecule/issues/3903
+ansible-compat<=4.0.0


### PR DESCRIPTION
As described in
https://github.com/ansible-community/molecule/issues/3903 the latest
updates in ansible-compat are breaking molecule.

While waiting for the proper fix, let's just pin things up.
