### PR TITLE
Add a new tag we can then filter on

### DIFF
--- a/ci/playbooks/edpm_build_images/edpm_image_builder.yml
+++ b/ci/playbooks/edpm_build_images/edpm_image_builder.yml
@@ -1,9 +1,10 @@
 ---
-- name: Bootstrap step
+- name: Boostrap node
   ansible.builtin.import_playbook: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/ci_framework/playbooks/01-bootstrap.yml"
-
 - hosts: all
   tasks:
     - name: Run EDPM image builder
+      tags:
+        - edpm_build_img
       ansible.builtin.import_role:
         name: edpm_build_images

--- a/ci/playbooks/edpm_build_images/run.yml
+++ b/ci/playbooks/edpm_build_images/run.yml
@@ -16,4 +16,4 @@
           {%-   endfor %}
           {%- endif %}
           -e @scenarios/centos-9/zuul_inventory.yml
-          --tags packages
+          --tags packages,edpm_build_img


### PR DESCRIPTION
Since adding --tags packages prevent running the second playbook tasks,         
let's take advantage of the behavior of import_role with tags: it will          
basically apply the passed tags down to the nested content, allowing            
then to filter on a second, dedicated tag without the need to actually          
edit the role itself.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
