### PR TITLE
Remove operator namespace workaround

### DIFF
--- a/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
+++ b/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
@@ -6,7 +6,6 @@ cifmw_install_yamls_vars:
   OUTPUT_BASEDIR: "{{ cifmw_basedir }}/artifacts/edpm_compute" # used by gen-edpm-compute-node.sh
   SSH_KEY: "{{ cifmw_basedir }}/artifacts/edpm_compute/ansibleee-ssh-key-id_rsa"
   NETWORK_ISOLATION: false
-  OPERATOR_NAMESPACE: openstack # temporary till https://github.com/openstack-k8s-operators/openstack-baremetal-operator/pull/20 is merged
   STORAGE_CLASS: crc-csi-hostpath-provisioner
   BMAAS_NODE_COUNT: 1
 


### PR DESCRIPTION
We added workaround to have a passing job, permanent fix[1] is merged and baremetal-operator is bumped in openstack-operator, we don't need this workaround anymore.

[1] https://github.com/openstack-k8s-operators/openstack-baremetal-operator/pull/20

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
