### PR TITLE
Set edpm-ansible.yml var file if file exists

### DIFF
--- a/ci/playbooks/edpm/run.yml
+++ b/ci/playbooks/edpm/run.yml
@@ -2,6 +2,11 @@
 - hosts: all
   gather_facts: true
   tasks:
+    - name: Check for edpm-ansible.yml file
+      ansible.builtin.stat:
+        path: "{{ ansible_user_dir }}/ci-framework-data/artifacts/edpm-ansible.yml"
+      register: edpm_file
+
     - name: Run Podified EDPM deployment
       ansible.builtin.command:
         chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
@@ -9,7 +14,7 @@
           ansible-playbook deploy-edpm.yml
           -e @scenarios/centos-9/base.yml
           -e @scenarios/centos-9/edpm_ci.yml
-          {%- if zuul_change_iist is defined and 'edpm-ansible' in zuul_change_list %}
+          {%- if edpm_file.stat.exists %}
           -e @{{ ansible_user_dir }}/ci-framework-data/artifacts/edpm-ansible.yml
           {%- endif %}
           {%- if cifmw_extras is defined %}


### PR DESCRIPTION
Currently existance of edpm-ansible.yml var file depends on zuul_change_list var. This var is set in different playbook but it does not passed in another playbook i.e. `run.yml`.

It leads to failure of testing edpm-ansible changes.

By making sure edpm-ansible.yml var file exists, it fixes the issue.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

