### PR TITLE
Improve documentation related to the requirements

### DIFF
--- a/docs/source/Quickstart/01_requirements.md
+++ b/docs/source/Quickstart/01_requirements.md
@@ -5,3 +5,32 @@ To run the ci-framework locally on your machine you will need:
 * 32 GB RAM
 * 120 GB free storage
 * 6 CPU
+
+# Needed packages
+In order to be able to start consuming the Framework, the following packages
+must be present on your system:
+
+* git
+* make
+* python3-pip
+* sudo
+
+# Needed specific configurations
+Your used must have full `sudo` access in order to:
+
+* install packages
+* push specific configurations linked to CRC
+
+While we try to keep the footprint low on the system, packages are needed, and
+some 3rd-party software require accesses, such as CRC.
+
+The best way to get that is to push this content to `/etc/suders.d/USERNAME`:
+```
+USERNAME ALL=(ALL) ALL
+```
+Of course, replace `USERNAME` by your user.
+
+## Specific access rights
+Since we're using libvirt within the "system" namespace (thanks to CRC, mostly),
+your user must be part of the "libvirt" user. While we manage this in one of
+the roles, you may need to logout/login in order to refresh your groups.

--- a/docs/source/Quickstart/02_nested_virt.md
+++ b/docs/source/Quickstart/02_nested_virt.md
@@ -7,6 +7,9 @@ In this section, you will learn how to set up your local development environment
 
 ## Pre-setup
 
+### Meet the requirements
+Please check [this page](./01_requirements.md) first.
+
 ### Nested virtualization support
 Ensure you have nested virtualization support on your hardware. You can follow [this documentation](https://docs.fedoraproject.org/en-US/quick-docs/using-nested-virtualization-in-kvm/).
 

--- a/docs/source/Quickstart/04_non-virt.md
+++ b/docs/source/Quickstart/04_non-virt.md
@@ -11,6 +11,9 @@ access to libvirtd. Verify you have `git` and `make` installed.
 ## Prepare your environment
 In order to do so, some steps should be done beforehand.
 
+### 0. Ensure you meet the requirements
+Please check [this page](./01_requirements.md) first.
+
 ### 1. Get the project and its dependencies
 ```Bash
 $ cd $HOME
@@ -63,7 +66,7 @@ requirements.
 
 ### 4. Place a pull secret in place
 
-Get the pull secret from `https://cloud.redhat.com/openshift/create/local`
+Get the pull secret from https://cloud.redhat.com/openshift/create/local
 and place it to `$HOME/pull-secret`.
 
 ### 5. Run the playbook


### PR DESCRIPTION
We must list the needed packages as well as the potential privileges we
need.
Mostly, we must point the `libvirt` group belonging.

A potential future improvement is to get a dedicated playbook that will
take care of the initial env bootstrap, to be launched only once. It
will check for the requirements, and output a nice message at the end,
asking the user to login/logout in order to refresh groups, for
instance, or any service message that may help ensuring a successful
deploy.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] Content of the docs/source is reflecting the changes
