### PR TITLE
Revert "Workaround wait condition issue"

### DIFF
--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -127,18 +127,6 @@
         src: "{{ cifmw_edpm_prepare_openstack_cr_manifest_paths.files[0].path }}"
       register: cifmw_edpm_prepare_ctrlplane_cr_slurp
 
-# Workaround for OSP-25980
-    - name: Wait for NeutronReady
-      environment:
-        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-        PATH: "{{ cifmw_path }}"
-      ansible.builtin.command:
-        cmd: >-
-          oc wait OpenStackControlPlane {{ (cifmw_edpm_prepare_ctrlplane_cr_slurp['content'] | b64decode | from_yaml).metadata.name }}
-          --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
-          --for=condition=OpenStackControlPlaneNeutronReady
-          --timeout=30m
-
     - name: Wait for OpenStack controlplane to be deployed
       environment:
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"


### PR DESCRIPTION
Related fix was mered in [1],
time to remove the workaround.
However other offenders are possible,
but we only C if we try.

[1] https://github.com/openstack-k8s-operators/openstack-operator/pull/394

This reverts commit e00ae59c04fd53d6038d631fd63c7e58052892ac.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
