### PR TITLE
Add barbican and swift operators to required-projects list

### DIFF
--- a/zuul.d/content_provider.yaml
+++ b/zuul.d/content_provider.yaml
@@ -24,6 +24,7 @@
       - roles/.*/molecule/.*
     required-projects:
       - opendev.org/zuul/zuul-jobs
+      - openstack-k8s-operators/barbican-operator
       - openstack-k8s-operators/ci-framework
       - openstack-k8s-operators/cinder-operator
       - openstack-k8s-operators/dataplane-operator
@@ -46,6 +47,7 @@
       - openstack-k8s-operators/ovn-operator
       - openstack-k8s-operators/placement-operator
       - openstack-k8s-operators/repo-setup
+      - openstack-k8s-operators/swift-operator
       - openstack-k8s-operators/tcib
       - openstack-k8s-operators/telemetry-operator
     pre-run:


### PR DESCRIPTION
Depends-On: https://review.rdoproject.org/r/c/config/+/49768

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running