### PR TITLE
Ensure we don't fail on stopped VM

### DIFF
--- a/ci_framework/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/clean_layout.yml
@@ -14,11 +14,15 @@
     var: cleanup_vms
 
 - name: Destroy machine
+  register: vm_destroy
   community.libvirt.virt:
     command: destroy
     name: "{{ item }}"
     uri: "qemu:///system"
   loop: "{{ cleanup_vms }}"
+  failed_when:
+    - vm_destroy.rc is defined
+    - vm_destroy.rc > 1
 
 - name: Undefine machine
   community.libvirt.virt:
@@ -42,11 +46,15 @@
     var: cleanup_nets
 
 - name: Destroy networks
+  register: net_destroy
   community.libvirt.virt_net:
     command: destroy
     name: "{{ item }}"
     uri: "qemu:///system"
   loop: "{{ cleanup_nets }}"
+  failed_when:
+    - net_destroy.rc is defined
+    - net_destroy.rc > 1
 
 - name: Undefine networks
   community.libvirt.virt_net:


### PR DESCRIPTION
It may happen the VM are already stopped (for instance after a
hypervisor reboot). This patch ensures we don't fail the whole cleanup
in that case.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
