### PR TITLE
Removed old dead EDPM log collection from edpm_deploy

### DIFF
--- a/ci_framework/roles/edpm_deploy/README.md
+++ b/ci_framework/roles/edpm_deploy/README.md
@@ -10,7 +10,6 @@ None
 * `cifmw_edpm_edploy_dataplane_operator_repo`: (String) Path to Dataplane-operator repo. Defaults to `"{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/dataplane-operator"`.
 * `cifmw_edpm_deploy_os_runner_img`: (String) OpenStack Runner image url. Defaults to `"quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest"`.
 * `cifmw_edpm_deploy_dataplane_cr`: (String) Path to Dataplane CR. Defaults to `"config/samples/dataplane_v1beta1_openstackdataplane.yaml"`.
-* `cifmw_edpm_deploy_log_path`: (String) Path to collect EDPM pods log. Defaults to `"{{ cifmw_edpm_deploy_basedir }}/logs/edpm/edpm_deploy.log"`.
 * `cifmw_edpm_deploy_retries`: (Integer) Number of retries for edpm deploy status. Defaults to `100`.
 * `cifmw_edpm_deploy_run_validation`: (Boolean) Run validation on EDPM node. Defaults to `False`.
 * `cifmw_edpm_deploy_dryrun`: (Boolean) Do a dry run on make edpm_deploy command. Defaults to `False`.

--- a/ci_framework/roles/edpm_deploy/defaults/main.yml
+++ b/ci_framework/roles/edpm_deploy/defaults/main.yml
@@ -19,7 +19,6 @@
 # All variables within this role should have a prefix of "cifmw_edpm_deploy"
 cifmw_edpm_deploy_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_edpm_deploy_manifests_dir: "{{ cifmw_manifests | default(cifmw_edpm_deploy_basedir ~ '/artifacts/manifests') }}"
-cifmw_edpm_deploy_log_path: "{{ cifmw_edpm_deploy_basedir }}/logs/edpm/edpm_deploy.log"
 cifmw_edpm_deploy_retries: 100
 cifmw_edpm_deploy_run_validation: false
 cifmw_edpm_deploy_dryrun: false

--- a/ci_framework/roles/edpm_deploy/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy/tasks/main.yml
@@ -80,36 +80,6 @@
           --for=condition=ready
           --timeout={{ cifmw_edpm_deploy_timeout }}m
 
-    - name: Get the logs of EDPM Deploy
-      when:
-        - deploy_status is defined
-        - "'rc' in deploy_status"
-        - deploy_status.rc == 0
-      ansible.builtin.shell: |
-        for POD in $(oc get pods -o name -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} | egrep "dataplane-deployment-|nova-edpm-compute");
-        do
-          echo $POD;
-          oc logs -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} $POD;
-        done
-      register: edpm_logs
-
-- name: Collect logs for EDPM deploy
-  when:
-    - edpm_logs is defined
-    - "'rc' in edpm_logs"
-    - edpm_logs.rc == 0
-  block:
-    - name: Check for edpm logs directory
-      ansible.builtin.file:
-        path: "{{ cifmw_edpm_deploy_log_path | dirname }}"
-        state: directory
-
-    - name: Collect EDPM deploy logs
-      ansible.builtin.copy:
-        mode: 0644
-        content: "{{ edpm_logs.stdout }}"
-        dest: "{{ cifmw_edpm_deploy_log_path }}"
-
 - name: Validate EDPM
   when: cifmw_edpm_deploy_run_validation | bool
   vars:


### PR DESCRIPTION
Those logs are already fetched by os_must_gather or by the crc log retrieval tasks in the artifacts role.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date
