### PR TITLE
Added taskfiles to collect edpm logs from edpm vms

### DIFF
--- a/ci_framework/roles/artifacts/tasks/edpm.yml
+++ b/ci_framework/roles/artifacts/tasks/edpm.yml
@@ -1,0 +1,43 @@
+---
+- name: List all of the existing virtual machines
+  ignore_errors: true
+  register: vms_list
+  community.libvirt.virt:
+    command: list_vms
+    uri: "qemu:///system"
+
+- name: Filter out edpm vm
+  ignore_errors: true
+  ansible.builtin.set_fact:
+    edpm_vm: "{{ vms_list.list_vms | select('match', '^edpm-.*$') }}"
+
+- name: Generate logs on EDPM vms
+  when:
+    - '"edpm-compute-0" in edpm_vm'
+  block:
+    - name: Generate logs on edpm vm
+      ignore_errors: true
+      ci_script:
+        output_dir: "{{ cifmw_artifacts_basedir }}/artifacts"
+        script: |-
+          ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{ cifmw_artifacts_basedir }}/artifacts/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100 <<EOF
+          set -xe;
+          mkdir -p /tmp/edpm
+          cp -r /var/log/ /tmp/edpm
+          cp -r /var/lib/config-data /tmp/edpm
+          cp -r /var/lib/nova /tmp/edpm
+          cp -r /etc/nftables /tmp/edpm
+          ip a > /tmp/edpm/network.txt
+          ip ro ls >> /tmp/edpm/network.txt
+          rpm -qa > /tmp/edpm/rpm_qa.txt
+          podman images > /tmp/edpm/podman_images.txt
+          ausearch -i | grep denied > /tmp/edpm/selinux-denials.log
+          journalctl -p warning -t kernel -o short -g DROPPING --no-pager &> /tmp/edpm/firewall-drops.txt
+          EOF
+
+    - name: Copy logs to host machine from edpm vm
+      ignore_errors: true
+      ci_script:
+        output_dir: "{{ cifmw_artifacts_basedir }}/artifacts"
+        script: |-
+          scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -v -r -i {{ cifmw_artifacts_basedir }}/artifacts/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100:/tmp/edpm {{ cifmw_artifacts_basedir }}/logs

--- a/ci_framework/roles/artifacts/tasks/main.yml
+++ b/ci_framework/roles/artifacts/tasks/main.yml
@@ -46,3 +46,6 @@
 
 - name: Gather CRC logs
   ansible.builtin.import_tasks: crc.yml
+
+- name: Gather EDPM logs
+  ansible.builtin.import_tasks: edpm.yml

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -83,6 +83,7 @@
       - ^ci_framework/playbooks/*
       - ^ci_framework/roles/edpm_prepare/(?!meta|README).*
       - ^ci_framework/roles/edpm_deploy/(?!meta|README).*
+      - ^ci_framework/roles/artifacts/tasks/edpm.yml
       - ^deploy-edpm.yml
       - ^scenarios/centos-9/edpm_ci.yml
 


### PR DESCRIPTION
It will allow developers to gather logs from edpm node and daignose the tempest related failures.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

