### PR TITLE
Gather facts in the 99-logs.yml playbook

### DIFF
--- a/ci_framework/playbooks/99-logs.yml
+++ b/ci_framework/playbooks/99-logs.yml
@@ -1,6 +1,6 @@
 - name: Logging playbook
   hosts: "{{ cifmw_target_host | default('localhost') }}"
-  gather_facts: false
+  gather_facts: true
   tasks:
     - name: Generate artifacts
       ansible.builtin.import_role:


### PR DESCRIPTION
Since this specific playbook may be called from another run, we want to
ensure facts are actually gathered.
This should prevent weird cases when the "run" stage in zuul fails to
do anything (or the pre-run is failing), hitting directly the "post-run"
stage.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
