### PR TITLE
Support post-config tweaks for CRC

### DIFF
--- a/ci_framework/roles/rhol_crc/defaults/main.yml
+++ b/ci_framework/roles/rhol_crc/defaults/main.yml
@@ -42,6 +42,8 @@ cifmw_rhol_crc_user_home: "{{ ansible_user_dir | default(lookup('env', 'HOME')) 
 cifmw_rhol_crc_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
 # Check the default values in vars
 cifmw_rhol_crc_config: {}
+# Post-config tweaks (raw commands)
+cifmw_rhol_post_crc_config: []
 
 # crc kubeconfig file
 cifmw_rhol_crc_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"

--- a/ci_framework/roles/rhol_crc/tasks/main.yml
+++ b/ci_framework/roles/rhol_crc/tasks/main.yml
@@ -90,6 +90,9 @@
             - name: Start RHOL/CRC
               ansible.builtin.command: "{{ cifmw_rhol_crc_binary }} start"
               register: cifmw_rhol_crc_cmd_start
+            
+            - name: Apply CRC post-configuration tweaks
+              ansible.builtin.import_tasks: post-configuration.yml
 
     - name: Attach default network to CRC
       when: cifmw_rhol_crc_use_installyamls|bool

--- a/ci_framework/roles/rhol_crc/tasks/post-configuration.yml
+++ b/ci_framework/roles/rhol_crc/tasks/post-configuration.yml
@@ -1,0 +1,27 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Apply CRC post configuration tweaks and if fail print
+  block:
+    - name: Set RHOL/CRC configuration options
+      ansible.builtin.command: "{{ item }}"
+      loop: "{{ cifmw_rhol_crc_post_config_defaults + cifmw_rhol_post_crc_config }}"
+      register: post_configuration_result
+  rescue:
+    - name: If fails print CRC post-configuration execution error
+      ansible.builtin.fail:
+          msg: "{{ post_configuration_result }}"

--- a/ci_framework/roles/rhol_crc/vars/main.yml
+++ b/ci_framework/roles/rhol_crc/vars/main.yml
@@ -47,3 +47,15 @@ cifmw_rhol_crc_sudoers_required_commands:
   - "/usr/bin/systemctl daemon-reload"
   - "/bin/chown root {{ ansible_user_dir }}/.crc/bin/crc-admin-helper-linux"
   - "/bin/chmod u+s\\,g+x {{ ansible_user_dir }}/.crc/bin/crc-admin-helper-linux"
+
+# Post configuration tweaks (raw commands)
+cifmw_rhol_crc_post_config_defaults:
+  - oc patch etcd cluster -p='{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true}}}' --type=merge
+  - oc patch authentications.operator.openshift.io cluster -p='{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableOAuthServer": true}}}' --type=merge
+  - oc scale --replicas=1 ingresscontroller/default -n openshift-ingress-operator
+  - oc scale --replicas=0 deployment.apps/console -n openshift-console
+  - oc scale --replicas=1 deployment.apps/downloads -n openshift-console
+  - oc scale --replicas=1 deployment.apps/oauth-openshift -n openshift-authentication
+  - oc scale --replicas=1 deployment.apps/packageserver -n openshift-operator-lifecycle-manager
+  - oc scale --replicas=0 deployment.apps/cluster-monitoring-operator -n openshift-monitoring
+  - oc delete project openshift-monitoring

--- a/docs/source/quickstart/04_non-virt.md
+++ b/docs/source/quickstart/04_non-virt.md
@@ -64,6 +64,9 @@ pre_infra:
 about 30G of RAM, 10 Cores and 120G of disk space. It's more than the minimal
 requirements.
 
+Use `cifmw_rhol_post_crc_config` list to specify any additional post-configuration
+commands for CRC.
+
 ### 4. Place a pull secret in place
 
 Get the pull secret from [here](https://cloud.redhat.com/openshift/create/local)


### PR DESCRIPTION
Provide a customizable list of the post-config CRC commands. By default, it replicates the list of tweaks applied in OCP Prow CI: https://github.com/openshift/release/pull/34536

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
