### PR TITLE
Introduce new CI layout for end-to-end jobs

### DIFF
--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -70,6 +70,7 @@
                 src: "important-logs.html"
 
         - name: Get some env related data
+          ignore_errors: true
           ansible.builtin.shell:
             chdir: "{{ ansible_user_dir }}/zuul-output/logs/"
             cmd: |

--- a/ci/playbooks/e2e-run.yml
+++ b/ci/playbooks/e2e-run.yml
@@ -13,7 +13,6 @@
           ansible-playbook deploy-edpm.yml
           -e @scenarios/centos-9/base.yml
           -e @scenarios/centos-9/install_yamls.yml
-          -e @scenarios/centos-9/ci.yml
           {%- if cifmw_extras is defined %}
           {%-   for extra_vars in cifmw_extras %}
           -e "{{   extra_vars }}"
@@ -28,7 +27,6 @@
           ansible-playbook deploy-edpm.yml
           -e @scenarios/centos-9/base.yml
           -e @scenarios/centos-9/install_yamls.yml
-          -e @scenarios/centos-9/ci.yml
           {%- if cifmw_extras is defined %}
           {%-   for extra_vars in cifmw_extras %}
           -e "{{   extra_vars }}"
@@ -44,7 +42,6 @@
           ansible-playbook deploy-edpm.yml
           -e @scenarios/centos-9/base.yml
           -e @scenarios/centos-9/install_yamls.yml
-          -e @scenarios/centos-9/ci.yml
           {%- if cifmw_extras is defined %}
           {%-   for extra_vars in cifmw_extras %}
           -e "{{   extra_vars }}"

--- a/ci/playbooks/wait-for-crc.yaml
+++ b/ci/playbooks/wait-for-crc.yaml
@@ -1,0 +1,160 @@
+---
+- hosts: crc
+  name: "tweak crc"
+  gather_facts: false
+  tasks:
+    - name: Harcode crc-pre script
+      become: true
+      ansible.builtin.copy:
+        dest: "/usr/local/bin/configure-pre-crc.sh"
+        mode: '0755'
+        owner: root
+        group: root
+        content: |-
+          #!/bin/bash
+
+          set -x
+
+          HOST_IP=$(ip route get 1.2.3.4 | awk '{print $7}' | head -n1)
+          HOST_DEF_INT=$(ip -br -4 a sh | grep $HOST_IP | awk '{print $1}')
+          ALL_DNS=$(nmcli -g IP4.DNS device show $HOST_DEF_INT)
+
+          DNS1=$(echo $ALL_DNS| cut -f1 -d'|')
+          DNS2=$(echo $ALL_DNS| cut -f2 -d'|')
+
+          if [ -z $DNS1 ]; then
+              echo "DNS1 is empty. Setting 1.1.1.1"
+              DNS1='1.1.1.1'
+          fi
+
+          if [ -z $DNS2 ]; then
+              echo "DNS2 is empty. Setting 8.8.8.8"
+              DNS2='8.8.8.8'
+          fi
+
+          cat << EOL | sudo tee /var/srv/dnsmasq.conf
+          user=root
+          port= 53
+          bind-interfaces
+          expand-hosts
+          log-queries
+          no-negcache
+          local=/crc.testing/
+          domain=crc.testing
+          address=/apps-crc.testing/192.168.122.10
+          address=/api.crc.testing/192.168.122.10
+          address=/api-int.crc.testing/192.168.122.10
+          address=/crc-74q6p-master-0.crc.testing/192.168.121.10
+          server=$DNS1
+          server=$DNS2
+          EOL
+
+          cat << EOL | sudo tee /etc/resolv.conf
+          nameserver 127.0.0.1
+          EOL
+
+          # stop overwriting /etc/resolv.conf after reboot
+          cat << EOL | sudo tee /etc/NetworkManager/conf.d/00-custom-crc.conf
+          [main]
+          dns=none
+          EOL
+
+          sudo systemctl reload NetworkManager
+
+    - name: Restart the service because zuul base job is overwriting /etc/resolv.conf
+      become: true
+      ansible.builtin.systemd:
+        state: restarted
+        name: crc-pre
+
+    - name: Restart dnsmasq
+      become: true
+      ansible.builtin.systemd:
+        state: restarted
+        name: crc-dnsmasq
+
+    - name: Wait for CRC to be ready
+      register: wait_crc
+      ansible.builtin.command: >-
+        oc login {{ cifmw_openshift_api }}
+        -u {{ cifmw_openshift_user }}
+        -p "{{ cifmw_openshift_password }}"
+        {%- if cifmw_openshift_skip_tls_verify | default(false) |bool %}
+        --insecure-skip-tls-verify=true
+        {%- endif %}
+      retries: 20
+      delay: 60
+      until:
+        - wait_crc is defined
+        - wait_crc.rc is defined
+        - wait_crc.rc == 0
+
+- hosts: controller
+  name: "tweak controller"
+  gather_facts: true
+  tasks:
+    - name: Create zuul-output directory
+      ansible.builtin.file:
+        path: "{{ ansible_user_dir }}/ci-framework-data/artifacts"
+        state: directory
+
+    - name: Save zuul inventory
+      ansible.builtin.copy:
+        dest: "{{ ansible_user_dir }}/ci-framework-data/artifacts/zuul_inventory.yml"
+        src: "{{ inventory_file }}"
+
+    - name: Set fact for CRC
+      ansible.builtin.set_fact:
+        crc_ip: "{{ hostvars['crc']['ansible_default_ipv4']['address'] }}"
+
+    - name: Add entries related to the CRC
+      become: true
+      vars:
+        crc_ip: "{{ hostvars['crc']['ansible_default_ipv4']['address'] }}"
+      ansible.builtin.lineinfile:
+        path: /etc/hosts
+        line: >
+          {{ crc_ip }} api.crc.testing
+          canary-openshift-ingress-canary.apps-crc.testing
+          console-openshift-console.apps-crc.testing
+          default-route-openshift-image-registry.apps-crc.testing
+          downloads-openshift-console.apps-crc.testing
+          oauth-openshift.apps-crc.testing
+        create: true
+
+    - name: Install other packages
+      become: true
+      ansible.builtin.package:
+        name:
+          - ansible-core
+          - make
+        state: present
+
+    - name: Generate an ssh keypair
+      ansible.builtin.command:
+        cmd: ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -P ''
+
+    - name: Get public key
+      register: pub_key_slurp
+      ansible.builtin.slurp:
+        path: "{{ ansible_user_dir }}/.ssh/id_ed25519.pub"
+
+    - name: Inject key in authorized_key
+      delegate_to: crc
+      ansible.posix.authorized_key:
+        user: core
+        key: "{{ pub_key_slurp['content'] | b64decode }}"
+
+    - name: Get the default iface connection
+      register: controller_default_connection_out
+      ansible.builtin.command:
+        cmd: "nmcli -g general.connection device show eth0"
+
+    - name: Add the deployment DNS in the controller resolv.conf
+      vars:
+        dns_servers_string: "192.168.122.10 {{ ansible_facts['dns']['nameservers'][0:1] | join(' ') }}"
+      become: true
+      ansible.builtin.shell:
+        cmd: |-
+          nmcli con mod '{{ controller_default_connection_out.stdout | trim }}' ipv4.dns '{{ dns_servers_string }}' ipv4.route-metric 100;
+          nmcli con up '{{ controller_default_connection_out.stdout | trim }}';

--- a/ci/templates/projects.yaml
+++ b/ci/templates/projects.yaml
@@ -7,15 +7,14 @@
     github-check:
       jobs:
         - noop
-        - ci-framework-crc-podified-galera-deployment
         - ci-framework-crc-podified-edpm-baremetal
-        - ci-framework-crc-podified-edpm-deployment
         - cifmw-tcib
         - cifmw-dev-prepare
         - cifmw-doc
-        - cifmw-end-to-end
-        - cifmw-end-to-end-nobuild-tagged
         - cifmw-kuttl
         - cifmw-edpm-build-images
         - cifmw-content-provider-build-images
+        - podified-multinode-edpm-e2e-nobuild-tagged-crc
+        - podified-multinode-edpm-deployment-crc
+        - podified-multinode-galera-deployment-crc
 # Start generated content

--- a/ci_framework/hooks/playbooks/fetch_compute_facts.yml
+++ b/ci_framework/hooks/playbooks/fetch_compute_facts.yml
@@ -1,0 +1,212 @@
+---
+- hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Ensure we know compute host keys
+      ansible.builtin.shell:
+        cmd: |
+          ssh-keyscan {{ hostvars[item].ansible_host }} >> ~/.ssh/known_hosts
+      loop: "{{ hostvars.keys() }}"
+      loop_control:
+        label: "{{ item }}"
+
+- hosts: all
+  gather_facts: true
+  tasks:
+    - name: Copy repositories from controller to compute
+      when:
+        - inventory_hostname is match('^compute.*')
+      become: true
+      ansible.builtin.copy:
+        dest: "/etc/yum.repos.d/"
+        src: "{{ cifmw_basedir }}/artifacts/repositories/"
+
+- hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Load parameters
+      ansible.builtin.include_vars:
+        dir: "{{ item }}"
+      loop:
+        - "{{ cifmw_basedir }}/artifacts/parameters"
+        - "/etc/ci/env"
+      loop_control:
+        label: "{{ item }}"
+
+    - name: Check we have some compute in inventory
+      ansible.builtin.set_fact:
+        has_compute: >-
+          {% set ns = namespace(found=false) -%}
+          {% for host in hostvars.keys() -%}
+          {%   if host is match('^compute.*') -%}
+          {%     set ns.found = true -%}
+          {%   endif -%}
+          {% endfor -%}
+          {{ ns.found }}
+
+    - name: Ensure that the isolated net was configured for crc
+      ansible.builtin.assert:
+        that:
+          - crc_ci_bootstrap_networks_out is defined
+          - "'crc' in crc_ci_bootstrap_networks_out"
+          - "'default' in crc_ci_bootstrap_networks_out['crc']"
+
+    - name: Ensure we have needed bits for compute when needed
+      when:
+        - has_compute | bool
+      ansible.builtin.assert:
+        that:
+          - "'compute' in crc_ci_bootstrap_networks_out"
+          - "'default' in crc_ci_bootstrap_networks_out['compute']"
+
+    - name: Set facts for further usage within the framework
+      ansible.builtin.set_fact:
+        cifmw_edpm_prepare_extra_vars:
+          NNCP_INTERFACE: "{{ crc_ci_bootstrap_networks_out.crc.default.iface }}"
+          NETWORK_MTU: "{{ crc_ci_bootstrap_networks_out.crc.default.mtu }}"
+
+    - name: Prepare EDPM deploy related facts and keys
+      when:
+        - has_compute | bool
+      block:
+        - name: Set specific fact for compute accesses
+          vars:
+            dns_servers: "{{ ((['192.168.122.10'] + ansible_facts['dns']['nameservers']) | unique)[0:2] }}"
+            edpm_install_yamls_vars:
+              SSH_KEY_FILE: "{{ ansible_user_dir }}/.ssh/id_rsa"
+              DATAPLANE_COMPUTE_IP: "{{ crc_ci_bootstrap_networks_out.compute.default.ip | ansible.utils.ipaddr('address') }}"
+              DATAPLANE_SSHD_ALLOWED_RANGES: "['0.0.0.0/0']"
+
+          ansible.builtin.set_fact:
+            cifmw_edpm_deploy_extra_vars: "{{ edpm_install_yamls_vars }}"
+            cifmw_edpm_deploy_dataplane_cr_kustomization: |-
+              apiVersion: kustomize.config.k8s.io/v1beta1
+              kind: Kustomization
+              resources:
+              namespace: {{ cifmw_install_yamls_defaults.NAMESPACE }}
+              patches:
+              - target:
+                  kind: OpenStackDataPlane
+                patch: |-
+                  - op: remove
+                    path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/edpm_network_config_template
+
+                  - op: replace
+                    path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/neutron_public_interface_name
+                    value: "{{ crc_ci_bootstrap_networks_out.compute.default.iface | default('') }}"
+
+                  - op: replace
+                    path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/ctlplane_mtu
+                    value: "{{ crc_ci_bootstrap_networks_out.compute.default.mtu | default('') }}"
+
+              {% if 'tenant' in crc_ci_bootstrap_networks_out.compute %}
+                  - op: replace
+                    path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/tenant_mtu
+                    value: "{{ crc_ci_bootstrap_networks_out.compute['tenant'].mtu | default('') }}"
+              {% endif %}
+
+              {% if 'storage' in crc_ci_bootstrap_networks_out.compute %}
+                  - op: replace
+                    path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/storage_mtu
+                    value: "{{ crc_ci_bootstrap_networks_out.compute['storage'].mtu | default('') }}"
+              {% endif %}
+
+              {% if 'internal-api' in crc_ci_bootstrap_networks_out.compute %}
+                  - op: replace
+                    path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/internal_api_mtu
+                    value: "{{ crc_ci_bootstrap_networks_out.compute['internal-api'].mtu | default('') }}"
+              {% endif %}
+
+                  - op: add
+                    path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/edpm_os_net_config_mappings
+                    value:
+                      net_config_data_lookup:
+                        edpm-compute:
+                          nic2: "{{ crc_ci_bootstrap_networks_out.compute.default.iface | default('') }}"
+
+                  - op: replace
+                    path: /spec/roles/edpm-compute/nodeTemplate/networkConfig
+                    value:
+                      template: |-
+                        {% raw %}
+                        ---
+                        {{ '{%' }} set mtu_list = [ctlplane_mtu] {{ '%}' }}
+                        {{ '{%' }} for network in role_networks {{ '%}' }}
+                        {{ '{{' }} mtu_list.append(lookup("vars", networks_lower[network] ~ "_mtu")) {{ '}}' }}
+                        {{ '{%-' }} endfor {{ '%}' }}
+                        {{ '{%' }} set min_viable_mtu = mtu_list | max {{ '%}' }}
+                        network_config:
+                        - type: ovs_bridge
+                          name: {{ '{{' }} neutron_physical_bridge_name {{ '}}' }}
+                          mtu: {{ '{{' }} min_viable_mtu {{ '}}' }}
+                          use_dhcp: false
+                          dns_servers: {{ '{{' }} ctlplane_dns_nameservers {{ '}}' }}
+                          domain: {{ '{{' }} dns_search_domains {{ '}}' }}
+                          addresses:
+                          - ip_netmask: {{ '{{' }} ctlplane_ip {{ '}}' }}/{{ '{{' }} ctlplane_subnet_cidr {{ '}}' }}
+                          members:
+                          - type: interface
+                            name: nic2
+                            mtu: {{ '{{' }} min_viable_mtu {{ '}}' }}
+                            # force the MAC address of the bridge to this interface
+                            primary: true
+                        {{ '{%' }} for network in role_networks {{ '%}' }}
+                          - type: vlan
+                            mtu: 1496
+                            vlan_id: {{ '{{' }} lookup('vars', networks_lower[network] ~ '_vlan_id') {{ '}}' }}
+                            addresses:
+                            - ip_netmask:
+                                {{ '{{' }} lookup("vars", networks_lower[network] ~ "_ip") {{ '}}' }}/{{ '{{' }} lookup('vars', networks_lower[network] ~ '_cidr') {{ '}}' }}
+                            routes: {{ '{{' }} lookup('vars', networks_lower[network] ~ '_host_routes') }}
+                        {{ '{%' }} endfor {{ '%}' }}
+                        {% endraw %}
+
+                  - op: replace
+                    path: /spec/roles/edpm-compute/nodeTemplate/ansibleUser
+                    value: "{{ hostvars.compute.ansible_user | default('zuul') }}"
+
+                  - op: replace
+                    path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/ctlplane_dns_nameservers
+                    value:
+              {% for dns_server in dns_servers %}
+                      - "{{ dns_server }}"
+              {% endfor %}
+
+
+        - name: Ensure we know about the private host keys
+          ansible.builtin.shell:
+            cmd: |
+              ssh-keyscan {{ cifmw_edpm_deploy_extra_vars.DATAPLANE_COMPUTE_IP }} >> ~/.ssh/known_hosts
+
+    - name: Save compute info
+      vars:
+        file_content:
+          cifmw_edpm_deploy_extra_vars: "{{ cifmw_edpm_deploy_extra_vars | default(omit) }}"
+          cifmw_edpm_deploy_dataplane_cr_kustomization: "{{ cifmw_edpm_deploy_dataplane_cr_kustomization | default(omit) }}"
+          cifmw_edpm_prepare_extra_vars: "{{ cifmw_edpm_prepare_extra_vars }}"
+          cifmw_edpm_prepare_openstack_cr_kustomization: |-
+            apiVersion: kustomize.config.k8s.io/v1beta1
+            kind: Kustomization
+            resources:
+            namespace: {{ cifmw_install_yamls_defaults.NAMESPACE }}
+            patches:
+            - target:
+                kind: OpenStackControlPlane
+              patch: |-
+                - op: replace
+                  path: /spec/dns/template/options
+                  value: [
+                    {
+                      "key": "server",
+                      "values": [ "192.168.122.10" ]
+                    },
+                    {
+                      "key": "no-negcache",
+                      "values": []
+                    }
+                  ]
+      ansible.builtin.copy:
+        dest: "{{ cifmw_basedir }}/artifacts/{{ step }}_{{ hook_name }}.yml"
+        content: "{{ file_content | to_nice_yaml }}"

--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -164,3 +164,30 @@
           --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
           --for=condition=ready
           --timeout={{ cifmw_edpm_prepare_timeout }}m
+
+- name: Wait for keystone to be ready
+  when: not cifmw_edpm_prepare_dry_run
+  block:
+    - name: Extract keystone endpoint host
+      register: _keystone_endpoint
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.command:
+        cmd: >-
+          oc get route keystone-public
+          --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+          -o jsonpath='{ .spec.host }'
+
+    - name: Wait for keystone endpoint to exist in DNS
+      register: _cifmw_edpm_prepare_check_keystone_dns
+      vars:
+        _keystone_response_codes: [200, 300, 301, 302, 401, 402, 403]
+      ansible.builtin.uri:
+        url: "http://{{ _keystone_endpoint.stdout | trim }}"
+        status_code: "{{ _keystone_response_codes }}"
+      retries: 20
+      delay: 10
+      until:
+        - _cifmw_edpm_prepare_check_keystone_dns.status is defined
+        - _cifmw_edpm_prepare_check_keystone_dns.status in _keystone_response_codes

--- a/scenarios/centos-9/ci.yml
+++ b/scenarios/centos-9/ci.yml
@@ -2,12 +2,11 @@
 ansible_user_dir: "{{ lookup('env', 'HOME') }}"
 cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
 
-cifmw_use_libvirt: true
-cifmw_use_crc: true
-
 cifmw_openshift_user: "kubeadmin"
 cifmw_openshift_password: "123456789"
 cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+
+cifmw_openshift_setup_skip_internal_registry: true
 
 pre_infra:
   - name: Download needed tools
@@ -17,6 +16,10 @@ pre_infra:
     source: "{{ cifmw_installyamls_repos }}/devsetup/download_tools.yaml"
 
 pre_deploy:
+  - name: Disable openstack marketplace
+    type: playbook
+    source: disable_os_marketplace.yml
+
   - name: Deploy toy ceph
     type: playbook
     source: ceph-deploy.yml

--- a/scenarios/centos-9/edpm_ci.yml
+++ b/scenarios/centos-9/edpm_ci.yml
@@ -4,16 +4,7 @@ cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-o
 cifmw_install_yamls_vars:
   DATAPLANE_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/dataplane-operator"
   STORAGE_CLASS: crc-csi-hostpath-provisioner
-
-cifmw_use_crc: true
-cifmw_use_libvirt: true
-cifmw_rhol_crc_use_installyamls: true
-
-pre_infra:
-  - name: Download needed tools
-    inventory: "{{ cifmw_installyamls_repos }}/devsetup/hosts"
-    type: playbook
-    source: "{{ cifmw_installyamls_repos }}/devsetup/download_tools.yaml"
+  BMO_SETUP: false
 
 # edpm_prepare role vars
 cifmw_operator_build_meta_name: "openstack-operator"
@@ -28,19 +19,27 @@ cifmw_openshift_setup_skip_internal_registry: true
 # openshift_login role vars
 cifmw_openshift_user: "kubeadmin"
 cifmw_openshift_password: "123456789"
+cifmw_openshift_api: api.crc.testing:6443
 cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+cifmw_openshift_skip_tls_verify: true
 
-# tempest related vars
-# Note(chandankumar): Enable tempest in check line once crc standalone work gets completed
-cifmw_run_tests: false
-cifmw_tempest_tests_allowed:
-  - tempest.scenario.test_server_basic_ops.TestServerBasicOps.test_server_basic_ops
 pre_deploy:
   - name: Disable openstack marketplace
     type: playbook
     source: disable_os_marketplace.yml
 
+pre_infra:
+  - name: Download needed tools
+    inventory: 'localhost,'
+    connection: local
+    type: playbook
+    source: "{{ cifmw_installyamls_repos }}/devsetup/download_tools.yaml"
+
 post_ctlplane_deploy:
+  - name: Tune rabbitmq resources
+    type: playbook
+    source: rabbitmq_tuning.yml
+
   - name: Validate podified control plane
     type: playbook
     source: validate_podified_deployment.yml
@@ -49,11 +48,3 @@ post_ctlplane_deploy:
       cifmw_openshift_login_kubeconfig: "{{ cifmw_openshift_login_kubeconfig }}"
       cifmw_path: "{{ cifmw_path }}"
       openstack_namespace: "{{ cifmw_install_yamls_defaults['NAMESPACE'] }}"
-
-  - name: Tune rabbitmq resources
-    type: playbook
-    source: rabbitmq_tuning.yml
-
-  - name: Restart Nova Schedular
-    type: playbook
-    source: restart_nova_scheduler.yml

--- a/scenarios/centos-9/install_yamls.yml
+++ b/scenarios/centos-9/install_yamls.yml
@@ -1,5 +1,3 @@
 ---
 cifmw_rhol_crc_use_installyamls: true
 cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
-cifmw_install_yamls_vars:
-  KUBECONFIG: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"

--- a/scenarios/centos-9/multinode-ci.yml
+++ b/scenarios/centos-9/multinode-ci.yml
@@ -1,0 +1,19 @@
+---
+cifmw_use_crc: false
+cifmw_use_libvirt: false
+
+cifmw_openshift_setup_skip_internal_registry_tls_verify: true
+
+post_infra:
+  - name: Fetch nodes facts and save them as parameters
+    type: playbook
+    inventory: "{{ ansible_user_dir }}/ci-framework-data/artifacts/zuul_inventory.yml"
+    source: fetch_compute_facts.yml
+
+post_ctlplane_deploy:
+  - name: Tune rabbitmq resources
+    type: playbook
+    source: rabbitmq_tuning.yml
+
+# Enable tempest
+cifmw_run_tests: true

--- a/scenarios/centos-9/nested_virt.yml
+++ b/scenarios/centos-9/nested_virt.yml
@@ -1,0 +1,13 @@
+---
+# This file is mostly used in CI for nested virtualization, since it will
+# deploy CRC VM onto a running VM, and create the compute as a VM on the same
+# host.
+cifmw_use_libvirt: true
+cifmw_use_crc: true
+cifmw_rhol_crc_use_installyamls: true
+
+# tempest related vars
+# Note(chandankumar): Enable tempest in check line once crc standalone work gets completed
+cifmw_run_tests: false
+cifmw_tempest_tests_allowed:
+  - tempest.scenario.test_server_basic_ops.TestServerBasicOps.test_server_basic_ops

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -56,6 +56,9 @@
     name: cifmw-crc-podified-edpm-deployment
     parent: cifmw-base-crc-openstack
     run: ci/playbooks/edpm/run.yml
+    vars:
+      cifmw_extras:
+        - '@scenarios/centos-9/nested_virt.yml'
 
 # Virtual Baremetal job with CRC and single compute node.
 - job:

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -1,0 +1,171 @@
+---
+# Base job definition for multinode. Provide base layout with CRC on a dedicated
+# nodeset, one compute and an ansible-controller.
+# At the end, you get an env ready to run the first stages of the ci-framework.
+# It also ensures post-run are common to all of the multinodes jobs we'll get
+# in that file.
+# In case you change the "nodeset" for your own job, please override
+# crc_ci_bootstrap_networking using *extra-vars*.
+- job:
+    name: cifmw-podified-multinode-edpm-base-crc
+    parent: base-extracted-crc
+    timeout: 10800
+    attempts: 1
+    nodeset:
+      nodes:
+        - name: controller
+          label: cloud-centos-9-stream-tripleo-vexxhost
+        - name: compute
+          label: cloud-centos-9-stream-tripleo-vexxhost
+        - name: crc
+          label: coreos-crc-extracted-xxl
+    irrelevant-files:
+      - .*/*.md
+    required-projects:
+      - openstack-k8s-operators/ci-framework
+      - openstack-k8s-operators/dataplane-operator
+      - openstack-k8s-operators/install_yamls
+      - openstack-k8s-operators/infra-operator
+      - openstack-k8s-operators/openstack-baremetal-operator
+      - openstack-k8s-operators/openstack-operator
+      - openstack-k8s-operators/repo-setup
+      - openstack-k8s-operators/edpm-ansible
+    roles:
+      - zuul: github.com/openstack-k8s-operatorsait/ci-framework
+    pre-run:
+      - ci/playbooks/wait-for-crc.yaml
+      - ci/playbooks/e2e-prepare.yml
+      - ci/playbooks/dump_zuul_vars.yml
+    post-run:
+      - ci/playbooks/e2e-collect-logs.yml
+      - ci/playbooks/collect-logs.yml
+    vars:
+      zuul_log_collection: true
+      registry_login_enabled: true
+      push_registry: quay.rdoproject.org
+      quay_login_secret_name: quay_nextgen_zuulgithubci
+      cifmw_artifacts_crc_sshkey: "~/.ssh/id_rsa"
+      cifmw_openshift_user: kubeadmin
+      cifmw_openshift_password: "123456789"
+      cifmw_openshift_api: api.crc.testing:6443
+      cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+      cifmw_openshift_skip_tls_verify: true
+      cifmw_use_libvirt: false
+      cifmw_zuul_target_host: controller
+      crc_ci_bootstrap_networking:
+        networks:
+          default:
+            mtu: 1500
+            range: 192.168.122.0/24
+          internal-api:
+            vlan: 20
+            range: 172.17.0.0/24
+          storage:
+            vlan: 21
+            range: 172.18.0.0/24
+          tenant:
+            vlan: 22
+            range: 172.19.0.0/24
+        instances:
+          controller:
+            networks:
+              default:
+                ip: 192.168.122.11
+          crc:
+            networks:
+              default:
+                ip: 192.168.122.10
+              internal-api:
+                ip: 172.17.0.5
+              storage:
+                ip: 172.18.0.5
+              tenant:
+                ip: 172.19.0.5
+          compute:
+            disable_default_gw: false
+            networks:
+              default:
+                ip: 192.168.122.100
+              internal-api:
+                ip: 172.17.0.100
+                config_nm: false
+              storage:
+                ip: 172.18.0.100
+                config_nm: false
+              tenant:
+                ip: 172.19.0.100
+                config_nm: false
+
+- job:
+    name: podified-multinode-edpm-deployment-crc
+    parent: cifmw-podified-multinode-edpm-base-crc
+    vars:
+      cifmw_extras:
+        - '@scenarios/centos-9/multinode-ci.yml'
+    run:
+      - ci/playbooks/edpm/run.yml
+
+- job:
+    name: podified-multinode-edpm-e2e-nobuild-tagged-crc
+    parent: cifmw-podified-multinode-edpm-base-crc
+    vars:
+      cifmw_extras:
+        - '@scenarios/centos-9/ci.yml'
+        - '@scenarios/centos-9/multinode-ci.yml'
+    run:
+      - ci/playbooks/e2e-run.yml
+    irrelevant-files:
+      - ^ci_framework/roles/.*_build
+      - ^ci_framework/roles/build.*
+      - ^ci_framework/roles/local_env_vm
+      - ^ci/templates
+      - ^docs
+      - ^.*/*.md
+      - ^OWNERS
+      - ^.github
+
+- job:
+    name: podified-multinode-galera-deployment-crc
+    parent: podified-multinode-edpm-deployment-crc
+    nodeset:
+      nodes:
+        - name: controller
+          label: cloud-centos-9-stream-tripleo-vexxhost
+        - name: crc
+          label: coreos-crc-extracted-xxl
+    vars:
+      cifmw_deploy_edpm: false
+      podified_validation: true
+      cifmw_run_tests: false
+      make_openstack_deploy_params:
+        GALERA_REPLICAS: 3
+    extra-vars:
+      crc_ci_bootstrap_networking:
+        networks:
+          default:
+            range: 192.168.122.0/24
+            mtu: 1500
+          internal-api:
+            vlan: 20
+            range: 172.17.0.0/24
+          storage:
+            vlan: 21
+            range: 172.18.0.0/24
+          tenant:
+            vlan: 22
+            range: 172.19.0.0/24
+        instances:
+          controller:
+            networks:
+              default:
+                ip: 192.168.122.11
+          crc:
+            networks:
+              default:
+                ip: 192.168.122.10
+              internal-api:
+                ip: 172.17.0.5
+              storage:
+                ip: 172.18.0.5
+              tenant:
+                ip: 172.19.0.5

--- a/zuul.d/edpm_periodic.yaml
+++ b/zuul.d/edpm_periodic.yaml
@@ -4,6 +4,7 @@
     parent: cifmw-crc-podified-edpm-deployment
     vars: &edpm_vars
       cifmw_extras:
+        - '@scenarios/centos-9/nested_virt.yml'
         - '@scenarios/centos-9/edpm_periodic.yml'
 
 - job:

--- a/zuul.d/end-to-end.yaml
+++ b/zuul.d/end-to-end.yaml
@@ -32,6 +32,7 @@
       - ^ci/templates
     vars:
       cifmw_extras:
+        - '@scenarios/centos-9/ci.yml'
         - '@scenarios/centos-9/ci-build.yml'
         - '@scenarios/centos-9/ceph_backends.yml'
     run: ci/playbooks/e2e-run.yml
@@ -51,6 +52,9 @@
       - ^.*/*.md
       - ^OWNERS
       - ^.github
+    vars:
+      cifmw_extras:
+        - '@scenarios/centos-9/ci.yml'
     run: ci/playbooks/e2e-run.yml
 
 # Run the dev workflow if we edit specific role(s)

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -2,17 +2,16 @@
     github-check:
       jobs:
       - noop
-      - ci-framework-crc-podified-galera-deployment
       - ci-framework-crc-podified-edpm-baremetal
-      - ci-framework-crc-podified-edpm-deployment
       - cifmw-tcib
       - cifmw-dev-prepare
       - cifmw-doc
-      - cifmw-end-to-end
-      - cifmw-end-to-end-nobuild-tagged
       - cifmw-kuttl
       - cifmw-edpm-build-images
       - cifmw-content-provider-build-images
+      - podified-multinode-edpm-e2e-nobuild-tagged-crc
+      - podified-multinode-edpm-deployment-crc
+      - podified-multinode-galera-deployment-crc
       - cifmw-molecule-artifacts
       - cifmw-molecule-build_containers
       - cifmw-molecule-build_openstack_packages


### PR DESCRIPTION
In order to improve stability while also allowing more flexibility with
"what we want to test", this patch introduces a new multinode layout for
CRC based end-to-end jobs.

cifmw-podified-edpm-base-multinode-crc provides the basis for the
3-nodes layout, providing one "ansible controller", a CRC instance and
one Compute node.
At the end of that base job, everything is ready to start running the CI
Framework - dependencies are installed, and you should get all of the
needed repositories, also for proper Depends-On support.
    
cifmw-podified-edpm-deployment-multinode-crc is an actual end-to-end
job, running the standard EDPM deployment with some tests.

- [X] new layout is in use and tested