### PR TITLE
Store edpm-ansible scenario file in artifacts directory.

### DIFF
--- a/ci/playbooks/build_runner_image.yml
+++ b/ci/playbooks/build_runner_image.yml
@@ -27,7 +27,7 @@
 
     - name: Make sure ci-framework directory exists
       ansible.builtin.file:
-        path: "{{ ansible_user_dir }}/ci-framework/"
+        path: "{{ ansible_user_dir }}/ci-framework-data/artifacts"
         state: directory
 
     - name: Create EDPM ansible var file
@@ -38,4 +38,4 @@
           cifmw_set_openstack_containers_operator_name: openstack-ansibleee
           cifmw_set_openstack_containers_overrides:
             ANSIBLEEE_IMAGE_URL_DEFAULT: "{{ ansibleee_runner_img }}"
-        dest: "{{ ansible_user_dir }}/ci-framework/edpm-ansible.yml"
+        dest: "{{ ansible_user_dir }}/ci-framework-data/artifacts/edpm-ansible.yml"

--- a/ci/playbooks/edpm/run.yml
+++ b/ci/playbooks/edpm/run.yml
@@ -9,8 +9,8 @@
           ansible-playbook deploy-edpm.yml
           -e @scenarios/centos-9/base.yml
           -e @scenarios/centos-9/edpm_ci.yml
-          {%- if 'edpm-ansible' in zuul_change_list %}
-          -e @{{ ansible_user_dir }}/ci-framework/edpm-ansible.yml
+          {%- if zuul_change_iist is defined and 'edpm-ansible' in zuul_change_list %}
+          -e @{{ ansible_user_dir }}/ci-framework-data/artifacts/edpm-ansible.yml
           {%- endif %}
           {%- if cifmw_extras is defined %}
           {%-   for extra_var in cifmw_extras %}


### PR DESCRIPTION
It will be useful for debugging.
It also fixes the case for zuul_change_list is undefined when e2e-prepare playbook is not used in the ci job.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
