### PR TITLE
Exporting cifmw_openshift_login_skip_tls_verify as global

### DIFF
--- a/ci_framework/roles/openshift_login/README.md
+++ b/ci_framework/roles/openshift_login/README.md
@@ -33,7 +33,7 @@ No privilege escalation needed.
 * `cifmw_openshift_login_retries`: (Integer) Number of attempts to retry the login action if it fails. Defaults to `10`.
 * `cifmw_openshift_login_retries_delay`: (Integer) Delay, in seconds, between login retries. Defaults to `20`.
 * `cifmw_openshift_login_assume_cert_system_user`: (Boolean) When trying cert key login from kubeconfig, assume that the inferred user is a `system:` admin. Defaults to `true`.
-* `cifmw_openshift_login_skip_tls_verify`: (Boolean) Skip TLS verification to login. Note: This option may break admin login using certs. Defaults to `false`.
+* `cifmw_openshift_login_skip_tls_verify`: (Boolean) Skip TLS verification to login. Note: This option may break admin login using certs. Defaults to `cifmw_openshift_skip_tls_verify` and `false` as last instance..
 
 ## Examples
 ### 1 - Login using user/password and API combination

--- a/ci_framework/roles/openshift_login/defaults/main.yml
+++ b/ci_framework/roles/openshift_login/defaults/main.yml
@@ -24,4 +24,4 @@ cifmw_openshift_login_force_refresh: false
 cifmw_openshift_login_assume_cert_system_user: true
 cifmw_openshift_login_retries: 10
 cifmw_openshift_login_retries_delay: 10
-cifmw_openshift_login_skip_tls_verify: false
+cifmw_openshift_login_skip_tls_verify: "{{ cifmw_openshift_skip_tls_verify | default(false) }}"

--- a/ci_framework/roles/openshift_login/tasks/login.yml
+++ b/ci_framework/roles/openshift_login/tasks/login.yml
@@ -30,7 +30,6 @@
     cifmw_openshift_login_api: "{{ cifmw_openshift_login_api | default(cifmw_openshift_api) | default(omit) }}"
     cifmw_openshift_login_cert_login: "{{ cifmw_openshift_login_cert_login | default(false)}}"
     cifmw_openshift_login_provided_token: "{{ cifmw_openshift_provided_token | default(omit) }}"
-    test_cat: true
     cacheable: true
 
 - name: Check if kubeconfig exists

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -28,6 +28,7 @@ provisioned with virtual baremetal vs pre-provisioned VM.
 * `cifmw_openshift_user`: (String) Login user. If provided, the user that logins.
 * `cifmw_openshift_provided_token`: (String) Initial login token. If provided, that token will be used to authenticate into OpenShift.
 * `cifmw_openshift_password`: (String) Login password. If provided is the password used for login in.
+* `cifmw_openshift_skip_tls_verify`: (Boolean) Skip TLS verification to login. Defaults to `false`.
 * `cifmw_use_opn`: (Bool) toggle openshift provisioner node support.
 * `cifmw_use_hive`: (Bool) toggle OpenShift deployment using hive operator.
 * `cifmw_openshift_crio_stats`: (Bool) toggle collecting cri-o stats in CRC deployment


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
