### PR TITLE
Add improved common validation for openshift_login molecule tests

### DIFF
--- a/ci_framework/roles/openshift_login/molecule/default/converge.yml
+++ b/ci_framework/roles/openshift_login/molecule/default/converge.yml
@@ -25,10 +25,7 @@
     - role: "openshift_login"
   tasks:
   - name: Assert variables are in place
-    ansible.builtin.assert:
-      that:
-        - cifmw_openshift_user is defined and cifmw_openshift_user == 'system:admin'
-        - cifmw_openshift_login_api is defined and cifmw_openshift_login_api == 'https://api.crc.testing:6443'
-        - cifmw_openshift_context is defined and cifmw_openshift_context != ''
-        # system:admin doesn't support token based login
-        - not cifmw_openshift_token is defined
+    vars:
+      kubeconfig_target_path: "{{ cifmw_openshift_kubeconfig }}"
+    ansible.builtin.import_tasks:
+      file: validate_login_facts.yml

--- a/ci_framework/roles/openshift_login/molecule/default/validate_login_facts.yml
+++ b/ci_framework/roles/openshift_login/molecule/default/validate_login_facts.yml
@@ -1,0 +1,53 @@
+---
+- name: Fetch kubeconfig content for validation
+  register: kubeconfig_slurp
+  ansible.builtin.slurp:
+    path: "{{ kubeconfig_target_path }}"
+
+- name: Prepare assertion data frpm kubeconfig
+  vars:
+    kubeconfig_yaml: "{{ kubeconfig_slurp ['content'] | b64decode | from_yaml }}"
+  block:
+    - name: Set kubeconfig context data for further asserts
+      ansible.builtin.set_fact:
+        kubeconfig_content: "{{ kubeconfig_yaml }}"
+        kubeconfig_context_name: "{{ kubeconfig_yaml['current-context'] }}"
+        kubeconfig_context: "{{ (kubeconfig_yaml['contexts'] | selectattr('name', 'equalto', kubeconfig_yaml['current-context']) | first).context }}"
+        cacheable: true
+
+    - name: Set kubeconfig user and server data for further asserts
+      ansible.builtin.set_fact:
+        kubeconfig_user_id: "{{ kubeconfig_context['user'] }}"
+        kubeconfig_user_name: "{{ kubeconfig_context['user'] | split('/') | first }}"
+        kubeconfig_user: "{{ (kubeconfig_yaml['users'] | selectattr('name', 'equalto', kubeconfig_context['user']) | first).user }}"
+        kubeconfig_cluster_name: "{{ kubeconfig_context['cluster'] }}"
+        kubeconfig_cluster: "{{ (kubeconfig_yaml['clusters'] | selectattr('name', 'equalto', kubeconfig_context['cluster']) | first).cluster }}"
+        cacheable: true
+
+- name: Assert variables are in place
+  ansible.builtin.assert:
+    that:
+      # kubeconfig
+      - cifmw_openshift_kubeconfig is defined and cifmw_openshift_kubeconfig == kubeconfig_target_path
+      - cifmw_openshift_login_kubeconfig is defined and cifmw_openshift_login_kubeconfig == cifmw_openshift_kubeconfig
+
+      # username
+      - cifmw_openshift_user is defined and cifmw_openshift_user == kubeconfig_user_name
+      - cifmw_openshift_login_user is defined and cifmw_openshift_login_user == cifmw_openshift_user
+
+      # API url
+      - cifmw_openshift_api is defined and cifmw_openshift_login_api == kubeconfig_cluster.server
+      - cifmw_openshift_login_api is defined and cifmw_openshift_login_api == cifmw_openshift_api
+
+      # kubeconfig context
+      - cifmw_openshift_context is defined and cifmw_openshift_context == kubeconfig_context_name
+      - cifmw_openshift_login_context is defined and cifmw_openshift_login_context == cifmw_openshift_context
+
+      # token, if available
+      - ('token' in kubeconfig_user) |
+        ternary(
+          cifmw_openshift_token is defined and
+          cifmw_openshift_token == kubeconfig_user['token'] and
+          cifmw_openshift_login_token is defined and
+          cifmw_openshift_login_token == cifmw_openshift_token
+        , true)

--- a/ci_framework/roles/openshift_login/molecule/login_pwd_kubeconfig/converge.yml
+++ b/ci_framework/roles/openshift_login/molecule/login_pwd_kubeconfig/converge.yml
@@ -30,9 +30,7 @@
         name: openshift_login
 
     - name: Assert variables are in place
-      ansible.builtin.assert:
-        that:
-          - cifmw_openshift_user is defined and cifmw_openshift_user == 'kubeadmin'
-          - cifmw_openshift_login_api is defined and cifmw_openshift_login_api == 'https://api.crc.testing:6443'
-          - cifmw_openshift_context is defined and cifmw_openshift_context != ''
-          - cifmw_openshift_token is defined and cifmw_openshift_token != ''
+      vars:
+        kubeconfig_target_path: "{{ cifmw_openshift_login_kubeconfig }}"
+      ansible.builtin.import_tasks:
+        file: "../default/validate_login_facts.yml"

--- a/ci_framework/roles/openshift_login/molecule/login_pwd_no_kubeconfig/converge.yml
+++ b/ci_framework/roles/openshift_login/molecule/login_pwd_no_kubeconfig/converge.yml
@@ -29,17 +29,8 @@
       ansible.builtin.import_role:
         name: openshift_login
 
-    - name: Check kubeconfig availabilty
-      register: kubeconfig_stat
-      ansible.builtin.stat:
-        path: "{{ ansible_user_dir + '/ci-framework-data/.kube/config' }}"
-
     - name: Assert variables are in place
-      ansible.builtin.assert:
-        that:
-          - cifmw_openshift_user is defined and cifmw_openshift_user == 'kubeadmin'
-          - cifmw_openshift_login_api is defined and cifmw_openshift_login_api == 'https://api.crc.testing:6443'
-          - cifmw_openshift_kubeconfig is defined and cifmw_openshift_kubeconfig == (ansible_user_dir + '/ci-framework-data/.kube/config')
-          - cifmw_openshift_context is defined and cifmw_openshift_context != ''
-          - cifmw_openshift_token is defined and cifmw_openshift_token != ''
-          - kubeconfig_stat.stat.exists
+      vars:
+        kubeconfig_target_path: "{{ ansible_user_dir + '/ci-framework-data/.kube/config' }}"
+      ansible.builtin.import_tasks:
+        file: "../default/validate_login_facts.yml"

--- a/ci_framework/roles/openshift_login/molecule/login_token_based/converge.yml
+++ b/ci_framework/roles/openshift_login/molecule/login_token_based/converge.yml
@@ -27,23 +27,11 @@
     cifmw_install_yamls_environment: {}
   tasks:
     - name: Login
-      ansible.builtin.debug:
-        msg: "{{ cifmw_openshift_provided_token }}"
-
-    - name: Login
       ansible.builtin.import_role:
         name: openshift_login
 
-    - name: Check kubeconfig availabilty
-      register: kubeconfig_stat
-      ansible.builtin.stat:
-        path: "{{ cifmw_openshift_kubeconfig }}"
-
     - name: Assert variables are in place
-      ansible.builtin.assert:
-        that:
-          - cifmw_openshift_user is defined and cifmw_openshift_user == 'kubeadmin'
-          - cifmw_openshift_login_api is defined and cifmw_openshift_login_api == 'https://api.crc.testing:6443'
-          - cifmw_openshift_context is defined and cifmw_openshift_context != ''
-          - cifmw_openshift_token is defined and cifmw_openshift_token != ''
-          - kubeconfig_stat.stat.exists
+      vars:
+        kubeconfig_target_path: "{{ cifmw_openshift_kubeconfig }}"
+      ansible.builtin.import_tasks:
+        file: "../default/validate_login_facts.yml"


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date
