### PR TITLE
Add support for passing custom uefi image

### DIFF
--- a/ci_framework/roles/edpm_deploy_baremetal/README.md
+++ b/ci_framework/roles/edpm_deploy_baremetal/README.md
@@ -14,6 +14,7 @@ This role doesn't need privilege scalation.
 * `cifmw_edpm_deploy_baremetal_wait_provisionserver_timeout_mins`: (integer) Timeout for waiting for the Provision Server deployment. Default: `20`
 * `cifmw_edpm_deploy_baremetal_wait_bmh_timeout_mins`: (integer) Timeout for waiting for the bare metal nodes. Default: `20`
 * `cifmw_edpm_deploy_baremetal_wait_dataplane_timeout_mins`: (integer) Timeout for waiting for the OpenStackDataPlane. Default: `30`
+* `cifmw_edpm_deploy_baremetal_uefi_image_url`: (String) The url from where we can pull the uefi container, Default: `quay.io/podified-antelope-centos9/edpm-hardened-uefi:current-podified`
 
 ## Examples
 ### 1 - Perform edpm baremetal deployment

--- a/ci_framework/roles/edpm_deploy_baremetal/defaults/main.yml
+++ b/ci_framework/roles/edpm_deploy_baremetal/defaults/main.yml
@@ -25,3 +25,5 @@ cifmw_edpm_deploy_baremetal_wait_provisionserver_timeout_mins: 20
 cifmw_edpm_deploy_baremetal_wait_ironic_timeout_mins: 20
 cifmw_edpm_deploy_baremetal_wait_bmh_timeout_mins: 20
 cifmw_edpm_deploy_baremetal_wait_dataplane_timeout_mins: 30
+cifmw_edpm_deploy_baremetal_default_uefi_image_url: "quay.io/podified-antelope-centos9/edpm-hardened-uefi:current-podified"
+cifmw_edpm_deploy_baremetal_uefi_image_url: "{{ cifmw_edpm_deploy_baremetal_default_uefi_image_url }}"

--- a/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -44,6 +44,22 @@
     name: 'install_yamls_makes'
     tasks_from: 'make_metallb_config'
 
+- name: Override uefi image url when we build uefi image via content_provider
+  when: cifmw_build_images_output is defined
+  set_fact:
+    cifmw_edpm_deploy_baremetal_uefi_image_url: "{{ cifmw_build_images_output['images']['edpm-hardened-uefi']['image'] }}"
+
+- name: Patch baremetal CSV to override the uefi image
+  when:
+    - not cifmw_edpm_deploy_baremetal_dry_run
+    - cifmw_edpm_deploy_baremetal_default_uefi_image_url != cifmw_edpm_deploy_baremetal_uefi_image_url
+  ansible.builtin.command:
+    cmd: >-
+      oc patch csv -n openstack-operators openstack-baremetal-operator.v0.0.1
+      --type='json' -p='[{"op":"replace",
+      "path":"/spec/install/spec/deployments/0/spec/template/spec/containers/1/env/0",
+      "value": {"name": "OS_CONTAINER_IMAGE_URL_DEFAULT", "value": "{{ cifmw_edpm_deploy_baremetal_uefi_image_url }}"}}]'
+
 - name: Install Dataplane with baremetal
   vars:
     make_edpm_baremetal_env: "{{ cifmw_edpm_deploy_baremetal_common_env |


### PR DESCRIPTION
We are creating content-provider job for building uefi image in Pr[1], with this commit we add support for passing custom uefi image in bmaas job.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/312

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
