### PR TITLE
Sets cifmw_openshift_setup_kubeconfig for rdo crc-base jobs

### DIFF
--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -35,6 +35,8 @@
       network_isolation: true
       crc_attach_default_interface: true
       bmo_setup: false
+      # This should be set here since is associated with parent job (base-crc) and not the scenario
+      cifmw_kubeconfig: "/home/zuul-worker/.crc/machines/crc/kubeconfig"
 
 # Install Yamls specific job
 - job:


### PR DESCRIPTION
This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
