### PR TITLE
Deploy and delete OCP clusters on physical systems using Hive operator.

### DIFF
--- a/ci_framework/roles/hive/README.md
+++ b/ci_framework/roles/hive/README.md
@@ -1,25 +1,170 @@
-# Role: hive
-This role can be used to claim clusters from a clusterpool.
-It assumes that oc > 4 is installed and configured.
+# hive
+Hive is an operator which runs as a service on top of Kubernetes/OpenShift.
+The service can be used to provision and perform initial configuration of
+OpenShift clusters.
 
-## Privilege escalation
-None
+This role is wrapper around the Hive service providing the following support
+
+* Cluster pools using OpenStack provider.
+* Deployment of clusters on physical servers.
+
+## Dependencies
+* `ci_setup`
+* `openshift_provisioner_node`: Required when `cifmw_hive_platform` is set to
+  `baremetal`
 
 ## Parameters
-* `cifmw_hive_platform`: (Required), the platform to install OpenShift. It
-  could be a cloud provider or baremetal. Supported values are ('openstack').
-* `cifmw_hive_kubeconfig`: (Required), absolute path to the kubeconfig file to
-  be used for communicating with the Hive operator.
-* `cifmw_hive_namespace`: (Required), OpenShift namespace that can be used for
-  creating the required resources (secrets, clusterimageset, etc.).
-* `cifmw_hive_action`: (Required), The action to be performed. Support values
-  are (claim_cluster' and 'unclaim_cluster').
-* `cifmw_hive_openstack_pool_name`: The name of OCP clusterpool to be used for
-  claim. Required when platform is openstack and clusterpool exists.
-* `cifmw_hive_openstack_claim_name`: The name of the claim to be used for the
-  claimed OCP resource in Hive.
-* `cifmw_hive_openstack_claim_life_time`: Time after which the cluster gets automatically deleted by the Hive operator. Defaults to 24h.
-* `cifmw_hive_openstack_claim_timeout`: Time after which the cluster claim times out. Defaults to 59m.
-* `cifmw_hive_oc_delete_timeout`: Time after which cluster delete times out. Defaults to 59m.
-* `cifmw_hive_basedir`: Base directory to  be used.
-* `cifmw_hive_artifacts_dir`: Directory where all artifacts produced (eg: kubeconfig file) will be stored.
+
+### Common required parameters
+* `cifmw_hive_kubeconfig`: (String) Absolute path to the kubeconfig file to be
+  used for authentication with the OpenShift instance hosting the Hive
+  instance.
+* `cifmw_hive_namespace`: (String) Name of the openshift namespace to be used
+   for creating resources like secrets, clusterimageset, clusterpool, etc.
+* `cifmw_hive_platform`: (String) the name of the supported provider to be
+  used for deployment. Supported values are `baremetal` | `openstack`.
+* `cifmw_hive_action`: (String) the action to be performed by Hive service.
+  The supported actions are `claim_cluster` | `unclaim_cluster` |
+  `deploy_cluster` | `delete_cluster`.
+
+### Common optional parameters
+* `cifmw_hive_basedir`: (String) Base directory. Defaults to `cifmw_basedir`
+  which defaults to `~/ci-framework-data`.
+* `cifmw_hive_artifacts_dir`: (String) Path to the artifacts directory.
+  Defaults to `{{ cifmw_basedir }}/artifacts/hive`.
+* `cifmw_hive_dry_run`: (Boolean) It prevents execution of `oc` commands found
+  in the play / role when it is enabled. It is useful for unit testing.
+  Defaults to `false`.
+* `cifmw_hive_oc_delete_timeout`: (String) Maximum allowed time that a resource
+  can take for a delete operation. Defaults to `59m`
+
+### OpenStack platform required parameters
+* `cifmw_hive_openstack_pool_name`: (String) The name of Hive clusterpool to be
+  used.
+* `cifmw_hive_openstack_claim_name`: (String) The name of the claim to be used
+  for the claimed OpenShift cluster.
+
+### OpenStack platform optional parameters
+* `cifmw_hive_openstack_claim_life_time`: (String) Maximum life time of the
+  claimed OpenShift cluster. Defaults to `24h`.
+* `cifmw_hive_openstack_claim_timeout`: (String) Maximum allowed time before
+  failing during the claim operation. Defaults to `59m`.
+
+### Baremetal platform required parameters
+* `cifmw_hive_baremetal`: (Dict) configurations related to the baremetal test
+  environment to be used for deploying OpenShift cluster.
+
+#### Supported keys in cifmw_hive_baremetal
+* `cluster_name`: (String) name of the OpenShift cluster.
+* `install_config`: (String) absolute path to the install file containing
+  information about the test environment. Refer to [Baremetal install config]
+  (#Baremetal-install-config) example.
+* `ocp_image`: (String) OpenShift release image to be used for deploying the
+  environment.
+
+## Return values
+* `cifmw_openshift_kubeconfig`: (String) absolute path to the kubeconfig of the
+  deployed OpenShift cluster.
+* `cifmw_openshift_user`: (String) name of the user associated with the deployed
+  OpenShift cluster.
+* `cifmw_openshift_password`: (String) password set for
+  `cifmw_openshift_username`.
+
+## Examples
+### Sample local variables file for using Hive
+```YAML
+cifmw_use_libvirt: true
+cifmw_use_opn: true
+cifmw_use_hive: true
+
+cifmw_basedir: "{{ ansible_user_dir }}/ci-framework-data"
+cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/install_yamls"
+
+cifmw_repo_setup_os_release: 'centos'
+cifmw_repo_setup_dist_major_version: 9
+
+cifmw_libvirt_manager_user: root
+cifmw_libvirt_manager_skip_edpm_compute_repos: true
+
+cifmw_opn_host: REDACTED
+cifmw_opn_external_network_iface: eno3
+cifmw_opn_dhcp: true
+cifmw_opn_use_provisioning_network: true
+cifmw_opn_prov_network_iface: eno1
+cifmw_opn_bootstrap_ipv4: REDACTED
+
+cifmw_hive_platform: baremetal
+cifmw_hive_action: deploy_cluster
+cifmw_hive_kubeconfig: "{{ ansible_user_dir }}/kubeconfig"
+cifmw_hive_namespace: openstack
+
+cifmw_hive_baremetal:
+  cluster_name: unittest-01
+  install_config: "{{ ansible_user_dir }}/install_config.yml"
+  ssh_key: 'ssh-ed25519 ...REDACTED'
+  ocp_image: "quay.io/openshift-release-dev/ocp-release:4.13.0-x86_64"
+
+cifmw_operator_build_push_registry: "default-route-openshift-image-registry.unittest-01.openstack.ccitredhat.com"
+cifmw_operator_build_meta_build: false
+
+pre_infra:
+  - name: Download needed tools
+    inventory: "{{ cifmw_installyamls_repos }}/devsetup/hosts"
+    type: playbook
+    source: "{{ cifmw_installyamls_repos }}/devsetup/download_tools.yaml"
+```
+
+### Baremetal install config
+```YAML
+apiVersion: v1
+baseDomain: mytest.openstack.local
+metadata:
+  name: test-01
+networking:
+  machineNetwork:
+    - cidr: 10.8.0.0/16
+  networkType: OpenShiftSDN
+compute:
+  - name: worker
+    replicas: 3
+controlPlane:
+  name: master
+  replicas: 3
+  platform:
+    baremetal: {}
+platform:
+  baremetal:
+    apiVIPs:
+      - 10.8.0.2
+    ingressVIPs:
+      - 10.8.0.3
+    provisioningNetworkCIDR: '172.22.0.0/24'
+    provisioningDHCPRange: "172.22.0.10,172.22.0.100"
+    provisioningNetwork: "Managed"
+    hosts:
+      - name: ocp
+        role: master
+        bmc:
+          address: 'idrac://ocp-1-mgmt.idrac.openstack.local'
+          username: idrac-user
+          password: idrac-pass
+          disableCertificateVerification: true
+        bootMACAddress: 'AA:16:3e:3a:18:00'
+        rootDeviceHints:
+          minSizeGigabytes: 500
+        bootMode: UEFI
+        networkConfig:
+          interfaces:
+            - name: eno1
+              type: ethernet
+              state: up
+              ipv4:
+                enabled: true
+                dhcp: true
+pullSecret: ''
+sshKey: 'ssh-ed25519 ...'
+```
+
+## Reference
+- [Hive](https://github.com/openshift/hive)
+- [OpenShift-Installer](https://docs.openshift.com/container-platform/4.13/installing/installing_bare_metal_ipi/ipi-install-overview.html)

--- a/ci_framework/roles/hive/defaults/main.yml
+++ b/ci_framework/roles/hive/defaults/main.yml
@@ -18,9 +18,12 @@
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_hive"
 
+cifmw_hive_dry_run: false
+
+cifmw_hive_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+cifmw_hive_artifacts_dir: "{{ cifmw_hive_basedir }}/artifacts/hive"
+
+cifmw_hive_oc_delete_timeout: 300
+
 cifmw_hive_openstack_claim_life_time: "24h"
 cifmw_hive_openstack_claim_timeout: "59m"
-cifmw_hive_oc_delete_timeout: "59m"
-cifmw_hive_basedir: "{{ cifmw_basedir | default( ansible_user_dir ~ '/ci-framework-data') }}"
-cifmw_hive_artifacts_dir: "{{ cifmw_hive_basedir }}/artifacts/hive"
-cifmw_hive_dry_run: false

--- a/ci_framework/roles/hive/meta/main.yml
+++ b/ci_framework/roles/hive/meta/main.yml
@@ -1,0 +1,45 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- hive
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: edpm
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+    - name: EL
+      versions:
+        - 9
+
+  galaxy_tags:
+    - edpm
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies:
+  - ci_setup

--- a/ci_framework/roles/hive/molecule/default/converge.yml
+++ b/ci_framework/roles/hive/molecule/default/converge.yml
@@ -14,25 +14,30 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
 - name: Converge
   hosts: all
+
   vars:
-    cifmw_hive_dry_run: true
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+    cifmw_hive_artifacts_dir: "{{ ansible_user_dir }}/ci-framework-data"
     cifmw_hive_kubeconfig: test_path
     cifmw_hive_platform: openstack
-    cifmw_hive_action: claim_cluster
-    cifmw_hive_openstack_pool_name: test-pool
     cifmw_hive_namespace: test-namespace
-    claim_name: test-claim-by-molecule
-    cifmw_hive_openstack_claim_name: test-claim
-    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
-  roles:
-    - role: "hive"
+    cifmw_hive_dry_run: true
 
   tasks:
-    - name: Ensure claim file is properly created
+    - name: Testing cluster_claim functionality.
+      vars:
+        cifmw_hive_action: claim_cluster
+        cifmw_hive_openstack_pool_name: test-pool
+        claim_name: test-claim-by-molecule
+        cifmw_hive_openstack_claim_name: test-claim
       block:
+        - name: Including the hive role
+          ansible.builtin.include_role:
+            name: hive
+
         - name: Gather template file
           register: template_file
           ansible.builtin.stat:
@@ -42,3 +47,81 @@
           ansible.builtin.assert:
             that:
               - template_file.stat.exists
+
+    - name: Testing baremetal provider
+      block:
+        - name: Create an empty file for testing
+          ansible.builtin.file:
+            path: "{{ cifmw_hive_artifacts_dir }}/fake_kubeconfig"
+            state: touch
+            mode: 0644
+
+        - name: Testing requirements - root ed25519 ssh key
+          register: root_ed25519_key
+          community.crypto.openssh_keypair:
+            path: "{{ cifmw_hive_artifacts_dir }}/id_ed25519_root"
+            type: ed25519
+
+        - name: Including the role with right values
+          vars:
+            cifmw_hive_platform: baremetal
+            cifmw_hive_action: deploy_cluster
+            cifmw_opn_host: 127.0.10.10
+            cifmw_opn_user: kni
+            cifmw_opn_user_ssh_key: "{{ root_ed25519_key }}"
+            cifmw_opn_host_ssh_key: "ssh - some-known-hosts-key"
+            cifmw_opn_bootstrap_boot_mac: "aa:ff:ee"
+            cifmw_opn_external_bridge_name: "baremetal"
+            cifmw_opn_prov_bridge_name: "provisioning"
+            cifmw_hive_namespace: "unittest"
+            cifmw_hive_kubeconfig: "{{ cifmw_hive_artifacts_dir }}/fake_kubeconfig"
+            cifmw_hive_baremetal:
+              cluster_name: "unittest-01"
+              install_config: "foo_bm_install_config.yml"
+              ocp_image: "registry.foo/openshift-release/ocp-fake:latest"
+              ssh_key: "{{ root_ed25519_key.public_key }}"
+          ansible.builtin.include_role:
+            role: hive
+
+        - name: Gathering the file informaiton that is expected to be generated
+          register: stat_results
+          ansible.builtin.stat:
+            path: "{{ cifmw_hive_artifacts_dir }}/{{ item }}"
+          loop:
+            - "ocp_image.yml"
+            - "ocp_ssh_private_key.yml"
+            - "bm_install_config.yml"
+            - "bm_deploy_config.yml"
+
+        - name: Verify the file stat
+          ansible.builtin.assert:
+            that:
+              - item.stat.exists is defined
+              - item.stat.exists
+          loop: "{{ stat_results.results }}"
+
+        - name: Verify the host access secret
+          vars:
+            data: '{{ lookup("file", "{{ cifmw_hive_artifacts_dir }}/ocp_ssh_private_key.yml") | from_yaml }}'
+          ansible.builtin.assert:
+            that:
+              - data.metadata.name == "unittest-01-ssh-pvt-key"
+
+        - name: Verify the install config
+          vars:
+            data: '{{ lookup("file", "{{ cifmw_hive_artifacts_dir }}/bm_install_config.yml") | from_yaml }}'
+          ansible.builtin.assert:
+            that:
+              - data.kind == "Secret"
+              - "'baseDomain: foo.bar' in data['stringData']['install-config.yaml']"
+              - "'apiVIPs:' in data['stringData']['install-config.yaml']"
+
+        - name: Verify the deploy definition
+          vars:
+            data: '{{ lookup("file", "{{ cifmw_hive_artifacts_dir }}/bm_deploy_config.yml") | from_yaml }}'
+          ansible.builtin.assert:
+            that:
+              - data.kind == "ClusterDeployment"
+              - data.metadata.name == "unittest-01"
+              - data.spec.platform.baremetal.libvirtSSHPrivateKeySecretRef.name == "unittest-01-ssh-pvt-key"
+              - data.spec.provisioning.sshKnownHosts | length == 1

--- a/ci_framework/roles/hive/molecule/default/foo_bm_install_config.yml
+++ b/ci_framework/roles/hive/molecule/default/foo_bm_install_config.yml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+baseDomain: foo.bar
+networking:
+  machineNetwork:
+    - cidr: 10.10.0.0/16
+  networkType: OpenShiftSDN
+compute:
+  - name: worker
+    replicas: 0
+controlPlane:
+  name: master
+  replicas: 1
+  platform:
+    baremetal: {}
+platform:
+  baremetal:
+    apiVIPs:
+      - 10.10.255.240
+    ingressVIPs:
+      - 10.10.255.241
+    hosts:
+      - name: controller-01
+        role: master
+        bmc:
+          address: 'ipmi://controller-01.mgmt.foo.bar'
+          username: foo
+          password: bar
+        bootMACAddress: aa-60-db-b2-3c-ff
+pullSecret: ''
+sshKey: 'ssh-ed25519 '

--- a/ci_framework/roles/hive/molecule/default/prepare.yml
+++ b/ci_framework/roles/hive/molecule/default/prepare.yml
@@ -17,9 +17,10 @@
 
 - name: Prepare
   hosts: all
+
   vars:
-    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
     ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
 
   roles:
     - role: test_deps

--- a/ci_framework/roles/hive/tasks/baremetal_delete_cluster.yml
+++ b/ci_framework/roles/hive/tasks/baremetal_delete_cluster.yml
@@ -1,0 +1,32 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Deletes a baremetal cluster deployed using Hive and it's associated
+# resources like SSH key & install config secrets. Along with the cluster
+# image set.
+
+- name: Remove the resources related to the deployed cluster
+  vars:
+    resource_type: "{{ item.type }}"
+    resource: "{{ item.name }}"
+  ansible.builtin.include_task:
+    file: oc_delete.yml
+  loop:
+    - {'type': 'clusterdeployment', 'name': "{{ cifmw_hive_baremetal.cluster_name }}" }
+    - {'type': 'clusterimageset', 'name': "{{ cifmw_hive_baremetal.cluster_name }}" }
+    - {'type': 'secret', 'name': "{{ cifmw_hive_baremetal.cluster_name }}-libvirtd-access" }
+    - {'type': 'secret', 'name': "{{ cifmw_hive_baremetal.cluster_name }}-provisioner-access" }
+    - {'type': 'secret', 'name': "{{ cifmw_hive_baremetal.cluster_name }}-install-config" }

--- a/ci_framework/roles/hive/tasks/baremetal_deploy_cluster.yml
+++ b/ci_framework/roles/hive/tasks/baremetal_deploy_cluster.yml
@@ -1,0 +1,112 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Get variables and set defaults only for unit testing.
+  ansible.builtin.set_fact:
+    cifmw_hive_bm_libvirt_user: "{{ hostvars[cifmw_opn_host]['cifmw_opn_user'] | default(cifmw_opn_user) }}"
+    cifmw_hive_bm_host_key: "{{ hostvars[cifmw_opn_host]['cifmw_opn_user_ssh_key'] | default(cifmw_opn_user_ssh_key) }}"
+    cifmw_hive_bm_host_ssh_print: "{{ hostvars[cifmw_opn_host]['cifmw_opn_host_ssh_key'] | default(cifmw_opn_host_ssh_key) }}"
+    cifmw_hive_bm_bootstrap_boot_mac: "{{ hostvars[cifmw_opn_host]['cifmw_opn_bootstrap_boot_mac'] | default(cifmw_opn_bootstrap_boot_mac) }}"
+    cifmw_hive_bm_provisioning_bridge_name: "{{ hostvars[cifmw_opn_host]['cifmw_opn_prov_bridge_name'] | default(cifmw_opn_prov_bridge_name) | default(omit) }}"
+    cifmw_hive_bm_external_bridge_name: "{{ hostvars[cifmw_opn_host]['cifmw_opn_external_bridge_name'] | default(cifmw_opn_external_bridge_name) }}"
+
+- name: Create a secret resource for provisioner node access
+  vars:
+    desc: "Provisioner SSH private key secret"
+    template_file: templates/private_key.yml.j2
+    dest_file: ocp_ssh_private_key.yml
+    secret_name: "{{ cifmw_hive_baremetal.cluster_name }}-ssh-pvt-key"
+    secret: "{{ lookup('file', cifmw_hive_bm_host_key.filename) }}"
+  ansible.builtin.include_tasks:
+    file: oc_apply.yml
+
+- name: Load baremetal install config
+  ansible.builtin.include_vars:
+    file: "{{ cifmw_hive_baremetal.install_config }}"
+    name: bm_install_config
+
+- name: Add dynamic values into the bm install config
+  ansible.builtin.set_fact:
+    bm_install_config: "{{ bm_install_config | combine(item, recursive=true) }}"
+  loop:
+    - {'metadata': {'name': "{{ cifmw_hive_baremetal.cluster_name }}" }}
+    - {'platform': {'baremetal': {'libvirtURI': "qemu+ssh://{{ cifmw_hive_bm_libvirt_user }}@{{ cifmw_opn_host }}/system" }}}
+    - {'platform': {'baremetal': {'externalMACAddress': "{{ cifmw_hive_bm_bootstrap_boot_mac }}" }}}
+    - {'platform': {'baremetal': {'externalBridge': "{{ cifmw_hive_bm_external_bridge_name }}" }}}
+
+- name: Add provisioning bridge name to install config
+  when:
+    - cifmw_hive_bm_provisioning_bridge_name is defined
+    - cifmw_hive_bm_provisioning_bridge_name | length > 0
+  vars:
+    prov_bridge_name: {'platform': {'baremetal': {'provisioningBridge': "{{ cifmw_hive_bm_provisioning_bridge_name }}" }}}
+  ansible.builtin.set_fact:
+    bm_install_config: "{{ bm_install_config | combine(prov_bridge_name, recursive=true) }}"
+
+- name: Gather the base domain of the OCP cluster
+  ansible.builtin.set_fact:
+    cifmw_hive_ocp_base_domain: "{{ bm_install_config.baseDomain }}"
+
+- name: Create a secret resource holding baremetal install config
+  vars:
+    desc: "install config secret"
+    template_file: templates/bm_install_config.yml.j2
+    dest_file: bm_install_config.yml
+    secret_name: "{{ cifmw_hive_baremetal.cluster_name }}-install-config"
+    install_config_yml: "{{ bm_install_config | to_nice_yaml(indent=2) }}"
+  ansible.builtin.include_tasks:
+    file: oc_apply.yml
+
+- name: Create a cluster image set resource
+  vars:
+    desc: "ocp cluster image"
+    template_file: templates/ocp_image.yml.j2
+    dest_file: ocp_image.yml
+    image_name: "{{ cifmw_hive_baremetal.cluster_name }}"
+    image_uri: "{{ cifmw_hive_baremetal.ocp_image }}"
+  ansible.builtin.include_tasks:
+    file: oc_apply.yml
+
+- name: Initiate OCP deployment on baremetal
+  vars:
+    desc: "OCP cluster deployment"
+    template_file: templates/bm_deploy_config.yml.j2
+    dest_file: bm_deploy_config.yml
+    known_host_entry: "{{ cifmw_opn_host }} {{ cifmw_hive_bm_host_ssh_print | trim }}"
+  ansible.builtin.include_tasks:
+    file: oc_apply.yml
+
+- name: Wait until OCP cluster is deployed and configured
+  when: not cifmw_hive_dry_run | bool
+  environment:
+    KUBECONFIG: "{{ cifmw_hive_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: "oc get clusterdeployment {{ cifmw_hive_baremetal.cluster_name }} -o jsonpath='{ .status.conditions }' "
+  register: cd_results
+  until: >
+    cd_results.rc != 0 or
+    cd_results.stdout | from_json | selectattr('status', '==', 'True') | selectattr('type', 'in', ['Provisioned', 'ProvisionStopped']) | length >= 1
+  retries: 360
+  delay: 30
+  failed_when: >
+    cd_results.stdout | from_json | selectattr('status', '==', 'True') | selectattr('type', '==', 'ProvisionStopped') | length >= 1 or
+    cd_results.rc != 0
+
+- name: Gather and set OCP access information
+  when: not cifmw_hive_dry_run | bool
+  ansible.builtin.include_tasks:
+    file: baremetal_gather_access.yml

--- a/ci_framework/roles/hive/tasks/baremetal_gather_access.yml
+++ b/ci_framework/roles/hive/tasks/baremetal_gather_access.yml
@@ -1,0 +1,76 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Collect the reference name of kubeconfig
+  environment:
+    KUBECONFIG: "{{ cifmw_hive_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: "oc get cd {{ cifmw_hive_baremetal.cluster_name }} -o jsonpath='{ .spec.clusterMetadata.adminKubeconfigSecretRef.name }'"
+  register: kubeconfig_ref
+
+- name: Gather the kubeconfig of the deployed cluster
+  environment:
+    KUBECONFIG: "{{ cifmw_hive_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: "oc extract secret/{{ kubeconfig_ref.stdout }} --keys kubeconfig --to={{ cifmw_hive_artifacts_dir }} --confirm"
+  register: kubeconfig_results
+
+- name: Collect the reference name of adminPassword
+  environment:
+    KUBECONFIG: "{{ cifmw_hive_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: "oc get cd {{ cifmw_hive_baremetal.cluster_name }} -o jsonpath='{ .spec.clusterMetadata.adminPasswordSecretRef.name }'"
+  register: admin_ref
+
+- name: Gather the username to be used for authentication against the deployed cluster
+  environment:
+    KUBECONFIG: "{{ cifmw_hive_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: "oc extract secret/{{ admin_ref.stdout }} --keys username --to=-"
+  register: username_out
+
+- name: Gather the credentials to be used for authentication against the deployed cluster
+  environment:
+    KUBECONFIG: "{{ cifmw_hive_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: "oc extract secret/{{ admin_ref.stdout }} --keys password --to=-"
+  register: password_out
+
+- name: Retrieve the webconsole URI
+  environment:
+    KUBECONFIG: "{{ cifmw_hive_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: "oc get cd {{ cifmw_hive_baremetal.cluster_name }} -o jsonpath='{ .status.webConsoleURL }' "
+  register: web_out
+
+- name: Loading the kubeconfig information
+  ansible.builtin.set_fact:
+    kubeconfig_dict: "{{ lookup('file', cifmw_hive_artifacts_dir + '/kubeconfig') | from_yaml }}"
+
+- name: Defining OCP access variables
+  ansible.builtin.set_fact:
+    cifmw_openshift_web_console_url: "{{ web_out.stdout }}"
+    cifmw_openshift_api: "{{ kubeconfig_dict.clusters[0].cluster.server }}"
+    cifmw_openshift_user: "{{ username_out.stdout }}"
+    cifmw_openshift_password: "{{ password_out.stdout }}"
+    cifmw_openshift_kubeconfig: "{{ cifmw_hive_artifacts_dir }}/kubeconfig"
+    cacheable: true

--- a/ci_framework/roles/hive/tasks/main.yml
+++ b/ci_framework/roles/hive/tasks/main.yml
@@ -14,25 +14,22 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
-- name: Assert that the required variables are defined and have values that are supported
+- name: Check for supported flows
   ansible.builtin.assert:
     that:
-      - "{{ item.cifmw_hive_platform_var_name }} is defined"
-      - "{% if lookup('vars', 'item').cifmw_hive_platform_vars_value is defined %}{{ item.cifmw_hive_platform_var_name }} in {{ item.cifmw_hive_platform_vars_value }}{% endif %}"
-    fail_msg: "value of {{item.cifmw_hive_platform_var_name}} is not supported or undefined."
-  loop:
-    - { cifmw_hive_platform_var_name: cifmw_hive_platform, cifmw_hive_platform_vars_value: ["openstack"]}
-    - { cifmw_hive_platform_var_name: cifmw_hive_action, cifmw_hive_platform_vars_value: ["claim_cluster", "unclaim_cluster"]}
-    - { cifmw_hive_platform_var_name: cifmw_hive_kubeconfig}
-    - { cifmw_hive_platform_var_name: cifmw_hive_namespace}
+      - 'cifmw_hive_platform in cifmw_hive_supported_platforms'
+      - 'cifmw_hive_action in cifmw_hive_supported_actions'
+
+- name: Check for required resources
+  ansible.builtin.assert:
+    that:
+      - cifmw_hive_namespace is defined
+      - cifmw_hive_kubeconfig is defined
 
 - name: Ensure hive output directory exists
   ansible.builtin.file:
     path: "{{ cifmw_hive_artifacts_dir }}"
     state: directory
 
-- name: "Performing {{ cifmw_hive_platform }} {{ cifmw_hive_action }}"
-  when:
-    - cifmw_hive_action is defined
-  ansible.builtin.import_tasks: "{{ cifmw_hive_platform }}_{{ cifmw_hive_action }}.yml"
+- name: "Performing {{ cifmw_hive_platform }} {{cifmw_hive_action }}"
+  ansible.builtin.include_tasks: "{{ cifmw_hive_platform }}_{{ cifmw_hive_action }}.yml"

--- a/ci_framework/roles/hive/tasks/oc_apply.yml
+++ b/ci_framework/roles/hive/tasks/oc_apply.yml
@@ -20,11 +20,11 @@
     dest: "{{ cifmw_hive_artifacts_dir }}/{{ dest_file }}"
     mode: 0644
 
-- name: "Applying the resource provided in {{ dest_file }}"
+- name: Create / modify the openshift resource
   when: not cifmw_hive_dry_run | bool
   environment:
-    PATH: "{{ cifmw_path }}"
     KUBECONFIG: "{{ cifmw_hive_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
   ansible.builtin.command:
     cmd: "oc apply -f {{ cifmw_hive_artifacts_dir }}/{{ dest_file }}"
   register: apply_result

--- a/ci_framework/roles/hive/tasks/openstack_unclaim_cluster.yml
+++ b/ci_framework/roles/hive/tasks/openstack_unclaim_cluster.yml
@@ -18,7 +18,7 @@
   vars:
     claim_name: "{{ cifmw_hive_openstack_claim_name }}"
     namespace: "{{ cifmw_hive_namespace }}"
-    resource: "clusterclaim"
-    resource_name: "{{ claim_name }}"
+    resource_type: "clusterclaim"
+    resource: "{{ claim_name }}"
   ansible.builtin.import_tasks:
     file: oc_delete.yml

--- a/ci_framework/roles/hive/templates/bm_deploy_config.yml.j2
+++ b/ci_framework/roles/hive/templates/bm_deploy_config.yml.j2
@@ -1,0 +1,26 @@
+---
+apiVersion: hive.openshift.io/v1
+kind: ClusterDeployment
+metadata:
+  name: {{ cifmw_hive_baremetal.cluster_name }}
+  namespace: {{ cifmw_hive_namespace }}
+  annotations:
+    hive.openshift.io/try-install-once: "true"
+spec:
+  baseDomain: {{ cifmw_hive_ocp_base_domain }}
+  clusterName: {{ cifmw_hive_baremetal.cluster_name }}
+  controlPlaneConfig:
+    servingCertificates: {}
+  platform:
+    baremetal:
+      libvirtSSHPrivateKeySecretRef:
+        name: {{ cifmw_hive_baremetal.cluster_name }}-ssh-pvt-key
+  provisioning:
+    installConfigSecretRef:
+      name: {{ cifmw_hive_baremetal.cluster_name }}-install-config
+    imageSetRef:
+      name: {{ cifmw_hive_baremetal.cluster_name }}
+    sshPrivateKeySecretRef:
+      name: {{ cifmw_hive_baremetal.cluster_name }}-ssh-pvt-key
+    sshKnownHosts:
+      - "{{ known_host_entry }}"

--- a/ci_framework/roles/hive/templates/bm_install_config.yml.j2
+++ b/ci_framework/roles/hive/templates/bm_install_config.yml.j2
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ secret_name }}
+  namespace: {{ cifmw_hive_namespace }}
+type: Opaque
+stringData:
+  install-config.yaml: |
+    {{ install_config_yml | indent(4) }}

--- a/ci_framework/roles/hive/templates/ocp_image.yml.j2
+++ b/ci_framework/roles/hive/templates/ocp_image.yml.j2
@@ -1,0 +1,8 @@
+---
+apiVersion: hive.openshift.io/v1
+kind: ClusterImageSet
+metadata:
+  name: {{ image_name }}
+  namespace: {{ cifmw_hive_namespace }}
+spec:
+  releaseImage: {{ image_uri }}

--- a/ci_framework/roles/hive/templates/private_key.yml.j2
+++ b/ci_framework/roles/hive/templates/private_key.yml.j2
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ secret_name }}
+  namespace: {{ cifmw_hive_namespace }}
+type: Opaque
+stringData:
+  ssh-privatekey: |
+    {{ secret | indent(4) }}

--- a/ci_framework/roles/hive/vars/main.yml
+++ b/ci_framework/roles/hive/vars/main.yml
@@ -14,14 +14,12 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: "Deleting {{ resource_type }}/{{ resource }}"
-  when: not cifmw_hive_dry_run | bool
-  environment:
-    KUBECONFIG: "{{ cifmw_hive_kubeconfig }}"
-    PATH: "{{ cifmw_path }}"
-  ansible.builtin.command:
-    cmd: "oc delete {{ resource_type }} {{ resource }} --force --timeout {{ cifmw_hive_oc_delete_timeout }}"
-  poll: 30
-  register: delete_result
-  ignore_errors: true
-  changed_when: delete_result.rc == 0
+cifmw_hive_supported_platforms:
+  - openstack
+  - baremetal
+
+cifmw_hive_supported_actions:
+  - claim_cluster
+  - unclaim_cluster
+  - deploy_cluster
+  - delete_cluster

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -24,8 +24,8 @@ provisioned with bmaas vs pre-provisioned VM.
 * `cifmw_use_libvirt`: (Bool) toggle libvirt support
 * `cifmw_use_crc`: (Bool) toggle rhol/crc usage
 * `cifmw_openshift_kubeconfig`: (String) Path to the kubeconfig file if externally provided.
-* `cifmw_use_hive`: This enables support for Hive. Defaults to false.
 * `cifmw_use_opn`: (Bool) toggle openshift provisioner node support.
+* `cifmw_use_hive`: (Bool) toggle OpenShift deployment using hive operator.
 
 #### Words of caution
 If you want to output the content in another location than `~/ci-framework-data`

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -90,6 +90,16 @@
       - ^ci_framework/roles/edpm_prepare/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
+    name: cifmw-molecule-hive
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: hive
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/hive/(?!meta).*
+      - ^ci/playbooks/molecule.*
+- job:
     name: cifmw-molecule-install_ca
     parent: cifmw-molecule-base
     vars:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -25,6 +25,7 @@
         - cifmw-molecule-edpm_deploy
         - cifmw-molecule-edpm_deploy_baremetal
         - cifmw-molecule-edpm_prepare
+        - cifmw-molecule-hive
         - cifmw-molecule-install_ca
         - cifmw-molecule-install_yamls
         - cifmw-molecule-libvirt_manager


### PR DESCRIPTION
Here support for deploying and deleting an OpenShift Container Platform using Hive operator is added. This role has the following dependencies

- oc_client
- openshift_provisioner_node

This role creates the necessary resources required by the Hive operator. It waits for the deployment to be complete before extracting the access information.

This PR has:
- [x] Appropriate testing (molecule, python unit tests)
- [x] Appropriate documentation (README in the role, main README is up-to-date)

**Depends on** #240 #275 
