### PR TITLE
Improve edpm log collection

### DIFF
--- a/ci_framework/roles/artifacts/tasks/edpm.yml
+++ b/ci_framework/roles/artifacts/tasks/edpm.yml
@@ -22,17 +22,21 @@
         script: |-
           ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{ cifmw_artifacts_basedir }}/artifacts/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100 <<EOF
           set -xe;
-          mkdir -p /tmp/edpm
-          cp -r /var/log/ /tmp/edpm
-          cp -r /var/lib/config-data /tmp/edpm
-          cp -r /var/lib/nova /tmp/edpm
-          cp -r /etc/nftables /tmp/edpm
-          ip a > /tmp/edpm/network.txt
-          ip ro ls >> /tmp/edpm/network.txt
-          rpm -qa > /tmp/edpm/rpm_qa.txt
-          podman images > /tmp/edpm/podman_images.txt
-          ausearch -i | grep denied > /tmp/edpm/selinux-denials.log
-          journalctl -p warning -t kernel -o short -g DROPPING --no-pager &> /tmp/edpm/firewall-drops.txt
+          mkdir -p /tmp/{{ edpm_vm[0] }}
+          cp -r /var/log/ /tmp/{{ edpm_vm[0] }}
+          cp -r /var/lib/openstack /tmp/{{ edpm_vm[0] }}
+          cp -r /var/lib/config-data /tmp/{{ edpm_vm[0] }}
+          cp -r /var/lib/cloud /tmp/{{ edpm_vm[0] }}
+          cp -r /etc/nftables /tmp/{{ edpm_vm[0] }}
+          cp -r /etc/os-net-config /tmp/{{ edpm_vm[0] }}
+          ovs-vsctl list Open_vSwitch > /tmp/{{ edpm_vm[0] }}/ovs_vsctl_list_openvswitch.txt
+          ip netns > /tmp/{{ edpm_vm[0] }}/ip_netns.txt
+          ip a > /tmp/{{ edpm_vm[0] }}/network.txt
+          ip ro ls >> /tmp/{{ edpm_vm[0] }}/network.txt
+          rpm -qa > /tmp/{{ edpm_vm[0] }}/rpm_qa.txt
+          podman images > /tmp/{{ edpm_vm[0] }}/podman_images.txt
+          ausearch -i | grep denied > /tmp/{{ edpm_vm[0] }}/selinux-denials.log
+          journalctl -p warning -t kernel -o short -g DROPPING --no-pager &> /tmp/{{ edpm_vm[0] }}/firewall-drops.txt
           EOF
 
     - name: Copy logs to host machine from edpm vm
@@ -40,4 +44,4 @@
       ci_script:
         output_dir: "{{ cifmw_artifacts_basedir }}/artifacts"
         script: |-
-          scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -v -r -i {{ cifmw_artifacts_basedir }}/artifacts/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100:/tmp/edpm {{ cifmw_artifacts_basedir }}/logs
+          scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -v -r -i {{ cifmw_artifacts_basedir }}/artifacts/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100:/tmp/{{ edpm_vm[0] }} {{ cifmw_artifacts_basedir }}/logs


### PR DESCRIPTION
This pr improves the edpm log collection based on feedback received on https://github.com/openstack-k8s-operators/ci-framework/pull/444:
- Changed the edpm directory name to edpm host name
- Collect openvswitch,os-net-config and netns logs
- Drop /var/lib/nova logs (contains instance sensitive info)

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

