### PR TITLE
Fix podified/edpm log collection

### DIFF
--- a/ci_framework/roles/artifacts/tasks/main.yml
+++ b/ci_framework/roles/artifacts/tasks/main.yml
@@ -56,15 +56,17 @@
     - always
   ansible.builtin.import_tasks: cleanup.yml
 
-- name: Gather logs when forced or tests failed
+- name: Run must gather logs when forced or tests failed
   when: cifmw_artifacts_gather_logs | bool or not cifmw_success_flag.stat.exists
-  block:
-    - name: Run os_must_gather
-      ansible.builtin.import_role:
-        name: os_must_gather
-  rescue:
-    - name: Get CRC logs if os_must_gather failed
-      ansible.builtin.import_tasks: crc.yml
-  always:
-    - name: Get EDPM logs
-      ansible.builtin.import_tasks: edpm.yml
+  ignore_errors: true
+  ansible.builtin.import_role:
+    name: os_must_gather
+
+- name: Collect crc logs when tests successed
+  ignore_errors: true
+  when: not cifmw_artifacts_gather_logs | bool or cifmw_success_flag.stat.exists
+  ansible.builtin.import_tasks: crc.yml
+
+- name: Get EDPM logs
+  ignore_errors: true
+  ansible.builtin.import_tasks: edpm.yml


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/ci-framework/pull/457 enables running os_must_gather role in case of failure but also addes resuce task to run crc and edpm log collection.

Since os_must_gather role runs must_gather tool to do the log collection and if must_gather fails, it also resuces operation to collect more logs on the node. The task associated with calling os_must_gather role is always going to get skipped if the job passes and we have no log collection for edpm and podified.

Developers have no logs to verify/check few things in passed jobs.

This pr fixes the same by running crc task file in case of passing job and os_must_gather role in case of failed job. We should always run edpm task files to collect edpm logs.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

