### PR TITLE
Add support for TLS verification skipping in Podman logins.

### DIFF
--- a/ci_framework/roles/openshift_setup/README.md
+++ b/ci_framework/roles/openshift_setup/README.md
@@ -8,4 +8,5 @@ No privilege escalation needed.
 ## Parameters
 * `cifmw_openshift_setup_dry_run`: (Boolean) Skips resources creation. Defaults to `false`.
 * `cifmw_openshift_setup_create_namespaces`: (Strings) Namespaces to create beforehand. Defaults to `[]`.
-* `cifmw_openshift_setup_skip_internal_registry_login`: (Boolean) Skips login to Internal Openshift registry. Defaults to `false`.
+* `cifmw_openshift_setup_skip_internal_registry`: (Boolean) Skips login and setup of the Internal Openshift registry. Defaults to `false`.
+* `cifmw_openshift_setup_skip_internal_registry_tls_verify`: (Boolean) Skip TLS verification for Podman login. Defaults to `false`.

--- a/ci_framework/roles/openshift_setup/defaults/main.yml
+++ b/ci_framework/roles/openshift_setup/defaults/main.yml
@@ -19,4 +19,5 @@
 # All variables within this role should have a prefix of "cifmw_openshift_setup"
 cifmw_openshift_setup_dry_run: false
 cifmw_openshift_setup_create_namespaces: []
-cifmw_openshift_setup_skip_internal_registry_login: false
+cifmw_openshift_setup_skip_internal_registry: false
+cifmw_openshift_setup_skip_internal_registry_tls_verify: false

--- a/ci_framework/roles/openshift_setup/tasks/main.yml
+++ b/ci_framework/roles/openshift_setup/tasks/main.yml
@@ -37,6 +37,7 @@
   when: not cifmw_openshift_setup_dry_run
 
 - name: Get internal OpenShift registry route
+  when: not cifmw_openshift_setup_skip_internal_registry | bool
   kubernetes.core.k8s_info:
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
     api_key: "{{ cifmw_openshift_token | default(omit)}}"
@@ -46,21 +47,10 @@
     namespace: openshift-image-registry
   register: cifmw_openshift_setup_registry_default_route
 
-- name: Login into OpenShift internal registry
-  when:
-    - cifmw_openshift_token is defined
-    - not cifmw_openshift_setup_skip_internal_registry_login
-    - cifmw_openshift_setup_registry_default_route.resources | default([]) | length > 0
-  ansible.builtin.command:
-    cmd: >-
-      podman login
-      -u {{ cifmw_openshift_user }}
-      -p {{ cifmw_openshift_token }}
-      {{ cifmw_openshift_setup_registry_default_route.resources[0].spec.host }}
-
 - name: Allow anonymous image-pulls in CRC registry for targeted namespaces
   with_items: "{{ cifmw_openshift_setup_namespaces }}"
   when:
+    - not cifmw_openshift_setup_skip_internal_registry | bool
     - not cifmw_openshift_setup_dry_run
     - (cifmw_openshift_setup_registry_default_route.resources | default([]) | length > 0)
   kubernetes.core.k8s:
@@ -82,3 +72,37 @@
       roleRef:
         kind: ClusterRole
         name: system:image-puller
+
+- name: Podman login into OpenShift registry
+  when:
+    - cifmw_openshift_token is defined
+    - not cifmw_openshift_setup_skip_internal_registry | bool
+    - cifmw_openshift_setup_registry_default_route.resources | length > 0
+  block:
+
+  - name: Wait for the image registry to be ready
+    kubernetes.core.k8s_info:
+      kind: Deployment
+      name: image-registry
+      namespace: openshift-image-registry
+      wait: true
+      wait_sleep: 10
+      wait_timeout: 600
+      wait_condition:
+        type: Available
+        status: "True"
+
+  - name: Login into OpenShift internal registry
+    ansible.builtin.command:
+      cmd: >-
+        podman login
+        -u {{ cifmw_openshift_user }}
+        -p {{ cifmw_openshift_token }}
+        {%- if cifmw_openshift_setup_skip_internal_registry_tls_verify|bool %}
+        --tls-verify=false
+        {%- endif %}
+        {{ cifmw_openshift_setup_registry_default_route.resources[0].spec.host }}
+    retries: 10
+    delay: 30
+    register: cifmw_openshift_setup_podman_login_stdout
+    until: cifmw_openshift_setup_podman_login_stdout.rc == 0

--- a/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
+++ b/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
@@ -20,7 +20,7 @@ cifmw_operator_build_meta_name: "openstack-operator"
 cifmw_edpm_deploy_baremetal: true
 
 # openshift_setup role vars
-cifmw_openshift_setup_skip_internal_registry_login: true
+cifmw_openshift_setup_skip_internal_registry: true
 
 # openshift_login role vars
 cifmw_openshift_user: "kubeadmin"

--- a/scenarios/centos-9/edpm_ci.yml
+++ b/scenarios/centos-9/edpm_ci.yml
@@ -25,7 +25,7 @@ cifmw_edpm_deploy_manifests_dir: "{{ cifmw_installyamls_repos }}/out"
 deploy_edpm: true
 
 # openshift_setup role vars
-cifmw_openshift_setup_skip_internal_registry_login: true
+cifmw_openshift_setup_skip_internal_registry: true
 
 # openshift_login role vars
 cifmw_openshift_user: "kubeadmin"


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date