### PR TITLE
Add a skip flag for compute_repos task

### DIFF
--- a/ci_framework/roles/libvirt_manager/README.md
+++ b/ci_framework/roles/libvirt_manager/README.md
@@ -23,3 +23,4 @@ Used for checking if:
 * `cifmw_libvirt_manager_installyamls`: (String) install_yamls repository location. Defaults to `cifmw_installyamls_repos` which defaults to `../..`
 * `cifmw_libvirt_manager_dryrun`: (Boolean) Toggle ci_make `dry_run` parameter. Defaults to `false`.
 * `cifmw_libvirt_manager_compute_amount`: (Integer) State the amount of computes you want. Defaults to `1`.
+* `cifmw_libvirt_manager_skip_edpm_compute_repos`: (Boolean) Intentionally skips the configuration of repos on EDPM compute nodes. Defaults to `False`.

--- a/ci_framework/roles/libvirt_manager/defaults/main.yml
+++ b/ci_framework/roles/libvirt_manager/defaults/main.yml
@@ -46,3 +46,4 @@ cifmw_libvirt_manager_crc_pool: "{{ cifmw_crc_pool | default(lookup('env', 'HOME
 cifmw_libvirt_manager_pool:
 cifmw_libvirt_manager_installyamls: "{{ cifmw_installyamls_repos | default('../..') }}"
 cifmw_libvirt_manager_dryrun: false
+cifmw_libvirt_manager_skip_edpm_compute_repos: false

--- a/ci_framework/roles/libvirt_manager/tasks/deploy_edpm_compute.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/deploy_edpm_compute.yml
@@ -84,6 +84,7 @@
       loop: "{{ edpm_vms_ips.results }}"
 
 - name: Configure repositories on external computes
+  when: not cifmw_libvirt_manager_skip_edpm_compute_repos
   vars:
     make_edpm_compute_repos_dryrun: "{{ cifmw_libvirt_manager_dryrun }}"
     make_edpm_compute_repos_params:


### PR DESCRIPTION
Some deployments/distros are not suported by repo-setup, so we need a way to skip it.

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
