### PR TITLE
Add a var in operator_build role to disable tls verify

### DIFF
--- a/ci_framework/roles/operator_build/README.md
+++ b/ci_framework/roles/operator_build/README.md
@@ -18,6 +18,7 @@ you want to build meta-operator too, so the role can properly replace api refere
 * `cifmw_operator_build_meta_build`: (Boolean) When set to `true` updates meta-operator's go.mod when build operators and builds meta-operator in the end. Default to `true`.
 * `cifmw_operator_build_meta_image_base`: (String) Name of the service added to be added to meta-operator build. Still limited to a sindle service (and operator). Default to `""`
 * `cifmw_operator_build_extra_bundles`: (List) List of additional bundles to be added in meta operator catalog build. Defaults to `[]`.
+* `cifmw_operator_build_push_registry_tls_verify`: (Boolean) Variable to control whether to enable/disable TLS verification for push registry . Defaults to `true`.
 
 ## TODO
 * Include tasks to get PR Owner and PR SHA info from **Prow** environment.

--- a/ci_framework/roles/operator_build/defaults/main.yml
+++ b/ci_framework/roles/operator_build/defaults/main.yml
@@ -39,3 +39,4 @@ cifmw_operator_build_meta_image_base: ""
 cifmw_operator_build_local_registry: 0
 # Additional bundles to be added in meta operator
 cifmw_operator_build_extra_bundles: []
+cifmw_operator_build_push_registry_tls_verify: true

--- a/ci_framework/roles/operator_build/tasks/build.yml
+++ b/ci_framework/roles/operator_build/tasks/build.yml
@@ -132,6 +132,7 @@
     target: docker-push
     params:
       IMG: "{{ operator_img }}"
+      VERIFY_TLS: "{{ cifmw_operator_build_push_registry_tls_verify }}"
   register: op_push_result
   until: op_push_result.failed is false
   retries: 5
@@ -227,6 +228,7 @@
     target: catalog-push
     params:
       CATALOG_IMG: "{{ operator_img_catalog }}"
+      VERIFY_TLS: "{{ cifmw_operator_build_push_registry_tls_verify }}"
   register: result
   until: result.failed is false
   retries: 5

--- a/scenarios/centos-9/content_provider.yml
+++ b/scenarios/centos-9/content_provider.yml
@@ -9,3 +9,4 @@ cifmw_operator_build_meta_build: true
 cifmw_operator_build_local_registry: 1
 cifmw_operator_build_extra_bundles:
  - "quay.io/openstack-k8s-operators/rabbitmq-cluster-operator-bundle@sha256:9ff91ad3c9ef1797b232fce2f9adf6ede5c3421163bff5b8a2a462c6a2b3a68b"
+cifmw_operator_build_push_registry_tls_verify: false


### PR DESCRIPTION
Our content-provider job fails to push container to local insecure docker registry container[1]

With this commit, we do following:-

1) Add a var in operator_build role to disable tls verify, default value is true.
2) Pass tls verify var as false in content-provider scenario.

[1] https://logserver.rdoproject.org/21/21/9598ecf117fcf91cbe3d237aabe4ae72b62756c9/github-check/openstack-baremetal-operator-content-provider/9c91ec3/job-output.txt

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
