### PR TITLE
Properly consume exposed modules/actions

### DIFF
--- a/.config/molecule/config_local.yml
+++ b/.config/molecule/config_local.yml
@@ -25,9 +25,9 @@ provisioner:
   env:
     ANSIBLE_STDOUT_CALLBACK: yaml
     ANSIBLE_ROLES_PATH: "${ANSIBLE_ROLES_PATH}:${HOME}/zuul-jobs/roles"
-    ANSIBLE_LIBRARY: "${ANSIBLE_LIBRARY:-/usr/share/ansible/plugins/modules}"
+    ANSIBLE_LIBRARY: "${ANSIBLE_LIBRARY:-/usr/share/ansible/plugins/modules}:${HOME}/.ansible/plugins/modules"
     ANSIBLE_FILTER_PLUGINS: "${ANSIBLE_FILTER_PLUGINS:-/usr/share/ansible/plugins/filter}"
-    ANSIBLE_ACTION_PLUGINS: "${ANSIBLE_ACTION_PLUGINS:-/usr/share/ansible/plugins/action}"
+    ANSIBLE_ACTION_PLUGINS: "${ANSIBLE_ACTION_PLUGINS:-/usr/share/ansible/plugins/action}:${HOME}/.ansible/plugins/action"
 
 scenario:
   test_sequence:

--- a/zuul.d/molecule-base.yaml
+++ b/zuul.d/molecule-base.yaml
@@ -3,7 +3,7 @@
 - job:
     name: cifmw-molecule-base
     nodeset: centos-stream-9
-    parent: base-minimal
+    parent: base-ci-framework
     pre-run: ci/playbooks/molecule-prepare.yml
     run: ci/playbooks/molecule-test.yml
     post-run: ci/playbooks/collect-logs.yml


### PR DESCRIPTION
This patch allows molecule to properly consume custom modules and
plugins as exposed by the "prep" step (it copies the plugins to
~/.ansible/plugins/).

It also changes the "parent" in order to ensure we get CI member keys,
atleast for the non-CRC job.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
