### PR TITLE
Fix typo in task description

### DIFF
--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -15,13 +15,13 @@
 - name: Import package build playbook
   ansible.builtin.import_playbook: ci_framework/playbooks/03-build-packages.yml
 
-- name: Import package build playbook
+- name: Import containers build playbook
   ansible.builtin.import_playbook: ci_framework/playbooks/04-build-containers.yml
 
-- name: Import package build playbook
+- name: Import operators build playbook
   ansible.builtin.import_playbook: ci_framework/playbooks/05-build-operators.yml
 
-- name: Import package build playbook
+- name: Import deploy edpm playbook
   ansible.builtin.import_playbook: ci_framework/playbooks/06-deploy-edpm.yml
 
 - name: Run log related tasks


### PR DESCRIPTION
All tasks were with the same description, which was hard to identify the steps checking the logs. This is a simple patch to fix the description for each task in the playbook.

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
