### PR TITLE
Collect pods status incase of must-gather failure

### DIFF
--- a/ci_framework/roles/os_must_gather/tasks/main.yml
+++ b/ci_framework/roles/os_must_gather/tasks/main.yml
@@ -54,4 +54,5 @@
         mkdir -p {{ cifmw_os_must_gather_output_dir }}/logs/oc_inspect
         for ns in openstack-operators openstack baremetal-operator-system openshift-machine-api cert-manager openshift-nmstate metallb-system; do
           oc adm inspect namespace/"${ns}" --dest-dir={{ cifmw_os_must_gather_output_dir }}/logs/oc_inspect || echo "Error getting logs from ${ns}"
+          oc get pods -n ${ns} > ${ns}_pods.txt
         done


### PR DESCRIPTION
Currently when os_must_gather fails, we collects lots of information related to different namespace. It is very hard to navigate through the logs directory. Getting the pod status of each namespace, it will fail to find the issues easily.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running

