### PR TITLE
Remove crc bits from cifmw-base-crc-openstack and rename it

### DIFF
--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -1,11 +1,22 @@
 ---
-# Base job for openstack crc based job
+# Base job for crc based job
 - job:
-    name: cifmw-base-crc-openstack
+    name: cifmw-base-crc
     nodeset: centos-9-crc-3xl
     timeout: 10800
     abstract: true
     parent: base-simple-crc
+    vars:
+      crc_parameters: "--memory 21000 --disk-size 120 --cpus 8"
+      pre_pull_images:
+        - registry.redhat.io/rhosp-rhel9/openstack-rabbitmq:17.0
+
+# Base job for openstack based job containing ci-framework bits
+- job:
+    name: cifmw-base-crc-openstack
+    parent: cifmw-base-crc
+    timeout: 10800
+    abstract: true
     irrelevant-files:
       - .*/*.md
     required-projects:
@@ -17,40 +28,26 @@
       - openstack-k8s-operators/repo-setup
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
+    pre-run:
+      - ci/playbooks/e2e-prepare.yml
+      - ci/playbooks/dump_zuul_vars.yml
+    post-run:
+      - ci/playbooks/e2e-collect-logs.yml
+      - ci/playbooks/collect-logs.yml
     vars:
-      crc_parameters: "--memory 21000 --disk-size 120 --cpus 8"
-      pre_pull_images:
-        - registry.redhat.io/rhosp-rhel9/openstack-rabbitmq:17.0
+      zuul_log_collection: true
 
 # EDPM job with single node
 - job:
     name: cifmw-crc-podified-edpm-deployment
     parent: cifmw-base-crc-openstack
-    run:
-      - ci/playbooks/e2e-prepare.yml
-      - ci/playbooks/dump_zuul_vars.yml
-      - ci/playbooks/edpm/run.yml
-    post-run:
-      - ci/playbooks/e2e-collect-logs.yml
-      - ci/playbooks/collect-logs.yml
-    vars:
-      # This should be set here since is associated with parent job (base-crc) and not the scenario
-      cifmw_openshift_kubeconfig: "/home/zuul/.crc/machines/crc/kubeconfig"
-      zuul_log_collection: true
+    run: ci/playbooks/edpm/run.yml
 
 # Bmaas job with CRC and two bmaas compute nodes.
 - job:
     name: cifmw-crc-podified-edpm-baremetal
     parent: cifmw-base-crc-openstack
-    run:
-      - ci/playbooks/e2e-prepare.yml
-      - ci/playbooks/dump_zuul_vars.yml
-      - ci/playbooks/edpm_baremetal_deployment/run.yml
-    post-run:
-      - ci/playbooks/e2e-collect-logs.yml
-      - ci/playbooks/collect-logs.yml
-    vars:
-      zuul_log_collection: true
+    run: ci/playbooks/edpm_baremetal_deployment/run.yml
 
 # Install Yamls specific job
 - job:


### PR DESCRIPTION
cifmw-base-crc-openstack uses base-simple-crc as a parent
and contains ci-framework and crc related jobs vars.
    
 It does not give a clear seperation between crc and ci-framework.
 This patch breaks the cifmw-base-crc-openstack into two jobs
 1. cifmw-base-crc containing the crc bits
 2. cifmw-base-openstack containing the ci-framework bits with
       pre-run and post-run playbook calls and vars
    
It also keeps the existing cifmw-base-crc-openstack job to avoid
breakage if someone is using it.
    
cifmw-base-openstack base job will provide the complete environment
 to use the ci-framework starting from pre-setup to log collection.
    
The run playbook needs to be called in the main job as it does not
gets overriden when main job is used as a parent.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
