### PR TITLE
Enable Network isolation in baremetal job

### DIFF
--- a/ci/playbooks/edpm_baremetal_deployment/run.yml
+++ b/ci/playbooks/edpm_baremetal_deployment/run.yml
@@ -2,7 +2,7 @@
 - hosts: all
   gather_facts: true
   tasks:
-    - name: Perform Podified and EDPM deployment on compute nodes provisioned with bmaas
+    - name: Perform Podified and EDPM deployment on compute nodes with virtual baremetal
       ansible.builtin.command:
         chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
         cmd: >-

--- a/ci_framework/playbooks/06-deploy-edpm.yml
+++ b/ci_framework/playbooks/06-deploy-edpm.yml
@@ -16,7 +16,7 @@
       ansible.builtin.import_role:
         name: edpm_prepare
 
-    - name: Perform Podified and EDPM deployment on compute nodes provisioned with bmaas
+    - name: Perform Podified and EDPM deployment on compute nodes with virtual baremetal
       when: cifmw_edpm_deploy_baremetal | default('false') | bool
       ansible.builtin.import_role:
         name: edpm_deploy_baremetal

--- a/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -28,22 +28,6 @@
       {% endif %}
     cifmw_edpm_deploy_baremetal_operators_build_output: "{{ operators_build_output }}"
 
-- name: Install metallb-operator
-  vars:
-    make_metallb_env: "{{ cifmw_edpm_deploy_baremetal_common_env }}"
-    make_metallb_dryrun: "{{ cifmw_edpm_deploy_baremetal_dry_run }}"
-  ansible.builtin.include_role:
-    name: 'install_yamls_makes'
-    tasks_from: 'make_metallb'
-
-- name: Configure metallb for DNS
-  vars:
-    make_metallb_config_env: "{{ cifmw_edpm_deploy_baremetal_common_env }}"
-    make_metallb_config_dryrun: "{{ cifmw_edpm_deploy_baremetal_dry_run }}"
-  ansible.builtin.include_role:
-    name: 'install_yamls_makes'
-    tasks_from: 'make_metallb_config'
-
 - name: Override uefi image url when we build uefi image via content_provider
   when: cifmw_build_images_output is defined
   set_fact:

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -16,7 +16,7 @@ are shared among multiple roles:
 * `cifmw_basedir`: The base directory for all of the artifacts. Defaults to
 `~/ci-framework-data`
 * `cifmw_edpm_deploy_baremetal`: (Bool) Toggle whether to deploy edpm on compute nodes
-provisioned with bmaas vs pre-provisioned VM.
+provisioned with virtual baremetal vs pre-provisioned VM.
 * `cifmw_installyamls_repos`: install_yamls repository location. Defaults to `../..`
 * `cifmw_manifests`: Directory where k8s related manifests will be places. Defaults to
 `{{ cifmw_basedir }}/manifests`

--- a/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
+++ b/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
@@ -6,12 +6,7 @@ cifmw_install_yamls_vars:
   OUTPUT_BASEDIR: "{{ cifmw_basedir }}/artifacts/edpm_compute" # used by gen-edpm-compute-node.sh
   DEPLOY_DIR: "{{ cifmw_basedir }}/artifacts/edpm_compute" # used during Baremetal deployment
   SSH_KEY: "{{ cifmw_basedir }}/artifacts/edpm_compute/ansibleee-ssh-key-id_rsa"
-  NETWORK_ISOLATION: false
-  PROVISIONING_INTERFACE: crc-bmaas
-  NNCP_INTERFACE: crc-bmaas
-  METALLB_POOL: 172.22.0.80-172.22.0.90
   STORAGE_CLASS: crc-csi-hostpath-provisioner
-  BMAAS_NODE_COUNT: 1
   DATAPLANE_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/dataplane-operator"
   INFRA_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/infra-operator"
 
@@ -24,7 +19,6 @@ pre_infra:
 # edpm_prepare role vars
 cifmw_operator_build_meta_name: "openstack-operator"
 cifmw_edpm_prepare_skip_crc_storage_creation: true
-cifmw_edpm_prepare_crc_attach_default_interface: false
 
 cifmw_edpm_deploy_baremetal: true
 

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -44,7 +44,7 @@
     parent: cifmw-base-crc-openstack
     run: ci/playbooks/edpm/run.yml
 
-# Bmaas job with CRC and single bmaas compute node.
+# Virtual Baremetal job with CRC and single compute node.
 - job:
     name: cifmw-crc-podified-edpm-baremetal
     parent: cifmw-base-crc-openstack


### PR DESCRIPTION
This reverts all changes initially done to disable network isolation now that we can use the same interface for both provisioning and other networks.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running