### PR TITLE
Role to set meta operators env variables

### DIFF
--- a/ci_framework/roles/edpm_prepare/README.md
+++ b/ci_framework/roles/edpm_prepare/README.md
@@ -12,3 +12,4 @@ This role doesn't need privilege scalation.
 * `cifmw_edpm_prepare_skip_openstack_operator:`: (Boolean) Intentionally skips the deployment of the OpenStack metaoperator. Defaults to `False`.
 * `cifmw_edpm_prepare_wait_subscription_retries`: (Integer) Number of retries, with 5 seconds delays, waiting for the OpenStack subscription to come up. Defaults to `5`.
 * `cifmw_edpm_prepare_crc_attach_default_interface`: (Boolean) Skips crc_attach_default_interface. Defaults to `true`.
+* `cifmw_edpm_prepare_update_os_containers`: (Boolean) Updates the openstack services containers env variable. Defaults to `false`.

--- a/ci_framework/roles/edpm_prepare/defaults/main.yml
+++ b/ci_framework/roles/edpm_prepare/defaults/main.yml
@@ -25,3 +25,4 @@ cifmw_edpm_prepare_dry_run: false
 cifmw_edpm_prepare_skip_crc_storage_creation: false
 cifmw_edpm_prepare_default_ansible_runner_image: "http://quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest"
 cifmw_edpm_prepare_ansible_runner_image: "{{ cifmw_edpm_prepare_default_ansible_runner_image }}"
+cifmw_edpm_prepare_update_os_containers: false

--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -115,6 +115,11 @@
       "path":"/spec/install/spec/deployments/0/spec/template/spec/containers/1/env/0",
       "value": {"name": "ANSIBLEEE_IMAGE_URL_DEFAULT", "value": "{{ cifmw_edpm_prepare_ansible_runner_image }}"}}]'
 
+- name: Update OpenStack Services containers Env
+  when: cifmw_edpm_prepare_update_os_containers | bool
+  ansible.builtin.include_role:
+    name: set_openstack_containers
+
 - name: Install OpenStack service
   vars:
     make_openstack_deploy_env: "{{ cifmw_edpm_prepare_common_env |

--- a/ci_framework/roles/set_openstack_containers/README.md
+++ b/ci_framework/roles/set_openstack_containers/README.md
@@ -1,0 +1,21 @@
+# set_openstack_containers
+A role to set the environment variables for openstack services containers and friends
+used during OpenStack services deployment using meta operator.
+
+## Parameters
+* `cifmw_set_openstack_containers_basedir`: Directory to store role generated contents. Defaults to `"{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"`
+* `cifmw_set_openstack_containers_registry`: Name of the container registry to pull containers from. Defaults to `quay.io`
+* `cifmw_set_openstack_containers_namespace`: Name of the container namespace. Defaults to `podified-antelope-centos9`
+* `cifmw_set_openstack_containers_tag`: Container tag. Defaults to `current-podified`
+* `cifmw_set_openstack_containers_tag_from_md5`: Get the tag from delorean.repo.md5. Defaults to `false`.
+* `cifmw_set_openstack_containers_dlrn_md5_path`: Full path of delorean.repo.md5. Defaults to `/etc/yum.repos.d/delorean.repo.md5`.
+* `cifmw_set_openstack_containers_overrides`: Extra container overrides. Defaults to `{}`
+
+## Examples
+```yaml
+- hosts: all
+  tasks:
+    - name: Generate env file for OpenStack containers services
+      ansible.builtin.include_role:
+        name: set_openstack_containers
+```

--- a/ci_framework/roles/set_openstack_containers/defaults/main.yml
+++ b/ci_framework/roles/set_openstack_containers/defaults/main.yml
@@ -1,0 +1,29 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_set_openstack_containers"
+cifmw_set_openstack_containers_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+cifmw_set_openstack_containers_registry: quay.io
+cifmw_set_openstack_containers_namespace: podified-antelope-centos9
+cifmw_set_openstack_containers_tag: current-podified
+cifmw_set_openstack_containers_operator_name: openstack
+cifmw_set_openstack_containers_tag_from_md5: false
+cifmw_set_openstack_containers_dlrn_md5_path: "/etc/yum.repos.d/delorean.repo.md5"
+
+# Set custom image url for non-openstack images
+cifmw_set_openstack_containers_overrides: {}

--- a/ci_framework/roles/set_openstack_containers/meta/main.yml
+++ b/ci_framework/roles/set_openstack_containers/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- set_openstack_containers
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: edpm
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - edpm
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/ci_framework/roles/set_openstack_containers/molecule/default/converge.yml
+++ b/ci_framework/roles/set_openstack_containers/molecule/default/converge.yml
@@ -1,0 +1,60 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  vars:
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+    cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+    make_openstack_wait_dryrun: true
+    cifmw_set_openstack_containers_operator_name: keystone
+    cifmw_install_yamls_environment:
+      KUBECONFIG: "{{ cifmw_openshift_kubeconfig  }}"
+      BMO_SETUP: false
+      NETWORK_ISOLATION: false
+    cifmw_install_yamls_defaults:
+      OPERATOR_NAMESPACE: openstack-operators
+  pre_tasks:
+    - name: Make download_tools
+      ansible.builtin.include_role:
+        name: 'install_yamls_makes'
+        tasks_from: 'make_download_tools'
+
+    - name: Run make keystone
+      vars:
+        make_keystone_env: "{{ cifmw_install_yamls_environment | combine({'PATH': cifmw_path}) }}"
+      ansible.builtin.include_role:
+        name: 'install_yamls_makes'
+        tasks_from: 'make_keystone'
+
+    - name: Wait for keystone operator to deployed
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.shell:
+        cmd: >-
+          oc get csv -l operators.coreos.com/keystone-operator.openstack-operators
+          --namespace={{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }}
+          --no-headers=true | grep -i "succeeded"
+      register: operator_status
+      until: operator_status.rc == 0
+      changed_when: false
+      retries: 30
+      delay: 30
+
+  roles:
+    - role: "set_openstack_containers"

--- a/ci_framework/roles/set_openstack_containers/molecule/default/molecule.yml
+++ b/ci_framework/roles/set_openstack_containers/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/set_openstack_containers/molecule/default/prepare.yml
+++ b/ci_framework/roles/set_openstack_containers/molecule/default/prepare.yml
@@ -1,0 +1,30 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  vars:
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+    cifmw_install_yamls_out_dir: "{{ ansible_user_dir }}/.ansible"
+  roles:
+    - role: test_deps
+    - role: ci_setup
+    - role: install_yamls
+  tasks:
+    - name: Ensure CRC is started
+      ansible.builtin.command:
+        cmd: crc start --memory 14000 --disk-size 80 --cpus 6

--- a/ci_framework/roles/set_openstack_containers/tasks/main.yml
+++ b/ci_framework/roles/set_openstack_containers/tasks/main.yml
@@ -1,0 +1,118 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: 'Make sure {{ cifmw_set_openstack_containers_basedir }} exists'
+  ansible.builtin.file:
+    path: "{{ cifmw_set_openstack_containers_basedir }}/artifacts"
+    state: directory
+
+- name: Set container tag from dlrn md5 hash file
+  when:
+    - cifmw_set_openstack_containers_tag_from_md5 | bool
+  block:
+    - name: Get the md5 hash from hash file
+      ansible.builtin.slurp:
+        src: "{{ cifmw_set_openstack_containers_dlrn_md5_path }}"
+      register: dlrn_md5
+
+    - name: Set container tag
+      ansible.builtin.set_fact:
+        cifmw_set_openstack_containers_tag: "{{ dlrn_md5['content'] | b64decode | trim }}"
+        cacheable: true
+
+- name: Set the operator name
+  ansible.builtin.set_fact:
+    operator_name: "{{ cifmw_set_openstack_containers_operator_name }}"
+    cacheable: true
+
+- name: Get all openstack pods
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.shell:
+    cmd: oc get pods -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} -o name
+  register: operator_pod
+
+- name: list all pods
+  ansible.builtin.debug:
+    var: operator_pod
+
+- name: Get the operator pod name
+  ansible.builtin.set_fact:
+    operator_pod: "{{ '\n'.join(operator_pod.stdout_lines) |regex_search('^pod/' ~ operator_name ~ '-operator-controller-manager-.*$', multiline=True) }}"
+
+- name: list all pods
+  ansible.builtin.debug:
+    msg: operator_pod
+
+- name: Get meta operator environment variable
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.shell:
+    cmd: >-
+      oc set env {{ operator_pod }} -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} --list
+  register: containers_env_list
+
+- name: Generate update_env_vars.sh script
+  ansible.builtin.template:
+    src: "update_env_vars.sh.j2"
+    dest: "{{ cifmw_set_openstack_containers_basedir }}/artifacts/update_env_vars.sh"
+    mode: 0755
+
+- name: Run update_env_vars.sh script
+  ansible.builtin.command: >-
+    {{ cifmw_set_openstack_containers_basedir }}/artifacts/update_env_vars.sh
+
+- name: Wait for reinstallation of meta operator
+  vars:
+    make_openstack_wait_env: "{{ cifmw_install_yamls_environment | combine({'PATH': cifmw_path}) }}"
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_openstack_wait'
+  when: operator_name == 'openstack'
+
+- name: wait for reinstallation of operator
+  vars:
+    make_wait_env: "{{ cifmw_install_yamls_environment | combine({'PATH': cifmw_path}) }}"
+    make_wait_params:
+      OPERATOR_NAME: "{{ operator_name }}"
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_wait'
+
+- name: Retrieve operator pods
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.shell:
+    cmd: oc get pods -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} -o name
+  register: operator_pod_name
+
+- name: Get the operator pod name
+  ansible.builtin.set_fact:
+    operator_pod_name: "{{ '\n'.join(operator_pod_name.stdout_lines) |regex_search('^pod/' ~ operator_name ~ '-operator-controller-manager-.*$', multiline=True) }}"
+
+- name: Get operator environment variable after update
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.shell:
+    cmd: >-
+      oc set env {{ operator_pod_name }} -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} --list > operator_env.txt
+  args:
+    chdir: "{{ cifmw_set_openstack_containers_basedir }}/artifacts"
+    creates: operator_env.txt

--- a/ci_framework/roles/set_openstack_containers/templates/update_env_vars.sh.j2
+++ b/ci_framework/roles/set_openstack_containers/templates/update_env_vars.sh.j2
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -eo pipefail
+
+{% set containers_dict = {} -%}
+{# Set the container registry url with namespace #}
+{% set _container_registry = cifmw_set_openstack_containers_registry + '/' + cifmw_set_openstack_containers_namespace -%}
+{# Environment variables contains = sign, Based on that we need to split with key and value #}
+{% for container in containers_env_list.stdout_lines if '=' in container -%}
+{%   set container_data = container.split('=') -%}
+{%   set _container_env = container_data[0] -%}
+{%   set _container = container_data[1] -%}
+{#   All the openstack services containers ends with current-podified tag #}
+{#   It filters out the same and update the container address with new url #}
+{%   if _container.endswith('current-podified') -%}
+{%     set _container_data = _container.split('/')[-1] -%}
+{%     set _container_name = _container_data.split(':')[0] -%}
+{%     set _container_address = _container_registry + '/' + _container_name + ':' + cifmw_set_openstack_containers_tag -%}
+{%     set _ = containers_dict.update({_container_env: _container_address}) -%}
+{#   This section overrides the non openstack services containers #}
+{%   elif cifmw_set_openstack_containers_overrides.items()|length > 0 -%}
+{%     if _container_env in cifmw_set_openstack_containers_overrides.items() -%}
+{%       set _ = containers_dict.update({_container_env: cifmw_set_openstack_containers_overrides[_container_env]}) -%}
+{%     endif -%}
+{%   endif -%}
+{% endfor -%}
+
+# patch csv
+oc get csv -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} \
+   -l operators.coreos.com/{{ operator_name }}-operator.openstack-operators -o=jsonpath='{.items[0]}' \
+   {% for key, value in containers_dict.items() -%}
+   | jq '(.spec.install.spec.deployments[0].spec.template.spec.containers[1].env[] | select(.name=={{ '\"' + key + '\"' }})) |= (.value={{ '\"' + value + '\"' }})' \
+   {% endfor -%}
+   > {{ cifmw_set_openstack_containers_basedir }}/artifacts/update_containers_patch.out
+
+
+# Apply patch
+oc patch csv -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} \
+   $(oc get csv -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} \
+   -l operators.coreos.com/{{ operator_name }}-operator.openstack-operators \
+   -o jsonpath='{.items[0].metadata.name}') \
+   --type=merge \
+   --patch-file={{ cifmw_set_openstack_containers_basedir }}/artifacts/update_containers_patch.out

--- a/docs/source/roles/set_openstack_containers.md
+++ b/docs/source/roles/set_openstack_containers.md
@@ -1,0 +1,1 @@
+../../../ci_framework/roles/set_openstack_containers/README.md

--- a/scripts/create_role_molecule
+++ b/scripts/create_role_molecule
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xe
 
-NEED_CRC_XL="cifmw-molecule-operator_deploy cifmw-molecule-rhol_crc cifmw-molecule-openshift_setup cifmw-molecule-openshift_login"
+NEED_CRC_XL="cifmw-molecule-operator_deploy cifmw-molecule-rhol_crc cifmw-molecule-openshift_setup cifmw-molecule-openshift_login cifmw-molecule-set_openstack_containers"
 PROJECT_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))/../"
 cp ${PROJECT_DIR}/ci/templates/projects.yaml ${PROJECT_DIR}/zuul.d/projects.yaml;
 echo '# DO NOT EDIT - generaged using make role_molecule' > ${PROJECT_DIR}/zuul.d/molecule.yaml

--- a/zuul.d/molecule-base.yaml
+++ b/zuul.d/molecule-base.yaml
@@ -12,3 +12,16 @@
     vars:
       roles_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/ci_framework/roles/{{ TEST_RUN }}"
       mol_config_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/.config/molecule/config_local.yml"
+
+- job:
+    name: cifmw-molecule-base-crc
+    nodeset: centos-9-crc-xl
+    parent: base-simple-crc
+    pre-run: ci/playbooks/molecule-prepare.yml
+    run: ci/playbooks/molecule-test.yml
+    post-run: ci/playbooks/collect-logs.yml
+    required-projects:
+      - github.com/openstack-k8s-operators/install_yamls
+    vars:
+      roles_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/ci_framework/roles/{{ TEST_RUN }}"
+      mol_config_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/.config/molecule/config_local.yml"

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -264,6 +264,16 @@
       - ^ci_framework/roles/run_hook/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 - job:
+    name: cifmw-molecule-set_openstack_containers
+    parent: cifmw-molecule-base-crc
+    vars:
+      TEST_RUN: set_openstack_containers
+    files:
+      - ^ansible-requirements.txt
+      - ^molecule-requirements.txt
+      - ^ci_framework/roles/set_openstack_containers/(?!meta|README).*
+      - ^ci/playbooks/molecule.*
+- job:
     name: cifmw-molecule-tempest
     parent: cifmw-molecule-base
     vars:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -43,5 +43,6 @@
         - cifmw-molecule-repo_setup
         - cifmw-molecule-rhol_crc
         - cifmw-molecule-run_hook
+        - cifmw-molecule-set_openstack_containers
         - cifmw-molecule-tempest
         - cifmw-molecule-test_deps


### PR DESCRIPTION
This role provides a way to overrides the registry address of
all the meta operator env variables.
    
By default the role should update the address of openstack
services containers to different registry with proper tag.
    
It will be useful for downstream.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

