### PR TITLE
Added missing namespaces in os_must_gather role

### DIFF
--- a/ci_framework/roles/os_must_gather/tasks/main.yml
+++ b/ci_framework/roles/os_must_gather/tasks/main.yml
@@ -52,6 +52,6 @@
         PATH: "{{ cifmw_path }}"
       ansible.builtin.shell: |
         mkdir -p {{ cifmw_os_must_gather_output_dir }}/logs/oc_inspect
-        for ns in openstack-operators openstack baremetal-operator-system openshift-machine-api; do
+        for ns in openstack-operators openstack baremetal-operator-system openshift-machine-api cert-manager openshift-nmstate metallb-system; do
           oc adm inspect namespace/"${ns}" --dest-dir={{ cifmw_os_must_gather_output_dir }}/logs/oc_inspect || echo "Error getting logs from ${ns}"
         done


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/openstack-must-gather/pull/3 adds cert-manager and openshift-nmstate namespace in openstack-must-gather.

The same needs to be updated to collect logs from these namespace if must-gather command fails.

It also includes metallb-system namespace in the same.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
