### PR TITLE
Add galera based podified job

### DIFF
--- a/ci/templates/projects.yaml
+++ b/ci/templates/projects.yaml
@@ -7,6 +7,7 @@
     github-check:
       jobs:
         - noop
+        - ci-framework-crc-podified-galera-deployment
         - ci-framework-crc-podified-edpm-baremetal
         - ci-framework-crc-podified-edpm-deployment
         - cifmw-dev-prepare

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -50,6 +50,17 @@
     parent: cifmw-base-crc-openstack
     run: ci/playbooks/edpm_baremetal_deployment/run.yml
 
+# Podified galera job
+- job:
+    name: cifmw-crc-podified-galera-deployment
+    parent: cifmw-crc-podified-edpm-deployment
+    vars:
+      deploy_edpm: false
+      cifmw_use_libvirt: false
+      podified_validation: true
+      make_openstack_deploy_params:
+        GALERA_REPLICAS: 3
+
 # Install Yamls specific job
 - job:
     name: ci-framework-crc-podified-edpm-deployment
@@ -58,6 +69,15 @@
       - ^ci_framework/playbooks/*
       - ^ci_framework/roles/edpm_prepare/(?!meta|README).*
       - ^ci_framework/roles/edpm_deploy/(?!meta|README).*
+      - ^deploy-edpm.yml
+      - ^scenarios/centos-9/edpm_ci.yml
+
+- job:
+    name: ci-framework-crc-podified-galera-deployment
+    parent: cifmw-crc-podified-galera-deployment
+    files:
+      - ^ci_framework/playbooks/*
+      - ^ci_framework/roles/edpm_prepare/(?!meta|README).*
       - ^deploy-edpm.yml
       - ^scenarios/centos-9/edpm_ci.yml
 

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -7,6 +7,7 @@
     github-check:
       jobs:
         - noop
+        - ci-framework-crc-podified-galera-deployment
         - ci-framework-crc-podified-edpm-baremetal
         - ci-framework-crc-podified-edpm-deployment
         - cifmw-dev-prepare


### PR DESCRIPTION
It is a new scenario job to test podified control plane with 3 galera replicas.

The same will run against install_yamls repo.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/373

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

