### PR TITLE
Ensure libguestfs is installed when gathering CRC VM logs

### DIFF
--- a/ci_framework/roles/artifacts/tasks/crc.yml
+++ b/ci_framework/roles/artifacts/tasks/crc.yml
@@ -1,4 +1,13 @@
 ---
+- name: Install packages required for gathering CRC VM logs
+  become: true
+  tags:
+    - bootstrap
+    - packages
+  ansible.builtin.package:
+    name: "{{ cifmw_artifacts_dependency_packages }}"
+    state: present
+
 # Get logs from CRC VM. We also get its XML.
 - name: Extract crc XML to find its disk
   register: crc_xml

--- a/ci_framework/roles/artifacts/vars/main.yml
+++ b/ci_framework/roles/artifacts/vars/main.yml
@@ -1,0 +1,25 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# While options found within the vars/ path can be overridden using extra
+# vars, items within this path are considered part of the role and not
+# intended to be modified.
+
+# All variables within this role should have a prefix of "cifmw_libvirt_manager"
+
+cifmw_artifacts_dependency_packages:
+  - libguestfs


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
