### PR TITLE
Update container tags ending with any filter

### DIFF
--- a/ci_framework/roles/set_openstack_containers/README.md
+++ b/ci_framework/roles/set_openstack_containers/README.md
@@ -15,6 +15,7 @@ The role will generate two 2 files in ~/ci-framework-data/artifacts/ directory a
 * `cifmw_set_openstack_containers_tag_from_md5`: Get the tag from delorean.repo.md5. Defaults to `false`.
 * `cifmw_set_openstack_containers_dlrn_md5_path`: Full path of delorean.repo.md5. Defaults to `/etc/yum.repos.d/delorean.repo.md5`.
 * `cifmw_set_openstack_containers_overrides`: Extra container overrides. Defaults to `{}`
+* `cifmw_set_openstack_containers_tag_filter`: Update container tags ending with. Defaults to `current-podified`
 
 ## Examples
 

--- a/ci_framework/roles/set_openstack_containers/defaults/main.yml
+++ b/ci_framework/roles/set_openstack_containers/defaults/main.yml
@@ -21,6 +21,7 @@ cifmw_set_openstack_containers_basedir: "{{ cifmw_basedir | default(ansible_user
 cifmw_set_openstack_containers_registry: quay.io
 cifmw_set_openstack_containers_namespace: podified-antelope-centos9
 cifmw_set_openstack_containers_tag: current-podified
+cifmw_set_openstack_containers_tag_filter: current-podified
 cifmw_set_openstack_containers_operator_name: openstack
 cifmw_set_openstack_containers_tag_from_md5: false
 cifmw_set_openstack_containers_dlrn_md5_path: "/etc/yum.repos.d/delorean.repo.md5"

--- a/ci_framework/roles/set_openstack_containers/templates/update_env_vars.sh.j2
+++ b/ci_framework/roles/set_openstack_containers/templates/update_env_vars.sh.j2
@@ -19,7 +19,7 @@ export PATH="{{ cifmw_path }}"
 {%     endif -%}
 {#   All the openstack services containers ends with current-podified tag #}
 {#   It filters out the same and update the container address with new url #}
-{%   elif _container.endswith('current-podified') -%}
+{%   elif _container.endswith(cifmw_set_openstack_containers_tag_filter) -%}
 {%     set _container_data = _container.split('/')[-1] -%}
 {%     set _container_name = _container_data.split(':')[0] -%}
 {%     set _container_address = _container_registry + '/' + _container_name + ':' + cifmw_set_openstack_containers_tag -%}


### PR DESCRIPTION
Currently we update openstack service containers based on current-podified, But in downstream, we use different `release-name` as a tag filter.

In order to make sure set_openstack_containers role works with downstream, We need to make filter tag as a var so that user can update it.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
