### PR TITLE
Pass proper namespace while collecting pods info

### DIFF
--- a/ci_framework/roles/artifacts/tasks/cluster_info.yml
+++ b/ci_framework/roles/artifacts/tasks/cluster_info.yml
@@ -24,7 +24,6 @@
       ansible.builtin.shell: |
         oc get {{ item }} > {{ cifmw_artifacts_basedir }}/logs/edpm/{{ item }}.log
       loop:
-        - pods
         - secrets
         - pv
         - events
@@ -39,19 +38,19 @@
 
     - name: Dump the logs of all pods
       ansible.builtin.shell: |
-        operator_pods=$(oc get pods -o name -n openstack-operators)
-        openstack_pods=$(oc get pods -o name -n openstack)
-        all_pods="$operator_pods $openstack_pods"
+        oc get pods -o name -n openstack-operators > operator_pods.txt
+        oc get pods -o name -n openstack > openstack_pods.txt
         # This is implicitly relying on the fact that the pod name is
         # prefixed with "pod/" so that the redirect places the logs
         # in the correct pod directory. That is why we do not cd after
         # creating the directory.
         mkdir pod
-        for pod in ${all_pods}; do
-          echo ${pod}
-          oc logs ${pod} > ${pod}-logs.txt
-          oc get -o yaml ${pod} > ${pod}.yaml
-          oc describe ${pod} > ${pod}-describe.txt
+        for ns in openstack-operators openstack; do
+          for pod in $(oc get pods -n $ns); do
+            oc logs ${pod} -n ${ns} > ${pod}-logs.txt
+            oc get -o yaml ${pod} -n ${ns} > ${pod}.yaml
+            oc describe ${pod} -n ${ns} > ${pod}-describe.txt
+          done
         done
         # so we rename the directory after populating it
         # to "pods" to consistently use plural names for


### PR DESCRIPTION
Currently we do not pass namespace while collecting pods data. It generates empty pod files. Based on controller-manager name in pod, set the proper namespace and then collect the logs.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [ ] ~~Appropriate documentation exists and/or is up-to-date:~~
  - [ ] ~~README in the role~~
  - [ ] ~~Content of the docs/source is reflecting the changes~~
