### PR TITLE
Collect logs for BMO and ironic

### DIFF
--- a/ci_framework/roles/artifacts/tasks/cluster_info.yml
+++ b/ci_framework/roles/artifacts/tasks/cluster_info.yml
@@ -47,7 +47,7 @@
         # in the correct pod directory. That is why we do not cd after
         # creating the directory.
         mkdir pod
-        for ns in openstack-operators openstack; do
+        for ns in openstack-operators openstack baremetal-operator-system openshift-machine-api; do
           for pod in $(oc get pods -o name -n ${ns}); do
             oc logs ${pod} -n ${ns} > ${pod}-logs.txt
             oc get -o yaml ${pod} -n ${ns} > ${pod}.yaml


### PR DESCRIPTION
We need to collect the logs for baremetal-operator and ironic used for baremetal provisioning.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running