### PR TITLE
Adds cifmw_extras to kuttl-run playbook

### DIFF
--- a/ci/playbooks/e2e-run.yml
+++ b/ci/playbooks/e2e-run.yml
@@ -11,12 +11,12 @@
           -e @scenarios/centos-9/base.yml
           -e @scenarios/centos-9/install_yamls.yml
           -e @scenarios/centos-9/ci.yml
-          -e @scenarios/centos-9/zuul_inventory.yml
           {%- if cifmw_extras is defined %}
           {%-   for extra_vars in cifmw_extras %}
           -e "{{   extra_vars }}"
           {%-   endfor %}
           {%- endif %}
+          -e @scenarios/centos-9/zuul_inventory.yml
           --tags packages
     - name: Tagged bootstrap - no packages
       ansible.builtin.command:
@@ -26,12 +26,12 @@
           -e @scenarios/centos-9/base.yml
           -e @scenarios/centos-9/install_yamls.yml
           -e @scenarios/centos-9/ci.yml
-          -e @scenarios/centos-9/zuul_inventory.yml
           {%- if cifmw_extras is defined %}
           {%-   for extra_vars in cifmw_extras %}
           -e "{{   extra_vars }}"
           {%-   endfor %}
           {%- endif %}
+          -e @scenarios/centos-9/zuul_inventory.yml
           --tags bootstrap
           --skip-tags packages
     - name: Not tagged bootstrap nor packages
@@ -42,10 +42,10 @@
           -e @scenarios/centos-9/base.yml
           -e @scenarios/centos-9/install_yamls.yml
           -e @scenarios/centos-9/ci.yml
-          -e @scenarios/centos-9/zuul_inventory.yml
           {%- if cifmw_extras is defined %}
           {%-   for extra_vars in cifmw_extras %}
           -e "{{   extra_vars }}"
           {%-   endfor %}
           {%- endif %}
+          -e @scenarios/centos-9/zuul_inventory.yml
           --skip-tags bootstrap,packages

--- a/ci/playbooks/edpm/run.yml
+++ b/ci/playbooks/edpm/run.yml
@@ -9,9 +9,9 @@
           ansible-playbook deploy-edpm.yml
           -e @scenarios/centos-9/base.yml
           -e @scenarios/centos-9/edpm_ci.yml
-          -e @scenarios/centos-9/zuul_inventory.yml
           {%- if cifmw_extras is defined %}
           {%-   for extra_var in cifmw_extras %}
           -e "{{   extra_var }}"
           {%-   endfor %}
           {%- endif %}
+          -e @scenarios/centos-9/zuul_inventory.yml

--- a/ci/playbooks/edpm_baremetal_deployment/run.yml
+++ b/ci/playbooks/edpm_baremetal_deployment/run.yml
@@ -9,9 +9,9 @@
           ansible-playbook deploy-edpm.yml
           -e @scenarios/centos-9/base.yml
           -e @scenarios/centos-9/edpm_baremetal_deployment_ci.yml
-          -e @scenarios/centos-9/zuul_inventory.yml
           {%- if cifmw_extras is defined %}
           {%-   for extra_var in cifmw_extras %}
           -e "{{   extra_var }}"
           {%-   endfor %}
           {%- endif %}
+          -e @scenarios/centos-9/zuul_inventory.yml

--- a/ci/playbooks/kuttl/run.yml
+++ b/ci/playbooks/kuttl/run.yml
@@ -9,4 +9,9 @@
           -e @scenarios/centos-9/base.yml
           -e @scenarios/centos-9/ci.yml
           -e @scenarios/centos-9/kuttl.yml
+          {%- if cifmw_extras is defined %}
+          {%-   for extra_vars in cifmw_extras %}
+          -e "{{   extra_vars }}"
+          {%-   endfor %}
+          {%- endif %}
           -e @scenarios/centos-9/zuul_inventory.yml


### PR DESCRIPTION
This patch adds cifmw_extras to kuttl run playbook to allow passing different scenarios files.
This patch also change the order of extra-vars in ansible-playbook calls. By moving zuul_inventory.yml to the end, it will allow us to overrides vars in zuul job definitions, which can be useful to:
 * avoid too many scenario files when change in the scenario is minimal
 * allow us to testproject a zuul job without changing the original scenario file.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
