### PR TITLE
tempest podman with host network

### DIFF
--- a/ci_framework/roles/tempest/tasks/main.yml
+++ b/ci_framework/roles/tempest/tasks/main.yml
@@ -44,6 +44,7 @@
     image: "{{ cifmw_tempest_image }}:{{ cifmw_tempest_image_tag }}"
     state: started
     auto_remove: "{{ cifmw_tempest_remove_container | default(false) }}"
+    network: host
     volume:
       - "{{ cifmw_tempest_artifacts_basedir }}/:/var/lib/tempest/external_files:Z"
     detach: false


### PR DESCRIPTION
In order to make the tempest container to be able to
reach the "public" network.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
