### PR TITLE
Update Ceph toy env vars

### DIFF
--- a/scenarios/centos-9/ceph_backends.yml
+++ b/scenarios/centos-9/ceph_backends.yml
@@ -15,8 +15,8 @@ cifmw_install_yamls_vars:
 cifmw_edpm_prepare_skip_crc_storage_creation: true
 
 cifmw_make_ceph_environment:
-  TIMEOUT: 90
-  DATA_SIZE: "10Gi"
+  CEPH_TIMEOUT: 90
+  CEPH_DATASIZE: "10Gi"
 
 pre_deploy:
   - name: Ceph deploy

--- a/scenarios/centos-9/ci.yml
+++ b/scenarios/centos-9/ci.yml
@@ -39,4 +39,4 @@ cifmw_run_tests: true
 # to load it and consume the parameters properly
 # Check hooks/playbooks/ceph-deploy.yml for the whole logic.
 cifmw_make_ceph_environment:
-  TIMEOUT: 90
+  CEPH_TIMEOUT: 90


### PR DESCRIPTION
This patch updates some Ceph variables to be in sync with new names[1].

[1] https://github.com/openstack-k8s-operators/install_yamls/commit/46803e5d2eb1309078fa4442da177c89fae97114

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
