### PR TITLE
Don't build the storage-bundle separately

### DIFF
--- a/ci_framework/roles/operator_build/README.md
+++ b/ci_framework/roles/operator_build/README.md
@@ -17,7 +17,6 @@ you want to build meta-operator too, so the role can properly replace api refere
 * `cifmw_operator_build_meta_src`: (String) Directory with src code for meta operator. Defaults to `"{{ ansible_user_dir }}/src/github.com/{{ cifmw_operator_build_org }}/{{ cifmw_operator_build_meta_name }}"`
 * `cifmw_operator_build_meta_build`: (Boolean) When set to `true` updates meta-operator's go.mod when build operators and builds meta-operator in the end. Default to `true`.
 * `cifmw_operator_build_meta_image_base`: (String) Name of the service added to be added to meta-operator build. Still limited to a sindle service (and operator). Default to `""`
-* `cifmw_operator_build_extra_bundles`: (List) List of additional bundles to be added in meta operator catalog build. Defaults to `[]`.
 * `cifmw_operator_build_push_registry_tls_verify`: (Boolean) Variable to control whether to enable/disable TLS verification for push registry . Defaults to `true`.
 
 ## TODO

--- a/ci_framework/roles/operator_build/defaults/main.yml
+++ b/ci_framework/roles/operator_build/defaults/main.yml
@@ -37,6 +37,4 @@ cifmw_operator_build_meta_src: "{{ ansible_user_dir }}/src/github.com/{{ cifmw_o
 cifmw_operator_build_meta_image_base: ""
 # Set vars for Local Registry
 cifmw_operator_build_local_registry: 0
-# Additional bundles to be added in meta operator
-cifmw_operator_build_extra_bundles: []
 cifmw_operator_build_push_registry_tls_verify: true

--- a/ci_framework/roles/operator_build/molecule/default/validate_outputs.yml
+++ b/ci_framework/roles/operator_build/molecule/default/validate_outputs.yml
@@ -29,7 +29,6 @@
   ansible.builtin.set_fact:
     op_img: "{{ op_registry_prefix }}:{{ op_tag }}"
     op_img_bundle: "{{ op_registry_prefix }}-bundle:{{ op_tag }}"
-    op_img_storage_bundle: "{{ op_registry_prefix }}-storage-bundle:{{ op_tag }}"
     op_img_catalog: "{{ op_registry_prefix }}-index:{{ op_tag }}"
 
 - name: "{{ operator.name }} - Ensure that role output dict contains the expected values"
@@ -39,5 +38,4 @@
       - cifmw_operator_build_output['operators'][operator.name]['git_commit_hash'] == op_tag
       - cifmw_operator_build_output['operators'][operator.name]['image'] == op_img
       - cifmw_operator_build_output['operators'][operator.name]['image_bundle'] == op_img_bundle
-      - cifmw_operator_build_output['operators'][operator.name]['image_storage_bundle'] == op_img_storage_bundle
       - cifmw_operator_build_output['operators'][operator.name]['image_catalog'] == op_img_catalog

--- a/ci_framework/roles/operator_build/tasks/build.yml
+++ b/ci_framework/roles/operator_build/tasks/build.yml
@@ -89,9 +89,7 @@
   ansible.builtin.set_fact:
     operator_img: "{{ operator_registry_prefix }}:{{ operator_tag }}"
     operator_img_bundle: "{{ operator_registry_prefix }}-bundle:{{ operator_tag }}"
-    operator_img_storage_bundle: "{{ operator_registry_prefix }}-storage-bundle:{{ operator_tag }}"
     operator_img_catalog: "{{ operator_registry_prefix }}-index:{{ operator_tag }}"
-    operator_bundles: "{{ cifmw_operator_build_extra_bundles | default([]) }}"
     cacheable: true
 
 - name: "{{ operator.name }} - Set operator build output"
@@ -102,7 +100,6 @@
           'git_src_dir': operator.src,
           'image': operator_img,
           'image_bundle': operator_img_bundle,
-          'image_storage_bundle': operator_img_storage_bundle,
           'image_catalog': operator_img_catalog,
         }}}, recursive=True)}}
 
@@ -151,32 +148,6 @@
       IMAGEBASE: "{{ operator.image_base | default('') }}"
       LOCAL_REGISTRY: "{{ cifmw_operator_build_local_registry | default ('') }}"
 
-- name: "{{ operator.name }} - Builds storage-bundle for meta-operator"
-  when:
-    - operator.name == cifmw_operator_build_meta_name
-  block:
-    - name: Call dep-bundle-build-push for meta-operator only
-      register: dep_bundle_build_push_result
-      until: dep_bundle_build_push_result.failed is false
-      retries: 5
-      delay: 10
-      ci_make:
-        dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
-        chdir: "{{ operator.src }}"
-        output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
-        target: dep-bundle-build-push
-        params:
-          IMG: "{{ operator_img }}"
-          BUNDLE_STORAGE_IMG: "{{ operator_img_storage_bundle }}"
-          IMAGENAMESPACE: "{{ cifmw_operator_build_push_org }}"
-          IMAGEREGISTRY: "{{ cifmw_operator_build_push_registry }}"
-          IMAGEBASE: "{{ operator.image_base | default('') }}"
-          LOCAL_REGISTRY: "{{ cifmw_operator_build_local_registry | default ('') }}"
-
-    - name: Add bundle to bundle list
-      set_fact:
-        operator_bundles: "{{ operator_bundles + [operator_img_storage_bundle] }}"
-
 - name: "{{ operator.name }} - Call bundle-build"
   ci_make:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
@@ -186,15 +157,10 @@
     params:
       IMG: "{{ operator_img }}"
       BUNDLE_IMG: "{{ operator_img_bundle }}"
-      BUNDLE_STORAGE_IMG: "{{ operator_img_storage_bundle }}"
       IMAGENAMESPACE: "{{ cifmw_operator_build_push_org }}"
       IMAGEREGISTRY: "{{ cifmw_operator_build_push_registry }}"
       IMAGEBASE: "{{ operator.image_base | default('') }}"
       LOCAL_REGISTRY: "{{ cifmw_operator_build_local_registry | default ('') }}"
-
-- name: "{{ operator.name }} - Add bundle to bundle list"
-  set_fact:
-    operator_bundles: "{{ operator_bundles + [operator_img_bundle] }}"
 
 - name: "{{ operator.name }} - Push bundle image"
   when:
@@ -216,7 +182,7 @@
     target: catalog-build
     params:
       CATALOG_IMG: "{{ operator_img_catalog }}"
-      BUNDLE_IMGS: "{{ operator_bundles | join(',')}}"
+      BUNDLE_IMG: "{{ operator_img_bundle }}"
 
 - name: "{{ operator.name }} - Call catalog-push"
   when:

--- a/scenarios/centos-9/ci-build.yml
+++ b/scenarios/centos-9/ci-build.yml
@@ -2,8 +2,6 @@
 cifmw_operator_build_push_registry: "default-route-openshift-image-registry.apps-crc.testing"
 cifmw_operator_build_push_org: "openstack-operators"
 cifmw_operator_build_meta_build: true
-cifmw_operator_build_extra_bundles:
- - "quay.io/openstack-k8s-operators/rabbitmq-cluster-operator-bundle@sha256:9ff91ad3c9ef1797b232fce2f9adf6ede5c3421163bff5b8a2a462c6a2b3a68b"
 cifmw_operator_build_operators:
   - name: mariadb-operator
     src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/mariadb-operator"

--- a/scenarios/centos-9/content_provider.yml
+++ b/scenarios/centos-9/content_provider.yml
@@ -7,6 +7,4 @@ cifmw_operator_build_push_org: "openstack-k8s-operators"
 cifmw_operator_build_org: "openstack-k8s-operators"
 cifmw_operator_build_meta_build: true
 cifmw_operator_build_local_registry: 1
-cifmw_operator_build_extra_bundles:
- - "quay.io/openstack-k8s-operators/rabbitmq-cluster-operator-bundle@sha256:9ff91ad3c9ef1797b232fce2f9adf6ede5c3421163bff5b8a2a462c6a2b3a68b"
 cifmw_operator_build_push_registry_tls_verify: false


### PR DESCRIPTION
It's not needed after PR[1].

[1]https://github.com/openstack-k8s-operators/openstack-operator/pull/340

- [x] Appropriate testing is done and actually running
