### PR TITLE
Ansible action plugin for oc commands

### DIFF
--- a/ci_framework/plugins/action/oc.py
+++ b/ci_framework/plugins/action/oc.py
@@ -4,8 +4,6 @@
 import os
 from pathlib import Path
 from ansible.errors import AnsibleError
-from ansible.module_utils.basic import get_bin_path
-from ansible.module_utils.six import ensure_text
 from ansible.plugins.action import ActionBase
 
 DOCUMENTATION = r'''
@@ -15,13 +13,13 @@ action: oc
 short_description: Execute OpensShift Client commands - oc -.
 
 description:
-- This module searches the oc binary, load the kubeconfig and execute the oc provided commands.
+- This module searches the oc binary in, load the kubeconfig and execute the oc provided commands.
 '''
 
 EXAMPLES = r'''
 - name: Display the current authenticated user
-    oc_cmd:
-    command: whoami -c
+    oc:
+    cmd: whoami -c
 - name: Display the current authenticated user and get cluster information
       oc:
         cmd: |
@@ -46,68 +44,41 @@ class ActionModule(ActionBase):
 
     def run(self, tmp=None, task_vars=None):
         super().run(tmp, task_vars)
-        module_args = self._task.args.copy()
 
-        if 'cmd' not in module_args or not module_args['cmd']:
+        # We're gonna use the shell module so we can pass same arguments
+        # https://docs.ansible.com/ansible/latest/collections/ansible/builtin/shell_module.html#parameter-cmd
+        if 'cmd' not in self._task.args or not self._task.args['cmd']:
             raise AnsibleError('"cmd" parameter is mandatory')
 
         # Get remote home, local or remote depending of the hosts
         user_home = Path(task_vars['ansible_user_dir']).resolve()
 
-        # Get cluster auth config path or take by default crc one
-        kubeconfig_path = task_vars.get(
-            'cifmw_kubeconfig', False) or user_home / ".crc/machines/crc/kubeconfig"
-        os.environ["KUBECONFIG"] = str(kubeconfig_path)
+        # Check if the environment KUBECONFIG is assigned in the playbook, if not
+        # we apply default one used in CRC
+        kube_config = {
+            'KUBECONFIG': user_home / '.crc/machines/crc/kubeconfig'
+        }
+        if not any('KUBECONFIG' in d for d in self._task.environment):
+            self._task.environment.append(kube_config)
 
-        # Additional default paths
         additional_exec_paths = [
             str(user_home / '.crc/bin'),
             str(user_home / '.crc/bin/oc'),
         ]
 
-        # We can provide additional PATHs
-        cifmw_oc_path = task_vars.get('cifmw_oc_path', False)
-        if cifmw_oc_path:
-            additional_exec_paths.append(cifmw_oc_path)
+        # We need to get the actual PATHs + append the additional ones
+        # where the oc binary can be located
+        self._task.environment.append(
+            {
+                'PATH': os.pathsep.join((additional_exec_paths + [task_vars['ansible_env']['PATH']]))
+            }
+        )
 
-        oc_binary = self._get_oc_binary(additional_exec_paths)
-
-        # Used if we send one in-line command or several using pipe in ansible
-        commands = module_args['cmd'].splitlines()
-        oc_cmd_results = []
-        for cmd in commands:
-            oc_cmd_results.append(self._execute_command(f"{oc_binary} {cmd}"))
-
-        module_args['return_content'] = True
-
-        result = {
-            'success': True,
-            'changed': True,
-            'error': '',
-            'stdout': oc_cmd_results
-        }
-
-        return result
-
-    def _execute_command(self, command):
-        """
-        Execute shell commands using Ansible built-in methods.
-        """
-        # We don't need to sanitize the input since it's done in this method
-        command_result = self._low_level_execute_command(cmd=command)
-
-        if command_result['rc'] != 0:
-            # ensure_text just to avoid some decode problems
-            stderr = ensure_text(command_result.get('stderr', ''))
-            raise AnsibleError(
-                f"{self._task.action}: failed to execute the command {command}. Return code: {command_result['rc']}. STDERR: {stderr}"
-            )
-        return ensure_text(command_result.get('stdout', '')).rstrip()
-
-    def _get_oc_binary(self, additional_exec_paths=None):
-        """
-        Search for the 'oc' binary in different paths. By default, it searches using
-        the defined paths in the get_bin_path Ansible function. Additional paths can be provided.
-        Raises an error if not found.
-        """
-        return get_bin_path('oc', opt_dirs=additional_exec_paths)
+        self._task.args['_raw_params'] = self._task.args.pop('cmd')
+        return self._shared_loader_obj.action_loader.get('ansible.builtin.shell',
+                                                         task=self._task,
+                                                         connection=self._connection,
+                                                         play_context=self._play_context,
+                                                         loader=self._loader,
+                                                         templar=self._templar,
+                                                         shared_loader_obj=self._shared_loader_obj).run(task_vars=task_vars)

--- a/ci_framework/plugins/action/oc.py
+++ b/ci_framework/plugins/action/oc.py
@@ -1,0 +1,113 @@
+# Copyright Red Hat, Inc.
+# Apache License Version 2.0 (see LICENSE)
+
+import os
+from pathlib import Path
+from ansible.errors import AnsibleError
+from ansible.module_utils.basic import get_bin_path
+from ansible.module_utils.six import ensure_text
+from ansible.plugins.action import ActionBase
+
+DOCUMENTATION = r'''
+---
+action: oc
+
+short_description: Execute OpensShift Client commands - oc -.
+
+description:
+- This module searches the oc binary, load the kubeconfig and execute the oc provided commands.
+'''
+
+EXAMPLES = r'''
+- name: Display the current authenticated user
+    oc_cmd:
+    command: whoami -c
+- name: Display the current authenticated user and get cluster information
+      oc:
+        cmd: |
+          whoami -c
+          cluster-info
+'''
+
+RETURN = r'''
+success:
+    description: Status of the module
+    type: bool
+    returned: always
+    sample: True
+stdout:
+    description: List with the command execution result/s
+    type: list
+    returned: always
+'''
+
+
+class ActionModule(ActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+        super().run(tmp, task_vars)
+        module_args = self._task.args.copy()
+
+        if 'cmd' not in module_args or not module_args['cmd']:
+            raise AnsibleError('"cmd" parameter is mandatory')
+
+        # Get remote home, local or remote depending of the hosts
+        user_home = Path(task_vars['ansible_user_dir']).resolve()
+
+        # Get cluster auth config path or take by default crc one
+        kubeconfig_path = task_vars.get(
+            'cifmw_kubeconfig', False) or user_home / ".crc/machines/crc/kubeconfig"
+        os.environ["KUBECONFIG"] = str(kubeconfig_path)
+
+        # Additional default paths
+        additional_exec_paths = [
+            str(user_home / '.crc/bin'),
+            str(user_home / '.crc/bin/oc'),
+        ]
+
+        # We can provide additional PATHs
+        cifmw_oc_path = task_vars.get('cifmw_oc_path', False)
+        if cifmw_oc_path:
+            additional_exec_paths.append(cifmw_oc_path)
+
+        oc_binary = self._get_oc_binary(additional_exec_paths)
+
+        # Used if we send one in-line command or several using pipe in ansible
+        commands = module_args['cmd'].splitlines()
+        oc_cmd_results = []
+        for cmd in commands:
+            oc_cmd_results.append(self._execute_command(f"{oc_binary} {cmd}"))
+
+        module_args['return_content'] = True
+
+        result = {
+            'success': True,
+            'changed': True,
+            'error': '',
+            'stdout': oc_cmd_results
+        }
+
+        return result
+
+    def _execute_command(self, command):
+        """
+        Execute shell commands using Ansible built-in methods.
+        """
+        # We don't need to sanitize the input since it's done in this method
+        command_result = self._low_level_execute_command(cmd=command)
+
+        if command_result['rc'] != 0:
+            # ensure_text just to avoid some decode problems
+            stderr = ensure_text(command_result.get('stderr', ''))
+            raise AnsibleError(
+                f"{self._task.action}: failed to execute the command {command}. Return code: {command_result['rc']}. STDERR: {stderr}"
+            )
+        return ensure_text(command_result.get('stdout', '')).rstrip()
+
+    def _get_oc_binary(self, additional_exec_paths=None):
+        """
+        Search for the 'oc' binary in different paths. By default, it searches using
+        the defined paths in the get_bin_path Ansible function. Additional paths can be provided.
+        Raises an error if not found.
+        """
+        return get_bin_path('oc', opt_dirs=additional_exec_paths)


### PR DESCRIPTION
Small Ansible action plugin that loads kubeconfig, search `oc` binary and execute `oc` commands.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate documentation exists and/or is up-to-date
