### PR TITLE
Allow to reproduce a CI run locally using libvirt

### DIFF
--- a/ci_framework/roles/libvirt_manager/defaults/main.yml
+++ b/ci_framework/roles/libvirt_manager/defaults/main.yml
@@ -47,3 +47,4 @@ cifmw_libvirt_manager_pool:
 cifmw_libvirt_manager_installyamls: "{{ cifmw_installyamls_repos | default('../..') }}"
 cifmw_libvirt_manager_dryrun: false
 cifmw_libvirt_manager_skip_edpm_compute_repos: false
+cifmw_libvirt_manager_daemon: libvirtd.service

--- a/ci_framework/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/clean_layout.yml
@@ -1,0 +1,56 @@
+---
+- name: List all of the existing virtual machines
+  register: vms_list
+  community.libvirt.virt:
+    command: list_vms
+    uri: "qemu:///system"
+
+- name: Filter out target environment
+  ansible.builtin.set_fact:
+    cleanup_vms: "{{ vms_list.list_vms | select('match', '^cifmw-.*$') }}"
+
+- name: Expose cleanup list
+  ansible.builtin.debug:
+    var: cleanup_vms
+
+- name: Destroy machine
+  community.libvirt.virt:
+    command: destroy
+    name: "{{ item }}"
+    uri: "qemu:///system"
+  loop: "{{ cleanup_vms }}"
+
+- name: Undefine machine
+  community.libvirt.virt:
+    command: undefine
+    name: "{{ item }}"
+    uri: "qemu:///system"
+  loop: "{{ cleanup_vms }}"
+
+- name: Get network list
+  register: nets_list
+  community.libvirt.virt_net:
+    command: list_nets
+    uri: "qemu:///system"
+
+- name: Filter out target nets
+  ansible.builtin.set_fact:
+    cleanup_nets: "{{ nets_list.list_nets | select('match', '^cifmw-.*$') }}"
+
+- name: Expose cleanup list
+  ansible.builtin.debug:
+    var: cleanup_nets
+
+- name: Destroy networks
+  community.libvirt.virt_net:
+    command: destroy
+    name: "{{ item }}"
+    uri: "qemu:///system"
+  loop: "{{ cleanup_nets }}"
+
+- name: Undefine networks
+  community.libvirt.virt_net:
+    command: undefine
+    name: "{{ item }}"
+    uri: "qemu:///system"
+  loop: "{{ cleanup_nets }}"

--- a/ci_framework/roles/libvirt_manager/tasks/create_vms.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/create_vms.yml
@@ -1,0 +1,121 @@
+---
+- name: "Create VM overlays for {{ vm_type }}"
+  ansible.builtin.command:
+    cmd: >-
+      qemu-img create
+      -o backing_file={{ vm_data.value.image_local_dir }}/{{ vm_data.value.disk_file_name }},backing_fmt=qcow2
+      -f qcow2
+      "{{ vm_type }}-{{ vm_id }}.qcow2" "{{ vm_data.value.disksize|default ('40') }}G"
+    creates: "{{ vm_type }}-{{ vm_id }}.qcow2"
+    chdir: "{{ cifmw_reproducer_basedir }}/workload"
+  loop: "{{ range(0, vm_data.value.amount|default(1)) }}"
+  loop_control:
+    index_var: vm_id
+    label: "{{ vm_type }}-{{ vm_id }}"
+
+- name: "Define VMs for type {{ vm_type }}"
+  community.libvirt.virt:
+    command: define
+    xml: "{{ lookup('template', 'domain.xml.j2') }}"
+    uri: "qemu:///system"
+  loop: "{{ range(0, vm_data.value.amount|default(1)) }}"
+  loop_control:
+    index_var: vm_id
+    label: "{{ vm_type }}-{{ vm_id }}"
+
+- name: "Start VMs for type {{ vm_type }}"
+  community.libvirt.virt:
+    state: running
+    name: "cifmw-{{ vm_type }}-{{ vm_id }}"
+    uri: "qemu:///system"
+  loop: "{{ range(0, vm_data.value.amount|default(1)) }}"
+  loop_control:
+    index_var: vm_id
+    label: "{{ vm_type }}-{{ vm_id }}"
+
+- name: "Grab IPs for nodes type {{ vm_type }}"
+  register: vm_ips
+  ansible.builtin.shell:
+    cmd: >-
+      virsh -c qemu:///system -q
+      domifaddr cifmw-{{ vm_type }}-{{ vm_id }} | head -1
+  loop: "{{ range(0, vm_data.value.amount|default(1)) }}"
+  loop_control:
+    index_var: vm_id
+    label: "{{ vm_type }}-{{ vm_id }}"
+  retries: 20
+  delay: 5
+  until:
+    - vm_ips.rc == 0
+    - vm_ips.stdout != ''
+
+- name: "(localhost) Inject ssh jumpers for {{ vm_type }}"
+  delegate_to: localhost
+  vars:
+    extracted_ip: "{{ (vm_ip.stdout.split())[3] |replace('/24','') }}"
+  ansible.builtin.blockinfile:
+    create: true
+    path: "~/.ssh/config"
+    marker: "## {mark} {{ vm_type }}-{{ vm_ip.item }}"
+    block: |-
+      Host {{ vm_type }}-{{ vm_ip.item }} cifmw-{{ vm_type }}-{{ vm_ip.item }} {{ extracted_ip }}
+        ProxyJump {{ ansible_user }}@{{ inventory_hostname }}
+        Hostname {{ extracted_ip }}
+        User zuul
+        StrictHostKeyChecking no
+        UserKnownHostsFile /dev/null
+  loop: "{{ vm_ips.results }}"
+  loop_control:
+    loop_var: vm_ip
+    label: "{{ vm_ip.item }}"
+
+- name: "({{ inventory_hostname }}) Inject ssh jumpers for {{ vm_type }}"
+  vars:
+    extracted_ip: "{{ (vm_ip.stdout.split())[3] |replace('/24','') }}"
+  ansible.builtin.blockinfile:
+    create: true
+    path: "~/.ssh/config"
+    marker: "## {mark} {{ vm_type }}-{{ vm_ip.item }}"
+    block: |-
+      Host {{ vm_type }}-{{ vm_ip.item }} cifmw-{{ vm_type }}-{{ vm_ip.item }} {{ extracted_ip }}
+        Hostname {{ extracted_ip }}
+        User zuul
+        StrictHostKeyChecking no
+        UserKnownHostsFile /dev/null
+  loop: "{{ vm_ips.results }}"
+  loop_control:
+    loop_var: vm_ip
+    label: "{{ vm_ip.item }}"
+
+- name: "Wait for VMs type {{ vm_type }} SSH"
+  delegate_to: localhost
+  ansible.builtin.wait_for:
+    host: "{{ vm_ip.item }}"
+    port: 22
+    delay: 5
+  loop: "{{ vm_ips.results }}"
+  loop_control:
+    loop_var: vm_ip
+    label: "{{ vm_ip.item }}"
+
+- name: "Configure VMs type {{ vm_type }}"
+  when:
+    - vm_type is not match('^crc.*$')
+  delegate_to: "{{ vm_type }}-{{ vm_id }}"
+  remote_user: "{{ vm_data.value.admin_user | default('root') }}"
+  ansible.builtin.shell:
+    executable: /bin/bash
+    cmd: |-
+      test -d /home/zuul && exit 0;
+      set -xe -o pipefail;
+      echo "{{ vm_type }}-{{ vm_id }}" | sudo tee /etc/hostname;
+      sudo hostname -F /etc/hostname;
+      sudo useradd -m -d /home/zuul zuul;
+      echo "zuul ALL=(ALL)	NOPASSWD: ALL" | sudo tee /etc/sudoers.d/zuul;
+      sudo -u zuul mkdir -p /home/zuul/.ssh /home/zuul/src/github.com/openstack-k8s-operators;
+      sudo cp ${HOME}/.ssh/authorized_keys /home/zuul/.ssh/;
+      chown -R zuul: /home/zuul/.ssh;
+  loop: "{{ range(0, vm_data.value.amount|default(1)) }}"
+  loop_control:
+    index_var: vm_id
+    label: "{{ vm_type }}-{{ vm_id }}"

--- a/ci_framework/roles/libvirt_manager/tasks/deploy_edpm_compute.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/deploy_edpm_compute.yml
@@ -25,30 +25,13 @@
     path: "{{ item }}"
     state: directory
   loop:
-    - "{{ compute_config.image_local_dir }}"
     - "{{ cifmw_libvirt_manager_basedir }}/workload"
     - "{{ cifmw_libvirt_manager_basedir }}/artifacts/edpm_compute"
 
-- name: Compute base image checks
-  block:
-    - name: Check if base image exists
-      ansible.builtin.stat:
-        path: "{{ compute_config.image_local_dir }}/{{ compute_config.disk_file_name }}"
-      register: disk_file_name_status
-
-    - name: Download base image
-      when:
-        - not disk_file_name_status.stat.exists
-      register: download_base_img
-      ansible.builtin.get_url:
-        url: "{{ compute_config.image_url }}"
-        dest: "{{ compute_config.image_local_dir }}/{{ compute_config.disk_file_name }}"
-        checksum: "sha256:{{ compute_config.sha256_image_name }}"
-      until:
-        - "'status_code' in download_base_img"
-        - download_base_img.status_code == 200
-      retries: 30
-      delay: 5
+- name: Ensure image is available
+  vars:
+    image_data: "{{ compute_config }}"
+  ansible.builtin.include_tasks: get_image.yml
 
 - name: Create EDPM compute VMs
   vars:

--- a/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -1,0 +1,93 @@
+---
+- name: Create needed worload directory
+  ansible.builtin.file:
+    path: "{{ cifmw_reproducer_basedir }}/workload"
+    state: directory
+
+- name: Ensure networks are defined
+  community.libvirt.virt_net:
+    command: define
+    name: "cifmw-{{ item.key }}"
+    xml: "{{ item.value | replace(item.key, 'cifmw-' ~ item.key) }}"
+    uri: "qemu:///system"
+  loop: "{{ cifmw_libvirt_manager_configuration.networks | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+
+- name: Ensure networks are created/started
+  community.libvirt.virt_net:
+    command: create
+    name: "cifmw-{{ item.key }}"
+    uri: "qemu:///system"
+  loop: "{{ cifmw_libvirt_manager_configuration.networks | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+
+- name: Ensure networks are active
+  community.libvirt.virt_net:
+    state: active
+    name: "cifmw-{{ item.key }}"
+    uri: "qemu:///system"
+  loop: "{{ cifmw_libvirt_manager_configuration.networks | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+
+- name: Ensure images are present
+  vars:
+    image_data: "{{ item.value }}"
+  ansible.builtin.include_tasks:
+    file: get_image.yml
+  loop: "{{ cifmw_libvirt_manager_configuration.vms | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+
+- name: Prepare base image with user and ssh accesses
+  when:
+    - item.key is not match('^crc.*$')
+  vars:
+    _admin_user: "{{ item.value.admin_user | default('root') }}"
+  ansible.builtin.shell:
+    cmd: >-
+      virt-sysprep -a "{{ item.value.image_local_dir }}/{{ item.value.disk_file_name }}"
+      --selinux-relabel
+      --firstboot-command "growpart /dev/sda 1"
+      --firstboot-command "xfs_growfs /"
+      --root-password "password:{{ item.value.password | default('fooBar') }}"
+      --ssh-inject {{ _admin_user }}:file:{{ ansible_user_dir }}/.ssh/authorized_keys
+      | tee -a {{ item.value.image_local_dir }}/{{ item.value.disk_file_name }}.log
+    creates: "{{ item.value.image_local_dir }}/{{ item.value.disk_file_name }}.log"
+  loop: "{{ cifmw_libvirt_manager_configuration.vms | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+
+- name: Create and run VMs
+  vars:
+    vm_type: "{{ vm_data.key }}"
+  ansible.builtin.include_tasks:
+    file: create_vms.yml
+  loop: "{{ cifmw_libvirt_manager_configuration.vms | dict2items }}"
+  loop_control:
+    label: "{{ vm_data.key }}"
+    loop_var: vm_data
+
+- name: Ensure we get proper access to CRC
+  vars:
+    crc_private_key: "{{ cifmw_libvirt_manager_configuration.vms.crc.image_local_dir }}/id_ecdsa"
+  block:
+    - name: Copy authorized_keys
+      ansible.builtin.command:
+        cmd: >-
+          scp -i {{ crc_private_key }}
+          ~/.ssh/authorized_keys
+          core@crc-0:.ssh/authorized_keys.d/custom
+
+    - name: Enable root access on CRC
+      ansible.builtin.shell:
+        cmd: |-
+          set -xe -o pipefail
+          cat << EOF | ssh -i {{ crc_private_key }} core@crc-0
+            sudo sed -i 's/PermitRootLogin no/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config.d/40-rhcos-defaults.conf;
+            sudo systemctl restart sshd;
+            sudo cp -r /home/core/.ssh/authorized_keys.d /root/.ssh;
+            sudo chown -R root: /root/.ssh;
+          EOF

--- a/ci_framework/roles/libvirt_manager/tasks/get_image.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/get_image.yml
@@ -1,0 +1,43 @@
+- name: Ensure directory exists
+  ansible.builtin.file:
+    path: "{{ image_data.image_local_dir }}"
+    state: directory
+
+- name: Check if base image exists
+  ansible.builtin.stat:
+    path: "{{ image_data.image_local_dir }}/{{ image_data.disk_file_name }}"
+    get_checksum: false
+  register: disk_file_name_status
+
+- name: Download base image
+  when:
+    - not disk_file_name_status.stat.exists
+    - image_data.image_url is defined
+  register: download_base_img
+  ansible.builtin.get_url:
+    url: "{{ image_data.image_url }}"
+    dest: "{{ image_data.image_local_dir }}/{{ image_data.disk_file_name }}"
+    checksum: >-
+      {% if image_data.sha256_image_name -%}
+      sha256:{{ image_data.sha256_image_name }}
+      {% endif -%}
+  until:
+    - download_base_img.status_code is defined
+    - download_base_img.status_code == 200
+  retries: 30
+  delay: 5
+
+- name: Validate image availability
+  block:
+    - name: Check image
+      register: image_status
+      ansible.builtin.stat:
+        path: "{{ image_data.image_local_dir }}/{{ image_data.disk_file_name }}"
+        get_checksum: false
+
+    - name: Assert image status
+      ansible.builtin.assert:
+        that:
+          - image_status.stat.exists is defined
+          - image_status.stat.exists|bool
+        msg: "Unable to find {{ image_data.image_local_dir }}/{{ image_data.disk_file_name }}!"

--- a/ci_framework/roles/libvirt_manager/tasks/polkit_rules.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/polkit_rules.yml
@@ -25,12 +25,16 @@
 
     # https://libvirt.org/auth.html#unix-socket-policykit-auth
     - name: Enable UNIX socket PolicyKit auth
+      register: polkit_rule
       ansible.builtin.template:
         src: 80-libvirt-manage.rules.j2
         dest: "{{ cifmw_libvirt_manager_polkit_rules_file }}"
         mode: 0644
 
     - name: Restart service polkit service
+      when:
+        - polkit_rule is defined
+        - polkit_rule is changed
       ansible.builtin.service:
         name: polkit
         state: restarted

--- a/ci_framework/roles/libvirt_manager/templates/domain.xml.j2
+++ b/ci_framework/roles/libvirt_manager/templates/domain.xml.j2
@@ -1,0 +1,106 @@
+<domain type='kvm'>
+  <name>cifmw-{{ vm_type }}-{{ vm_id }}</name>
+  <memory unit='GB'>{{ vm_data.value.memory | default(2) }}</memory>
+  <vcpu placement='static'>{{ vm_data.value.cpu | default(2) }}</vcpu>
+  <os>
+    <type arch='x86_64' machine='q35'>hvm</type>
+    <boot dev='hd'/>
+    <bootmenu enable='no'/>
+  </os>
+  <cpu mode='host-passthrough' check='none'/>
+  <clock offset='utc'>
+    <timer name='rtc' tickpolicy='catchup'/>
+    <timer name='pit' tickpolicy='delay'/>
+    <timer name='hpet' present='no'/>
+  </clock>
+  <features>
+    <acpi/>
+    <apic/>
+  </features>
+  <devices>
+    <emulator>/usr/libexec/qemu-kvm</emulator>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='{{ cifmw_reproducer_basedir }}/workload/{{ vm_type }}-{{ vm_id }}.qcow2'/>
+      <target dev='sda' bus='sata'/>
+    </disk>
+    {% for network in vm_data.value.nets %}
+    <interface type='network'>
+      <source network='cifmw-{{ network }}'/>
+      <mac address='{{ '24:42:%02i'|format(vm_id|int) |random_mac }}'/>
+      <model type="virtio"/>
+    </interface>
+    {% endfor %}
+    <controller type='usb' index='0' model='ich9-ehci1'>
+      <alias name='usb'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x7'/>
+    </controller>
+    <controller type='usb' index='0' model='ich9-uhci1'>
+      <alias name='usb'/>
+      <master startport='0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0' multifunction='on'/>
+    </controller>
+    <controller type='usb' index='0' model='ich9-uhci2'>
+      <alias name='usb'/>
+      <master startport='2'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x1'/>
+    </controller>
+    <controller type='usb' index='0' model='ich9-uhci3'>
+      <alias name='usb'/>
+      <master startport='4'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x2'/>
+    </controller>
+    <controller type='pci' index='0' model='pcie-root'>
+      <alias name='pci.0'/>
+    </controller>
+    <controller type='virtio-serial' index='0'>
+      <alias name='virtio-serial0'/>
+      <address type='pci'/>
+    </controller>
+    <serial type='pty'>
+      <source path='/dev/pts/1'/>
+      <log file="/var/log/libvirt/qemu/{{ vm_type }}-{{ vm_id }}-serial.log" append="off"/>
+      <target type='isa-serial' port='0'>
+        <model name='isa-serial'/>
+      </target>
+      <alias name='serial0'/>
+    </serial>
+    <console type='pty' tty='/dev/pts/1'>
+      <log file="/var/log/libvirt/qemu/{{ vm_type }}-{{ vm_id }}-console.log" append="off"/>
+      <source path='/dev/pts/1'/>
+      <target type='serial' port='0'/>
+      <alias name='serial0'/>
+    </console>
+    <input type='tablet' bus='usb'>
+      <alias name='input0'/>
+      <address type='usb' bus='0' port='1'/>
+    </input>
+    <input type='mouse' bus='ps2'>
+      <alias name='input1'/>
+    </input>
+    <input type='keyboard' bus='ps2'>
+      <alias name='input2'/>
+    </input>
+    <video>
+      <model type='virtio' vram='16384' heads='1' primary='yes'/>
+      <alias name='video0'/>
+      <address type='pci'/>
+    </video>
+    <memballoon model='virtio'>
+      <alias name='balloon0'/>
+      <address type='pci'/>
+    </memballoon>
+    <rng model='virtio'>
+      <backend model='random'>/dev/urandom</backend>
+      <alias name='rng0'/>
+      <address type='pci'/>
+    </rng>
+  </devices>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <pm>
+    <suspend-to-mem enabled='no'/>
+    <suspend-to-disk enabled='no'/>
+  </pm>
+</domain>

--- a/ci_framework/roles/reproducer/README.md
+++ b/ci_framework/roles/reproducer/README.md
@@ -1,0 +1,20 @@
+# reproducer
+Role to deploy close to CI layout on a hypervisor.
+
+## Privilege escalation
+None
+
+## Parameters
+* `cifmw_reproducer_basedir`: (String) Base directory. Defaults to `cifmw_basedir`, which defaults to `~/ci-framework-data`.
+* `cifmw_reproducer_ctl_ip4`: (String) IPv4 address for ansible controller on the *private* interface. Defaults to 192.168.122.10.
+* `cifmw_reproducer_ctl_gw4`: (String) IPv4 gateway for ansible controller on the *private* interface. Defaults to 192.168.122.1.
+* `cifmw_reproducer_crc_ip4`: (String) IPv4 address for CRC node on the *private* interface. Defaults to 192.168.122.11.
+* `cifmw_reproducer_crc_gw4`: (String) IPv4 gateway for CRC node on the *private* interface. Defaults to 192.168.122.1.
+* `cifmw_reproducer_kubecfg`: (String) Path to the CRC kubeconfig file. Defaults to the image_local_dir defined in the cifmw_libvirt_manager_configuration dict.
+* `cifmw_reproducer_repositories`: (List[mapping]) List of repositories you want to synchronize from your local machine to the ansible controller.
+
+## Warning
+This role isn't intended to be called outside of the `reproducer.yml` playbook.
+
+## Examples
+Please follow the [documentation about the overall "reproducer" feature](https://ci-framework.readthedocs.io/en/latest/cookbooks/reproducer.html).

--- a/ci_framework/roles/reproducer/defaults/main.yml
+++ b/ci_framework/roles/reproducer/defaults/main.yml
@@ -14,23 +14,12 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Start and enable libvirt service
-  become: true
-  ansible.builtin.service:
-    name: "{{ cifmw_libvirt_manager_daemon }}"
-    state: started
-    enabled: yes
 
-- name: Get libvirt group users
-  ansible.builtin.getent:
-    database: group
-    key: libvirt
-  register: libvirt_group_users
-
-- name: Add user if not exists in libvirt group
-  when: "'cifmw_libvirt_manager_user' not in ansible_facts.getent_group['libvirt']"
-  become: true
-  ansible.builtin.user:
-    name: "{{ cifmw_libvirt_manager_user }}"
-    groups: libvirt
-    append: true
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_reproducer"
+cifmw_reproducer_basedir: "{{ cifmw_basedir | default( ansible_user_dir ~ '/ci-framework-data') }}"
+cifmw_reproducer_ctl_ip4: 192.168.122.10
+cifmw_reproducer_ctl_gw4: 192.168.122.1
+cifmw_reproducer_crc_ip4: 192.168.122.11
+cifmw_reproducer_crc_gw4: 192.168.122.1
+cifmw_reproducer_kubecfg: "{{ cifmw_libvirt_manager_configuration.vms.crc.image_local_dir }}/kubeconfig"

--- a/ci_framework/roles/reproducer/meta/main.yml
+++ b/ci_framework/roles/reproducer/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- reproducer
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: edpm
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - edpm
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/ci_framework/roles/reproducer/molecule/default/converge.yml
+++ b/ci_framework/roles/reproducer/molecule/default/converge.yml
@@ -14,23 +14,10 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Start and enable libvirt service
-  become: true
-  ansible.builtin.service:
-    name: "{{ cifmw_libvirt_manager_daemon }}"
-    state: started
-    enabled: yes
 
-- name: Get libvirt group users
-  ansible.builtin.getent:
-    database: group
-    key: libvirt
-  register: libvirt_group_users
-
-- name: Add user if not exists in libvirt group
-  when: "'cifmw_libvirt_manager_user' not in ansible_facts.getent_group['libvirt']"
-  become: true
-  ansible.builtin.user:
-    name: "{{ cifmw_libvirt_manager_user }}"
-    groups: libvirt
-    append: true
+- name: Converge
+  hosts: all
+  tasks:
+    - name: No molecule for this one
+      ansible.builtin.debug:
+        msg: No molecule for that role

--- a/ci_framework/roles/reproducer/molecule/default/molecule.yml
+++ b/ci_framework/roles/reproducer/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/reproducer/tasks/cleanup.yml
+++ b/ci_framework/roles/reproducer/tasks/cleanup.yml
@@ -14,23 +14,12 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Start and enable libvirt service
-  become: true
-  ansible.builtin.service:
-    name: "{{ cifmw_libvirt_manager_daemon }}"
-    state: started
-    enabled: yes
+- name: Clean libvirt resources
+  ansible.builtin.import_role:
+    name: libvirt_manager
+    tasks_from: clean_layout
 
-- name: Get libvirt group users
-  ansible.builtin.getent:
-    database: group
-    key: libvirt
-  register: libvirt_group_users
-
-- name: Add user if not exists in libvirt group
-  when: "'cifmw_libvirt_manager_user' not in ansible_facts.getent_group['libvirt']"
-  become: true
-  ansible.builtin.user:
-    name: "{{ cifmw_libvirt_manager_user }}"
-    groups: libvirt
-    append: true
+- name: Remove basedir
+  ansible.builtin.file:
+    path: "{{ cifmw_reproducer_basedir }}"
+    state: absent

--- a/ci_framework/roles/reproducer/tasks/main.yml
+++ b/ci_framework/roles/reproducer/tasks/main.yml
@@ -1,0 +1,97 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Discover latest image for CS9
+  ansible.builtin.import_role:
+    name: discover_latest_image
+
+- name: Deploy layout on target host
+  ansible.builtin.import_role:
+    name: libvirt_manager
+    tasks_from: deploy_layout
+
+- name: Ensure crc-0 knows about its second NIC
+  delegate_to: crc-0
+  remote_user: root
+  community.general.nmcli:
+    autoconnect: true
+    conn_name: private_net
+    ifname: enp2s0
+    type: ethernet
+    ip4: "{{ cifmw_reproducer_crc_ip4 }}"
+    gw4: "{{ cifmw_reproducer_crc_gw4 }}"
+    state: present
+
+- name: Get kubeconfig file from crc directory
+  register: kubeconfig
+  ansible.builtin.slurp:
+    path: "{{ cifmw_reproducer_kubecfg }}"
+
+- name: Configure controller-0
+  delegate_to: controller-0
+  remote_user: root
+  block:
+    - name: Ensure controller-0 has an IP in private network
+      community.general.nmcli:
+        autoconnect: true
+        conn_name: private_net
+        ifname: eth1
+        type: ethernet
+        ip4: "{{ cifmw_reproducer_ctl_ip4 }}"
+        gw4: "{{ cifmw_reproducer_ctl_gw4 }}"
+        state: present
+
+    - name: Create kube directory
+      ansible.builtin.file:
+        path: "/home/zuul/.kube"
+        state: directory
+        owner: zuul
+        group: zuul
+        mode: 0755
+
+    - name: Inject kubeconfig content
+      ansible.builtin.copy:
+        dest: "/home/zuul/.kube/config"
+        content: "{{ kubeconfig.content | b64decode }}"
+
+    - name: Inject crc related host entry
+      ansible.builtin.lineinfile:
+        path: /etc/hosts
+        line: >-
+          {{ cifmw_reproducer_crc_ip4 }} api.crc.testing
+          canary-openshift-ingress-canary.apps-crc.testing
+          console-openshift-console.apps-crc.testing
+          default-route-openshift-image-registry.apps-crc.testing
+          downloads-openshift-console.apps-crc.testing
+          oauth-openshift.apps-crc.testing
+
+    - name: Install some tools
+      ansible.builtin.package:
+        name:
+          - ansible-core
+          - bash-completion
+          - git-core
+          - tmux
+          - vim
+
+- name: Sync known repositories to ansible controller
+  local_action:
+    module: ansible.builtin.command
+    cmd: >-
+      rsync -ar {{ item.src }} zuul@controller-0:{{ item.dest }}
+  loop: "{{ cifmw_reproducer_repositories }}"
+  loop_control:
+    label: "{{ item.src | basename }}"

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -11,6 +11,7 @@ args
 auth
 authfile
 autoscale
+autostart
 awk
 baremetal
 basedir
@@ -61,6 +62,7 @@ crds
 creds
 cri
 crio
+ctl
 ctlplane
 ctx
 dataplane
@@ -150,6 +152,7 @@ keyring
 kni
 kube
 kubeadmin
+kubecfg
 kubeconfig
 kubectl
 kubernetes
@@ -305,6 +308,7 @@ virsh
 virt
 virthosts
 virtualized
+virtuser
 visudo
 vlc
 vm

--- a/docs/source/cookbooks/reproducer.md
+++ b/docs/source/cookbooks/reproducer.md
@@ -1,0 +1,159 @@
+# Reproduce CI layout
+The CI Framework allows to reproduce the same layout we're consuming in CI.
+
+While it's not that different from the install_yamls standard layout (one CRC,
+one Compute), the CI layout introduces a third node (ansible controller), and
+all of the nodes have two network interfaces.
+
+## Tested environment
+This reproducer has been successfully tested on a CentOS Stream 9 hypervisor
+running latest CRC qcow2, and latest CentOS Stream 9 qcow2 images.
+
+It *may* work on RHEL based hypervisor and VMs, provided you give the correct
+information for the [discover_latest_image](../roles/discover_latest_image.md)
+role/plugin, or download beforehand the images and consume them from within the
+configuration, but it **wasn't tested** (yet).
+
+## The playbooks
+You will find `reproducer.yml` playbook at the root of the project, as well as
+a specific `scenarios/reproducers` directory.
+
+A second playbook, `reproducer-clean.yml`, allows to remove the created
+resources. Please keep in mind it's destructive, and you won't be able to
+recover anything after the run: virtual machines are destroyed and undefined,
+and the image layers are removed.
+
+## Prerequisites
+### CRC
+The CRC VM has to be properly set up prior running the reproducer play. You
+may get to that leveraging wither the rhol_crc role from the CI Framework, or
+manually by calling `crc setup && crc start -p pull-secret`.
+
+Once the CRC VM is properly started, you can then stop it and undefine it as
+follow:
+```Bash
+$ virsh -c qemu:///system destroy crc
+$ virsh -c qemu:///system undefine crc
+```
+
+Since most of the ranges are hard-coded for now, please ensure no network is
+pre-existing:
+```Bash
+$ virsh -c qemu:///system net-list --all
+$ virsh -c qemu:///system net-destroy <NETWORK>
+$ virsh -c qemu:///system net-undefine <NETWORK>
+```
+
+You then have to ensure you have the following content on the target hypervisor:
+- ~/.crc/machine/crc/crc.qcow2
+- ~/.crc/machine/crc/id_*
+- ~/.crc/machine/crc/kubeconfig
+
+### Ssh authorized_keys
+On the target hypervisor, you have to ensure the ~/.ssh/authorized_keys has all
+of the needed public keys. It will then be copied in the various virtual machines
+the reproducer will create.
+
+## Needed parameters
+While we provide the "simple" layout, consuming three nodes, you may want
+to provide your own layout, maybe with more compute, or some other kind of
+node.
+
+In any cases, the following data are the bare minimal:
+
+- `cifmw_path`: you can take the same value as in the provided file, or extend it as needed
+- `cifmw_libvirt_manager_configuration`: this dict is mandatory in order to create the layout.
+
+In the `cifmw_libvirt_manager_configuration`, there are also some conventions
+and mandatory content/information.
+
+In the `vms` section, please ensure you have at least "controller" and "crc".
+Those names are fixed and used later as static reference.
+
+In the `networks` section, you can define your own custom networks. Usually,
+you can take the same values we provide in the existing layout.
+
+Note that, if you just want to get more compute, you can play with the `amount`
+value. It will then create `compute-[0..n]` virtual machines.
+
+### Extra parameter: cifmw_reproducer_repositories
+
+This parameter allows you to pass a list of repositories you want to sync from
+your local laptop onto the ansible controller machine. The form is pretty easy:
+```YAML
+cifmw_reproducer_repositories:
+  - src: "{{ playbook_dir }}"
+    dest: "src/github.com/openstack-k8s-operators/"
+  - src: "{{ cifmw_install_yamls_repo }}"
+    dest: "src/github.com/openstack-k8s-operators/"
+```
+This one will ensure you have ci_framework as well as install_yamls in a
+known location on the virtual machine. The dest path matches the one we usually
+get in CI.
+
+## Inventory
+This feature can be launched against your own desktop or laptop, but also
+against a remote hypervisor (preferred due to resources). You can therefore
+create your own inventory as follow:
+```YAML
+---
+# inventory_hypervisor.yml
+all:
+  hosts:
+    hypervisor:
+     ansible_user: your_remote_user
+     [any other ansible connection options]
+```
+
+## Usage
+Once the layout matches your needs, you just need to run the following:
+```Bash
+$ ansible-playbook -K -i inventory_hypervisor.yml \
+    reproducer.yml \
+    -e cifmw_target_host=hypervisor \
+    -e @scenarios/reproducers/3-nodes.yml
+```
+Note: the `-K` option instructs ansible to request `sudo` password. This is
+needed in case you don't have the `NOPASSWD` option in the sudoers. Of course,
+if you're using root as the remote user, you won't need that option either.
+
+### Deploy succeeds, what's next?
+Once the deploy is over, you will end with ready-to-use virtual machines,
+provided you passed the needed repositories to sync.
+
+The reproducers injects proper ssh configuration in order to jump on the nodes
+using their name. Usually, you'll just need to reach to the "controller":
+```Bash
+$ ssh controller-0
+```
+You'll end on the machine, using "zuul" user. Then, you're all set to run the
+framework, like we [do in the CI](https://github.com/openstack-k8s-operators/ci-framework/tree/main/ci/playbooks).
+
+## Cleaning
+In order to clean the deployed layout, you can just call the `reproducer-clean.yml`
+playbook. It will clean the virtual machines:
+```Bash
+$ ansible-playbook -i inventory_hypervisor.yml reproducer-clean.yml
+```
+It doesn't require any environment file since it will list all of the existing
+virtual machines, and clean the ones which name starts with `cifmw-`.
+It will also remove the disk images - so if you did set a custom basedir in the
+deployment, you would need to pass it down accordingly.
+
+## Expected layout with the default 3-nodes.yml environment
+The provided file should create the following resources on your environment:
+```Bash
+$ virsh net-list --all
+ Name            State    Autostart   Persistent
+--------------------------------------------------
+ cifmw-default   active   no          yes
+ cifmw-public    active   no          yes
+
+$ virsh list --all
+ Id   Name                 State
+------------------------------------
+ 4    cifmw-compute-0      running
+ 5    cifmw-controller-0   running
+ 6    cifmw-crc-0          running
+```
+The "Id" value may change.

--- a/reproducer-clean.yml
+++ b/reproducer-clean.yml
@@ -1,0 +1,8 @@
+- name: Clean reproducer layout
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: true
+  tasks:
+    - name: Call reproducer.cleanup
+      ansible.builtin.import_role:
+        name: reproducer
+        tasks_from: cleanup.yml

--- a/reproducer.yml
+++ b/reproducer.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Reproducer Play
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: true
+  roles:
+    - role: libvirt_manager
+    - role: reproducer

--- a/scenarios/reproducers/3-nodes.yml
+++ b/scenarios/reproducers/3-nodes.yml
@@ -1,0 +1,73 @@
+---
+# This is local to your desktop/laptop.
+# We can't use ansible_user_dir here, unless you have the same user on the
+# hypervisor and locally.
+cifmw_install_yamls_repo: "~/src/github.com/openstack-k8s-operators/install_yamls"
+# This will be created on the hypervisor.
+cifmw_basedir: "{{ ansible_user_dir }}/ci-framework-data"
+cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+
+# first one will copy ci-framework onto the ansible controller.
+# Second one will copy install_yamls onto the ansible controller.
+cifmw_reproducer_repositories:
+  - src: "{{ playbook_dir }}"
+    dest: "src/github.com/openstack-k8s-operators/"
+  - src: "{{ cifmw_install_yamls_repo }}"
+    dest: "src/github.com/openstack-k8s-operators/"
+cifmw_libvirt_manager_configuration:
+  vms:
+    compute:
+      amount: 1
+      image_url: "{{ cifmw_discovered_image_url }}"
+      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "centos-stream-9.qcow2"
+      disksize: 50
+      memory: 8
+      cpus: 4
+      nets:
+        - public
+        - default
+    controller:
+      image_url: "{{ cifmw_discovered_image_url }}"
+      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "centos-stream-9.qcow2"
+      disksize: 50
+      memory: 8
+      cpus: 4
+      nets:
+        - public
+        - default
+    crc:
+      admin_user: core
+      image_local_dir: "{{ ansible_user_dir }}/.crc/machines/crc/"
+      disk_file_name: "crc.qcow2"
+      disksize: 150
+      memory: 32
+      cpus: 24
+      nets:
+        - public
+        - default
+  networks:
+    public: |-
+      <network>
+        <name>public</name>
+        <forward mode='nat'/>
+        <bridge name='public' stp='on' delay='0'/>
+        <mac address='52:54:00:6a:f2:dc'/>
+        <ip family='ipv4' address='192.168.100.1' prefix='24'>
+          <dhcp>
+            <range start='192.168.100.10' end='192.168.100.100'/>
+          </dhcp>
+        </ip>
+      </network>
+    default: |-
+      <network>
+        <name>default</name>
+        <forward mode='nat'/>
+        <bridge name='default' stp='on' delay='0'/>
+        <mac address='52:54:00:fd:be:d0'/>
+        <ip family='ipv4' address='192.168.122.1' prefix='24'>
+        </ip>
+      </network>

--- a/scenarios/reproducers/README.md
+++ b/scenarios/reproducers/README.md
@@ -1,0 +1,5 @@
+# Reproducer scenarios usage
+
+These environment files should be used with the "reproducer.yml" playbook.
+Please refer to [the doc](https://ci-framework.readthedocs.io/en/latest/cookbooks/reproducer.html)
+about its usage.

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -336,6 +336,16 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
+    - ^ci_framework/roles/reproducer/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    name: cifmw-molecule-reproducer
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: reproducer
+- job:
+    files:
+    - ^ansible-requirements.txt
+    - ^molecule-requirements.txt
     - ^ci_framework/roles/rhol_crc/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-rhol_crc

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -46,6 +46,7 @@
       - cifmw-molecule-polarion
       - cifmw-molecule-registry_deploy
       - cifmw-molecule-repo_setup
+      - cifmw-molecule-reproducer
       - cifmw-molecule-rhol_crc
       - cifmw-molecule-run_hook
       - cifmw-molecule-set_openstack_containers


### PR DESCRIPTION
With the new job layout involving 3 nodes (CRC, Compute and an Ansible
controller), we have to provide people a way to reproduce such a job.

This patch extends the libvirt_manager role, as well as create a new
kind of "scenario" for reproducers. The intend there is to get multiple
"layouts" in order to mimic CI runs on a local environment.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
