### PR TITLE
Dynamically generate sanity-check ignore file based on Ansible version

### DIFF
--- a/ci_framework/tests/sanity/ignore-2.14.txt
+++ b/ci_framework/tests/sanity/ignore-2.14.txt
@@ -1,1 +1,0 @@
-ignore.txt

--- a/ci_framework/tests/sanity/ignore-2.15.txt
+++ b/ci_framework/tests/sanity/ignore-2.15.txt
@@ -1,1 +1,0 @@
-ignore.txt

--- a/scripts/run_ansible_test
+++ b/scripts/run_ansible_test
@@ -42,6 +42,11 @@ mkdir -p ${HOME}/code/ansible_collections/cifmw/general
 cp -ra ${PROJECT_DIR}ci_framework/* ${HOME}/code/ansible_collections/cifmw/general/
 ln -fs ${collection_path}/* ${HOME}/code/ansible_collections/
 
+# Create/append the sanity exceptions for the current ansible version
+ansible_version=$(python3 -c "import ansible; print(ansible.__version__)" | sed 's/\.[^.]*$//')
+cat  "${HOME}/code/ansible_collections/cifmw/general/tests/sanity/ignore.txt" >> \
+    "${HOME}/code/ansible_collections/cifmw/general/tests/sanity/ignore-${ansible_version}.txt"
+
 pushd ${HOME}/code/ansible_collections/cifmw/general
 ${ansible_test} sanity --test validate-modules
 if [ -d tests/integration ]; then


### PR DESCRIPTION
ansible-test uses a fixed pattern to fetch the ignore file to use for sanity checks, based on it's own version. This commit copies/appends the content of the ansible ignore.txt file to the collections ignore one to a ignore file with the proper filename based on the installed ansible version.

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
