### PR TITLE
Add task to create tempestconf profile

### DIFF
--- a/ci_framework/roles/tempest/README.md
+++ b/ci_framework/roles/tempest/README.md
@@ -15,3 +15,25 @@ become - Required to install required rpm packages
 * `cifmw_tempest_remove_container`: (Boolean) Cleanup tempest container after it is done. Default to `false`
 * `cifmw_tempest_tests_skipped`: (List) List of tests to be skipped. Setting this will not use the `list_skipped` plugin
 * `cifmw_tempest_tests_allowed`: (List) List of tests to be executed. Setting this will not use the `list_allowed` plugin
+* `cifmw_tempest_tempestconf_profile`: (Dictionary) List of settings to be overwritten in tempest.conf.
+
+## Use of cifmw_tempest_tempestconf_profile
+
+You can pass arguments to tempestconf and also override tempest config options.
+The tempest config options goes under overrides, while the tempestconf options
+goes in the root of the dictionary, for example:
+
+```
+cifmw_tempest_tempestconf_profile:
+debug: true
+deployer-input: /etc/tempest-deployer-input.conf
+overrides:
+    validation.run_ssh: false
+    telemetry.alarm_granularity: '60'
+```
+
+Where debug is the same as passing `--debug` to cli and deployer-input is the
+same as `--deployer-input`. Under overrides, you have validation.run_ssh as
+false, this will create in tempest.conf under validation section an option
+run_ssh as false. The same with telemetry.alarm_granularity, it will create
+under telemetry section an option alarm_granularity set to 60.

--- a/ci_framework/roles/tempest/tasks/configure-tempest.yml
+++ b/ci_framework/roles/tempest/tasks/configure-tempest.yml
@@ -29,3 +29,11 @@
   ansible.builtin.template:
     src: clouds.yaml.j2
     dest: "{{ cifmw_tempest_artifacts_basedir }}/clouds.yaml"
+
+# Check README to see examples of how to set cifmw_tempest_tempestconf_profile
+- name: Create profile.yaml file
+  when: cifmw_tempest_tempestconf_profile is defined
+  ansible.builtin.copy:
+    content: "{{ cifmw_tempest_tempestconf_profile | to_nice_yaml }}"
+    dest: "{{ cifmw_tempest_artifacts_basedir }}/profile.yaml"
+    mode: "0644"

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -70,6 +70,7 @@ ctx
 dataplane
 dd'd
 delorean
+deployer
 deps
 dest
 dev
@@ -288,6 +289,7 @@ svm
 systemd
 tcib
 tdciagigtlesa
+tempestconf
 testcases
 timestamper
 tldca


### PR DESCRIPTION
Tempestconf has an --option profile that can pass overrided options to tempest. In some jobs, we do need to pass different configuration to tempest.conf that tempestconf don't detect or if we don't want to run some validation for example.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
