### PR TITLE
Ony report DLRN results when var is true

### DIFF
--- a/ci_framework/roles/dlrn_report/tasks/main.yml
+++ b/ci_framework/roles/dlrn_report/tasks/main.yml
@@ -14,8 +14,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Install dlrnapi-client
-  ansible.builtin.import_tasks: install.yml
+- name: Only report DLRN results when var is set
+  when: cifmw_dlrn_report_result | bool
+  block:
+    - name: Install dlrnapi-client
+      ansible.builtin.import_tasks: install.yml
 
-- name: Report DLRN results
-  ansible.builtin.import_tasks: dlrn_report_results.yml
+    - name: Report DLRN results
+      ansible.builtin.import_tasks: dlrn_report_results.yml


### PR DESCRIPTION
cifmw_dlrn_report_result should be set to true
otherwise skip the whole role.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
