### PR TITLE
Some quick corrections to zuul and Containerfile.test

### DIFF
--- a/ci/templates/projects.yaml
+++ b/ci/templates/projects.yaml
@@ -3,3 +3,4 @@
     github-check:
       jobs:
         - cifmw-end-to-end
+        - cifmw-end-to-end-nobuild

--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -15,11 +15,11 @@
     cifmw_edpm_prepare_common_env:
       OUT: "{{ cifmw_edpm_prepare_manifests_dir }}"
     cifmw_edpm_prepare_make_openstack_env: |
-      {% if cifmw_operator_build_meta_name in operators_build_output %}
+      {% if cifmw_operator_build_meta_name is defined and cifmw_operator_build_meta_name in operators_build_output %}
       OPENSTACK_IMG: {{ operators_build_output[cifmw_operator_build_meta_name].image }}
       {% endif %}
     cifmw_edpm_prepare_make_openstack_deploy_env: |
-      {% if cifmw_operator_build_meta_name in operators_build_output %}
+      {% if cifmw_operator_build_meta_name is defined and cifmw_operator_build_meta_name in operators_build_output %}
       OPENSTACK_BRANCH: ""
       GIT_CLONE_OPTS: "-l"
       OPENSTACK_REPO: operators_build_output[cifmw_operator_build_meta_name].git_src_dir

--- a/ci_framework/roles/operator_build/tasks/build.yml
+++ b/ci_framework/roles/operator_build/tasks/build.yml
@@ -155,6 +155,10 @@
     - operator.name == cifmw_operator_build_meta_name
   block:
     - name: Call dep-bundle-build-push for meta-operator only
+      register: dep_bundle_build_push_result
+      until: dep_bundle_build_push_result.failed is false
+      retries: 5
+      delay: 10
       ci_make:
         dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
         chdir: "{{ operator.src }}"

--- a/containerfiles/Containerfile.tests
+++ b/containerfiles/Containerfile.tests
@@ -4,6 +4,7 @@ ENV USE_VENV=no
 ENV MOLECULE_CONFIG=.config/molecule/config_local.yml
 
 RUN adduser -d / -M prow
+RUN echo "prow ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/prow
 
 COPY ../ /opt/sources
 RUN chown -R prow: /opt/sources

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -3,6 +3,7 @@
     github-check:
       jobs:
         - cifmw-end-to-end
+        - cifmw-end-to-end-nobuild
         - cifmw-molecule-artifacts
         - cifmw-molecule-build_openstack_packages
         - cifmw-molecule-ci_setup


### PR DESCRIPTION
First, we want to enable the cifmw-end-to-end-nobuild job - it was
missing in the patch that created it, so it was never launched until
now.

Second, we want to make the local test container a bit more "like a
system" and allow to leverage sudo from the rootless "prow" user. It may
help debugging some situations.

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
