### PR TITLE
Early load hooks env in logs playbook

### DIFF
--- a/ci_framework/roles/artifacts/tasks/edpm.yml
+++ b/ci_framework/roles/artifacts/tasks/edpm.yml
@@ -29,14 +29,10 @@
           ansible.builtin.include_vars:
             file: /etc/ci/env/networking-info.yml
 
-        - name: Load generated hook env file for SSH key
-          ansible.builtin.include_vars:
-            dir: "{{ cifmw_artifacts_basedir }}/artifacts"
-            depth: 1
-            files_matching: '^(pre|post).*\.yml$'
-
         - name: Extract Compute from zuul mapping if any
-          when: crc_ci_bootstrap_networks_out is defined
+          when:
+            - crc_ci_bootstrap_networks_out is defined
+            - cifmw_edpm_deploy_extra_vars
           ansible.builtin.set_fact:
             ssh_key_file: "{{ cifmw_edpm_deploy_extra_vars.SSH_KEY_FILE }}"
             edpm_vms: >-

--- a/ci_framework/roles/artifacts/tasks/main.yml
+++ b/ci_framework/roles/artifacts/tasks/main.yml
@@ -34,6 +34,13 @@
     path: "{{ cifmw_artifacts_basedir }}/artifacts"
     state: directory
 
+- name: Load generated hook environment for further usage
+  ansible.builtin.include_vars:
+    dir: "{{ cifmw_artifacts_basedir }}/artifacts"
+    depth: 1
+    files_matching: '^(pre|post).*\.yml$'
+  ignore_errors: true
+
 - name: Gather environment data
   tags:
     - always


### PR DESCRIPTION
As the hooks variables may be used for logs collection those ones should be loaded early beforehand.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date