### PR TITLE
Deploy metallb for DNS in baremetal job

### DIFF
--- a/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -28,6 +28,22 @@
       {% endif %}
     cifmw_edpm_deploy_baremetal_operators_build_output: "{{ operators_build_output }}"
 
+- name: Install metallb-operator
+  vars:
+    make_metallb_env: "{{ cifmw_edpm_deploy_baremetal_common_env }}"
+    make_metallb_dryrun: "{{ cifmw_edpm_deploy_baremetal_dry_run }}"
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_metallb'
+
+- name: Configure metallb for DNS
+  vars:
+    make_metallb_config_env: "{{ cifmw_edpm_deploy_baremetal_common_env }}"
+    make_metallb_config_dryrun: "{{ cifmw_edpm_deploy_baremetal_dry_run }}"
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_metallb_config'
+
 - name: Install Dataplane with baremetal
   vars:
     make_edpm_baremetal_env: "{{ cifmw_edpm_deploy_baremetal_common_env |

--- a/ci_framework/roles/install_yamls/defaults/main.yml
+++ b/ci_framework/roles/install_yamls/defaults/main.yml
@@ -25,10 +25,12 @@ cifmw_install_yamls_manifests_dir: "{{ cifmw_manifests | default(cifmw_install_y
 # cifmw_install_yamls_vars:
 #   MICROSHIFT: 1
 #   NAMESPACE: openstack
+#   METALLB_POOL would be removed once https://github.com/openstack-k8s-operators/install_yamls/pull/356 merges.
 cifmw_install_yamls_repo: "{{ cifmw_installyamls_repos | default(ansible_user_dir ~ '/src/github.com/openstack-k8s-operators/install_yamls') }}"
 cifmw_install_yamls_tasks_out: "{{ cifmw_install_yamls_out_dir }}/roles/install_yamls_makes/tasks"
 cifmw_install_yamls_whitelisted_vars:
   - DEPLOY_DIR
+  - METALLB_POOL
   - KUBECONFIG
   - OUTPUT_BASEDIR
   - OUTPUT_DIR

--- a/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
+++ b/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
@@ -8,6 +8,8 @@ cifmw_install_yamls_vars:
   SSH_KEY: "{{ cifmw_basedir }}/artifacts/edpm_compute/ansibleee-ssh-key-id_rsa"
   NETWORK_ISOLATION: false
   PROVISIONING_INTERFACE: crc-bmaas
+  NNCP_INTERFACE: crc-bmaas
+  METALLB_POOL: 172.22.0.80-172.22.0.90
   STORAGE_CLASS: crc-csi-hostpath-provisioner
   BMAAS_NODE_COUNT: 1
   DATAPLANE_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/dataplane-operator"


### PR DESCRIPTION
This is is required to configure the endpoint. As we're not using NETWORK_ISOLATION=true with baremetal job we have to configure it separately for DNS LB endpoint.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

