### PR TITLE
Removed the legacy global edpm_env

### DIFF
--- a/ci_framework/hooks/playbooks/ceph-deploy.yml
+++ b/ci_framework/hooks/playbooks/ceph-deploy.yml
@@ -24,12 +24,16 @@
     # let's default to an empty hash.
     - name: Run make_ceph
       vars:
-        make_ceph_environment: >-
-          {{ cifmw_make_ceph_environment | default({}) |
-              combine({
+        make_ceph_env: >-
+          {{
+          cifmw_install_yamls_environment |
+          combine(
+            cifmw_make_ceph_environment | default({}) |
+            combine({
                 'KUBECONFIG': cifmw_openshift_kubeconfig,
                 'PATH': cifmw_path
-              })
+            })
+          )
           }}
       ansible.builtin.include_role:
         role: install_yamls_makes

--- a/ci_framework/plugins/modules/generate_make_tasks.py
+++ b/ci_framework/plugins/modules/generate_make_tasks.py
@@ -59,13 +59,10 @@ import os
 
 
 MAKE_TMPL = '''---
-- name: Set environment fact
-  ansible.builtin.set_fact:
-    make_%(target)s_environment: "{{ edpm_env | combine(make_%(target)s_env|default({})) }}"
-    cacheable: true
-- name: Debug make_%(target)s_environment
+- name: Debug make_%(target)s_env
+  when: make_%(target)s_env is defined
   ansible.builtin.debug:
-    var: make_%(target)s_environment
+    var: make_%(target)s_env
 - name: Debug make_%(target)s_params
   when: make_%(target)s_params is defined
   ansible.builtin.debug:
@@ -81,7 +78,7 @@ MAKE_TMPL = '''---
     target: %(target)s
     dry_run: "{{ make_%(target)s_dryrun|default(false)|bool }}"
     params: "{{ make_%(target)s_params|default(omit) }}"
-  environment: "{{ make_%(target)s_environment }}"
+  environment: "{{ make_%(target)s_env | default({}) }}"
 '''
 
 NO_OUTDIR = 'Directory %s does not exist. Please create it.'

--- a/ci_framework/roles/edpm_deploy/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy/tasks/main.yml
@@ -18,13 +18,12 @@
   tags:
     - always
   ansible.builtin.set_fact:
-    cifmw_edpm_deploy_env: |
-      PATH: "{{ cifmw_path }}"
+    cifmw_edpm_deploy_env: "{{ cifmw_install_yamls_environment | combine({'PATH': cifmw_path }) }}"
     cacheable: true
 
 - name: Deploy EDPM
   vars:
-    make_edpm_deploy_env: "{{ cifmw_edpm_deploy_env | from_yaml }}"
+    make_edpm_deploy_env: "{{ cifmw_edpm_deploy_env }}"
     make_edpm_deploy_dryrun: "{{ cifmw_edpm_deploy_dryrun | bool }}"
   ansible.builtin.include_role:
     name: 'install_yamls_makes'
@@ -103,6 +102,8 @@
         dest: "{{ cifmw_edpm_deploy_log_path }}"
 
 - name: Validate EDPM
+  vars:
+    make_edpm_deploy_instance_env: "{{ cifmw_edpm_deploy_env }}"
   ansible.builtin.include_role:
     name: 'install_yamls_makes'
     tasks_from: 'make_edpm_deploy_instance'

--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -20,9 +20,11 @@
   vars:
     operators_build_output: "{{ (cifmw_operator_build_output | default({'operators':{}})).operators }}"
   ansible.builtin.set_fact:
-    cifmw_edpm_prepare_common_env:
-      PATH: "{{ cifmw_path }}"
-      KUBECONFIG : "{{ cifmw_openshift_kubeconfig }}"
+    cifmw_edpm_prepare_common_env: >-
+      {{
+        cifmw_install_yamls_environment |
+        combine({'PATH': cifmw_path, 'KUBECONFIG': cifmw_openshift_kubeconfig})
+      }}
     cifmw_edpm_prepare_make_openstack_env: |
       {% if cifmw_operator_build_meta_name is defined and cifmw_operator_build_meta_name in operators_build_output %}
       OPENSTACK_IMG: {{ operators_build_output[cifmw_operator_build_meta_name].image_catalog }}

--- a/ci_framework/roles/install_yamls/molecule/default/converge.yml
+++ b/ci_framework/roles/install_yamls/molecule/default/converge.yml
@@ -26,10 +26,10 @@
     - role: "install_yamls"
 
   tasks:
-    - name: Ensure we get edpm_env fact
+    - name: Ensure we get cifmw_install_yamls_environment fact
       ansible.builtin.assert:
         that:
-          - edpm_env is defined
+          - cifmw_install_yamls_environment is defined
 
     - name: Gather some file data
       register: make_files

--- a/ci_framework/roles/install_yamls/tasks/main.yml
+++ b/ci_framework/roles/install_yamls/tasks/main.yml
@@ -25,11 +25,15 @@
     - "{{ cifmw_install_yamls_tasks_out }}"
 
 - name: "Get environment structure"
+  tags:
+    - always
   register: get_makefiles_env_output
   get_makefiles_env:
     base_path: "{{ cifmw_install_yamls_repo }}"
 
 - name: Create env var if needed
+  tags:
+    - always
   when: cifmw_install_yamls_vars is defined
   block:
     - name: Ensure Output directory exists
@@ -37,9 +41,9 @@
         path: "{{ cifmw_install_yamls_out_dir }}"
         state: directory
 
-    - name: Set environment override edpm_env fact
+    - name: Set environment override cifmw_install_yamls_environment fact
       ansible.builtin.set_fact:
-        edpm_env: >-
+        cifmw_install_yamls_environment: >-
           {{
             cifmw_install_yamls_vars.keys() |
             map('upper') |
@@ -52,7 +56,7 @@
     - name: Ensure user cifmw_install_yamls_vars contains existing Makefile variables
       ansible.builtin.assert:
         that: >-
-         edpm_env.keys() |
+         cifmw_install_yamls_environment.keys() |
          difference(
           get_makefiles_env_output.makefiles_values.keys() | list +
           cifmw_install_yamls_whitelisted_vars | default([])
@@ -66,33 +70,43 @@
       ansible.builtin.copy:
         dest: "{{ cifmw_install_yamls_out_dir }}/{{ cifmw_install_yamls_envfile }}"
         content: |-
-          {% for k,v in edpm_env.items() %}
+          {% for k,v in cifmw_install_yamls_environment.items() %}
           export {{ k }}={{ v }}
           {% endfor %}
 
 - name: Export empty dict in case we don't provide environment overrides
+  tags:
+    - always
   when:
     - cifmw_install_yamls_vars is not defined
   ansible.builtin.set_fact:
-    edpm_env:
+    cifmw_install_yamls_environment:
       OUT: "{{ cifmw_install_yamls_manifests_dir }}"
     cacheable: true
 
 - name: Set install_yamls default values
+  tags:
+    - always
   ansible.builtin.set_fact:
-    cifmw_install_yamls_defaults: "{{ get_makefiles_env_output.makefiles_values  | combine(edpm_env) }}"
+    cifmw_install_yamls_defaults: "{{ get_makefiles_env_output.makefiles_values  | combine(cifmw_install_yamls_environment) }}"
     cacheable: true
 
 - name: Show the env structure
+  tags:
+    - always
   ansible.builtin.debug:
-    var: edpm_env
+    var: cifmw_install_yamls_environment
 
 - name: "Generate make targets"
+  tags:
+    - always
   register: cifmw_generate_makes
   generate_make_tasks:
     install_yamls_path: "{{ cifmw_install_yamls_repo }}"
     output_directory: "{{ cifmw_install_yamls_tasks_out }}"
 
 - name: Debug generate_make module
+  tags:
+    - always
   ansible.builtin.debug:
     var: cifmw_generate_makes

--- a/ci_framework/roles/libvirt_manager/tasks/deploy_edpm_compute.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/deploy_edpm_compute.yml
@@ -14,9 +14,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Extract configs of interest from cifmw_libvirt_manager_configuration
+- name: Set compute config and common environment facts
   ansible.builtin.set_fact:
     compute_config: "{{ cifmw_libvirt_manager_configuration['vms']['compute'] }}"
+    cifmw_libvirt_manager_common_env: "{{ cifmw_install_yamls_environment | combine({'PATH': cifmw_path }) }}"
+    cacheable: true
 
 - name: Ensure needed directories exist
   ansible.builtin.file:
@@ -51,13 +53,16 @@
     make_edpm_compute_dryrun: "{{ cifmw_libvirt_manager_dryrun }}"
     make_edpm_compute_params:
       EDPM_COMPUTE_SUFFIX: "{{ item }}"
-    make_edpm_compute_env:
-      PATH: "{{ cifmw_path }}"
-      EDPM_COMPUTE_VCPUS: "{{ compute_config.cpus }}"
-      EDPM_COMPUTE_RAM: "{{ compute_config.memory }}"
-      EDPM_COMPUTE_DISK_SIZE: "{{ compute_config.disksize }}"
-      CRC_POOL: "{{ compute_config.image_local_dir }}"
-      DISK_FILEPATH: "{{ cifmw_libvirt_manager_basedir }}/workload/edpm-compute-{{ item }}.qcow2"
+    make_edpm_compute_env: >-
+      {{ cifmw_libvirt_manager_common_env |
+        combine({
+          'EDPM_COMPUTE_VCPUS': compute_config.cpus,
+          'EDPM_COMPUTE_RAM': compute_config.memory,
+          'EDPM_COMPUTE_DISK_SIZE': compute_config.disksize,
+          'CRC_POOL': compute_config.image_local_dir,
+          'DISK_FILEPATH': cifmw_libvirt_manager_basedir + "/workload/edpm-compute-" + item + ".qcow2"
+        })
+      }}
   ansible.builtin.include_role:
     name: 'install_yamls_makes'
     tasks_from: 'make_edpm_compute.yml'
@@ -89,8 +94,12 @@
     make_edpm_compute_repos_dryrun: "{{ cifmw_libvirt_manager_dryrun }}"
     make_edpm_compute_repos_params:
       EDPM_COMPUTE_SUFFIX: "{{ item }}"
-    make_edpm_compute_repos_env:
-      CMDS_FILE: "{{ cifmw_libvirt_manager_basedir }}/artifacts/edpm_compute/compute_repo-{{ item }}.sh"
+    make_edpm_compute_repos_env: >-
+      {{ cifmw_libvirt_manager_common_env |
+        combine({
+          'CMDS_FILE': cifmw_libvirt_manager_basedir + "/artifacts/edpm_compute/compute_repo-" + item + ".sh"
+        })
+      }}
   ansible.builtin.include_role:
     name: 'install_yamls_makes'
     tasks_from: 'make_edpm_compute_repos.yml'


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
