### PR TITLE
Removed the non neady NeutronReady condition.

### DIFF
--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -154,18 +154,6 @@
         output_dir: "{{ cifmw_edpm_prepare_basedir }}/artifacts"
         script: "oc apply -f {{ cifmw_edpm_prepare_openstack_cr_manifest_paths.files[0].path }}"
 
-    # Workaround for OSP-25980
-    - name: Wait for NeutronReady
-      environment:
-        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-        PATH: "{{ cifmw_path }}"
-      ansible.builtin.command:
-        cmd: >-
-          oc wait OpenStackControlPlane {{ cifmw_edpm_kustomize_last_cr_content.metadata.name }}
-          --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
-          --for=condition=OpenStackControlPlaneNeutronReady
-          --timeout={{ cifmw_edpm_prepare_timeout }}m
-
     - name: Wait for OpenStack controlplane to be deployed
       environment:
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"


### PR DESCRIPTION
In the past OpenStackControlPlane CR conditions reported a global ready even if the services were not properly deployed. Thas spurious ready condition is now fixed and now is safe to trust the global ready condition only.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date