### PR TITLE
Move data directory to a more understandable name

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,7 @@
 [defaults]
 action_plugins = ./plugins/action:~/plugins/action:/usr/share/ansible/plugins/action
 library = ./plugins/modules:~/plugins/modules:/usr/share/ansible/plugins/modules
-roles_path = ~/ci-framework/artifacts/roles:./ci_framework/roles:/usr/share/ansible/roles:/etc/ansible/roles:~/.ansible/roles
+roles_path = ~/ci-framework-data/artifacts/roles:./ci_framework/roles:/usr/share/ansible/roles:/etc/ansible/roles:~/.ansible/roles
 log_path = ~/ansible.log
 # We may consider ansible.builtin.junit
 callbacks_enabled = ansible.posix.profile_tasks

--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -16,26 +16,26 @@
             chdir: "{{ ansible_user_dir }}/zuul-output/logs"
             cmd: cp /tmp/report.html .
 
-        - name: Check if we get ci-framework basedir
+        - name: Check if we get ci-framework-data basedir
           register: cifmw_state
           ansible.builtin.stat:
-            path: "{{ ansible_user_dir }}/ci-framework"
+            path: "{{ ansible_user_dir }}/ci-framework-data"
 
-        - name: Collect ci-framework content of interest
+        - name: Collect ci-framework-data content of interest
           when:
             - cifmw_state.stat.exists | bool
           block:
-            - name: Create ci-framework log directory for zuul
+            - name: Create ci-framework-data log directory for zuul
               ansible.builtin.file:
-                path: "{{ ansible_user_dir }}/zuul-output/logs/ci-framework"
+                path: "{{ ansible_user_dir }}/zuul-output/logs/ci-framework-data"
                 state: directory
 
             - name: Copy ci-framework interesting files
               ansible.builtin.shell:
-                chdir: "{{ ansible_user_dir }}/zuul-output/logs/ci-framework"
+                chdir: "{{ ansible_user_dir }}/zuul-output/logs/ci-framework-data"
                 cmd: |
-                  cp -ra {{ ansible_user_dir }}/ci-framework/logs . ;
-                  cp -ra {{ ansible_user_dir }}/ci-framework/artifacts . ;
+                  cp -ra {{ ansible_user_dir }}/ci-framework-data/logs . ;
+                  cp -ra {{ ansible_user_dir }}/ci-framework-data/artifacts . ;
 
             - name: Check for Zuul inventory file
               ansible.builtin.stat:
@@ -46,7 +46,7 @@
               when: cifmw_zuul_state.stat.exists | bool
               ansible.builtin.copy:
                 remote_src: true
-                dest: "{{ ansible_user_dir }}/ci-framework/logs"
+                dest: "{{ ansible_user_dir }}/ci-framework-data/logs"
                 src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/scenarios/centos-9/zuul_inventory.yml"
 
         - name: Get some env related data
@@ -72,7 +72,7 @@
           ansible.builtin.shell:
             chdir: "{{ ansible_user_dir }}/zuul-output/logs/"
             cmd: |
-              ls -lRZ --hide=venv --hide=repo-setup {{ ansible_user_dir }}/ci-framework > ./selinux-listing.log;
+              ls -lRZ --hide=venv --hide=repo-setup {{ ansible_user_dir }}/ci-framework-data > ./selinux-listing.log;
               ausearch -i | grep denied > ./selinux-denials.log
 
         - name: Create system configuration directory

--- a/ci_framework/playbooks/01-bootstrap.yml
+++ b/ci_framework/playbooks/01-bootstrap.yml
@@ -35,5 +35,5 @@
 
     - name: Create artifacts with custom params
       ansible.builtin.copy:
-        dest: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework') }}/artifacts/custom-params.yml"
+        dest: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts/custom-params.yml"
         content: "{{ ci_framework_params | to_nice_yaml }}"

--- a/ci_framework/playbooks/99-logs.yml
+++ b/ci_framework/playbooks/99-logs.yml
@@ -28,7 +28,7 @@
         - name: Copy ansible log to proper location
           ansible.builtin.copy:
             src: "{{ ansible_user_dir }}/ansible.log"
-            dest: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework') }}/logs/ansible.log-{{ filename_date.stdout|trim }}"
+            dest: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/logs/ansible.log-{{ filename_date.stdout|trim }}"
             remote_src: true
 
         - name: Remove original log from home directory
@@ -44,7 +44,7 @@
         - name: Copy facts to dated directory
           ansible.builtin.copy:
             src: "{{ ansible_user_dir }}/ansible_facts_cache"
-            dest: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework') }}/artifacts/ansible_facts-{{ filename_date.stdout|trim }}"
+            dest: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts/ansible_facts-{{ filename_date.stdout|trim }}"
             remote_src: true
 
         - name: Clean ansible fact cache

--- a/ci_framework/plugins/README.md
+++ b/ci_framework/plugins/README.md
@@ -17,7 +17,7 @@ Example:
         state: directory
     - name: Run pre-commit tests
       ci_make:
-        chdir: "~/code/github.com/ci-framework"
+        chdir: "~/code/github.com/ci-framework-data"
         output_dir: /tmp/artifacts
         target: pre_commit
         params:

--- a/ci_framework/plugins/modules/generate_make_tasks.py
+++ b/ci_framework/plugins/modules/generate_make_tasks.py
@@ -72,7 +72,7 @@ MAKE_TMPL = '''---
     var: make_%(target)s_params
 - name: Run %(target)s
   ci_make:
-    output_dir: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework') }}/artifacts"
+    output_dir: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts"
     chdir: "%(chdir)s"
     target: %(target)s
     dry_run: "{{ make_%(target)s_dryrun|default(false)|bool }}"

--- a/ci_framework/roles/artifacts/README.md
+++ b/ci_framework/roles/artifacts/README.md
@@ -6,7 +6,7 @@ in the defined base directory.
 None - writes happen only in the user home.
 
 ## Parameters
-* `cifmw_artifacts_basedir`: (String) Base directory. Defaults to `cifmw_basedir` which defaults to `~/ci-framework`.
+* `cifmw_artifacts_basedir`: (String) Base directory. Defaults to `cifmw_basedir` which defaults to `~/ci-framework-data`.
 
 ## Examples
 Usually we'll import the role as-is at the very start of the playbook, and

--- a/ci_framework/roles/artifacts/defaults/main.yml
+++ b/ci_framework/roles/artifacts/defaults/main.yml
@@ -17,4 +17,4 @@
 
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_artifacts"
-cifmw_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}"
+cifmw_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"

--- a/ci_framework/roles/artifacts/molecule/default/converge.yml
+++ b/ci_framework/roles/artifacts/molecule/default/converge.yml
@@ -26,7 +26,7 @@
         - name: Gather environment files
           register: env_files
           ansible.builtin.stat:
-            path: "{{ ansible_user_dir }}/ci-framework/artifacts/{{ item }}"
+            path: "{{ ansible_user_dir }}/ci-framework-data/artifacts/{{ item }}"
           loop:
             - ansible-vars.yml
             - ansible-facts.yml
@@ -47,7 +47,7 @@
         - name: Get stat on pkg listing file
           register: pkg_list
           ansible.builtin.stat:
-            path: "{{ ansible_user_dir }}/ci-framework/artifacts/installed-packages.yml"
+            path: "{{ ansible_user_dir }}/ci-framework-data/artifacts/installed-packages.yml"
         - name: Check package list exists
           ansible.builtin.assert:
             that:

--- a/ci_framework/roles/ci_setup/README.md
+++ b/ci_framework/roles/ci_setup/README.md
@@ -5,7 +5,7 @@ Ensure you have the needed directories and packages for the rest of the tasks.
 - install packages
 
 ## Parameters
-* `cifmw_ci_setup_basedir`: (String) Base directory for the directory tree. Default to `~/ci-framework`.
+* `cifmw_ci_setup_basedir`: (String) Base directory for the directory tree. Default to `~/ci-framework-data`.
 * `cifmw_ci_setup_packages`: (List) List of packages to install.
 
 ## Cleanup

--- a/ci_framework/roles/ci_setup/defaults/main.yml
+++ b/ci_framework/roles/ci_setup/defaults/main.yml
@@ -17,4 +17,4 @@
 
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_ci_setup"
-cifmw_ci_setup_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}"
+cifmw_ci_setup_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"

--- a/ci_framework/roles/ci_setup/molecule/default/converge.yml
+++ b/ci_framework/roles/ci_setup/molecule/default/converge.yml
@@ -31,10 +31,10 @@
         - name: Stat directory
           register: dir_stat
           ansible.builtin.stat:
-            path: "{{ ansible_user_dir }}/ci-framework/volumes"
+            path: "{{ ansible_user_dir }}/ci-framework-data/volumes"
         - name: Debug
           debug:
-            msg: "{{ ansible_user_dir }}/ci-framework/volumes"
+            msg: "{{ ansible_user_dir }}/ci-framework-data/volumes"
         - name: Validate directory state
           ansible.builtin.assert:
             that:
@@ -51,7 +51,7 @@
         - name: Stat directory
           register: dir_stat
           ansible.builtin.stat:
-            path: "{{ ansible_user_dir }}/ci-framework/volumes"
+            path: "{{ ansible_user_dir }}/ci-framework-data/volumes"
         - name: Validate directory state
           ansible.builtin.assert:
             that:

--- a/ci_framework/roles/edpm_deploy/README.md
+++ b/ci_framework/roles/edpm_deploy/README.md
@@ -5,7 +5,7 @@ Peform External compute deploy on the pre-provisioned node from openshift cluste
 None
 
 ## Parameters
-* `cifmw_edpm_deploy_basedir`: (String) Base directory. Defaults to `cifmw_basedir` which defaults to `~/ci-framework`.
+* `cifmw_edpm_deploy_basedir`: (String) Base directory. Defaults to `cifmw_basedir` which defaults to `~/ci-framework-data`.
 * `cifmw_edpm_deploy_manifests_dir`: (String) Directory in where install_yamls output manifests will be placed. Defaults to `"{{ cifmw_manifests | default(cifmw_edpm_deploy_basedir ~ '/artifacts/manifests') }}"`.
 * `cifmw_edpm_edploy_dataplane_operator_repo`: (String) Path to Dataplane-operator repo. Defaults to `"{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/dataplane-operator"`.
 * `cifmw_edpm_deploy_os_runner_img`: (String) OpenStack Runner image url. Defaults to `"quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest"`.

--- a/ci_framework/roles/edpm_deploy/defaults/main.yml
+++ b/ci_framework/roles/edpm_deploy/defaults/main.yml
@@ -17,7 +17,7 @@
 
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_edpm_deploy"
-cifmw_edpm_deploy_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}"
+cifmw_edpm_deploy_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_edpm_deploy_manifests_dir: "{{ cifmw_manifests | default(cifmw_edpm_deploy_basedir ~ '/artifacts/manifests') }}"
 cifmw_edpm_deploy_log_path: "{{ cifmw_edpm_deploy_basedir }}/logs/edpm/edpm_deploy.log"
 cifmw_edpm_deploy_retries: 100

--- a/ci_framework/roles/edpm_prepare/README.md
+++ b/ci_framework/roles/edpm_prepare/README.md
@@ -5,7 +5,7 @@ Prepares the environment to deploy OpenStack control plane and compute nodes.
 This role doesn't need privilege scalation.
 
 ## Parameters
-* `cifmw_edpm_prepare_basedir`: (String) Base directory. Defaults to `cifmw_basedir` which defaults to `~/ci-framework`.
+* `cifmw_edpm_prepare_basedir`: (String) Base directory. Defaults to `cifmw_basedir` which defaults to `~/ci-framework-data`.
 * `cifmw_edpm_prepare_dry_run`: (Boolean) Skips resources installations and waits. Defaults to false.
 * `cifmw_edpm_prepare_manifests_dir`: String) Directory in where install_yamls output manifests will be placed. Defaults to `"{{ cifmw_edpm_prepare_basedir }}/artifacts/manifests"`
 * `cifmw_edpm_prepare_skip_crc_storage_creation`: (Boolean) Intentionally skips the deployment of the CRC storage related resources. Defaults to `False`.

--- a/ci_framework/roles/edpm_prepare/defaults/main.yml
+++ b/ci_framework/roles/edpm_prepare/defaults/main.yml
@@ -17,7 +17,7 @@
 
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_edpm_prepare"
-cifmw_edpm_prepare_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}"
+cifmw_edpm_prepare_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_edpm_prepare_manifests_dir: "{{ cifmw_manifests | default(cifmw_edpm_prepare_basedir ~ '/artifacts/manifests') }}"
 cifmw_edpm_prepare_skip_openstack_operator: false
 cifmw_edpm_prepare_wait_subscription_retries: 30

--- a/ci_framework/roles/edpm_prepare/molecule/default/prepare.yml
+++ b/ci_framework/roles/edpm_prepare/molecule/default/prepare.yml
@@ -19,7 +19,7 @@
   hosts: all
   vars:
     ansible_user_dir: "{{ lookup('env', 'HOME') }}"
-    cifmw_basedir: "{{ ansible_user_dir }}/ci-framework"
+    cifmw_basedir: "{{ ansible_user_dir }}/ci-framework-data"
     cifmw_install_yamls_tasks_out: "{{ ansible_user_dir }}/zuul-jobs/roles/install_yamls_makes/tasks"
     cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
     cifmw_install_yamls_defaults:

--- a/ci_framework/roles/install_yamls/README.md
+++ b/ci_framework/roles/install_yamls/README.md
@@ -5,7 +5,7 @@ It contains a set of playbooks to deploy podified control plane.
 
 ## Parameters
 * `cifmw_install_yamls_envfile`: (String) Environment file containing all the Makefile overrides. Defaults to `install_yamls`.
-* `cifmw_install_yamls_out_dir`: (String) `install_yamls` output directory to store generated output. Defaults to `{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}/artifacts"`.
+* `cifmw_install_yamls_out_dir`: (String) `install_yamls` output directory to store generated output. Defaults to `{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts"`.
 * `cifmw_install_yamls_vars`: (Dict) A dict containing Makefile overrides.
 * `cifmw_install_yamls_repo`: (String) `install_yamls` repo path. Defaults to `{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls`.
 * `cifmw_install_yamls_whitelisted_vars`: (List) Allowed variables in `cifmw_install_yamls_vars` that are not part of `install_yamls` Makefiles.

--- a/ci_framework/roles/install_yamls/defaults/main.yml
+++ b/ci_framework/roles/install_yamls/defaults/main.yml
@@ -18,7 +18,7 @@
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_install_yamls"
 cifmw_install_yamls_envfile: "install_yamls.sh"
-cifmw_install_yamls_out_dir_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}"
+cifmw_install_yamls_out_dir_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_install_yamls_out_dir: "{{ cifmw_install_yamls_out_dir_basedir }}/artifacts"
 cifmw_install_yamls_manifests_dir: "{{ cifmw_manifests | default(cifmw_install_yamls_out_dir_basedir ~ '/artifacts/manifests') }}"
 # A list of Install_yamls makefile vars that needs to be exported

--- a/ci_framework/roles/install_yamls/molecule/default/converge.yml
+++ b/ci_framework/roles/install_yamls/molecule/default/converge.yml
@@ -34,7 +34,7 @@
     - name: Gather some file data
       register: make_files
       ansible.builtin.stat:
-        path: "{{ ansible_user_dir }}/ci-framework/artifacts/roles/install_yamls_makes/tasks/{{ item }}.yml"
+        path: "{{ ansible_user_dir }}/ci-framework-data/artifacts/roles/install_yamls_makes/tasks/{{ item }}.yml"
       loop:
         - make_all
         - make_crc

--- a/ci_framework/roles/libvirt_manager/README.md
+++ b/ci_framework/roles/libvirt_manager/README.md
@@ -14,7 +14,7 @@ Used for checking if:
     - `polkit_rules.yml`: Add polkit rules under `/etc/`.
 
 ## Parameters
-* `cifmw_libvirt_manager_basedir`: (String) Base directory. Defaults to `cifmw_basedir` which defaults to `~/ci-framework`.
+* `cifmw_libvirt_manager_basedir`: (String) Base directory. Defaults to `cifmw_basedir` which defaults to `~/ci-framework-data`.
 * `cifmw_libvirt_manager_enable_virtualization_module`: (Boolean) If `true` it will enable the virtualization module in case it's not already and if the hosts allow it. Defaults to `false`.
 * `cifmw_libvirt_manager_user`: (String) User used for libvirt. Default: the one in the environment variable `USER`.
 * `cifmw_libvirt_manager_images_url`: (String) Location basedir for the image URI. Defaults to `https://cloud.centos.org/centos/9-stream/x86_64/images`.

--- a/ci_framework/roles/libvirt_manager/defaults/main.yml
+++ b/ci_framework/roles/libvirt_manager/defaults/main.yml
@@ -18,7 +18,7 @@
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_libvirt_manager"
 
-cifmw_libvirt_manager_basedir: "{{ cifmw_basedir | default( ansible_user_dir ~ '/ci-framework') }}"
+cifmw_libvirt_manager_basedir: "{{ cifmw_basedir | default( ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_libvirt_manager_enable_virtualization_module: false
 cifmw_libvirt_manager_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
 cifmw_libvirt_manager_images_url: https://cloud.centos.org/centos/9-stream/x86_64/images

--- a/ci_framework/roles/local_env_vm/README.md
+++ b/ci_framework/roles/local_env_vm/README.md
@@ -11,7 +11,7 @@ this role creates).
 None.
 
 ## Parameters
-* `cifmw_local_env_vm_basedir`: (String) Base directory. Defaults to `{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}`.
+* `cifmw_local_env_vm_basedir`: (String) Base directory. Defaults to `{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}`.
 * `cifmw_local_env_vm_pullsecret`: (String) Location of the pull-secret file. Defaults to `{{ ansible_user_dir }}/pull-secret`.
 * `cifmw_local_env_vm_space`: (String) Disk space allocated to the VM. Defaults to `120G`.
 * `cifmw_local_env_vm_memory`: (Integer) Allocated memory. Defaults to `22572`.

--- a/ci_framework/roles/local_env_vm/defaults/main.yml
+++ b/ci_framework/roles/local_env_vm/defaults/main.yml
@@ -17,7 +17,7 @@
 
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_local_env_vm"
-cifmw_local_env_vm_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}"
+cifmw_local_env_vm_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_local_env_vm_pullsecret: "{{ ansible_user_dir }}/pull-secret"
 cifmw_local_env_vm_space: "120G"
 cifmw_local_env_vm_memory: "22572"

--- a/ci_framework/roles/operator_build/README.md
+++ b/ci_framework/roles/operator_build/README.md
@@ -4,7 +4,7 @@ When building an operator from a Pull Request, it is mandatory to provide the PR
 you want to build meta-operator too, so the role can properly replace api references in meta-operator.
 
 ## Parameters
-* `cifmw_operator_build_basedir`: (String) Base directory. Defaults to `cifmw_basedir` which defaults to `~/ci-framework`.
+* `cifmw_operator_build_basedir`: (String) Base directory. Defaults to `cifmw_basedir` which defaults to `~/ci-framework-data`.
 * `cifmw_operator_build_dryrun`: (Boolean) Toggle `ci_make` `dry_run` flag. Defaults to `False`.
 * `cifmw_operator_build_golang_ct`: (String) Reference to the golang container. Defaults to `docker.io/library/golang:1.19`.
 * `cifmw_operator_build_golang_alt_ct`: (String) Reference to an alternative golang container. Defaults to `quay.io/projectquay/golang:1.19`.

--- a/ci_framework/roles/operator_build/defaults/main.yml
+++ b/ci_framework/roles/operator_build/defaults/main.yml
@@ -14,7 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-cifmw_operator_build_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}"
+cifmw_operator_build_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_operator_build_dryrun: false
 cifmw_operator_build_golang_ct: "docker.io/library/golang:1.19"
 cifmw_operator_build_golang_alt_ct: "quay.rdoproject.org/openstack-k8s-operators/golang:1.19"

--- a/ci_framework/roles/operator_deploy/README.md
+++ b/ci_framework/roles/operator_deploy/README.md
@@ -5,7 +5,7 @@ Deploy only selected operator(s) on OpenShift
 None
 
 ## Parameters
-* `cifmw_operator_deploy_basedir`: (String) Directory where we will have the RHOL/CRC binary and the configuration (e.g. `artifacts/.rhol_crc_pull_secret.txt`). Default to `cifmw_basedir` which defaults to `~/ci-framework`.
+* `cifmw_operator_deploy_basedir`: (String) Directory where we will have the RHOL/CRC binary and the configuration (e.g. `artifacts/.rhol_crc_pull_secret.txt`). Default to `cifmw_basedir` which defaults to `~/ci-framework-data`.
 * `cifmw_operator_deploy_installyamls`: (String) `install_yamls` root location. Defaults to `cifmw_installyamls_repos` which defaults to `../..`.
 * `cifmw_operator_deploy_list`: (List) List of the operators to deploy. It must match a proper target in install_yamls Makefile.
 

--- a/ci_framework/roles/operator_deploy/defaults/main.yml
+++ b/ci_framework/roles/operator_deploy/defaults/main.yml
@@ -19,7 +19,7 @@
 # All variables within this role should have a prefix of "cifmw_operator_deploy"
 
 # output base directory
-cifmw_operator_deploy_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}"
+cifmw_operator_deploy_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 # List of operators you want to deploy
 cifmw_operator_deploy_list: []
 # install_yamls repository location

--- a/ci_framework/roles/pkg_build/README.md
+++ b/ci_framework/roles/pkg_build/README.md
@@ -6,7 +6,7 @@ registry, and then run one container per package to build.
 None
 
 ## Parameters
-* `cifmw_pkg_build_basedir`: (String) Base directory. Defaults to `cifmw_basedir` which  defaults to `~/ci-framework`.
+* `cifmw_pkg_build_basedir`: (String) Base directory. Defaults to `cifmw_basedir` which  defaults to `~/ci-framework-data`.
 * `cifmw_pkg_build_ctx_name`: (String) Container full name. Defaults to `localhost/cifmw-buildpkgs`.
 * `cifmw_pkg_build_ctx_tag`: (String) Container tag. Defaults to `latest`.
 * `cifmw_pkg_build_ctx_push`: (Boolean) Whether the container has to be pushed to some remote registry. Defaults to `false`.

--- a/ci_framework/roles/pkg_build/defaults/main.yml
+++ b/ci_framework/roles/pkg_build/defaults/main.yml
@@ -17,7 +17,7 @@
 
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_pkg_build"
-cifmw_pkg_build_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}"
+cifmw_pkg_build_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_pkg_build_ctx_name: "localhost/cifmw-buildpkgs"
 cifmw_pkg_build_ctx_tag: "latest"
 cifmw_pkg_build_ctx_push: false

--- a/ci_framework/roles/repo_setup/README.md
+++ b/ci_framework/roles/repo_setup/README.md
@@ -5,7 +5,7 @@ Please explain the role purpose.
 `become` may be set to true if you're deploying the repositories for the system.
 
 ## Parameters
-* `cifmw_repo_setup_basedir`: (String) Installation base directory. Defaults to `cifmw_basedir` which defaults to `~/ci-framework`.
+* `cifmw_repo_setup_basedir`: (String) Installation base directory. Defaults to `cifmw_basedir` which defaults to `~/ci-framework-data`.
 * `cifmw_repo_setup_promotion`: (String) Promotion line you want to deploy. Defaults to `current-podified`.
 * `cifmw_repo_setup_branch`: (String) Branch/release you want to deploy. Defaults to `zed`.
 * `cifmw_repo_setup_dlrn_uri`: (String) DLRN base URI. Defaults to `https://trunk.rdoproject.org/`.

--- a/ci_framework/roles/repo_setup/defaults/main.yml
+++ b/ci_framework/roles/repo_setup/defaults/main.yml
@@ -20,7 +20,7 @@
 # To get dlrn md5 hash for components [baremetal,cinder,clients,cloudops,common,
 # compute,glance,manila,network,octavia,security,swift,tempest,podified,ui,validation]
 # cifmw_repo_setup_component: <component name>
-cifmw_repo_setup_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}"
+cifmw_repo_setup_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_repo_setup_promotion: "podified-ci-testing"
 cifmw_repo_setup_branch: "zed"
 cifmw_repo_setup_dlrn_uri: "https://trunk.rdoproject.org/"

--- a/ci_framework/roles/repo_setup/molecule/default/converge.yml
+++ b/ci_framework/roles/repo_setup/molecule/default/converge.yml
@@ -27,7 +27,7 @@
         - name: Stat some files
           register: file_stats
           ansible.builtin.stat:
-            path: "{{ ansible_user_dir }}/ci-framework/{{ item }}"
+            path: "{{ ansible_user_dir }}/ci-framework-data/{{ item }}"
           loop:
             - 'artifacts/repositories/delorean.repo.md5'
         - name: Assert file status
@@ -46,7 +46,7 @@
         - name: Stat some files
           register: file_stats
           ansible.builtin.stat:
-            path: "{{ ansible_user_dir }}/ci-framework/{{ item }}"
+            path: "{{ ansible_user_dir }}/ci-framework-data/{{ item }}"
           loop:
             - 'artifacts/repositories/delorean.repo.md5'
             - 'venv'

--- a/ci_framework/roles/rhol_crc/README.md
+++ b/ci_framework/roles/rhol_crc/README.md
@@ -8,7 +8,7 @@ Become - required for the tasks in `sudoers_grant.yml` and `sudoers_revoke.yml` 
 
 ## Parameters
 
-* `cifmw_rhol_crc_basedir`: (String) Directory where we will have the RHOL/CRC binary and the configuration (e.g. `artifacts/.rhol_crc_pull_secret.txt`). Default to `cifmw_basedir` which defaults to `~/ci-framework`.
+* `cifmw_rhol_crc_basedir`: (String) Directory where we will have the RHOL/CRC binary and the configuration (e.g. `artifacts/.rhol_crc_pull_secret.txt`). Default to `cifmw_basedir` which defaults to `~/ci-framework-data`.
 * `cifmw_edpm_deploy_installyamls`: (String) install_yamls root location. Defaults to `cifmw_installyamls_repos` which defaults to `../..`.
 * `cifmw_rhol_crc_use_installyamls`: (Boolean) Tell the role to leverage install_yamls `crc` related targets. Defaults to `False`.
 * `cifmw_rhol_crc_dryrun`: (Boolean) Toggle the `ci_make` `dry_run` parameter. Defaults to `False`.

--- a/ci_framework/roles/rhol_crc/defaults/main.yml
+++ b/ci_framework/roles/rhol_crc/defaults/main.yml
@@ -33,7 +33,7 @@ cifmw_rhol_crc_tarball_name: crc-linux-amd64.tar.xz
 cifmw_rhol_crc_tarball_checksum_name: crc-linux-amd64.tar.xz.sha256
 cifmw_rhol_crc_base_url: https://mirror.openshift.com/pub/openshift-v4/clients/crc/{{ cifmw_rhol_crc_version }}
 # In case we don't use cifmw_basedir it will get the base_dir of the project if .git exists - change dir does not affect other tasks:
-cifmw_rhol_crc_basedir: "{{ cifmw_basedir | default( ansible_user_dir ~ '/ci-framework') }}"
+cifmw_rhol_crc_basedir: "{{ cifmw_basedir | default( ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_rhol_crc_binary_folder: "{{ cifmw_rhol_crc_basedir }}/bin"
 cifmw_rhol_crc_binary: "{{ cifmw_rhol_crc_basedir }}/bin/crc"
 cifmw_rhol_crc_force_cleanup: false

--- a/ci_framework/roles/rhol_crc/molecule/default/prepare.yml
+++ b/ci_framework/roles/rhol_crc/molecule/default/prepare.yml
@@ -19,7 +19,7 @@
   hosts: all
   vars:
     ansible_user_dir: "{{ lookup('env', 'HOME') }}"
-    cifmw_basedir: "{{ ansible_user_dir }}/ci-framework"
+    cifmw_basedir: "{{ ansible_user_dir }}/ci-framework-data"
     cifmw_install_yamls_defaults:
       NAMESPACE: openstack
   roles:

--- a/ci_framework/roles/rhol_crc/molecule/install_yamls/prepare.yml
+++ b/ci_framework/roles/rhol_crc/molecule/install_yamls/prepare.yml
@@ -19,7 +19,7 @@
   hosts: all
   vars:
     ansible_user_dir: "{{ lookup('env', 'HOME') }}"
-    cifmw_basedir: "{{ ansible_user_dir }}/ci-framework"
+    cifmw_basedir: "{{ ansible_user_dir }}/ci-framework-data"
     cifmw_install_yamls_tasks_out: "{{ ansible_user_dir }}/.ansible/roles/install_yamls_makes/tasks"
     cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
     cifmw_install_yamls_defaults:

--- a/ci_framework/roles/run_hook/README.md
+++ b/ci_framework/roles/run_hook/README.md
@@ -34,7 +34,7 @@ to do so, the hook playbook has to create a YAML file as follow:
 ```
 The location and name are fixed. Both `cifmw_basedir`, `step` and `hook_name` are passed
 down to the hook playbook. Note that the value of `cifmw_basedir` will default
-to `~/ci-framework` if you don't pass it.
+to `~/ci-framework-data` if you don't pass it.
 
 In the same way, hooks may be able to consume data from a previous hook by loading
 the generated fil using `ansible.builtin.include_vars`, using the mentioned path.

--- a/ci_framework/roles/run_hook/tasks/playbook.yml
+++ b/ci_framework/roles/run_hook/tasks/playbook.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Set playbook {{ hook.name }} path"
   set_fact:
-    cifmw_basedir: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework') }}"
+    cifmw_basedir: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}"
     hook_name: "{{ hook.name | regex_replace('([^\x00-\x7F]|\\s|`)+', '_') |lower }}"
     playbook_path: >-
       {%- if hook.source is not ansible.builtin.abs -%}

--- a/docs/source/Quickstart/02_nested_virt.md
+++ b/docs/source/Quickstart/02_nested_virt.md
@@ -74,7 +74,7 @@ cd /home/zuul/src/ci-framework
 Run the ansible command
 
 ```Bash
-ansible-playbook -e @/home/zuul/src/ci-framework/scenarios/centos-9/local-env.yml deploy-edpm.yml
+ansible-playbook -e @scenarios/centos-9/local-env.yml deploy-edpm.yml
 ```
 
 ℹ️ You may want to discover other existing scenarios in the `/scenarios` location.
@@ -85,15 +85,15 @@ Running the following commands will clean up the provisionned VM:
 ```Bash
 virsh -c qemu:///system destroy cifmw-vm
 virsh -c qemu:///system undefine cifmw-vm
-rm -rf ~/ci-framework
+rm -rf ~/ci-framework-data
 ```
 
 ## I want some details
 
 The `make` target will call `ansible-playbook` against the dev-local-env.yml playbook. This playbook will then:
-- create some directories located in `~/ci-framework`
-- generate an ephemeral SSH keypair in `~/ci-framework/artifacts` and allow it in the VM
-- fetch the latest CentOS Stream 9 image and store it in `~/ci-framework/images`
-- create a layered image based upon that CS9 image, and store i in `~/ci-framework/images`
+- create some directories located in `~/ci-framework-data`
+- generate an ephemeral SSH keypair in `~/ci-framework-data/artifacts` and allow it in the VM
+- fetch the latest CentOS Stream 9 image and store it in `~/ci-framework-data/images`
+- create a layered image based upon that CS9 image, and store i in `~/ci-framework-data/images`
 - bootstrap the VM, installing some softwares, configuring services and all
 - inject a block in your `~/.ssh/config` file for an easy access

--- a/docs/source/Usage/01_usage.md
+++ b/docs/source/Usage/01_usage.md
@@ -14,7 +14,7 @@ There are two levels of parameters we may provide:
 The following parameters allow to set a common value for parameters that
 are shared among multiple roles:
 * `cifmw_basedir`: The base directory for all of the artifacts. Defaults to
-`~/ci-framework`
+`~/ci-framework-data`
 * `cifmw_installyamls_repos`: install_yamls repository location. Defaults to `../..`
 * `cifmw_manifests`: Directory where k8s related manifests will be places. Defaults to
 `{{ cifmw_basedir }}/manifests`
@@ -24,7 +24,7 @@ are shared among multiple roles:
 * `cifmw_kubeconfig`: (String) Path to the kubeconfig file if externally provided.
 
 #### Words of caution
-If you want to output the content in another location than `~/ci-framework`
+If you want to output the content in another location than `~/ci-framework-data`
 (namely set the `cifmw_basedir` to some other location), you will have to update
 the `ansible.cfg`, updating the value of `roles_path` so that it includes
 this new location.

--- a/scenarios/centos-9/base.yml
+++ b/scenarios/centos-9/base.yml
@@ -2,4 +2,4 @@
 # Configure base system to match centos
 cifmw_repo_setup_os_release: 'centos'
 cifmw_repo_setup_dist_major_version: 9
-cifmw_basedir: "{{ ansible_user_dir }}/ci-framework"
+cifmw_basedir: "{{ ansible_user_dir }}/ci-framework-data"

--- a/zuul.d/content_provider.yaml
+++ b/zuul.d/content_provider.yaml
@@ -24,4 +24,4 @@
       - ci/playbooks/content_provider/run.yml
     post-run: ci/playbooks/collect-logs.yml
     vars:
-      cifmw_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}"
+      cifmw_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"


### PR DESCRIPTION
This should avoid issues when users clone the repository in the home
directory directly.

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/204