### PR TITLE
Use base-simple-crc as a parent for EDPM jobs

### DIFF
--- a/ci_framework/roles/edpm_deploy/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy/tasks/main.yml
@@ -33,31 +33,43 @@
     - not cifmw_edpm_deploy_dryrun | bool
   block:
     - name: Get info about dataplane node
+      environment:
+        PATH: "{{ cifmw_path }}"
       ansible.builtin.shell: |
-        oc get openstackdataplane
-        oc get openstackdataplanerole
-        oc get openstackdataplanenode
-        oc get pods | grep edpm
+        oc get openstackdataplane -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+        oc get openstackdataplanerole -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+        oc get openstackdataplanenode -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+        oc get pods -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} | grep edpm
       ignore_errors: true
 
     - name: Get nova-edpm-compute-0-deploy-nova pod name
       register: edpm_pod
+      environment:
+        PATH: "{{ cifmw_path }}"
       ansible.builtin.shell:
-        cmd: oc get pods -o name | grep -m1  nova-edpm-compute-0-deploy-nova
+        cmd: oc get pods -o name -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} | grep -m1  nova-edpm-compute-0-deploy-nova
       until: edpm_pod.rc == 0
       retries: "{{ cifmw_edpm_deploy_retries }}"
       delay: 50
 
     - name: Wait for nova-edpm-compute-0-deploy-nova pod to finish
       register: deploy_status
-      ansible.builtin.command: "oc wait --timeout=0 --for=jsonpath='{.status.phase}'=Succeeded {{ edpm_pod.stdout |trim }}"
+      environment:
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.command: "oc wait -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} --timeout=0 --for=jsonpath='{.status.phase}'=Succeeded {{ edpm_pod.stdout |trim }}"
       until: deploy_status.rc == 0
       retries: "{{ cifmw_edpm_deploy_retries }}"
       delay: 20
 
 - name: Get the logs of EDPM Deploy
-  ansible.builtin.shell:
-    for POD in $(oc get pods -o name | egrep "dataplane-deployment-|nova-edpm-compute"); do echo $POD; oc logs $POD; done
+  environment:
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.shell: |
+    for POD in $(oc get pods -o name -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} | egrep "dataplane-deployment-|nova-edpm-compute");
+    do
+      echo $POD;
+      oc logs -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} $POD;
+    done
   register: edpm_logs
   when:
     - deploy_status is defined

--- a/ci_framework/roles/edpm_prepare/README.md
+++ b/ci_framework/roles/edpm_prepare/README.md
@@ -11,3 +11,4 @@ This role doesn't need privilege scalation.
 * `cifmw_edpm_prepare_skip_crc_storage_creation`: (Boolean) Intentionally skips the deployment of the CRC storage related resources. Defaults to `False`.
 * `cifmw_edpm_prepare_skip_openstack_operator:`: (Boolean) Intentionally skips the deployment of the OpenStack metaoperator. Defaults to `False`.
 * `cifmw_edpm_prepare_wait_subscription_retries`: (Integer) Number of retries, with 5 seconds delays, waiting for the OpenStack subscription to come up. Defaults to `5`.
+* `cifmw_edpm_prepare_crc_attach_default_interface`: (Boolean) Skips crc_attach_default_interface. Defaults to `true`.

--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -29,6 +29,12 @@
     name: 'install_yamls_makes'
     tasks_from: 'make_crc_storage'
 
+- name: Attach default network to CRC
+  ansible.builtin.include_role:
+    name: "install_yamls_makes"
+    tasks_from: "make_crc_attach_default_interface.yml"
+  when: cifmw_edpm_prepare_crc_attach_default_interface | default ('true') | bool
+
 - name: Get internal OpenShift registry route
   environment:
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"

--- a/scenarios/centos-9/edpm_ci.yml
+++ b/scenarios/centos-9/edpm_ci.yml
@@ -6,13 +6,19 @@ cifmw_install_yamls_vars:
   OUTPUT_BASEDIR: "{{ cifmw_basedir }}/artifacts/edpm_compute" # used by gen-edpm-compute-node.sh
   SSH_KEY: "{{ cifmw_basedir }}/artifacts/edpm_compute/ansibleee-ssh-key-id_rsa"
   DATAPLANE_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/dataplane-operator"
+  STORAGE_CLASS: crc-csi-hostpath-provisioner
+
+pre_infra:
+  - name: Download needed tools
+    inventory: "{{ cifmw_installyamls_repos }}/devsetup/hosts"
+    type: playbook
+    source: "{{ cifmw_installyamls_repos }}/devsetup/download_tools.yaml"
 
 # edpm_deploy role vars
 cifmw_edpm_deploy_run_validation: true
 # edpm_prepare role vars
-cifmw_edpm_prepare_skip_openstack_operator: true
-
 cifmw_operator_build_meta_name: "openstack-operator"
+cifmw_edpm_prepare_skip_crc_storage_creation: true
 
 # edpm_deploy role vars
 cifmw_edpm_deploy_manifests_dir: "{{ cifmw_installyamls_repos }}/out"

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -5,7 +5,7 @@
     nodeset: centos-9-crc-3xl
     timeout: 10800
     abstract: true
-    parent: base-crc
+    parent: base-simple-crc
     irrelevant-files:
       - .*/*.md
     required-projects:
@@ -17,7 +17,7 @@
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     vars:
-      crc_parameters: "--memory 20000 --disk-size 120 --cpus 6"
+      crc_parameters: "--memory 21000 --disk-size 120 --cpus 8"
       pre_pull_images:
         - registry.redhat.io/rhosp-rhel9/openstack-rabbitmq:17.0
 
@@ -33,10 +33,6 @@
       - ci/playbooks/e2e-collect-logs.yml
       - ci/playbooks/collect-logs.yml
     vars:
-      network_isolation: true
-      crc_attach_default_interface: true
-      bmo_setup: false
-      operators_namespace: openstack-operators
       # This should be set here since is associated with parent job (base-crc) and not the scenario
       cifmw_openshift_kubeconfig: "/home/zuul/.crc/machines/crc/kubeconfig"
       zuul_log_collection: true
@@ -50,9 +46,3 @@
       - ^ci_framework/roles/edpm_deploy/(?!meta|README).*
       - ^deploy-edpm.yml
       - ^scenarios/centos-9/edpm_ci.yml
-    vars:
-      cifmw_operator_build_output:
-          operators:
-              openstack-operator:
-                  git_src_dir: /home/zuul/src/github.com/openstack-k8s-operators/openstack-operator
-                  image_catalog: quay.io/openstack-k8s-operators/openstack-operator-index:latest


### PR DESCRIPTION
This patch drops base-crc zuul job parent where we used to run
`make openstack` in the config repo in favor of base-simple-crc.
    
base-simple-crc job will start the crc node only in pre-run
step. It will execute the complete framework from scratch by
running the whole steps defined in deploy-edpm.yml playbook to
do the EDPM deployment and validate it.
    
This patch drops the vars related to base-crc and uses all the
default defined like network-isolation from the install_yamls.
It also drops cifmw_operator_build_output var which is no longer
needed.
    
It also adds a pre_infra step to install the required tools.
It includes vars related crc to drive the complete workflow.
    

This PR has:
- [x] Appropriate testing (molecule, python unit tests)
- [ ] ~~Appropriate documentation (README in the role, main README is up-to-date)~~
