### PR TITLE
Insert rabbitmq-cluster-operator bundle to bundle list

### DIFF
--- a/ci_framework/roles/operator_build/tasks/build.yml
+++ b/ci_framework/roles/operator_build/tasks/build.yml
@@ -176,6 +176,10 @@
       set_fact:
         operator_bundles: "{{ operator_bundles + [operator_img_storage_bundle] }}"
 
+    - name: Add Rabbitmq cluster operator bundle
+      ansible.builtin.set_fact:
+        operator_bundles: "{{ operator_bundles + ['quay.io/openstack-k8s-operators/rabbitmq-cluster-operator-bundle@sha256:9ff91ad3c9ef1797b232fce2f9adf6ede5c3421163bff5b8a2a462c6a2b3a68b'] }}"
+
 - name: "{{ operator.name }} - Call bundle-build"
   ci_make:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"


### PR DESCRIPTION
https://github.com/openshift/release/pull/39733 adds the rabbitmq bundle to bundle list. It fixes the issue related to ```
constraints not satisfiable: subscription openstack-operator requires openstack-operator-index/openstack/alpha/openstack-operator.v0.0.1, subscription openstack-operator exists,
bundle openstack-operator.v0.0.1 requires an operator with package: cluster-operator and with version in range: >=0.0.0
```

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
