### PR TITLE
Ensure cifmw_kubeconfig is set if externally given out of infra step

### DIFF
--- a/ci_framework/playbooks/02-infra.yml
+++ b/ci_framework/playbooks/02-infra.yml
@@ -21,6 +21,14 @@
       ansible.builtin.include_role:
         name: rhol_crc
 
+    - name: Set cifmw_kubeconfig if not yet set
+      when:
+        - cifmw_kubeconfig is not defined
+        - "'KUBECONFIG' in ansible_env"
+      ansible.builtin.set_fact:
+        cifmw_kubeconfig: "{{ ansible_env.KUBECONFIG }}"
+        cacheable: true
+
     - name: Setup Openshift cluster
       ansible.builtin.include_role:
         name: openshift_setup


### PR DESCRIPTION
This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
