### PR TITLE
Be explicit with ssh key permissions

### DIFF
--- a/ci_framework/roles/local_env_vm/tasks/main.yml
+++ b/ci_framework/roles/local_env_vm/tasks/main.yml
@@ -27,6 +27,7 @@
     size: 512
     path: "{{ cifmw_local_env_vm_basedir }}/artifacts/local_env_vm_key"
     force: true
+    mode: "600"
 
 - name: Debug
   ansible.builtin.debug:


### PR DESCRIPTION
On my system, the key is created with 0640 permissions, this fails the `local_env_create` installation and prevents logging into the `cifmw-vm` vm.

Example error:
```
TASK [local_env_vm : Copy requested content to the local_env VM dest={{ cifmw_local_vm_ip }}:/home/zuul/src/ci-framework, src={{ role_path }}/../../../] ***
Tuesday 25 July 2023  21:19:44 +1000 (0:00:00.603)       0:04:10.446 **********
zuul@192.168.122.35's password:
zuul@192.168.122.35's password:
zuul@192.168.122.35's password:
fatal: [localhost]: FAILED! => {"changed": false, "cmd": "/usr/bin/rsync --delay-updates -F --compress --archive --rsh='/usr/bin/ssh -S none -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' --out-format='<<CHANGED>>%i %n%L' /home/ldenny/ci-framework/ci_framework/roles/local_env_vm/../../../ 192.168.122.35:/home/zuul/src/ci-framework", "msg": "Warning: Permanently added '192.168.122.35' (ED25519) to the list of known hosts.\r\n@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\r\n@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @\r\n@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\r\nPermissions 0640 for '/home/ldenny/ci-framework-data/artifacts/local_env_vm_key' are too open.\r\nIt is required that your private key files are NOT accessible by others.\r\nThis private key will be ignored.\r\nLoad key \"/home/ldenny/ci-framework-data/artifacts/local_env_vm_key\": bad permissions\r\nPermission denied, please try again.\r\nPermission denied, please try again.\r\nzuul@192.168.122.35: Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password).\r\nrsync: connection unexpectedly closed (0 bytes received so far) [sender]\nrsync error: unexplained error (code 255) at io.c(228) [sender=3.2.3]\n", "rc": 255}
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
