### PR TITLE
Move log collection in post-run zuul step

### DIFF
--- a/ci/playbooks/e2e-collect-logs.yml
+++ b/ci/playbooks/e2e-collect-logs.yml
@@ -8,9 +8,4 @@
         cmd: >-
           ansible-playbook ci_framework/playbooks/99-logs.yml
           -e @scenarios/centos-9/base.yml
-          -e @scenarios/centos-9/edpm_ci.yml
           -e @scenarios/centos-9/zuul_inventory.yml
-      when:
-        - edpm_deploy_status is defined
-        - "'rc' in edpm_deploy_status"
-        - edpm_deploy_status.rc == 0

--- a/ci/playbooks/edpm/run.yml
+++ b/ci/playbooks/edpm/run.yml
@@ -15,4 +15,3 @@
           -e "{{   extra_var }}"
           {%-   endfor %}
           {%- endif %}
-      register: edpm_deploy_status

--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -26,3 +26,4 @@
 
 - name: Run log related tasks
   ansible.builtin.import_playbook: ci_framework/playbooks/99-logs.yml
+  when: not zuul_log_collection | default ('false') | bool

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -30,7 +30,7 @@
       - ci/playbooks/dump_zuul_vars.yml
       - ci/playbooks/edpm/run.yml
     post-run:
-      - ci/playbooks/edpm/post.yml
+      - ci/playbooks/e2e-collect-logs.yml
       - ci/playbooks/collect-logs.yml
     vars:
       network_isolation: true
@@ -39,6 +39,7 @@
       operators_namespace: openstack-operators
       # This should be set here since is associated with parent job (base-crc) and not the scenario
       cifmw_kubeconfig: "/home/zuul/.crc/machines/crc/kubeconfig"
+      zuul_log_collection: true
 
 # Install Yamls specific job
 - job:

--- a/zuul.d/end-to-end.yaml
+++ b/zuul.d/end-to-end.yaml
@@ -13,13 +13,16 @@
     parent: base-simple-crc
     vars:
       crc_parameters: "--memory 20000 --disk-size 120 --cpus 6"
+      zuul_log_collection: true
       cifmw_extras:
         - '@scenarios/centos-9/ci-build.yml'
     pre-run: ci/playbooks/e2e-prepare.yml
     run:
       - ci/playbooks/dump_zuul_vars.yml
       - ci/playbooks/e2e-run.yml
-    post-run: ci/playbooks/collect-logs.yml
+    post-run:
+      - ci/playbooks/e2e-collect-logs.yml
+      - ci/playbooks/collect-logs.yml
     required-projects:
       - github.com/openstack-k8s-operators/install_yamls
     timeout: 5400
@@ -38,12 +41,15 @@
       - ^OWNERS
     vars:
       crc_parameters: "--memory 20000 --disk-size 120 --cpus 6"
+      zuul_log_collection: true
     parent: base-simple-crc
     pre-run: ci/playbooks/e2e-prepare.yml
     run:
       - ci/playbooks/dump_zuul_vars.yml
       - ci/playbooks/e2e-run.yml
-    post-run: ci/playbooks/collect-logs.yml
+    post-run:
+      - ci/playbooks/e2e-collect-logs.yml
+      - ci/playbooks/collect-logs.yml
     required-projects:
       - github.com/openstack-k8s-operators/install_yamls
     timeout: 5400


### PR DESCRIPTION
Currently 99-logs.yml playbook is used to collect logs during edpm deployment and runned as a part of
deploy-edpm.yml playbook. But any playbook before 99-logs.yml playbook fails in deploy-edpm.yaml, then log collection fails.

In order to fix this issue, we are going to call 99-logs.yml from e2e-collect-logs.yml playbook. It will be called as a part of post-run zuul step so that log collection always happen as.

It will be runned in e2e and edpm jobs.

Note: it drops edpm/post.yml playbook (which is not working as expected.)

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [ ] ~~Appropriate documentation exists and/or is up-to-date:~~
  - [ ] ~~README in the role~~
  - [ ] ~~Content of the docs/source is reflecting the changes~~
