### PR TITLE
Parse images file without beautifulsoup4

### DIFF
--- a/ci_framework/plugins/README.md
+++ b/ci_framework/plugins/README.md
@@ -45,6 +45,10 @@ Any of the `ansible.builtin.uri` module is supported.
   * description: Image prefix we want to filter.
   * required: True
   * type: str
+* `images_file`:
+  * description: Name of the file that contain the images with the corresponding hash
+  * required: False
+  * type: str
 
 ## Example:
 ```YAML
@@ -58,7 +62,8 @@ Any of the `ansible.builtin.uri` module is supported.
   ansible.builtin.set_fact:
     cifmw_discovered_image_name: "{{ discovered_image['data']['image_name'] }}"
     cifmw_discovered_image_url: "{{ discovered_image['data']['image_url'] }}"
-    cifmw_discovered_sha256: "{{ discovered_image['data']['sha256'] }}"
+    cifmw_discovered_hash: "{{ discovered_image['data']['hash'] }}"
+    cifmw_discovered_hash_algorithm: "{{ discovered_image['data']['hash_algorithm'] }}"
     cacheable: true
 ```
 

--- a/ci_framework/roles/discover_latest_image/README.md
+++ b/ci_framework/roles/discover_latest_image/README.md
@@ -1,15 +1,16 @@
 # discover_latest_image
 
-An Ansible role to discover latest Centos image.
+An Ansible role to discover latest Centos/RHEL image.
 
 ## Requirements
 
-This role is currently written for Centos.
+This role is currently written for Centos and RHEL.
 
 ## Role Variables
 
 * `cifmw_discover_latest_image_base_url`: (String) Base Url from where we can pull the Centos Image. Defaults to `<https://cloud.centos.org/centos/{{ ansible_distribution_major_version }}-stream/x86_64/images/.`
 * `cifmw_discover_latest_image_qcow_prefix`: (String) Qcow2 image prefix on base_url which will be used as a filter to find latest Centos Image. Defaults to `CentOS-Stream-GenericCloud-`.
+* `cifmw_discover_latest_image_images_file`: (String) Name of the file that contain the images with the corresponding hash. Default: `CHECKSUM`. Check the `IMAGES_FILES` constant of the `discover_latest_image.py` plugin.
 
 
 ## Examples

--- a/ci_framework/roles/discover_latest_image/defaults/main.yml
+++ b/ci_framework/roles/discover_latest_image/defaults/main.yml
@@ -20,3 +20,4 @@
 cifmw_discover_latest_image_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
 cifmw_discover_latest_image_base_url: https://cloud.centos.org/centos/{{ ansible_distribution_major_version }}-stream/x86_64/images/
 cifmw_discover_latest_image_qcow_prefix: CentOS-Stream-GenericCloud-
+cifmw_discover_latest_image_images_file: CHECKSUM

--- a/ci_framework/roles/discover_latest_image/molecule/default/converge.yml
+++ b/ci_framework/roles/discover_latest_image/molecule/default/converge.yml
@@ -27,8 +27,9 @@
         that:
           - cifmw_discovered_image_name is defined
           - cifmw_discovered_image_url is defined
-          - cifmw_discovered_sha256 is defined
+          - cifmw_discovered_hash is defined
+          - cifmw_discovered_hash_algorithm is defined
 
     - name: Print discover_latest_image variables
       ansible.builtin.debug:
-        msg: "{{ cifmw_discovered_image_name, cifmw_discovered_image_url, cifmw_discovered_sha256 }}"
+        msg: "{{ cifmw_discovered_image_name, cifmw_discovered_image_url, cifmw_discovered_hash, cifmw_discovered_hash_algorithm }}"

--- a/ci_framework/roles/discover_latest_image/tasks/main.yml
+++ b/ci_framework/roles/discover_latest_image/tasks/main.yml
@@ -19,10 +19,12 @@
   discover_latest_image:
     url: "{{ cifmw_discover_latest_image_base_url }}"
     image_prefix: "{{ cifmw_discover_latest_image_qcow_prefix }}"
+    images_file: "{{ cifmw_discover_latest_image_images_file }}"
 
 - name: Export facts accordingly
   ansible.builtin.set_fact:
     cifmw_discovered_image_name: "{{ discovered_image['data']['image_name'] }}"
     cifmw_discovered_image_url: "{{ discovered_image['data']['image_url'] }}"
-    cifmw_discovered_sha256: "{{ discovered_image['data']['sha256'] }}"
+    cifmw_discovered_hash: "{{ discovered_image['data']['hash'] }}"
+    cifmw_discovered_hash_algorithm: "{{ discovered_image['data']['hash_algorithm'] }}"
     cacheable: true

--- a/ci_framework/roles/libvirt_manager/defaults/main.yml
+++ b/ci_framework/roles/libvirt_manager/defaults/main.yml
@@ -31,7 +31,7 @@ cifmw_libvirt_manager_configuration:
     compute:
       amount: "{{ cifmw_libvirt_manager_compute_amount }}"
       image_url: "{{ cifmw_discovered_image_url | default('{{ cifmw_libvirt_manager_images_url }}/CentOS-Stream-GenericCloud-9-20230410.0.x86_64.qcow2') }}"
-      sha256_image_name: "{{ cifmw_discovered_sha256 | default('8a5abbf8b0dda3e4e49b5112ffae3fff022bf97a5f53b868adbfb80c75c313fe') }}"
+      sha256_image_name: "{{ cifmw_discovered_hash | default('8a5abbf8b0dda3e4e49b5112ffae3fff022bf97a5f53b868adbfb80c75c313fe') }}"
       image_local_dir: "{{ cifmw_libvirt_manager_basedir }}/images/"
       disk_file_name: "centos-9-stream.qcow2"
       # GB

--- a/ci_framework/roles/local_env_vm/tasks/main.yml
+++ b/ci_framework/roles/local_env_vm/tasks/main.yml
@@ -46,7 +46,7 @@
       ansible.builtin.get_url:
         url: "{{ cifmw_discovered_image_url }}"
         dest: "{{ cifmw_local_env_vm_basedir }}/images/{{ cifmw_discovered_image_name }}"
-        checksum: "sha256:{{ cifmw_discovered_sha256 }}"
+        checksum: "{{ cifmw_discovered_hash_algorithm }}:{{ cifmw_discovered_hash }}"
       until:
         - dload_img.status_code is defined
         - dload_img.status_code == 200

--- a/docs/source/quickstart/03_psi.md
+++ b/docs/source/quickstart/03_psi.md
@@ -66,7 +66,7 @@ ssh cloud-user@<obtained IP> -i ~/.ssh/rhos-jenkins
 ```
 sudo yum -y groupinstall "Development Tools"
 sudo yum -y install  qemu-img qemu-kvm libguestfs libguestfs-tools-c wget pip
-python3 -m pip install --user ansible jmespath beautifulsoup4
+python3 -m pip install --user ansible jmespath
 ```
 
 6. **Continue with Quickstart**

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pbr>=1.6
 requests
-beautifulsoup4


### PR DESCRIPTION
Removed The beautifulsoup4 library to parse the HTML content of the CentOS mirror images list. In this case we can go directly into the CHECKSUM file and get the lastest image without parsing an entire HTML file.

Result:

```
{'success': True, 'changed': True, 'error': '', 'data': {'image_name': 'CentOS-Stream-GenericCloud-9-20230612.0.x86_64.qcow2', 'image_url': 'https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230612.0.x86_64.qcow2', 'sha256': 'bd0b39afe40d06bc7b92279aea9e85372d4dfa2bafe8f02ad11ce486193c44d8'}}
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
