### PR TITLE
Add support to skip registry login

### DIFF
--- a/ci_framework/roles/openshift_setup/README.md
+++ b/ci_framework/roles/openshift_setup/README.md
@@ -8,3 +8,4 @@ No privilege escalation needed.
 ## Parameters
 * `cifmw_openshift_setup_dry_run`: (Boolean) Skips resources creation. Defaults to `false`.
 * `cifmw_openshift_setup_create_namespaces`: (Strings) Namespaces to create beforehand. Defaults to `[]`.
+* `cifmw_openshift_setup_skip_internal_registry_login`: (Boolean) Skips login to Internal Openshift registry. Defaults to `false`.

--- a/ci_framework/roles/openshift_setup/defaults/main.yml
+++ b/ci_framework/roles/openshift_setup/defaults/main.yml
@@ -19,3 +19,4 @@
 # All variables within this role should have a prefix of "cifmw_openshift_setup"
 cifmw_openshift_setup_dry_run: false
 cifmw_openshift_setup_create_namespaces: []
+cifmw_openshift_setup_skip_internal_registry_login: false

--- a/ci_framework/roles/openshift_setup/tasks/main.yml
+++ b/ci_framework/roles/openshift_setup/tasks/main.yml
@@ -37,7 +37,9 @@
   when: not cifmw_openshift_setup_dry_run
 
 - name: Setup podman access to internal registry
-  when: cifmw_openshift_token is defined
+  when:
+    - cifmw_openshift_token is defined
+    - not cifmw_openshift_setup_skip_internal_registry_login
   vars:
     ansible_callback_diy_runner_on_skipped_msg: |
       skipping: [{{ inventory_hostname }}]

--- a/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
+++ b/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
@@ -18,6 +18,9 @@ pre_infra:
 cifmw_operator_build_meta_name: "openstack-operator"
 cifmw_edpm_deploy_baremetal: true
 
+# openshift_setup role vars
+cifmw_openshift_setup_skip_internal_registry_login: true
+
 # openshift_login role vars
 cifmw_openshift_user: "kubeadmin"
 cifmw_openshift_password: "123456789"

--- a/scenarios/centos-9/edpm_ci.yml
+++ b/scenarios/centos-9/edpm_ci.yml
@@ -24,6 +24,9 @@ cifmw_edpm_prepare_skip_crc_storage_creation: true
 cifmw_edpm_deploy_manifests_dir: "{{ cifmw_installyamls_repos }}/out"
 deploy_edpm: true
 
+# openshift_setup role vars
+cifmw_openshift_setup_skip_internal_registry_login: true
+
 # openshift_login role vars
 cifmw_openshift_user: "kubeadmin"
 cifmw_openshift_password: "123456789"


### PR DESCRIPTION
With this commit,  we do the following:-

1) Add a variable `cifmw_openshift_setup_skip_internal_registry_login` in openshift_setup role to skip registry login. This default to false 

2) For edpm deployment and baremetal deployment jobs in CI we pull needed containers from content-provider jobs, so we are passing `cifmw_openshift_setup_skip_internal_registry_login: true` via scenario file to skip internal registry login.

Recently, we are seeing lot of random failures during internal registry login so skiping this task as we don't consume anything from internal registry.

[1] https://logserver.rdoproject.org/21/221/3e2f992b0875a82a4178c52ec87dc22142eef674/github-check/dataplane-operator-crc-podified-edpm-baremetal/4d77948/job-output.txt

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
