### PR TITLE
[dlrn_report] use shell module instead of ci_script

### DIFF
--- a/ci_framework/roles/dlrn_report/tasks/dlrn_report_results.yml
+++ b/ci_framework/roles/dlrn_report/tasks/dlrn_report_results.yml
@@ -9,9 +9,8 @@
     name: repo_setup
 
 - name: Report results to dlrn for the tested hash
-  ci_script:
-    output_dir: "{{ cifmw_dlrn_report_workspace }}/artifacts"
-    script: |
+  ansible.builtin.shell:
+    cmd: |
       {% if zuul_success is defined and zuul_success |bool %}
       echo "REPORTING SUCCESS TO DLRN API"
       {% else %}


### PR DESCRIPTION
dlrn_report uses ci_script module within the role. dlrn_report will be consumed in post-run. Zuul will invoke it via post playbook.

Zuul does not discovers the ci_script module leading to role failure. It is a known limitation of the zuul. Using shell module fixes the issue.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

