### PR TITLE
Allow to pass arbitrary extra vars to playbook

### DIFF
--- a/ci/playbooks/e2e-run.yml
+++ b/ci/playbooks/e2e-run.yml
@@ -11,7 +11,9 @@
           -e @scenarios/centos-9/base.yml
           -e @scenarios/centos-9/install_yamls.yml
           -e @scenarios/centos-9/ci.yml
-          {%- if cifmw_ci_builds | default(false) | bool %}
-          -e @scenarios/centos-9/ci-build.yml
-          {%- endif %}
           -e @scenarios/centos-9/zuul_inventory.yml
+          {%- if cifmw_extras is defined %}
+          {%-   for extra_vars in cifmw_extras %}
+          -e "{{   extra_vars }}"
+          {%-   endfor %}
+          {%- endif %}

--- a/ci/playbooks/edpm/run.yml
+++ b/ci/playbooks/edpm/run.yml
@@ -10,7 +10,9 @@
           -e @scenarios/centos-9/base.yml
           -e @scenarios/centos-9/edpm_ci.yml
           -e @scenarios/centos-9/zuul_inventory.yml
-          {%- if make_edpm_deploy_env is defined %}
-          -e "make_edpm_deploy_env={{ make_edpm_deploy_env }}"
-          {% endif %}
+          {%- if cifmw_extras is defined %}
+          {%-   for extra_var in cifmw_extras %}
+          -e "{{   extra_var }}"
+          {%-   endfor %}
+          {%- endif %}
       register: edpm_deploy_status

--- a/zuul.d/end-to-end.yaml
+++ b/zuul.d/end-to-end.yaml
@@ -6,10 +6,11 @@
     files:
       - ^ci_framework/roles/.*_build
       - ^ci_framework/roles/build.*
+    parent: base-simple-crc
     vars:
       crc_parameters: "--memory 20000 --disk-size 120 --cpus 6"
-      cifmw_ci_builds: true
-    parent: base-simple-crc
+      cifmw_extras:
+        - '@scenarios/centos-9/ci-build.yml'
     pre-run: ci/playbooks/e2e-prepare.yml
     run:
       - ci/playbooks/dump_zuul_vars.yml
@@ -29,7 +30,6 @@
       - ^ci_framework/roles/local_env_vm
     vars:
       crc_parameters: "--memory 20000 --disk-size 120 --cpus 6"
-      cifmw_ci_builds: false
     parent: base-simple-crc
     pre-run: ci/playbooks/e2e-prepare.yml
     run:


### PR DESCRIPTION
By setting cifmw_extras variable in zuul job definition, we are now
allowed to pass any arbitrary "--extra-vars" option - being a plain
key/value, or pointer to a file.

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
