### PR TITLE
Actually get nested virt

### DIFF
--- a/ci_framework/roles/local_env_vm/tasks/main.yml
+++ b/ci_framework/roles/local_env_vm/tasks/main.yml
@@ -92,7 +92,8 @@
       --name "{{ cifmw_vm_name }}"
       --memory "{{ cifmw_local_env_vm_memory }}"
       --vcpus "{{ cifmw_local_env_vm_cpu }}"
-      --cpu host
+      --cpu host-passthrough
+      --machine q35
       --os-variant=centos-stream9
       --graphics {{ cifmw_local_env_vm_graphics }}
       --noautoconsole


### PR DESCRIPTION
Without those options, at least on CS9 hypervisor, nested virt didn't
seem to work.

A VM created with this patch applied passes the `virt-host-validate`
CLI.

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
