### PR TITLE
Use zuul clonned dataplane-operator code for edpm deploy

### DIFF
--- a/scenarios/centos-9/edpm_ci.yml
+++ b/scenarios/centos-9/edpm_ci.yml
@@ -6,6 +6,7 @@ cifmw_install_yamls_vars:
   OUTPUT_DIR: "{{ cifmw_basedir }}/artifacts/edpm_compute" # used by gen-ansibleee-ssh-key.sh
   OUTPUT_BASEDIR: "{{ cifmw_basedir }}/artifacts/edpm_compute" # used by gen-edpm-compute-node.sh
   SSH_KEY: "{{ cifmw_basedir }}/artifacts/edpm_compute/ansibleee-ssh-key-id_rsa"
+  DATAPLANE_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/dataplane-operator"
 
 # edpm_deploy role vars
 cifmw_edpm_deploy_run_validation: true

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -11,6 +11,7 @@
     required-projects:
       - openstack-k8s-operators/install_yamls
       - openstack-k8s-operators/openstack-operator
+      - openstack-k8s-operators/dataplane-operator
       - github.com/openstack-k8s-operators/ci-framework
       - github.com/openstack-k8s-operators/repo-setup
     roles:


### PR DESCRIPTION
Currently in Zuul CI, The default install_yamls default vars for DATAPLANE_REPO is pointing to
"https://github.com/openstack-k8s-operators/dataplane-operator.git". During make edpm_deploy, the dataplane-operator code is clonned from github and the job is not testing the actual code.

By setting DATAPLANE_REPO value under cifmw_edpm_deploy_env var, make sure zuul clonned dataplane-operator code is used.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [ ] ~~Appropriate documentation exists and/or is up-to-date:~~
  - [ ] ~~README in the role~~
  - [ ] ~~Content of the docs/source is reflecting the changes~~
