### PR TITLE
Set cifmw_run_tests to false by default and run tempest on e2e jobs

### DIFF
--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -30,7 +30,7 @@
 
 - name: Import run test playbook
   ansible.builtin.import_playbook: ci_framework/playbooks/08-run-tests.yml
-  when: cifmw_run_tests | default('true') | bool
+  when: cifmw_run_tests | default('false') | bool
 
 - name: Run log related tasks
   ansible.builtin.import_playbook: ci_framework/playbooks/99-logs.yml

--- a/scenarios/centos-9/ci.yml
+++ b/scenarios/centos-9/ci.yml
@@ -28,6 +28,9 @@ post_ctlplane_deploy:
 cifmw_install_yamls_vars:
   BMO_SETUP: false
 
+# Enable tempest
+cifmw_run_tests: true
+
 # The actual ceph_make task understands "make_ceph_environment".
 # But since we're calling it via hook, in order to expose it properly, we
 # have to prefix it with "cifmw_". It will then end in the generated file from

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -48,8 +48,6 @@
     name: cifmw-crc-podified-edpm-baremetal
     parent: cifmw-base-crc-openstack
     run: ci/playbooks/edpm_baremetal_deployment/run.yml
-    vars:
-      cifmw_run_tests: false
 
 # Install Yamls specific job
 - job:


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/ci-framework/pull/216
enable tempest on end to end and edpm job.

Currently edpm and baremetal jobs run on multiple projects. Since it
is added recently. it is failing on EDPM job. It will block the prs.

This change changes the default value for cifmw_run_tests to false
and enable it in end to end jobs only.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

