### PR TITLE
Drop quote from delorean.repo.md5 content

### DIFF
--- a/ci_framework/roles/repo_setup/tasks/artifacts.yml
+++ b/ci_framework/roles/repo_setup/tasks/artifacts.yml
@@ -17,5 +17,5 @@
 - name: Dump full hash in delorean.repo.md5 file
   ansible.builtin.copy:
     content: |
-      "{{ _get_hash.stdout | from_json | community.general.json_query('full_hash') }}"
+      {{ _get_hash.stdout | from_json | community.general.json_query('full_hash') }}
     dest: "{{ cifmw_repo_setup_basedir }}/artifacts/repositories/delorean.repo.md5"


### PR DESCRIPTION
Currently repo-setup roles delorean.repo.md5 content with "". It causes issues when we consumes the output in different tasks. Removing quotes while running creating the md5 file fixes the issue.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

