### PR TITLE
Disable e2e skip of the edpm_prepare metaoperator deployment

### DIFF
--- a/ci/playbooks/e2e-prepare.yml
+++ b/ci/playbooks/e2e-prepare.yml
@@ -2,6 +2,10 @@
 - hosts: controller
   gather_facts: true
   tasks:
+    - name: Clone repos in the job workspace
+      include_role:
+        name: prepare-workspace
+
     - name: Output pip related things
       ansible.builtin.command:
         cmd: pip --version
@@ -18,6 +22,7 @@
         name:
           - make
           - python3
+          - podman
 
     - name: Install requirements
       community.general.make:

--- a/ci_framework/hooks/playbooks/rabbitmq_tuning.yml
+++ b/ci_framework/hooks/playbooks/rabbitmq_tuning.yml
@@ -9,7 +9,7 @@
 
     - name: Patch rabbitmq resources for lower resource consumption
       ansible.builtin.shell: |
-        crname=$(oc get openstackcontrolplane -o name)
+        crname=$(oc get openstackcontrolplane -o name -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }})
         oc patch ${crname} --type json -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} \
           -p='[{"op": "replace", "path": "/spec/rabbitmq/templates/rabbitmq/resources/requests/cpu", "value": 500m}]'
         oc patch ${crname} --type json -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} \

--- a/ci_framework/playbooks/05-build-operators.yml
+++ b/ci_framework/playbooks/05-build-operators.yml
@@ -23,6 +23,10 @@
           ansible.builtin.command: |
             oc registry login --insecure=true
 
+        - name: CRC project create
+          ansible.builtin.command: |
+            oc new-project openstack
+
     - name: Build operator and meta-operator
       when:
         - cifmw_operator_build_operators is defined

--- a/ci_framework/roles/edpm_deploy/defaults/main.yml
+++ b/ci_framework/roles/edpm_deploy/defaults/main.yml
@@ -19,9 +19,6 @@
 # All variables within this role should have a prefix of "cifmw_edpm_deploy"
 cifmw_edpm_deploy_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}"
 cifmw_edpm_deploy_manifests_dir: "{{ cifmw_manifests | default(cifmw_edpm_deploy_basedir ~ '/artifacts/manifests') }}"
-cifmw_edpm_edploy_dataplane_operator_repo: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/dataplane-operator"
-cifmw_edpm_deploy_os_runner_img: "quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest"
-cifmw_edpm_deploy_dataplane_cr: "config/samples/dataplane_v1beta1_openstackdataplane.yaml"
 cifmw_edpm_deploy_log_path: "{{ cifmw_edpm_deploy_basedir }}/logs/edpm/edpm_deploy.log"
 cifmw_edpm_deploy_retries: 100
 cifmw_edpm_deploy_run_validation: false

--- a/ci_framework/roles/edpm_deploy/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy/tasks/main.yml
@@ -18,16 +18,13 @@
   ansible.builtin.set_fact:
     cifmw_edpm_deploy_env: |
       OUT: "{{ cifmw_edpm_deploy_manifests_dir }}"
-      DATAPLANE_REPO: "{{ cifmw_edpm_edploy_dataplane_operator_repo }}"
-      OPENSTACK_RUNNER_IMG: "{{ cifmw_edpm_deploy_os_runner_img }}"
-      OPENSTACK_DATAPLANE: "{{ cifmw_edpm_deploy_dataplane_cr }}"
       PATH: "{{ cifmw_path }}"
-    make_edpm_deploy_dryrun: "{{ cifmw_edpm_deploy_dryrun | bool }}"
     cacheable: true
 
 - name: Deploy EDPM
   vars:
-    make_edpm_deploy: "{{ combine(cifmw_edpm_deploy_env | from_yaml) }}"
+    make_edpm_deploy_env: "{{ cifmw_edpm_deploy_env | from_yaml }}"
+    make_edpm_deploy_dryrun: "{{ cifmw_edpm_deploy_dryrun | bool }}"
   ansible.builtin.include_role:
     name: 'install_yamls_makes'
     tasks_from: 'make_edpm_deploy'

--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -23,8 +23,25 @@
       {% if cifmw_operator_build_meta_name is defined and cifmw_operator_build_meta_name in operators_build_output %}
       OPENSTACK_BRANCH: ""
       GIT_CLONE_OPTS: "-l"
-      OPENSTACK_REPO: operators_build_output[cifmw_operator_build_meta_name].git_src_dir
+      OPENSTACK_REPO: {{ operators_build_output[cifmw_operator_build_meta_name].git_src_dir }}
       {% endif %}
+    cifmw_edpm_prepare_operators_build_output: "{{ operators_build_output }}"
+
+- name: Get internal OpenShift registry route
+  ansible.builtin.command:
+    cmd: "oc get route default-route -n openshift-image-registry -o jsonpath='{.spec.host}'"
+  register: cifmw_edpm_prepare_registry_default_route
+  ignore_errors: true
+
+- name: Allow image internal OpenShift registry image pulling
+  ansible.builtin.shell:
+    cmd: >
+      oc policy add-role-to-user system:image-puller system:anonymous -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} &&
+      oc policy add-role-to-user system:image-puller system:unauthenticated -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+  when:
+    - cifmw_operator_build_meta_name is defined and cifmw_operator_build_meta_name in cifmw_edpm_prepare_operators_build_output
+    - cifmw_edpm_prepare_operators_build_output[cifmw_operator_build_meta_name].image_catalog.split('/')[0] == cifmw_edpm_prepare_registry_default_route.stdout
+    - cifmw_edpm_prepare_registry_default_route is succeeded
 
 - name: Prepare inputs
   vars:
@@ -55,7 +72,7 @@
       until: cifmw_edpm_prepare_wait_installplan_out.rc == 0 and cifmw_edpm_prepare_wait_installplan_out.stdout != ""
       register: cifmw_edpm_prepare_wait_installplan_out
       retries: "{{ cifmw_edpm_prepare_wait_subscription_retries }}"
-      delay: 5
+      delay: 10
 
     - name: Wait for OpenStack operator to get installed
       ansible.builtin.command:

--- a/ci_framework/roles/rhol_crc/tasks/install_yamls.yml
+++ b/ci_framework/roles/rhol_crc/tasks/install_yamls.yml
@@ -6,7 +6,7 @@
 
 - name: Cleanup if needed/wanted
   when:
-    - "'crc' in vm_domains.list_vms"
+    - "'crc' in vm_domains"
     - cifmw_rhol_crc_force_cleanup|bool
   vars:
     make_crc_cleanup_dryrun: "{{ cifmw_rhol_crc_dryrun }}"
@@ -31,12 +31,3 @@
   ansible.builtin.include_role:
     name: "install_yamls_makes"
     tasks_from: "make_crc.yml"
-
-- name: Attach default network to CRC
-  vars:
-    make_crc_attach_default_interface_dryrun: "{{ cifmw_rhol_crc_dryrun }}"
-    make_crc_attach_default_interface_env:
-      PATH: "{{ cifmw_path }}"
-  ansible.builtin.include_role:
-    name: "install_yamls_makes"
-    tasks_from: "make_crc_attach_default_interface.yml"

--- a/ci_framework/roles/rhol_crc/tasks/main.yml
+++ b/ci_framework/roles/rhol_crc/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: Get VM domains through Virt
   community.libvirt.virt:
-    command: list_vms
+    command: info
     uri: "qemu:///system"
   register: vm_domains
 
@@ -33,7 +33,9 @@
 - name: Set VM status
   ansible.builtin.set_fact:
     crc_present: >-
-      {%- if 'crc' in vm_domains.list_vms -%}{{ true }}{%- else -%}{{ false }}{%- endif -%}
+      {%- if 'crc' in vm_domains -%}{{ true }}{%- else -%}{{ false }}{%- endif -%}
+    crc_running: >-
+      {%- if 'crc' in vm_domains and vm_domains.crc.state == 'running' -%}{{ true }}{%- else -%}{{ false }}{%- endif -%}
 
 - name: Fail if crc domain is already defined
   ansible.builtin.fail:
@@ -43,47 +45,61 @@
     - not cifmw_rhol_crc_force_cleanup|bool
     - not cifmw_rhol_crc_reuse | bool
 
-- name: Manage RHOL/CRC if not existing
-  when: (cifmw_rhol_crc_force_cleanup|bool) or not crc_present|bool
+- name: Clean/deploy CRC
   block:
-    - name: Check RHOL/CRC binary exists
-      ansible.builtin.stat:
-        path: "{{ cifmw_rhol_crc_binary }}"
-      register: cifmw_rhol_crc_binary_stat
-
-    - name: Get RHOL/CRC binary if does not exist
-      ansible.builtin.include_tasks: binary.yml
-      when: not cifmw_rhol_crc_binary_stat.stat.exists
-
-    - name: Setup sudoers file for sudo commands in RHOL/CRC setup
-      ansible.builtin.include_tasks: sudoers_grant.yml
-
-    - name: Clean RHOL/CRC if wanted
-      when:
-        - crc_present|bool
-        - cifmw_rhol_crc_force_cleanup | bool
-      ansible.builtin.include_tasks: cleanup.yml
-
-    - name: Configure RHOL/CRC using install_yamls
-      when:
-        - cifmw_rhol_crc_use_installyamls|bool
-      ansible.builtin.include_tasks: install_yamls.yml
-
-    - name: Manually configure RHOL/CRC
-      when:
-        - not cifmw_rhol_crc_use_installyamls|bool
+    - name: Retrieve RHOL/CRC if not existing
+      when: (cifmw_rhol_crc_force_cleanup|bool) or not crc_present|bool
       block:
-        - name: Set RHOL/CRC configuration options
-          ansible.builtin.include_tasks: configuration.yml
+        - name: Check RHOL/CRC binary exists
+          ansible.builtin.stat:
+            path: "{{ cifmw_rhol_crc_binary }}"
+          register: cifmw_rhol_crc_binary_stat
 
-        - name: Setup RHOL/CRC
-          ansible.builtin.command: "{{ cifmw_rhol_crc_binary }} setup"
-          register: cifmw_rhol_crc_cmd_setup
+        - name: Get RHOL/CRC binary if does not exist
+          ansible.builtin.include_tasks: binary.yml
+          when: not cifmw_rhol_crc_binary_stat.stat.exists
 
-        - name: Start RHOL/CRC
-          ansible.builtin.command: "{{ cifmw_rhol_crc_binary }} start"
-          register: cifmw_rhol_crc_cmd_start
+        - name: Setup sudoers file for sudo commands in RHOL/CRC setup
+          ansible.builtin.include_tasks: sudoers_grant.yml
 
+        - name: Clean RHOL/CRC if wanted
+          when:
+            - crc_present|bool
+            - cifmw_rhol_crc_force_cleanup | bool
+          ansible.builtin.include_tasks: cleanup.yml
+
+    - name: Configure and start RHOL/CRC
+      when: (cifmw_rhol_crc_force_cleanup|bool) or not crc_running|bool
+      block:
+        - name: Configure RHOL/CRC using install_yamls
+          when: cifmw_rhol_crc_use_installyamls|bool
+          ansible.builtin.include_tasks: install_yamls.yml
+
+        - name: Manually configure RHOL/CRC
+          when: not cifmw_rhol_crc_use_installyamls|bool
+          block:
+            - name: Set RHOL/CRC configuration options
+              ansible.builtin.include_tasks: configuration.yml
+
+            - name: Setup RHOL/CRC
+              ansible.builtin.command: "{{ cifmw_rhol_crc_binary }} setup"
+              register: cifmw_rhol_crc_cmd_setup
+
+            - name: Start RHOL/CRC
+              ansible.builtin.command: "{{ cifmw_rhol_crc_binary }} start"
+              register: cifmw_rhol_crc_cmd_start
+
+    - name: Attach default network to CRC
+      when: cifmw_rhol_crc_use_installyamls|bool
+      vars:
+        make_crc_attach_default_interface_dryrun: "{{ cifmw_rhol_crc_dryrun }}"
+        make_crc_attach_default_interface_env:
+          PATH: "{{ cifmw_path }}"
+      ansible.builtin.include_role:
+        name: "install_yamls_makes"
+        tasks_from: "make_crc_attach_default_interface.yml"
+
+  always:
     - name: Delete sudoers file
       ansible.builtin.include_tasks: sudoers_revoke.yml
 

--- a/scenarios/centos-9/ci-build.yml
+++ b/scenarios/centos-9/ci-build.yml
@@ -1,6 +1,6 @@
 ---
 cifmw_operator_build_push_registry: "default-route-openshift-image-registry.apps-crc.testing"
-cifmw_operator_build_push_org: "default"
+cifmw_operator_build_push_org: "openstack"
 cifmw_operator_build_meta_build: true
 cifmw_operator_build_operators:
   - name: mariadb-operator

--- a/scenarios/centos-9/ci.yml
+++ b/scenarios/centos-9/ci.yml
@@ -5,10 +5,24 @@ cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-o
 cifmw_use_libvirt: true
 cifmw_use_crc: true
 
+pre_infra:
+  - name: Download needed tools
+    inventory: "{{ cifmw_installyamls_repos }}/devsetup/hosts"
+    type: playbook
+    source: "{{ cifmw_installyamls_repos }}/devsetup/download_tools.yaml"
+
 pre_deploy:
   - name: Deploy toy ceph
     type: playbook
     source: ceph-deploy.yml
+
+post_ctlplane_deploy:
+  - name: Tune rabbitmq resources
+    type: playbook
+    source: rabbitmq_tuning.yml
+
+edpm_env:
+  BMO_SETUP: false
 
 # The actual ceph_make task understands "make_ceph_environment".
 # But since we're calling it via hook, in order to expose it properly, we
@@ -18,5 +32,3 @@ pre_deploy:
 # Check hooks/playbooks/ceph-deploy.yml for the whole logic.
 cifmw_make_ceph_environment:
   TIMEOUT: 90
-
-cifmw_edpm_prepare_dry_run: true

--- a/zuul.d/end-to-end.yaml
+++ b/zuul.d/end-to-end.yaml
@@ -3,25 +3,26 @@
 - job:
     name: cifmw-end-to-end
     nodeset: centos-9-crc-xxl
-    timeout: 5400
     files:
       - ^ci_framework/roles/.*_build
       - ^ci_framework/roles/build.*
     vars:
       crc_parameters: "--memory 20000 --disk-size 120 --cpus 6"
       cifmw_ci_builds: true
-    parent: base-crc
+    parent: base-simple-crc
     pre-run: ci/playbooks/e2e-prepare.yml
     run:
       - ci/playbooks/dump_zuul_vars.yml
       - ci/playbooks/e2e-run.yml
     post-run: ci/playbooks/collect-logs.yml
+    required-projects:
+      - github.com/openstack-k8s-operators/install_yamls
+    timeout: 5400
 
 # Run the "nobuild" for any other change. It's smaller and faster.
 - job:
     name: cifmw-end-to-end-nobuild
     nodeset: centos-9-crc-xxl
-    timeout: 5400
     irrelevant-files:
       - ^ci_framework/roles/.*_build
       - ^ci_framework/roles/build.*
@@ -29,12 +30,15 @@
     vars:
       crc_parameters: "--memory 20000 --disk-size 120 --cpus 6"
       cifmw_ci_builds: false
-    parent: base-crc
+    parent: base-simple-crc
     pre-run: ci/playbooks/e2e-prepare.yml
     run:
       - ci/playbooks/dump_zuul_vars.yml
       - ci/playbooks/e2e-run.yml
     post-run: ci/playbooks/collect-logs.yml
+    required-projects:
+      - github.com/openstack-k8s-operators/install_yamls
+    timeout: 5400
 
 # Run the dev workflow if we edit specific role(s)
 - job:


### PR DESCRIPTION
As a first approach the metaoperator deployment was disabled in e2e test to speed up the delivery of the role meanwhile the role was fixed for zuul deployments, as it hanged in the wait for the operator subscription.

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
