### PR TITLE
Remove useless env file

### DIFF
--- a/ci/playbooks/e2e-collect-logs.yml
+++ b/ci/playbooks/e2e-collect-logs.yml
@@ -8,4 +8,3 @@
         cmd: >-
           ansible-playbook ci_framework/playbooks/99-logs.yml
           -e @scenarios/centos-9/base.yml
-          -e @scenarios/centos-9/zuul_inventory.yml


### PR DESCRIPTION
Especially useless when it's not created due to earlier failure, leading
to a failure to collect logs..

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
