### PR TITLE
Set proper image element files based on distro

### DIFF
--- a/ci_framework/roles/edpm_build_images/tasks/run.yml
+++ b/ci_framework/roles/edpm_build_images/tasks/run.yml
@@ -9,7 +9,12 @@
     DIB_YUM_REPO_CONF: "{{ cifmw_edpm_build_images_dib_yum_repo_conf | join(' ') }}"
     ELEMENTS_PATH: "{{ cifmw_edpm_build_images_elements | join(':') }}"
   ansible.builtin.shell: >-
-    diskimage-builder images/edpm-hardened-uefi-{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version }}-stream.yaml
+    diskimage-builder
+    {% if ansible_distribution | lower == 'centos' %}
+    images/edpm-hardened-uefi-{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version }}-stream.yaml
+    {% else %}
+    images/edpm-hardened-uefi-rhel-{{ ansible_distribution_major_version }}.yaml
+    {% endif %}
     > {{ cifmw_edpm_build_images_basedir }}/logs/edpm_images/edpm_hardened_uefi_image_build.log
     2> {{ cifmw_edpm_build_images_basedir }}/logs/edpm_images/edpm_hardened_uefi_image_build_err.log
   args:
@@ -25,7 +30,12 @@
     DIB_YUM_REPO_CONF: "{{ cifmw_edpm_build_images_dib_yum_repo_conf | join(' ') }}"
     ELEMENTS_PATH: "{{ cifmw_edpm_build_images_elements | join(':') }}"
   ansible.builtin.shell: >-
-    diskimage-builder images/ironic-python-agent-{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version }}-stream.yaml
+    diskimage-builder
+    {% if ansible_distribution | lower == 'centos' %}
+    images/ironic-python-agent-{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version }}-stream.yaml
+    {% else %}
+    images/ironic-python-agent-rhel-{{ ansible_distribution_major_version }}.yaml
+    {% endif %}
     > {{ cifmw_edpm_build_images_basedir }}/logs/edpm_images/ironic_python_agent_image_build.log
     2> {{ cifmw_edpm_build_images_basedir }}/logs/edpm_images/ironic_python_agent_image_build_err.log
   args:


### PR DESCRIPTION
Image element files in edpm-image-builder repo are ending with 9-stream.yaml for centos and -9.yaml for Red Hat. We need to add conditional in order to make sure proper image elements file are passed to diskimage builder otherwise edpm image building will fail.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

