### PR TITLE
Remove name and override-checkout from required projects

### DIFF
--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -17,7 +17,7 @@
       OUT: "{{ cifmw_edpm_prepare_manifests_dir }}"
     cifmw_edpm_prepare_make_openstack_env: |
       {% if cifmw_operator_build_meta_name is defined and cifmw_operator_build_meta_name in operators_build_output %}
-      OPENSTACK_IMG: {{ operators_build_output[cifmw_operator_build_meta_name].image }}
+      OPENSTACK_IMG: {{ operators_build_output[cifmw_operator_build_meta_name].image_catalog }}
       {% endif %}
     cifmw_edpm_prepare_make_openstack_deploy_env: |
       {% if cifmw_operator_build_meta_name is defined and cifmw_operator_build_meta_name in operators_build_output %}

--- a/ci_framework/tests/sanity/ignore-2.15.txt
+++ b/ci_framework/tests/sanity/ignore-2.15.txt
@@ -1,0 +1,1 @@
+ignore.txt

--- a/zuul.d/content_provider.yaml
+++ b/zuul.d/content_provider.yaml
@@ -7,22 +7,14 @@
       - opendev.org/zuul/zuul-jobs
       - openstack-k8s-operators/install_yamls
       - openstack-k8s-operators/openstack-operator
-      - name: github.com/openstack-k8s-operators/ci-framework
-        override-checkout: main
-      - name: github.com/openstack-k8s-operators/repo-setup
-        override-checkout: main
-      - name: openstack-k8s-operators/openstack-ansibleee-operator
-        override-checkout: main
-      - name: openstack-k8s-operators/keystone-operator
-        override-checkout: main
-      - name: openstack-k8s-operators/nova-operator
-        override-checkout: main
-      - name: openstack-k8s-operators/mariadb-operator
-        override-checkout: main
-      - name: openstack-k8s-operators/dataplane-operator
-        override-checkout: main
-      - name: openstack-k8s-operators/placement-operator
-        override-checkout: main
+      - github.com/openstack-k8s-operators/ci-framework
+      - github.com/openstack-k8s-operators/repo-setup
+      - openstack-k8s-operators/openstack-ansibleee-operator
+      - openstack-k8s-operators/keystone-operator
+      - openstack-k8s-operators/nova-operator
+      - openstack-k8s-operators/mariadb-operator
+      - openstack-k8s-operators/dataplane-operator
+      - openstack-k8s-operators/placement-operator
     pre-run:
       - ci/playbooks/content_provider/pre.yml
     run:

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -2,21 +2,19 @@
 # Base job for openstack crc based job
 - job:
     name: cifmw-base-crc-openstack
-    nodeset: centos-9-crc-xxl
+    nodeset: centos-9-crc-3xl
     timeout: 10800
     abstract: true
     parent: base-crc
     required-projects:
-      - github.com/openstack-k8s-operators/install_yamls
+      - openstack-k8s-operators/install_yamls
       - openstack-k8s-operators/openstack-operator
-      - name: github.com/openstack-k8s-operators/ci-framework
-        override-checkout: main
-      - name: github.com/openstack-k8s-operators/repo-setup
-        override-checkout: main
+      - github.com/openstack-k8s-operators/ci-framework
+      - github.com/openstack-k8s-operators/repo-setup
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     vars:
-      crc_parameters: "--memory 16000 --disk-size 120 --cpus 6"
+      crc_parameters: "--memory 20000 --disk-size 120 --cpus 6"
       pre_pull_images:
         - registry.redhat.io/rhosp-rhel9/openstack-rabbitmq:17.0
 
@@ -49,4 +47,4 @@
           operators:
               openstack-operator:
                   git_src_dir: /home/zuul-worker/src/github.com/openstack-k8s-operators/openstack-operator
-                  image: quay.io/openstack-k8s-operators/openstack-operator-index:latest
+                  image_catalog: quay.io/openstack-k8s-operators/openstack-operator-index:latest

--- a/zuul.d/end-to-end.yaml
+++ b/zuul.d/end-to-end.yaml
@@ -4,7 +4,7 @@
     nodeset: centos-9-crc-xxl
     timeout: 5400
     vars:
-      crc_parameters: "--memory 16000 --disk-size 120 --cpus 6"
+      crc_parameters: "--memory 20000 --disk-size 120 --cpus 6"
       cifmw_ci_builds: true
     parent: base-crc
     pre-run: ci/playbooks/e2e-prepare.yml
@@ -18,7 +18,7 @@
     nodeset: centos-9-crc-xxl
     timeout: 5400
     vars:
-      crc_parameters: "--memory 16000 --disk-size 120 --cpus 6"
+      crc_parameters: "--memory 20000 --disk-size 120 --cpus 6"
       cifmw_ci_builds: false
     parent: base-crc
     pre-run: ci/playbooks/e2e-prepare.yml

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -6,7 +6,7 @@
     run: ci/playbooks/molecule-test.yml
     post-run: ci/playbooks/collect-logs.yml
     required-projects:
-      - github.com/openstack-k8s-operators/install_yamls
+      - openstack-k8s-operators/install_yamls
 - job:
     name: cifmw-molecule-artifacts
     parent: cifmw-molecule-base

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -12,6 +12,12 @@
         label: centos-9-stream-crc-xxl
 
 - nodeset:
+    name: centos-9-crc-3xl
+    nodes:
+      - name: controller
+        label: centos-9-stream-crc-3xl
+
+- nodeset:
     name: centos-stream-9
     nodes:
       - name: controller


### PR DESCRIPTION
    Recently the default branch of all openstack-k8s-operators
    projects is changed from master to main.
    
    We donot need to hardcode the repo name and override-checkout
    in the Zuul job definition. This patch does the same.
    
    It also includes other changes:
    - Adds centos-9-crc-3xl nodeset for edpm jobs and
      also bumps the crc ram to 20 GB.
    - Adds ignore-2.15.txt to fix ansible tests.
    - image_catalog instead of image to reference
      the OPENSTACK_IMG value.
    
    Signed-off-by: Chandan Kumar <raukadah@gmail.com>


This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
