### PR TITLE
Improve content provider to work with standalone crc job

### DIFF
--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -118,6 +118,7 @@
             cmd: |
               cp -r /etc/libvirt/*.conf libvirt/;
               chown "{{ ansible_user }}" *
+              cp /etc/containers/registries.conf {{ ansible_user_dir }}/zuul-output/logs/
 
         - name: Copy generated documentation if available
           when:

--- a/ci/playbooks/content_provider/content_provider.yml
+++ b/ci/playbooks/content_provider/content_provider.yml
@@ -15,6 +15,16 @@
       ansible.builtin.include_role:
         name: registry_deploy
 
+    - name: Set var for cifmw_operator_build_operators var
+      when:
+        - project is defined
+        - "'short_name' in project"
+      ansible.builtin.set_fact:
+        cifmw_operator_build_operators:
+          - name: "openstack-operator"
+            src: "~/src/github.com/{{ cifmw_operator_build_org }}/openstack-operator"
+            image_base: "{{ project.short_name | split('-') | first }}"
+
     - name: Build Operators
       ansible.builtin.include_role:
         name: operator_build

--- a/ci/playbooks/content_provider/run.yml
+++ b/ci/playbooks/content_provider/run.yml
@@ -47,5 +47,5 @@
         data:
           zuul:
             pause: true
-          content_provider_registry_ip: "{{ content_provider_ip | default('nowhere') }}"
+          content_provider_registry_ip: "{{ content_provider_ip | default('nowhere') | trim }}"
           cifmw_operator_build_output: "{{ inner_ansible_vars.cifmw_operator_build_output }}"

--- a/ci/playbooks/set_crc_insecure_registry.yml
+++ b/ci/playbooks/set_crc_insecure_registry.yml
@@ -1,0 +1,48 @@
+---
+- name: Patch the image.config.openshift.io resource to include insecure registry
+  ansible.builtin.shell: |
+    oc patch --type=merge --patch='{
+    "spec": {
+      "registrySources": {
+        "insecureRegistries": [
+        "{{ content_provider_registry_ip }}:5001"
+        ]
+      }
+    }
+    }' image.config.openshift.io/cluster
+
+- name: Patch the image.config.openshift.io resource to allow insecure registry
+  ansible.builtin.shell: |
+    oc patch --type=merge --patch='{
+    "spec": {
+      "registrySources": {
+        "allowedRegistries": [
+        "{{ content_provider_registry_ip }}:5001",
+        "quay.io",
+        "registry.redhat.io",
+        "image-registry.openshift-image-registry.svc:5000"
+        ]
+      }
+    }
+    }' image.config.openshift.io/cluster
+
+- name: Set Insecure registry for content provider
+  become: true
+  ansible.builtin.blockinfile:
+    state: present
+    insertafter: EOF
+    dest: /etc/containers/registries.conf
+    content: |-
+      [[registry]]
+      location = "{{ content_provider_registry_ip }}:5001"
+      insecure = true
+      blocked = false
+      mirror-by-digest-only = false
+      prefix = ""
+
+- name: Restart crio
+  become: true
+  ansible.builtin.service:
+    name: crio
+    state: reloaded
+    enabled: true

--- a/ci/playbooks/wait-for-crc.yaml
+++ b/ci/playbooks/wait-for-crc.yaml
@@ -89,6 +89,10 @@
         - wait_crc.rc is defined
         - wait_crc.rc == 0
 
+    - name: Set insecure registry on crc node
+      ansible.builtin.include_tasks: set_crc_insecure_registry.yml
+      when: content_provider_registry_ip is defined
+
 - hosts: controller
   name: "tweak controller"
   gather_facts: true

--- a/zuul.d/content_provider.yaml
+++ b/zuul.d/content_provider.yaml
@@ -1,6 +1,6 @@
 ---
 - job:
-    name: content-provider-base
+    name: openstack-k8s-operators-content-provider
     parent: base-ci-framework
     nodeset: centos-stream-9
     irrelevant-files:
@@ -14,6 +14,14 @@
       - ^renovate.json$
       - ^tests/.*$
       - ^kuttl-test.yaml$
+      - molecule/.*
+      - molecule-requirements.txt
+      - .github/workflows
+      - scripts/.*
+      - docs/.*
+      - contribute/.*
+      - tests
+      - roles/.*/molecule/.*
     required-projects:
       - opendev.org/zuul/zuul-jobs
       - openstack-k8s-operators/ci-framework
@@ -42,10 +50,14 @@
       - openstack-k8s-operators/telemetry-operator
     pre-run:
       - ci/playbooks/content_provider/pre.yml
-    run:
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_vars.yml
+    run:
       - ci/playbooks/content_provider/run.yml
     post-run: ci/playbooks/collect-logs.yml
     vars:
       cifmw_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+
+- job:
+    name: content-provider-base
+    parent: openstack-k8s-operators-content-provider

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -31,7 +31,7 @@
       - openstack-k8s-operators/repo-setup
       - openstack-k8s-operators/edpm-ansible
     roles:
-      - zuul: github.com/openstack-k8s-operatorsait/ci-framework
+      - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run:
       - ci/playbooks/wait-for-crc.yaml
       - ci/playbooks/e2e-prepare.yml


### PR DESCRIPTION
It adds following improvements to the content provider:
    - Adds single content provider, can be used at all places
    - Sets cifmw_operator_build_operators var with in the job
    - Adds playbook to update content provider ip on crc node
    - Collects the registries.conf outpu

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/476