### PR TITLE
Improve trigger for CRC log gathering

### DIFF
--- a/ci_framework/roles/artifacts/tasks/crc.yml
+++ b/ci_framework/roles/artifacts/tasks/crc.yml
@@ -16,6 +16,7 @@
     state: directory
 
 - name: Extract crc logs from VM
+  register: guestfish_copy_out
   environment:
     LIBGUESTFS_BACKEND: direct
     LIBVIRT_DEFAULT_URI: "qemu:///system"
@@ -24,3 +25,7 @@
       guestfish -d crc -r run :
       mount /dev/sda4 / :
       copy-out /ostree/deploy/rhcos/var/log/pods {{ cifmw_artifacts_basedir }}/logs/crc/
+  retries: 5
+  delay: 5
+  until: guestfish_copy_out.rc == 0
+  ignore_errors: true

--- a/ci_framework/roles/artifacts/tasks/main.yml
+++ b/ci_framework/roles/artifacts/tasks/main.yml
@@ -44,10 +44,16 @@
     - always
   ansible.builtin.import_tasks: cluster_info.yml
 
+- name: Check if we have CRC
+  tags:
+    - always
+  ansible.builtin.import_role:
+    name: rhol_crc
+    tasks_from: find_crc.yml
+
 - name: Gather CRC logs
   when:
-    - cifmw_use_crc is defined
-    - cifmw_use_crc | bool
+    - crc_present|bool
   tags:
     - always
   ansible.builtin.import_tasks: crc.yml

--- a/ci_framework/roles/rhol_crc/tasks/find_crc.yml
+++ b/ci_framework/roles/rhol_crc/tasks/find_crc.yml
@@ -1,0 +1,23 @@
+---
+- name: Catch potential error
+  block:
+    - name: Get VM domains through Virt
+      community.libvirt.virt:
+        command: info
+        uri: "qemu:///system"
+      register: vm_domains
+  rescue:
+    - name: No libvirt support
+      ansible.builtin.set_fact:
+        vm_domains:
+          empty: 'No libvirt link could be found'
+
+# The way ansible/jinja2 wants to match a string is horrible - so we must rely
+# on some terrible "if true then true else false" pattern...
+- name: Set VM status
+  ansible.builtin.set_fact:
+    cacheable: true
+    crc_present: >-
+      {%- if 'crc' in vm_domains -%}{{ true }}{%- else -%}{{ false }}{%- endif -%}
+    crc_running: >-
+      {%- if 'crc' in vm_domains and vm_domains.crc.state == 'running' -%}{{ true }}{%- else -%}{{ false }}{%- endif -%}

--- a/ci_framework/roles/rhol_crc/tasks/main.yml
+++ b/ci_framework/roles/rhol_crc/tasks/main.yml
@@ -24,20 +24,10 @@
     - artifacts
     - bin
 
-- name: Get VM domains through Virt
-  community.libvirt.virt:
-    command: info
-    uri: "qemu:///system"
-  register: vm_domains
-
-# The way ansible/jinja2 wants to match a string is horrible - so we must rely
-# on some terrible "if true then true else false" pattern...
-- name: Set VM status
-  ansible.builtin.set_fact:
-    crc_present: >-
-      {%- if 'crc' in vm_domains -%}{{ true }}{%- else -%}{{ false }}{%- endif -%}
-    crc_running: >-
-      {%- if 'crc' in vm_domains and vm_domains.crc.state == 'running' -%}{{ true }}{%- else -%}{{ false }}{%- endif -%}
+- name: Verify CRC status
+  tags:
+    - always
+  ansible.builtin.import_tasks: find_crc.yml
 
 - name: Fail if crc domain is already defined
   ansible.builtin.fail:


### PR DESCRIPTION
It may happen CRC is consumed without actually being bootstraped with
the Framework, meaning we may miss the `cifmw_use_crc` parameter.

This change tries to detect the CRC VM, re-using the rhol_crc role. In
order to do so, the specific code is now extracted in its own tasks
file, so that we may call it from anywhere without having the whole role
running.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
