### PR TITLE
Drop `Patch CSV for ansible runner image` task

### DIFF
--- a/ci_framework/roles/edpm_prepare/defaults/main.yml
+++ b/ci_framework/roles/edpm_prepare/defaults/main.yml
@@ -23,6 +23,4 @@ cifmw_edpm_prepare_skip_openstack_operator: false
 cifmw_edpm_prepare_wait_subscription_retries: 30
 cifmw_edpm_prepare_dry_run: false
 cifmw_edpm_prepare_skip_crc_storage_creation: false
-cifmw_edpm_prepare_default_ansible_runner_image: "http://quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest"
-cifmw_edpm_prepare_ansible_runner_image: "{{ cifmw_edpm_prepare_default_ansible_runner_image }}"
 cifmw_edpm_prepare_update_os_containers: false

--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -101,20 +101,6 @@
           --namespace={{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }}
           --for=jsonpath='{.status.phase}'=Complete --timeout=20m
 
-- name: Patch CSV for ansible runner image
-  when:
-    - not cifmw_edpm_prepare_dry_run
-    - cifmw_edpm_prepare_ansible_runner_image != cifmw_edpm_prepare_default_ansible_runner_image
-  environment:
-    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-    PATH: "{{ cifmw_path }}"
-  ansible.builtin.command:
-    cmd: >-
-      oc patch csv -n openstack-operators openstack-ansibleee-operator.v0.0.1
-      --type='json' -p='[{"op":"replace",
-      "path":"/spec/install/spec/deployments/0/spec/template/spec/containers/1/env/0",
-      "value": {"name": "ANSIBLEEE_IMAGE_URL_DEFAULT", "value": "{{ cifmw_edpm_prepare_ansible_runner_image }}"}}]'
-
 - name: Update OpenStack Services containers Env
   when: cifmw_edpm_prepare_update_os_containers | bool
   ansible.builtin.include_role:


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/edpm-ansible/pull/210 updates ee runner image var using set_openstack_containers role which makes `Patch CSV for ansible runner image` task no longer used. So removing it.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

