### PR TITLE
Dump edpm container images in separate log file

### DIFF
--- a/ci_framework/roles/edpm_build_images/tasks/post.yaml
+++ b/ci_framework/roles/edpm_build_images/tasks/post.yaml
@@ -34,3 +34,9 @@
       loop:
         - edpm-hardened-uefi
         - ironic-python-agent
+
+- name: Dump edpm container images in the file
+  args:
+    chdir: "{{ cifmw_edpm_image_builder_repo_path }}"
+  ansible.builtin.shell: |
+    buildah images | grep -E '(edpm-hardened-uefi|ironic-python-agent)' | tee -a {{ cifmw_edpm_build_images_basedir }}/logs/containers-built.log

--- a/zuul.d/edpm_build_images.yaml
+++ b/zuul.d/edpm_build_images.yaml
@@ -25,3 +25,4 @@
       - ^ci/playbooks/edpm_build_images/.*
       - ^scenarios/centos-9/edpm_build_images_ci.yml
       - ^zuul.d/edpm_build_images.yaml
+      - ^ci_framework/roles/edpm_build_images/*


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/424

- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
