### PR TITLE
Remove the unwanted cifmw_edpm_prepare_intall_yamls_output_dir var

### DIFF
--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -77,7 +77,7 @@
   block:
     - name: Find the OpenStack CR manifest
       ansible.builtin.find:
-        paths: "{{ cifmw_edpm_prepare_intall_yamls_output_dir }}/{{ cifmw_install_yamls_defaults['NAMESPACE'] }}/openstack/cr"
+        paths: "{{ cifmw_edpm_prepare_manifests_dir }}/{{ cifmw_install_yamls_defaults['NAMESPACE'] }}/openstack/cr"
         contains: "kind: OpenStackControlPlane"
         patterns: "*.yaml"
       register: cifmw_edpm_prepare_openstack_cr_manifest_paths

--- a/scenarios/centos-9/edpm_ci.yml
+++ b/scenarios/centos-9/edpm_ci.yml
@@ -13,13 +13,11 @@ cifmw_edpm_deploy_run_validation: true
 cifmw_edpm_prepare_skip_crc_storage_creation: true
 cifmw_edpm_prepare_skip_openstack_operator: true
 cifmw_edpm_prepare_make_openstack_deploy_env:
-  OUT: "{{ cifmw_installyamls_repos }}/out"
   STORAGE_CLASS: crc-csi-hostpath-provisioner
-cifmw_edpm_prepare_intall_yamls_output_dir: "{{ cifmw_installyamls_repos }}/out"
+
 cifmw_operator_build_meta_name: "openstack-operator"
 edpm_env:
   STORAGE_CLASS: crc-csi-hostpath-provisioner
-  OUT: "{{ cifmw_installyamls_repos }}/out"
 
 # edpm_deploy role vars
 cifmw_edpm_deploy_manifests_dir: "{{ cifmw_installyamls_repos }}/out"


### PR DESCRIPTION
The cifmw_edpm_prepare_intall_yamls_output_dir was part of the edpm_prepare role initial release and it was kept by error as it was replaced by cifmw_edpm_prepare_manifests_dir.

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
