### PR TITLE
Ensure we're having cifmw_path parameter

### DIFF
--- a/ci_framework/playbooks/99-logs.yml
+++ b/ci_framework/playbooks/99-logs.yml
@@ -2,6 +2,15 @@
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
+    - name: Set custom cifmw PATH reusable fact
+      tags:
+        - always
+      when:
+        - cifmw_path is not defined
+      ansible.builtin.set_fact:
+        cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+        cacheable: true
+
     - name: Generate artifacts
       ansible.builtin.import_role:
         name: artifacts


### PR DESCRIPTION
Since this playbook may be running outside of the main deploy-edpm.yml
play, we have to ensure cifmw_path is set.

This is especially true within zuul CI, since this 99-logs.yml is
launched from the post-run stage.

We could consume the generated custom-params.yml file, but since it may
not exist in case of (really) early failure of the "run" stage, we'd
rather statically add the missing parts.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
