### PR TITLE
Fixed the syntax error

### DIFF
--- a/ci_framework/roles/copy_container/tasks/main.yml
+++ b/ci_framework/roles/copy_container/tasks/main.yml
@@ -38,8 +38,10 @@
   register: go_build
   ci_script:
     output_dir: "{{ cifmw_artifacts_basedir }}/artifacts"
-    cmd: go build
-    chdir: "{{ temporary_copy_container_dir.path }}"
+    cmd: |
+      pushd "{{ temporary_copy_container_dir.path }}"
+      go build
+      popd
   changed_when: false
 
 - name: Copy binary to /usr/local/bin (CentOS 8)


### PR DESCRIPTION
As in the "ci-script" plugins [1] we don't have 'chdir' option and that is causing syntax error in the periodic jobs [2].

[1]: https://github.com/openstack-k8s-operators/ci-framework/blob/main/ci_framework/plugins/action/ci_script.py#L20
[2]: https://logserver.rdoproject.org/65/49365/1/check/periodic-edpm-container-image-quay-push-centos-9-master/cd9d1d4/job-output.txt

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
