### PR TITLE
Improvement to tempest role

### DIFF
--- a/ci_framework/playbooks/08-run-tests.yml
+++ b/ci_framework/playbooks/08-run-tests.yml
@@ -9,6 +9,8 @@
   gather_facts: false
   tasks:
     - name: Run tempest
+      tags:
+        - tests
       ansible.builtin.import_role:
         name: tempest
 

--- a/ci_framework/roles/tempest/README.md
+++ b/ci_framework/roles/tempest/README.md
@@ -12,3 +12,4 @@ become - Required to install required rpm packages
 * `cifmw_tempest_image`: (String) Name of the tempest image to be used. Default to `quay.io/podified-antelope-centos9/openstack-tempest`
 * `cifmw_tempest_image_tag`: (String) Tag for the `cifmw_tempest_image`. Default to `current-podified`
 * `cifmw_tempest_dry_run`: (Boolean) Whether tempest should run or not. Default to `false`
+* `cifmw_tempest_remove_container`: (Boolean) Cleanup tempest container after it is done. Default to `false`

--- a/ci_framework/roles/tempest/defaults/main.yml
+++ b/ci_framework/roles/tempest/defaults/main.yml
@@ -25,3 +25,4 @@ cifmw_tempest_default_jobs:
 cifmw_tempest_image: quay.io/podified-antelope-centos9/openstack-tempest
 cifmw_tempest_image_tag: current-podified
 cifmw_tempest_dry_run: false
+cifmw_tempest_remove_container: false

--- a/ci_framework/roles/tempest/tasks/main.yml
+++ b/ci_framework/roles/tempest/tasks/main.yml
@@ -37,8 +37,37 @@
     cmd: "podman unshare chown 42480:42480 -R {{ cifmw_tempest_artifacts_basedir }}"
   when: not cifmw_tempest_dry_run | bool
 
-# > {{ cifmw_tempest_artifacts_basedir }}/tempest_output.log"
 - name: Run tempest
-  ansible.builtin.command:
-    cmd: "podman run -v {{ cifmw_tempest_artifacts_basedir }}/:/var/lib/tempest/external_files:Z {{ cifmw_tempest_image }}:{{ cifmw_tempest_image_tag }}"
+  ignore_errors: true
+  containers.podman.podman_container:
+    name: tempest
+    image: "{{ cifmw_tempest_image }}:{{ cifmw_tempest_image_tag }}"
+    state: started
+    auto_remove: "{{ cifmw_tempest_remove_container | default(false) }}"
+    volume:
+      - "{{ cifmw_tempest_artifacts_basedir }}/:/var/lib/tempest/external_files:Z"
+    detach: false
   when: not cifmw_tempest_dry_run | bool
+  register: tempest_run_output
+
+- name: Change tempest directory permission back to original
+  become: true
+  ansible.builtin.file:
+    path: "{{ cifmw_tempest_artifacts_basedir }}"
+    state: directory
+    recurse: true
+    owner: "{{ lookup('env', 'USER') }}"
+    group: "{{ lookup('env', 'USER') }}"
+
+- name: Save logs from podman
+  when: not cifmw_tempest_dry_run | bool
+  ansible.builtin.copy:
+    dest: "{{ cifmw_tempest_artifacts_basedir}}/podman_tempest.log"
+    content: |
+      "{{ tempest_run_output.stdout }}"
+
+- name: Fail if podman container did not succeed
+  when: not cifmw_tempest_dry_run | bool
+  assert:
+    that:
+      - "tempest_run_output.failed == false"

--- a/zuul.d/end-to-end.yaml
+++ b/zuul.d/end-to-end.yaml
@@ -51,8 +51,6 @@
       - ^OWNERS
       - ^.github
     run: ci/playbooks/e2e-run.yml
-    vars:
-      cifmw_run_tests: false
 
 # Run the dev workflow if we edit specific role(s)
 - job:


### PR DESCRIPTION
Replace the ansible.builtin.command for podman_container. This makes it more "ansible way" to run a container.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
