### PR TITLE
Remove install_yamls operator repositories from artifacts

### DIFF
--- a/ci_framework/roles/artifacts/tasks/cleanup.yml
+++ b/ci_framework/roles/artifacts/tasks/cleanup.yml
@@ -1,0 +1,11 @@
+---
+- name: Cleanup unnecesary directories
+  tags:
+    - always
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ cifmw_manifests | default(cifmw_artifacts_basedir ~ '/artifacts/manifests') }}/operator"
+  loop_control:
+    label: "{{ item }}"

--- a/ci_framework/roles/artifacts/tasks/main.yml
+++ b/ci_framework/roles/artifacts/tasks/main.yml
@@ -44,6 +44,11 @@
     - always
   ansible.builtin.import_tasks: cluster_info.yml
 
+- name: Cleanup artifacts before finishing
+  tags:
+    - always
+  ansible.builtin.import_tasks: cleanup.yml
+
 - name: Check if we have CRC
   tags:
     - always


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date: