### PR TITLE
Run commands before and after kuttl run

### DIFF
--- a/ci/playbooks/kuttl/e2e-kuttl.yml
+++ b/ci/playbooks/kuttl/e2e-kuttl.yml
@@ -11,10 +11,10 @@
         tasks_from: 'make_download_tools'
 
     - name: Run kuttl tests
-      ansible.builtin.include_role:
-        name: 'install_yamls_makes'
-        tasks_from: 'make_{{ item }}_kuttl.yml'
+      include_tasks: run-kuttl-tests.yml
       loop: "{{ cifmw_kuttl_tests_operator_list | default(['cinder' 'keystone']) }}"
+      loop_control:
+        loop_var: operator
 
 - name: Run log related tasks
   ansible.builtin.import_playbook: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/ci_framework/playbooks/99-logs.yml"

--- a/ci/playbooks/kuttl/run-kuttl-tests.yml
+++ b/ci/playbooks/kuttl/run-kuttl-tests.yml
@@ -1,0 +1,17 @@
+---
+- name: 'Get resource status before {{ operator }}_kuttl run'
+  ansible.builtin.shell: |
+    {{ item }} >> {{ cifmw_artifacts_basedir }}/logs/cmd_before_{{ operator }}_kuttl.log
+  loop: "{{ commands_before_kuttl_run }}"
+  ignore_errors: true
+
+- name: 'Run make_{{ operator }}_kuttl'
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_{{ operator }}_kuttl.yml'
+
+- name: 'Get resource status after {{ operator }}_kuttl run'
+  ansible.builtin.shell: |
+    {{ item }} > {{ cifmw_artifacts_basedir }}/logs/cmd_after_{{ operator }}_kuttl.log
+  loop: "{{ commands_after_kuttl_run }}"
+  ignore_errors: true

--- a/scenarios/centos-9/kuttl.yml
+++ b/scenarios/centos-9/kuttl.yml
@@ -1,3 +1,4 @@
 ---
 cifmw_install_yamls_vars:
   STORAGE_CLASS: crc-csi-hostpath-provisioner
+cifmw_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"

--- a/zuul.d/kuttl.yaml
+++ b/zuul.d/kuttl.yaml
@@ -25,5 +25,7 @@
       cifmw_kuttl_tests_operator_list:
         - cinder
         - ansibleee
-        - ovs
-        - neutron
+      commands_before_kuttl_run:
+        - oc get pv
+      commands_after_kuttl_run:
+        - oc get pv


### PR DESCRIPTION
This pr improves the kuttl zuul job by adding two vars.
command_before_kuttl_run and command_after_kuttl_run will be used
to run specific commands before and after kuttl run.
    
It will help to debug kuttl issues when multiple kuttl tests are
triggered with in a job.
    
Signed-off-by: Ronelle Landy <rlandy@redhat.com>
Co-authored-by: Chandan Kumar <raukadah@gmail.com>

This PR has:
- [x] Appropriate testing (molecule, python unit tests)
- [ ] ~~Appropriate documentation (README in the role, main README is up-to-date)~~
