### PR TITLE
Wait OpenStackDataplane resource instead of the deploy pod.

### DIFF
--- a/ci_framework/roles/edpm_deploy/README.md
+++ b/ci_framework/roles/edpm_deploy/README.md
@@ -14,7 +14,7 @@ None
 * `cifmw_edpm_deploy_retries`: (Integer) Number of retries for edpm deploy status. Defaults to `100`.
 * `cifmw_edpm_deploy_run_validation`: (Boolean) Run validation on EDPM node. Defaults to `False`.
 * `cifmw_edpm_deploy_dryrun`: (Boolean) Do a dry run on make edpm_deploy command. Defaults to `False`.
-* `cifmw_edpm_deploy_nova_pod_name`: (String) Name of the nova deployment pod started by an EDPM deploy. Defaults to `nova-edpm-compute-0-deploy-nova`.
+* `cifmw_edpm_deploy_timeout`: (Integer) Time, in minutes to wait for the deployment to be ready. Defaults to `40`.
 
 ## TODO
 - Add support for deploying multiple compute node

--- a/ci_framework/roles/edpm_deploy/defaults/main.yml
+++ b/ci_framework/roles/edpm_deploy/defaults/main.yml
@@ -23,4 +23,4 @@ cifmw_edpm_deploy_log_path: "{{ cifmw_edpm_deploy_basedir }}/logs/edpm/edpm_depl
 cifmw_edpm_deploy_retries: 100
 cifmw_edpm_deploy_run_validation: false
 cifmw_edpm_deploy_dryrun: false
-cifmw_edpm_deploy_nova_pod_name: nova-edpm-compute-0-deploy-nova
+cifmw_edpm_deploy_timeout: 40

--- a/ci_framework/roles/edpm_deploy/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy/tasks/main.yml
@@ -68,68 +68,31 @@
         name: edpm_kustomize
 
     - name: Apply the OpenStackDataPlane CR
-      environment:
-        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-        PATH: "{{ cifmw_path }}"
       when: not cifmw_edpm_deploy_dryrun
       ci_script:
         output_dir: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
         script: "oc apply -f {{ cifmw_edpm_deploy_cr_manifest_paths.files[0].path }}"
 
-- name: Wait for EDPM compute deployment to finish
-  when:
-    - not cifmw_edpm_deploy_dryrun | bool
-  environment:
-    PATH: "{{ cifmw_path }}"
-    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-  block:
-    - name: Get info about dataplane node
-      ci_script:
-        output_dir: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
-        script: |-
-          oc get openstackdataplane -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
-          oc get openstackdataplanerole -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
-          oc get openstackdataplanenode -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
-          oc get pods -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} | grep edpm
-      ignore_errors: true
-
-    - name: Get EDPM nova deployment pod name
-      register: edpm_pod
-      ansible.builtin.shell:
-        cmd: >-
-          oc get pods -o name
-          -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} |
-          grep -m1  {{ cifmw_edpm_deploy_nova_pod_name }}
-      until: edpm_pod.rc == 0
-      retries: "{{ cifmw_edpm_deploy_retries }}"
-      delay: 50
-
-    - name: Wait for EDPM nova deployment pod to finish
-      register: deploy_status
+    - name: Wait for OpenStackDataplane to be deployed
       ansible.builtin.command:
         cmd: >-
-          oc wait -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
-          --timeout=0 --for=jsonpath='{.status.phase}'=Succeeded
-          {{ edpm_pod.stdout |trim }}
-      until: deploy_status.rc == 0
-      retries: "{{ cifmw_edpm_deploy_retries }}"
-      delay: 20
+          oc wait OpenStackDataplane {{ cifmw_edpm_kustomize_last_cr_content.metadata.name }}
+          --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+          --for=condition=ready
+          --timeout={{ cifmw_edpm_deploy_timeout }}m
 
-- name: Get the logs of EDPM Deploy
-  when:
-    - deploy_status is defined
-    - "'rc' in deploy_status"
-    - deploy_status.rc == 0
-  environment:
-    PATH: "{{ cifmw_path }}"
-    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-  ansible.builtin.shell: |
-    for POD in $(oc get pods -o name -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} | egrep "dataplane-deployment-|nova-edpm-compute");
-    do
-      echo $POD;
-      oc logs -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} $POD;
-    done
-  register: edpm_logs
+    - name: Get the logs of EDPM Deploy
+      when:
+        - deploy_status is defined
+        - "'rc' in deploy_status"
+        - deploy_status.rc == 0
+      ansible.builtin.shell: |
+        for POD in $(oc get pods -o name -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} | egrep "dataplane-deployment-|nova-edpm-compute");
+        do
+          echo $POD;
+          oc logs -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} $POD;
+        done
+      register: edpm_logs
 
 - name: Collect logs for EDPM deploy
   when:


### PR DESCRIPTION
Till now we were waiting for the deployment of EDPM to finish by waiting for the deployment pod, that may fail and can be relaunched by the deploy job. If the pod fails to deploy we weren't aware that maybe the next pod succeed and we marked the entire run as failed.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date