### PR TITLE
Rename cifmw_repo_setup_opts to cifmw_repo_setup_additional_repos

### DIFF
--- a/ci_framework/roles/repo_setup/README.md
+++ b/ci_framework/roles/repo_setup/README.md
@@ -13,7 +13,7 @@ Please explain the role purpose.
 * `cifmw_repo_setup_os_release`: (String) Operating system release. Defaults to `{{ ansible_distribution|lower }}`.
 * `cifmw_repo_setup_src`: (String) repo-setup repository location. Defaults to `https://github.com/openstack-k8s-operators/repo-setup`.
 * `cifmw_repo_setup_output`: (String) Repository files output. Defaults to `{{ cifmw_repo_setup_basedir }}/artifacts/repositories`.
-* `cifmw_repo_setup_opts`: (String) Additional options we may to pass to repo_setup. Defaults to `''`.
+* `cifmw_repo_setup_additional_repos`: (String) Additional repos(ceph, deps) to enable. Defaults to `''`.
 * `cifmw_repo_setup_env`: (Dict) Environment variables to be passed to repo_setup cli . Defaults to `'{}'`.
 * `cifmw_repo_setup_enable_rhos_release`: (Boolean) Toggle `rhos-release` support. Defaults to `False`.
 

--- a/ci_framework/roles/repo_setup/defaults/main.yml
+++ b/ci_framework/roles/repo_setup/defaults/main.yml
@@ -30,7 +30,7 @@ cifmw_repo_setup_dist_major_version: "{{ ansible_distribution_major_version }}"
 cifmw_repo_setup_src: "https://github.com/openstack-k8s-operators/repo-setup"
 cifmw_repo_setup_output: "{{ cifmw_repo_setup_basedir }}/artifacts/repositories"
 cifmw_repo_setup_env: {}
-cifmw_repo_setup_opts: ''
+cifmw_repo_setup_additional_repos: ''
 
 # Variables related to rhos-release tools
 # rhos-release is used in downstream to populate downstream base os repos

--- a/ci_framework/roles/repo_setup/tasks/configure.yml
+++ b/ci_framework/roles/repo_setup/tasks/configure.yml
@@ -4,10 +4,9 @@
   ansible.builtin.command:
     cmd: >-
       {{ cifmw_repo_setup_basedir }}/venv/bin/repo-setup
-      {{ cifmw_repo_setup_promotion }}
+      {{ cifmw_repo_setup_promotion }} {{ cifmw_repo_setup_additional_repos }}
       -d {{ cifmw_repo_setup_os_release }}{{ cifmw_repo_setup_dist_major_version }}
       -b {{ cifmw_repo_setup_branch }}
       --rdo-mirror {{ cifmw_repo_setup_rdo_mirror }}
       -o {{ cifmw_repo_setup_output }}
-      {{ cifmw_repo_setup_opts }}
   environment: "{{ cifmw_repo_setup_env | default ({}) }}"

--- a/ci_framework/roles/test_deps/tasks/main.yml
+++ b/ci_framework/roles/test_deps/tasks/main.yml
@@ -72,7 +72,7 @@
     cifmw_repo_setup_branch: "master"
     cifmw_repo_setup_promotion: "current-podified"
     cifmw_repo_setup_os_release: "centos"
-    cifmw_repo_setup_opts: "{{ test_deps_setup_ceph | ternary('ceph', '', omit) }}"
+    cifmw_repo_setup_additional_repos: "{{ test_deps_setup_ceph | ternary('ceph', '', omit) }}"
   ansible.builtin.include_role:
     name: "repo_setup"
 


### PR DESCRIPTION
repo-setup provides a way to enable additional repos like ceph or deps like this:
```
❯ repo-setup current-podified ceph -d centos9 -b master --rdo-mirror https://trunk.rdoproject.org/ -o /tmp/repos/
WARNING: Unsupported platform 'fedora38' detected by repo-setup, centos9 will be used unless you use CLI param to change it.
Installed repo delorean to /tmp/repos/delorean.repo
Installed repo delorean-master-testing to /tmp/repos/delorean-master-testing.repo
Installed repo repo-setup-centos-ceph-pacific to /tmp/repos/repo-setup-centos-ceph-pacific.repo
Installed repo repo-setup-centos-highavailability to /tmp/repos/repo-setup-centos-highavailability.repo
Installed repo repo-setup-centos-powertools to /tmp/repos/repo-setup-centos-powertools.repo
Installed repo repo-setup-centos-appstream to /tmp/repos/repo-setup-centos-appstream.repo
Installed repo repo-setup-centos-baseos to /tmp/repos/repo-setup-centos-baseos.repo
Cache was expired
0 files removed
```

If we pass ceph as cifmw_repo_setup_opts, it breaks the repo-setup tooling. It creates confusion. In order to fix that, it renames the cifmw_repo_setup_opts to cifmw_repo_setup_additional_repos.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
