### PR TITLE
Admin network setup role

### DIFF
--- a/ansible-requirements.txt
+++ b/ansible-requirements.txt
@@ -3,3 +3,4 @@ importlib-metadata
 jsonschema  # MIT
 oauthlib>=3.2.0 # k8s lib that requires manual upgrade
 kubernetes
+openstacksdk

--- a/ci_framework/playbooks/07-admin-setup.yml
+++ b/ci_framework/playbooks/07-admin-setup.yml
@@ -1,0 +1,18 @@
+- name: Run pre_admin_setup hooks
+  vars:
+    hooks: "{{ pre_admin_setup | default([]) }}"
+    step: pre_admin_setup
+  ansible.builtin.import_playbook: ./hooks.yml
+
+- hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Create openstack network elements
+      ansible.builtin.import_role:
+        name: os_net_setup
+
+- name: Run post_admin_setup hooks
+  vars:
+    hooks: "{{ post_admin_setup | default([]) }}"
+    step: post_admin_setup
+  ansible.builtin.import_playbook: ./hooks.yml

--- a/ci_framework/roles/os_net_setup/README.md
+++ b/ci_framework/roles/os_net_setup/README.md
@@ -1,0 +1,12 @@
+## Role: os_net_setup
+This is typically an admin task before going into production,
+creating network for the users.
+
+### Privilege escalation
+Not as sudo, but needs access to k8s openstack namespace and
+being an openstack admin on the API.
+
+### Parameters
+* `cifmw_os_net_setup_config`: See an example in ci_framework/roles/os_net_setup/defaults/main.yml
+* `cifmw_os_net_setup_kubeconfig_context`: context used for k8s auth from a KUBECONFIG
+* `cifmw_os_net_setup_kubeconfig_location`: KUBECONFIG location

--- a/ci_framework/roles/os_net_setup/defaults/main.yml
+++ b/ci_framework/roles/os_net_setup/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_os_net_setup"
+cifmw_os_net_setup_config:
+  - name: public
+    external: true
+    provider_network_type: flat
+    provider_physical_network: datacentre
+    subnets:
+      - name: public_subnet
+        cidr: 192.168.122.0/24
+        allocation_pool_start: 192.168.122.200
+        allocation_pool_end: 192.168.122.210
+        gateway_ip: 192.168.122.1
+        enable_dhcp: false
+cifmw_os_net_setup_kubeconfig_context: admin
+# cifmw_os_net_setup_kubeconfig_location defaults to cifmw_install_yamls_vars.KUBECONFIG

--- a/ci_framework/roles/os_net_setup/meta/main.yml
+++ b/ci_framework/roles/os_net_setup/meta/main.yml
@@ -1,0 +1,22 @@
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- os_net_setup
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: openstack
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - openstack
+
+dependencies: []

--- a/ci_framework/roles/os_net_setup/molecule/default/converge.yml
+++ b/ci_framework/roles/os_net_setup/molecule/default/converge.yml
@@ -14,18 +14,12 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-collections:
-  - name: https://github.com/ansible-collections/ansible.posix
-    type: git
-  - name: https://github.com/ansible-collections/community.general
-    type: git
-  - name: https://github.com/containers/ansible-podman-collections
-    type: git
-  - name: https://github.com/ansible-collections/community.libvirt
-    type: git
-  - name: https://github.com/ansible-collections/community.crypto
-    type: git
-  - name: https://github.com/ansible-collections/kubernetes.core
-    type: git
-  - name: https://github.com/openstack/ansible-collections-openstack
-    type: git
+
+- name: Converge
+  hosts: all
+  tasks:
+    - name: No molecule for that role
+      ansible.builtin.debug:
+        msg: |
+          No molecule for that role, since it covered
+          by the e2e job

--- a/ci_framework/roles/os_net_setup/molecule/default/molecule.yml
+++ b/ci_framework/roles/os_net_setup/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/os_net_setup/tasks/main.yml
+++ b/ci_framework/roles/os_net_setup/tasks/main.yml
@@ -1,0 +1,48 @@
+- name: get openstack admin credentials from k8s
+  vars:
+      k8s_kubeconfig: "{{ cifmw_os_net_setup_kudeconfig_location | default(cifmw_install_yamls_vars.KUBECONFIG) | default(ansible_user_dir + '/.crc/machines/crc/kubeconfig') }}"
+      k8s_context: "{{ cifmw_os_net_setup_kubeconfig_context | default('admin') }}"
+  block:
+  - name: Get clouds.yaml configuration
+    kubernetes.core.k8s_info:
+      kubeconfig: "{{ k8s_kubeconfig }}"
+      context: "{{ k8s_context }}"
+      kind: ConfigMap
+      namespace: openstack
+      name: openstack-config
+    register: clouds_yaml
+
+  - name: Get the OSP admin password
+    kubernetes.core.k8s_info:
+      kubeconfig: "{{ k8s_kubeconfig }}"
+      context: "{{ k8s_context }}"
+      kind: Secret
+      namespace: openstack
+      name: openstack-config-secret
+    register: osp_secret
+
+- name: Construct auth param for openstack
+  block:
+  - name: Set openstack auth fact
+    ansible.builtin.set_fact:
+      openstack_auth: |
+        {{ ((clouds_yaml.resources[0].data['clouds.yaml']| from_yaml)['clouds']['default'] |
+        combine ({'auth': { 'password' : (osp_secret.resources[0].data['secure.yaml']|b64decode|from_yaml)['clouds']['default']['auth']['password']} }, recursive=true))['auth'] }}
+      region_name: "{{ (clouds_yaml.resources[0].data['clouds.yaml']| from_yaml)['clouds']['default']['region_name'] }}"
+  rescue:
+  - fail:
+      msg: |
+        Failed to Retrive auth Infomation
+        clouds.yaml: {{ clouds_yaml }}
+        osp_secret: {{ osp_secret }}
+
+- openstack.cloud.networks_info:
+    auth: "{{ openstack_auth }}"
+  register: net_info
+
+- name: Process network list element
+  ansible.builtin.include_tasks:
+    file: subtask_net.yml
+  loop: "{{ cifmw_os_net_setup_config|flatten(levels=1) }}"
+  loop_control:
+    loop_var: net_item

--- a/ci_framework/roles/os_net_setup/tasks/subtask_net.yml
+++ b/ci_framework/roles/os_net_setup/tasks/subtask_net.yml
@@ -1,0 +1,46 @@
+- name: Process network list elements
+  openstack.cloud.network:
+     admin_state_up: '{{ net_args.admin_state_up | default(omit) }}'
+     dns_domain: '{{ net_args.dns_domain | default(omit) }}'
+     external: '{{ net_args.external | default(omit) }}'
+     mtu: '{{ net_args.mtu | default(omit) }}'
+     name: '{{ net_args.name | default(omit) }}'
+     port_security_enabled: '{{ net_args.port_security_enabled | default(omit) }}'
+     provider_network_type: '{{ net_args.provider_network_type | default(omit) }}'
+     provider_physical_network: '{{ net_args.provider_physical_network | default(omit) }}'
+     provider_segmentation_id: '{{ net_args.provider_segmentation_id | default(omit) }}'
+     shared: '{{ net_args.shared | default(omit) }}'
+     region_name: '{{ region_name }}'
+     state: present
+     auth: "{{ openstack_auth }}"
+  vars:
+    net_args: "{{ net_item | combine ({'subnets': omit}, recursive=true) }}"
+  register:
+     net_info
+
+- name: Process subnet list elements
+  openstack.cloud.subnet:
+     allocation_pool_end: '{{ subnet_item.allocation_pool_end | default(omit) }}'
+     allocation_pool_start: '{{ subnet_item.allocation_pool_start | default(omit) }}'
+     cidr: '{{ subnet_item.cidr | default(omit) }}'
+     description: '{{ subnet_item.description | default(omit) }}'
+     disable_gateway_ip: '{{ subnet_item.disable_gateway_ip | default(omit) }}'
+     dns_nameservers: '{{ subnet_item.dns_nameservers | default(omit) }}'
+     extra_attrs: '{{ subnet_item.extra_attrs | default(omit) }}'
+     gateway_ip: '{{ subnet_item.gateway_ip | default(omit) }}'
+     host_routes: '{{ subnet_item.host_routes | default(omit) }}'
+     ip_version: '{{ subnet_item.ip_version | default(omit) }}'
+     ipv6_address_mode: '{{ subnet_item.ipv6_address_mode | default(omit) }}'
+     ipv6_ra_mode: '{{ subnet_item.ipv6_ra_mode | default(omit) }}'
+     is_dhcp_enabled: '{{ subnet_item.is_dhcp_enabled | default(omit) }}'
+     name: '{{ subnet_item.name | default(omit) }}'
+     network: "{{ net_info.id }}"
+     prefix_length: '{{ subnet_item.prefix_length | default(omit) }}'
+     subnet_pool: '{{ subnet_item.subnet_pool | default(omit) }}'
+     use_default_subnet_pool: '{{ subnet_item.use_default_subnet_pool | default(omit) }}'
+     region_name: '{{ region_name }}'
+     state: present
+     auth: "{{ openstack_auth }}"
+  loop: "{{ net_item.subnets | flatten(levels=1) }}"
+  loop_control:
+    loop_var: subnet_item

--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -24,6 +24,9 @@
 - name: Import deploy edpm playbook
   ansible.builtin.import_playbook: ci_framework/playbooks/06-deploy-edpm.yml
 
+- name: Import admin setup related playbook
+  ansible.builtin.import_playbook: ci_framework/playbooks/07-admin-setup.yml
+
 - name: Run log related tasks
   ansible.builtin.import_playbook: ci_framework/playbooks/99-logs.yml
   when: not zuul_log_collection | default ('false') | bool

--- a/docs/source/roles/os_net_setup.md
+++ b/docs/source/roles/os_net_setup.md
@@ -1,0 +1,1 @@
+../../../ci_framework/roles/os_net_setup/README.md

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -58,6 +58,8 @@ Allowed parameter names are:
 * `post_ctlplane_deploy`: after Control Plane deployment
 * `pre_tests`: before running tests
 * `post_tests`: after running tests
+* `pre_admin_setup`: before admin setup
+* `post_admin_setup`: before admin setup
 * `pre_reporting`: before running reporting
 * `post_reporting`: after running reporting
 


### PR DESCRIPTION
Adding basic subnet and network creation using
ansible modules now.
Currenly only network and subnet supported,
but it might be exteded with routers and subnetpools

This PR has:
- [x] Appropriate testing (molecule, python unit tests)
- [x] Appropriate documentation (README in the role, main README is up-to-date)
