### PR TITLE
Add environment vars for kuttl test runs

### DIFF
--- a/ci/playbooks/kuttl/run-kuttl-tests.yml
+++ b/ci/playbooks/kuttl/run-kuttl-tests.yml
@@ -1,9 +1,36 @@
 ---
+- name: Set environment vars for kuttl test
+  ansible.builtin.set_fact:
+    cifmw_kuttl_tests_env: >-
+      {{
+        cifmw_install_yamls_environment |
+        combine(cifmw_kuttl_tests_env_vars | default({})) |
+        combine({'PATH': cifmw_path})
+      }}
+
+- name: 'Run make crc_storage_cleanup_with_retries'
+  vars:
+    make_crc_storage_cleanup_with_retries_env: "{{ cifmw_kuttl_tests_env }}"
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_crc_storage_cleanup_with_retries.yml'
+
+- name: 'Run make crc_storage_with_retries'
+  vars:
+    make_crc_storage_with_retries_env: "{{ cifmw_kuttl_tests_env }}"
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_crc_storage_with_retries.yml'
+
 - name: 'Get resource status before {{ operator }}_kuttl run'
   ansible.builtin.shell: |
     {{ item }} >> {{ cifmw_artifacts_basedir }}/logs/cmd_before_{{ operator }}_kuttl.log
   loop: "{{ commands_before_kuttl_run }}"
   ignore_errors: true
+
+- name: 'Set make_{{ operator }}_kuttl_env vars'
+  ansible.builtin.set_fact:
+    make_{{ operator }}_kuttl_env: "{{ cifmw_kuttl_tests_env }}"
 
 - name: 'Run make_{{ operator }}_kuttl'
   ansible.builtin.include_role:

--- a/scenarios/centos-9/kuttl.yml
+++ b/scenarios/centos-9/kuttl.yml
@@ -1,4 +1,5 @@
 ---
 cifmw_install_yamls_vars:
-  STORAGE_CLASS: crc-csi-hostpath-provisioner
+  OPERATOR_BASE_DIR: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators"
+  BMO_SETUP: false
 cifmw_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"


### PR DESCRIPTION
This patch now provides install_yamls environment vars to each kuttl test run. It also supports specific kuttl test environment vars using "cifmw_kuttl_tests_env_vars"

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
