### PR TITLE
Add support of `--build-args` agrs in edpm_build_images role

### DIFF
--- a/ci_framework/roles/edpm_build_images/README.md
+++ b/ci_framework/roles/edpm_build_images/README.md
@@ -29,6 +29,7 @@ None
 * `cifmw_edpm_build_images_push_registry_namespace`: (String) Namespace on registry where we want to push container images. Default: `podified-main-centos9`.
 * `cifmw_edpm_build_images_cert_path`: (String) Cert path. Default: `/etc/pki/ca-trust/source/anchors/rh.crt`
 * `cifmw_edpm_build_images_cert_install`: (Boolean) Whether to install cert in the image. Default: false
+* `cifmw_edpm_build_images_base_image`: (String) Base image to package the edpm and ipa qcow2 images into the container images for rhel distro.
 
 ### Example
 ```YAML

--- a/ci_framework/roles/edpm_build_images/defaults/main.yml
+++ b/ci_framework/roles/edpm_build_images/defaults/main.yml
@@ -55,3 +55,4 @@ cifmw_edpm_build_images_push_registry_namespace: 'podified-main-centos9'
 cifmw_edpm_build_images_push_container_images: false
 cifmw_edpm_build_images_cert_path: /etc/pki/ca-trust/source/anchors/rh.crt
 cifmw_edpm_build_images_cert_install: false
+cifmw_edpm_build_images_base_image: 'quay.io/centos/centos:stream9-minimal'

--- a/ci_framework/roles/edpm_build_images/tasks/package.yml
+++ b/ci_framework/roles/edpm_build_images/tasks/package.yml
@@ -10,6 +10,7 @@
     cmd: >-
       buildah bud -f ./Containerfile.image
       -t edpm-hardened-uefi:{{ cifmw_edpm_build_images_tag }}
+      --build-arg BASE_IMAGE={{ cifmw_edpm_build_images_base_image }}
       --logfile {{ cifmw_edpm_build_images_basedir }}/logs/edpm_images/edpm_hardened_uefi_container_package.log
 
 - name: Package ironic-python-agent image inside container image
@@ -23,4 +24,5 @@
     cmd: >-
       buildah bud -f ./Containerfile.ramdisk
       -t ironic-python-agent:{{ cifmw_edpm_build_images_tag }}
+      --build-arg BASE_IMAGE={{ cifmw_edpm_build_images_base_image }}
       --logfile {{ cifmw_edpm_build_images_basedir }}/logs/edpm_images/ironic_python_agent_container_package.log


### PR DESCRIPTION
This PR adds support of --build-args while
Packaging edpm and ipa image inside container image.


As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
