### PR TITLE
Replacing existing note about PR with explicit version requirement

### DIFF
--- a/ci_framework/plugins/README.md
+++ b/ci_framework/plugins/README.md
@@ -4,8 +4,7 @@ parameter, `output_dir`, in order to output the `make` generated command.
 It also adds a new optional parameter, `dry_run`, allowing to NOT run
 `community.general.make` module, but get a file with the passed parameters.
 
-It requires a pull-request to merge in the community.general collection:
-https://github.com/ansible-collections/community.general/pull/6160
+Requires `community.general` collection v6.5.0 or higher.
 
 Example:
 ```YAML

--- a/ci_framework/plugins/action/ci_make.py
+++ b/ci_framework/plugins/action/ci_make.py
@@ -1,7 +1,5 @@
-# This specific action plugin needs a version of community.general collection
-# providing this patch:
-# https://github.com/ansible-collections/community.general/pull/6160
-# While the "make" command will actually run, it won't be able to generate
+# Requires `community.general` collection v6.5.0 or higher.
+# Otherwise the "make" command will actually run, it won't be able to generate
 # the needed file.
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type


### PR DESCRIPTION
The required change was merged and released[0] some time ago. There is no need to keep the reference to original PR, instead a note of the minimum release required was included in both docs and inline comments.

[0] https://github.com/ansible-collections/community.general/blob/stable-6/CHANGELOG.rst#v650

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
