### PR TITLE
Add the local IMAGE vars to bundle-build

### DIFF
--- a/ci_framework/roles/operator_build/tasks/build.yml
+++ b/ci_framework/roles/operator_build/tasks/build.yml
@@ -157,6 +157,10 @@
     params:
       IMG: "{{ operator_img }}"
       BUNDLE_IMG: "{{ operator_img_bundle }}"
+      IMAGENAMESPACE: "{{ cifmw_operator_build_push_org }}"
+      IMAGEREGISTRY: "{{ cifmw_operator_build_push_registry }}"
+      IMAGEBASE: "{{ operator.image_base | default('') }}"
+      LOCAL_REGISTRY: "{{ cifmw_operator_build_local_registry | default (0) }}"
 
 - name: "{{ operator.name }} - Push bundle image"
   when:


### PR DESCRIPTION
openstack-operator has bundle as a prerequisite for bundle-build which is not in other operators. So we still need to pass these vars to bundle-build.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
