### PR TITLE
Set DEPLOY_DIR var in BM jobs

### DIFF
--- a/ci_framework/roles/install_yamls/defaults/main.yml
+++ b/ci_framework/roles/install_yamls/defaults/main.yml
@@ -28,6 +28,7 @@ cifmw_install_yamls_manifests_dir: "{{ cifmw_manifests | default(cifmw_install_y
 cifmw_install_yamls_repo: "{{ cifmw_installyamls_repos | default(ansible_user_dir ~ '/src/github.com/openstack-k8s-operators/install_yamls') }}"
 cifmw_install_yamls_tasks_out: "{{ cifmw_install_yamls_out_dir }}/roles/install_yamls_makes/tasks"
 cifmw_install_yamls_whitelisted_vars:
+  - DEPLOY_DIR
   - KUBECONFIG
   - OUTPUT_BASEDIR
   - OUTPUT_DIR

--- a/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
+++ b/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
@@ -4,6 +4,7 @@ cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-o
 cifmw_install_yamls_vars:
   OUTPUT_DIR: "{{ cifmw_basedir }}/artifacts/edpm_compute" # used by gen-ansibleee-ssh-key.sh
   OUTPUT_BASEDIR: "{{ cifmw_basedir }}/artifacts/edpm_compute" # used by gen-edpm-compute-node.sh
+  DEPLOY_DIR: "{{ cifmw_basedir }}/artifacts/edpm_compute" # used during Baremetal deployment
   SSH_KEY: "{{ cifmw_basedir }}/artifacts/edpm_compute/ansibleee-ssh-key-id_rsa"
   NETWORK_ISOLATION: false
   STORAGE_CLASS: crc-csi-hostpath-provisioner


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/install_yamls/pull/339/files#diff-274a7c302ea3acca968d0bda33efaca145d8e14cb3b905c6f7a56b87fcd5ef38R18 adds DEPLOY_DIR var in BMAAS EDPM compute deployment.

This var needs to be set to collect proper logs and artifacts once the deployment completes.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

