### PR TITLE
Ensuring log dir is only queries for selinux info if it exists

### DIFF
--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -49,6 +49,12 @@
                 dest: "{{ ansible_user_dir }}/ci-framework-data/logs"
                 src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/scenarios/centos-9/zuul_inventory.yml"
 
+            - name: Get SELinux listing
+              ansible.builtin.shell:
+                chdir: "{{ ansible_user_dir }}/zuul-output/logs/"
+                cmd: |
+                  ls -lRZ --hide=venv --hide=repo-setup {{ ansible_user_dir }}/ci-framework-data > ./selinux-listing.log;
+
         - name: Get some env related data
           ansible.builtin.shell:
             chdir: "{{ ansible_user_dir }}/zuul-output/logs/"
@@ -72,7 +78,6 @@
           ansible.builtin.shell:
             chdir: "{{ ansible_user_dir }}/zuul-output/logs/"
             cmd: |
-              ls -lRZ --hide=venv --hide=repo-setup {{ ansible_user_dir }}/ci-framework-data > ./selinux-listing.log;
               ausearch -i | grep denied > ./selinux-denials.log
 
         - name: Create system configuration directory


### PR DESCRIPTION
I've noticed some uncaught errorrs in the cifmw-doc execution.[0] I'm going to try some minimal changes to address them.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running


[0] https://review.rdoproject.org/zuul/build/fc109862c5814c1692300d79bd637742/console