### PR TITLE
Inject a README file in generated logs

### DIFF
--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -56,6 +56,11 @@
                 cmd: |
                   ls -lRZ --hide=venv --hide=repo-setup {{ ansible_user_dir }}/ci-framework-data > ./selinux-listing.log;
 
+            - name: Generate log index
+              ansible.builtin.copy:
+                dest: "{{ ansible_user_dir }}/zuul-output/logs/README.html"
+                src: "important-logs.html"
+
         - name: Get some env related data
           ansible.builtin.shell:
             chdir: "{{ ansible_user_dir }}/zuul-output/logs/"

--- a/ci/playbooks/files/important-logs.html
+++ b/ci/playbooks/files/important-logs.html
@@ -1,0 +1,46 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+<head>
+<title>README for CIFMW Logs</title>
+</head>
+<body>
+<style>
+        .collapsible {
+            background-color: #777;
+            color: white;
+            cursor: pointer;
+            padding: 18px;
+            width: 100%;
+            border: none;
+            text-align: left;
+            outline: none;
+            font-size: 15px;
+        }
+
+        .active, .collapsible:hover {
+            background-color: #555;
+        }
+
+        .content {
+            padding: 0 18px;
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height 0.2s ease-out;
+            background-color: #f1f1f1;
+        }
+</style>
+<h3>Logs of interest</h3>
+<ul>
+  <li><a href="./ci-framework-data/logs">All Framework logs</a></li>
+  <li><a href="./ci-framework-data/logs/crc">CRC dedicated logs</a></li>
+  <li><a href="./ci-framework-data/logs/edpm">EDPM logs and data</a></li>
+  <li><a href="./selinux-denials.log">SELinux denials</a></li>
+</ul>
+<h3>Generated content of interest</h3>
+<ul>
+  <li><a href="./ci-framework-data/artifacts">Artifacts</a></li>
+  <li><a href="./ci-framework-data/artifacts/roles">Generated role</a></li>
+  <li><a href="./ci-framework-data/artifacts/parameters">Ansible parameters</a></li>
+  <li><a href="./ci-framework-data/artifacts/manifests">Operator manifests</a></li>
+</ul>
+</body>


### PR DESCRIPTION
This should help users getting straight to the logs.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
