### PR TITLE
Adjusting ci_make for community.general > 6.5.0

### DIFF
--- a/ci_framework/plugins/action/ci_make.py
+++ b/ci_framework/plugins/action/ci_make.py
@@ -121,27 +121,18 @@ class ActionModule(ActionBase):
         else:
             m_ret = {'command': json.dumps(module_args)}
 
-        # We can only check the "command" availability now, once the module
-        # has been called, unfortunately.
-        scriptable = True
-        if 'command' not in m_ret:
-            m_ret['command'] = json.dumps(module_args)
-            scriptable = False
-
         # Write the reproducer script
         exports = self.extract_env(task_vars)
         s_file = os.path.join(output_dir, fname)
         copy_args = {'dest': s_file}
-        if scriptable:
-            data = {
-                'chdir': module_args['chdir'],
-                'cmd': m_ret['command'],
-                'exports': '\n'.join(exports)
-            }
-            copy_args['content'] = TMPL_REPRODUCER % data
-            copy_args['mode'] = '0755'
-        else:
-            copy_args['content'] = json.dumps(task_vars['environment']) + m_ret['command']
+
+        data = {
+            'chdir': module_args['chdir'],
+            'cmd': m_ret['command'],
+            'exports': '\n'.join(exports)
+        }
+        copy_args['content'] = TMPL_REPRODUCER % data
+        copy_args['mode'] = '0755'
 
         file_task.args.update(copy_args)
         Display().debug(f'Pushing {s_file}')

--- a/requirements.yml
+++ b/requirements.yml
@@ -19,6 +19,7 @@ collections:
     type: git
   - name: https://github.com/ansible-collections/community.general
     type: git
+    version: "6.5.0"
   - name: https://github.com/containers/ansible-podman-collections
     type: git
   - name: https://github.com/ansible-collections/community.libvirt


### PR DESCRIPTION
Collection requirement was pinned to version 6.5.0 as it is the first one to include adjusted make module.

The module no longer checks for presence of the 'command' key in the returned dictionary, as such situation can not arise since version 6.5.0.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
