### PR TITLE
Skip zuul jobs for update in .github directory

### DIFF
--- a/zuul.d/content_provider.yaml
+++ b/zuul.d/content_provider.yaml
@@ -5,6 +5,7 @@
     nodeset: centos-stream-9
     irrelevant-files:
       - .*/*.md
+      - ^.github/.*$
       - ^LICENSE$
       - ^OWNERS$
       - ^OWNERS_ALIASES$

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -19,6 +19,7 @@
     abstract: true
     irrelevant-files:
       - .*/*.md
+      - ^.github/.*$
       - ^LICENSE$
       - ^OWNERS$
       - ^OWNERS_ALIASES$


### PR DESCRIPTION
The .github directory contains settings used by Github (eg. workflow) and change in the directory does not need zuul tests.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
