### PR TITLE
Retry `make_crc_storage` task

### DIFF
--- a/ci_framework/plugins/modules/generate_make_tasks.py
+++ b/ci_framework/plugins/modules/generate_make_tasks.py
@@ -71,6 +71,10 @@ MAKE_TMPL = '''---
   ansible.builtin.debug:
     var: make_%(target)s_params
 - name: Run %(target)s
+  retries: "{{ make_%(target)s_retries | default(omit) }}"
+  delay: "{{ make_%(target)s_delay | default(omit) }}"
+  until: "{{ make_%(target)s_until | default(true) }}"
+  register: "make_%(target)s_status"
   ci_make:
     output_dir: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts"
     chdir: "%(chdir)s"

--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -20,6 +20,9 @@
   vars:
     make_crc_storage_env: "{{ cifmw_edpm_prepare_common_env }}"
     make_crc_storage_dryrun: "{{ cifmw_edpm_prepare_dry_run }}"
+    make_crc_storage_retries: 10
+    make_crc_storage_delay: 2
+    make_crc_storage_until: "make_crc_storage_status is not failed"
   when: not cifmw_edpm_prepare_skip_crc_storage_creation | bool
   ansible.builtin.include_role:
     name: 'install_yamls_makes'


### PR DESCRIPTION
It may happen this specific task fails. In such case, we may want to
give some more chances to it.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [ ] ~~Appropriate documentation exists and/or is up-to-date:~~
  - [ ] ~~README in the role~~
  - [ ] ~~Content of the docs/source is reflecting the changes~~

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/222