### PR TITLE
Actually enable tags in ansible

### DIFF
--- a/ci_framework/playbooks/01-bootstrap.yml
+++ b/ci_framework/playbooks/01-bootstrap.yml
@@ -1,4 +1,5 @@
-- hosts: "{{ cifmw_target_host | default('localhost') }}"
+- name: Bootstrap playbook
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: true
   tasks:
     - name: Set custom cifmw PATH reusable fact
@@ -9,23 +10,23 @@
         cacheable: true
 
     - name: Install custom CAs as soon as possible
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: install_ca
 
     - name: Run repo_setup
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: repo_setup
 
     - name: Prepare install_yamls make targets
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: install_yamls
 
     - name: Run ci_setup role
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         role: ci_setup
 
     - name: Get latest image for future reference
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         role: discover_latest_image
 
     - name: Get customized parameters

--- a/ci_framework/playbooks/02-infra.yml
+++ b/ci_framework/playbooks/02-infra.yml
@@ -4,21 +4,22 @@
     step: pre_infra
   ansible.builtin.import_playbook: ./hooks.yml
 
-- hosts: "{{ cifmw_target_host | default('localhost') }}"
+- name: Infra playbook
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
     - name: Ensure libvirt is present/configured
       when:
         - cifmw_use_libvirt is defined
         - cifmw_use_libvirt | bool
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: libvirt_manager
 
     - name: Prepare CRC
       when:
         - cifmw_use_crc is defined
         - cifmw_use_crc | bool
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: rhol_crc
 
     - name: Login into Openshift cluster
@@ -28,11 +29,11 @@
         name: openshift_login
 
     - name: Setup Openshift cluster
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: openshift_setup
 
     - name: Prepare container package builder
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: pkg_build
       when:
         - cifmw_pkg_build_list is defined

--- a/ci_framework/playbooks/03-build-packages.yml
+++ b/ci_framework/playbooks/03-build-packages.yml
@@ -4,14 +4,15 @@
     step: pre_package_build
   ansible.builtin.import_playbook: ./hooks.yml
 
-- hosts: "{{ cifmw_target_host | default('localhost') }}"
+- name: Build package playbook
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
     - name: Build packages
       when:
         - cifmw_pkg_build_list is defined
         - cifmw_pkg_build_list | length > 0
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: pkg_build
         tasks_from: build.yml
 

--- a/ci_framework/playbooks/04-build-containers.yml
+++ b/ci_framework/playbooks/04-build-containers.yml
@@ -4,7 +4,8 @@
     step: pre_container_build
   ansible.builtin.import_playbook: ./hooks.yml
 
-- hosts: "{{ cifmw_target_host | default('localhost') }}"
+- name: Build container playbook
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
     - name: Nothing to do yet

--- a/ci_framework/playbooks/05-build-operators.yml
+++ b/ci_framework/playbooks/05-build-operators.yml
@@ -4,7 +4,8 @@
     step: pre_operator_build
   ansible.builtin.import_playbook: ./hooks.yml
 
-- hosts: "{{ cifmw_target_host | default('localhost') }}"
+- name: Build operators playbook
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   environment:
     PATH: "{{ cifmw_path }}"
@@ -13,7 +14,7 @@
       when:
         - cifmw_operator_build_operators is defined
         - cifmw_operator_build_operators | length > 0
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: operator_build
 
 - name: Run post_operator_build hooks

--- a/ci_framework/playbooks/06-deploy-edpm.yml
+++ b/ci_framework/playbooks/06-deploy-edpm.yml
@@ -4,17 +4,18 @@
     step: pre_deploy
   ansible.builtin.import_playbook: ./hooks.yml
 
-- hosts: "{{ cifmw_target_host | default('localhost') }}"
+- name: Prepare EDPM baremetal playbook
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
     - name: Perform Podified and EDPM deployment on compute nodes provisioned with bmaas
       when: cifmw_edpm_deploy_baremetal | default('false') | bool
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: edpm_deploy_baremetal
 
     - name: Deploy podified control plane
       when: not cifmw_edpm_deploy_baremetal | default('false') | bool
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: edpm_prepare
 
 - name: Run post_ctlplane_deploy hooks
@@ -32,13 +33,13 @@
       when: not cifmw_edpm_deploy_baremetal | default('false') | bool
       block:
       - name: Create and provision external computes
-        ansible.builtin.include_role:
+        ansible.builtin.import_role:
           name: libvirt_manager
           tasks_from: deploy_edpm_compute.yml
 
       - name: Deploy EDPM
         when: deploy_edpm | default('false') | bool
-        ansible.builtin.include_role:
+        ansible.builtin.import_role:
           name: edpm_deploy
 
 - name: Run post_deploy hooks

--- a/ci_framework/playbooks/99-logs.yml
+++ b/ci_framework/playbooks/99-logs.yml
@@ -1,8 +1,9 @@
-- hosts: "{{ cifmw_target_host | default('localhost') }}"
+- name: Logging playbook
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
     - name: Generate artifacts
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: artifacts
 
     - name: Ensure ansible.log is at the expected location

--- a/ci_framework/playbooks/hooks.yml
+++ b/ci_framework/playbooks/hooks.yml
@@ -1,9 +1,10 @@
-- hosts: "{{ cifmw_target_host | default('localhost') }}"
+- name: Hook playbook
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
     - name: Run hook
       when:
         - hooks is defined
         - hooks | length > 0
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: run_hook

--- a/ci_framework/roles/build_openstack_packages/tasks/main.yml
+++ b/ci_framework/roles/build_openstack_packages/tasks/main.yml
@@ -15,13 +15,13 @@
 # under the License.
 
 - name: Install dlrn
-  ansible.builtin.include_tasks: install_dlrn.yml
+  ansible.builtin.import_tasks: install_dlrn.yml
 
 - name: Run dlrn
-  ansible.builtin.include_tasks: run_dlrn.yml
+  ansible.builtin.import_tasks: run_dlrn.yml
 
 - name: Create repo
-  ansible.builtin.include_tasks: create_repo.yml
+  ansible.builtin.import_tasks: create_repo.yml
 
 - name: Cleanup dlrn
-  ansible.builtin.include_tasks: cleanup_dlrn.yml
+  ansible.builtin.import_tasks: cleanup_dlrn.yml

--- a/ci_framework/roles/ci_setup/tasks/cleanup.yml
+++ b/ci_framework/roles/ci_setup/tasks/cleanup.yml
@@ -4,4 +4,4 @@
     - cleanup
   vars:
     directory_state: absent
-  ansible.builtin.include_tasks: directories.yml
+  ansible.builtin.import_tasks: directories.yml

--- a/ci_framework/roles/ci_setup/tasks/main.yml
+++ b/ci_framework/roles/ci_setup/tasks/main.yml
@@ -22,11 +22,11 @@
 - name: Install packages
   tags:
     - always
-  include_tasks: packages.yml
+  import_tasks: packages.yml
 
 - name: Create directories
   tags:
     - always
   vars:
     directory_state: directory
-  include_tasks: directories.yml
+  import_tasks: directories.yml

--- a/ci_framework/roles/copy_container/tasks/main.yml
+++ b/ci_framework/roles/copy_container/tasks/main.yml
@@ -74,7 +74,7 @@
     - enable_cron|default(true)|bool
     - ansible_distribution == 'CentOS'
     - ansible_distribution_version < '9'
-  ansible.builtin.include_tasks: cron.yml
+  ansible.builtin.import_tasks: cron.yml
 
 - name: Configure cronjobs
   become: true

--- a/ci_framework/roles/libvirt_manager/tasks/main.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/main.yml
@@ -24,20 +24,20 @@
 - name: Virtualization check and configuration tasks
   tags:
     - bootstrap
-  ansible.builtin.include_tasks: virtualization_prerequisites.yml
+  ansible.builtin.import_tasks: virtualization_prerequisites.yml
 
 - name: Install packages and dependencies
   tags:
     - packages
     - bootstrap
-  ansible.builtin.include_tasks: packages.yml
+  ansible.builtin.import_tasks: packages.yml
 
 - name: Add polkit rules
   tags:
     - bootstrap
-  ansible.builtin.include_tasks: polkit_rules.yml
+  ansible.builtin.import_tasks: polkit_rules.yml
 
 - name: Check Virsh usage
   tags:
     - bootstrap
-  ansible.builtin.include_tasks: virsh_checks.yml
+  ansible.builtin.import_tasks: virsh_checks.yml

--- a/ci_framework/roles/openshift_login/tasks/login.yml
+++ b/ci_framework/roles/openshift_login/tasks/login.yml
@@ -98,8 +98,7 @@
           }}
 
     - name: Fetch token
-      ansible.builtin.include_tasks:
-        file: try_login.yml
+      ansible.builtin.include_tasks: try_login.yml
 
   rescue:
     - fail:
@@ -110,5 +109,4 @@
       ansible.builtin.pause:
         seconds: "{{ cifmw_openshift_login_retries_delay }}"
 
-    - ansible.builtin.include_tasks:
-        file: login.yml
+    - ansible.builtin.include_tasks: login.yml

--- a/ci_framework/roles/repo_setup/tasks/main.yml
+++ b/ci_framework/roles/repo_setup/tasks/main.yml
@@ -15,11 +15,11 @@
 # under the License.
 
 - name: Install repo-setup
-  ansible.builtin.include_tasks: install.yml
+  ansible.builtin.import_tasks: install.yml
 - name: Configure repo-setup
-  ansible.builtin.include_tasks: configure.yml
+  ansible.builtin.import_tasks: configure.yml
 - name: Generate additional artifacts
-  ansible.builtin.include_tasks: artifacts.yml
+  ansible.builtin.import_tasks: artifacts.yml
 - name: Generate downstream base os repos
-  ansible.builtin.include_tasks: rhos_release.yml
+  ansible.builtin.import_tasks: rhos_release.yml
   when: cifmw_repo_setup_enable_rhos_release | bool

--- a/ci_framework/roles/rhol_crc/tasks/main.yml
+++ b/ci_framework/roles/rhol_crc/tasks/main.yml
@@ -58,30 +58,30 @@
           register: cifmw_rhol_crc_binary_stat
 
         - name: Get RHOL/CRC binary if does not exist
-          ansible.builtin.include_tasks: binary.yml
+          ansible.builtin.import_tasks: binary.yml
           when: not cifmw_rhol_crc_binary_stat.stat.exists
 
         - name: Setup sudoers file for sudo commands in RHOL/CRC setup
-          ansible.builtin.include_tasks: sudoers_grant.yml
+          ansible.builtin.import_tasks: sudoers_grant.yml
 
         - name: Clean RHOL/CRC if wanted
           when:
             - crc_present|bool
             - cifmw_rhol_crc_force_cleanup | bool
-          ansible.builtin.include_tasks: cleanup.yml
+          ansible.builtin.import_tasks: cleanup.yml
 
     - name: Configure and start RHOL/CRC
       when: (cifmw_rhol_crc_force_cleanup|bool) or not crc_running|bool
       block:
         - name: Configure RHOL/CRC using install_yamls
           when: cifmw_rhol_crc_use_installyamls|bool
-          ansible.builtin.include_tasks: install_yamls.yml
+          ansible.builtin.import_tasks: install_yamls.yml
 
         - name: Manually configure RHOL/CRC
           when: not cifmw_rhol_crc_use_installyamls|bool
           block:
             - name: Set RHOL/CRC configuration options
-              ansible.builtin.include_tasks: configuration.yml
+              ansible.builtin.import_tasks: configuration.yml
 
             - name: Setup RHOL/CRC
               ansible.builtin.command: "{{ cifmw_rhol_crc_binary }} setup"
@@ -103,7 +103,7 @@
 
   always:
     - name: Delete sudoers file
-      ansible.builtin.include_tasks: sudoers_revoke.yml
+      ansible.builtin.import_tasks: sudoers_revoke.yml
 
 - name: Set OpenShift CRC credentials
   ansible.builtin.set_fact:
@@ -114,4 +114,4 @@
 
 - name: Add crc kubeconfig
   when: cifmw_rhol_crc_creds | bool
-  ansible.builtin.include_tasks: add_crc_creds.yml
+  ansible.builtin.import_tasks: add_crc_creds.yml


### PR DESCRIPTION
Tags aren't passed down "as-is" when we use `include_role` or
`include_tasks`. This is due to the fact `include_*` dynamically load
the target on runtime.

Changing most of the `include` by `import` helps ensuring we get proper
tags support in the project.
It also should improve the performances, since ansible is able to load
most of its content during the "boot" of the run.

Usually, we should rely on `import` and keep the `include` only for
dynamic loading, such as "load that tasks file in a loop".

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
