### PR TITLE
Add SoftwareFactory ZUUL app to all operators

### DIFF
--- a/zuul.d/content_provider.yaml
+++ b/zuul.d/content_provider.yaml
@@ -16,18 +16,30 @@
       - ^kuttl-test.yaml$
     required-projects:
       - opendev.org/zuul/zuul-jobs
-      - openstack-k8s-operators/install_yamls
-      - openstack-k8s-operators/openstack-operator
-      - github.com/openstack-k8s-operators/ci-framework
-      - github.com/openstack-k8s-operators/repo-setup
-      - openstack-k8s-operators/openstack-ansibleee-operator
-      - openstack-k8s-operators/keystone-operator
-      - openstack-k8s-operators/nova-operator
-      - openstack-k8s-operators/mariadb-operator
+      - openstack-k8s-operators/ci-framework
+      - openstack-k8s-operators/cinder-operator
       - openstack-k8s-operators/dataplane-operator
-      - openstack-k8s-operators/placement-operator
+      - openstack-k8s-operators/designate-operator
+      - openstack-k8s-operators/glance-operator
+      - openstack-k8s-operators/heat-operator
+      - openstack-k8s-operators/horizon-operator
+      - openstack-k8s-operators/infra-operator
+      - openstack-k8s-operators/install_yamls
+      - openstack-k8s-operators/ironic-operator
+      - openstack-k8s-operators/keystone-operator
+      - openstack-k8s-operators/manila-operator
+      - openstack-k8s-operators/mariadb-operator
+      - openstack-k8s-operators/neutron-operator
+      - openstack-k8s-operators/nova-operator
+      - openstack-k8s-operators/octavia-operator
+      - openstack-k8s-operators/openstack-ansibleee-operator
       - openstack-k8s-operators/openstack-baremetal-operator
+      - openstack-k8s-operators/openstack-operator
       - openstack-k8s-operators/ovn-operator
+      - openstack-k8s-operators/placement-operator
+      - openstack-k8s-operators/repo-setup
+      - openstack-k8s-operators/tcib
+      - openstack-k8s-operators/telemetry-operator
     pre-run:
       - ci/playbooks/content_provider/pre.yml
     run:


### PR DESCRIPTION
To prevent from future problems with missing `openstack-operators` let's add them all at once.

Depends-On: https://review.rdoproject.org/r/c/config/+/49761

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running