### PR TITLE
Examples deploy edpm explicit

### DIFF
--- a/docs/source/quickstart/04_non-virt.md
+++ b/docs/source/quickstart/04_non-virt.md
@@ -49,6 +49,7 @@ cifmw_rhol_crc_config:
   memory: 30520
   disk-size: 120
 cifmw_use_libvirt: true
+cifmw_deploy_edpm: true
 cifmw_use_crc: true
 cifmw_operator_build_push_registry: "default-route-openshift-image-registry.apps-crc.testing"
 cifmw_operator_build_meta_build: false

--- a/scenarios/centos-9/local-env.yml
+++ b/scenarios/centos-9/local-env.yml
@@ -3,6 +3,7 @@ cifmw_install_yamls_vars:
   BMO_SETUP: false
 
 cifmw_use_libvirt: true
+cifmw_deploy_edpm: true
 cifmw_use_crc: true
 cifmw_operator_build_push_registry: "default-route-openshift-image-registry.apps-crc.testing"
 cifmw_rhol_crc_use_installyamls: true


### PR DESCRIPTION
Adding explicit setting for edpm deployment
for nested and non nested deployment.
The non-nested one does not deploys edpm
without this flag.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
