### PR TITLE
Convert -nobuild job to -tagged-nobuild

### DIFF
--- a/ci/playbooks/e2e-run.yml
+++ b/ci/playbooks/e2e-run.yml
@@ -3,7 +3,7 @@
 - hosts: controller
   gather_facts: true
   tasks:
-    - name: Run deploy-edpm playbook
+    - name: Tagged packages
       ansible.builtin.command:
         chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
         cmd: >-
@@ -17,3 +17,35 @@
           -e "{{   extra_vars }}"
           {%-   endfor %}
           {%- endif %}
+          --tags packages
+    - name: Tagged bootstrap - no packages
+      ansible.builtin.command:
+        chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
+        cmd: >-
+          ansible-playbook deploy-edpm.yml
+          -e @scenarios/centos-9/base.yml
+          -e @scenarios/centos-9/install_yamls.yml
+          -e @scenarios/centos-9/ci.yml
+          -e @scenarios/centos-9/zuul_inventory.yml
+          {%- if cifmw_extras is defined %}
+          {%-   for extra_vars in cifmw_extras %}
+          -e "{{   extra_vars }}"
+          {%-   endfor %}
+          {%- endif %}
+          --tags bootstrap
+          --skip-tags packages
+    - name: Not tagged bootstrap nor packages
+      ansible.builtin.command:
+        chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
+        cmd: >-
+          ansible-playbook deploy-edpm.yml
+          -e @scenarios/centos-9/base.yml
+          -e @scenarios/centos-9/install_yamls.yml
+          -e @scenarios/centos-9/ci.yml
+          -e @scenarios/centos-9/zuul_inventory.yml
+          {%- if cifmw_extras is defined %}
+          {%-   for extra_vars in cifmw_extras %}
+          -e "{{   extra_vars }}"
+          {%-   endfor %}
+          {%- endif %}
+          --skip-tags bootstrap,packages

--- a/ci/templates/projects.yaml
+++ b/ci/templates/projects.yaml
@@ -12,6 +12,6 @@
         - cifmw-dev-prepare
         - cifmw-doc
         - cifmw-end-to-end
-        - cifmw-end-to-end-nobuild
+        - cifmw-end-to-end-nobuild-tagged
         - cifmw-kuttl
 # Start generated content

--- a/ci_framework/playbooks/01-bootstrap.yml
+++ b/ci_framework/playbooks/01-bootstrap.yml
@@ -3,6 +3,8 @@
   gather_facts: true
   tasks:
     - name: Set custom cifmw PATH reusable fact
+      tags:
+        - always
       when:
         - cifmw_path is not defined
       ansible.builtin.set_fact:
@@ -10,31 +12,47 @@
         cacheable: true
 
     - name: Install custom CAs as soon as possible
+      tags:
+        - bootstrap
+        - packages
       ansible.builtin.import_role:
         name: install_ca
 
     - name: Run repo_setup
+      tags:
+        - bootstrap
+        - packages
       ansible.builtin.import_role:
         name: repo_setup
 
     - name: Prepare install_yamls make targets
+      tags:
+        - bootstrap
       ansible.builtin.import_role:
         name: install_yamls
 
     - name: Run ci_setup role
+      tags:
+        - bootstrap
       ansible.builtin.import_role:
         role: ci_setup
 
     - name: Get latest image for future reference
+      tags:
+        - bootstrap
       ansible.builtin.import_role:
         role: discover_latest_image
 
     - name: Get customized parameters
+      tags:
+        - always
       ansible.builtin.set_fact:
         ci_framework_params: >-
           {{ hostvars[inventory_hostname] | dict2items | selectattr("key", "match", "^cifmw_")|list|items2dict }}
 
     - name: Create artifacts with custom params
+      tags:
+        - always
       ansible.builtin.copy:
         dest: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts/custom-params.yml"
         content: "{{ ci_framework_params | to_nice_yaml }}"

--- a/ci_framework/roles/artifacts/tasks/cluster_info.yml
+++ b/ci_framework/roles/artifacts/tasks/cluster_info.yml
@@ -11,7 +11,9 @@
   ignore_errors: true
 
 - name: Collect data from cluster
-  when: oc_installed.rc == 0
+  when:
+    - oc_installed is defined
+    - oc_installed.rc == 0
   block:
     - name: Create logs/edpm directory
       ansible.builtin.file:

--- a/zuul.d/end-to-end.yaml
+++ b/zuul.d/end-to-end.yaml
@@ -29,8 +29,10 @@
     timeout: 5400
 
 # Run the "nobuild" for any other change. It's smaller and faster.
+# Note: this job also leverage the "--tags" and "--skip-tags" in order to
+# ensure such runs are consistent.
 - job:
-    name: cifmw-end-to-end-nobuild
+    name: cifmw-end-to-end-nobuild-tagged
     nodeset: centos-9-crc-xxl
     irrelevant-files:
       - ^ci_framework/roles/.*_build

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -12,7 +12,7 @@
         - cifmw-dev-prepare
         - cifmw-doc
         - cifmw-end-to-end
-        - cifmw-end-to-end-nobuild
+        - cifmw-end-to-end-nobuild-tagged
         - cifmw-kuttl
 # Start generated content
         - cifmw-molecule-artifacts


### PR DESCRIPTION
This job goal is to ensure tags are covering the needs accordingly.

Running the deploy-edpm.yml playbook three times with a combination of
`--tags` and `--skip-tags` should ensure we're delivering the needed
feature.

Note that, as we get more and more tags, we may need to revisit this
base job.

Since it's a 100% overlap with the "-nobuild" job, we just convert that
one, saving resources.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
