### PR TITLE
Gather cluster related logs for kuttl job

### DIFF
--- a/zuul.d/kuttl.yaml
+++ b/zuul.d/kuttl.yaml
@@ -14,6 +14,7 @@
       - ci/playbooks/dump_zuul_vars.yml
       - ci/playbooks/kuttl/run.yml
     post-run:
+      - ci/playbooks/e2e-collect-logs.yml
       - ci/playbooks/collect-logs.yml
     required-projects:
       - github.com/openstack-k8s-operators/install_yamls


### PR DESCRIPTION
Currently we are not collecting any cluster related logs on kuttl jobs. If a job fails, we have no idea about the reason of failure.

Gathering cluster logs using e2e-collect-logs.yml playbook will help to troubleshoot the issue.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/536

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

