### PR TITLE
Use set_openstack_containers role to patch baremetal operator

### DIFF
--- a/ci_framework/roles/edpm_deploy_baremetal/README.md
+++ b/ci_framework/roles/edpm_deploy_baremetal/README.md
@@ -14,7 +14,6 @@ This role doesn't need privilege scalation.
 * `cifmw_edpm_deploy_baremetal_wait_provisionserver_timeout_mins`: (integer) Timeout for waiting for the Provision Server deployment. Default: `20`
 * `cifmw_edpm_deploy_baremetal_wait_bmh_timeout_mins`: (integer) Timeout for waiting for the bare metal nodes. Default: `20`
 * `cifmw_edpm_deploy_baremetal_wait_dataplane_timeout_mins`: (integer) Timeout for waiting for the OpenStackDataPlane. Default: `30`
-* `cifmw_edpm_deploy_baremetal_uefi_image_url`: (String) The url from where we can pull the uefi container, Default: `quay.io/podified-antelope-centos9/edpm-hardened-uefi:current-podified`
 
 ## Examples
 ### 1 - Perform edpm baremetal deployment

--- a/ci_framework/roles/edpm_deploy_baremetal/defaults/main.yml
+++ b/ci_framework/roles/edpm_deploy_baremetal/defaults/main.yml
@@ -25,5 +25,3 @@ cifmw_edpm_deploy_baremetal_wait_provisionserver_timeout_mins: 20
 cifmw_edpm_deploy_baremetal_wait_ironic_timeout_mins: 20
 cifmw_edpm_deploy_baremetal_wait_bmh_timeout_mins: 20
 cifmw_edpm_deploy_baremetal_wait_dataplane_timeout_mins: 30
-cifmw_edpm_deploy_baremetal_default_uefi_image_url: "quay.io/podified-antelope-centos9/edpm-hardened-uefi:current-podified"
-cifmw_edpm_deploy_baremetal_uefi_image_url: "{{ cifmw_edpm_deploy_baremetal_default_uefi_image_url }}"

--- a/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -28,21 +28,20 @@
       {% endif %}
     cifmw_edpm_deploy_baremetal_operators_build_output: "{{ operators_build_output }}"
 
-- name: Override uefi image url when we build uefi image via content_provider
+- name: set facts for baremetal UEFI image url
+  ansible.builtin.set_fact:
+    cifmw_set_openstack_containers_overrides:
+      OS_CONTAINER_IMAGE_URL_DEFAULT: "{{ cifmw_build_images_output['images']['edpm-hardened-uefi']['image'] }}"
+    cacheable: true
   when: cifmw_build_images_output is defined
-  set_fact:
-    cifmw_edpm_deploy_baremetal_uefi_image_url: "{{ cifmw_build_images_output['images']['edpm-hardened-uefi']['image'] }}"
 
 - name: Patch baremetal CSV to override the uefi image
-  when:
-    - not cifmw_edpm_deploy_baremetal_dry_run
-    - cifmw_edpm_deploy_baremetal_default_uefi_image_url != cifmw_edpm_deploy_baremetal_uefi_image_url
-  ansible.builtin.command:
-    cmd: >-
-      oc patch csv -n openstack-operators openstack-baremetal-operator.v0.0.1
-      --type='json' -p='[{"op":"replace",
-      "path":"/spec/install/spec/deployments/0/spec/template/spec/containers/1/env/0",
-      "value": {"name": "OS_CONTAINER_IMAGE_URL_DEFAULT", "value": "{{ cifmw_edpm_deploy_baremetal_uefi_image_url }}"}}]'
+  when: not cifmw_edpm_deploy_baremetal_dry_run
+  vars:
+    cifmw_edpm_prepare_update_os_containers: true
+    cifmw_set_openstack_containers_operator_name: openstack-baremetal
+  ansible.builtin.include_role:
+    name: set_openstack_containers
 
 - name: Install Dataplane with baremetal
   vars:

--- a/ci_framework/roles/set_openstack_containers/tasks/main.yml
+++ b/ci_framework/roles/set_openstack_containers/tasks/main.yml
@@ -56,7 +56,7 @@
 
 - name: list all pods
   ansible.builtin.debug:
-    msg: operator_pod
+    var: operator_pod
 
 - name: Get meta operator environment variable
   environment:
@@ -105,6 +105,10 @@
 - name: Get the operator pod name
   ansible.builtin.set_fact:
     operator_pod_name: "{{ '\n'.join(operator_pod_name.stdout_lines) |regex_search('^pod/' ~ operator_name ~ '-operator-controller-manager-.*$', multiline=True) }}"
+
+- name: Print the operator pod name
+  ansible.builtin.debug:
+    var: operator_pod_name
 
 - name: Get operator environment variable after update
   environment:

--- a/ci_framework/roles/set_openstack_containers/templates/update_env_vars.sh.j2
+++ b/ci_framework/roles/set_openstack_containers/templates/update_env_vars.sh.j2
@@ -9,18 +9,18 @@ set -eo pipefail
 {%   set container_data = container.split('=') -%}
 {%   set _container_env = container_data[0] -%}
 {%   set _container = container_data[1] -%}
+{#   This section overrides the non openstack services containers #}
+{%   if cifmw_set_openstack_containers_overrides.keys()|length > 0 -%}
+{%     if _container_env in cifmw_set_openstack_containers_overrides.keys() -%}
+{%       set _ = containers_dict.update({_container_env: cifmw_set_openstack_containers_overrides[_container_env]}) -%}
+{%     endif -%}
 {#   All the openstack services containers ends with current-podified tag #}
 {#   It filters out the same and update the container address with new url #}
-{%   if _container.endswith('current-podified') -%}
+{%   elif _container.endswith('current-podified') -%}
 {%     set _container_data = _container.split('/')[-1] -%}
 {%     set _container_name = _container_data.split(':')[0] -%}
 {%     set _container_address = _container_registry + '/' + _container_name + ':' + cifmw_set_openstack_containers_tag -%}
 {%     set _ = containers_dict.update({_container_env: _container_address}) -%}
-{#   This section overrides the non openstack services containers #}
-{%   elif cifmw_set_openstack_containers_overrides.keys()|length > 0 -%}
-{%     if _container_env in cifmw_set_openstack_containers_overrides.keys() -%}
-{%       set _ = containers_dict.update({_container_env: cifmw_set_openstack_containers_overrides[_container_env]}) -%}
-{%     endif -%}
 {%   endif -%}
 {% endfor -%}
 


### PR DESCRIPTION
set_openstack_containers role takes care of updating the env vars for any operator.

This pr uses the set_openstack_containers role to update the baremetal operator csv with the correct image.

Note: It also bumps crc ram to 24 GB as the edpm jobs are failing consistently.

Tested here: https://github.com/openstack-k8s-operators/edpm-image-builder/pull/11 and
results: https://github.com/openstack-k8s-operators/edpm-image-builder/pull/11#issuecomment-1633820238

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

