### PR TITLE
Use centos-stream-9 nodeset instead of crc nodeset

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,6 +1,6 @@
 - job:
     name: cifmw-molecule-base
-    nodeset: centos-9-crc-xl
+    nodeset: centos-stream-9
     parent: base-minimal
     pre-run: ci/playbooks/molecule-prepare.yml
     run: ci/playbooks/molecule-test.yml
@@ -119,6 +119,7 @@
       - ^ci/playbooks/molecule.*
 - job:
     name: cifmw-molecule-operator_deploy
+    nodeset: centos-9-crc-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: operator_deploy
@@ -159,6 +160,7 @@
       - ^ci/playbooks/molecule.*
 - job:
     name: cifmw-molecule-rhol_crc
+    nodeset: centos-9-crc-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: rhol_crc


### PR DESCRIPTION
    CRC nodeset have higher memory and molecule jobs does not
    need higher memory.
    
    centos-stream-9 is a normal nodeset with low memory footprint.
    It will be useful for running molecule job. It will avoid the
    unwanted resources wastage.
    
    operator_deploy and rhol_crc molecule jobs requires crc node
    for testing.
    
    Signed-off-by: Chandan Kumar <raukadah@gmail.com>


This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
