### PR TITLE
Some cleaning in ansible

### DIFF
--- a/ci_framework/roles/ci_setup/tasks/directories.yml
+++ b/ci_framework/roles/ci_setup/tasks/directories.yml
@@ -11,6 +11,6 @@
     - "{{ cifmw_ci_setup_basedir }}/logs"
     - "{{ cifmw_ci_setup_basedir }}/tmp"
     - "{{ cifmw_ci_setup_basedir }}/volumes"
-    - "{{ cifmw_ci_setup_basedir }}//artifacts/parameters"
+    - "{{ cifmw_ci_setup_basedir }}/artifacts/parameters"
   loop_control:
     label: "{{ item }}"

--- a/ci_framework/roles/edpm_build_images/README.md
+++ b/ci_framework/roles/edpm_build_images/README.md
@@ -11,7 +11,6 @@ None
 
 ### Parameters
 * `cifmw_edpm_build_images_basedir`: Base directory. Defaults to `cifmw_basedir` which  defaults to `~/ci-framework`.
-* `cifmw_edpm_build_images_artifacts`: Build images logs.
 * `cifmw_edpm_build_images_via_rpm`: Whether to install `edpm-image-builder` repo using rpm or not.
 * `cifmw_build_host_packages`: List of packges required to build the images.
 * `cifmw_edpm_build_images_elements`: Elements path which contains `edpm-image-builder` and `ironic-python-agent-builder` repo.

--- a/ci_framework/roles/edpm_build_images/defaults/main.yml
+++ b/ci_framework/roles/edpm_build_images/defaults/main.yml
@@ -19,7 +19,6 @@
 # All variables within this role should have a prefix of "cifmw_edpm_build_images"
 
 cifmw_edpm_build_images_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
-cifmw_edpm_build_images_artifacts: "{{ cifmw_edpm_build_images_basedir }}/artifacts"
 cifmw_edpm_build_images_via_rpm: true
 cifmw_edpm_build_images_host_packages:
   - diskimage-builder

--- a/ci_framework/roles/install_yamls/tasks/main.yml
+++ b/ci_framework/roles/install_yamls/tasks/main.yml
@@ -21,7 +21,7 @@
     path: "{{ item }}"
     state: directory
   loop:
-    - "{{ cifmw_install_yamls_out_dir }}/artifacts"
+    - "{{ cifmw_install_yamls_out_dir }}"
     - "{{ cifmw_install_yamls_tasks_out }}"
 
 - name: "Get environment structure"


### PR DESCRIPTION
While trying to find why we get a weird "artifacts/artifacts" empty
directory, I found some other inconsistent content, like a double "/"
and a parameter that doesn't seem to be used anywhere.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
