### PR TITLE
Do not kick any molecule nor e2e job on .md editions

### DIFF
--- a/ci/templates/molecule.yaml
+++ b/ci/templates/molecule.yaml
@@ -7,5 +7,5 @@
     files:
       - ^ansible-requirements.txt
       - ^molecule-requirements.txt
-      - ^ci_framework/roles/ROLE/(?!meta).*
+      - ^ci_framework/roles/ROLE/(?!meta|README).*
       - ^ci/playbooks/molecule.*

--- a/ci/templates/projects.yaml
+++ b/ci/templates/projects.yaml
@@ -6,6 +6,7 @@
     name: openstack-k8s-operators/ci-framework
     github-check:
       jobs:
+        - noop
         - ci-framework-crc-podified-edpm-deployment
         - cifmw-dev-prepare
         - cifmw-end-to-end

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -6,6 +6,8 @@
     timeout: 10800
     abstract: true
     parent: base-crc
+    irrelevant-files:
+      - .*/*.md
     required-projects:
       - openstack-k8s-operators/install_yamls
       - openstack-k8s-operators/openstack-operator
@@ -39,8 +41,8 @@
     name: ci-framework-crc-podified-edpm-deployment
     parent: cifmw-crc-podified-edpm-deployment
     files:
-      - ^ci_framework/roles/edpm_prepare
-      - ^ci_framework/roles/edpm_deploy
+      - ^ci_framework/roles/edpm_prepare/(?!meta|README).*
+      - ^ci_framework/roles/edpm_deploy/(?!meta|README).*
       - ^deploy-edpm.yml
     vars:
       cifmw_operator_build_output:

--- a/zuul.d/end-to-end.yaml
+++ b/zuul.d/end-to-end.yaml
@@ -4,8 +4,11 @@
     name: cifmw-end-to-end
     nodeset: centos-9-crc-xxl
     files:
-      - ^ci_framework/roles/.*_build
-      - ^ci_framework/roles/build.*
+      - ^ci_framework/roles/.*_build/(?!meta|README).*
+      - ^ci_framework/roles/build.*/(?!meta|README).*
+    irrelevant-files:
+      - ^.*/*.md
+      - ^ci/templates
     parent: base-simple-crc
     vars:
       crc_parameters: "--memory 20000 --disk-size 120 --cpus 6"
@@ -28,6 +31,9 @@
       - ^ci_framework/roles/.*_build
       - ^ci_framework/roles/build.*
       - ^ci_framework/roles/local_env_vm
+      - ^ci/templates
+      - ^docs
+      - ^.*/*.md
     vars:
       crc_parameters: "--memory 20000 --disk-size 120 --cpus 6"
     parent: base-simple-crc
@@ -46,7 +52,7 @@
     nodeset: centos-stream-9
     parent: base-ci-framework
     files:
-      - ^ci_framework/roles/local_env_vm
+      - ^ci_framework/roles/local_env_vm/(?!meta|README).*
     pre-run:
       - ci/playbooks/molecule-prepare.yml
     run:

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -7,7 +7,7 @@
     files:
       - ^ansible-requirements.txt
       - ^molecule-requirements.txt
-      - ^ci_framework/roles/artifacts/(?!meta).*
+      - ^ci_framework/roles/artifacts/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
     name: cifmw-molecule-build_openstack_packages
@@ -17,7 +17,7 @@
     files:
       - ^ansible-requirements.txt
       - ^molecule-requirements.txt
-      - ^ci_framework/roles/build_openstack_packages/(?!meta).*
+      - ^ci_framework/roles/build_openstack_packages/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
     name: cifmw-molecule-ci_setup
@@ -27,7 +27,7 @@
     files:
       - ^ansible-requirements.txt
       - ^molecule-requirements.txt
-      - ^ci_framework/roles/ci_setup/(?!meta).*
+      - ^ci_framework/roles/ci_setup/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
     name: cifmw-molecule-copy_container
@@ -37,7 +37,7 @@
     files:
       - ^ansible-requirements.txt
       - ^molecule-requirements.txt
-      - ^ci_framework/roles/copy_container/(?!meta).*
+      - ^ci_framework/roles/copy_container/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
     name: cifmw-molecule-discover_latest_image
@@ -47,7 +47,7 @@
     files:
       - ^ansible-requirements.txt
       - ^molecule-requirements.txt
-      - ^ci_framework/roles/discover_latest_image/(?!meta).*
+      - ^ci_framework/roles/discover_latest_image/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
     name: cifmw-molecule-edpm_deploy
@@ -57,7 +57,7 @@
     files:
       - ^ansible-requirements.txt
       - ^molecule-requirements.txt
-      - ^ci_framework/roles/edpm_deploy/(?!meta).*
+      - ^ci_framework/roles/edpm_deploy/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
     name: cifmw-molecule-edpm_prepare
@@ -67,7 +67,7 @@
     files:
       - ^ansible-requirements.txt
       - ^molecule-requirements.txt
-      - ^ci_framework/roles/edpm_prepare/(?!meta).*
+      - ^ci_framework/roles/edpm_prepare/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
     name: cifmw-molecule-install_ca
@@ -77,7 +77,7 @@
     files:
       - ^ansible-requirements.txt
       - ^molecule-requirements.txt
-      - ^ci_framework/roles/install_ca/(?!meta).*
+      - ^ci_framework/roles/install_ca/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
     name: cifmw-molecule-install_yamls
@@ -87,7 +87,7 @@
     files:
       - ^ansible-requirements.txt
       - ^molecule-requirements.txt
-      - ^ci_framework/roles/install_yamls/(?!meta).*
+      - ^ci_framework/roles/install_yamls/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
     name: cifmw-molecule-libvirt_manager
@@ -97,7 +97,7 @@
     files:
       - ^ansible-requirements.txt
       - ^molecule-requirements.txt
-      - ^ci_framework/roles/libvirt_manager/(?!meta).*
+      - ^ci_framework/roles/libvirt_manager/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
     name: cifmw-molecule-local_env_vm
@@ -107,7 +107,7 @@
     files:
       - ^ansible-requirements.txt
       - ^molecule-requirements.txt
-      - ^ci_framework/roles/local_env_vm/(?!meta).*
+      - ^ci_framework/roles/local_env_vm/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
     name: cifmw-molecule-operator_build
@@ -117,7 +117,7 @@
     files:
       - ^ansible-requirements.txt
       - ^molecule-requirements.txt
-      - ^ci_framework/roles/operator_build/(?!meta).*
+      - ^ci_framework/roles/operator_build/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
     name: cifmw-molecule-operator_deploy
@@ -128,7 +128,7 @@
     files:
       - ^ansible-requirements.txt
       - ^molecule-requirements.txt
-      - ^ci_framework/roles/operator_deploy/(?!meta).*
+      - ^ci_framework/roles/operator_deploy/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
     name: cifmw-molecule-pkg_build
@@ -138,7 +138,7 @@
     files:
       - ^ansible-requirements.txt
       - ^molecule-requirements.txt
-      - ^ci_framework/roles/pkg_build/(?!meta).*
+      - ^ci_framework/roles/pkg_build/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
     name: cifmw-molecule-registry_deploy
@@ -148,7 +148,7 @@
     files:
       - ^ansible-requirements.txt
       - ^molecule-requirements.txt
-      - ^ci_framework/roles/registry_deploy/(?!meta).*
+      - ^ci_framework/roles/registry_deploy/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
     name: cifmw-molecule-repo_setup
@@ -158,7 +158,7 @@
     files:
       - ^ansible-requirements.txt
       - ^molecule-requirements.txt
-      - ^ci_framework/roles/repo_setup/(?!meta).*
+      - ^ci_framework/roles/repo_setup/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
     name: cifmw-molecule-rhol_crc
@@ -169,7 +169,7 @@
     files:
       - ^ansible-requirements.txt
       - ^molecule-requirements.txt
-      - ^ci_framework/roles/rhol_crc/(?!meta).*
+      - ^ci_framework/roles/rhol_crc/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
     name: cifmw-molecule-run_hook
@@ -179,7 +179,7 @@
     files:
       - ^ansible-requirements.txt
       - ^molecule-requirements.txt
-      - ^ci_framework/roles/run_hook/(?!meta).*
+      - ^ci_framework/roles/run_hook/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
     name: cifmw-molecule-test_deps
@@ -189,5 +189,5 @@
     files:
       - ^ansible-requirements.txt
       - ^molecule-requirements.txt
-      - ^ci_framework/roles/test_deps/(?!meta).*
+      - ^ci_framework/roles/test_deps/(?!meta|README).*
       - ^ci/playbooks/molecule.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -6,6 +6,7 @@
     name: openstack-k8s-operators/ci-framework
     github-check:
       jobs:
+        - noop
         - ci-framework-crc-podified-edpm-deployment
         - cifmw-dev-prepare
         - cifmw-end-to-end


### PR DESCRIPTION
Until now, even if we were only editing .md files (aka doc), we would
end with at least the end-to-end-nobuild job running and, if we were
editing a role README.md, we'd see its molecule job being kicked.

This patch ensures zuul won't be triggered on .md nor on /docs/
modifications, meaning less load and time on zuul infra.
