### PR TITLE
Update mol test playbook for consuming it in edpm-ansible jobs

### DIFF
--- a/ci/playbooks/molecule-prepare.yml
+++ b/ci/playbooks/molecule-prepare.yml
@@ -21,5 +21,5 @@
 
     - name: Install venv
       community.general.make:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
+        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}"
         target: setup_molecule

--- a/ci/playbooks/molecule-test.yml
+++ b/ci/playbooks/molecule-test.yml
@@ -9,5 +9,5 @@
         LC_ALL: en_US.utf8
         LANG: en_US.utf8
       ansible.builtin.command:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/ci_framework/roles/{{ TEST_RUN }}"
-        cmd: "molecule -c {{ ansible_user_dir }}/{{ zuul.project.src_dir }}/.config/molecule/config_local.yml test --all"
+        chdir: "{{ roles_dir }}"
+        cmd: "molecule -c {{ mol_config_dir }} test --all"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -7,6 +7,9 @@
     post-run: ci/playbooks/collect-logs.yml
     required-projects:
       - openstack-k8s-operators/install_yamls
+    vars:
+      roles_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/ci_framework/roles/{{ TEST_RUN }}"
+      mol_config_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/.config/molecule/config_local.yml"
 - job:
     name: cifmw-molecule-artifacts
     parent: cifmw-molecule-base


### PR DESCRIPTION
In order to use ci-framework molecule base zuul jobs in edpm-ansible
project, We need to make the roles path and molecule config path
configurable using ansible vars in molecule-test.yml playbook.
    
It will help to override the roles_path with edpm_ansible roles
and test it via zuul jobs.
    
Here is the edpm-ansible pr [1] which uses the same.
    
[1]. https://github.com/openstack-k8s-operators/edpm-ansible/pull/154


This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
