### PR TITLE
Protect 99-logs and subsequent artifacts role

### DIFF
--- a/ci_framework/playbooks/99-logs.yml
+++ b/ci_framework/playbooks/99-logs.yml
@@ -2,21 +2,31 @@
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: true
   tasks:
-    - name: Set custom cifmw PATH reusable fact
-      tags:
-        - always
+    - name: Ensure cifmw_basedir param is set
       when:
-        - cifmw_path is not defined
+        - cifmw_basedir is not defined
       ansible.builtin.set_fact:
-        cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
-        cacheable: true
+        cifmw_basedir: "{{ ansible_user_dir }}/ci-framework-data"
 
-    - name: Load parameters files
-      tags:
-        - always
-      ansible.builtin.include_vars:
-        dir: "{{ cifmw_basedir }}/artifacts/parameters"
-      ignore_errors: yes
+    - name: Try to load parameters files
+      block:
+        - name: Check directory availabilty
+          register: param_dir
+          ansible.builtin.stat:
+            path: "{{ cifmw_basedir }}/artifacts/parameters"
+
+        - name: Load parameters files
+          when:
+            - param_dir.stat.exists | bool
+          ansible.builtin.include_vars:
+            dir: "{{ cifmw_basedir }}/artifacts/parameters"
+      always:
+        - name: Set custom cifmw PATH reusable fact
+          when:
+            - cifmw_path is not defined
+          ansible.builtin.set_fact:
+            cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+            cacheable: true
 
     - name: Generate artifacts
       ansible.builtin.import_role:

--- a/ci_framework/roles/artifacts/tasks/cluster_info.yml
+++ b/ci_framework/roles/artifacts/tasks/cluster_info.yml
@@ -4,9 +4,9 @@
 # possible, even if the cluster is not in a good state so we use
 # ignore_errors: true.
 - name: Check for oc command
-  ansible.builtin.command: which oc
+  ansible.builtin.command: command -v oc
   environment:
-    PATH: "{{ cifmw_path }}"
+    PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
   register: oc_installed
   ignore_errors: true
 


### PR DESCRIPTION
It may happen some of the needed pieces are missing from the environment
parameters - especially in zuul jobs, since the 99-logs.yml playbook is
running standalone.

This patch should ensure we won't break the log gathering, especially
when it comes to `oc` calls - where we may need a crafted PATH among
things.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
