### PR TITLE
Fix the spacing issue in condition check

### DIFF
--- a/ci_framework/roles/dlrn_report/tasks/dlrn_report_results.yml
+++ b/ci_framework/roles/dlrn_report/tasks/dlrn_report_results.yml
@@ -9,34 +9,34 @@
     name: repo_setup
 
 - name: Report results to dlrn for the tested hash
-  ansible.builtin.shell:
+  ansible.builtin.command:
     cmd: >-
-      {% if zuul_success is defined and zuul_success |bool %}
+      {% if zuul_success is defined and zuul_success |bool -%}
       echo "REPORTING SUCCESS TO DLRN API";
-      {% else %}
+      {% else -%}
       echo "REPORTING FAILURE TO DLRN API";
-      {% endif %}
+      {% endif -%}
       export SSL_CA_BUNDLE="/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt";
       dlrnapi --url {{ cifmw_repo_setup_dlrn_api_url }}
-      {%- if cifmw_dlrn_report_dlrnapi_host_principal is defined and cifmw_dlrn_report_kerberos_auth|bool -%}
+      {% if cifmw_dlrn_report_dlrnapi_host_principal is defined and cifmw_dlrn_report_kerberos_auth|bool -%}
       --server-principal {{ cifmw_dlrn_report_dlrnapi_host_principal }} --auth-method kerberosAuth
-      {%- endif -%}
+      {% endif -%}
       report-result
-      {%- if (cifmw_repo_setup_full_hash is defined) and (cifmw_repo_setup_full_hash != 'None') -%}
+      {% if (cifmw_repo_setup_full_hash is defined) and (cifmw_repo_setup_full_hash | length > 0) -%}
       --agg-hash {{ cifmw_repo_setup_full_hash }}
-      {%- endif -%}
-      {% if (cifmw_repo_setup_extended_hash is defined) and (cifmw_repo_setup_extended_hash != 'None') -%}
+      {% endif -%}
+      {% if (cifmw_repo_setup_extended_hash is defined) and (cifmw_repo_setup_extended_hash | length > 0) -%}
       --extended_hash {{ cifmw_repo_setup_extended_hash }}
-      {%- endif -%}
-      {% if (cifmw_repo_setup_commit_hash is defined) and (cifmw_repo_setup_commit_hash != 'None')-%}
+      {% endif -%}
+      {% if (cifmw_repo_setup_commit_hash is defined) and (cifmw_repo_setup_commit_hash | length > 0) -%}
       --commit_hash {{ cifmw_repo_setup_commit_hash }}
-      {%- endif -%}
-      {% if (cifmw_repo_setup_distro_hash is defined) and (cifmw_repo_setup_distro_hash != 'None') -%}
+      {% endif -%}
+      {% if (cifmw_repo_setup_distro_hash is defined) and (cifmw_repo_setup_distro_hash | length > 0) -%}
       --distro_hash {{ cifmw_repo_setup_distro_hash }}
-      {%- endif -%}
+      {% endif -%}
       --job-id {{ zuul.job }}
       --info-url "{{ log_host_url | default('https://logserver.rdoproject.org') }}/{{ zuul_log_path }}"
-      --timestamp $(date +%s) \
+      --timestamp $(date +%s)
       --success {{ zuul_success | bool }}
   environment: |
     {{ zuul | zuul_legacy_vars | combine({


### PR DESCRIPTION
Usage of `-` in conditional check is cancating all the dlrn report arguments leading to random failures. It also fixes the dlrn hash vars having "" returned by repo-setup role.
```
"cifmw_repo_setup_commit_hash": "",
        "cifmw_repo_setup_distro_hash": "",
        "cifmw_repo_setup_dlrn_api_url": "https://trunk.rdoproject.org/api-centos9-antelope",
        "cifmw_repo_setup_extended_hash": "",
        "cifmw_repo_setup_full_hash": "43bc77e1054a2e185169a239919a5207",
        "cifmw_repo_setup_release": "antelope"
```
Now it uses length to check whether an dlrn hash var is empty or not.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

