### PR TITLE
Add collect container stats

### DIFF
--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -73,6 +73,17 @@
             cmd: |
               cp {{ ansible_user_dir }}/*.log .;
 
+        - name: Copy crio stats log file
+          ansible.builtin.copy:
+            src: /tmp/crio-stats.log
+            dest: "{{ ansible_user_dir }}/zuul-output/logs/"
+            owner: "{{ ansible_user }}"
+            group: "{{ ansible_user }}"
+            mode: "0644"
+            remote_src: true
+          when: cifmw_openshift_crio_stats | default(true)
+          ignore_errors: true
+
         - name: Get SELinux related data
           become: true
           ignore_errors: true # if the ausearch | grep fails, we don't want to fail.

--- a/ci/playbooks/e2e-prepare.yml
+++ b/ci/playbooks/e2e-prepare.yml
@@ -28,3 +28,10 @@
       community.general.make:
         chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
         target: setup_molecule
+
+    - name: Add cronjob to trigger job stats
+      ansible.builtin.cron:
+        name: Get cri-o container stats
+        minute: "*"
+        job: "/usr/bin/date >> /tmp/crio-stats.log; {{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/scripts/get-stats.sh >> /tmp/crio-stats.log"
+      when: cifmw_openshift_crio_stats | default(true)

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -30,6 +30,7 @@ provisioned with bmaas vs pre-provisioned VM.
 * `cifmw_openshift_password`: (String) Login password. If provided is the password used for login in.
 * `cifmw_use_opn`: (Bool) toggle openshift provisioner node support.
 * `cifmw_use_hive`: (Bool) toggle OpenShift deployment using hive operator.
+* `cifmw_openshift_crio_stats`: (Bool) toggle collecting cri-o stats in CRC deployment
 
 #### Words of caution
 If you want to output the content in another location than `~/ci-framework-data`

--- a/scripts/get-stats.sh
+++ b/scripts/get-stats.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+## Shell Opts ----------------------------------------------------------------
+set -o pipefail
+set -x
+
+DURATION_TIME=${DURATION_TIME:-10}
+
+NODE_NAMES=$(/usr/local/bin/oc get node -o name -l node-role.kubernetes.io/worker)
+if [ -z "$NODE_NAMES" ]; then
+    echo "Unable to determine node name with 'oc' command."
+    exit 1
+fi
+
+for node in $NODE_NAMES; do
+    /usr/local/bin/oc debug $node -T -- chroot /host /usr/bin/bash -c "crictl stats -a -s $DURATION_TIME |  (sed -u 1q; sort -k 2 -h -r)"
+done


### PR DESCRIPTION
This script with the cronjob will collect container stats in cri-o runtime. Later, these statistics will help the CI team to debug the status of the CRC job.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
