### PR TITLE
Fixes for kuttl tests

### DIFF
--- a/ci/playbooks/kuttl/e2e-kuttl.yml
+++ b/ci/playbooks/kuttl/e2e-kuttl.yml
@@ -19,6 +19,10 @@
         name: 'install_yamls_makes'
         tasks_from: 'make_download_tools'
 
+    - name: Login into Openshift cluster
+      ansible.builtin.include_role:
+        name: openshift_login
+
     - name: Attach default network to CRC
       when:
         - kuttl_make_crc_attach_default_interface | default ('true') | bool

--- a/ci/playbooks/kuttl/run-kuttl-tests.yml
+++ b/ci/playbooks/kuttl/run-kuttl-tests.yml
@@ -1,9 +1,42 @@
 ---
+
+- name: Set environment vars for kuttl test
+  ansible.builtin.set_fact:
+    cifmw_kuttl_tests_env: >-
+      {{
+        cifmw_install_yamls_environment |
+        combine(cifmw_kuttl_tests_env_vars | default({})) |
+        combine({'PATH': cifmw_path})
+      }}
+
+- name: 'Run make crc_storage_cleanup_with_retries'
+  vars:
+    make_crc_storage_cleanup_with_retries_env: "{{ cifmw_kuttl_tests_env }}"
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_crc_storage_cleanup_with_retries.yml'
+
+- name: 'Run make crc_storage_with_retries'
+  vars:
+    make_crc_storage_with_retries_env: "{{ cifmw_kuttl_tests_env }}"
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_crc_storage_with_retries.yml'
+
+
 - name: 'Get resource status before {{ operator }}_kuttl run'
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
   ansible.builtin.shell: |
     {{ item }} >> {{ cifmw_artifacts_basedir }}/logs/cmd_before_{{ operator }}_kuttl.log
   loop: "{{ commands_before_kuttl_run }}"
   ignore_errors: true
+
+
+- name: 'Set make_{{ operator }}_kuttl_env vars'
+  ansible.builtin.set_fact:
+    make_{{ operator }}_kuttl_env: "{{ cifmw_kuttl_tests_env }}"
 
 - name: 'Run make_{{ operator }}_kuttl'
   ansible.builtin.include_role:
@@ -11,6 +44,9 @@
     tasks_from: 'make_{{ operator }}_kuttl.yml'
 
 - name: 'Get resource status after {{ operator }}_kuttl run'
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
   ansible.builtin.shell: |
     {{ item }} > {{ cifmw_artifacts_basedir }}/logs/cmd_after_{{ operator }}_kuttl.log
   loop: "{{ commands_after_kuttl_run }}"

--- a/ci/templates/projects.yaml
+++ b/ci/templates/projects.yaml
@@ -12,7 +12,7 @@
         - cifmw-tcib
         - cifmw-dev-prepare
         - cifmw-doc
-        - cifmw-kuttl
+        - cifmw-multinode-kuttl
         - cifmw-edpm-build-images
         - cifmw-content-provider-build-images
         - podified-multinode-edpm-e2e-nobuild-tagged-crc

--- a/scenarios/centos-9/kuttl.yml
+++ b/scenarios/centos-9/kuttl.yml
@@ -1,4 +1,5 @@
 ---
 cifmw_install_yamls_vars:
-  STORAGE_CLASS: crc-csi-hostpath-provisioner
+  OPERATOR_BASE_DIR: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators"
+  BMO_SETUP: false
 cifmw_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"

--- a/zuul.d/kuttl_multinode.yaml
+++ b/zuul.d/kuttl_multinode.yaml
@@ -1,0 +1,71 @@
+---
+- job:
+    name: cifmw-base-multinode-kuttl
+    parent: cifmw-podified-multinode-edpm-base-crc
+    timeout: 5400
+    abstract: true
+    nodeset:
+      nodes:
+        - name: controller
+          label: cloud-centos-9-stream-tripleo-vexxhost
+        - name: crc
+          label: coreos-crc-extracted-xxl
+    vars:
+      zuul_log_collection: true
+    extra-vars:
+      crc_ci_bootstrap_networking:
+        networks:
+          default:
+            range: 192.168.122.0/24
+            mtu: 1500
+          internal-api:
+            vlan: 20
+            range: 172.17.0.0/24
+          storage:
+            vlan: 21
+            range: 172.18.0.0/24
+          tenant:
+            vlan: 22
+            range: 172.19.0.0/24
+        instances:
+          controller:
+            networks:
+              default:
+                ip: 192.168.122.11
+          crc:
+            networks:
+              default:
+                ip: 192.168.122.10
+              internal-api:
+                ip: 172.17.0.5
+              storage:
+                ip: 172.18.0.5
+              tenant:
+                ip: 172.19.0.5
+    pre-run:
+      - ci/playbooks/e2e-prepare.yml
+    run:
+      - ci/playbooks/dump_zuul_vars.yml
+      - ci/playbooks/kuttl/run.yml
+    post-run:
+      - ci/playbooks/collect-logs.yml
+    required-projects:
+      - github.com/openstack-k8s-operators/install_yamls
+
+- job:
+    name: cifmw-multinode-kuttl
+    parent: cifmw-base-multinode-kuttl
+    files:
+      - ^ci/playbooks/kuttl/.*
+      - ^scenarios/centos-9/kuttl.yml
+      - ^zuul.d/kuttl.yaml
+    vars:
+      cifmw_kuttl_tests_operator_list:
+        - ansibleee
+        - keystone
+      commands_before_kuttl_run:
+        - oc get pv
+        - oc get all
+      commands_after_kuttl_run:
+        - oc get pv
+        - oc get all

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -5,7 +5,7 @@
       - cifmw-tcib
       - cifmw-dev-prepare
       - cifmw-doc
-      - cifmw-kuttl
+      - cifmw-multinode-kuttl
       - cifmw-edpm-build-images
       - cifmw-content-provider-build-images
       - podified-multinode-edpm-e2e-nobuild-tagged-crc


### PR DESCRIPTION
Fixes for kuttl tests

Kuttl tests are failing in the downstream jobs. After holding a node to debug it passes after running make crc_storage and then the kuttl.
Otherwise it fails with "message: '0/1 nodes are available: 1 pod has unbound immediate PersistentVolumeClaims."

This patch:
1. Moves kuttl tests to new multinode layout
2. Adds steps to create PVs before and remove them after kuttl run
3. Includes cifmw vars
4. Removes storage class
 
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
- [X] README in the role
- [X] Content of the docs/source is reflecting the changes
