### PR TITLE
Allow to override repo-setup in downstream

### DIFF
--- a/ci_framework/roles/edpm_deploy_baremetal/README.md
+++ b/ci_framework/roles/edpm_deploy_baremetal/README.md
@@ -15,6 +15,7 @@ This role doesn't need privilege escalation.
 * `cifmw_edpm_deploy_baremetal_wait_bmh_timeout_mins`: (integer) Timeout for waiting for the bare metal nodes. Default: `20`
 * `cifmw_edpm_deploy_baremetal_wait_dataplane_timeout_mins`: (integer) Timeout for waiting for the OpenStackDataPlane. Default: `30`
 * `cifmw_edpm_deploy_baremetal_update_os_containers`: (Boolean) Update the uefi image. Default: `false`
+* `cifmw_edpm_deploy_baremetal_repo_setup_override`: (Boolean) Override the repo-setup service in OpenStackDataPlane with repo-setup-downstream. Default: `false`
 
 ## Examples
 ### 1 - Perform edpm baremetal deployment

--- a/ci_framework/roles/edpm_deploy_baremetal/defaults/main.yml
+++ b/ci_framework/roles/edpm_deploy_baremetal/defaults/main.yml
@@ -26,3 +26,4 @@ cifmw_edpm_deploy_baremetal_wait_ironic_timeout_mins: 20
 cifmw_edpm_deploy_baremetal_wait_bmh_timeout_mins: 20
 cifmw_edpm_deploy_baremetal_wait_dataplane_timeout_mins: 30
 cifmw_edpm_deploy_baremetal_update_os_containers: false
+cifmw_edpm_deploy_baremetal_repo_setup_override: false

--- a/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -115,6 +115,63 @@
   ansible.builtin.debug:
     var: compute_nodes_output.stdout_lines
 
+- name: Patch OpenStackDataPlane to add repo-setup-downstream service
+  when:
+    - cifmw_edpm_deploy_baremetal_repo_setup_override
+    - not cifmw_edpm_deploy_baremetal_dry_run
+  block:
+    # This file will be created in downstream job's pre-playbook
+    - name: Create repo-setup-downstream OpenStackDataPlaneService
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.command:
+        cmd: >-
+          oc apply -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+          -f "{{ cifmw_installyamls_repos }}/devsetup/edpm/services/dataplane_v1beta1_openstackdataplaneservice_reposetup_downstream.yaml"
+
+    # We can drop this step once we drop dev-preview#1 jobs in downstream
+    # This is added because install_yamls is tagged and we don't
+    # have repo-setup service in OpenStackDataPlane in v0.1.0 tag
+    - name: Get list of services defined under OpenStackDataPlane resource
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.command:
+        cmd: >-
+          oc get openstackdataplane openstack-edpm
+          -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+          -o jsonpath='{.spec.roles.edpm-compute.services[*]}'
+      register: services_list
+      changed_when: false
+      ignore_errors: yes
+
+    # to-do:  We can drop this step once we drop dev-preview#1 jobs in downstream
+    - name: Patch OpenStackDataPlane resource to add "repo-setup-downstream" service
+      when: "'repo-setup' not in services_list.stdout"
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.command:
+        cmd: >-
+          oc patch openstackdataplane openstack-edpm
+          -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+          --type json
+          -p '[{"op": "add", "path": "/spec/roles/edpm-compute/services/0", "value": "repo-setup-downstream"}]'
+
+    # to-do: We can drop the when condition once we drop dev-preview#1 jobs in downstream
+    - name: Patch OpenStackDataPlane resource to replace "repo-setup" with "repo-setup-downstream" service
+      when: "'repo-setup' in services_list.stdout"
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.command:
+        cmd: >-
+          oc patch openstackdataplane openstack-edpm
+          -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+          --type json
+          -p '[{"op": "replace", "path": "/spec/roles/edpm-compute/services/0", "value": "repo-setup-downstream"}]'
+
 - name: Patch OpenStackDataPlane
   when: not cifmw_edpm_deploy_baremetal_dry_run
   environment:


### PR DESCRIPTION
With this PR, we do the following:-

* Create the repo-setup-downstream OpenStackDataPlaneService (which is
  created in downstream pre-playbook)

* Determine if repo-setup service is present in OpenStackDataPlane
or not. We need this check because install_yamls is tagged and we 
don't have repo-setup service in OpenStackDataPlane in v0.1.0 tag

* Add/Replace repo-setup-downstream with repo-setup service.

* We will do a cleanup in future once we drop dev-preview#1 job to 
  add repo-setup and will only keep replacing logic here.


As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
