### PR TITLE
Allow skipping CRC storage deployment in edpm_prepare

### DIFF
--- a/ci_framework/roles/edpm_prepare/README.md
+++ b/ci_framework/roles/edpm_prepare/README.md
@@ -8,5 +8,6 @@ This role doesn't need privilege scalation.
 * `cifmw_edpm_prepare_basedir`: (String) Base directory. Defaults to `cifmw_basedir` which defaults to **~/ci-framework**.
 * `cifmw_edpm_prepare_dry_run`: (Boolean) Skips resources installations and waits. Defaults to false.
 * `cifmw_edpm_prepare_manifests_dir`: String) Directory in where install_yamls output manifests will be placed. Defaults to **"{{ cifmw_edpm_prepare_basedir }}/artifacts/manifests"**
-* `cifmw_edpm_skip_openstack_operator:`: (Boolean) Intentionally skips the deployment of the OpenStack metaoperator. Defaults to false.
+* `cifmw_edpm_prepare_skip_crc_storage_creation`: (Boolean) Intentionally skips the deployment of the CRC storage related resources. Defaults to false.
+* `cifmw_edpm_prepare_skip_openstack_operator:`: (Boolean) Intentionally skips the deployment of the OpenStack metaoperator. Defaults to false.
 * `cifmw_edpm_prepare_wait_subscription_retries`: (Integer) Number of retries, with 5 seconds delays, waiting for the OpenStack subscription to come up. Defaults to 5.

--- a/ci_framework/roles/edpm_prepare/defaults/main.yml
+++ b/ci_framework/roles/edpm_prepare/defaults/main.yml
@@ -19,6 +19,7 @@
 # All variables within this role should have a prefix of "cifmw_edpm_prepare"
 cifmw_edpm_prepare_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}"
 cifmw_edpm_prepare_manifests_dir: "{{ cifmw_manifests | default(cifmw_edpm_prepare_basedir ~ '/artifacts/manifests') }}"
-cifmw_edpm_skip_openstack_operator: false
+cifmw_edpm_prepare_skip_openstack_operator: false
 cifmw_edpm_prepare_wait_subscription_retries: 30
 cifmw_edpm_prepare_dry_run: false
+cifmw_edpm_prepare_skip_crc_storage_creation: false

--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -4,6 +4,7 @@
   when:
     - cifmw_use_crc is defined
     - cifmw_use_crc | bool
+    - not cifmw_edpm_prepare_skip_crc_storage_creation | bool
   ansible.builtin.include_role:
     name: 'install_yamls_makes'
     tasks_from: 'make_crc_storage'
@@ -35,7 +36,7 @@
 
 # TODO: Prepare a proper operator list that dictates what operators to deploy instead of relaying on a simple flag
 - name: OpenStack meta-operator installation
-  when: not cifmw_edpm_skip_openstack_operator
+  when: not cifmw_edpm_prepare_skip_openstack_operator
   block:
   - name: Install OpenStack operator
     vars:


### PR DESCRIPTION
This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
