### PR TITLE
Add zuul based ironic tempest tests

### DIFF
--- a/hooks/playbooks/control_plane_ironic.yml
+++ b/hooks/playbooks/control_plane_ironic.yml
@@ -1,0 +1,27 @@
+---
+- name: Kustomize ControlPlane for ironic service
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Ensure the kustomizations dir exists
+      ansible.builtin.file:
+        path: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/{{ item }}"
+        state: directory
+      loop:
+        - controlplane
+
+    - name: Create kustomization to enable ironic
+      ansible.builtin.copy:
+        dest: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/controlplane/98-ironic-kustomization.yaml"
+        content: |-
+          apiVersion: kustomize.config.k8s.io/v1beta1
+          kind: Kustomization
+          resources:
+          namespace: {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+          patches:
+          - target:
+              kind: OpenStackControlPlane
+            patch: |-
+              - op: add
+                path: /spec/ironic/enabled
+                value: {{ cifmw_services_ironic_enabled | default('false') }}

--- a/roles/tempest/files/list_allowed.yml
+++ b/roles/tempest/files/list_allowed.yml
@@ -34,3 +34,8 @@ groups:
       - manila_tempest_tests.tests.api
     releases:
       - all
+  - name: ironic-operator
+    tests:
+      - ironic_tempest_plugin.tests.api
+    releases:
+      - all

--- a/roles/tempest/files/list_skipped.yml
+++ b/roles/tempest/files/list_skipped.yml
@@ -1112,3 +1112,156 @@ known_failures:
         reason: IBM cloud exposes MTU setup differences exposing a real issue
         lp: https://issues.redhat.com/browse/OSPCIX-126
     jobs: []
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodeProtected.test_node_protected
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_allocations.TestBackfill.test_backfill_allocation
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodeProtected.test_node_protected_from_deletion
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_allocations.TestBackfill.test_backfill_without_resource_class
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodeProtected.test_node_protected_negative
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodesProtectedOldApi.test_node_protected_old_api
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodeProtected.test_node_protected_set_unset
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodestates.TestNodeStatesV1_4.test_set_node_provision_state
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodesVif.test_vif_already_set
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodesVif.test_vif_on_port
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodestates.TestNodeStatesV1_1.test_set_node_provision_state
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodesVif.test_vif_on_portgroup
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestHardwareInterfaces.test_reset_interfaces
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestResetInterfaces.test_reset_interfaces
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodestates.TestNodeStatesV1_6.test_set_node_provision_state
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodestates.TestNodeStatesV1_11.test_set_node_provision_state
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodestates.TestNodeStatesV1_2.test_set_node_provision_state
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator

--- a/scenarios/centos-9/ironic.yml
+++ b/scenarios/centos-9/ironic.yml
@@ -1,0 +1,30 @@
+---
+cifmw_install_yamls_vars:
+  BMO_SETUP: false
+  STORAGE_CLASS: crc-csi-hostpath-provisioner
+  INSTALL_CERT_MANAGER: false
+
+cifmw_edpm_prepare_skip_crc_storage_creation: true
+
+pre_deploy:
+  - name: Kustomize OpenStack CR
+    type: playbook
+    source: control_plane_ironic.yml
+
+cifmw_services_ironic_enabled: true
+
+cifmw_run_tests: true
+cifmw_tempest_default_groups: &test_operator_list
+  - openstack-operator
+  - keystone-operator
+  - ironic-operator
+cifmw_tempest_default_jobs: *test_operator_list
+
+cifmw_tempest_tests_allowed_override_scenario: true
+
+cifmw_tempest_tempestconf_profile:
+  create: true
+  debug: true
+  os_cloud: default
+  overrides:
+    identity.v3_endpoint_type: public

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -211,6 +211,38 @@
       - ci/playbooks/edpm/run.yml
 
 - job:
+    name: podified-multinode-edpm-ironic-nobuild-tagged-crc
+    parent: cifmw-podified-multinode-edpm-base-crc
+    nodeset:
+      nodes:
+        - name: controller
+          label: cloud-centos-9-stream-tripleo-vexxhost
+        - name: compute-0
+          label: cloud-centos-9-stream-tripleo-vexxhost
+        - name: crc
+          label: coreos-crc-extracted-3xl
+      groups:
+        - name: computes
+          nodes:
+            - compute-0
+    vars:
+      cifmw_extras:
+        - '@scenarios/centos-9/ci.yml'
+        - '@scenarios/centos-9/multinode-ci.yml'
+        - '@scenarios/centos-9/ironic.yml'
+    run:
+      - ci/playbooks/e2e-run.yml
+    irrelevant-files:
+      - ^roles/.*_build
+      - ^roles/build.*
+      - ^roles/local_env_vm
+      - ^ci/templates
+      - ^docs
+      - ^.*/*.md
+      - ^OWNERS
+      - ^.github
+
+- job:
     name: podified-multinode-hci-deployment-crc
     parent: podified-multinode-hci-deployment-crc-3comp
     files:


### PR DESCRIPTION
Ironic tempest tests can be run by default
on job using the scenarios/centos-9/ironic.yml file.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
