### PR TITLE
Create placeholder for cookbooks

### DIFF
--- a/docs/source/Cookbooks/01_comingsoon.md
+++ b/docs/source/Cookbooks/01_comingsoon.md
@@ -1,0 +1,6 @@
+# Coming soon
+
+We're working hard in order to provide small but efficient receipts for a daily
+usage.
+
+Stay tuned!

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,6 +26,14 @@ project.
 
 .. toctree::
    :maxdepth: 1
+   :caption: Cookbooks
+   :glob:
+
+   Cookbooks/*
+
+
+.. toctree::
+   :maxdepth: 1
    :caption: Internals
    :glob:
 


### PR DESCRIPTION
Small but efficient receipts are needed and will find place in this
location.

Let's advertise it already, so that users will know we're working on
this kind of content.

As a pull request owner and reviewers, I checked that:
- [X] Content of the docs/source is reflecting the changes
