### PR TITLE
Add playbook to validate podified deployment

### DIFF
--- a/ci_framework/hooks/playbooks/validate_podified_deployment.yml
+++ b/ci_framework/hooks/playbooks/validate_podified_deployment.yml
@@ -1,0 +1,24 @@
+---
+- hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Make sure Nova api service is up and running
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_login_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.shell: |
+        oc get pods -n {{ openstack_namespace }} --selector service=nova-api -o jsonpath={.items[*].status.phase}
+      register: nova_service
+      until: nova_service.stdout == "Running"
+      changed_when: false
+      retries: 100
+      delay: 50
+
+    - name: List compute and network resources
+      when: podified_validation | default ('false') | bool
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_login_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.shell: |
+        oc rsh -n {{ openstack_namespace }} openstackclient openstack compute service list;
+        oc rsh -n {{ openstack_namespace }} openstackclient openstack network agent list;

--- a/scenarios/centos-9/edpm_ci.yml
+++ b/scenarios/centos-9/edpm_ci.yml
@@ -35,6 +35,15 @@ pre_deploy:
     source: disable_os_marketplace.yml
 
 post_ctlplane_deploy:
+  - name: Validate podified control plane
+    type: playbook
+    source: validate_podified_deployment.yml
+    extra_vars:
+      podified_validation: "{{ podified_validation | default ('false') | bool }}"
+      cifmw_openshift_login_kubeconfig: "{{ cifmw_openshift_login_kubeconfig }}"
+      cifmw_path: "{{ cifmw_path }}"
+      openstack_namespace: "{{ cifmw_install_yamls_defaults['NAMESPACE'] }}"
+
   - name: Tune rabbitmq resources
     type: playbook
     source: rabbitmq_tuning.yml


### PR DESCRIPTION
On install_yamls repo, we run podified control plane and edpm based zuul jobs.

The existing ci-framework provides a way to deploy podified and edpm deployment. It also provides utility to validate the edpm deployment but not podified deployment.

This patch adds the playbook to validate the deployment and improves the coverage against install_yamls.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- ~~[ ] Appropriate documentation exists and/or is up-to-date:~~
  - ~~[ ] README in the role~~
  - ~~[ ] Content of the docs/source is reflecting the changes~~
