### PR TITLE
Negative testing for ci_make

### DIFF
--- a/ci_framework/tests/integration/targets/make/tasks/main.yml
+++ b/ci_framework/tests/integration/targets/make/tasks/main.yml
@@ -17,6 +17,8 @@
       FOO_BAR ?= "toto"
       help:
       > @echo "This is the help thing showing ${FOO_BAR}"
+      failing:
+      > @exit 255
 
 - name: Run ci_make without any params
   register: no_params
@@ -92,6 +94,17 @@
     output_dir: /tmp/artifacts
     target: help
 
+- name: Run ci_make with a faulty command
+  block:
+    - name: Run failing target
+      register: failing_make
+      failed_when:
+        - failing_make.stderr is not match(".*Error 255.*")
+      ci_make:
+        chdir: /tmp/project_makefile
+        output_dir: /tmp/artifacts
+        target: failing
+
 
 - name: Check generated files
   tags:
@@ -122,6 +135,11 @@
             f17389a98ce38f871c3b69f1ad8b9956b7f95958
           "/tmp/logs/ci_make_006_run_ci_make_with_environment_parameter_and_default.log":
             33d4f79ce503647c036a927bbf409189e79b1fd4
+          "/tmp/logs/ci_make_007_run_failing_target.log":
+            88aa7bc8f90b26effa2b0d6cc528530b7bc6f75f
+          "/tmp/artifacts/ci_make_007_run_failing_target.sh":
+            0294daf29cbd1b1a68268ae698d5e74a8c527632
+
     - name: Gather files
       register: reproducer_scripts
       ansible.builtin.stat:


### PR DESCRIPTION
Under some circustances, community.general.make doesn't return the
"command" key in its dict.
Usually, this happens when the underlying "run_command" is failing,
leading to an early exit of the module, without the generated command.

This patch adds a test in order to ensure such a case is properly caught
in the action plugin, and ensures the generated reproducer script is
correct, i.e. showing the json_dump() of the passed parameters.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
