### PR TITLE
Iterate over containers_overrides keys not items

### DIFF
--- a/ci_framework/roles/set_openstack_containers/templates/update_env_vars.sh.j2
+++ b/ci_framework/roles/set_openstack_containers/templates/update_env_vars.sh.j2
@@ -17,8 +17,8 @@ set -eo pipefail
 {%     set _container_address = _container_registry + '/' + _container_name + ':' + cifmw_set_openstack_containers_tag -%}
 {%     set _ = containers_dict.update({_container_env: _container_address}) -%}
 {#   This section overrides the non openstack services containers #}
-{%   elif cifmw_set_openstack_containers_overrides.items()|length > 0 -%}
-{%     if _container_env in cifmw_set_openstack_containers_overrides.items() -%}
+{%   elif cifmw_set_openstack_containers_overrides.keys()|length > 0 -%}
+{%     if _container_env in cifmw_set_openstack_containers_overrides.keys() -%}
 {%       set _ = containers_dict.update({_container_env: cifmw_set_openstack_containers_overrides[_container_env]}) -%}
 {%     endif -%}
 {%   endif -%}


### PR DESCRIPTION
cifmw_set_openstack_containers_overrides is a dict[1] defined in set_openstack_containers role. for existance of key with in the cifmw_set_openstack_containers_overrides, we need to iterate over keys not items[2], otherwise it will return false.

The set_openstack_containers will not work as expected.

[1]. https://github.com/openstack-k8s-operators/ci-framework/pull/319/files#diff-c2ef2456cbef833792ce04c56e80deb9a66c04677b4ea7dc9e8b9e97135bb380R29 

[2]. https://github.com/openstack-k8s-operators/ci-framework/pull/319/files#diff-6d2b66141d52a5f38f826e943615052b988c09a063ddd111ab29e65be893317cR21

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

  - [x] Content of the docs/source is reflecting the changes
