### PR TITLE
Fix task name typo in openshift_login role

### DIFF
--- a/ci_framework/roles/openshift_login/tasks/login.yml
+++ b/ci_framework/roles/openshift_login/tasks/login.yml
@@ -37,7 +37,7 @@
     path: "{{ cifmw_openshift_login_kubeconfig }}"
   register: cifmw_openshift_login_kubeconfig_stat
 
-- name: Assert that enough data for login in is provided
+- name: Assert that enough data is provided to log in to OpenShift
   ansible.builtin.assert:
     that: >-
       cifmw_openshift_login_kubeconfig_stat.stat.exists or


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] Content of the docs/source is reflecting the changes
