### PR TITLE
ansible-requirements include

### DIFF
--- a/scripts/setup_env
+++ b/scripts/setup_env
@@ -60,7 +60,7 @@ sudo -k
 
 function run_pip {
     "${PIP}" install \
-             -c "${PROJECT_DIR}ansible-requirements.txt" \
+             -r "${PROJECT_DIR}ansible-requirements.txt" \
              -r "${PROJECT_DIR}requirements.txt" \
              -r "${PROJECT_DIR}test-requirements.txt" \
              -r "${PROJECT_DIR}molecule-requirements.txt" ${@:-}

--- a/scripts/setup_molecule
+++ b/scripts/setup_molecule
@@ -44,7 +44,7 @@ case ${USE_VENV} in
 esac
 
 ${PIP} install \
-        -c "${PROJECT_DIR}ansible-requirements.txt" \
+        -r "${PROJECT_DIR}ansible-requirements.txt" \
         -r "${PROJECT_DIR}molecule-requirements.txt" ${@:-}
 ${GALAXY} collection install --timeout=120 \
         -p "${COLLECTION_PATH}" \


### PR DESCRIPTION
Ansible-requirements per chat supposed to include
the remote deps, which is actually localhost
in a typical case so adding them by default.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
