### PR TITLE
Set proper container registry url and hash for edpm_deploy

### DIFF
--- a/ci_framework/roles/edpm_deploy/defaults/main.yml
+++ b/ci_framework/roles/edpm_deploy/defaults/main.yml
@@ -24,3 +24,4 @@ cifmw_edpm_deploy_retries: 100
 cifmw_edpm_deploy_run_validation: false
 cifmw_edpm_deploy_dryrun: false
 cifmw_edpm_deploy_timeout: 40
+cifmw_edpm_deploy_registry_url: "{{ cifmw_install_yamls_defaults['DATAPLANE_REGISTRY_URL'] }}"

--- a/ci_framework/roles/edpm_deploy/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy/tasks/main.yml
@@ -22,6 +22,8 @@
       {{
         cifmw_install_yamls_environment |
         combine({'PATH': cifmw_path}) |
+        combine({'DATAPLANE_REGISTRY_URL': cifmw_edpm_deploy_registry_url }) |
+        combine({'DATAPLANE_CONTAINER_TAG': cifmw_repo_setup_full_hash | default(cifmw_install_yamls_defaults['DATAPLANE_CONTAINER_TAG']) }) |
         combine(cifmw_edpm_deploy_extra_vars | default({}))
       }}
     cacheable: true

--- a/ci_framework/roles/repo_setup/defaults/main.yml
+++ b/ci_framework/roles/repo_setup/defaults/main.yml
@@ -21,7 +21,7 @@
 # compute,glance,manila,network,octavia,security,swift,tempest,podified,ui,validation]
 # cifmw_repo_setup_component: <component name>
 cifmw_repo_setup_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
-cifmw_repo_setup_promotion: "podified-ci-testing"
+cifmw_repo_setup_promotion: "current-podified"
 cifmw_repo_setup_branch: "antelope"
 cifmw_repo_setup_dlrn_uri: "https://trunk.rdoproject.org/"
 cifmw_repo_setup_rdo_mirror: "{{ cifmw_repo_setup_dlrn_uri }}"

--- a/scenarios/centos-9/edpm_periodic.yml
+++ b/scenarios/centos-9/edpm_periodic.yml
@@ -9,3 +9,4 @@ cifmw_set_openstack_containers_dlrn_md5_path: "{{ cifmw_basedir }}/artifacts/rep
 cifmw_edpm_prepare_update_os_containers: true
 cifmw_set_openstack_containers_namespace: "podified-main-centos9"
 cifmw_run_tests: true
+cifmw_edpm_deploy_registry_url: "{{ cifmw_set_openstack_containers_registry }}/{{ cifmw_set_openstack_containers_namespace }}"


### PR DESCRIPTION
edpm_deploy lacks the support for setting proper registry url and container hash.

In downstream and RDO periodic job, we use different container registries. In order to test proper content, we need to set the proper registries otherwise we will see weired issues.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

