### PR TITLE
Collect all the errors in a single file

### DIFF
--- a/ci_framework/roles/artifacts/tasks/gather_errors.yml
+++ b/ci_framework/roles/artifacts/tasks/gather_errors.yml
@@ -1,0 +1,7 @@
+---
+- name: Gather all errrors in a single file
+  ansible.builtin.shell: |
+    grep -rE '^[-0-9]+ [0-9:\.]+ [0-9 ]*ERROR ' {{ cifmw_artifacts_basedir }}/logs |
+    sed "s/\(.*\)\(20[0-9][0-9]-[0-9][0-9]-[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\.[0-9]\+\)\(.*\)/\2 ERROR \1\3/g" > /tmp/errors.txt;
+    mv /tmp/errors.txt {{ cifmw_artifacts_basedir }}/logs/errors.txt
+  ignore_errors: true

--- a/ci_framework/roles/artifacts/tasks/main.yml
+++ b/ci_framework/roles/artifacts/tasks/main.yml
@@ -46,3 +46,6 @@
 
 - name: Gather CRC logs
   ansible.builtin.import_tasks: crc.yml
+
+- name: Gather all errors at one place
+  ansible.builtin.import_tasks: gather_errors.yml


### PR DESCRIPTION
It will allow developers to look for errors at one place and make it's easier to navigate over logs.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running

