### PR TITLE
Update ci-framework to support DP CRD design

### DIFF
--- a/ci_framework/roles/edpm_deploy/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy/tasks/main.yml
@@ -33,7 +33,7 @@
     dest: "{{ ansible_user_dir }}/ci-framework-data/artifacts/hostvars-dump.yml"
     content: "{{ hostvars | to_nice_yaml }}"
 
-- name: Prepare OpenStack Dataplane CR
+- name: Prepare OpenStack Dataplane NodeSet CR
   vars:
     make_edpm_deploy_prep_env: "{{ cifmw_edpm_deploy_env }}"
     make_edpm_deploy_prep_dryrun: "{{ cifmw_edpm_deploy_dryrun | bool }}"
@@ -41,7 +41,7 @@
     name: 'install_yamls_makes'
     tasks_from: 'make_edpm_deploy_prep'
 
-- name: Kustomize and deploy OpenStackDataPlane
+- name: Kustomize and deploy OpenStackDataPlaneNodeSet
   when:
     - not cifmw_edpm_deploy_dryrun | bool
   vars:
@@ -59,23 +59,37 @@
     PATH: "{{ cifmw_path }}"
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
   block:
-    - name: Perform kustomizations to the OpenStackDataPlane CR
+    - name: Find the OpenStack Dataplane NodeSet CR manifest
+      ansible.builtin.find:
+        paths: "{{ cifmw_edpm_deploy_manifests_dir }}/{{ cifmw_install_yamls_defaults['NAMESPACE'] }}/dataplane/cr"
+        contains: "kind: OpenStackDataPlaneNodeSet"
+        excludes: "kind: Kustomization"
+        patterns: "*.yaml"
+      register: cifmw_edpm_deploy_cr_manifest_paths
+
+    - name: Ensure manifest exists
+      ansible.builtin.assert:
+        that: cifmw_edpm_deploy_cr_manifest_paths.matched == 1
+        quiet: true
+        msg: "Cannot determine OpenStackDataPlaneNodeSet deployment manifest"
+
+    - name: Perform kustomizations to the OpenStackDataPlaneNodeSet CR
       vars:
         cifmw_edpm_kustomize_cr_path: "{{ cifmw_edpm_deploy_openstack_cr_path }}"
         cifmw_edpm_kustomize_content: "{{ cifmw_edpm_deploy_dataplane_cr_kustomization | default('{}') }}"
       ansible.builtin.include_role:
         name: edpm_kustomize
 
-    - name: Apply the OpenStackDataPlane CR
+    - name: Apply the OpenStackDataPlaneNodeSet CR
       when: not cifmw_edpm_deploy_dryrun
       ci_script:
         output_dir: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
         script: "oc apply -f {{ cifmw_edpm_deploy_openstack_cr_path }}"
 
-    - name: Wait for OpenStackDataplane to be deployed
+    - name: Wait for OpenStackDataplaneNodeSet to be deployed
       ansible.builtin.command:
         cmd: >-
-          oc wait OpenStackDataplane {{ cifmw_edpm_kustomize_last_cr_content.metadata.name }}
+          oc wait OpenStackDataplaneNodeSet {{ cifmw_edpm_kustomize_last_cr_content.metadata.name }}
           --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
           --for=condition=ready
           --timeout={{ cifmw_edpm_deploy_timeout }}m

--- a/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -115,7 +115,7 @@
   ansible.builtin.debug:
     var: compute_nodes_output.stdout_lines
 
-- name: Patch OpenStackDataPlane to add repo-setup-downstream service
+- name: Patch OpenStackDataPlaneNodeSet to add repo-setup-downstream service
   when:
     - cifmw_edpm_deploy_baremetal_repo_setup_override
     - not cifmw_edpm_deploy_baremetal_dry_run
@@ -133,57 +133,57 @@
     # We can drop this step once we drop dev-preview#1 jobs in downstream
     # This is added because install_yamls is tagged and we don't
     # have repo-setup service in OpenStackDataPlane in v0.1.0 tag
-    - name: Get list of services defined under OpenStackDataPlane resource
+    - name: Get list of services defined under OpenStackDataPlaneNodeSet resource
       environment:
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
       ansible.builtin.command:
         cmd: >-
-          oc get openstackdataplane openstack-edpm
+          oc get openstackdataplanenodeset openstack-edpm-ipam
           -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
-          -o jsonpath='{.spec.roles.edpm-compute.services[*]}'
+          -o jsonpath='{.spec.services[*]}'
       register: services_list
       changed_when: false
       ignore_errors: yes
 
     # to-do:  We can drop this step once we drop dev-preview#1 jobs in downstream
-    - name: Patch OpenStackDataPlane resource to add "repo-setup-downstream" service
+    - name: Patch OpenStackDataPlaneNodeSet resource to add "repo-setup-downstream" service
       when: "'repo-setup' not in services_list.stdout"
       environment:
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
       ansible.builtin.command:
         cmd: >-
-          oc patch openstackdataplane openstack-edpm
+          oc patch openstackdataplanenodeset openstack-edpm-ipam
           -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
           --type json
-          -p '[{"op": "add", "path": "/spec/roles/edpm-compute/services/0", "value": "repo-setup-downstream"}]'
+          -p '[{"op": "add", "path": "/spec/services/0", "value": "repo-setup-downstream"}]'
 
     # to-do: We can drop the when condition once we drop dev-preview#1 jobs in downstream
-    - name: Patch OpenStackDataPlane resource to replace "repo-setup" with "repo-setup-downstream" service
+    - name: Patch OpenStackDataPlaneNodeSet resource to replace "repo-setup" with "repo-setup-downstream" service
       when: "'repo-setup' in services_list.stdout"
       environment:
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
       ansible.builtin.command:
         cmd: >-
-          oc patch openstackdataplane openstack-edpm
+          oc patch openstackdataplanenodeset openstack-edpm-ipam
           -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
           --type json
-          -p '[{"op": "replace", "path": "/spec/roles/edpm-compute/services/0", "value": "repo-setup-downstream"}]'
+          -p '[{"op": "replace", "path": "/spec/services/0", "value": "repo-setup-downstream"}]'
 
-- name: Patch OpenStackDataPlane
+- name: Patch OpenStackDataPlaneNodeSet
   when: not cifmw_edpm_deploy_baremetal_dry_run
   environment:
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
     PATH: "{{ cifmw_path }}"
   ansible.builtin.command:
     cmd: >-
-      oc patch openstackdataplane openstack-edpm
+      oc patch openstackdataplanenodeset openstack-edpm-ipam
       --type=merge -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
       -p '{"spec":{"deployStrategy":{"deploy":true}}}'
 
-- name: Wait for OpenStackDataPlane to be Ready
+- name: Wait for OpenStackDataPlaneNodeSet to be Ready
   when: not cifmw_edpm_deploy_baremetal_dry_run
   environment:
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
@@ -191,5 +191,5 @@
   ansible.builtin.command:
     cmd: >-
       oc wait --timeout={{ cifmw_edpm_deploy_baremetal_wait_dataplane_timeout_mins }}m
-      --for=condition=Ready openstackdataplane openstack-edpm
+      --for=condition=Ready openstackdataplanenodeset openstack-edpm-ipam
       -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}

--- a/ci_framework/roles/edpm_kustomize/README.md
+++ b/ci_framework/roles/edpm_kustomize/README.md
@@ -15,36 +15,36 @@ None
   vars:
     cifmw_edpm_kustomize_cr_path: "/path/to/resource.yml"
     cifmw_edpm_kustomize_content: |-
-        apiVersion: kustomize.config.k8s.io/v1beta1
-        kind: Kustomization
-        resources:
-        namespace: {{ cifmw_install_yamls_defaults.NAMESPACE }}
-        patches:
-        - target:
-            kind: OpenStackDataPlane
-          patch: |-
-            - op: replace
-              path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/edpm_network_config_template
-              value: "{{ cifmw_edpm_deploy_extra_vars.DATAPLANE_NETWORK_CONFIG_TEMPLATE }}"
+       apiVersion: kustomize.config.k8s.io/v1beta1
+       kind: Kustomization
+       resources:
+       namespace: {{ cifmw_install_yamls_defaults.NAMESPACE }}
+       patches:
+       - target:
+           kind: OpenStackDataPlaneNodeSet
+         patch: |-
+           - op: replace
+             path: /spec/nodeTemplate/ansible/ansibleVars/neutron_public_interface_name
+             value: "eno1"
 
-            - op: replace
-              path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/neutron_public_interface_name
-              value: "{{ crc_ci_bootstrap_networks_out.compute.default.iface }}"
+           - op: replace
+             path: /spec/nodeTemplate/ansible/ansibleVars/ctlplane_mtu
+             value: "1350"
 
-            - op: replace
-              path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/ctlplane_mtu
-              value: "{{ crc_ci_bootstrap_networks_out.compute.default.mtu }}"
+           - op: replace
+             path: /spec/nodeTemplate/ansible/ansibleUser
+             value: "{{ hostvars.compute.ansible_user | default('zuul') }}"
 
-            - op: replace
-              path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/edpm_os_net_config_mappings
-              value:
-                net_config_data_lookup:
-                  edpm-compute:
-                    nic1: "{{ crc_ci_bootstrap_networks_out.compute.default.iface }}"
+           - op: replace
+             path: /spec/nodeTemplate/ansible/ansibleVars/edpm_os_net_config_mappings
+             value:
+               net_config_data_lookup:
+                 edpm-compute:
+                   nic1: "{{ crc_ci_bootstrap_networks_out.compute.default.iface }}"
 
-            - op: replace
-              path: /spec/roles/edpm-compute/nodeTemplate/ansibleUser
-              value: "{{ hostvars.compute.ansible_user | default('zuul') }}"
+           - op: replace
+             path: /spec/nodeTemplate/ansible/ansibleUser
+             value: "{{ hostvars.compute.ansible_user | default('zuul') }}"
   ansible.builtin.include_role:
     name: edpm_kustomize
 ```

--- a/ci_framework/roles/edpm_kustomize/molecule/default/converge.yml
+++ b/ci_framework/roles/edpm_kustomize/molecule/default/converge.yml
@@ -35,18 +35,18 @@
           namespace: {{ cifmw_install_yamls_defaults.NAMESPACE }}
           patches:
           - target:
-              kind: OpenStackDataPlane
+              kind: OpenStackDataPlaneNodeSet
             patch: |-
               - op: replace
-                path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/neutron_public_interface_name
+                path: /spec/nodeTemplate/ansible/ansibleVars/neutron_public_interface_name
                 value: "eno1"
 
               - op: replace
-                path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/ctlplane_mtu
+                path: /spec/nodeTemplate/ansible/ansibleVars/ctlplane_mtu
                 value: "1350"
 
               - op: replace
-                path: /spec/roles/edpm-compute/nodeTemplate/ansibleUser
+                path: /spec/nodeTemplate/ansible/ansibleUser
                 value: "{{ hostvars.compute.ansible_user | default('zuul') }}"
       ansible.builtin.include_role:
         name: edpm_kustomize

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -227,6 +227,7 @@ openshiftsdn
 openssl
 openstack
 openstackdataplane
+openstackdataplanenodeset
 opn
 orchestrator
 os


### PR DESCRIPTION
We are making significant changes to the Dataplane CRD design. Subsequently, these changes need to be reflected within the ci-framework.

Namely, the change removes OpenStackDataPlane, OpenStackDataPlaneRole and OpenStackDataPlaneNode. These are replaced by a single OpenStackDataPlaneNodeSet CR.



As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
