### PR TITLE
os_net_setup: rely on openshift_login context

### DIFF
--- a/ci_framework/playbooks/07-admin-setup.yml
+++ b/ci_framework/playbooks/07-admin-setup.yml
@@ -4,9 +4,14 @@
     step: pre_admin_setup
   ansible.builtin.import_playbook: ./hooks.yml
 
-- hosts: "{{ cifmw_target_host | default('localhost') }}"
+- name: Post-deployment admin setup steps
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
+    - name: Load parameters files
+      ansible.builtin.include_vars:
+        dir: "{{ cifmw_basedir }}/artifacts/parameters"
+
     - name: Create openstack network elements
       ansible.builtin.import_role:
         name: os_net_setup

--- a/ci_framework/roles/os_net_setup/README.md
+++ b/ci_framework/roles/os_net_setup/README.md
@@ -1,12 +1,11 @@
-## Role: os_net_setup
+## os_net_setup
 This is typically an admin task before going into production,
 creating network for the users.
 
 ### Privilege escalation
 Not as sudo, but needs access to k8s openstack namespace and
 being an openstack admin on the API.
+That is provided by `openshift_login` role.
 
 ### Parameters
 * `cifmw_os_net_setup_config`: See an example in ci_framework/roles/os_net_setup/defaults/main.yml
-* `cifmw_os_net_setup_kubeconfig_context`: context used for k8s auth from a KUBECONFIG
-* `cifmw_os_net_setup_kubeconfig_location`: KUBECONFIG location

--- a/ci_framework/roles/os_net_setup/defaults/main.yml
+++ b/ci_framework/roles/os_net_setup/defaults/main.yml
@@ -13,5 +13,3 @@ cifmw_os_net_setup_config:
         allocation_pool_end: 192.168.122.210
         gateway_ip: 192.168.122.1
         enable_dhcp: false
-cifmw_os_net_setup_kubeconfig_context: admin
-# cifmw_os_net_setup_kubeconfig_location defaults to cifmw_install_yamls_vars.KUBECONFIG

--- a/ci_framework/roles/os_net_setup/tasks/main.yml
+++ b/ci_framework/roles/os_net_setup/tasks/main.yml
@@ -1,12 +1,9 @@
 - name: get openstack admin credentials from k8s
-  vars:
-      k8s_kubeconfig: "{{ cifmw_os_net_setup_kudeconfig_location | default(cifmw_install_yamls_vars.KUBECONFIG) | default(ansible_user_dir + '/.crc/machines/crc/kubeconfig') }}"
-      k8s_context: "{{ cifmw_os_net_setup_kubeconfig_context | default('admin') }}"
   block:
   - name: Get clouds.yaml configuration
     kubernetes.core.k8s_info:
-      kubeconfig: "{{ k8s_kubeconfig }}"
-      context: "{{ k8s_context }}"
+      kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+      context: "{{ cifmw_openshift_context }}"
       kind: ConfigMap
       namespace: openstack
       name: openstack-config
@@ -14,8 +11,8 @@
 
   - name: Get the OSP admin password
     kubernetes.core.k8s_info:
-      kubeconfig: "{{ k8s_kubeconfig }}"
-      context: "{{ k8s_context }}"
+      kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+      context: "{{ cifmw_openshift_context }}"
       kind: Secret
       namespace: openstack
       name: openstack-config-secret


### PR DESCRIPTION
~Correction for one of the variables referenced in os_net_setup role is named with typo - kudeconfig instead of kubeconfig. (changed based on comments)~

os_net_setup: rely on openshift_login context

Switch os_net_setup to use k8s credentials (kubeconfig/context)
provided by openshift_login instead of having it's own variables for that.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date
