### PR TITLE
Adds edpm/baremetal periodic jobs

### DIFF
--- a/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
+++ b/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
@@ -8,6 +8,8 @@ cifmw_install_yamls_vars:
   NETWORK_ISOLATION: false
   STORAGE_CLASS: crc-csi-hostpath-provisioner
   BMAAS_NODE_COUNT: 1
+  DATAPLANE_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/dataplane-operator"
+  INFRA_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/infra-operator"
 
 pre_infra:
   - name: Download needed tools

--- a/scenarios/centos-9/edpm_periodic.yml
+++ b/scenarios/centos-9/edpm_periodic.yml
@@ -1,0 +1,5 @@
+---
+cifmw_repo_setup_branch: master
+cifmw_repo_setup_promotion: podified-ci-testing
+make_edpm_compute_repos_params:
+  REPO_SETUP_CMD: "{{ cifmw_repo_setup_promotion }} -b {{ cifmw_repo_setup_branch }}"

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -23,6 +23,7 @@
       - openstack-k8s-operators/ci-framework
       - openstack-k8s-operators/dataplane-operator
       - openstack-k8s-operators/install_yamls
+      - openstack-k8s-operators/infra-operator
       - openstack-k8s-operators/openstack-baremetal-operator
       - openstack-k8s-operators/openstack-operator
       - openstack-k8s-operators/repo-setup

--- a/zuul.d/edpm_periodic.yaml
+++ b/zuul.d/edpm_periodic.yaml
@@ -1,0 +1,25 @@
+---
+- job:
+    name: periodic-podified-edpm-deployment-master-ocp-crc-1cs9
+    parent: cifmw-crc-podified-edpm-deployment
+    vars: &edpm_vars
+      cifmw_extras:
+        - '@scenarios/centos-9/edpm_periodic.yml'
+
+- job:
+    name: periodic-podified-edpm-baremetal-master-ocp-crc
+    parent: cifmw-crc-podified-edpm-baremetal
+    vars: *edpm_vars
+
+# Antelope jobs
+- job:
+    name: periodic-podified-edpm-deployment-antelope-ocp-crc-1cs9
+    parent: periodic-podified-edpm-deployment-master-ocp-crc-1cs9
+    vars:
+      cifmw_repo_setup_branch: antelope
+
+- job:
+    name: periodic-podified-edpm-baremetal-antelope-ocp-crc
+    parent: periodic-podified-edpm-baremetal-master-ocp-crc
+    vars:
+      cifmw_repo_setup_branch: antelope


### PR DESCRIPTION
This patch adds the job definition for edpm/baremetal
periodic jobs for master and antelope release.
    
It will be used in periodic lines to validate the openstack
services container.
    

Testing here: https://review.rdoproject.org/r/c/testproject/+/49017

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running


