### PR TITLE
add collection of Openstack CR instances.

### DIFF
--- a/ci_framework/roles/artifacts/tasks/cluster_info.yml
+++ b/ci_framework/roles/artifacts/tasks/cluster_info.yml
@@ -1,4 +1,8 @@
 ---
+# Note if any of the tasks fail, we will still try to collect the data
+# from the cluster. This is because we want to collect as much data as
+# possible, even if the cluster is not in a good state so we use
+# ignore_errors: true.
 - name: Check for oc command
   ansible.builtin.command: which oc
   environment:
@@ -30,13 +34,37 @@
     - name: Dump the logs of all pods
       ansible.builtin.shell: |
         all_pods=$(oc get pods -o name)
+        # This is implicitly relying on the fact that the pod name is
+        # prefixed with "pod/" so that the redirect places the logs
+        # in the correct pod directory. That is why we do not cd after
+        # creating the directory.
         mkdir pod
-        for pod in $all_pods; do
-          echo $pod
-          oc logs $pod > ${pod}-logs.txt
-          oc get -o yaml $pod > ${pod}.yaml
-          oc describe $pod > ${pod}-describe.txt
+        for pod in ${all_pods}; do
+          echo ${pod}
+          oc logs ${pod} > ${pod}-logs.txt
+          oc get -o yaml ${pod} > ${pod}.yaml
+          oc describe ${pod} > ${pod}-describe.txt
         done
+        # so we rename the directory after populating it
+        # to "pods" to consistently use plural names for
+        # collected resources.
+        mv pod pods
+      args:
+        chdir: "{{ cifmw_artifacts_basedir }}/logs/edpm"
+      changed_when: true
+      ignore_errors: true
+
+    - name: Dump all openstack CRs
+      ansible.builtin.shell: |
+        mkdir crs
+        pushd crs
+          all_crds=$(oc get crd | awk '/openstack/ { print $1}' | awk -F '.' '{print $1}')
+          for cr in ${all_crds}; do
+            echo ${crd}
+            oc get -o yaml ${cr} > ${cr}.yaml
+            oc describe ${cr} > ${cr}-describe.txt
+          done
+        popd
       args:
         chdir: "{{ cifmw_artifacts_basedir }}/logs/edpm"
       changed_when: true


### PR DESCRIPTION
This change extends the artifact collection to
include the output of get and describe on all openstack
CRDs.

This will allow the collection of both the rendered CRs
and the status of them to allow failures to be debugged.

Signed-off-by: Sean Mooney <work@seanmooney.info>

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
