### PR TITLE
Get the pods names with all information

### DIFF
--- a/ci_framework/roles/artifacts/tasks/cluster_info.yml
+++ b/ci_framework/roles/artifacts/tasks/cluster_info.yml
@@ -40,8 +40,8 @@
 
     - name: Dump the logs of all pods
       ansible.builtin.shell: |
-        oc get pods -o name -n openstack-operators > operator_pods.txt
-        oc get pods -o name -n openstack > openstack_pods.txt
+        oc get pods -n openstack-operators > operator_pods.txt
+        oc get pods -n openstack > openstack_pods.txt
         # This is implicitly relying on the fact that the pod name is
         # prefixed with "pod/" so that the redirect places the logs
         # in the correct pod directory. That is why we do not cd after


### PR DESCRIPTION
Currently we are listing the pod names in the logs. It does not provide useful information about the status which makes harder for user to debug.

Getting the detailed status about all pods improves the debugging.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

