### PR TITLE
Create EDPM vm when deploy_edpm is set to true

### DIFF
--- a/ci_framework/playbooks/06-deploy-edpm.yml
+++ b/ci_framework/playbooks/06-deploy-edpm.yml
@@ -37,7 +37,9 @@
         dir: "{{ cifmw_basedir }}/artifacts/parameters"
 
     - name: Create VMs and Deploy EDPM
-      when: not cifmw_edpm_deploy_baremetal | default('false') | bool
+      when:
+        - not cifmw_edpm_deploy_baremetal | default('false') | bool
+        - deploy_edpm | default('false') | bool
       block:
       - name: Create and provision external computes
         ansible.builtin.import_role:
@@ -45,7 +47,6 @@
           tasks_from: deploy_edpm_compute.yml
 
       - name: Deploy EDPM
-        when: deploy_edpm | default('false') | bool
         ansible.builtin.import_role:
           name: edpm_deploy
 


### PR DESCRIPTION
deploy-edpm.yml is used in edpm, baremetal and podified deployment job. In podified deployment job, we do not do the EDPM deployment but vms were getting created.

It eats the space and lets the unwanted failure.

This patch disables the EDPM vm creation task and create it only when required.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

