### PR TITLE
Set default value for registry_login_enabled

### DIFF
--- a/ci/playbooks/e2e-prepare.yml
+++ b/ci/playbooks/e2e-prepare.yml
@@ -50,4 +50,4 @@
   when:
     - zuul_change_list is defined
     - "'edpm-ansible' in zuul_change_list"
-    - registry_login_enabled | bool
+    - registry_login_enabled | default('false') | bool


### PR DESCRIPTION
registry_login_enabled var is only set in edpm job. This var is used in `Build openstack-ansibleee-runner image` task, does not have default value. When e2e-prepare.yml playbook is called and this var is not defined. It leads to undefined error.

Setting the default value fixes the issue.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
