### PR TITLE
Add Dev-preview workaround to finish EDPM deployment

### DIFF
--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -35,6 +35,17 @@
 - name: Import admin setup related playbook
   ansible.builtin.import_playbook: ci_framework/playbooks/07-admin-setup.yml
 
+  # Note(Chandan): It is a know issue with the dev-preview nova-operator that
+  # it runs the libvirt and nova-compute deployment twice but reports ready
+  # status after the first run. So with this sleep the job waits for the
+  # deployment to really stabilize before start running the tempest tests.
+- name: Sleep for 5 mins to finish th EDPM deployment
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  tasks:
+    - name: Add a sleep for 5 mins
+      ansible.builtin.pause:
+        minutes: 5
+
 - name: Import run test playbook
   ansible.builtin.import_playbook: ci_framework/playbooks/08-run-tests.yml
   when: cifmw_run_tests | default('false') | bool


### PR DESCRIPTION
It is a know issue with the dev-preview nova-operator that 
it runs the libvirt and nova-compute deployment twice but 
reports ready status after the first run. So with this sleep 
the job waits for the deployment to really stabilize before 
start running the tempest tests.
    
Adding 5 sleep before running tests as a workaround fixes
the issue.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

