### PR TITLE
edpm_prepare: custom timeout for ControlPlane

### DIFF
--- a/ci_framework/roles/edpm_prepare/defaults/main.yml
+++ b/ci_framework/roles/edpm_prepare/defaults/main.yml
@@ -23,3 +23,4 @@ cifmw_edpm_prepare_skip_openstack_operator: false
 cifmw_edpm_prepare_wait_subscription_retries: 30
 cifmw_edpm_prepare_dry_run: false
 cifmw_edpm_prepare_skip_crc_storage_creation: false
+cifmw_edpm_prepare_ctrlplane_timeout: "30m"

--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -142,7 +142,7 @@
           oc wait OpenStackControlPlane {{ (cifmw_edpm_prepare_ctrlplane_cr_slurp['content'] | b64decode | from_yaml).metadata.name }}
           --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
           --for=condition=OpenStackControlPlaneNeutronReady
-          --timeout=30m
+          --timeout={{ cifmw_edpm_prepare_ctrlplane_timeout | default('30m') }}
 
     - name: Wait for OpenStack controlplane to be deployed
       environment:
@@ -153,4 +153,4 @@
           oc wait OpenStackControlPlane {{ (cifmw_edpm_prepare_ctrlplane_cr_slurp['content'] | b64decode | from_yaml).metadata.name }}
           --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
           --for=condition=ready
-          --timeout=30m
+          --timeout={{ cifmw_edpm_prepare_ctrlplane_timeout | default('30m') }}


### PR DESCRIPTION
Enable setting custom timeout for ControPlane deployment getting Ready. In some cases (esp nested virtualization) it seems it might need extra time.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
