### PR TITLE
Collect output of cluster-info command

### DIFF
--- a/ci_framework/roles/artifacts/tasks/cluster_info.yml
+++ b/ci_framework/roles/artifacts/tasks/cluster_info.yml
@@ -78,3 +78,13 @@
         chdir: "{{ cifmw_artifacts_basedir }}/logs/edpm"
       changed_when: true
       ignore_errors: true
+
+    - name: Dump cluster info for debugging
+      ansible.builtin.shell: |
+        mkdir cluster_info
+        oc cluster-info dump --all-namespaces -o yaml --output-directory={{ cifmw_artifacts_basedir }}/logs/cluster_info
+        oc cluster-info -o yaml > {{ cifmw_artifacts_basedir }}/logs/cluster_info.yaml
+      args:
+        chdir: "{{ cifmw_artifacts_basedir }}/logs"
+      changed_when: true
+      ignore_errors: true


### PR DESCRIPTION
It will be useful to collect more logs about
the cluster.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

