### PR TITLE
Retry getting k8s resource

### DIFF
--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -132,6 +132,18 @@
         src: "{{ cifmw_edpm_prepare_openstack_cr_manifest_paths.files[0].path }}"
       register: cifmw_edpm_prepare_ctrlplane_cr_slurp
 
+# Workaround for OSP-25980
+    - name: Wait for NeutronReady
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.command:
+        cmd: >-
+          oc wait OpenStackControlPlane {{ (cifmw_edpm_prepare_ctrlplane_cr_slurp['content'] | b64decode | from_yaml).metadata.name }}
+          --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+          --for=condition=OpenStackControlPlaneNeutronReady
+          --timeout=30m
+
     - name: Wait for OpenStack controlplane to be deployed
       environment:
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"

--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -24,9 +24,8 @@
 - name: Import deploy edpm playbook
   ansible.builtin.import_playbook: ci_framework/playbooks/06-deploy-edpm.yml
 
-# Deactivate for now this step: OSP-25843
-#- name: Import admin setup related playbook
-#  ansible.builtin.import_playbook: ci_framework/playbooks/07-admin-setup.yml
+- name: Import admin setup related playbook
+  ansible.builtin.import_playbook: ci_framework/playbooks/07-admin-setup.yml
 
 - name: Run log related tasks
   ansible.builtin.import_playbook: ci_framework/playbooks/99-logs.yml


### PR DESCRIPTION
Looks like some cases the requested resource
is not provided at this point of time.

`better say sorry than ask for permission` retry
strategy put here until better solution
comes.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
