### PR TITLE
Adding CodeQL badge to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CI-Framework
 
+[![CodeQL](https://github.com/openstack-k8s-operators/ci-framework/actions/workflows/codeql.yml/badge.svg)](https://github.com/openstack-k8s-operators/ci-framework/actions/workflows/codeql.yml)
+
 Still under heavy development - more info coming soon.
 
 ## Use Makefile for your own CI


### PR DESCRIPTION
Exceedingly simple way to demonstrate our CI status. 

This PR has:
- [x] Appropriate testing (molecule, python unit tests)
- [x] Appropriate documentation (README in the role, main README is up-to-date)
