### PR TITLE
Create tempest role

### DIFF
--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -36,6 +36,7 @@
                 cmd: |
                   cp -ra {{ ansible_user_dir }}/ci-framework-data/logs . ;
                   cp -ra {{ ansible_user_dir }}/ci-framework-data/artifacts . ;
+                  cp -ra {{ ansible_user_dir }}/ci-framework-data/tests . || true ;
 
             - name: Check for Zuul inventory file
               ansible.builtin.stat:

--- a/ci_framework/playbooks/08-run-tests.yml
+++ b/ci_framework/playbooks/08-run-tests.yml
@@ -1,0 +1,19 @@
+- name: Run pre_tests hooks
+  vars:
+    hooks: "{{ pre_tempest | default([]) }}"
+    step: pre_tests
+  ansible.builtin.import_playbook: ./hooks.yml
+
+- name: Tests playbook
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Run tempest
+      ansible.builtin.import_role:
+        name: tempest
+
+- name: Run post_tests hooks
+  vars:
+    hooks: "{{ post_tempest | default([]) }}"
+    step: post_tests
+  ansible.builtin.import_playbook: ./hooks.yml

--- a/ci_framework/plugins/README.md
+++ b/ci_framework/plugins/README.md
@@ -85,6 +85,47 @@ Description: Generate task file per Makefile target.
   * required: True
   * type: str
 
+# modules/tempest_list_allowed
+Description: Generate list of tests to be executed by tempest
+
+## options:
+* `yaml_file`:
+  * description: Path to a yaml file containing the tests
+  * required: True
+  * type: str
+* `job`:
+  * description: Name of the job to be used in the filter.
+  * required: False
+  * type: str
+* `groups`:
+  * description: List of groups to be used in the filter.
+  * required: False
+  * type: list
+* `release`
+  * description: Release version
+  * type: str
+  * default: master
+
+# modules/tempest_list_skipped
+Description: Generate list of tests to be skipped by tempest
+
+## options:
+
+* `yaml_file`:
+  * description: Path to a yaml file containing the tests
+  * required: True
+  * type: str
+* `jobs`:
+  * description: List of the jobs to be used in the filter.
+  * required: False
+  * type: list
+* `release`:
+  * description: Release name to be used in the filter. Default is 'master'
+  * required: False
+  * type: str
+  * default: master
+
+
 ## Calling generated tasks
 In order to benefit of the generated role and tasks, you have to ensure ansible
 knows about the role location. By default, it will be in

--- a/ci_framework/plugins/modules/tempest_list_allowed.py
+++ b/ci_framework/plugins/modules/tempest_list_allowed.py
@@ -1,0 +1,144 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2023, Arx Cruz <acruz@redhat.com>
+# Apache License Version 2.0 (see LICENSE)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: tempest_list_allowed
+
+short_description: Parse filtered tests to tempest
+
+description:
+  - Parse filtered tests to be executed by tempest
+
+options:
+  yaml_file:
+    description:
+    - Path to a yaml file containing the tests in openstack-tempest-skiplist
+      format
+    required: True
+    type: str
+  job:
+    description:
+    - Name of the job to be used in the filter.
+    required: False
+    type: str
+  groups:
+    description:
+    - List of groups to be used in the filter. It has more precedence than job
+    required: False
+    type: list
+    elements: str
+  release:
+    description:
+    - Release version
+    type: str
+    default: master
+
+author:
+  - Arx Cruz (@arxcruz)
+
+'''
+
+EXAMPLES = r'''
+- name: Get list of allowed tests
+  tempest_list_allowed:
+    yaml_file: /tmp/allowed.yaml
+    job: tripleo-ci-centos-8-standalone
+    groups:
+     - default
+'''
+
+RETURN = r'''
+allowed_tests:
+  description:
+    - List of tests filtered
+  returned: Always
+  type: list
+  sample: [
+    "tempest.api.volume.test_volumes_snapshots.VolumesSnapshotTestJSON"
+    ]
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+import yaml
+
+
+def _filter_allowed_tests(groups, release, job, yaml_file):
+    tests = []
+    if yaml_file:
+        if groups:
+            everything = yaml_file.get('groups', [])
+            for group in groups:
+                group_tests = list(filter(
+                    lambda x:
+                        x.get('name', '') == group, everything))
+                group_tests = list(filter(
+                    lambda x:
+                        any(r in ['all', release] for r in x.get(
+                            'releases', [])),
+                        group_tests))
+                if len(group_tests) > 0:
+                    tests = tests + group_tests
+        if job:
+            everything = yaml_file.get('jobs', [])
+            job_tests = list(filter(
+                lambda x: x.get('name', '') == job,
+                everything))
+            job_tests = list(filter(
+                lambda x:
+                    any(r in ['all', release] for r in x.get(
+                        'releases', [])),
+                    job_tests))
+            if len(job_tests) > 0:
+                tests = job_tests
+    return [t for sublist in tests for t in sublist.get('tests', [])]
+
+
+def main():
+
+    module_args = {
+        'yaml_file': {'type': 'str', 'required': True},
+        'job': {'type': 'str', 'required': False},
+        'groups': {'type': 'list', 'elements': 'str'},
+        'release': {'type': 'str', 'default': 'master'}
+    }
+
+    result = {
+        'changed': True,
+        'message': '',
+        'allowed_tests': []
+    }
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False
+    )
+    if not module.params['yaml_file']:
+        module.fail_json(msg="A yaml file must be provided!")
+
+    if not module.params['job'] and not module.params['groups']:
+        module.fail_json(msg="You must specify either job or group parameter!")
+
+    with open(module.params['yaml_file']) as yf:
+        _yaml_file = yaml.safe_load(yf)
+
+    _groups = module.params['groups']
+    _release = module.params['release']
+    _job = module.params['job']
+
+    tests = _filter_allowed_tests(_groups, _release, _job, _yaml_file)
+
+    allowed_tests = tests
+
+    result.update({'allowed_tests': allowed_tests})
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/ci_framework/plugins/modules/tempest_list_skipped.py
+++ b/ci_framework/plugins/modules/tempest_list_skipped.py
@@ -1,0 +1,125 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2023, Arx Cruz <acruz@redhat.com>
+# Apache License Version 2.0 (see LICENSE)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: tempest_list_skipped
+
+short_description: Parse skipped tests from tempest
+
+description:
+  - Parse filtered tests to be skipped by tempest
+
+options:
+  yaml_file:
+    description:
+      - Path to a yaml file containing the skipped tests in
+        openstack-tempest-skiplist format
+    required: True
+    type: str
+  jobs:
+    description:
+      - List of the jobs to be used in the filter. Passing the jobs it will
+        filter only tests that have the specified jobs in the jobs list.
+    required: False
+    type: list
+    elements: str
+  release:
+    description:
+      - Release name to be used in the filter. Default is set to 'master'
+    required: False
+    default: master
+    type: str
+
+author:
+  - Arx Cruz (@arxcruz)
+
+'''
+
+
+EXAMPLES = r'''
+- name: Get list of skipped tests
+  tempest_list_skipped:
+    yaml_file: /tmp/skipped.yaml
+    job: edpm
+    release: master
+'''
+
+
+RETURN = r'''
+skipped_tests:
+  description:
+    - List of tests filtered
+  returned: Always
+  type: list
+  sample: [
+    "tempest.api.volume.test_volumes_snapshots.VolumesSnapshotTestJSON"
+    ]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+import yaml
+
+
+def run_module():
+    module_args = {
+        'yaml_file': {'type': 'str', 'required': True},
+        'jobs': {'type': 'list', 'required': False, 'elements': 'str'},
+        'release': {'type': 'str', 'required': False, 'default': 'master'}
+    }
+
+    result = dict(
+        changed=True,
+        message='',
+        skipped_tests=[]
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args
+    )
+    if not module.params['yaml_file']:
+        module.fail_json(msg="A yaml file must be provided!")
+
+    _release = module.params['release']
+    _jobs = module.params['jobs']
+    with open(module.params['yaml_file']) as yf:
+        _yaml_file = yaml.safe_load(yf)
+
+    tests = _filter_skipped_tests(_jobs, _release, _yaml_file)
+    skipped_tests = tests
+
+    result.update({'skipped_tests': skipped_tests})
+    module.exit_json(**result)
+
+
+def _filter_skipped_tests(jobs, release, yaml_file):
+    if len(yaml_file) > 0:
+        tests = yaml_file.get('known_failures', [])
+
+        if jobs:
+            tests = [test for test in tests
+                     if (not test.get('jobs', [])) or (
+                         [job for job in jobs if job in test.get('jobs', [])]
+                     )]
+
+        if release:
+            tests = [test for test in tests
+                     if [rel for rel in test.get('releases', [])
+                         if rel['name'] == release]]
+
+        if len(tests) > 0:
+            return [test.get('test') for test in tests]
+    return []
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/ci_framework/roles/tempest/README.md
+++ b/ci_framework/roles/tempest/README.md
@@ -1,0 +1,14 @@
+# tempest
+Role to setup and run tempest tests
+
+## Privilege escalation
+become - Required to install required rpm packages
+
+## Parameters
+
+* `cifmw_tempest_artifacts_basedir`: (String) Directory where we will have all tempest files. Default to `cifmw_basedir/artifacts/tempest` which defaults to `~/ci-framework-data/artifacts/tempest`.
+* `cifmw_tempest_default_groups`: (List) List of groups in the include list to search for tests to be executed
+* `cifmw_tempest_default_jobs`: (List) List of jobs in the esclude list to search for tests to be excluded
+* `cifmw_tempest_image`: (String) Name of the tempest image to be used. Default to `quay.io/podified-antelope-centos9/openstack-tempest`
+* `cifmw_tempest_image_tag`: (String) Tag for the `cifmw_tempest_image`. Default to `current-podified`
+* `cifmw_tempest_dry_run`: (Boolean) Whether tempest should run or not. Default to `false`

--- a/ci_framework/roles/tempest/defaults/main.yml
+++ b/ci_framework/roles/tempest/defaults/main.yml
@@ -1,0 +1,27 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_tempest"
+cifmw_tempest_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}/tests/tempest"
+cifmw_tempest_default_groups:
+  - default
+cifmw_tempest_default_jobs:
+  - default
+cifmw_tempest_image: quay.io/podified-antelope-centos9/openstack-tempest
+cifmw_tempest_image_tag: current-podified
+cifmw_tempest_dry_run: false

--- a/ci_framework/roles/tempest/files/list_allowed.yml
+++ b/ci_framework/roles/tempest/files/list_allowed.yml
@@ -1,0 +1,36 @@
+groups:
+  - name: default
+    tests:
+      - tempest.api.identity.*.v3
+    releases:
+      - all
+  - name: openstack-operator
+    tests:
+      - tempest.api.identity.*.v3
+    releases:
+      - all
+  - name: cinder-operator
+    tests:
+      - tempest.api.volume
+    releases:
+      - all
+  - name: keystone-operator
+    tests:
+      - tempest.api.identity.*.v3
+    releases:
+      - all
+  - name: neutron-operator
+    tests:
+      - tempest.api.network.*
+    releases:
+      - all
+  - name: nova-operator
+    tests:
+      - tempest.api.compute.*
+    releases:
+      - all
+  - name: manila-operator
+    tests:
+      - manila_tempest_tests.tests.api
+    releases:
+      - all

--- a/ci_framework/roles/tempest/files/list_skipped.yml
+++ b/ci_framework/roles/tempest/files/list_skipped.yml
@@ -1,0 +1,1093 @@
+known_failures:
+  # Neutron operator
+  - test: 'tempest.api.network.admin.test_ports.PortsAdminExtendedAttrsIpV6TestJSON'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - neutron-operator
+  - test: 'tempest.api.network.admin.test_ports.PortsAdminExtendedAttrsTestJSON'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - neutron-operator
+  # Cinder operator
+  - test: 'tempest.api.volume.admin.test_volume_types.VolumeTypesTest.test_volume_crud_with_volume_type_and_extra_specs'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - cinder-operator
+  - test: 'tempest.api.volume.admin.test_volumes_actions.VolumesActionsTest.test_force_detach_volume'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - cinder-operator
+  - test: 'tempest.api.volume.test_volumes_actions.VolumesActionsTest.test_attach_detach_volume_to_instance'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - cinder-operator
+  - test: 'tempest.api.volume.test_volumes_actions.VolumesActionsTest.test_get_volume_attachment'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - cinder-operator
+  - test: 'tempest.api.volume.test_volumes_backup.VolumesBackupsTest.test_backup_create_attached_volume'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - cinder-operator
+  - test: 'tempest.api.volume.test_volumes_backup.VolumesBackupsTest.test_volume_backup_create_get_detailed_list_restore_delete'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - cinder-operator
+  - test: 'tempest.api.volume.test_volumes_negative.VolumesNegativeTest.test_attach_volumes_with_nonexistent_volume_id'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - cinder-operator
+  - test: 'tempest.api.volume.test_volumes_snapshots.VolumesSnapshotTestJSON.test_snapshot_create_delete_with_volume_in_use'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - cinder-operator
+  - test: 'tempest.api.volume.test_volumes_snapshots.VolumesSnapshotTestJSON.test_snapshot_create_offline_delete_online'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - cinder-operator
+  # Nova operator
+  - test: tempest.api.compute.admin.test_hypervisor_negative.HypervisorAdminNegativeUnderV252Test.test_search_hypervisor_with_non_admin_user
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hypervisor.HypervisorAdminTestJSON.test_get_hypervisor_list
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hypervisor.HypervisorAdminTestJSON.test_get_hypervisor_list_details
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hypervisor_negative.HypervisorAdminNegativeUnderV252Test.test_show_servers_with_non_admin_user
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_aggregates_negative.AggregatesAdminNegativeTestJSON.test_aggregate_add_existent_host
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hypervisor.HypervisorAdminTestJSON.test_get_hypervisor_show_details
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_auto_allocate_network.AutoAllocateNetworkTest.test_server_create_no_allocate
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_aggregates_negative.AggregatesAdminNegativeTestJSON.test_aggregate_add_host_as_user
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_auto_allocate_network.AutoAllocateNetworkTest.test_server_multi_create_auto_allocate
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hosts.HostsAdminTestJSON.test_show_host_detail
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_delete_server.DeleteServersAdminTestJSON.test_admin_delete_servers_of_others
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hypervisor_negative.HypervisorAdminNegativeTestJSON.test_get_hypervisor_uptime_with_non_admin_user
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hypervisor_negative.HypervisorAdminNegativeTestJSON.test_show_hypervisor_with_non_admin_user
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_delete_server.DeleteServersAdminTestJSON.test_delete_server_while_in_error_state
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_aggregates_negative.AggregatesAdminNegativeTestJSON.test_aggregate_remove_host_as_user
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hypervisor.HypervisorAdminUnderV252Test.test_get_hypervisor_show_servers
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hypervisor.HypervisorAdminUnderV252Test.test_search_hypervisor
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_services.ServicesAdminTestJSON.test_get_service_by_service_binary_name
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hypervisor.HypervisorAdminV253TestBase.test_list_show_detail_hypervisors
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_volumes_negative.VolumesAdminNegativeTest.test_update_attached_volume_with_nonexistent_volume_in_body
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_servers.ServersAdmin275Test.test_rebuild_update_server_275
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hypervisor.HypervisorAdminV228Test.test_get_list_hypervisor_details
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_volumes_negative.VolumesAdminNegativeTest.test_update_attached_volume_with_nonexistent_volume_in_uri
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.images.test_images_negative.ImagesNegativeTestJSON.test_create_image_from_deleted_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_server_external_events.ServerExternalEventsTest.test_create_server_external_events
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_server_diagnostics.ServerDiagnosticsTest.test_get_server_diagnostics
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_create_server.ServersWithSpecificFlavorTestJSON.test_verify_created_server_ephemeral_disk
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_device_tagging.TaggedBootDevicesTest.test_tagged_boot_devices
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_server_diagnostics.ServerDiagnosticsV248Test.test_get_server_diagnostics
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.floating_ips.test_floating_ips_actions.FloatingIPsTestJSON.test_allocate_floating_ip
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers.ServersTestJSON.test_create_server_specify_multibyte_character_name
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.floating_ips.test_floating_ips_actions.FloatingIPsTestJSON.test_delete_floating_ip
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_server_diagnostics_negative.ServerDiagnosticsNegativeTest.test_get_server_diagnostics_by_non_admin
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_attach_interfaces.AttachInterfacesTestJSON.test_create_list_show_delete_interfaces_by_fixed_ip
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_attach_interfaces.AttachInterfacesTestJSON.test_create_list_show_delete_interfaces_by_network_port
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.security_groups.test_security_groups.SecurityGroupsTestJSON.test_list_security_groups_by_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_disk_config.ServerDiskConfigTestJSON.test_rebuild_server_with_auto_disk_config
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers.ServersTestJSON.test_create_server_with_ipv6_addr_only
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_attach_interfaces.AttachInterfacesTestJSON.test_reassign_port_between_servers
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_disk_config.ServerDiskConfigTestJSON.test_rebuild_server_with_manual_disk_config
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers.ServersTestJSON.test_create_specify_keypair
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_availability_zone.AZV2TestJSON.test_get_availability_zone_list_with_non_admin_user
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_attach_interfaces.AttachInterfacesUnderV243Test.test_add_remove_fixed_ip
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_device_tagging.TaggedAttachmentsTest.test_tagged_attachment
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_disk_config.ServerDiskConfigTestJSON.test_update_server_from_auto_to_manual
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_delete_server.DeleteServersTestJSON.test_delete_active_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers.ServersTestJSON.test_create_with_existing_server_name
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_create_server_multi_nic.ServersTestMultiNic.test_verify_duplicate_network_nics
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_delete_server.DeleteServersTestJSON.test_delete_server_while_in_attached_volume
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers.ServersTestJSON.test_update_access_server_address
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.security_groups.test_security_groups.SecurityGroupsTestJSON.test_server_security_groups
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_attach_interfaces.AttachInterfacesV270Test.test_create_get_list_interfaces
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.volumes.test_attach_volume.AttachVolumeTestJSON.test_attach_detach_volume
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_create_server_multi_nic.ServersTestMultiNic.test_verify_multiple_nics_order
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers_microversions.ServerShowV257Test.test_rebuild_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers.ServersTestJSON.test_update_server_name
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.volumes.test_attach_volume.AttachVolumeTestJSON.test_list_get_volume_attachments
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_delete_server.DeleteServersTestJSON.test_delete_server_while_in_pause_state
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_device_tagging.TaggedBootDevicesTest_v242.test_tagged_boot_devices
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_delete_server.DeleteServersTestJSON.test_delete_server_while_in_shelved_state
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.volumes.test_attach_volume_negative.AttachVolumeNegativeTest.test_attach_attached_volume_to_different_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_actions.ServersAaction247Test.test_create_backup
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_volume.AttachSCSIVolumeTestJSON.test_attach_scsi_disk_with_config_drive
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_delete_server.DeleteServersTestJSON.test_delete_server_while_in_shutoff_state
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.volumes.test_attach_volume_negative.AttachVolumeNegativeTest.test_attach_attached_volume_to_same_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers_microversions.ServerShowV254Test.test_rebuild_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.volumes.test_attach_volume_negative.AttachVolumeNegativeTest.test_delete_attached_volume
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_delete_server.DeleteServersTestJSON.test_delete_server_while_in_suspended_state
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers.ServerShowV247Test.test_update_rebuild_list_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_group.ServerGroupTestJSON.test_create_server_with_scheduler_hint_group
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_multiple_create.MultipleCreateTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.images.test_images.ImagesTestJSON.test_create_image_from_paused_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_instance_actions.InstanceActionsV221TestJSON.test_get_list_deleted_instance_actions
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.images.test_images.ImagesTestJSON.test_create_image_from_stopped_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.images.test_images.ImagesTestJSON.test_create_image_from_suspended_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.images.test_images.ImagesTestJSON.test_create_server_from_snapshot
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.images.test_images.ImagesTestJSON.test_delete_saving_image
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.volumes.test_attach_volume.AttachVolumeShelveTestJSON.test_attach_volume_shelved_or_offload_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.volumes.test_attach_volume.AttachVolumeShelveTestJSON.test_detach_volume_shelved_or_offload_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_servers_negative.ServersAdminNegativeTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.floating_ips.test_list_floating_ips.FloatingIPDetailsTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_create_server.ServersTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_tags.ServerTagsTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.images.test_images_oneserver_negative.ImagesOneServerNegativeTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.floating_ips.test_floating_ips_actions.FloatingIPsAssociationTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_addresses_negative.ServerAddressesNegativeTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_servers.ServersAdminTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_create_server.ServersTestBootFromVolume
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_simple_tenant_usage.TenantUsagesTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_addresses.ServerAddressesTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_create_server.ServersTestManualDisk
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.floating_ips.test_floating_ips_actions_negative.FloatingIPsAssociationNegativeTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_metadata_negative.ServerMetadataNegativeTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.images.test_images_oneserver.ImagesOneServerTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_instance_actions_negative.InstanceActionsNegativeTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers_negative.ServersNegativeTestMultiTenantJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_password.ServerPasswordTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_instance_actions.InstanceActionsTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_list_servers_negative.ListServersNegativeTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_rescue.ServerRescueTestJSONUnderV235
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_list_server_filters.ListServerFiltersTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers_negative.ServersNegativeTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_rescue.ServerRescueTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_rescue_negative.ServerRescueNegativeTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.images.test_list_image_filters.ListImageFiltersTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_availability_zone.AZAdminV2TestJSON.test_get_availability_zone_list
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: manila_tempest_tests.tests.api.test_share_network_subnets.ShareNetworkSubnetsTest.test_create_delete_subnet
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Fix not landed yet
+        lp: http://no.bug
+    jobs:
+      - manila-operator
+  - test: tempest.api.compute.admin.test_live_migration_negative.LiveMigrationNegativeTest.test_live_block_migration_suspended
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Test env does not have compute
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_live_migration_negative.LiveMigrationNegativeTest.test_invalid_host_for_migration
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Test env does not have compute
+        lp: http://no.bug
+    jobs:
+      - nova-operator

--- a/ci_framework/roles/tempest/meta/main.yml
+++ b/ci_framework/roles/tempest/meta/main.yml
@@ -1,0 +1,42 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- tempest
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: edpm
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - edpm
+    - tempest
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/ci_framework/roles/tempest/molecule/default/converge.yml
+++ b/ci_framework/roles/tempest/molecule/default/converge.yml
@@ -1,0 +1,24 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_tempest_dry_run: true
+  roles:
+    - role: "tempest"

--- a/ci_framework/roles/tempest/molecule/default/molecule.yml
+++ b/ci_framework/roles/tempest/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/tempest/molecule/default/prepare.yml
+++ b/ci_framework/roles/tempest/molecule/default/prepare.yml
@@ -1,0 +1,30 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_basedir: "{{ ansible_user_dir }}/ci-framework-data"
+    cifmw_install_yamls_tasks_out: "{{ ansible_user_dir }}/zuul-jobs/roles/install_yamls_makes/tasks"
+    cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
+    cifmw_install_yamls_defaults:
+      NAMESPACE: openstack
+  roles:
+    - role: test_deps
+    - role: ci_setup
+    - role: install_yamls

--- a/ci_framework/roles/tempest/tasks/configure-tempest.yml
+++ b/ci_framework/roles/tempest/tasks/configure-tempest.yml
@@ -1,0 +1,29 @@
+- name: Get keystone data
+  register: keystone_data
+  environment:
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.shell:
+    cmd: oc get keystoneapi keystone -n openstack -o json
+
+- name: Set keystone vars
+  ansible.builtin.set_fact:
+    keystone_secret_name: "{{ keystone_data.stdout | from_json | community.general.json_query('spec.secret') }}"
+    keystone_passwd_select: "{{ keystone_data.stdout | from_json | community.general.json_query('spec.passwordSelectors.admin') }}"
+    keystone_api: "{{ keystone_data.stdout | from_json | community.general.json_query('status.apiEndpoint.public') }}"
+
+- name: Get credentials data
+  register: os_password_data
+  environment:
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.shell:
+    cmd: 'oc get secret {{ keystone_secret_name }} -n openstack -o json'
+
+- name: Get password data
+  ansible.builtin.set_fact:
+    os_password: >-
+      {{ os_password_data.stdout | from_json | community.general.json_query('data.' ~ keystone_passwd_select) | ansible.builtin.b64decode }}
+
+- name: Get clouds.yaml
+  ansible.builtin.template:
+    src: clouds.yaml.j2
+    dest: "{{ cifmw_tempest_artifacts_basedir }}/clouds.yaml"

--- a/ci_framework/roles/tempest/tasks/main.yml
+++ b/ci_framework/roles/tempest/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure podman is installed
+  become: true
+  ansible.builtin.package:
+    name: podman
+    state: present
+
+- name: Create tempest directories
+  ansible.builtin.file:
+    path: "{{ cifmw_tempest_artifacts_basedir }}"
+    state: directory
+
+- name: Setup tempest tests
+  ansible.builtin.include_tasks: tempest-tests.yml
+
+- name: Configure tempest
+  ansible.builtin.include_tasks: configure-tempest.yml
+  when: not cifmw_tempest_dry_run | bool
+
+- name: Set proper permission for tempest directory
+  ansible.builtin.shell:
+    cmd: "podman unshare chown 42480:42480 -R {{ cifmw_tempest_artifacts_basedir }}"
+  when: not cifmw_tempest_dry_run | bool
+
+# > {{ cifmw_tempest_artifacts_basedir }}/tempest_output.log"
+- name: Run tempest
+  ansible.builtin.command:
+    cmd: "podman run -v {{ cifmw_tempest_artifacts_basedir }}/:/var/lib/tempest/external_files:Z {{ cifmw_tempest_image }}:{{ cifmw_tempest_image_tag }}"
+  when: not cifmw_tempest_dry_run | bool

--- a/ci_framework/roles/tempest/tasks/tempest-tests.yml
+++ b/ci_framework/roles/tempest/tasks/tempest-tests.yml
@@ -1,0 +1,58 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+- name: Copy list_allowed to artifacts dir
+  ansible.builtin.copy:
+    dest: "{{ cifmw_tempest_artifacts_basedir }}/list_allowed.yml"
+    src: "list_allowed.yml"
+
+- name: Copy list_skipped to artifacts dir
+  ansible.builtin.copy:
+    dest: "{{ cifmw_tempest_artifacts_basedir }}/list_skipped.yml"
+    src: "list_skipped.yml"
+
+- name: Get list of tests to be executed
+  tempest_list_allowed:
+    yaml_file: "{{ cifmw_tempest_artifacts_basedir }}/list_allowed.yml"
+    groups: "{{ cifmw_tempest_default_groups }}"
+    # job: "{{ cifmw_tempest_job_name | default(omit) }}"
+  register:
+    list_allowed
+
+- name: Show tests to be executed
+  ansible.builtin.debug:
+    msg: "{{ list_allowed }}"
+
+- name: Get list of tests to be excluded
+  tempest_list_skipped:
+    yaml_file: "{{ cifmw_tempest_artifacts_basedir }}/list_skipped.yml"
+    jobs: "{{ cifmw_tempest_default_jobs }}"
+  register:
+    list_skipped
+
+- name: Show tests to be excluded
+  ansible.builtin.debug:
+    msg: "{{ list_skipped.skipped_tests }}"
+
+- name: Creating include.txt
+  ansible.builtin.copy:
+    dest: "{{ cifmw_tempest_artifacts_basedir }}/include.txt"
+    content: "{% for test in list_allowed.allowed_tests %}{{ test }}\n{% endfor %}"
+
+- name: Creating exclude.txt
+  ansible.builtin.copy:
+    dest: "{{ cifmw_tempest_artifacts_basedir }}/exclude.txt"
+    content: "{% for test in list_skipped.skipped_tests %}{{ test }}\n{% endfor %}"

--- a/ci_framework/roles/tempest/templates/clouds.yaml.j2
+++ b/ci_framework/roles/tempest/templates/clouds.yaml.j2
@@ -1,0 +1,10 @@
+clouds:
+  default:
+    auth:
+      auth_url: {{ (keystone_api == '') | ternary('http://keystone-public-openstack.apps-crc.testing', keystone_api)}}
+      project_name: admin
+      username: admin
+      user_domain_name: Default
+      project_domain_name: Default
+      password: {{ (os_password == '') | ternary('12345678', os_password) }}
+    region_name: regionOne

--- a/ci_framework/tests/sanity/ignore.txt
+++ b/ci_framework/tests/sanity/ignore.txt
@@ -1,2 +1,4 @@
 plugins/modules/get_makefiles_env.py validate-modules:missing-gplv3-license # ignore license check
 plugins/modules/generate_make_tasks.py validate-modules:missing-gplv3-license # ignore license check
+plugins/modules/tempest_list_allowed.py validate-modules:missing-gplv3-license # ignore license check
+plugins/modules/tempest_list_skipped.py validate-modules:missing-gplv3-license # ignore license check

--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -28,6 +28,10 @@
 #- name: Import admin setup related playbook
 #  ansible.builtin.import_playbook: ci_framework/playbooks/07-admin-setup.yml
 
+- name: Import run test playbook
+  ansible.builtin.import_playbook: ci_framework/playbooks/08-run-tests.yml
+  when: cifmw_run_tests | default('true') | bool
+
 - name: Run log related tasks
   ansible.builtin.import_playbook: ci_framework/playbooks/99-logs.yml
   when: not zuul_log_collection | default ('false') | bool

--- a/docs/source/roles/tempest.md
+++ b/docs/source/roles/tempest.md
@@ -1,0 +1,1 @@
+../../../ci_framework/roles/tempest/README.md

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -48,6 +48,8 @@
     name: cifmw-crc-podified-edpm-baremetal
     parent: cifmw-base-crc-openstack
     run: ci/playbooks/edpm_baremetal_deployment/run.yml
+    vars:
+      cifmw_run_tests: false
 
 # Install Yamls specific job
 - job:

--- a/zuul.d/end-to-end.yaml
+++ b/zuul.d/end-to-end.yaml
@@ -50,6 +50,8 @@
       - ^OWNERS
       - ^.github
     run: ci/playbooks/e2e-run.yml
+    vars:
+      cifmw_run_tests: false
 
 # Run the dev workflow if we edit specific role(s)
 - job:

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -255,6 +255,16 @@
       - ^ci_framework/roles/run_hook/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
+    name: cifmw-molecule-tempest
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: tempest
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/tempest/(?!meta|README).*
+      - ^ci/playbooks/molecule.*
+- job:
     name: cifmw-molecule-test_deps
     parent: cifmw-molecule-base
     vars:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -40,5 +40,6 @@
         - cifmw-molecule-repo_setup
         - cifmw-molecule-rhol_crc
         - cifmw-molecule-run_hook
+        - cifmw-molecule-tempest
         - cifmw-molecule-test_deps
         - cifmw-molecule-hive


### PR DESCRIPTION
This is a *very* simple role to run tempest.
At the moment it does have the following:
* tempest_list_allowed to list tests to be executed
* tempest_list_skipped to list tests to be excluded
* Configure the include and exclude list of tests
* Run tempest via podman command line In the future, the podman run will be replace with a pod.

This PR has:
- [x] Appropriate testing (molecule, python unit tests)
- [x] Appropriate documentation (README in the role, main README is up-to-date)
