### PR TITLE
Correct loop label

### DIFF
--- a/ci_framework/roles/ci_setup/tasks/directories.yml
+++ b/ci_framework/roles/ci_setup/tasks/directories.yml
@@ -12,4 +12,4 @@
     - "{{ cifmw_ci_setup_basedir }}/tmp"
     - "{{ cifmw_ci_setup_basedir }}/volumes"
   loop_control:
-    label: "{{ cifmw_ci_setup_basedir }}/{{ item }}"
+    label: "{{ item }}"


### PR DESCRIPTION
The "item" is now an absolute path, meaning we're seeing something wrong
in the loop, while the code is actually correct.

This PR has:
- [X] Appropriate testing (molecule, python unit tests)
- [X] Appropriate documentation (README in the role, main README is up-to-date)
