### PR TITLE
Fixing the install_yamls expected cloned path

### DIFF
--- a/scenarios/centos-9/install_yamls.yml
+++ b/scenarios/centos-9/install_yamls.yml
@@ -1,5 +1,5 @@
 ---
 cifmw_rhol_crc_use_installyamls: true
-cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github/openstack-k8s-operators/install_yamls"
+cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
 cifmw_install_yamls_vars:
   KUBECONFIG: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
