### PR TITLE
[Content provider]Return cifmw_operator_build_output var to child job

### DIFF
--- a/ci/playbooks/content_provider/content_provider.yml
+++ b/ci/playbooks/content_provider/content_provider.yml
@@ -19,7 +19,7 @@
         name: operator_build
 
     - name: Get the containers list from container registry
-      ansible.builtin.command: curl -X GET localhost:5001/v2/_catalog
+      ansible.builtin.command: "curl -X GET {{ cifmw_rp_registry_ip }}:5001/v2/_catalog"
       register: cp_imgs
 
     - name: Add the container list to file

--- a/ci/playbooks/content_provider/pre.yml
+++ b/ci/playbooks/content_provider/pre.yml
@@ -10,3 +10,11 @@
       package:
         name: ansible-core
         state: present
+
+    - name: Discover an IPv4 for provider job
+      ansible.builtin.set_fact:
+        cifmw_rp_registry_ip: >-
+          {{ hostvars[groups.all[0]].ansible_host if hostvars[groups.all[0]].ansible_host
+          is match("[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+")
+          else hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}
+        cacheable: true

--- a/ci/playbooks/content_provider/run.yml
+++ b/ci/playbooks/content_provider/run.yml
@@ -11,13 +11,20 @@
           -e @scenarios/centos-9/base.yml
           -e @scenarios/centos-9/content_provider.yml
           -e @scenarios/centos-9/zuul_inventory.yml
+          -e "cifmw_rp_registry_ip={{ cifmw_rp_registry_ip }}"
 
-    - name: Discover an IPv4 for provider job
+    - name: Include inner ansible vars file
+      ansible.builtin.slurp:
+        src: "{{ cifmw_artifacts_basedir }}/artifacts/ansible-vars.yml"
+      register: inner_ansible
+
+    - name: Get inner ansible vars
       ansible.builtin.set_fact:
-        content_provider_ip: >-
-          {{ hostvars[groups.all[0]].ansible_host if hostvars[groups.all[0]].ansible_host
-          is match("[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+")
-          else hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}
+        inner_ansible_vars: "{{ inner_ansible.content | b64decode | from_yaml }}"
+
+    - name: Set content provider
+      ansible.builtin.set_fact:
+        content_provider_ip: "{{ cifmw_rp_registry_ip }} "
 
     - name: Return Zuul Data
       ansible.builtin.debug:
@@ -31,3 +38,4 @@
           zuul:
             pause: true
           content_provider_registry_ip: "{{ content_provider_ip | default('nowhere') }}"
+          cifmw_operator_build_output: "{{ inner_ansible_vars.cifmw_operator_build_output }}"

--- a/ci_framework/roles/operator_build/tasks/build.yml
+++ b/ci_framework/roles/operator_build/tasks/build.yml
@@ -183,6 +183,7 @@
     output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
     target: bundle-build
     params:
+      IMG: "{{ operator_img }}"
       BUNDLE_IMG: "{{ operator_img_bundle }}"
       BUNDLE_STORAGE_IMG: "{{ operator_img_storage_bundle }}"
       IMAGENAMESPACE: "{{ cifmw_operator_build_push_org }}"

--- a/ci_framework/roles/registry_deploy/tasks/main.yml
+++ b/ci_framework/roles/registry_deploy/tasks/main.yml
@@ -55,5 +55,5 @@
     dest: /etc/containers/registries.conf
     content: |-
       [[registry]]
-      location = "localhost:{{ cifmw_rp_registry_port }}"
+      location = "{{ cifmw_rp_registry_ip }}:{{ cifmw_rp_registry_port }}"
       insecure = true

--- a/scenarios/centos-9/content_provider.yml
+++ b/scenarios/centos-9/content_provider.yml
@@ -2,7 +2,7 @@
 ansible_user_dir: "{{ lookup('env', 'HOME') }}"
 cifmw_project_root: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
 cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
-cifmw_operator_build_push_registry: "localhost:5001"
+cifmw_operator_build_push_registry: "{{ cifmw_rp_registry_ip | default('localhost') }}:5001"
 cifmw_operator_build_push_org: "openstack-k8s-operators"
 cifmw_operator_build_org: "openstack-k8s-operators"
 cifmw_operator_build_meta_build: true

--- a/zuul.d/content_provider.yaml
+++ b/zuul.d/content_provider.yaml
@@ -22,3 +22,5 @@
       - ci/playbooks/dump_zuul_vars.yml
       - ci/playbooks/content_provider/run.yml
     post-run: ci/playbooks/collect-logs.yml
+    vars:
+      cifmw_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}"


### PR DESCRIPTION
The child job depends on content provider. The content provider
needs to return cifmw_operator_build_output var to the child job
so that child job should consume the proper operator images
to do the deployment.
    
This patch also removes the hardcoded content provider ip
and replace it with var. It also moves the tasks to discover
the content provider ip in pre and pass it as a var to
 the inner ansible call.
    
Note: It also fixes the operator_build role to include
the operator image during make_bundle.
    
    Signed-off-by: Chandan Kumar <raukadah@gmail.com>

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
