### PR TITLE
Added information about NTP server config

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -40,6 +40,8 @@ cephx
 cfg
 cguujglklirwawqujgnjdglklmfzb
 chdir
+chrony
+chronyc
 ci
 cidr
 cifmw
@@ -106,6 +108,7 @@ frmo
 fsid
 fultonj
 fwcybtb
+gapped
 genericcloud
 gerrit
 githooks
@@ -208,6 +211,7 @@ nodetemplate
 noop
 nopasswd
 nsawvudc
+ntp
 nwy
 oc
 ocp

--- a/docs/source/quickstart/99_FAQ.md
+++ b/docs/source/quickstart/99_FAQ.md
@@ -59,3 +59,14 @@ You can review the logs to see the error with:
 ```Bash
 oc logs -n openstack -l component=cinder-api
 ```
+
+## Working in air gapped environment
+
+### Wait for OpenStackDataplane to be deployed
+If deployment of `OpenStackDataplane` fails, please ensure if you have an access to `pool.ntp.org`.
+During the deployment, `chronyc` is trying to sync up with default NTP servers.
+If you don't have an access, you can provide modify your `env.yml` file to include:
+```
+cifmw_install_yamls_vars:
+  DATAPLANE_CHRONY_NTP_SERVER: "<your_chosen_ntp_server>"
+```


### PR DESCRIPTION
When working in air-gapped environment, without an access to default NTP servers, deployment of OpenStackDataplane fails without a reasonable information.
Extended FAQ documentation with an appropriate note, to ensure proper understanding of the problem.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
