### PR TITLE
Remove openshift-marketplace; install cert-manager without marketplace

### DIFF
--- a/ci/playbooks/e2e-run.yml
+++ b/ci/playbooks/e2e-run.yml
@@ -6,6 +6,11 @@
   vars:
     ci_framework_src_dir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
   tasks:
+    - name: Install cert-manager
+      community.general.make:
+        chdir: "{{ ci_framework_src_dir }}"
+        target: install-cert-manager
+
     - name: Tagged packages
       ansible.builtin.command:
         chdir: "{{ ci_framework_src_dir }}"

--- a/ci_framework/hooks/playbooks/disable_os_marketplace.yml
+++ b/ci_framework/hooks/playbooks/disable_os_marketplace.yml
@@ -8,3 +8,10 @@
         PATH: "{{ cifmw_path }}"
       ansible.builtin.command: >-
         oc patch operatorhubs/cluster --type merge --patch '{"spec":{"sources":[{"disabled": true,"name": "redhat-marketplace"}]}}'
+
+    - name: Delete marketplace namespace
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.command: >-
+        oc delete namespace openshift-marketplace

--- a/olm-deps/cert-manager.yaml
+++ b/olm-deps/cert-manager.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+spec:
+  channel: stable
+  name: cert-manager
+  source: operatorhubio-catalog
+  sourceNamespace: olm


### PR DESCRIPTION
The openshift-marketplace namespace is not needed to keep when the redhat-marketplace cluster operator was disabled.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
