### PR TITLE
Add simple tox target for testing from Prow CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ tests: pre_commit molecule ## Run all tests with dependencies install
 .PHONY: tests_nodeps
 tests_nodeps: pre_commit_nodeps molecule_nodeps ## Run all tests without installing dependencies
 
+.PHONY: tox
+tox: ## Run tox based on the tox.ini file
+	tox -v
+
 ##@ Molecule testing
 .PHONY: molecule
 molecule: setup_molecule molecule_nodeps ## Run molecule tests with dependencies install

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 pre-commit # MIT
 mock
+tox


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
