### PR TITLE
Ensure status_code is in the registered dict

### DIFF
--- a/ci_framework/roles/libvirt_manager/tasks/deploy_edpm_compute.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/deploy_edpm_compute.yml
@@ -44,7 +44,9 @@
         url: "{{ compute_config.image_url }}"
         dest: "{{ compute_config.image_local_dir }}/{{ compute_config.disk_file_name }}"
         checksum: "sha256:{{ compute_config.sha256_image_name }}"
-      until: download_base_img.status_code == 200
+      until:
+        - "'status_code' in download_base_img"
+        - download_base_img.status_code == 200
       retries: 30
       delay: 5
 


### PR DESCRIPTION
It may happen status_code isn't in the dict, leading to weird failure.
While this is apparently a random failure, it does hit at least in CI
(and could be reproduced locally with a simple playbook).

Ensuring the dict key is present should, hopefully, avoid a failure.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
