### PR TITLE
Setting defaults for command key of the returned dict

### DIFF
--- a/ci_framework/plugins/action/ci_make.py
+++ b/ci_framework/plugins/action/ci_make.py
@@ -126,7 +126,7 @@ class ActionModule(ActionBase):
 
         data = {
             'chdir': module_args['chdir'],
-            'cmd': m_ret['command'],
+            'cmd': m_ret.get('command', json.dumps(module_args)),
             'exports': '\n'.join(exports)
         }
         copy_args['content'] = TMPL_REPRODUCER % data


### PR DESCRIPTION
It appears that the `community.general.make` module may not return the entire expected dictionary in some cases.

This change sets defaults for the value of the 'command' key, in order to prevent errors.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
