### PR TITLE
Remove dependency on discover_latest_image

### DIFF
--- a/ci_framework/roles/libvirt_manager/meta/main.yml
+++ b/ci_framework/roles/libvirt_manager/meta/main.yml
@@ -38,5 +38,4 @@ galaxy_info:
 
 # List your role dependencies here, one per line. Be sure to remove the '[]' above,
 # if you add dependencies to this list.
-dependencies:
-  - discover_latest_image
+dependencies: []


### PR DESCRIPTION
libvirt_manager role has a dependency on discover_latest_image. Removing this dependency allows us not to include this role (discover_latest_image) with other workflow branches. For example: OCP deployment on physical servers using Hive operator.

`discover_latest_image` is included as part of 01-bootstrap hence we can remove the dependency without causing a failure.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running