### PR TITLE
Use ci_script instead of shell in edpm_deploy role

### DIFF
--- a/ci_framework/roles/edpm_deploy/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy/tasks/main.yml
@@ -37,11 +37,13 @@
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
   block:
     - name: Get info about dataplane node
-      ansible.builtin.shell: |
-        oc get openstackdataplane -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
-        oc get openstackdataplanerole -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
-        oc get openstackdataplanenode -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
-        oc get pods -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} | grep edpm
+      ci_script:
+        output_dir: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
+        script: |-
+          oc get openstackdataplane -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+          oc get openstackdataplanerole -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+          oc get openstackdataplanenode -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+          oc get pods -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} | grep edpm
       ignore_errors: true
 
     - name: Get nova-edpm-compute-0-deploy-nova pod name


### PR DESCRIPTION
It will help to log the output in a file, useful for debugging later.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

