### PR TITLE
Fixing edpm_deploy molecule test default var

### DIFF
--- a/ci_framework/roles/edpm_deploy/molecule/default/prepare.yml
+++ b/ci_framework/roles/edpm_deploy/molecule/default/prepare.yml
@@ -19,6 +19,8 @@
   hosts: all
   vars:
     cifmw_basedir: "/tmp/ci-framework"
+    cifmw_install_yamls_defaults:
+      NAMESPACE: openstack
   roles:
     - role: test_deps
     - role: ci_setup


### PR DESCRIPTION
Since the addition of openstack-k8s-operators/ci-framework#147 the edpm_deploy molecule test will fail as it will call ci_setup without a default value for the cifmw_install_yamls_defaults variable, needed there to create the CR directory, what is namespace dependant.

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
