### PR TITLE
edpm_build_images periodic job

### DIFF
--- a/ci/playbooks/edpm_build_images/edpm_image_builder.yml
+++ b/ci/playbooks/edpm_build_images/edpm_image_builder.yml
@@ -3,6 +3,19 @@
   ansible.builtin.import_playbook: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/ci_framework/playbooks/01-bootstrap.yml"
 - hosts: all
   tasks:
+    - name: Read hash from delorean.repo.md5 file
+      tags:
+        - edpm_build_img
+      ansible.builtin.slurp:
+        path: "{{ cifmw_basedir }}/artifacts/repositories/delorean.repo.md5"
+      register: file_content
+
+    - name: Set fact for cifmw_edpm_build_images_tag var
+      tags:
+        - edpm_build_img
+      ansible.builtin.set_fact:
+        cifmw_edpm_build_images_tag: "{{ file_content['content'] | b64decode | string | trim }}"
+
     - name: Run EDPM image builder
       tags:
         - edpm_build_img

--- a/ci_framework/roles/edpm_build_images/README.md
+++ b/ci_framework/roles/edpm_build_images/README.md
@@ -25,6 +25,9 @@ None
 * `cifmw_edpm_build_images_dib_yum_repo_conf`: (List) List of yum repos to be used, By default we select i.e `cifmw_edpm_build_images_dib_yum_repo_conf_centos` var or `cifmw_edpm_build_images_dib_yum_repo_conf_rhel` based on distro var.
 * `cifmw_edpm_build_images_tag`: (String) Tag with which we want to build container images. Default: `latest`.
 * `cifmw_edpm_build_images_dry_run`: (Boolean) Whether to perform a dry run of the image build. Default: false.
+* `cifmw_edpm_build_images_push_container_images`: (Boolean) Whether to push container images to remote registry. Default: false.
+* `cifmw_edpm_build_images_push_registry`: (String) Push registry where we want to push container images. Default: `quay.rdoproject.org`.
+* `cifmw_edpm_build_images_push_registry_namespace`: (String) Namespace on registry where we want to push container images. Default: `podified-main-centos9`.
 
 ### Example
 ```YAML

--- a/ci_framework/roles/edpm_build_images/defaults/main.yml
+++ b/ci_framework/roles/edpm_build_images/defaults/main.yml
@@ -51,3 +51,6 @@ cifmw_edpm_build_images_dib_yum_repo_conf: >-
   {%- endif %}
 cifmw_edpm_build_images_tag: 'latest'
 cifmw_edpm_build_images_dry_run: false
+cifmw_edpm_build_images_push_registry: 'quay.rdoproject.org'
+cifmw_edpm_build_images_push_registry_namespace: 'podified-main-centos9'
+cifmw_edpm_build_images_push_container_images: false

--- a/ci_framework/roles/edpm_build_images/tasks/main.yml
+++ b/ci_framework/roles/edpm_build_images/tasks/main.yml
@@ -41,3 +41,7 @@
 
 - name: Package build images inside container image
   ansible.builtin.import_tasks: package.yml
+
+- name: Push container images to quay.rdoproject.org
+  when: cifmw_edpm_build_images_push_container_images | bool
+  ansible.builtin.import_tasks: post.yaml

--- a/ci_framework/roles/edpm_build_images/tasks/post.yaml
+++ b/ci_framework/roles/edpm_build_images/tasks/post.yaml
@@ -1,0 +1,36 @@
+---
+- name: "Push images to registry with {{ cifmw_edpm_build_images_tag }} tag"
+  containers.podman.podman_image:
+    name: "{{ item }}"
+    push_args:
+      dest: "{{ cifmw_edpm_build_images_push_registry }}/{{ cifmw_edpm_build_images_push_registry_namespace }}"
+    tag: "{{ cifmw_edpm_build_images_tag }}"
+    pull: false
+    push: yes
+  loop:
+    - edpm-hardened-uefi
+    - ironic-python-agent
+
+- name: Retag and push the images with podified-ci-testing tag
+  when: cifmw_repo_setup_promotion == "podified-ci-testing"
+  block:
+    - name: Retag the images with podified-ci-testing tag
+      containers.podman.podman_tag:
+        image: "{{ item }}:{{ cifmw_edpm_build_images_tag }}"
+        target_names:
+          - "{{ item }}:podified-ci-testing"
+      loop:
+        - edpm-hardened-uefi
+        - ironic-python-agent
+
+    - name: Push images to registry with podified-ci-testing tag
+      containers.podman.podman_image:
+        name: "{{ item }}"
+        push_args:
+          dest: "{{ cifmw_edpm_build_images_push_registry }}/{{ cifmw_edpm_build_images_push_registry_namespace }}"
+        tag: podified-ci-testing
+        pull: false
+        push: yes
+      loop:
+        - edpm-hardened-uefi
+        - ironic-python-agent

--- a/zuul.d/edpm_build_images.yaml
+++ b/zuul.d/edpm_build_images.yaml
@@ -4,7 +4,7 @@
     nodeset: centos-stream-9
     timeout: 5400
     abstract: true
-    parent: base-ci-framework
+    parent: edpm-image-build-base
     required-projects:
       - github.com/openstack-k8s-operators/edpm-image-builder
     pre-run:

--- a/zuul.d/edpm_periodic.yaml
+++ b/zuul.d/edpm_periodic.yaml
@@ -11,6 +11,16 @@
     parent: cifmw-crc-podified-edpm-baremetal
     vars: *edpm_vars
 
+- job:
+    name: periodic-edpm-build-push-images-centos-9-master
+    parent: cifmw-base-edpm-build-images
+    vars:
+      cifmw_repo_setup_branch: master
+      cifmw_repo_setup_promotion: podified-ci-testing
+      openstack_release: master
+      cifmw_edpm_build_images_push_container_images: true
+      registry_login_enabled: true
+
 # Antelope jobs
 - job:
     name: periodic-podified-edpm-deployment-antelope-ocp-crc-1cs9
@@ -25,3 +35,11 @@
     vars:
       cifmw_repo_setup_branch: antelope
       cifmw_set_openstack_containers_namespace: podified-{{ cifmw_repo_setup_branch }}-centos9
+
+- job:
+    name: periodic-edpm-build-push-images-centos-9-antelope
+    parent: periodic-edpm-build-push-images-centos-9-master
+    vars:
+      cifmw_repo_setup_branch: antelope
+      openstack_release: "{{ cifmw_repo_setup_branch }}"
+      cifmw_edpm_build_images_push_registry_namespace: "podified-{{ cifmw_repo_setup_branch }}-centos9"


### PR DESCRIPTION
With this commit, we do the following:-

* * Change parent of job `cifmw-base-edpm-build-images` to
`edpm-image-build-base` as it have secrets to push images.
* Enhance image build playbook to read hash from delorean.repo.md5
* Set cifmw_edpm_build_images_tag with the hash we found in
delorean.repo.md5 file
* Add a task file to push images to remote registry which will be
included based on `cifmw_edpm_build_images_push_container_images`
var, by default `false`
* We will build and push container image with hash found in
delorean.repo.md5.
* Retag the container image with `podified-ci-testing` hash if
we are running this job in periodic line.
(when cifmw_repo_setup_promotion: podified-ci-testing)
* Add periodic job definition for building uefi/ipa image.



As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
