### PR TITLE
Correct ci_script call

### DIFF
--- a/ci_framework/roles/copy_container/tasks/main.yml
+++ b/ci_framework/roles/copy_container/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: Ensure directory is present
+  ansible.builtin.file:
+    path: "{{ cifmw_copy_ct_basedir }}/{{ item }}"
+    state: directory
+  loop:
+    - artifacts
+    - logs
+
 - name: Install HyperScale repository (btrfs-progs requirement)
   when:
     - ansible_distribution == 'CentOS'
@@ -38,7 +46,7 @@
   register: go_build
   ci_script:
     output_dir: "{{ cifmw_copy_ct_basedir }}/artifacts"
-    cmd: go build
+    script: go build
     chdir: "{{ temporary_copy_container_dir.path }}"
   changed_when: false
 


### PR DESCRIPTION
while replacing "shell" and "command" by "ci_script", we must ensure we
also correct the actual parameters.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running

Test-project: https://review.rdoproject.org/r/c/testproject/+/49365
