### PR TITLE
PoC for ci_script implementation

### DIFF
--- a/ci_framework/roles/copy_container/tasks/main.yml
+++ b/ci_framework/roles/copy_container/tasks/main.yml
@@ -37,6 +37,7 @@
 - name: Build the copy-container
   register: go_build
   ci_script:
+    output_dir: "{{ cifmw_artifacts_basedir }}/artifacts"
     cmd: go build
     chdir: "{{ temporary_copy_container_dir.path }}"
   changed_when: false

--- a/ci_framework/roles/copy_container/tasks/main.yml
+++ b/ci_framework/roles/copy_container/tasks/main.yml
@@ -36,7 +36,7 @@
 
 - name: Build the copy-container
   register: go_build
-  ansible.builtin.command:
+  ci_script:
     cmd: go build
     chdir: "{{ temporary_copy_container_dir.path }}"
   changed_when: false


### PR DESCRIPTION
On this PoC, I implemented the change from builtin shell/command into our own ci_script plugin. On this proof of concept I am implementing it on the copy_container role.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
