### PR TITLE
Allow to chose target for CI playbooks

### DIFF
--- a/ci/playbooks/build_runner_image.yml
+++ b/ci/playbooks/build_runner_image.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   tasks:
     - name: Get git tag for image tagging
       register: edpm_ansible_tag

--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Run block

--- a/ci/playbooks/content_provider/pre.yml
+++ b/ci/playbooks/content_provider/pre.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   tasks:
     - name: Clone repos in the job workspace
       include_role:

--- a/ci/playbooks/content_provider/run.yml
+++ b/ci/playbooks/content_provider/run.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Deploy content provider

--- a/ci/playbooks/e2e-collect-logs.yml
+++ b/ci/playbooks/e2e-collect-logs.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Ensure we have the ci-framework on host

--- a/ci/playbooks/edpm/run.yml
+++ b/ci/playbooks/edpm/run.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Check for edpm-ansible.yml file

--- a/ci/playbooks/edpm_baremetal_deployment/run.yml
+++ b/ci/playbooks/edpm_baremetal_deployment/run.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Check for edpm-ansible.yml file

--- a/ci/playbooks/edpm_build_images/edpm_build_images_content_provider_run.yaml
+++ b/ci/playbooks/edpm_build_images/edpm_build_images_content_provider_run.yaml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Build edpm images

--- a/ci/playbooks/edpm_build_images/edpm_image_builder.yml
+++ b/ci/playbooks/edpm_build_images/edpm_image_builder.yml
@@ -1,7 +1,7 @@
 ---
 - name: Boostrap node
   ansible.builtin.import_playbook: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/ci_framework/playbooks/01-bootstrap.yml"
-- hosts: all
+- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   tasks:
     - name: Read hash from delorean.repo.md5 file
       tags:

--- a/ci/playbooks/edpm_build_images/run.yml
+++ b/ci/playbooks/edpm_build_images/run.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Run EDPM build image

--- a/ci/playbooks/tcib/run.yml
+++ b/ci/playbooks/tcib/run.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Discover the host ip


### PR DESCRIPTION
With the new multinode layout, "all" target will fail since zuul would
try to run things on crc and compute (and any other nodes).

This patch introduces a new `cifmw_zuul_target_host` parameter in those
CI specific playbooks, in order to avoid any potential conflict with the
existing `cifmw_host_target` top level parameter.

Please note this patch takes care of the "all" targets only. Some plays
were already using "controller", and some other were using
cifmw_host_target (with a default to localhost).
In order to not break things for now, we discard those and will address
them in a follow-up, if needed.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
