### PR TITLE
Enabling tempest role to use variables to allowed and skipped tests

### DIFF
--- a/ci_framework/roles/tempest/README.md
+++ b/ci_framework/roles/tempest/README.md
@@ -13,3 +13,5 @@ become - Required to install required rpm packages
 * `cifmw_tempest_image_tag`: (String) Tag for the `cifmw_tempest_image`. Default to `current-podified`
 * `cifmw_tempest_dry_run`: (Boolean) Whether tempest should run or not. Default to `false`
 * `cifmw_tempest_remove_container`: (Boolean) Cleanup tempest container after it is done. Default to `false`
+* `cifmw_tempest_tests_skipped`: (List) List of tests to be skipped. Setting this will not use the `list_skipped` plugin
+* `cifmw_tempest_tests_allowed`: (List) List of tests to be executed. Setting this will not use the `list_allowed` plugin

--- a/ci_framework/roles/tempest/tasks/tempest-tests.yml
+++ b/ci_framework/roles/tempest/tasks/tempest-tests.yml
@@ -14,45 +14,76 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 #
-- name: Copy list_allowed to artifacts dir
-  ansible.builtin.copy:
-    dest: "{{ cifmw_tempest_artifacts_basedir }}/list_allowed.yml"
-    src: "list_allowed.yml"
+- name: Configuring tests to be executed via skiplist
+  when: cifmw_tempest_tests_allowed is not defined
+  block:
+    - name: Copy list_allowed to artifacts dir
+      ansible.builtin.copy:
+        dest: "{{ cifmw_tempest_artifacts_basedir }}/list_allowed.yml"
+        src: "list_allowed.yml"
 
-- name: Copy list_skipped to artifacts dir
-  ansible.builtin.copy:
-    dest: "{{ cifmw_tempest_artifacts_basedir }}/list_skipped.yml"
-    src: "list_skipped.yml"
+    - name: Get list of tests to be executed
+      tempest_list_allowed:
+        yaml_file: "{{ cifmw_tempest_artifacts_basedir }}/list_allowed.yml"
+        groups: "{{ cifmw_tempest_default_groups }}"
+        job: "{{ cifmw_tempest_job_name | default(omit) }}"
+      register:
+        list_allowed
 
-- name: Get list of tests to be executed
-  tempest_list_allowed:
-    yaml_file: "{{ cifmw_tempest_artifacts_basedir }}/list_allowed.yml"
-    groups: "{{ cifmw_tempest_default_groups }}"
-    # job: "{{ cifmw_tempest_job_name | default(omit) }}"
-  register:
-    list_allowed
+    - name: Creating include.txt
+      ansible.builtin.copy:
+        dest: "{{ cifmw_tempest_artifacts_basedir }}/include.txt"
+        content: "{% for test in list_allowed.allowed_tests %}{{ test }}\n{% endfor %}"
 
-- name: Show tests to be executed
-  ansible.builtin.debug:
-    msg: "{{ list_allowed }}"
+    - name: Show tests to be executed
+      ansible.builtin.debug:
+        msg: "{{ list_allowed }}"
 
-- name: Get list of tests to be excluded
-  tempest_list_skipped:
-    yaml_file: "{{ cifmw_tempest_artifacts_basedir }}/list_skipped.yml"
-    jobs: "{{ cifmw_tempest_default_jobs }}"
-  register:
-    list_skipped
+- name: Configuring tests to be skipped via skiplist
+  when: cifmw_tempest_tests_skipped is not defined
+  block:
+    - name: Copy list_skipped to artifacts dir
+      ansible.builtin.copy:
+        dest: "{{ cifmw_tempest_artifacts_basedir }}/list_skipped.yml"
+        src: "list_skipped.yml"
 
-- name: Show tests to be excluded
-  ansible.builtin.debug:
-    msg: "{{ list_skipped.skipped_tests }}"
+    - name: Get list of tests to be excluded
+      tempest_list_skipped:
+        yaml_file: "{{ cifmw_tempest_artifacts_basedir }}/list_skipped.yml"
+        jobs: "{{ cifmw_tempest_default_jobs }}"
+      register:
+        list_skipped
 
-- name: Creating include.txt
-  ansible.builtin.copy:
-    dest: "{{ cifmw_tempest_artifacts_basedir }}/include.txt"
-    content: "{% for test in list_allowed.allowed_tests %}{{ test }}\n{% endfor %}"
+    - name: Creating exclude.txt
+      ansible.builtin.copy:
+        dest: "{{ cifmw_tempest_artifacts_basedir }}/exclude.txt"
+        content: "{% for test in list_skipped.skipped_tests %}{{ test }}\n{% endfor %}"
 
-- name: Creating exclude.txt
-  ansible.builtin.copy:
-    dest: "{{ cifmw_tempest_artifacts_basedir }}/exclude.txt"
-    content: "{% for test in list_skipped.skipped_tests %}{{ test }}\n{% endfor %}"
+    - name: Show tests to be excluded
+      ansible.builtin.debug:
+        msg: "{{ list_skipped.skipped_tests }}"
+
+
+- name: Configuring tests to be executed via cifmw_tempest_tests_allowed
+  when: cifmw_tempest_tests_allowed is defined
+  block:
+    - name: Creating include.txt
+      ansible.builtin.copy:
+        dest: "{{ cifmw_tempest_artifacts_basedir }}/include.txt"
+        content: "{% for test in cifmw_tempest_tests_allowed %}{{ test }}\n{% endfor %}"
+
+    - name: Show tests to be executed
+      ansible.builtin.debug:
+        msg: "{{ cifmw_tempest_tests_allowed }}"
+
+- name: Configuring tests to be skipped via cifmw_tempest_tests_skipped
+  when: cifmw_tempest_tests_skipped is defined
+  block:
+    - name: Creating exclude.txt
+      ansible.builtin.copy:
+        dest: "{{ cifmw_tempest_artifacts_basedir }}/exclude.txt"
+        content: "{% for test in cifmw_tempest_tests_skipped %}{{ test }}\n{% endfor %}"
+
+    - name: Show tests to be executed
+      ansible.builtin.debug:
+        msg: "{{ cifmw_tempest_tests_allowed }}"


### PR DESCRIPTION
This patch add two new variables in tempest role to list the tests to be executed and skipped. With this, the list_allowed and list_skipped plugins will be ignored. This is good to test a job before add the tests on the skip and/or allowed list.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
