### PR TITLE
Ensure we collect logs from compute(s) with new layout

### DIFF
--- a/ci_framework/roles/artifacts/tasks/edpm.yml
+++ b/ci_framework/roles/artifacts/tasks/edpm.yml
@@ -1,47 +1,91 @@
 ---
-- name: List all of the existing virtual machines
-  ignore_errors: true
-  register: vms_list
-  community.libvirt.virt:
-    command: list_vms
-    uri: "qemu:///system"
-
-- name: Filter out edpm vm
-  ignore_errors: true
-  ansible.builtin.set_fact:
-    edpm_vm: "{{ vms_list.list_vms | select('match', '^edpm-.*$') }}"
-
-- name: Generate logs on EDPM vms
-  when:
-    - '"edpm-compute-0" in edpm_vm'
+- name: Check for virtualized compute
   block:
-    - name: Generate logs on edpm vm
-      ignore_errors: true
-      ci_script:
-        output_dir: "{{ cifmw_artifacts_basedir }}/artifacts"
-        script: |-
-          ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{ cifmw_artifacts_basedir }}/artifacts/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100 <<EOF
-          set -xe;
-          mkdir -p /tmp/{{ edpm_vm[0] }}
-          cp -r /var/log/ /tmp/{{ edpm_vm[0] }}
-          cp -r /var/lib/openstack /tmp/{{ edpm_vm[0] }}
-          cp -r /var/lib/config-data /tmp/{{ edpm_vm[0] }}
-          cp -r /var/lib/cloud /tmp/{{ edpm_vm[0] }}
-          cp -r /etc/nftables /tmp/{{ edpm_vm[0] }}
-          cp -r /etc/os-net-config /tmp/{{ edpm_vm[0] }}
-          ovs-vsctl list Open_vSwitch > /tmp/{{ edpm_vm[0] }}/ovs_vsctl_list_openvswitch.txt
-          ip netns > /tmp/{{ edpm_vm[0] }}/ip_netns.txt
-          ip a > /tmp/{{ edpm_vm[0] }}/network.txt
-          ip ro ls >> /tmp/{{ edpm_vm[0] }}/network.txt
-          rpm -qa > /tmp/{{ edpm_vm[0] }}/rpm_qa.txt
-          podman images > /tmp/{{ edpm_vm[0] }}/podman_images.txt
-          ausearch -i | grep denied > /tmp/{{ edpm_vm[0] }}/selinux-denials.log
-          journalctl -p warning -t kernel -o short -g DROPPING --no-pager &> /tmp/{{ edpm_vm[0] }}/firewall-drops.txt
-          EOF
+    - name: List all of the existing virtual machines
+      register: vms_list
+      community.libvirt.virt:
+        command: list_vms
+        uri: "qemu:///system"
 
-    - name: Copy logs to host machine from edpm vm
-      ignore_errors: true
-      ci_script:
-        output_dir: "{{ cifmw_artifacts_basedir }}/artifacts"
-        script: |-
-          scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -v -r -i {{ cifmw_artifacts_basedir }}/artifacts/edpm/ansibleee-ssh-key-id_rsa root@192.168.122.100:/tmp/{{ edpm_vm[0] }} {{ cifmw_artifacts_basedir }}/logs
+    - name: Filter out edpm vm
+      ansible.builtin.set_fact:
+        ssh_key_file: "{{ cifmw_artifacts_basedir }}/artifacts/edpm/ansibleee-ssh-key-id_rsa"
+        edpm_vms: >-
+          {%- set listing=vms_list.list_vms | select('match', '^edpm-.*$') -%}
+          {%- if listing | length == 1 -%}
+          ['192.168.122.100']
+          {%- endif -%}
+  rescue:
+    - name: Check for network info env file
+      register: network_env_file
+      ansible.builtin.stat:
+        path: /etc/ci/env/networking-info.yml
+
+    - name: Extract data from network env file if available
+      when:
+        - network_env_file.stat.exists
+      block:
+        - name: Load network env file
+          ansible.builtin.include_vars:
+            file: /etc/ci/env/networking-info.yml
+
+        - name: Load generated hook env file for SSH key
+          ansible.builtin.include_vars:
+            dir: "{{ cifmw_artifacts_basedir }}/artifacts"
+            depth: 1
+            file_matching: '^(pre|post).*\.yml$'
+
+        - name: Extract Compute from zuul mapping if any
+          when: crc_ci_bootstrap_networks_out is defined
+          ansible.builtin.set_fact:
+            ssh_key_file: "{{ cifmw_edpm_deploy_extra_vars.SSH_KEY_FILE }}"
+            edpm_vms: >-
+              {{
+                crc_ci_bootstrap_networks_out | dict2items |
+                selectattr('key', 'match', '^compute.*$') |
+                map(attribute='value.default.ip') | default([])
+              }}
+  always:
+    - name: Generate logs on EDPM vms
+      when:
+        - edpm_vms is defined
+        - edpm_vms | length > 0
+      block:
+        - name: "Generate logs on edpm vm {{ item }}"
+          ignore_errors: true
+          ci_script:
+            output_dir: "{{ cifmw_artifacts_basedir }}/artifacts"
+            script: |-
+              ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{ ssh_key_file }} root@{{ item }} <<EOF
+              set -xe;
+              mkdir -p /tmp/{{ item }}
+              cp -r /var/log/ /tmp/{{ item }}
+              cp -r /var/lib/openstack /tmp/{{ item }}
+              cp -r /var/lib/config-data /tmp/{{ item }}
+              cp -r /var/lib/cloud /tmp/{{ item }}
+              cp -r /etc/nftables /tmp/{{ item }}
+              cp -r /etc/os-net-config /tmp/{{ item }}
+              ovs-vsctl list Open_vSwitch > /tmp/{{ item }}/ovs_vsctl_list_openvswitch.txt
+              ip netns > /tmp/{{ item }}/ip_netns.txt
+              ip a > /tmp/{{ item }}/network.txt
+              ip ro ls >> /tmp/{{ item }}/network.txt
+              rpm -qa > /tmp/{{ item }}/rpm_qa.txt
+              podman images > /tmp/{{ item }}/podman_images.txt
+              ausearch -i | grep denied > /tmp/{{ item }}/selinux-denials.log
+              journalctl -p warning -t kernel -o short -g DROPPING --no-pager &> /tmp/{{ item }}/firewall-drops.txt
+              EOF
+          loop: "{{ edpm_vms }}"
+          loop_control:
+            label: "{{ item }}"
+
+        - name: "Copy logs to host machine from {{ item }}"
+          ignore_errors: true
+          ci_script:
+            output_dir: "{{ cifmw_artifacts_basedir }}/artifacts"
+            script: >-
+              scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -v
+              -r -i {{ ssh_key_file }}
+              root@{{ item }}:/tmp/{{ item }} {{ cifmw_artifacts_basedir }}/logs
+          loop: "{{ edpm_vms }}"
+          loop_control:
+            label: "{{ item }}"


### PR DESCRIPTION
The new layout as introduced in #361 doesn't use libvirt anymore on the
main host. Therefore, we must ensure we can gather logs from the compute
node.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
