### PR TITLE
Use cifmw_openshift_setup_registry_tls_enable var to disable tls

### DIFF
--- a/ci_framework/roles/openshift_setup/README.md
+++ b/ci_framework/roles/openshift_setup/README.md
@@ -8,3 +8,4 @@ No privilege escalation needed.
 ## Parameters
 * `cifmw_openshift_setup_dry_run`: (Boolean) Skips resources creation. Defaults to `false`.
 * `cifmw_openshift_setup_create_namespaces`: (Strings) Namespaces to create beforehand. Defaults to `[]`.
+* `cifmw_openshift_setup_registry_tls_enable`: (Boolean) Enable tls_verify with openshift registy login. Defaults to `false`.

--- a/ci_framework/roles/openshift_setup/defaults/main.yml
+++ b/ci_framework/roles/openshift_setup/defaults/main.yml
@@ -19,3 +19,4 @@
 # All variables within this role should have a prefix of "cifmw_openshift_setup"
 cifmw_openshift_setup_dry_run: false
 cifmw_openshift_setup_create_namespaces: []
+cifmw_openshift_setup_registry_tls_enable: false

--- a/ci_framework/roles/openshift_setup/tasks/main.yml
+++ b/ci_framework/roles/openshift_setup/tasks/main.yml
@@ -61,4 +61,5 @@
         podman login
         -u {{ cifmw_openshift_user }}
         -p {{ cifmw_openshift_token }}
+        --tls-verify= {{ cifmw_openshift_setup_registry_tls_enable | bool }}
         {{ cifmw_openshift_setup_registry_default_route.resources[0].spec.host }}


### PR DESCRIPTION
openshift-image-registry is an internal registry. We need to use
`tls-verify=false` while logging to internal registry otherwise it
will give
```
pinging container registry default-route-openshift-image-registry.apps-crc.testing:
received unexpected HTTP status: 503 Service Unavailable
```
    
This patch add cifmw_openshift_setup_registry_tls_enable to set the
value of tls-verify during podman login to internal registry.
    
The same is taken from here[1].
    
[1]. https://access.redhat.com/documentation/en-us/red_hat_codeready_containers/1.21/html/getting_started_guide/using-codeready-containers_gsg#accessing-the-internal-openshift-registry_gsg
    


As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

