### PR TITLE
Adding a new role - openshift_provisioner_node

### DIFF
--- a/ci_framework/playbooks/02-infra.yml
+++ b/ci_framework/playbooks/02-infra.yml
@@ -4,9 +4,8 @@
     step: pre_infra
   ansible.builtin.import_playbook: ./hooks.yml
 
-- name: Infra playbook
-  hosts: "{{ cifmw_target_host | default('localhost') }}"
-  gather_facts: false
+- name: Prepare host virtualization
+  hosts: "{{ ('virthosts' in groups) | ternary('virthosts', cifmw_target_host | default('localhost') ) }}"
   tasks:
     - name: Load parameters files
       ansible.builtin.include_vars:
@@ -18,6 +17,21 @@
         - cifmw_use_libvirt | bool
       ansible.builtin.import_role:
         name: libvirt_manager
+
+    - name: Perpare OpenShift provisioner node
+      when:
+        - cifmw_use_opn is defined
+        - cifmw_use_opn | bool
+      ansible.builtin.import_role:
+        name: openshift_provisioner_node
+
+- name: Prepare the platform
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Load parameters files
+      ansible.builtin.include_vars:
+        dir: "{{ cifmw_basedir }}/artifacts/parameters"
 
     - name: Prepare CRC
       when:
@@ -37,11 +51,11 @@
         name: openshift_setup
 
     - name: Prepare container package builder
-      ansible.builtin.import_role:
-        name: pkg_build
       when:
         - cifmw_pkg_build_list is defined
         - cifmw_pkg_build_list | length > 0
+      ansible.builtin.import_role:
+        name: pkg_build
 
 - name: Run post_infra hooks
   vars:

--- a/ci_framework/roles/openshift_provisioner_node/README.md
+++ b/ci_framework/roles/openshift_provisioner_node/README.md
@@ -1,0 +1,80 @@
+# openshift_provisioner_node
+This role performs all the necessary tasks required to run the OpenShift
+installer. The designated host is prepared to run the installation program and
+hosts the bootstrap VM that deploys the controller/s of a new OpenShift
+Container Platform cluster.
+
+Bootstrap VM is used in the process of deploying an OpenShift Container
+platform cluster.
+
+## Prerequisites
+* `libvirt_manager` role
+
+## Privilege escalation
+`become`: Is required to install packages, configure services and networking.
+
+## Parameters
+* `cifmw_opn_host`: (String) IPv4 address of the machine that would be hosting
+  the bootstrap VM.
+* `cifmw_opn_external_bridge_name`: (String) Name of the external bridge to be
+  created for attaching with the bootstrap VM. It is associated to the
+  baremetal network. Defaults to `baremetal`.
+* `cifmw_opn_external_network_iface`: (String) Name of the iface to be attached
+  to the external bridge.
+* `cifmw_opn_use_provisioning_network`: (Boolean) If enabled, the necessary
+  steps to configure the provisioning network is executed. Defaults to `false`.
+* `cifmw_opn_prov_bridge_name`: (String) Name of the provisioning bridge to be
+  created for attaching with the bootstrap VM. It is associated to the
+  provisioning network. Defaults to `provisioning`.
+* `cifmw_opn_prov_network_iface`: (String) Name of the iface to be attached to
+  the provisioning bridge.
+* `cifmw_opn_user`: (String) Name of the user to be passed to openshift
+  installer. Defaults to `kni`.
+* `cifmw_opn_dry_run`: (Boolean) Set this variable to `true` for unit testing
+  the role. It is mainly for development purpose.
+
+## Examples
+
+### Use a separate network for deployment of OCP cluster.
+```YAML
+cifmw_use_libvirt_manager: true
+
+cifmw_use_opn: true
+cifmw_opn_host: 192.168.20.10
+cifmw_opn_external_network_iface: eth0
+cifmw_opn_prov_network_iface: eth1
+```
+
+### Use a virtual media for OCP cluster deployment
+```YAML
+cifmw_use_libvirt_manager: true
+
+cifmw_use_opn: true
+cifmw_opn_host: 192.168.20.10
+cifmw_opn_external_network_iface: eno3
+```
+
+### Use provisioning network with internal DHCP
+```YAML
+cifmw_use_libvirt_manager: true
+
+cifmw_use_opn: true
+cifmw_opn_host: 192.168.20.10
+cifmw_opn_external_network_iface: eno1
+cifmw_opn_prov_network_iface: eno2
+```
+
+### Inventory file
+```YAML
+all:
+  hosts:
+    localhost:
+      ansible_connection: local
+  children:
+    virthosts:
+      hosts:
+        foo.bar:
+```
+
+## Reference
+[OpenShift-Installer](https://docs.openshift.com/container-platform/4.13/installing/installing_bare_metal_ipi/ipi-install-overview.html)

--- a/ci_framework/roles/openshift_provisioner_node/defaults/main.yml
+++ b/ci_framework/roles/openshift_provisioner_node/defaults/main.yml
@@ -1,0 +1,26 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_opn"
+
+cifmw_opn_external_bridge_name: "baremetal"
+cifmw_opn_prov_bridge_name: "provisioning"
+
+cifmw_opn_basedir: "{{ cifmw_basedir | default( ansible_user_dir ~ '/ci-framework-data') }}"
+cifmw_opn_artifacts_dir: "{{ cifmw_opn_basedir }}/artifacts"
+cifmw_opn_dry_run: false

--- a/ci_framework/roles/openshift_provisioner_node/files/add_bridge_port.sh
+++ b/ci_framework/roles/openshift_provisioner_node/files/add_bridge_port.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Usage:
+#  bash add_bridge_port.sh <bridge-name> <iface>
+#
+#      <bridge-name>    Name of the bridge
+#      <iface>          network device name
+set -euo pipefail
+
+BRIDGE_NAME=${1}
+IFACE_NAME=${2}
+
+CONN_NAME=$(nmcli -t -f GENERAL.CONNECTION dev show ${IFACE_NAME} | cut -d ':' -f 2)
+PORT_NAME=${BRIDGE_NAME}-p0
+
+check_port=$(nmcli con show | grep -c ${PORT_NAME}) || true
+
+if [ ${check_port} -ne 0 ]; then
+    echo "Bridge port available. Nothing to do"
+    exit 0
+fi
+
+check_iface=$(nmcli dev status | grep -c ${IFACE_NAME}) || true
+
+if [ ${check_iface} -eq 0 ]; then
+    echo "Invalid device name"
+    exit 1
+fi
+
+nohup bash -c "
+    nmcli con down \"${CONN_NAME}\"
+    nmcli con delete \"${CONN_NAME}\"
+    nmcli con add connection.type 802-3-ethernet \
+        connection.id ${PORT_NAME} \
+        connection.interface-name ${IFACE_NAME} \
+        connection.master ${BRIDGE_NAME} \
+        connection.slave-type bridge
+"
+
+echo "${IFACE_NAME} is added as a port to ${BRIDGE_NAME} successfully."

--- a/ci_framework/roles/openshift_provisioner_node/meta/main.yml
+++ b/ci_framework/roles/openshift_provisioner_node/meta/main.yml
@@ -1,0 +1,44 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- openshift_provisioner_node
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: edpm
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+    - name: EL
+      versions:
+        - 9
+
+  galaxy_tags:
+    - edpm
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/ci_framework/roles/openshift_provisioner_node/molecule/defaults/converge.yml
+++ b/ci_framework/roles/openshift_provisioner_node/molecule/defaults/converge.yml
@@ -1,0 +1,47 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  gather_facts: true
+
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+    cifmw_opn_dry_run: true
+    cifmw_use_opn: true
+    cifmw_opn_use_provisioning_network: false
+    cifmw_opn_user: kni
+
+  tasks:
+    - name: Including the openshift provisioner node role.
+      ansible.builtin.include_role:
+        name: openshift_provisioner_node
+
+    - name: Verify user is created
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ cifmw_opn_user }}"
+
+    - name: Verify external network bridge exists
+      ansible.builtin.command:
+        cmd: "nmcli con show baremetal"
+
+    - name: Perform cleanup
+      ansible.builtin.include_role:
+        name: openshift_provisioner_node
+        tasks_from: cleanup.yml

--- a/ci_framework/roles/openshift_provisioner_node/molecule/defaults/molecule.yml
+++ b/ci_framework/roles/openshift_provisioner_node/molecule/defaults/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/openshift_provisioner_node/molecule/defaults/prepare.yml
+++ b/ci_framework/roles/openshift_provisioner_node/molecule/defaults/prepare.yml
@@ -1,0 +1,30 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+    cifmw_basedir: "{{ ansible_user_dir }}/ci-framework-data"
+    cifmw_use_libvirt_manager: true
+
+  roles:
+    - role: test_deps
+    - role: ci_setup
+    - role: libvirt_manager

--- a/ci_framework/roles/openshift_provisioner_node/tasks/add_bridges.yml
+++ b/ci_framework/roles/openshift_provisioner_node/tasks/add_bridges.yml
@@ -1,0 +1,64 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Create the external network connection
+  tags:
+    - bootstrap
+  become: true
+  community.general.nmcli:
+    type: bridge
+    conn_name: "{{ cifmw_opn_external_bridge_name }}"
+    stp: false
+    state: present
+
+- name: Verify external network interface is defined
+  tags:
+    - bootstrap
+  when:
+    - cifmw_opn_external_network_iface is undefined
+    - not cifmw_opn_dry_run | bool
+  ansible.builtin.fail:
+    msg: "cifmw_opn_external_network_iface is not defined"
+
+- name: Add iface to the external network connection
+  tags:
+    - bootstrap
+  when: not cifmw_opn_dry_run | bool
+  become: true
+  ansible.builtin.script:
+    cmd: files/add_bridge_port.sh "{{ cifmw_opn_external_bridge_name }}" "{{ cifmw_opn_external_network_iface }}"
+
+- name: Provisioning network configuration
+  tags:
+    - bootstrap
+  when:
+    - cifmw_opn_use_provisioning_network is defined
+    - cifmw_opn_use_provisioning_network | bool
+    - cifmw_opn_prov_network_iface is defined
+  block:
+    - name: Create the provisioning network connection
+      become: true
+      community.general.nmcli:
+        type: bridge
+        conn_name: "{{ cifmw_opn_prov_bridge_name }}"
+        ip4: "{{ cifmw_opn_prov_bridge_ipv4 }}"
+        stp: false
+        state: present
+
+    - name: Add iface to the provisioning network connection
+      become: true
+      ansible.builtin.script:
+        cmd: files/add_bridge_port.sh "{{ cifmw_opn_prov_bridge_name }}" "{{ cifmw_opn_prov_network_iface }}"

--- a/ci_framework/roles/openshift_provisioner_node/tasks/add_user.yml
+++ b/ci_framework/roles/openshift_provisioner_node/tasks/add_user.yml
@@ -1,0 +1,44 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: "Adding {{ cifmw_opn_user }} to the system"
+  tags:
+    - bootstrap
+  become: true
+  ansible.builtin.user:
+    name: "{{ cifmw_opn_user }}"
+    comment: "OpenShift installer"
+    append: true
+    groups: libvirt
+    state: present
+
+- name: Generate SSH keys
+  tags:
+    - bootstrap
+  community.crypto.openssh_keypair:
+    path: "{{ cifmw_opn_artifacts_dir }}/{{ cifmw_opn_user }}_id_ed25519"
+    type: "ed25519"
+  register: cifmw_opn_user_ssh_key
+  delegate_to: localhost
+
+- name: Enable passwordless access
+  tags:
+    - bootstrap
+  become: true
+  ansible.posix.authorized_key:
+    user: "{{ cifmw_opn_user }}"
+    key: "{{ cifmw_opn_user_ssh_key.public_key }}"
+    state: present

--- a/ci_framework/roles/openshift_provisioner_node/tasks/add_virtual_network.yml
+++ b/ci_framework/roles/openshift_provisioner_node/tasks/add_virtual_network.yml
@@ -1,0 +1,42 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: "Define virtual network {{ item }}"
+  tags:
+    - bootstrap
+  become: true
+  vars:
+    virt_net_name: "{{ item }}"
+  community.libvirt.virt_net:
+    command: define
+    name: "{{ item }}"
+    xml: "{{ lookup('template', 'templates/virt_net.xml.j2') }}"
+
+- name: "Start the network - {{ item }}"
+  tags:
+    - bootstrap
+  become: true
+  community.libvirt.virt_net:
+    name: "{{ item }}"
+    state: active
+
+- name: "Enable autostart of {{ item }} network"
+  tags:
+    - bootstrap
+  become: true
+  community.libvirt.virt_net:
+    name: "{{ item }}"
+    autostart: true

--- a/ci_framework/roles/openshift_provisioner_node/tasks/cleanup.yml
+++ b/ci_framework/roles/openshift_provisioner_node/tasks/cleanup.yml
@@ -1,0 +1,34 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Cleaning up the virtual networks
+  ansible.builtin.include_tasks:
+    file: cleanup_virtual_network.yml
+  loop:
+    - "{{ cifmw_opn_external_bridge_name }}"
+    - "{{ cifmw_opn_prov_bridge_name }}"
+
+- name: Remove provisioning network
+  become: true
+  community.general.nmcli:
+    conn_name: "{{ cifmw_opn_prov_bridge_name }}"
+    state: absent
+
+- name: Remove the user
+  become: true
+  ansible.builtin.user:
+    name: "{{ cifmw_opn_user }}"
+    state: absent

--- a/ci_framework/roles/openshift_provisioner_node/tasks/cleanup_virtual_network.yml
+++ b/ci_framework/roles/openshift_provisioner_node/tasks/cleanup_virtual_network.yml
@@ -1,0 +1,29 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: "Stopping {{ item }} virtual network"
+  become: true
+  community.libvirt.virt_net:
+    name: "{{ item }}"
+    command: destroy
+  ignore_errors: true
+
+- name: "Remove {{ item }} virtual network"
+  become: true
+  community.libvirt.virt_net:
+    name: "{{ item }}"
+    command: undefine
+  ignore_errors: true

--- a/ci_framework/roles/openshift_provisioner_node/tasks/install_packages.yml
+++ b/ci_framework/roles/openshift_provisioner_node/tasks/install_packages.yml
@@ -1,0 +1,24 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Install required packages need to execute openshift installer
+  tags:
+    - packages
+    - bootstrap
+  become: true
+  ansible.builtin.package:
+    name: "{{ cifmw_opn_required_packages }}"
+    state: present

--- a/ci_framework/roles/openshift_provisioner_node/tasks/main.yml
+++ b/ci_framework/roles/openshift_provisioner_node/tasks/main.yml
@@ -1,0 +1,78 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Create the artifacts directory
+  tags:
+    - bootstrap
+  ansible.builtin.file:
+    path: "{{ cifmw_opn_artifacts_dir }}"
+    state: directory
+  delegate_to: localhost
+
+- name: Add users
+  tags:
+    - bootstrap
+  ansible.builtin.import_tasks:
+    file: add_user.yml
+
+- name: Install required packages for the installer
+  tags:
+    - packages
+    - bootstrap
+  ansible.builtin.import_tasks:
+    file: install_packages.yml
+
+- name: Check network settings are inline with installer requirement
+  tags:
+    - bootstrap
+  ansible.builtin.import_tasks:
+    file: add_bridges.yml
+
+- name: Check required virtualization networks
+  tags:
+    - bootstrap
+  ansible.builtin.include_tasks:
+    file: add_virtual_network.yml
+  loop:
+    - "{{ cifmw_opn_external_bridge_name }}"
+    - "{{ cifmw_opn_prov_bridge_name }}"
+
+- name: Cache the MAC addresses
+  tags:
+    - bootstrap
+  ansible.builtin.set_fact:
+    cifmw_opn_bootstrap_boot_mac: "{{ '52:54:00' | community.general.random_mac }}"
+    cacheable: true
+
+- name: Read host SSH fingerprint
+  ansible.builtin.slurp:
+    src: '/etc/ssh/ssh_host_ecdsa_key.pub'
+  register: ssh_fp
+
+- name: Set the role output parameters
+  ansible.builtin.set_fact:
+    cifmw_opn_host_ssh_key: "{{ ssh_fp['content'] | b64decode | trim }}"
+    cifmw_opn_user: "{{ cifmw_opn_user }}"
+    cifmw_opn_external_bridge_name: "{{ cifmw_opn_external_bridge_name }}"
+    cacheable: true
+
+- name: Cache provisioning bridge name
+  when:
+    - cifmw_opn_use_provisioning_network is defined
+    - cifmw_opn_use_provisioning_network | bool
+  ansible.builtin.set_fact:
+    cifmw_opn_prov_bridge_name: "{{ cifmw_opn_prov_bridge_name }}"
+    cacheable: true

--- a/ci_framework/roles/openshift_provisioner_node/templates/virt_net.xml.j2
+++ b/ci_framework/roles/openshift_provisioner_node/templates/virt_net.xml.j2
@@ -1,0 +1,5 @@
+<network>
+  <name>{{ virt_net_name }}</name>
+  <forward mode="bridge" />
+  <bridge name="{{ virt_net_name }}" />
+</network>

--- a/ci_framework/roles/openshift_provisioner_node/vars/main.yml
+++ b/ci_framework/roles/openshift_provisioner_node/vars/main.yml
@@ -1,0 +1,32 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# While options found within the vars/ path can be overridden using extra
+# vars, items within this path are considered part of the role and not
+# intended to be modified.
+
+# All variables within this role should have a prefix of "cifmw_opn"
+
+cifmw_opn_prov_bridge_ipv4: "172.22.0.254/24"
+cifmw_opn_user: "kni"
+cifmw_opn_required_packages:
+  - python3-devel
+  - NetworkManager-libnm
+  - nm-connection-editor
+  - python3-libsemanage
+  - python3-lxml
+  - python3-policycoreutils

--- a/docs/source/roles/openshift_provisioner_node.md
+++ b/docs/source/roles/openshift_provisioner_node.md
@@ -1,0 +1,1 @@
+../../../ci_framework/roles/openshift_provisioner_node/README.md

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -25,6 +25,7 @@ provisioned with bmaas vs pre-provisioned VM.
 * `cifmw_use_crc`: (Bool) toggle rhol/crc usage
 * `cifmw_openshift_kubeconfig`: (String) Path to the kubeconfig file if externally provided.
 * `cifmw_use_hive`: This enables support for Hive. Defaults to false.
+* `cifmw_use_opn`: (Bool) toggle openshift provisioner node support.
 
 #### Words of caution
 If you want to output the content in another location than `~/ci-framework-data`

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -141,6 +141,17 @@
       - ^ci_framework/roles/openshift_login/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
+    name: cifmw-molecule-openshift_provisioner_node
+    nodeset: centos-9-crc-xl
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: openshift_provisioner_node
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/openshift_provisioner_node/(?!meta|README).*
+      - ^ci/playbooks/molecule.*
+- job:
     name: cifmw-molecule-openshift_setup
     nodeset: centos-9-crc-xl
     parent: cifmw-molecule-base

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -30,6 +30,7 @@
         - cifmw-molecule-libvirt_manager
         - cifmw-molecule-local_env_vm
         - cifmw-molecule-openshift_login
+        - cifmw-molecule-openshift_provisioner_node
         - cifmw-molecule-openshift_setup
         - cifmw-molecule-operator_build
         - cifmw-molecule-operator_deploy


### PR DESCRIPTION
This role performs the required steps to configure the host that is designated for running the initial installation steps of openshift.

Here, `02-infra.yml` is segregated to accommodate  execution of a set of tasks against `virthosts` group. This is done to address the requirement wherein the initial target host is destroyed by the OpenShift installer after bringing up the OpenShift controllers. The artifacts created in the target host would be lost. 

This addresses a gap when
- SNO is deployed using openshift installer or Hive.
- OCP HA cluster is deployed using openshift installer or Hive.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
