### PR TITLE
Consider `None` value of hash variables in conditional check

### DIFF
--- a/ci_framework/roles/dlrn_report/tasks/dlrn_report_results.yml
+++ b/ci_framework/roles/dlrn_report/tasks/dlrn_report_results.yml
@@ -22,16 +22,16 @@
       --server-principal {{ cifmw_dlrn_report_dlrnapi_host_principal }} --auth-method kerberosAuth
       {%- endif -%}
       report-result
-      {%- if cifmw_repo_setup_full_hash is defined -%}
+      {%- if (cifmw_repo_setup_full_hash is defined) and (cifmw_repo_setup_full_hash != 'None') -%}
       --agg-hash {{ cifmw_repo_setup_full_hash }}
       {%- endif -%}
-      {% if cifmw_repo_setup_extended_hash is defined -%}
+      {% if (cifmw_repo_setup_extended_hash is defined) and (cifmw_repo_setup_extended_hash != 'None') -%}
       --extended_hash {{ cifmw_repo_setup_extended_hash }}
       {%- endif -%}
-      {% if cifmw_repo_setup_commit_hash is defined -%}
+      {% if (cifmw_repo_setup_commit_hash is defined) and (cifmw_repo_setup_commit_hash != 'None')-%}
       --commit_hash {{ cifmw_repo_setup_commit_hash }}
       {%- endif -%}
-      {% if cifmw_repo_setup_distro_hash is defined -%}
+      {% if (cifmw_repo_setup_distro_hash is defined) and (cifmw_repo_setup_distro_hash != 'None') -%}
       --distro_hash {{ cifmw_repo_setup_distro_hash }}
       {%- endif -%}
       --job-id {{ zuul.job }}


### PR DESCRIPTION
In dlrn_report role, repo_setup provides dlrn _hash related vars. Each of these vars either return a hash value or None string.

In order to make sure, dlrn hash vars are not empty, we also need for `None` string case in conditional check otherwise the dlrn_report task will fail.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

