### PR TITLE
Bump edpm crc ram to 24000

### DIFF
--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -7,7 +7,7 @@
     abstract: true
     parent: base-simple-crc
     vars:
-      crc_parameters: "--memory 22000 --disk-size 120 --cpus 10"
+      crc_parameters: "--memory 24000 --disk-size 120 --cpus 10"
       pre_pull_images:
         - registry.redhat.io/rhosp-rhel9/openstack-rabbitmq:17.0
 


### PR DESCRIPTION
Currently EDPM and Baremetal jobs are failing with
```
error: You must be logged in to the server (Unauthorized)
```

Bumping ram might give some space to make the job green.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

