### PR TITLE
Moving documentation build script into separate file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-docs/source/_build/
-docs/virtdocs/
+docs/_build/
+docs/_venv/
 **/__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -148,15 +148,7 @@ local_env_create: ## Create a virtualized lab on your local machine. Nested virt
 		ansible-playbook -i localhost, -c local dev-local-env.yml ${LOCAL_ENV_OPTS}; \
 	fi
 
-VIRTENV_FOLDER_NAME = virtdocs
 ##@ Generate documentation
 .PHONY: docs
 docs: ## Create documentation under docs/build/html
-	cd docs && \
-		rm -rf source/_build; \
-	python -m venv $(VIRTENV_FOLDER_NAME) && \
-	. virtdocs/bin/activate && \
-	pip install -r doc-requirements.txt && \
-	cd source && \
-	make html && \
-	rm -rf $(VIRTENV_FOLDER_NAME)
+	./docs/source/build-docs.sh

--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -93,7 +93,7 @@
             - doc_available | default(false) | bool
           ansible.builtin.copy:
             remote_src: true
-            src: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/docs/source/_build/html"
+            src: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/docs/_build/html"
             dest: "{{ ansible_user_dir }}/zuul-output/logs/doc_build"
 
       always:

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,7 +1,7 @@
 pbr
 sphinx>=1.5.1
-sphinx-autobuild
-sphinx_rtd_theme
+sphinx-autobuild>=2021.3.1
+sphinx_rtd_theme>=1.2.2
 Pygments>=2.2.0
 reno>=2.5.0
 sphinxemoji

--- a/docs/source/Makefile
+++ b/docs/source/Makefile
@@ -5,7 +5,7 @@
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
-BUILDDIR      = _build
+BUILDDIR      = ../_build
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4

--- a/docs/source/build-docs.sh
+++ b/docs/source/build-docs.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+DOCS_DIR="./docs"
+VENV_DIR=${DOCS_DIR}/_venv
+
+python -m venv ${VENV_DIR} && source ${VENV_DIR}/bin/activate
+cd ${DOCS_DIR}/source
+
+make clean
+
+pip install -r ../doc-requirements.txt
+make html
+
+deactivate


### PR DESCRIPTION
Moving the script for doc building in docs source directory will allow for cleaner code. The new script also handles one shot virtual environment, cleanup of artifacts from previous build, and errors.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
