### PR TITLE
Use OPERATOR_NAMESPACE in operator installation

### DIFF
--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -39,7 +39,9 @@
   ansible.builtin.shell:
     cmd: >
       oc policy add-role-to-user system:image-puller system:anonymous -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} &&
-      oc policy add-role-to-user system:image-puller system:unauthenticated -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+      oc policy add-role-to-user system:image-puller system:unauthenticated -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} &&
+      oc policy add-role-to-user system:image-puller system:anonymous -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} &&
+      oc policy add-role-to-user system:image-puller system:unauthenticated -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }}
   when:
     - cifmw_operator_build_meta_name is defined and cifmw_operator_build_meta_name in cifmw_edpm_prepare_operators_build_output
     - cifmw_edpm_prepare_operators_build_output[cifmw_operator_build_meta_name].image_catalog.split('/')[0] == cifmw_edpm_prepare_registry_default_route.stdout
@@ -73,7 +75,7 @@
       environment:
         PATH: "{{ cifmw_path }}"
       ansible.builtin.command:
-        cmd: oc get sub openstack-operator --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }} -o=jsonpath='{.status.installplan.name}'
+        cmd: oc get sub openstack-operator --namespace={{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} -o=jsonpath='{.status.installplan.name}'
       until: cifmw_edpm_prepare_wait_installplan_out.rc == 0 and cifmw_edpm_prepare_wait_installplan_out.stdout != ""
       register: cifmw_edpm_prepare_wait_installplan_out
       retries: "{{ cifmw_edpm_prepare_wait_subscription_retries }}"
@@ -85,7 +87,7 @@
       ansible.builtin.command:
         cmd: >
           oc wait InstallPlan {{ cifmw_edpm_prepare_wait_installplan_out.stdout }}
-          --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }} --for=jsonpath='{.status.phase}'=Complete --timeout=20m
+          --namespace={{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} --for=jsonpath='{.status.phase}'=Complete --timeout=20m
 
 - name: Install OpenStack service
   vars:

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -35,6 +35,7 @@
       network_isolation: true
       crc_attach_default_interface: true
       bmo_setup: false
+      operators_namespace: openstack-operators
       # This should be set here since is associated with parent job (base-crc) and not the scenario
       cifmw_kubeconfig: "/home/zuul/.crc/machines/crc/kubeconfig"
 


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/install_yamls/pull/289 adds openstack_operators namespace for openstack operators.

The same needs to be fixed in ci-framework tool to finish the operator installation.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [ ] ~~Appropriate documentation exists and/or is up-to-date:~~
  - [ ] ~~README in the role~~
  - [ ] ~~Content of the docs/source is reflecting the changes~~
