### PR TITLE
Ensure we keep correct order

### DIFF
--- a/ci/templates/molecule.yaml.j2
+++ b/ci/templates/molecule.yaml.j2
@@ -1,4 +1,4 @@
-{% for role_name in role_names %}
+{% for role_name in role_names | sort %}
 - job:
     name: cifmw-molecule-{{ role_name }}
     parent: cifmw-molecule-base

--- a/scripts/create_role_molecule.py
+++ b/scripts/create_role_molecule.py
@@ -81,7 +81,7 @@ def regenerate_projects_zuul_jobs_yaml(generated_paths):
         projects_jobs_info = yaml.safe_load(file)
 
     # Add each role name after the generated content
-    for role_directory in generated_paths['roles_dir'].iterdir():
+    for role_directory in sorted(generated_paths['roles_dir'].iterdir()):
         if not role_directory.is_dir():
             logging.warning("Skipping. Not a role directory")
             continue

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -112,6 +112,16 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
+    - ^ci_framework/roles/dlrn_report/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    name: cifmw-molecule-dlrn_report
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: dlrn_report
+- job:
+    files:
+    - ^ansible-requirements.txt
+    - ^molecule-requirements.txt
     - ^ci_framework/roles/edpm_build_images/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-edpm_build_images
@@ -138,6 +148,16 @@
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: edpm_deploy_baremetal
+- job:
+    files:
+    - ^ansible-requirements.txt
+    - ^molecule-requirements.txt
+    - ^ci_framework/roles/edpm_kustomize/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    name: cifmw-molecule-edpm_kustomize
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: edpm_kustomize
 - job:
     files:
     - ^ansible-requirements.txt
@@ -363,23 +383,3 @@
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: test_deps
-- job:
-    files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
-    - ^ci_framework/roles/edpm_kustomize/(?!meta|README).*
-    - ^ci/playbooks/molecule.*
-    name: cifmw-molecule-edpm_kustomize
-    parent: cifmw-molecule-base
-    vars:
-      TEST_RUN: edpm_kustomize
-- job:
-    files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
-    - ^ci_framework/roles/dlrn_report/(?!meta|README).*
-    - ^ci/playbooks/molecule.*
-    name: cifmw-molecule-dlrn_report
-    parent: cifmw-molecule-base
-    vars:
-      TEST_RUN: dlrn_report

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -24,9 +24,11 @@
       - cifmw-molecule-cifmw_create_admin
       - cifmw-molecule-copy_container
       - cifmw-molecule-discover_latest_image
+      - cifmw-molecule-dlrn_report
       - cifmw-molecule-edpm_build_images
       - cifmw-molecule-edpm_deploy
       - cifmw-molecule-edpm_deploy_baremetal
+      - cifmw-molecule-edpm_kustomize
       - cifmw-molecule-edpm_prepare
       - cifmw-molecule-hive
       - cifmw-molecule-install_ca
@@ -49,6 +51,4 @@
       - cifmw-molecule-set_openstack_containers
       - cifmw-molecule-tempest
       - cifmw-molecule-test_deps
-      - cifmw-molecule-edpm_kustomize
-      - cifmw-molecule-dlrn_report
     name: openstack-k8s-operators/ci-framework


### PR DESCRIPTION
Sorting project name should ensure we don't get any random output,
allowing a smoother diff whenever we regenerate the project list.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
