### PR TITLE
Add playbooks and job to run kuttl tests

### DIFF
--- a/ci/playbooks/kuttl/e2e-kuttl.yml
+++ b/ci/playbooks/kuttl/e2e-kuttl.yml
@@ -1,0 +1,20 @@
+---
+- name: Bootstrap step
+  ansible.builtin.import_playbook: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/ci_framework/playbooks/01-bootstrap.yml"
+
+- name: Deploy and run KUTTL operator tests
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  tasks:
+    - name: Download install_yamls deps
+      ansible.builtin.include_role:
+        name: 'install_yamls_makes'
+        tasks_from: 'make_download_tools'
+
+    - name: Run kuttl tests
+      ansible.builtin.include_role:
+        name: 'install_yamls_makes'
+        tasks_from: 'make_{{ item }}_kuttl.yml'
+      loop: "{{ cifmw_kuttl_tests_operator_list | default(['cinder' 'keystone']) }}"
+
+- name: Run log related tasks
+  ansible.builtin.import_playbook: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/ci_framework/playbooks/99-logs.yml"

--- a/ci/playbooks/kuttl/run.yml
+++ b/ci/playbooks/kuttl/run.yml
@@ -1,0 +1,12 @@
+- hosts: controller
+  gather_facts: true
+  tasks:
+    - name: Run kuttl tests playbook
+      ansible.builtin.command:
+        chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
+        cmd: >-
+          ansible-playbook ci/playbooks/kuttl/e2e-kuttl.yml
+          -e @scenarios/centos-9/base.yml
+          -e @scenarios/centos-9/ci.yml
+          -e @scenarios/centos-9/kuttl.yml
+          -e @scenarios/centos-9/zuul_inventory.yml

--- a/scenarios/centos-9/kuttl.yml
+++ b/scenarios/centos-9/kuttl.yml
@@ -1,0 +1,4 @@
+---
+edpm_env:
+  OUT: "{{ cifmw_installyamls_repos }}/out"
+  STORAGE_CLASS: crc-csi-hostpath-provisioner

--- a/zuul.d/kuttl.yaml
+++ b/zuul.d/kuttl.yaml
@@ -1,0 +1,29 @@
+---
+- job:
+    name: cifmw-base-kuttl
+    nodeset: centos-9-crc-xxl
+    timeout: 5400
+    abstract: true
+    vars:
+      crc_parameters: "--memory 20000 --disk-size 120 --cpus 6"
+    parent: base-crc
+    pre-run:
+      - ci/playbooks/e2e-prepare.yml
+      - ci/playbooks/dump_zuul_vars.yml
+    run:
+      - ci/playbooks/kuttl/run.yml
+    post-run: ci/playbooks/collect-logs.yml
+
+- job:
+    name: cifmw-kuttl
+    parent: cifmw-base-kuttl
+    files:
+      - ^ci/playbooks/kuttl/.*
+      - ^scenarios/centos-9/kuttl.yml
+      - ^zuul.d/kuttl.yaml
+    vars:
+      cifmw_kuttl_tests_operator_list:
+        - cinder
+        - ansibleee
+        - ovs
+        - neutron

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -19,3 +19,4 @@
         - cifmw-molecule-rhol_crc
         - cifmw-molecule-run_hook
         - cifmw-molecule-test_deps
+        - cifmw-kuttl


### PR DESCRIPTION
This pr adds playbooks and job to run tests.
    
    Below are the playbooks:
    - ci/playbooks/kuttl/run.yml:
      Run kuttl tests in CI using e2e-kuttl.yml
    - ci/playbooks/kuttl/e2e-kuttl.yml:
      Contains the tasks for preparing the
      environment for running kuttl tests and calling
      trigger-kuttl-tests.yml to run the kuttl tests
    - trigger-kuttl-tests.yml:
      Install an operator and runs the kuttl tests
    
    scenarios/centos-9/kuttl.yml: contains all the
    vars overrides needed to run the kuttl tests.
    
    zuul.d/kuttl.yaml: contains the kuttl job definitions
    
    We can use cifmw-base-kuttl job as a parent and set
    the cifmw_kuttl_tests_operator_list var in the job
    definition. It will run the kuttl tests for each
    operators.
    
    Signed-off-by: Ronelle Landy <rlandy@redhat.com>
    Co-authored-by: Chandan Kumar <raukadah@gmail.com>


This PR has:
- [ x ] Appropriate testing (molecule, python unit tests)
- [ x ] Appropriate documentation (README in the role, main README is up-to-date)
