### PR TITLE
Change base container image ubi9->centos

### DIFF
--- a/ci_framework/roles/build_containers/defaults/main.yml
+++ b/ci_framework/roles/build_containers/defaults/main.yml
@@ -43,5 +43,5 @@ cifmw_build_containers_volume_mounts:
 # cifmw_build_containers_build_timeout
 cifmw_build_containers_repo_dir: "{{ cifmw_build_containers_basedir }}/artifacts/repositories"
 cifmw_build_containers_image_tag: current-podified
-cifmw_build_containers_containers_base_image: registry.access.redhat.com/ubi9:latest
+cifmw_build_containers_containers_base_image: quay.io/centos/centos:stream9
 cifmw_build_containers_cleanup: false


### PR DESCRIPTION
A FIPS enabled EDPM node is currently failing because libvirt doesn't start[1], logging this message:

  error : virRandomBytes:113 : internal error: failed to generate byte
          stream: An error has been detected in the library and cannot continue
          operations.

In any FIPS enabled environment this issue can be replicated in a container:

  # podman run --rm quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified gnutls-cli-debug
  Error in GnuTLS initialization: Error while performing self checks.
  global state initialization error

The root cause of this is that the centos gnutls package installed in the container doesn't work with a ubi9 base image when FIPS is enforced. The centos gnutls works with a centos base image, and the ubi gnutls package works with a ubi9 base image[2].

This change switches the base image to centos:stream9 specifically to fix this FIPS issue, but there may be other problems with mixing packages across distros.

[1] http://pastebin.test.redhat.com/1108025
[2] http://pastebin.test.redhat.com/1108270

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
