### PR TITLE
Run os_must_gather only in case of failure

### DIFF
--- a/ci_framework/playbooks/99-logs.yml
+++ b/ci_framework/playbooks/99-logs.yml
@@ -32,10 +32,6 @@
       ansible.builtin.import_role:
         name: artifacts
 
-    - name: Run os_must_gather
-      ansible.builtin.import_role:
-        name: os_must_gather
-
     - name: Ensure ansible.log is at the expected location
       register: ansible_log_state
       ansible.builtin.stat:

--- a/ci_framework/roles/artifacts/README.md
+++ b/ci_framework/roles/artifacts/README.md
@@ -10,6 +10,7 @@ None - writes happen only in the user home.
 * `cifmw_artifacts_crc_host`: (String) Hostname of the CRC instance. Defaults to `api.crc.testing`.
 * `cifmw_artifacts_crc_user`: (String) Username to connect to the CRC instance. Defaults to `core`.
 * `cifmw_artifacts_crc_sshkey`: (String) Path to the private SSH key to connect to CRC. Defaults to `~/.crc/machines/crc/id_ecdsa`.
+* `cifmw_artifacts_gather_logs`: (Boolean) Force gathering of logs, even in the case of successful test run. Defaults to `false`
 
 ## Examples
 Usually we'll import the role as-is at the very start of the playbook, and

--- a/ci_framework/roles/artifacts/defaults/main.yml
+++ b/ci_framework/roles/artifacts/defaults/main.yml
@@ -21,3 +21,4 @@ cifmw_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-fra
 cifmw_artifacts_crc_host: "api.crc.testing"
 cifmw_artifacts_crc_user: "core"
 cifmw_artifacts_crc_sshkey: "~/.crc/machines/crc/id_ecdsa"
+cifmw_artifacts_gather_logs: "false"

--- a/ci_framework/roles/artifacts/tasks/main.yml
+++ b/ci_framework/roles/artifacts/tasks/main.yml
@@ -14,6 +14,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Verify if "success" flag exists after successful tests execution
+  register: cifmw_success_flag
+  ansible.builtin.stat:
+    path: "{{ ansible_user_dir }}/cifmw-success"
+
 - name: Ensure we have at least minimal ansible facts
   tags:
     - always
@@ -44,8 +49,15 @@
     - always
   ansible.builtin.import_tasks: cleanup.yml
 
-- name: Gather CRC logs
-  ansible.builtin.import_tasks: crc.yml
-
-- name: Gather EDPM logs
-  ansible.builtin.import_tasks: edpm.yml
+- name: Gather logs when forced or tests failed
+  when: cifmw_artifacts_gather_logs | bool or not cifmw_success_flag.stat.exists
+  block:
+    - name: Run os_must_gather
+      ansible.builtin.import_role:
+        name: os_must_gather
+  rescue:
+    - name: Get CRC logs if os_must_gather failed
+      ansible.builtin.import_tasks: crc.yml
+  always:
+    - name: Get EDPM logs
+      ansible.builtin.import_tasks: edpm.yml

--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -6,6 +6,14 @@
 # openstack-k8s-operators/install_yaml repository in order to leverage its
 # own methods.
 
+- name: Remove status flag
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  tasks:
+    - name: Delete success flag if exists
+      ansible.builtin.file:
+        path: "{{ ansible_user_dir }}/cifmw-success"
+        state: absent
+
 - name: Bootstrap step
   ansible.builtin.import_playbook: ci_framework/playbooks/01-bootstrap.yml
 
@@ -30,6 +38,14 @@
 - name: Import run test playbook
   ansible.builtin.import_playbook: ci_framework/playbooks/08-run-tests.yml
   when: cifmw_run_tests | default('false') | bool
+
+- name: Inject status flag
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  tasks:
+    - name: Inject success flag
+      ansible.builtin.file:
+        path: "{{ ansible_user_dir }}/cifmw-success"
+        state: touch
 
 - name: Run log related tasks
   ansible.builtin.import_playbook: ci_framework/playbooks/99-logs.yml


### PR DESCRIPTION
Run os_must_gather only in case of a failure which happened during "run" step in ZUUL.
By doing so, we're reducing post-run job by about 450-600s, also preserving disk space.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
