### PR TITLE
Installing oc  as part of ci_setup

### DIFF
--- a/ci_framework/roles/ci_setup/README.md
+++ b/ci_framework/roles/ci_setup/README.md
@@ -7,6 +7,9 @@ Ensure you have the needed directories and packages for the rest of the tasks.
 ## Parameters
 * `cifmw_ci_setup_basedir`: (String) Base directory for the directory tree. Default to `~/ci-framework-data`.
 * `cifmw_ci_setup_packages`: (List) List of packages to install.
+* `cifmw_ci_setup_openshift_client_version`: (String) Version of openshift
+  client to be installed on the system. Defaults to `stable` i.e. the latest
+  stable release of the client.
 
 ## Cleanup
 You may call the `cleanup.yml` role in order to clear the directory tree.

--- a/ci_framework/roles/ci_setup/defaults/main.yml
+++ b/ci_framework/roles/ci_setup/defaults/main.yml
@@ -17,4 +17,6 @@
 
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_ci_setup"
+
 cifmw_ci_setup_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+cifmw_ci_setup_openshift_client_version: "stable"

--- a/ci_framework/roles/ci_setup/meta/main.yml
+++ b/ci_framework/roles/ci_setup/meta/main.yml
@@ -32,6 +32,9 @@ galaxy_info:
     - name: CentOS
       versions:
         - 9
+    - name: EL
+      versions:
+        - 9
 
   galaxy_tags:
     - edpm

--- a/ci_framework/roles/ci_setup/molecule/default/converge.yml
+++ b/ci_framework/roles/ci_setup/molecule/default/converge.yml
@@ -14,10 +14,10 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
 - name: Converge
   hosts: all
   vars:
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
     cifmw_install_yamls_defaults:
       NAMESPACE: openstack
       DATAPLANE_RUNNER_IMG: foo
@@ -26,32 +26,70 @@
     - name: Default include
       ansible.builtin.import_role:
         name: ci_setup
+
     - name: Check directory creation
       block:
         - name: Stat directory
           register: dir_stat
           ansible.builtin.stat:
             path: "{{ ansible_user_dir }}/ci-framework-data/volumes"
+
         - name: Debug
           debug:
             msg: "{{ ansible_user_dir }}/ci-framework-data/volumes"
+
         - name: Validate directory state
           ansible.builtin.assert:
             that:
               - dir_stat.stat.isdir is defined
               - dir_stat.stat.isdir
+
+    - name: Verify openshift client
+      block:
+        - name: Get oc stat informaiton
+          register: oc_stat
+          ansible.builtin.stat:
+            path: "{{ ansible_user_dir }}/bin/oc"
+
+        - name: Verify the oc stat information
+          ansible.builtin.assert:
+            that:
+              - oc_stat.stat.exists is defined
+              - oc_stat.stat.exists | bool
+
+        - name: Verify openshift client version
+          register: oc_ver
+          environment:
+            PATH: "{{ cifmw_path }}"
+          ansible.builtin.command:
+            cmd: "oc version -o yaml"
+
+        - name: Debug - oc version output
+          ansible.builtin.debug:
+            msg: "{{ oc_ver.stdout }}"
+
+        - name: Compare the expected version
+          vars:
+            oc_ver_dict: "{{ oc_ver.stdout | from_yaml }}"
+            oc_major_version: "{{ oc_ver_dict.releaseClientVersion | split('.') | first }}"
+          ansible.builtin.assert:
+            that:
+              - oc_major_version | int >= 4
+
     - name: Clean up directories
       vars:
         directory_state: absent
       ansible.builtin.import_role:
         name: ci_setup
         tasks_from: cleanup.yml
+
     - name: Check directory removal
       block:
         - name: Stat directory
           register: dir_stat
           ansible.builtin.stat:
             path: "{{ ansible_user_dir }}/ci-framework-data/volumes"
+
         - name: Validate directory state
           ansible.builtin.assert:
             that:

--- a/ci_framework/roles/ci_setup/tasks/packages.yml
+++ b/ci_framework/roles/ci_setup/tasks/packages.yml
@@ -8,3 +8,34 @@
   ansible.builtin.package:
     name: "{{ cifmw_ci_setup_packages }}"
     state: latest
+
+- name: Install openshift client
+  block:
+    - name: Gather version of openshift client if it exists
+      register: oc_version
+      environment:
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.command:
+        cmd: "oc version -o yaml"
+
+    - name: Check if version of openshift client is supported
+      vars:
+        oc_version_data: "{{ oc_version.stdout | from_yaml }}"
+        oc_major_version: "{{ oc_version_data.releaseClientVersion | split('.') | first }}"
+      ansible.builtin.assert:
+        that:
+          - oc_major_version | int >= cifmw_ci_setup_openshift_minimum_version
+  rescue:
+    - name: Ensure openshift client install path is present
+      ansible.builtin.file:
+        path: "{{ cifmw_ci_setup_openshift_client_install_path }}"
+        state: directory
+        mode: 0755
+
+    - name: Install openshift cient
+      ansible.builtin.unarchive:
+        src: "{{ cifmw_ci_setup_openshift_client_download_uri }}/{{ cifmw_ci_setup_openshift_client_version }}/openshift-client-linux.tar.gz"
+        dest: "{{ cifmw_ci_setup_openshift_client_install_path }}"
+        remote_src: true
+        mode: 0755
+        creates: "{{ cifmw_ci_setup_openshift_client_install_path }}/oc"

--- a/ci_framework/roles/ci_setup/vars/main.yml
+++ b/ci_framework/roles/ci_setup/vars/main.yml
@@ -1,2 +1,26 @@
 ---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_ci_setup"
+
 cifmw_ci_setup_packages: []
+
+# openshift client
+cifmw_ci_setup_openshift_client_download_uri: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp"
+cifmw_ci_setup_openshift_minimum_version: 4
+cifmw_ci_setup_openshift_client_install_path: "{{ ansible_user_dir }}/bin"


### PR DESCRIPTION
OpenShift client is installed as part of ci_setup role. This is to enable `hive` role to leverage the binary for its task.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
