### PR TITLE
Ensure CI playbooks have a name

### DIFF
--- a/ci/playbooks/build_runner_image.yml
+++ b/ci/playbooks/build_runner_image.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+- name: "Run ci/playbooks/build_runner_image.yml"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   tasks:
     - name: Get git tag for image tagging
       register: edpm_ansible_tag

--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+- name: "Run ci/playbooks/collect-logs.yml"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Run block

--- a/ci/playbooks/content_provider/content_provider.yml
+++ b/ci/playbooks/content_provider/content_provider.yml
@@ -2,7 +2,8 @@
 - name: Bootstrap step
   ansible.builtin.import_playbook: "{{ cifmw_project_root }}/ci_framework/playbooks/01-bootstrap.yml"
 
-- hosts: "{{ cifmw_target_host | default('localhost') }}"
+- name: "Run ci/playbooks/content_provider/content_provider.yml"
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: true
   tasks:
     - name: Install necessary dependencies

--- a/ci/playbooks/content_provider/pre.yml
+++ b/ci/playbooks/content_provider/pre.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+- name: "Run ci/playbooks/content_provider/pre.yml"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   tasks:
     - name: Clone repos in the job workspace
       include_role:

--- a/ci/playbooks/content_provider/run.yml
+++ b/ci/playbooks/content_provider/run.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+- name: "Run ci/playbooks/content_provider/run.yml"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Deploy content provider

--- a/ci/playbooks/dev-workflow.yml
+++ b/ci/playbooks/dev-workflow.yml
@@ -1,6 +1,6 @@
 ---
-
-- hosts: controller
+- name: "Run ci/playbooks/dev-workflow.yml"
+  hosts: controller
   gather_facts: true
   tasks:
     - name: Push fake pull-secret

--- a/ci/playbooks/dump_zuul_vars.yml
+++ b/ci/playbooks/dump_zuul_vars.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: controller
+- name: "Run ci/playbooks/dump_zuul_vars.yml"
+  hosts: controller
   gather_facts: true
   tasks:
     - name: Slurp Zuul inventory

--- a/ci/playbooks/e2e-collect-logs.yml
+++ b/ci/playbooks/e2e-collect-logs.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+- name: "Run ci/playbooks/e2e-collect-logs.yml"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Ensure we have the ci-framework on host

--- a/ci/playbooks/e2e-prepare.yml
+++ b/ci/playbooks/e2e-prepare.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: controller
+- name: "Run ci/playbooks/e2e-prepare.yml"
+  hosts: controller
   gather_facts: true
   tasks:
     - name: Clone repos in the job workspace

--- a/ci/playbooks/e2e-run.yml
+++ b/ci/playbooks/e2e-run.yml
@@ -1,6 +1,7 @@
 ---
 
-- hosts: controller
+- name: "Run ci/playbooks/e2e-run.yml"
+  hosts: controller
   gather_facts: true
   vars:
     ci_framework_src_dir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"

--- a/ci/playbooks/edpm/run.yml
+++ b/ci/playbooks/edpm/run.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+- name: "Run ci/playbooks/edpm/run.yml"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Check for edpm-ansible.yml file

--- a/ci/playbooks/edpm_baremetal_deployment/run.yml
+++ b/ci/playbooks/edpm_baremetal_deployment/run.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+- name: "Run ci/playbooks/edpm_baremetal_deployment/run.yml"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Check for edpm-ansible.yml file

--- a/ci/playbooks/edpm_build_images/edpm_build_images_content_provider.yaml
+++ b/ci/playbooks/edpm_build_images/edpm_build_images_content_provider.yaml
@@ -1,5 +1,6 @@
 ---
-- hosts: "{{ cifmw_target_host | default('localhost') }}"
+- name: "Run ci/playbooks/edpm_build_images/edpm_build_images_content_provider.yaml"
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: true
   tasks:
     - name: Deploy content provider registry

--- a/ci/playbooks/edpm_build_images/edpm_build_images_content_provider_run.yaml
+++ b/ci/playbooks/edpm_build_images/edpm_build_images_content_provider_run.yaml
@@ -1,5 +1,6 @@
 ---
-- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+- name: "Run ci/playbooks/edpm_build_images/edpm_build_images_content_provider_run.yaml"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Build edpm images

--- a/ci/playbooks/edpm_build_images/edpm_image_builder.yml
+++ b/ci/playbooks/edpm_build_images/edpm_image_builder.yml
@@ -1,7 +1,9 @@
 ---
 - name: Boostrap node
   ansible.builtin.import_playbook: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/ci_framework/playbooks/01-bootstrap.yml"
-- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+
+- name: "Run ci/playbooks/edpm_build_images/edpm_image_builder.yml"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   tasks:
     - name: Read hash from delorean.repo.md5 file
       tags:

--- a/ci/playbooks/edpm_build_images/run.yml
+++ b/ci/playbooks/edpm_build_images/run.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+- name: "Run ci/playbooks/edpm_build_images/run.yml"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Run EDPM build image

--- a/ci/playbooks/kuttl/run.yml
+++ b/ci/playbooks/kuttl/run.yml
@@ -1,4 +1,5 @@
-- hosts: controller
+- name: "Run ci/playbooks/kuttl/run.yml"
+  hosts: controller
   gather_facts: true
   tasks:
     - name: Run kuttl tests playbook

--- a/ci/playbooks/molecule-prepare.yml
+++ b/ci/playbooks/molecule-prepare.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: controller
+- name: "Run ci/playbooks/molecule-prepare.yml"
+  hosts: controller
   gather_facts: true
   tasks:
     - name: Prepare workspace

--- a/ci/playbooks/molecule-test.yml
+++ b/ci/playbooks/molecule-test.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: controller
+- name: "Run ci/playbooks/molecule-test.yml"
+  hosts: controller
   gather_facts: true
   tasks:
     - name: Run molecule

--- a/ci/playbooks/pre-doc.yml
+++ b/ci/playbooks/pre-doc.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: controller
+- name: "Run ci/playbooks/pre-doc.yml"
+  hosts: controller
   gather_facts: true
   tasks:
     - name: Clone repos in the job workspace

--- a/ci/playbooks/run-doc.yml
+++ b/ci/playbooks/run-doc.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: controller
+- name: "Run ci/playbooks/run-doc.yml"
+  hosts: controller
   gather_facts: true
   tasks:
     - name: Build doc

--- a/ci/playbooks/tcib/run.yml
+++ b/ci/playbooks/tcib/run.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+- name: "Run ci/playbooks/tcib/run.yml"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Discover the host ip

--- a/ci/playbooks/tcib/tcib.yml
+++ b/ci/playbooks/tcib/tcib.yml
@@ -2,7 +2,8 @@
 - name: Bootstrap step
   ansible.builtin.import_playbook: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/ci_framework/playbooks/01-bootstrap.yml"
 
-- hosts: "{{ cifmw_target_host | default('localhost') }}"
+- name: "Run ci/playbooks/tcib/tcib.yml"
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: true
   tasks:
     - name: Deploy local registry


### PR DESCRIPTION
Using the play path as a name allows an easy understanding in case of
issues, since we can easily find what play failed.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
