### PR TITLE
Integrate OCP deployment using Hive

### DIFF
--- a/ci_framework/playbooks/02-infra.yml
+++ b/ci_framework/playbooks/02-infra.yml
@@ -33,6 +33,13 @@
       ansible.builtin.include_vars:
         dir: "{{ cifmw_basedir }}/artifacts/parameters"
 
+    - name: Deploy OCP using Hive
+      when:
+        - cifmw_use_hive is defined
+        - cifmw_use_hive | bool
+      ansible.builtin.import_role:
+        name: hive
+
     - name: Prepare CRC
       when:
         - cifmw_use_crc is defined

--- a/ci_framework/roles/hive/meta/main.yml
+++ b/ci_framework/roles/hive/meta/main.yml
@@ -41,5 +41,4 @@ galaxy_info:
 
 # List your role dependencies here, one per line. Be sure to remove the '[]' above,
 # if you add dependencies to this list.
-dependencies:
-  - ci_setup
+dependencies: []


### PR DESCRIPTION
Inserting platform (OCP) creation using the Hive operator.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
