### PR TITLE
Filter hosts in CI playbook

### DIFF
--- a/ci/playbooks/build_runner_image.yml
+++ b/ci/playbooks/build_runner_image.yml
@@ -1,6 +1,13 @@
 ---
 - hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   tasks:
+    - name: Filter out host if needed
+      when:
+        - cifmw_zuul_target_host is defined
+        - cifmw_zuul_target_host != 'all'
+        - inventory_hostname != cifmw_zuul_target_host
+      ansible.builtin.meta: end_host
+
     - name: Get git tag for image tagging
       register: edpm_ansible_tag
       ansible.builtin.command:

--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -2,6 +2,13 @@
 - hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
+    - name: Filter out host if needed
+      when:
+        - cifmw_zuul_target_host is defined
+        - cifmw_zuul_target_host != 'all'
+        - inventory_hostname != cifmw_zuul_target_host
+      ansible.builtin.meta: end_host
+
     - name: Run block
       block:
         - name: Ensure file is present

--- a/ci/playbooks/content_provider/pre.yml
+++ b/ci/playbooks/content_provider/pre.yml
@@ -1,6 +1,13 @@
 ---
 - hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   tasks:
+    - name: Filter out host if needed
+      when:
+        - cifmw_zuul_target_host is defined
+        - cifmw_zuul_target_host != 'all'
+        - inventory_hostname != cifmw_zuul_target_host
+      ansible.builtin.meta: end_host
+
     - name: Clone repos in the job workspace
       include_role:
         name: prepare-workspace

--- a/ci/playbooks/content_provider/run.yml
+++ b/ci/playbooks/content_provider/run.yml
@@ -2,6 +2,13 @@
 - hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
+    - name: Filter out host if needed
+      when:
+        - cifmw_zuul_target_host is defined
+        - cifmw_zuul_target_host != 'all'
+        - inventory_hostname != cifmw_zuul_target_host
+      ansible.builtin.meta: end_host
+
     - name: Deploy content provider
       environment:
         ANSIBLE_CONFIG: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/ansible.cfg"

--- a/ci/playbooks/e2e-collect-logs.yml
+++ b/ci/playbooks/e2e-collect-logs.yml
@@ -2,6 +2,13 @@
 - hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
+    - name: Filter out host if needed
+      when:
+        - cifmw_zuul_target_host is defined
+        - cifmw_zuul_target_host != 'all'
+        - inventory_hostname != cifmw_zuul_target_host
+      ansible.builtin.meta: end_host
+
     - name: Ensure we have the ci-framework on host
       register: cifmw_status
       ansible.builtin.stat:

--- a/ci/playbooks/edpm/run.yml
+++ b/ci/playbooks/edpm/run.yml
@@ -2,6 +2,13 @@
 - hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
+    - name: Filter out host if needed
+      when:
+        - cifmw_zuul_target_host is defined
+        - cifmw_zuul_target_host != 'all'
+        - inventory_hostname != cifmw_zuul_target_host
+      ansible.builtin.meta: end_host
+
     - name: Check for edpm-ansible.yml file
       ansible.builtin.stat:
         path: "{{ ansible_user_dir }}/ci-framework-data/artifacts/edpm-ansible.yml"

--- a/ci/playbooks/edpm_baremetal_deployment/run.yml
+++ b/ci/playbooks/edpm_baremetal_deployment/run.yml
@@ -2,6 +2,13 @@
 - hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
+    - name: Filter out host if needed
+      when:
+        - cifmw_zuul_target_host is defined
+        - cifmw_zuul_target_host != 'all'
+        - inventory_hostname != cifmw_zuul_target_host
+      ansible.builtin.meta: end_host
+
     - name: Check for edpm-ansible.yml file
       ansible.builtin.stat:
         path: "{{ ansible_user_dir }}/ci-framework-data/artifacts/edpm-ansible.yml"

--- a/ci/playbooks/edpm_build_images/edpm_build_images_content_provider_run.yaml
+++ b/ci/playbooks/edpm_build_images/edpm_build_images_content_provider_run.yaml
@@ -2,6 +2,13 @@
 - hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
+    - name: Filter out host if needed
+      when:
+        - cifmw_zuul_target_host is defined
+        - cifmw_zuul_target_host != 'all'
+        - inventory_hostname != cifmw_zuul_target_host
+      ansible.builtin.meta: end_host
+
     - name: Build edpm images
       environment:
         ANSIBLE_CONFIG: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/ansible.cfg"

--- a/ci/playbooks/edpm_build_images/edpm_image_builder.yml
+++ b/ci/playbooks/edpm_build_images/edpm_image_builder.yml
@@ -3,6 +3,13 @@
   ansible.builtin.import_playbook: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/ci_framework/playbooks/01-bootstrap.yml"
 - hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   tasks:
+    - name: Filter out host if needed
+      when:
+        - cifmw_zuul_target_host is defined
+        - cifmw_zuul_target_host != 'all'
+        - inventory_hostname != cifmw_zuul_target_host
+      ansible.builtin.meta: end_host
+
     - name: Read hash from delorean.repo.md5 file
       tags:
         - edpm_build_img

--- a/ci/playbooks/edpm_build_images/run.yml
+++ b/ci/playbooks/edpm_build_images/run.yml
@@ -2,6 +2,13 @@
 - hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
+    - name: Filter out host if needed
+      when:
+        - cifmw_zuul_target_host is defined
+        - cifmw_zuul_target_host != 'all'
+        - inventory_hostname != cifmw_zuul_target_host
+      ansible.builtin.meta: end_host
+
     - name: Run EDPM build image
       environment:
         ANSIBLE_CONFIG: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/ansible.cfg"

--- a/ci/playbooks/tcib/run.yml
+++ b/ci/playbooks/tcib/run.yml
@@ -2,6 +2,13 @@
 - hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
+    - name: Filter out host if needed
+      when:
+        - cifmw_zuul_target_host is defined
+        - cifmw_zuul_target_host != 'all'
+        - inventory_hostname != cifmw_zuul_target_host
+      ansible.builtin.meta: end_host
+
     - name: Discover the host ip
       ansible.builtin.set_fact:
         node_ip: >-


### PR DESCRIPTION
We cannot use a parameter as `hosts` value in zuul playbooks. The
parameters as passed via the "vars" and related job parameters are
injected in the inventory, and not exposed during the ansible-playbook
startup, but only once it's loaded and ready.

At that stage, the playbook already defaulted to the `all` value,
preventing clean and nice filtering.

We'd need to pass the parameter as actual --extra-vars, but this isn't
possible in zuul.

We therefore have to leverage the `end_host` meta to skip the host if we
set the cifmw_zuul_target_host parameter.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
