### PR TITLE
Run e2e-prepare and dump-zuul-vars playbook in pre

### DIFF
--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -22,9 +22,10 @@
 - job:
     name: cifmw-crc-podified-edpm-deployment
     parent: cifmw-base-crc-openstack
-    run:
+    pre-run:
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_vars.yml
+    run:
       - ci/playbooks/edpm/run.yml
     post-run:
       - ci/playbooks/edpm/post.yml


### PR DESCRIPTION
in edpm-ansible edpm zuul job pre-run step, we generate var file in run time and store it in ci-framework repo dir.

prepare-workspace is called again by e2e-prepare playbook which overrides the ci-framework repo directory and existing generated content vanished.

Moving these both the playbooks in pre fixes the issue.

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
