### PR TITLE
Add var for EDPM nova deployment pod name

### DIFF
--- a/ci_framework/roles/edpm_deploy/README.md
+++ b/ci_framework/roles/edpm_deploy/README.md
@@ -14,6 +14,7 @@ None
 * `cifmw_edpm_deploy_retries`: (Integer) Number of retries for edpm deploy status. Defaults to `100`.
 * `cifmw_edpm_deploy_run_validation`: (Boolean) Run validation on EDPM node. Defaults to `False`.
 * `cifmw_edpm_deploy_dryrun`: (Boolean) Do a dry run on make edpm_deploy command. Defaults to `False`.
+* `cifmw_edpm_deploy_nova_pod_name`: (String) Name of the nova deployment pod started by an EDPM deploy. Defaults to `nova-edpm-compute-0-deploy-nova`.
 
 ## TODO
 - Add support for deploying multiple compute node

--- a/ci_framework/roles/edpm_deploy/defaults/main.yml
+++ b/ci_framework/roles/edpm_deploy/defaults/main.yml
@@ -23,3 +23,4 @@ cifmw_edpm_deploy_log_path: "{{ cifmw_edpm_deploy_basedir }}/logs/edpm/edpm_depl
 cifmw_edpm_deploy_retries: 100
 cifmw_edpm_deploy_run_validation: false
 cifmw_edpm_deploy_dryrun: false
+cifmw_edpm_deploy_nova_pod_name: nova-edpm-compute-0-deploy-nova

--- a/ci_framework/roles/edpm_deploy/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy/tasks/main.yml
@@ -46,18 +46,18 @@
           oc get pods -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} | grep edpm
       ignore_errors: true
 
-    - name: Get nova-edpm-compute-0-deploy-nova pod name
+    - name: Get EDPM nova deployment pod name
       register: edpm_pod
       ansible.builtin.shell:
         cmd: >-
           oc get pods -o name
           -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} |
-          grep -m1  nova-edpm-compute-0-deploy-nova
+          grep -m1  {{ cifmw_edpm_deploy_nova_pod_name }}
       until: edpm_pod.rc == 0
       retries: "{{ cifmw_edpm_deploy_retries }}"
       delay: 50
 
-    - name: Wait for nova-edpm-compute-0-deploy-nova pod to finish
+    - name: Wait for EDPM nova deployment pod to finish
       register: deploy_status
       ansible.builtin.command:
         cmd: >-


### PR DESCRIPTION
This is needed by the linked PR for dataplane-operator which changes the
name of the Pod for the nova deployment. Adding a var to set the value
of the Pod name allows us to move forward with that PR in a backwards
compatible way.

Needed-By: https://github.com/openstack-k8s-operators/dataplane-operator/pull/337

Signed-off-by: James Slagle <jslagle@redhat.com>

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
- [X] README in the role
- [X] Content of the docs/source is reflecting the changes
