### PR TITLE
Ignore computes deployment when cifmw_use_libvirt is false

### DIFF
--- a/ci_framework/playbooks/06-deploy-edpm.yml
+++ b/ci_framework/playbooks/06-deploy-edpm.yml
@@ -40,6 +40,9 @@
       when: not cifmw_edpm_deploy_baremetal | default('false') | bool
       block:
       - name: Create and provision external computes
+        when:
+          - cifmw_use_libvirt is defined
+          - cifmw_use_libvirt | bool
         ansible.builtin.import_role:
           name: libvirt_manager
           tasks_from: deploy_edpm_compute.yml

--- a/scenarios/centos-9/edpm_ci.yml
+++ b/scenarios/centos-9/edpm_ci.yml
@@ -8,6 +8,8 @@ cifmw_install_yamls_vars:
   DATAPLANE_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/dataplane-operator"
   STORAGE_CLASS: crc-csi-hostpath-provisioner
 
+cifmw_use_libvirt: true
+
 pre_infra:
   - name: Download needed tools
     inventory: "{{ cifmw_installyamls_repos }}/devsetup/hosts"


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date.
