### PR TITLE
DNM - Always create and cleanup storage on each kuttl run

### DIFF
--- a/ci/playbooks/kuttl/run-kuttl-tests.yml
+++ b/ci/playbooks/kuttl/run-kuttl-tests.yml
@@ -5,10 +5,32 @@
   loop: "{{ commands_before_kuttl_run }}"
   ignore_errors: true
 
+- name: Setup storage in CRC
+  when:
+    - not cifmw_kuttle_skip_crc_storage_creation | default(false) | bool
+  vars:
+    make_crc_storage_retries: 10
+    make_crc_storage_delay: 2
+    make_crc_storage_until: "make_crc_storage_status is not failed"
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_crc_storage'
+
 - name: 'Run make_{{ operator }}_kuttl'
   ansible.builtin.include_role:
     name: 'install_yamls_makes'
     tasks_from: 'make_{{ operator }}_kuttl.yml'
+
+- name: Cleanup storage in CRC
+  when:
+    - not cifmw_kuttle_skip_crc_storage_creation | default(false) | bool
+  vars:
+    make_crc_storage_retries: 10
+    make_crc_storage_delay: 2
+    make_crc_storage_until: "make_crc_storage_cleanup_status is not failed"
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_crc_storage_cleanup'
 
 - name: 'Get resource status after {{ operator }}_kuttl run'
   ansible.builtin.shell: |

--- a/scenarios/centos-9/kuttl.yml
+++ b/scenarios/centos-9/kuttl.yml
@@ -1,4 +1,3 @@
 ---
-cifmw_install_yamls_vars:
-  STORAGE_CLASS: crc-csi-hostpath-provisioner
+cifmw_kuttle_skip_crc_storage_creation: false
 cifmw_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
