### PR TITLE
Fix cifmw_edpm_deploy_baremetal_common_env vars

### DIFF
--- a/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -18,9 +18,11 @@
   vars:
     operators_build_output: "{{ (cifmw_operator_build_output | default({'operators':{}})).operators }}"
   ansible.builtin.set_fact:
-    cifmw_edpm_deploy_baremetal_common_env:
-      KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-      PATH: "{{ cifmw_path }}"
+    cifmw_edpm_deploy_baremetal_common_env: >-
+      {{
+        cifmw_install_yamls_environment |
+        combine({'PATH': cifmw_path, 'KUBECONFIG': cifmw_openshift_kubeconfig})
+      }}
     cifmw_edpm_deploy_baremetal_make_openstack_env: |
       {% if cifmw_operator_build_meta_name is defined and cifmw_operator_build_meta_name in operators_build_output %}
       OPENSTACK_IMG: {{ operators_build_output[cifmw_operator_build_meta_name].image_catalog }}


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/ci-framework/pull/241 drops the legacy global edpm_env var and combines cifmw_install_yamls_environment var with role specific common_env var.

The patch adds the same in baremetal edpm role.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

