### PR TITLE
Add documentation about molecule tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ create_new_role:
 	ansible-galaxy role init --role-skeleton _skeleton_role_ --init-path ci_framework/roles ${ROLE_NAME}
 
 .PHONY: role_molecule
-role_molecule:
+role_molecule: ## Regenerate the molecule jobs configuration
 	bash scripts/create_role_molecule
 
 .PHONY: new_role

--- a/docs/source/Development/02_molecule.md
+++ b/docs/source/Development/02_molecule.md
@@ -1,0 +1,23 @@
+# Molecule configuration/testing
+
+All of the roles should get proper molecule tests. When you generate a new
+role using `make new_role ROLE_NAME=my_role`, you will end with a basic role
+structure, including the molecule part.
+
+[More information about molecule](https://molecule.readthedocs.io/)
+
+## My test needs CRC
+By default, molecule tests are configured to consume a simple CentOS Stream 9
+node in Zuul. But it may happen you need to talk to an OpenShift API within
+your role.
+
+In order to consume a CRC node, you have to edit the following file:
+[scripts/create_role_molecule](https://github.com/openstack-k8s-operators/ci-framework/blob/main/scripts/create_role_molecule)
+and, on line 4, append your new job name to the `NEED_CRC_XL` list.
+
+For now, we "only" support the crc-xl nodeset. It should cover most of the
+needs for molecule. It matches the **centos-9-stream-crc-xl**
+[label in rdoproject](https://review.rdoproject.org/zuul/labels).
+
+Once you have edited the script, re-generate the molecule job:
+`make role_molecule`.


### PR DESCRIPTION
It may happen a molecule job needs CRC - this patch explains how to
consume it.

It also add a doc string in the Makefile in order to expose the
"role_molecule" target whenever we run `make help`.
