### PR TITLE
Add ci-framework in required-projects list for content-provider-build-images-base job

### DIFF
--- a/zuul.d/edpm_build_images_content_provider.yaml
+++ b/zuul.d/edpm_build_images_content_provider.yaml
@@ -7,6 +7,7 @@
     required-projects:
       - opendev.org/zuul/zuul-jobs
       - github.com/openstack-k8s-operators/edpm-image-builder
+      - github.com/openstack-k8s-operators/ci-framework
     pre-run:
       - ci/playbooks/content_provider/pre.yml
     run:


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
