### PR TITLE
Use edpm-builder-image rpm for periodic jobs

### DIFF
--- a/ci_framework/roles/edpm_build_images/tasks/package.yml
+++ b/ci_framework/roles/edpm_build_images/tasks/package.yml
@@ -4,7 +4,6 @@
     - (cifmw_edpm_build_images_hardened_uefi | bool) or (cifmw_edpm_build_images_all | bool)
     - cifmw_edpm_build_images_hardened_uefi_package | bool
     - not cifmw_edpm_build_images_dry_run
-  become: "{{ cifmw_edpm_build_images_via_rpm }}"
   args:
     chdir: "{{ cifmw_edpm_image_builder_repo_path }}"
   ansible.builtin.command:
@@ -18,7 +17,6 @@
     - (cifmw_edpm_build_images_ironic_python_agent | bool) or (cifmw_edpm_build_images_all | bool)
     - cifmw_edpm_build_images_ironic_python_agent_package | bool
     - not cifmw_edpm_build_images_dry_run
-  become: "{{ cifmw_edpm_build_images_via_rpm }}"
   args:
     chdir: "{{ cifmw_edpm_image_builder_repo_path }}"
   ansible.builtin.command:

--- a/zuul.d/edpm_build_images.yaml
+++ b/zuul.d/edpm_build_images.yaml
@@ -15,7 +15,6 @@
     post-run: ci/playbooks/collect-logs.yml
     vars:
       cifmw_repo_setup_branch: antelope
-      cifmw_edpm_build_images_via_rpm: false
       cifmw_repo_setup_output: "/etc/yum.repos.d/"
       ansible_user_dir: "{{ lookup('env', 'HOME') }}"
 


### PR DESCRIPTION
With this PR, we start using `edpm-builder-image` rpm for image build jobs.

Image build content-provider will continue using
the zuul cloned repo content and not the rpm content
as per design.

Also, removing unneccesary become as this task can we executed
without become.

- [x] Appropriate testing is done and actually running
