### PR TITLE
Provide a way to add certs with in the image

### DIFF
--- a/ci_framework/roles/edpm_build_images/README.md
+++ b/ci_framework/roles/edpm_build_images/README.md
@@ -28,6 +28,8 @@ None
 * `cifmw_edpm_build_images_push_container_images`: (Boolean) Whether to push container images to remote registry. Default: false.
 * `cifmw_edpm_build_images_push_registry`: (String) Push registry where we want to push container images. Default: `quay.rdoproject.org`.
 * `cifmw_edpm_build_images_push_registry_namespace`: (String) Namespace on registry where we want to push container images. Default: `podified-main-centos9`.
+* `cifmw_edpm_build_images_cert_path`: (String) Cert path. Default: `/etc/pki/ca-trust/source/anchors/rh.crt`
+* `cifmw_edpm_build_images_cert_install`: (Boolean) Whether to install cert in the image. Default: false
 
 ### Example
 ```YAML

--- a/ci_framework/roles/edpm_build_images/defaults/main.yml
+++ b/ci_framework/roles/edpm_build_images/defaults/main.yml
@@ -54,3 +54,5 @@ cifmw_edpm_build_images_dry_run: false
 cifmw_edpm_build_images_push_registry: 'quay.rdoproject.org'
 cifmw_edpm_build_images_push_registry_namespace: 'podified-main-centos9'
 cifmw_edpm_build_images_push_container_images: false
+cifmw_edpm_build_images_cert_path: /etc/pki/ca-trust/source/anchors/rh.crt
+cifmw_edpm_build_images_cert_install: false

--- a/ci_framework/roles/edpm_build_images/tasks/add_cert.yml
+++ b/ci_framework/roles/edpm_build_images/tasks/add_cert.yml
@@ -1,0 +1,28 @@
+---
+- name: Check if cert exits
+  stat:
+    path: "{{ cifmw_edpm_build_images_cert_path }}"
+  register: cert_path
+
+- name: Install neccessary rpm and customize image to push correct certs in Image.
+  when: cert_path.stat.exists|bool
+  block:
+    - name: Install libguestfs packages
+      tags:
+        - bootstrap
+        - packages
+      become: true
+      ansible.builtin.package:
+        name:
+          - libguestfs
+          - libguestfs-tools
+          - libguestfs-tools-c
+        state: present
+
+    - name: Add cert if it exists
+      ansible.builtin.command: >
+        virt-customize -a {{ cifmw_edpm_build_images_basedir }}/{{ cifmw_discovered_image_name }}
+        --upload {{ cifmw_edpm_build_images_cert_path }}:{{ cifmw_edpm_build_images_cert_path }}
+        --run-command 'update-ca-trust'
+      environment:
+        LIBGUESTFS_BACKEND: direct

--- a/ci_framework/roles/edpm_build_images/tasks/main.yml
+++ b/ci_framework/roles/edpm_build_images/tasks/main.yml
@@ -36,6 +36,10 @@
   retries: 60
   delay: 10
 
+- name: Add certs to the image
+  when: cifmw_edpm_build_images_cert_install | bool
+  ansible.builtin.import_tasks: add_cert.yml
+
 - name: Run edpm-image-builder
   ansible.builtin.import_tasks: run.yml
 


### PR DESCRIPTION
In Downstream, We have rpms to install certs in order to work with internal urls. This pr provides a way to install the certs on the image itself.

By using cifmw_edpm_build_images_cert_install_command var, we can install a specific cert there.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

