### PR TITLE
Grab CRC VM logs from its disk image

### DIFF
--- a/ci_framework/roles/artifacts/tasks/crc.yml
+++ b/ci_framework/roles/artifacts/tasks/crc.yml
@@ -1,0 +1,26 @@
+---
+# Get logs from CRC VM. We also get its XML.
+- name: Extract crc XML to find its disk
+  register: crc_xml
+  ansible.builtin.command:
+    cmd: virsh -c qemu:///system dumpxml crc
+
+- name: Output XML into a file
+  ansible.builtin.copy:
+    dest: "{{ cifmw_artifacts_basedir }}/artifacts/crc-vm.xml"
+    content: "{{ crc_xml.stdout }}"
+
+- name: Create crc logs directory
+  ansible.builtin.file:
+    path: "{{ cifmw_artifacts_basedir }}/logs/crc"
+    state: directory
+
+- name: Extract crc logs from VM
+  environment:
+    LIBGUESTFS_BACKEND: direct
+    LIBVIRT_DEFAULT_URI: "qemu:///system"
+  ansible.builtin.command:
+    cmd: >-
+      guestfish -d crc -r run :
+      mount /dev/sda4 / :
+      copy-out /ostree/deploy/rhcos/var/log/pods {{ cifmw_artifacts_basedir }}/logs/crc/

--- a/ci_framework/roles/artifacts/tasks/main.yml
+++ b/ci_framework/roles/artifacts/tasks/main.yml
@@ -43,3 +43,11 @@
   tags:
     - always
   ansible.builtin.import_tasks: cluster_info.yml
+
+- name: Gather CRC logs
+  when:
+    - cifmw_use_crc is defined
+    - cifmw_use_crc | bool
+  tags:
+    - always
+  ansible.builtin.import_tasks: crc.yml


### PR DESCRIPTION
As commented in the files directly, this must be the last action done
against CRC: after those tasks are done, the VM is stopped.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
