### PR TITLE
Extend generate_make_tasks documentation

### DIFF
--- a/ci_framework/plugins/README.md
+++ b/ci_framework/plugins/README.md
@@ -85,3 +85,53 @@ Description: Generate task file per Makefile target.
   * description: Absolute path to the output directory. It must exists
   * required: True
   * type: str
+
+## Calling generated tasks
+In order to benefit of the generated role and tasks, you have to ensure ansible
+knows about the role location. By default, it will be in
+`{{cifmw_basedir}}/artifacts/roles/install_yamls`, and this path is already
+injected in the `ansible.cfg` provided by the project.
+
+### Task inclusion
+Leveraging `ansible.builtin.include_role` and its `tasks_from` parameter, you
+may call the generated task file for the desired `make` target. For instance:
+```YAML
+- name: Prepare storage in CRC
+  vars:
+    make_crc_storage_env: "{{ cifmw_edpm_prepare_common_env }}"
+    make_crc_storage_dryrun: "{{ cifmw_edpm_prepare_dry_run }}"
+  when: not cifmw_edpm_prepare_skip_crc_storage_creation | bool
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_crc_storage'
+```
+This block will call the `make crc_storage` command, passing some variables
+that will then be transfered to the `ci_make` call.
+
+### Available parameters
+* `make_TARGET_env`: (List) Allows to pass `environment` parameter to the task.
+* `make_TARGET_params`: (List) Allows to pass `make` parameters.
+* `make_TARGET_dryrun`: (Boolean) Toggle `dry_run` flag of `ci_make`.
+* `make_TARGET_retries`: (Integer) Number of retries for `ci_make` task.
+* `make_TARGET_delay`: (Integer) Delay between retries for `ci_make` task.
+* `make_TARGET_until`: (String) Early exit condition (`until`) for `ci_make` retries.
+
+### `until` condition
+When you want to leverage `retries`, it's always good to get an `until` condition.
+In order to make things easier, the generated task exposes `make_TARGET_status`,
+allowing an easy `make_TARGET_status is not failed` condition:
+```YAML
+
+- name: Prepare storage in CRC
+  vars:
+    make_crc_storage_env: "{{ cifmw_edpm_prepare_common_env }}"
+    make_crc_storage_dryrun: "{{ cifmw_edpm_prepare_dry_run }}"
+    make_crc_storage_retries: 10
+    make_crc_storage_delay: 2
+    make_crc_storage_until: "make_crc_storage_status is not failed"
+  when: not cifmw_edpm_prepare_skip_crc_storage_creation | bool
+  register: crc_storage_status
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_crc_storage'
+```


### PR DESCRIPTION
Since this module generate tasks, it's good to get the actual parameters
we may pass down. This is especially important since the install_yamls
wrapper should be widely used in the framework.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/223

As a pull request owner and reviewers, I checked that:
- [ ] ~~Appropriate testing is done and actually running~~
- [X] Appropriate documentation exists and/or is up-to-date:
  - [ ] ~~README in the role~~
  - [X] Content of the docs/source is reflecting the changes
