### PR TITLE
Initial relase of the openshift_setup role

### DIFF
--- a/ansible-requirements.txt
+++ b/ansible-requirements.txt
@@ -1,3 +1,5 @@
 ansible>=7.0.0
 importlib-metadata
 jsonschema  # MIT
+oauthlib>=3.2.0 # k8s lib that requires manual upgrade
+kubernetes

--- a/ci_framework/playbooks/02-infra.yml
+++ b/ci_framework/playbooks/02-infra.yml
@@ -13,12 +13,18 @@
         - cifmw_use_libvirt | bool
       ansible.builtin.include_role:
         name: libvirt_manager
+
     - name: Prepare CRC
       when:
         - cifmw_use_crc is defined
         - cifmw_use_crc | bool
       ansible.builtin.include_role:
         name: rhol_crc
+
+    - name: Setup Openshift cluster
+      ansible.builtin.include_role:
+        name: openshift_setup
+
     - name: Prepare container package builder
       ansible.builtin.include_role:
         name: pkg_build

--- a/ci_framework/playbooks/05-build-operators.yml
+++ b/ci_framework/playbooks/05-build-operators.yml
@@ -23,10 +23,6 @@
           ansible.builtin.command: |
             oc registry login --insecure=true
 
-        - name: CRC project create
-          ansible.builtin.command: |
-            oc new-project openstack
-
     - name: Build operator and meta-operator
       when:
         - cifmw_operator_build_operators is defined

--- a/ci_framework/roles/openshift_setup/README.md
+++ b/ci_framework/roles/openshift_setup/README.md
@@ -1,0 +1,11 @@
+# openshift_setup
+Prepares the target OpenShift cluster to be used by further steps:
+- Project/Namespace creation
+
+## Privilege escalation
+No privilege escalation needed.
+
+## Parameters
+* `cifmw_openshift_setup_kubeconfig`: (String) Path to the kubeconfig file. Defaults to `cifmw_kubeconfig`.
+* `cifmw_openshift_setup_dry_run`: (Boolean) Skips resources creation. Defaults to `false`.
+* `cifmw_openshift_setup_create_namespaces`: (Strings) Namespaces to create beforehand. Defaults to `[]`.

--- a/ci_framework/roles/openshift_setup/defaults/main.yml
+++ b/ci_framework/roles/openshift_setup/defaults/main.yml
@@ -14,16 +14,10 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-collections:
-  - name: https://github.com/ansible-collections/ansible.posix
-    type: git
-  - name: https://github.com/ansible-collections/community.general
-    type: git
-  - name: https://github.com/containers/ansible-podman-collections
-    type: git
-  - name: https://github.com/ansible-collections/community.libvirt
-    type: git
-  - name: https://github.com/ansible-collections/community.crypto
-    type: git
-  - name: https://github.com/ansible-collections/kubernetes.core
-    type: git
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_openshift_setup"
+cifmw_openshift_setup_dry_run: false
+cifmw_openshift_setup_create_namespaces: []
+
+# cifmw_openshift_setup_kubeconfig: <path to the kubenconfig>, defaults to cifmw_kubeconfig

--- a/ci_framework/roles/openshift_setup/meta/main.yml
+++ b/ci_framework/roles/openshift_setup/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- openshift_setup
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: edpm
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - edpm
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/ci_framework/roles/openshift_setup/molecule/default/converge.yml
+++ b/ci_framework/roles/openshift_setup/molecule/default/converge.yml
@@ -14,16 +14,13 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-collections:
-  - name: https://github.com/ansible-collections/ansible.posix
-    type: git
-  - name: https://github.com/ansible-collections/community.general
-    type: git
-  - name: https://github.com/containers/ansible-podman-collections
-    type: git
-  - name: https://github.com/ansible-collections/community.libvirt
-    type: git
-  - name: https://github.com/ansible-collections/community.crypto
-    type: git
-  - name: https://github.com/ansible-collections/kubernetes.core
-    type: git
+
+- name: Converge
+  hosts: all
+  vars:
+    cifmw_openshift_setup_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+    cifmw_install_yamls_defaults:
+      NAMESPACE: openstack
+      OPERATOR_NAMESPACE: openstack-operators
+  roles:
+    - role: "openshift_setup"

--- a/ci_framework/roles/openshift_setup/molecule/default/molecule.yml
+++ b/ci_framework/roles/openshift_setup/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/openshift_setup/molecule/default/prepare.yml
+++ b/ci_framework/roles/openshift_setup/molecule/default/prepare.yml
@@ -14,16 +14,12 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-collections:
-  - name: https://github.com/ansible-collections/ansible.posix
-    type: git
-  - name: https://github.com/ansible-collections/community.general
-    type: git
-  - name: https://github.com/containers/ansible-podman-collections
-    type: git
-  - name: https://github.com/ansible-collections/community.libvirt
-    type: git
-  - name: https://github.com/ansible-collections/community.crypto
-    type: git
-  - name: https://github.com/ansible-collections/kubernetes.core
-    type: git
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps
+  tasks:
+    - name: Ensure CRC is started
+      ansible.builtin.command:
+        cmd: crc start

--- a/ci_framework/roles/openshift_setup/tasks/cleanup.yml
+++ b/ci_framework/roles/openshift_setup/tasks/cleanup.yml
@@ -14,16 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-collections:
-  - name: https://github.com/ansible-collections/ansible.posix
-    type: git
-  - name: https://github.com/ansible-collections/community.general
-    type: git
-  - name: https://github.com/containers/ansible-podman-collections
-    type: git
-  - name: https://github.com/ansible-collections/community.libvirt
-    type: git
-  - name: https://github.com/ansible-collections/community.crypto
-    type: git
-  - name: https://github.com/ansible-collections/kubernetes.core
-    type: git
+- name: Cleaning the World
+  debug:
+    msg: "So here openshift_setup should clean things up!"

--- a/ci_framework/roles/openshift_setup/tasks/main.yml
+++ b/ci_framework/roles/openshift_setup/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Fetch namespaces to create
+  ansible.builtin.set_fact:
+    cifmw_openshift_setup_namespaces: >-
+      {{
+        ((
+            ([cifmw_install_yamls_defaults['NAMESPACE']] +
+              [cifmw_install_yamls_defaults['OPERATOR_NAMESPACE']] if 'OPERATOR_NAMESPACE' is in cifmw_install_yamls_defaults else []
+            ) if cifmw_install_yamls_defaults is defined else []
+        ) + cifmw_openshift_setup_create_namespaces) | unique
+      }}
+
+- name: Create required namespaces
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_setup_kubeconfig | default(cifmw_kubeconfig) }}"
+    name: "{{ item }}"
+    kind: Namespace
+    state: present
+  with_items: "{{ cifmw_openshift_setup_namespaces }}"
+  when: not cifmw_openshift_setup_dry_run

--- a/ci_framework/roles/rhol_crc/tasks/main.yml
+++ b/ci_framework/roles/rhol_crc/tasks/main.yml
@@ -103,6 +103,11 @@
     - name: Delete sudoers file
       ansible.builtin.include_tasks: sudoers_revoke.yml
 
+- name: Set ci-framework kubeconfig
+  ansible.builtin.set_fact:
+    cifmw_kubeconfig: "{{ cifmw_rhol_crc_kubeconfig }}"
+    cacheable: true
+
 - name: Add crc kubeconfig
   when: cifmw_rhol_crc_creds | bool
   ansible.builtin.include_tasks: add_crc_creds.yml

--- a/docs/source/Roles/openshift_setup.md
+++ b/docs/source/Roles/openshift_setup.md
@@ -1,0 +1,1 @@
+../../../ci_framework/roles/openshift_setup/README.md

--- a/docs/source/Usage/01_usage.md
+++ b/docs/source/Usage/01_usage.md
@@ -21,6 +21,7 @@ are shared among multiple roles:
 * `cifmw_path`: customized PATH. Defaults to `~/.crc/bin:~/.crc/bin/oc:~/bin:${PATH}`
 * `cifmw_use_libvirt`: (Bool) toggle libvirt support
 * `cifmw_use_crc`: (Bool) toggle rhol/crc usage
+* `cifmw_kubeconfig`: (String) Path to the kubeconfig file if externally provided.
 
 #### Words of caution
 If you want to output the content in another location than `~/ci-framework`

--- a/molecule-requirements.txt
+++ b/molecule-requirements.txt
@@ -14,6 +14,8 @@ netaddr
 jinja2
 jmespath
 ansible-core
+oauthlib>=3.2.0 # k8s lib that requires manual upgrade
+kubernetes
 
 # Allows to unpin cryptography
 pyOpenSSL>=22.1.0

--- a/scripts/create_role_molecule
+++ b/scripts/create_role_molecule
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xe
 
-NEED_CRC_XL="cifmw-molecule-operator_deploy cifmw-molecule-rhol_crc"
+NEED_CRC_XL="cifmw-molecule-operator_deploy cifmw-molecule-rhol_crc cifmw-molecule-openshift_setup"
 PROJECT_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))/../"
 cp ${PROJECT_DIR}/ci/templates/projects.yaml ${PROJECT_DIR}/zuul.d/projects.yaml;
 echo '# DO NOT EDIT - generaged using make role_molecule' > ${PROJECT_DIR}/zuul.d/molecule.yaml

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -110,6 +110,17 @@
       - ^ci_framework/roles/local_env_vm/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
+    name: cifmw-molecule-openshift_setup
+    nodeset: centos-9-crc-xl
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: openshift_setup
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/openshift_setup/(?!meta|README).*
+      - ^ci/playbooks/molecule.*
+- job:
     name: cifmw-molecule-operator_build
     parent: cifmw-molecule-base
     vars:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -25,6 +25,7 @@
         - cifmw-molecule-install_yamls
         - cifmw-molecule-libvirt_manager
         - cifmw-molecule-local_env_vm
+        - cifmw-molecule-openshift_setup
         - cifmw-molecule-operator_build
         - cifmw-molecule-operator_deploy
         - cifmw-molecule-pkg_build


### PR DESCRIPTION
This is the first release of the openshift_setup role. This role is meant to be used in the infra phase to provision and configure the target OpenShift cluster before progressing to further steps. At this point the role only creates the expected needed projects/namespaces for image pushing and deployments, but it will contain RBAC configuration as well.
This commit starts to build up a more generic and consolidated way of mananing cluster commands through the Ansible module instead of direct calls to OC and adds a global `cifmw_kubeconfig` variable that is expected to be present always after the infra step and that any other step further in the chain can use to access the cluster.

This PR has:
- [x] Appropriate testing (molecule, python unit tests)
- [x] Appropriate documentation (README in the role, main README is up-to-date)
