### PR TITLE
Enable tempest on EDPM job

### DIFF
--- a/scenarios/centos-9/edpm_ci.yml
+++ b/scenarios/centos-9/edpm_ci.yml
@@ -18,8 +18,6 @@ pre_infra:
     type: playbook
     source: "{{ cifmw_installyamls_repos }}/devsetup/download_tools.yaml"
 
-# edpm_deploy role vars
-cifmw_edpm_deploy_run_validation: true
 # edpm_prepare role vars
 cifmw_operator_build_meta_name: "openstack-operator"
 cifmw_edpm_prepare_skip_crc_storage_creation: true
@@ -36,6 +34,10 @@ cifmw_openshift_user: "kubeadmin"
 cifmw_openshift_password: "123456789"
 cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
 
+# tempest related vars
+cifmw_run_tests: true
+cifmw_tempest_tests_allowed:
+  - tempest.scenario.test_server_basic_ops.TestServerBasicOps.test_server_basic_ops
 pre_deploy:
   - name: Disable openstack marketplace
     type: playbook

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -71,6 +71,7 @@
       cifmw_deploy_edpm: false
       cifmw_use_libvirt: false
       podified_validation: true
+      cifmw_run_tests: false
       make_openstack_deploy_params:
         GALERA_REPLICAS: 3
 


### PR DESCRIPTION
It enable tempest.scenario.test_server_basic_ops.TestServerBasicOps test to validate the EDPM deployment.
    

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running


