### PR TITLE
Adding new openshift_login role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/source/_build/
 docs/virtdocs/
+**/__pycache__/

--- a/ci_framework/hooks/playbooks/ceph-deploy.yml
+++ b/ci_framework/hooks/playbooks/ceph-deploy.yml
@@ -24,13 +24,22 @@
     # let's default to an empty hash.
     - name: Run make_ceph
       vars:
-        make_ceph_environment: "{{ cifmw_make_ceph_environment | default({}) }}"
+        make_ceph_environment: >-
+          {{ cifmw_make_ceph_environment | default({}) |
+              combine({
+                'KUBECONFIG': cifmw_openshift_kubeconfig,
+                'PATH': cifmw_path
+              })
+          }}
       ansible.builtin.include_role:
         role: install_yamls_makes
         tasks_from: "make_ceph.yml"
 
     - name: Get ceph uuid
       register: generated_uuid
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
       ansible.builtin.command:
         cmd: oc get secret ceph-conf-files -o json
 

--- a/ci_framework/hooks/playbooks/disable_os_marketplace.yml
+++ b/ci_framework/hooks/playbooks/disable_os_marketplace.yml
@@ -2,11 +2,9 @@
 - hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
   gather_facts: false
   tasks:
-    - name: Perform CRC login
-      ansible.builtin.include_role:
-        name: rhol_crc
-        tasks_from: add_crc_creds.yml
-
     - name: Disable the openshift-marketplace
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_login_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
       ansible.builtin.command: >-
         oc patch operatorhubs/cluster --type merge --patch '{"spec":{"sources":[{"disabled": true,"name": "redhat-marketplace"}]}}'

--- a/ci_framework/hooks/playbooks/rabbitmq_tuning.yml
+++ b/ci_framework/hooks/playbooks/rabbitmq_tuning.yml
@@ -2,12 +2,10 @@
 - hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
   gather_facts: false
   tasks:
-    - name: Perform CRC login
-      ansible.builtin.include_role:
-        name: rhol_crc
-        tasks_from: add_crc_creds.yml
-
     - name: Patch rabbitmq resources for lower resource consumption
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_login_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
       ansible.builtin.shell: |
         crname=$(oc get openstackcontrolplane -o name -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }})
         oc patch ${crname} --type json -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} \

--- a/ci_framework/hooks/playbooks/restart_nova_scheduler.yml
+++ b/ci_framework/hooks/playbooks/restart_nova_scheduler.yml
@@ -2,11 +2,9 @@
 - hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
   gather_facts: false
   tasks:
-    - name: Perform CRC login
-      ansible.builtin.include_role:
-        name: rhol_crc
-        tasks_from: add_crc_creds.yml
-
     - name: Restart nova-scheduler to pick up cell1
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_login_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
       ansible.builtin.command: >-
         oc delete pod -n {{ cifmw_install_yamls_defaults['NAMESPACE'] | default('openstack') }} -l service=nova-scheduler

--- a/ci_framework/playbooks/02-infra.yml
+++ b/ci_framework/playbooks/02-infra.yml
@@ -21,13 +21,11 @@
       ansible.builtin.include_role:
         name: rhol_crc
 
-    - name: Set cifmw_kubeconfig if not yet set
-      when:
-        - cifmw_kubeconfig is not defined
-        - "'KUBECONFIG' in ansible_env"
-      ansible.builtin.set_fact:
-        cifmw_kubeconfig: "{{ ansible_env.KUBECONFIG }}"
-        cacheable: true
+    - name: Login into Openshift cluster
+      vars:
+        cifmw_openshift_login_force_refresh: true
+      ansible.builtin.include_role:
+        name: openshift_login
 
     - name: Setup Openshift cluster
       ansible.builtin.include_role:

--- a/ci_framework/playbooks/05-build-operators.yml
+++ b/ci_framework/playbooks/05-build-operators.yml
@@ -9,20 +9,6 @@
   environment:
     PATH: "{{ cifmw_path }}"
   tasks:
-    - name: Perform cluster login
-      when:
-        - cifmw_use_crc is defined
-        - cifmw_use_crc | bool
-      block:
-        - name: Perform CRC login
-          ansible.builtin.include_role:
-            name: rhol_crc
-            tasks_from: add_crc_creds.yml
-
-        - name: CRC registry login
-          ansible.builtin.command: |
-            oc registry login --insecure=true
-
     - name: Build operator and meta-operator
       when:
         - cifmw_operator_build_operators is defined

--- a/ci_framework/roles/edpm_prepare/molecule/default/converge.yml
+++ b/ci_framework/roles/edpm_prepare/molecule/default/converge.yml
@@ -19,8 +19,10 @@
   hosts: all
   vars:
     cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
-    cifmw_use_crc: true
     cifmw_operator_build_meta_name: openstack
     cifmw_edpm_prepare_dry_run: true
+    cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+    cifmw_openshift_user: "kubeadmin"
+    cifmw_openshift_password: "123456789"
   roles:
     - role: "edpm_prepare"

--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -4,6 +4,7 @@
   ansible.builtin.set_fact:
     cifmw_edpm_prepare_common_env:
       PATH: "{{ cifmw_path }}"
+      KUBECONFIG : "{{ cifmw_openshift_kubeconfig }}"
     cifmw_edpm_prepare_make_openstack_env: |
       {% if cifmw_operator_build_meta_name is defined and cifmw_operator_build_meta_name in operators_build_output %}
       OPENSTACK_IMG: {{ operators_build_output[cifmw_operator_build_meta_name].image_catalog }}
@@ -30,6 +31,7 @@
 
 - name: Get internal OpenShift registry route
   environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
     PATH: "{{ cifmw_path }}"
   ansible.builtin.command:
     cmd: "oc get route default-route -n openshift-image-registry -o jsonpath='{.spec.host}'"
@@ -38,6 +40,7 @@
 
 - name: Allow image internal OpenShift registry image pulling
   environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
     PATH: "{{ cifmw_path }}"
   ansible.builtin.shell:
     cmd: >
@@ -61,21 +64,20 @@
 # TODO: Prepare a proper operator list that dictates what operators to deploy instead of relaying on a simple flag
 - name: OpenStack meta-operator installation
   when: not cifmw_edpm_prepare_skip_openstack_operator
-  block:
-  - name: Install OpenStack operator
-    vars:
-      make_openstack_env: "{{ cifmw_edpm_prepare_common_env |
-        combine(cifmw_edpm_prepare_make_openstack_env | from_yaml)}}"
-      make_openstack_dryrun: "{{ cifmw_edpm_prepare_dry_run }}"
-    ansible.builtin.include_role:
-      name: 'install_yamls_makes'
-      tasks_from: 'make_openstack'
+  vars:
+    make_openstack_env: "{{ cifmw_edpm_prepare_common_env |
+      combine(cifmw_edpm_prepare_make_openstack_env | from_yaml)}}"
+    make_openstack_dryrun: "{{ cifmw_edpm_prepare_dry_run }}"
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_openstack'
 
 - name: Wait for OpenStack control plane to be installed
   when: not cifmw_edpm_prepare_dry_run
   block:
     - name: Wait for OpenStack subscription creation
       environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
       ansible.builtin.command:
         cmd: oc get sub openstack-operator --namespace={{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} -o=jsonpath='{.status.installplan.name}'
@@ -86,6 +88,7 @@
 
     - name: Wait for OpenStack operator to get installed
       environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
       ansible.builtin.command:
         cmd: >
@@ -124,6 +127,7 @@
 
     - name: Wait for OpenStack controlplane to be deployed
       environment:
+        KUBECONFIG: "{{ cifmw_openshift_login_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
       ansible.builtin.command:
         cmd: >-

--- a/ci_framework/roles/openshift_login/README.md
+++ b/ci_framework/roles/openshift_login/README.md
@@ -1,0 +1,74 @@
+# openshift_login
+Manages OpenShift login operations
+
+This role performs OpenShift login based on calls to the `oc` cli tool and exposes a well defined set of
+variables that, after a successful login, can be used as credentials and API endpoints in other parts of
+the framework. If more than one login attempts are neeeded the role retries as many time as dictated by
+`cifmw_openshift_login_retries`.
+
+Many login scenarios are allowed by passing or ommiting the following variables:
+- `cifmw_openshift_login_kubeconfig`: The kubeconfig file path, if not given, the role will try to use user/password login
+    and will create the kubeconfig in the default location `~/.kube/config`.
+- `cifmw_openshift_login_api`: The OpenShift API endpoint. If not given the role will extract it from the kubeconfig.
+- `cifmw_openshift_login_user` and `cifmw_openshift_login_password`: User/password for password based logins.
+
+After successful login, the following variables will hold all the needed information to perform call to the cluster:
+* `cifmw_openshift_login_api` and `cifmw_openshift_api`: OpenShift API endpoint.
+* `cifmw_openshift_login_kubeconfig` and `cifmw_openshift_kubeconfig`: Current kubeconfig file. Token and context populated with the latest changes.
+* `cifmw_openshift_login_context` and `cifmw_openshift_context`: The current selected context in `cifmw_openshift_login_kubeconfig`/`cifmw_openshift_kubeconfig`.
+* `cifmw_openshift_login_token` and `cifmw_openshift_token`: OpenShift token/API key.
+* `cifmw_openshift_login_user` and `cifmw_openshift_user`: The user associated to the `cifmw_openshift_login_token`/`cifmw_openshift_token`.
+
+## Privilege escalation
+No privilege escalation needed.
+
+## Parameters
+* `cifmw_openshift_login_kubeconfig`: (String) Optional. Path to the kubeconfig file. Defaults to `cifmw_openshift_kubeconfig` and `~/.kube/config` as last instance.
+* `cifmw_openshift_login_api`: (String) Optional. Path to the kubeconfig file. Defaults to `cifmw_openshift_api` and to the real API endpoint after login.
+* `cifmw_openshift_login_user`: (String) Optional. Login user. If provided, the user that logins. Defaults to `cifmw_openshift_user` and to the logged in user after login.
+* `cifmw_openshift_login_password`: (String) Optional. Login password. If provided is the password used for login in. Defaults to `cifmw_openshift_password`.
+* `cifmw_openshift_login_force_refresh`: (Boolean) Disallow reusing already existing token. Defaults to `false`.
+* `cifmw_openshift_login_retries`: (Integer) Number of attempts to retry the login action if it fails. Defaults to `10`.
+* `cifmw_openshift_login_retries_delay`: (Integer) Delay, in seconds, between login retries. Defaults to `20`.
+* `cifmw_openshift_login_assume_cert_system_user`: (Boolean) When trying cert key login from kubeconfig, assume that the infered user is a `system:` admin. Defaults to `true`.
+* `cifmw_openshift_login_skip_tls_verify`: (Boolean) Skip TLS verification to login. Note: This option may break admin login using certs. Defaults to `false`.
+
+## Examples
+### 1 - Login using user/password and API convination
+```yaml
+- hosts: all
+  tasks:
+    - name: Log in user/password/API
+      include_role:
+        name: openshift_login
+      vars:
+        cifmw_openshift_login_api: "https://api.crc.testing:6443"
+        cifmw_openshift_login_user: "kubeadmin"
+        cifmw_openshift_login_password: "12345678"
+```
+
+### 2 - Login using user/password and kubeconfig convination
+```yaml
+- hosts: all
+  tasks:
+    - name: Log in user/password/API
+      include_role:
+        name: openshift_login
+      vars:
+        # API infered from the given kubeconfig
+        cifmw_openshift_login_kubeconfig: "/home/zuul/.crc/machines/crc/kubeconfig"
+        cifmw_openshift_login_user: "kubeadmin"
+        cifmw_openshift_login_password: "12345678"
+```
+
+### 3 - Login using admin kubeconfig
+```yaml
+- hosts: all
+  tasks:
+    - name: Log in user/password/API
+      include_role:
+        name: openshift_login
+      vars:
+        # X509 key in the kubeconfig client data
+        cifmw_openshift_login_kubeconfig: "/home/zuul/.crc/machines/crc/kubeconfig"
+```

--- a/ci_framework/roles/openshift_login/defaults/main.yml
+++ b/ci_framework/roles/openshift_login/defaults/main.yml
@@ -16,6 +16,12 @@
 
 
 # All variables intended for modification should be placed in this file.
-# All variables within this role should have a prefix of "cifmw_openshift_setup"
-cifmw_openshift_setup_dry_run: false
-cifmw_openshift_setup_create_namespaces: []
+# All variables within this role should have a prefix of "cifmw_openshift_login"
+cifmw_openshift_login_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+cifmw_openshift_login_kubeconfig_default_path: "{{ cifmw_openshift_login_basedir ~ '/.kube/config' }}"
+
+cifmw_openshift_login_force_refresh: false
+cifmw_openshift_login_assume_cert_system_user: true
+cifmw_openshift_login_retries: 10
+cifmw_openshift_login_retries_delay: 10
+cifmw_openshift_login_skip_tls_verify: false

--- a/ci_framework/roles/openshift_login/meta/main.yml
+++ b/ci_framework/roles/openshift_login/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- openshift_login
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: edpm
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - edpm
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/ci_framework/roles/openshift_login/molecule/default/converge.yml
+++ b/ci_framework/roles/openshift_login/molecule/default/converge.yml
@@ -15,7 +15,10 @@
 # under the License.
 
 
-# All variables intended for modification should be placed in this file.
-# All variables within this role should have a prefix of "cifmw_openshift_setup"
-cifmw_openshift_setup_dry_run: false
-cifmw_openshift_setup_create_namespaces: []
+- name: Converge
+  hosts: all
+  vars:
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+    cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+  roles:
+    - role: "openshift_login"

--- a/ci_framework/roles/openshift_login/molecule/default/molecule.yml
+++ b/ci_framework/roles/openshift_login/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/openshift_login/molecule/default/prepare.yml
+++ b/ci_framework/roles/openshift_login/molecule/default/prepare.yml
@@ -15,7 +15,11 @@
 # under the License.
 
 
-# All variables intended for modification should be placed in this file.
-# All variables within this role should have a prefix of "cifmw_openshift_setup"
-cifmw_openshift_setup_dry_run: false
-cifmw_openshift_setup_create_namespaces: []
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps
+  tasks:
+    - name: Ensure CRC is started
+      ansible.builtin.command:
+        cmd: crc start

--- a/ci_framework/roles/openshift_login/tasks/cleanup.yml
+++ b/ci_framework/roles/openshift_login/tasks/cleanup.yml
@@ -14,8 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
-# All variables intended for modification should be placed in this file.
-# All variables within this role should have a prefix of "cifmw_openshift_setup"
-cifmw_openshift_setup_dry_run: false
-cifmw_openshift_setup_create_namespaces: []
+- name: Cleaning the World
+  debug:
+    msg: "So here openshift_login should clean things up!"

--- a/ci_framework/roles/openshift_login/tasks/login.yml
+++ b/ci_framework/roles/openshift_login/tasks/login.yml
@@ -1,0 +1,114 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Set role variables
+  ansible.builtin.set_fact:
+    cifmw_openshift_login_kubeconfig: >-
+     {{
+      cifmw_openshift_login_kubeconfig |
+      default(cifmw_openshift_kubeconfig) |
+      default(
+        ansible_env.KUBECONFIG if 'KUBECONFIG' in ansible_env else
+        cifmw_openshift_login_kubeconfig_default_path
+      ) | trim
+     }}
+    cifmw_openshift_login_user: "{{ cifmw_openshift_login_user | default(cifmw_openshift_user) | default(omit) }}"
+    cifmw_openshift_login_password: "{{ cifmw_openshift_login_password | default(cifmw_openshift_password) | default(omit) }}"
+    cifmw_openshift_login_api: "{{ cifmw_openshift_login_api | default(cifmw_openshift_api) | default(omit) }}"
+    cifmw_openshift_login_cert_login: "{{ cifmw_openshift_login_cert_login | default(false)}}"
+    test_cat: true
+    cacheable: true
+
+- name: Check if kubeconfig exists
+  ansible.builtin.stat:
+    path: "{{ cifmw_openshift_login_kubeconfig }}"
+  register: cifmw_openshift_login_kubeconfig_stat
+
+- name: Assert that enough data for login in is provided
+  ansible.builtin.assert:
+    that: >-
+      cifmw_openshift_login_kubeconfig_stat.stat.exists or
+      (
+        (cifmw_openshift_login_user is defined) and
+        (cifmw_openshift_login_password is defined) and
+        (cifmw_openshift_login_api is defined)
+      )
+    msg: "If an existing kubeconfig is not provided user/pwd and API URL must be given"
+
+- name: Fetch kubeconfig content
+  when:
+    - cifmw_openshift_login_user is not defined
+    - cifmw_openshift_login_kubeconfig_stat.stat.exists
+  ansible.builtin.slurp:
+    src: "{{ cifmw_openshift_login_kubeconfig }}"
+  register: cifmw_openshift_login_kubeconfig_content_b64
+
+- name: Fetch x509 key based users
+  when:
+    - cifmw_openshift_login_user is not defined
+    - cifmw_openshift_login_kubeconfig_content_b64.content is defined
+  vars:
+    key_based_users_query: 'users[?user."client-key-data"].name'
+  ansible.builtin.set_fact:
+    cifmw_openshift_login_key_based_users: >-
+      {{
+        cifmw_openshift_login_kubeconfig_content_b64.content |
+        b64decode |
+        from_yaml |
+        community.general.json_query(key_based_users_query) |
+        map("split", "/") |
+        map("first")
+      }}
+    cacheable: true
+
+- name: Assign key based user if not provided and available
+  when:
+    - cifmw_openshift_login_user is not defined
+    - cifmw_openshift_login_key_based_users | default([]) | length > 0
+  ansible.builtin.set_fact:
+    cifmw_openshift_login_user: >-
+      {{
+        (cifmw_openshift_login_assume_cert_system_user | ternary('system:', '')) +
+        (cifmw_openshift_login_key_based_users | map('replace', 'system:', '') | unique | first)
+      }}
+    cifmw_openshift_login_cert_login: true
+    cacheable: true
+
+- name: Try fetch OpenShift's token
+  block:
+    - name: Set the retry count
+      ansible.builtin.set_fact:
+        cifmw_openshift_login_retries_cnt: >-
+          {{
+            0 if cifmw_openshift_login_retries_cnt is undefined else
+            cifmw_openshift_login_retries_cnt|int + 1
+          }}
+
+    - name: Fetch token
+      ansible.builtin.include_tasks:
+        file: try_login.yml
+
+  rescue:
+    - fail:
+        msg: Token fetch failed after retries
+      when: cifmw_openshift_login_retries_cnt|int == cifmw_openshift_login_retries
+
+    - name: Wait before reattempt
+      ansible.builtin.pause:
+        seconds: "{{ cifmw_openshift_login_retries_delay }}"
+
+    - ansible.builtin.include_tasks:
+        file: login.yml

--- a/ci_framework/roles/openshift_login/tasks/main.yml
+++ b/ci_framework/roles/openshift_login/tasks/main.yml
@@ -1,0 +1,56 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: OpenShift login
+  ansible.builtin.include_tasks:
+    file: "login.yml"
+
+- name: Fetch OpenShift API URL
+  environment:
+    PATH: "{{ cifmw_path }}"
+    KUBECONFIG: "{{ cifmw_openshift_login_kubeconfig }}"
+  ansible.builtin.command:
+    cmd: "oc whoami --show-server=true"
+  register: cifmw_openshift_login_api_out
+
+- name: Fetch OpenShift kubeconfig context
+  environment:
+    PATH: "{{ cifmw_path }}"
+    KUBECONFIG: "{{ cifmw_openshift_login_kubeconfig }}"
+  ansible.builtin.command:
+    cmd: "oc whoami -c"
+  register: cifmw_openshift_login_context_out
+
+- name: Fetch OpenShift current user
+  environment:
+    PATH: "{{ cifmw_path }}"
+    KUBECONFIG: "{{ cifmw_openshift_login_kubeconfig }}"
+  ansible.builtin.command:
+    cmd: "oc whoami"
+  register: cifmw_openshift_login_user_out
+  retries: "{{ cifmw_openshift_login_retries }}"
+  delay: "{{ cifmw_openshift_login_retries_delay }}"
+
+- name: Set OpenShift user, context and API facts
+  ansible.builtin.set_fact:
+    cifmw_openshift_login_api: "{{ cifmw_openshift_login_api_out.stdout }}"
+    cifmw_openshift_login_context: "{{ cifmw_openshift_login_context_out.stdout }}"
+    cifmw_openshift_login_user: "{{ cifmw_openshift_login_user_out.stdout }}"
+    cifmw_openshift_api: "{{ cifmw_openshift_login_api_out.stdout }}"
+    cifmw_openshift_context: "{{ cifmw_openshift_login_context_out.stdout }}"
+    cifmw_openshift_user: "{{ cifmw_openshift_login_user_out.stdout }}"
+    cifmw_openshift_token: "{{ cifmw_openshift_login_token | default(omit) }}"
+    cacheable: true

--- a/ci_framework/roles/openshift_login/tasks/try_login.yml
+++ b/ci_framework/roles/openshift_login/tasks/try_login.yml
@@ -1,0 +1,79 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Try get OpenShift access token
+  when:
+    - not cifmw_openshift_login_cert_login
+    - not cifmw_openshift_login_force_refresh
+  environment:
+    PATH: "{{ cifmw_path }}"
+    KUBECONFIG: "{{ cifmw_openshift_login_kubeconfig }}"
+  ansible.builtin.command:
+    cmd: "oc whoami -t"
+  register: cifmw_openshift_login_whoami_out
+  ignore_errors: true
+
+- name: Fetch OpenShift token
+  when: >-
+    (cifmw_openshift_login_whoami_out.skipped | default(false)) or
+    cifmw_openshift_login_whoami_out.rc != 0 or not
+    cifmw_openshift_login_whoami_out.stdout
+  environment:
+    PATH: "{{ cifmw_path }}"
+    KUBECONFIG: "{{ cifmw_openshift_login_kubeconfig }}"
+  ansible.builtin.command:
+    cmd: >-
+      oc login
+      {%- if cifmw_openshift_login_user is defined %}
+      -u {{ cifmw_openshift_login_user }}
+      {%- endif %}
+      {%- if cifmw_openshift_login_password is defined %}
+      -p {{ cifmw_openshift_login_password }}
+      {%- endif %}
+      {%- if cifmw_openshift_login_skip_tls_verify|bool %}
+      --insecure-skip-tls-verify=true
+      {%- endif %}
+      {%- if cifmw_openshift_login_api is defined %}
+      {{ cifmw_openshift_login_api }}
+      {%- endif %}
+  register: cifmw_openshift_login_login_out
+
+- name: Ensure kubeconfig is provided
+  ansible.builtin.assert:
+    that: cifmw_openshift_login_kubeconfig != ""
+
+- name: Fetch new OpenShift access token
+  when:
+    - not cifmw_openshift_login_cert_login
+    - not (cifmw_openshift_login_login_out.skipped | default(false))
+  environment:
+    PATH: "{{ cifmw_path }}"
+    KUBECONFIG: "{{ cifmw_openshift_login_kubeconfig }}"
+  ansible.builtin.command:
+    cmd: "oc whoami -t"
+  register: cifmw_openshift_login_new_token_out
+
+- name: Set new OpenShift token
+  when: >-
+    (not cifmw_openshift_login_whoami_out.skipped | default(false)) or
+    (not cifmw_openshift_login_new_token_out.skipped | default(false))
+  ansible.builtin.set_fact:
+    cifmw_openshift_login_token: >-
+      {{
+        (not cifmw_openshift_login_new_token_out.skipped | default(false)) |
+        ternary(cifmw_openshift_login_new_token_out.stdout, cifmw_openshift_login_whoami_out.stdout)
+      }}
+    cacheable: true

--- a/ci_framework/roles/openshift_login/vars/main.yml
+++ b/ci_framework/roles/openshift_login/vars/main.yml
@@ -15,7 +15,8 @@
 # under the License.
 
 
-# All variables intended for modification should be placed in this file.
-# All variables within this role should have a prefix of "cifmw_openshift_setup"
-cifmw_openshift_setup_dry_run: false
-cifmw_openshift_setup_create_namespaces: []
+# While options found within the vars/ path can be overridden using extra
+# vars, items within this path are considered part of the role and not
+# intended to be modified.
+
+# All variables within this role should have a prefix of "cifmw_openshift_login"

--- a/ci_framework/roles/openshift_setup/README.md
+++ b/ci_framework/roles/openshift_setup/README.md
@@ -6,6 +6,5 @@ Prepares the target OpenShift cluster to be used by further steps:
 No privilege escalation needed.
 
 ## Parameters
-* `cifmw_openshift_setup_kubeconfig`: (String) Path to the kubeconfig file. Defaults to `cifmw_kubeconfig`.
 * `cifmw_openshift_setup_dry_run`: (Boolean) Skips resources creation. Defaults to `false`.
 * `cifmw_openshift_setup_create_namespaces`: (Strings) Namespaces to create beforehand. Defaults to `[]`.

--- a/ci_framework/roles/openshift_setup/molecule/default/converge.yml
+++ b/ci_framework/roles/openshift_setup/molecule/default/converge.yml
@@ -18,9 +18,9 @@
 - name: Converge
   hosts: all
   vars:
-    cifmw_openshift_setup_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
     cifmw_install_yamls_defaults:
       NAMESPACE: openstack
       OPERATOR_NAMESPACE: openstack-operators
+    cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
   roles:
     - role: "openshift_setup"

--- a/ci_framework/roles/openshift_setup/tasks/main.yml
+++ b/ci_framework/roles/openshift_setup/tasks/main.yml
@@ -27,9 +27,38 @@
 
 - name: Create required namespaces
   kubernetes.core.k8s:
-    kubeconfig: "{{ cifmw_openshift_setup_kubeconfig | default(cifmw_kubeconfig) }}"
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
     name: "{{ item }}"
     kind: Namespace
     state: present
   with_items: "{{ cifmw_openshift_setup_namespaces }}"
   when: not cifmw_openshift_setup_dry_run
+
+- name: Setup podman access to internal registry
+  when: cifmw_openshift_token is defined
+  vars:
+    ansible_callback_diy_runner_on_skipped_msg: |
+      skipping: [{{ inventory_hostname }}]
+      msg: Podman registry setup skipped cause login is no token based.
+    ansible_callback_diy_runner_on_skipped_msg_color: green
+  block:
+  - name: Get internal OpenShift registry route
+    kubernetes.core.k8s_info:
+      kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+      api_key: "{{ cifmw_openshift_token | default(omit)}}"
+      context: "{{ cifmw_openshift_context | default(omit)}}"
+      kind: Route
+      name: default-route
+      namespace: openshift-image-registry
+    register: cifmw_openshift_setup_registry_default_route
+
+  - name: Login into OpenShift internal registry
+    when: cifmw_openshift_setup_registry_default_route.resources | length > 0
+    ansible.builtin.command:
+      cmd: >-
+        podman login
+        -u {{ cifmw_openshift_user }}
+        -p {{ cifmw_openshift_token }}
+        {{ cifmw_openshift_setup_registry_default_route.resources[0].spec.host }}

--- a/ci_framework/roles/rhol_crc/tasks/main.yml
+++ b/ci_framework/roles/rhol_crc/tasks/main.yml
@@ -103,9 +103,11 @@
     - name: Delete sudoers file
       ansible.builtin.include_tasks: sudoers_revoke.yml
 
-- name: Set ci-framework kubeconfig
+- name: Set OpenShift CRC credentials
   ansible.builtin.set_fact:
-    cifmw_kubeconfig: "{{ cifmw_rhol_crc_kubeconfig }}"
+    cifmw_openshift_kubeconfig: "{{ cifmw_rhol_crc_kubeconfig }}"
+    cifmw_openshift_user: "kubeadmin"
+    cifmw_openshift_password: "{{ cifmw_rhol_crc_kubeadmin_pwd }}"
     cacheable: true
 
 - name: Add crc kubeconfig

--- a/docs/source/Roles/openshift_login.md
+++ b/docs/source/Roles/openshift_login.md
@@ -1,0 +1,1 @@
+../../../ci_framework/roles/openshift_login/README.md

--- a/docs/source/Usage/01_usage.md
+++ b/docs/source/Usage/01_usage.md
@@ -21,7 +21,7 @@ are shared among multiple roles:
 * `cifmw_path`: customized PATH. Defaults to `~/.crc/bin:~/.crc/bin/oc:~/bin:${PATH}`
 * `cifmw_use_libvirt`: (Bool) toggle libvirt support
 * `cifmw_use_crc`: (Bool) toggle rhol/crc usage
-* `cifmw_kubeconfig`: (String) Path to the kubeconfig file if externally provided.
+* `cifmw_openshift_kubeconfig`: (String) Path to the kubeconfig file if externally provided.
 
 #### Words of caution
 If you want to output the content in another location than `~/ci-framework-data`

--- a/scenarios/centos-9/ci-build.yml
+++ b/scenarios/centos-9/ci-build.yml
@@ -1,6 +1,6 @@
 ---
 cifmw_operator_build_push_registry: "default-route-openshift-image-registry.apps-crc.testing"
-cifmw_operator_build_push_org: "openstack"
+cifmw_operator_build_push_org: "openstack-operators"
 cifmw_operator_build_meta_build: true
 cifmw_operator_build_extra_bundles:
  - "quay.io/openstack-k8s-operators/rabbitmq-cluster-operator-bundle@sha256:9ff91ad3c9ef1797b232fce2f9adf6ede5c3421163bff5b8a2a462c6a2b3a68b"

--- a/scenarios/centos-9/ci.yml
+++ b/scenarios/centos-9/ci.yml
@@ -5,6 +5,10 @@ cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-o
 cifmw_use_libvirt: true
 cifmw_use_crc: true
 
+cifmw_openshift_user: "kubeadmin"
+cifmw_openshift_password: "123456789"
+cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+
 pre_infra:
   - name: Download needed tools
     inventory: "{{ cifmw_installyamls_repos }}/devsetup/hosts"

--- a/scenarios/centos-9/edpm_ci.yml
+++ b/scenarios/centos-9/edpm_ci.yml
@@ -2,7 +2,6 @@
 ansible_user_dir: "{{ lookup('env', 'HOME') }}"
 cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
 cifmw_install_yamls_vars:
-  KUBECONFIG: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
   OUTPUT_DIR: "{{ cifmw_basedir }}/artifacts/edpm_compute" # used by gen-ansibleee-ssh-key.sh
   OUTPUT_BASEDIR: "{{ cifmw_basedir }}/artifacts/edpm_compute" # used by gen-edpm-compute-node.sh
   SSH_KEY: "{{ cifmw_basedir }}/artifacts/edpm_compute/ansibleee-ssh-key-id_rsa"
@@ -18,6 +17,11 @@ cifmw_operator_build_meta_name: "openstack-operator"
 # edpm_deploy role vars
 cifmw_edpm_deploy_manifests_dir: "{{ cifmw_installyamls_repos }}/out"
 deploy_edpm: true
+
+# openshift_login role vars
+cifmw_openshift_user: "kubeadmin"
+cifmw_openshift_password: "123456789"
+cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
 
 pre_deploy:
   - name: Disable openstack marketplace

--- a/scripts/create_role_molecule
+++ b/scripts/create_role_molecule
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xe
 
-NEED_CRC_XL="cifmw-molecule-operator_deploy cifmw-molecule-rhol_crc cifmw-molecule-openshift_setup"
+NEED_CRC_XL="cifmw-molecule-operator_deploy cifmw-molecule-rhol_crc cifmw-molecule-openshift_setup cifmw-molecule-openshift_login"
 PROJECT_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))/../"
 cp ${PROJECT_DIR}/ci/templates/projects.yaml ${PROJECT_DIR}/zuul.d/projects.yaml;
 echo '# DO NOT EDIT - generaged using make role_molecule' > ${PROJECT_DIR}/zuul.d/molecule.yaml

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -38,7 +38,7 @@
       bmo_setup: false
       operators_namespace: openstack-operators
       # This should be set here since is associated with parent job (base-crc) and not the scenario
-      cifmw_kubeconfig: "/home/zuul/.crc/machines/crc/kubeconfig"
+      cifmw_openshift_kubeconfig: "/home/zuul/.crc/machines/crc/kubeconfig"
       zuul_log_collection: true
 
 # Install Yamls specific job

--- a/zuul.d/end-to-end.yaml
+++ b/zuul.d/end-to-end.yaml
@@ -6,7 +6,8 @@
     files:
       - ^ci_framework/roles/.*_build/(?!meta|README).*
       - ^ci_framework/roles/build.*/(?!meta|README).*
-      - ^ci_framework/roles/openshift_setup/(?!meta|README).*
+      - ^ci_framework/roles/openshift_*/(?!meta|README).*
+      - ^ci_framework/playbooks/.*build.*.yml
     irrelevant-files:
       - ^.*/*.md
       - ^ci/templates

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -110,6 +110,17 @@
       - ^ci_framework/roles/local_env_vm/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
+    name: cifmw-molecule-openshift_login
+    nodeset: centos-9-crc-xl
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: openshift_login
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/openshift_login/(?!meta|README).*
+      - ^ci/playbooks/molecule.*
+- job:
     name: cifmw-molecule-openshift_setup
     nodeset: centos-9-crc-xl
     parent: cifmw-molecule-base

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -25,6 +25,7 @@
         - cifmw-molecule-install_yamls
         - cifmw-molecule-libvirt_manager
         - cifmw-molecule-local_env_vm
+        - cifmw-molecule-openshift_login
         - cifmw-molecule-openshift_setup
         - cifmw-molecule-operator_build
         - cifmw-molecule-operator_deploy


### PR DESCRIPTION
This roles enables the framework to perform OpenShift logins in a consistent way by centralizing all login related actions into it. It based on explicit calls to the `oc` cli tool, that manages authentication underneath based on a given set of role variables. Depending on the variables that are passed to the role the `oc login` command arguments are build allowing multiple scenarios, like:
- Login with user, password and API endpoint
- Login with a kubeconfig file only
- Login with a kubeconfig file but overriden user/password Despite the given login variables used, the role sets at the end of it's execution the API URL, user, context, kubeconfig and token that applies to the whole run, taht way, any consumer in the playbook can use those credentials to login.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
