### PR TITLE
Add edpm build images role

### DIFF
--- a/ci/playbooks/edpm_build_images/edpm_image_builder.yml
+++ b/ci/playbooks/edpm_build_images/edpm_image_builder.yml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  tasks:
+    - ansible.builtin.import_role:
+        name: repo_setup
+      vars:
+       cifmw_repo_setup_output: "/etc/yum.repos.d/"
+    - ansible.builtin.import_role:
+        name: edpm_build_images

--- a/ci/playbooks/edpm_build_images/run.yml
+++ b/ci/playbooks/edpm_build_images/run.yml
@@ -1,0 +1,18 @@
+---
+- hosts: all
+  gather_facts: true
+  tasks:
+    - name: Run EDPM build image
+      environment:
+        ANSIBLE_CONFIG: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/ansible.cfg"
+      ansible.builtin.command:
+        chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
+        cmd: >-
+          ansible-playbook ci/playbooks/edpm_build_images/edpm_image_builder.yml
+          -e @scenarios/centos-9/base.yml
+          {%- if cifmw_extras is defined %}
+          {%-   for extra_vars in cifmw_extras %}
+          -e "{{   extra_vars }}"
+          {%-   endfor %}
+          {%- endif %}
+          -e @scenarios/centos-9/zuul_inventory.yml

--- a/ci/templates/projects.yaml
+++ b/ci/templates/projects.yaml
@@ -14,4 +14,5 @@
         - cifmw-end-to-end
         - cifmw-end-to-end-nobuild-tagged
         - cifmw-kuttl
+        - cifmw-edpm-build-image
 # Start generated content

--- a/ci_framework/roles/edpm_build_images/README.md
+++ b/ci_framework/roles/edpm_build_images/README.md
@@ -1,0 +1,36 @@
+# edpm_build_images
+This role will build EDPM hardened uefi and ironic-python-agent image.
+This role also call the `discover_latest_image` and download the latest image,
+set proper exports for element and build images.
+It will package the images inside a container image for distribution based on
+the variables "cifmw_edpm_build_images_ironic_python_agent_package" and
+"cifmw_edpm_build_images_hardened_uefi_package".
+
+### Privilege escalation
+None
+
+### Parameters
+* `cifmw_edpm_build_images_basedir`: Base directory. Defaults to `cifmw_basedir` which  defaults to `~/ci-framework`.
+* `cifmw_edpm_build_images_artifacts`: Build images logs.
+* `cifmw_edpm_build_images_via_rpm`: Whether to install `edpm-image-builder` repo using rpm or not.
+* `cifmw_build_host_packages`: List of packges required to build the images.
+* `cifmw_edpm_build_images_elements`: Elements path which contains `edpm-image-builder` and `ironic-python-agent-builder` repo.
+* `cifmw_edpm_build_images_all`: (Boolean) Build both the `edpm-hardened-uefi` and `ironic-python-agent` images when it true. Default to false.
+* `cifmw_edpm_build_images_hardened_uefi`: (Boolean) Build `edpm-hardened-uefi` image when it true. Default to false.
+* `cifmw_edpm_build_images_ironic_python_agent`: (Boolean) Build `ironic-python-agent-builder` image when it true. Default to false.
+* `cifmw_edpm_build_images_hardened_uefi_package`: (Boolean) Packaged `edpm-hardened-uefi` image inside a container image for distribution. Default to false.
+* `cifmw_edpm_build_images_ironic_python_agent_package`: (Boolean) Packaged  `ironic-python-agent-builder` image inside a container image for distribution. Default to false.
+* `cifmw_edpm_build_images_dib_yum_repo_conf_centos`:  (List) List of yum repos to be used on centos node.
+* `cifmw_edpm_build_images_dib_yum_repo_conf_rhel`: (List) List of yum repos to be used on rhel node.
+* `cifmw_edpm_build_images_dib_yum_repo_conf`: (List) List of yum repos to be used, By default we select i.e `cifmw_edpm_build_images_dib_yum_repo_conf_centos` var or `cifmw_edpm_build_images_dib_yum_repo_conf_rhel` based on distro var.
+* `cifmw_edpm_build_images_tag`: (String) Tag with which we want to build container images. Default: `latest`.
+* `cifmw_edpm_build_images_dry_run`: (Boolean) Whether to perform a dry run of the image build. Default: false.
+
+### Example
+```YAML
+---
+- hosts: localhost
+  gather_facts: true
+  tasks:
+    - ansible.builtin.import_role:
+        name: edpm_build_images

--- a/ci_framework/roles/edpm_build_images/defaults/main.yml
+++ b/ci_framework/roles/edpm_build_images/defaults/main.yml
@@ -1,0 +1,53 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_edpm_build_images"
+
+cifmw_edpm_build_images_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+cifmw_edpm_build_images_artifacts: "{{ cifmw_edpm_build_images_basedir }}/artifacts"
+cifmw_edpm_build_images_via_rpm: true
+cifmw_edpm_build_images_host_packages:
+  - diskimage-builder
+  - openstack-ironic-python-agent-builder
+  - buildah
+cifmw_edpm_image_builder_repo_path: >-
+  {%- if cifmw_edpm_build_images_via_rpm | bool -%}
+    /usr/share/edpm-image-builder/
+  {%- else -%}
+    {{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/edpm-image-builder
+  {%- endif -%}
+cifmw_edpm_build_images_elements:
+  - "/usr/share/ironic-python-agent-builder/dib/"
+  - "{{ cifmw_edpm_image_builder_repo_path }}/dib/"
+cifmw_edpm_build_images_all: true
+cifmw_edpm_build_images_hardened_uefi: false
+cifmw_edpm_build_images_ironic_python_agent: false
+cifmw_edpm_build_images_hardened_uefi_package: true
+cifmw_edpm_build_images_ironic_python_agent_package: true
+cifmw_edpm_build_images_dib_yum_repo_conf_centos:
+  - /etc/yum.repos.d/*
+cifmw_edpm_build_images_dib_yum_repo_conf_rhel:
+  - /etc/yum.repos.d/*
+cifmw_edpm_build_images_dib_yum_repo_conf: >-
+  {% if ansible_distribution == 'RedHat' -%}
+  {{ cifmw_edpm_build_images_dib_yum_repo_conf_rhel }}
+  {%- else -%}
+  {{ cifmw_edpm_build_images_dib_yum_repo_conf_centos }}
+  {%- endif %}
+cifmw_edpm_build_images_tag: 'latest'
+cifmw_edpm_build_images_dry_run: false

--- a/ci_framework/roles/edpm_build_images/meta/main.yml
+++ b/ci_framework/roles/edpm_build_images/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- edpm_build_images
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: edpm
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - edpm
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/ci_framework/roles/edpm_build_images/molecule/default/converge.yml
+++ b/ci_framework/roles/edpm_build_images/molecule/default/converge.yml
@@ -1,0 +1,25 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_edpm_build_images_dry_run: true
+    cifmw_edpm_build_images_via_rpm: false
+  roles:
+    - role: "edpm_build_images"

--- a/ci_framework/roles/edpm_build_images/molecule/default/molecule.yml
+++ b/ci_framework/roles/edpm_build_images/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/edpm_build_images/molecule/default/prepare.yml
+++ b/ci_framework/roles/edpm_build_images/molecule/default/prepare.yml
@@ -1,0 +1,21 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps

--- a/ci_framework/roles/edpm_build_images/tasks/install.yml
+++ b/ci_framework/roles/edpm_build_images/tasks/install.yml
@@ -1,0 +1,25 @@
+---
+- name: Add edpm-image-builder to the list of packages to be installed on host
+  set_fact:
+    cifmw_edpm_build_images_host_packages: "{{ cifmw_edpm_build_images_host_packages + ['edpm-image-builder'] }}"
+  when:
+    - cifmw_edpm_build_images_via_rpm
+    - not cifmw_edpm_build_images_dry_run
+
+- name: Install required packages
+  when:
+    - not cifmw_edpm_build_images_dry_run
+  become: true
+  ansible.builtin.package:
+    name: "{{ cifmw_edpm_build_images_host_packages }}"
+    state: latest
+  tags:
+    - bootstrap
+    - packages
+
+- name: Ensure logs/edpm_images directory
+  ansible.builtin.file:
+    path: "{{ cifmw_edpm_build_images_basedir }}/logs/edpm_images"
+    state: directory
+  tags:
+    - bootstrap

--- a/ci_framework/roles/edpm_build_images/tasks/main.yml
+++ b/ci_framework/roles/edpm_build_images/tasks/main.yml
@@ -1,0 +1,43 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Install edpm-image-builder
+  ansible.builtin.import_tasks: install.yml
+
+- name: Find latest image name
+  when:
+    - cifmw_discovered_image_url is not defined
+    - not cifmw_edpm_build_images_dry_run
+  ansible.builtin.import_role:
+    name: discover_latest_image
+
+- name: Download TripleO source image
+  when:
+    - not cifmw_edpm_build_images_dry_run
+  ansible.builtin.get_url:
+    url: "{{ cifmw_discovered_image_url }}"
+    dest: "{{ cifmw_edpm_build_images_basedir }}"
+    timeout: 20
+  register: result
+  until: result is success
+  retries: 60
+  delay: 10
+
+- name: Run edpm-image-builder
+  ansible.builtin.import_tasks: run.yml
+
+- name: Package build images inside container image
+  ansible.builtin.import_tasks: package.yml

--- a/ci_framework/roles/edpm_build_images/tasks/package.yml
+++ b/ci_framework/roles/edpm_build_images/tasks/package.yml
@@ -1,0 +1,28 @@
+---
+- name: Package edpm-hardened-uefi image inside container image
+  when:
+    - (cifmw_edpm_build_images_hardened_uefi | bool) or (cifmw_edpm_build_images_all | bool)
+    - cifmw_edpm_build_images_hardened_uefi_package | bool
+    - not cifmw_edpm_build_images_dry_run
+  become: "{{ cifmw_edpm_build_images_via_rpm }}"
+  args:
+    chdir: "{{ cifmw_edpm_image_builder_repo_path }}"
+  ansible.builtin.command:
+    cmd: >-
+      buildah bud -f ./Containerfile.image
+      -t edpm-hardened-uefi:{{ cifmw_edpm_build_images_tag }}
+      --logfile {{ cifmw_edpm_build_images_basedir }}/logs/edpm_images/edpm_hardened_uefi_container_package.log
+
+- name: Package ironic-python-agent image inside container image
+  when:
+    - (cifmw_edpm_build_images_ironic_python_agent | bool) or (cifmw_edpm_build_images_all | bool)
+    - cifmw_edpm_build_images_ironic_python_agent_package | bool
+    - not cifmw_edpm_build_images_dry_run
+  become: "{{ cifmw_edpm_build_images_via_rpm }}"
+  args:
+    chdir: "{{ cifmw_edpm_image_builder_repo_path }}"
+  ansible.builtin.command:
+    cmd: >-
+      buildah bud -f ./Containerfile.ramdisk
+      -t ironic-python-agent:{{ cifmw_edpm_build_images_tag }}
+      --logfile {{ cifmw_edpm_build_images_basedir }}/logs/edpm_images/ironic_python_agent_container_package.log

--- a/ci_framework/roles/edpm_build_images/tasks/run.yml
+++ b/ci_framework/roles/edpm_build_images/tasks/run.yml
@@ -1,0 +1,32 @@
+---
+- name: Build EDPM hardened uefi image
+  become: "{{ cifmw_edpm_build_images_via_rpm }}"
+  when:
+    - (cifmw_edpm_build_images_hardened_uefi | bool) or (cifmw_edpm_build_images_all | bool)
+    - not cifmw_edpm_build_images_dry_run
+  environment:
+    DIB_LOCAL_IMAGE: "{{ cifmw_edpm_build_images_basedir }}/{{ cifmw_discovered_image_name }}"
+    DIB_YUM_REPO_CONF: "{{ cifmw_edpm_build_images_dib_yum_repo_conf | join(' ') }}"
+    ELEMENTS_PATH: "{{ cifmw_edpm_build_images_elements | join(':') }}"
+  ansible.builtin.shell: >-
+    diskimage-builder images/edpm-hardened-uefi-{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version }}-stream.yaml
+    > {{ cifmw_edpm_build_images_basedir }}/logs/edpm_images/edpm_hardened_uefi_image_build.log
+    2> {{ cifmw_edpm_build_images_basedir }}/logs/edpm_images/edpm_hardened_uefi_image_build_err.log
+  args:
+    chdir: "{{ cifmw_edpm_image_builder_repo_path }}"
+
+- name: Build ironic-python-agent image
+  become: "{{ cifmw_edpm_build_images_via_rpm }}"
+  when:
+    - (cifmw_edpm_build_images_ironic_python_agent | bool) or (cifmw_edpm_build_images_all | bool)
+    - not cifmw_edpm_build_images_dry_run
+  environment:
+    DIB_LOCAL_IMAGE: "{{ cifmw_edpm_build_images_basedir }}/{{ cifmw_discovered_image_name }}"
+    DIB_YUM_REPO_CONF: "{{ cifmw_edpm_build_images_dib_yum_repo_conf | join(' ') }}"
+    ELEMENTS_PATH: "{{ cifmw_edpm_build_images_elements | join(':') }}"
+  ansible.builtin.shell: >-
+    diskimage-builder images/ironic-python-agent-{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version }}-stream.yaml
+    > {{ cifmw_edpm_build_images_basedir }}/logs/edpm_images/ironic_python_agent_image_build.log
+    2> {{ cifmw_edpm_build_images_basedir }}/logs/edpm_images/ironic_python_agent_image_build_err.log
+  args:
+    chdir: "{{ cifmw_edpm_image_builder_repo_path }}"

--- a/docs/source/roles/edpm_build_images.md
+++ b/docs/source/roles/edpm_build_images.md
@@ -1,0 +1,1 @@
+../../../ci_framework/roles/edpm_build_images/README.md

--- a/zuul.d/edpm_build_images.yaml
+++ b/zuul.d/edpm_build_images.yaml
@@ -1,0 +1,26 @@
+---
+- job:
+    name: cifmw-base-edpm-build-images
+    nodeset: centos-stream-9
+    timeout: 5400
+    abstract: true
+    parent: base-ci-framework
+    required-projects:
+      - github.com/openstack-k8s-operators/edpm-image-builder
+    pre-run:
+      - ci/playbooks/molecule-prepare.yml
+    run:
+      - ci/playbooks/dump_zuul_vars.yml
+      - ci/playbooks/edpm_build_images/run.yml
+    post-run: ci/playbooks/collect-logs.yml
+    vars:
+      cifmw_repo_setup_branch: antelope
+      cifmw_edpm_build_images_via_rpm: false
+
+- job:
+    name: cifmw-edpm-build-images
+    parent: cifmw-base-edpm-build-images
+    files:
+      - ^ci/playbooks/edpm_build_images/.*
+      - ^scenarios/centos-9/edpm_build_images_ci.yml
+      - ^zuul.d/edpm_build_images.yaml

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -10,6 +10,16 @@
       - ^ci_framework/roles/artifacts/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
+    name: cifmw-molecule-edpm-build-images
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: edpm_build_images
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/edpm_build_images/(?!meta|README).*
+      - ^ci/playbooks/molecule.*
+- job:
     name: cifmw-molecule-build_openstack_packages
     parent: cifmw-molecule-base
     vars:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -14,8 +14,10 @@
         - cifmw-end-to-end
         - cifmw-end-to-end-nobuild-tagged
         - cifmw-kuttl
+        - cifmw-edpm-build-images
 # Start generated content
         - cifmw-molecule-artifacts
+        - cifmw-molecule-edpm-build-images
         - cifmw-molecule-build_openstack_packages
         - cifmw-molecule-ci_setup
         - cifmw-molecule-copy_container


### PR DESCRIPTION
This PR added below list of stuff
- [x] edpm-hardened-uefi and ironic-python-agent build images role
- [x] Molecule job to test the role
- [x] Appropriate documentation (README in the role, main README is up-to-date)
