### PR TITLE
Add edpm and ipa build images content provider check job

### DIFF
--- a/ci/playbooks/edpm_build_images/edpm_build_images_content_provider.yaml
+++ b/ci/playbooks/edpm_build_images/edpm_build_images_content_provider.yaml
@@ -1,0 +1,65 @@
+---
+- hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: true
+  tasks:
+    - name: Deploy content provider registry
+      ansible.builtin.include_role:
+        name: registry_deploy
+
+    - name: Call repo setup
+      ansible.builtin.import_role:
+        name: repo_setup
+      vars:
+       cifmw_repo_setup_output: "/etc/yum.repos.d/"
+
+    - name: Get latest commit when no PR is provided
+      ansible.builtin.command:
+        cmd: git show-ref --head --hash head
+      args:
+        chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/edpm-image-builder"
+      register: git_head_out
+
+    - name: Set pr_sha to be used as image tag
+      ansible.builtin.set_fact:
+        pr_sha: "{{ git_head_out.stdout | trim }}"
+        cacheable: true
+
+    - name: Build edpm and ipa images
+      ansible.builtin.include_role:
+        name: edpm_build_images
+      vars:
+        cifmw_edpm_build_images_tag: "{{ pr_sha }}"
+
+    - name: Push edpm-hardened-uefi image to registry
+      containers.podman.podman_image:
+        name: "{{ item }}"
+        push_args:
+          dest: "{{ cifmw_rp_registry_ip | default('localhost') }}:5001"
+        tag: "{{ pr_sha }}"
+        push: yes
+      loop:
+        - edpm-hardened-uefi
+        - ironic-python-agent
+
+    - name: Set build images output
+      ansible.builtin.set_fact:
+        cifmw_build_images_output:
+          images:
+            edpm-hardened-uefi:
+              image: "{{ cifmw_rp_registry_ip | default('localhost') }}:5001/edpm-hardened-uefi:{{ pr_sha }}"
+            ironic-python-agent:
+              image: "{{ cifmw_rp_registry_ip | default('localhost') }}:5001/ironic-python-agent:{{ pr_sha }}"
+        cacheable: true
+
+    - name: Get the containers list from container registry
+      ansible.builtin.command: "curl -X GET {{ cifmw_rp_registry_ip }}:5001/v2/_catalog"
+      register: cp_imgs
+
+    - name: Add the container list to file
+      ansible.builtin.copy:
+        mode: 0644
+        content: "{{ cp_imgs.stdout }}"
+        dest: "{{ ansible_user_dir }}/ci-framework-data/logs/local_registry.log"
+
+- name: Run log related tasks
+  ansible.builtin.import_playbook: "{{ cifmw_project_root }}/ci_framework/playbooks/99-logs.yml"

--- a/ci/playbooks/edpm_build_images/edpm_build_images_content_provider_run.yaml
+++ b/ci/playbooks/edpm_build_images/edpm_build_images_content_provider_run.yaml
@@ -1,0 +1,47 @@
+---
+- hosts: all
+  gather_facts: true
+  tasks:
+    - name: Build edpm images
+      environment:
+        ANSIBLE_CONFIG: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/ansible.cfg"
+      ansible.builtin.command:
+        chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
+        cmd: >-
+          ansible-playbook ci/playbooks/edpm_build_images/edpm_build_images_content_provider.yaml
+          -e @scenarios/centos-9/base.yml
+          {%- if cifmw_extras is defined %}
+          {%-   for extra_vars in cifmw_extras %}
+          -e "{{   extra_vars }}"
+          {%-   endfor %}
+          {%- endif %}
+          -e @scenarios/centos-9/zuul_inventory.yml
+          -e @scenarios/centos-9/edpm_build_images_content_provider.yml
+          -e "cifmw_rp_registry_ip={{ cifmw_rp_registry_ip }}"
+
+    - name: Include inner ansible vars file
+      ansible.builtin.slurp:
+        src: "{{ cifmw_artifacts_basedir }}/artifacts/ansible-vars.yml"
+      register: inner_ansible
+
+    - name: Get inner ansible vars
+      ansible.builtin.set_fact:
+        inner_ansible_vars: "{{ inner_ansible.content | b64decode | from_yaml }}"
+
+    - name: Set content provider
+      ansible.builtin.set_fact:
+        content_provider_ip: "{{ cifmw_rp_registry_ip }}"
+
+    - name: Return Zuul Data
+      ansible.builtin.debug:
+        msg: >-
+          Running Content provider registry on
+          {{ content_provider_ip | default('nowhere') }}
+
+    - name: Set up content registry IP address
+      zuul_return:
+        data:
+          zuul:
+            pause: true
+          content_provider_registry_ip: "{{ content_provider_ip | default('nowhere') }}"
+          cifmw_build_images_output: "{{ inner_ansible_vars.cifmw_build_images_output }}"

--- a/ci/templates/projects.yaml
+++ b/ci/templates/projects.yaml
@@ -15,4 +15,5 @@
         - cifmw-end-to-end-nobuild-tagged
         - cifmw-kuttl
         - cifmw-edpm-build-image
+        - cifmw-content-provider-build-images
 # Start generated content

--- a/scenarios/centos-9/edpm_build_images_content_provider.yml
+++ b/scenarios/centos-9/edpm_build_images_content_provider.yml
@@ -1,0 +1,4 @@
+---
+ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+cifmw_project_root: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
+cifmw_edmp_build_images_push_registry: "{{ cifmw_rp_registry_ip | default('localhost') }}:5001"

--- a/zuul.d/edpm_build_images_content_provider.yaml
+++ b/zuul.d/edpm_build_images_content_provider.yaml
@@ -1,0 +1,29 @@
+---
+- job:
+    name: content-provider-build-images-base
+    parent: base-ci-framework
+    nodeset: centos-stream-9
+    abstract: true
+    required-projects:
+      - opendev.org/zuul/zuul-jobs
+      - github.com/openstack-k8s-operators/edpm-image-builder
+    pre-run:
+      - ci/playbooks/content_provider/pre.yml
+    run:
+      - ci/playbooks/e2e-prepare.yml
+      - ci/playbooks/dump_zuul_vars.yml
+      - ci/playbooks/edpm_build_images/edpm_build_images_content_provider_run.yaml
+    post-run: ci/playbooks/collect-logs.yml
+    vars:
+      cifmw_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+      cifmw_repo_setup_branch: antelope
+      cifmw_edpm_build_images_via_rpm: false
+
+- job:
+    name: cifmw-content-provider-build-images
+    parent: content-provider-build-images-base
+    files:
+      - ^ci/playbooks/edpm_build_images/edpm_build_images_content_provider.yaml
+      - ^ci/playbooks/edpm_build_images/edpm_build_images_content_provider_run.yaml
+      - ^ci_framework/roles/edpm_build_images/*
+      - ^zuul.d/edpm_build_images_content_provider.yaml

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -15,6 +15,7 @@
         - cifmw-end-to-end-nobuild-tagged
         - cifmw-kuttl
         - cifmw-edpm-build-images
+        - cifmw-content-provider-build-images
 # Start generated content
         - cifmw-molecule-artifacts
         - cifmw-molecule-edpm-build-images


### PR DESCRIPTION
This PR add edpm and ipa content provider build images base job and cifmw-content-provider-build-images job.
cifmw-content-provider-build-images which is basically test content provider build images work flow.

content-provider-build-images-base does below stuff:
1. Creates a local registry on server and push the container images on it. 
3. Returns zuul data - content_provider_registry_ip and cifmw_build_images_output

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

