### PR TITLE
[dlrn_report] escape the spaces in shell task

### DIFF
--- a/ci_framework/roles/dlrn_report/tasks/dlrn_report_results.yml
+++ b/ci_framework/roles/dlrn_report/tasks/dlrn_report_results.yml
@@ -10,31 +10,30 @@
 
 - name: Report results to dlrn for the tested hash
   ansible.builtin.shell:
-    cmd: |
+    cmd: >-
       {% if zuul_success is defined and zuul_success |bool %}
-      echo "REPORTING SUCCESS TO DLRN API"
+      echo "REPORTING SUCCESS TO DLRN API";
       {% else %}
-      echo "REPORTING FAILURE TO DLRN API"
+      echo "REPORTING FAILURE TO DLRN API";
       {% endif %}
-      export SSL_CA_BUNDLE="/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt"
+      export SSL_CA_BUNDLE="/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt";
       dlrnapi --url {{ cifmw_repo_setup_dlrn_api_url }}
-      {% if cifmw_dlrn_report_dlrnapi_host_principal is defined and cifmw_dlrn_report_kerberos_auth|bool %}
-      --server-principal {{ cifmw_dlrn_report_dlrnapi_host_principal }}
-      --auth-method kerberosAuth
-      {% endif %}
+      {%- if cifmw_dlrn_report_dlrnapi_host_principal is defined and cifmw_dlrn_report_kerberos_auth|bool -%}
+      --server-principal {{ cifmw_dlrn_report_dlrnapi_host_principal }} --auth-method kerberosAuth
+      {%- endif -%}
       report-result
-      {% if cifmw_repo_setup_full_hash is defined %}
+      {%- if cifmw_repo_setup_full_hash is defined -%}
       --agg-hash {{ cifmw_repo_setup_full_hash }}
-      {% endif %}
-      {% if cifmw_repo_setup_extended_hash is defined %}
+      {%- endif -%}
+      {% if cifmw_repo_setup_extended_hash is defined -%}
       --extended_hash {{ cifmw_repo_setup_extended_hash }}
-      {% endif %}
-      {% if cifmw_repo_setup_commit_hash is defined %}
+      {%- endif -%}
+      {% if cifmw_repo_setup_commit_hash is defined -%}
       --commit_hash {{ cifmw_repo_setup_commit_hash }}
-      {% endif %}
-      {% if cifmw_repo_setup_distro_hash is defined %}
+      {%- endif -%}
+      {% if cifmw_repo_setup_distro_hash is defined -%}
       --distro_hash {{ cifmw_repo_setup_distro_hash }}
-      {% endif %}
+      {%- endif -%}
       --job-id {{ zuul.job }}
       --info-url "{{ log_host_url | default('https://logserver.rdoproject.org') }}/{{ zuul_log_path }}"
       --timestamp $(date +%s) \


### PR DESCRIPTION
Due to use of `|` in shell tasks, each line is treated as a single command, leading to failure of the task. Let' use `>-` to avoid the same.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

