### PR TITLE
Add cifmw_operator_build_extra_bundles to content provider scenario

### DIFF
--- a/scenarios/centos-9/content_provider.yml
+++ b/scenarios/centos-9/content_provider.yml
@@ -7,3 +7,5 @@ cifmw_operator_build_push_org: "openstack-k8s-operators"
 cifmw_operator_build_org: "openstack-k8s-operators"
 cifmw_operator_build_meta_build: true
 cifmw_operator_build_local_registry: 1
+cifmw_operator_build_extra_bundles:
+ - "quay.io/openstack-k8s-operators/rabbitmq-cluster-operator-bundle@sha256:9ff91ad3c9ef1797b232fce2f9adf6ede5c3421163bff5b8a2a462c6a2b3a68b"


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/ci-framework/pull/204 adds extra bundle option to operator_build role. It needs to be included in content provider scenario so that meta operator are built successfully.

This PR has:
- [ ] Appropriate testing (molecule, python unit tests)
- [ ] Appropriate documentation (README in the role, main README is up-to-date)
