### PR TITLE
pass make_edpm_deploy_env as a dict

### DIFF
--- a/ci/playbooks/edpm/run.yml
+++ b/ci/playbooks/edpm/run.yml
@@ -11,6 +11,6 @@
           -e @scenarios/centos-9/edpm_ci.yml
           -e @scenarios/centos-9/zuul_inventory.yml
           {%- if make_edpm_deploy_env is defined %}
-          -e "make_edpm_deploy_env={{ make_edpm_deploy_env }}"
+          -e "{'make_edpm_deploy_env':{{ make_edpm_deploy_env | from_yaml }}}"
           {% endif %}
       register: edpm_deploy_status


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/edpm-ansible/pull/161 sets
make_edpm_deploy_env ansible var as dict. This vars needs to be passed
as dict also to inner ansible during edpm deployment otherwise it
will fail the execution complaining dict and str cannot concatenation.
    
This patch fixes the same.


This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
