### PR TITLE
Run make_crc_attach_default_interface in kuttl tests

### DIFF
--- a/ci/playbooks/kuttl/e2e-kuttl.yml
+++ b/ci/playbooks/kuttl/e2e-kuttl.yml
@@ -10,6 +10,13 @@
         name: 'install_yamls_makes'
         tasks_from: 'make_download_tools'
 
+    - name: Attach default network to CRC
+      when:
+        - kuttl_make_crc_attach_default_interface | default ('true') | bool
+      ansible.builtin.include_role:
+        name: "install_yamls_makes"
+        tasks_from: "make_crc_attach_default_interface"
+
     - name: Run kuttl tests
       include_tasks: run-kuttl-tests.yml
       loop: "{{ cifmw_kuttl_tests_operator_list | default(['cinder' 'keystone']) }}"


### PR DESCRIPTION
In kuttl tests, we call make openstack_deploy_prep which
calls network isolation behind the scenes. If we donot run
make_crc_attach_default_interface in the job, then
nmstate operator installations will fail on crc.
    
In order to fix that, we need to run make_crc_attach_default_interface
always in kuttl job.
    
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/277

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

