### PR TITLE
Replace crc passwd for nested crc jobs

### DIFF
--- a/scenarios/centos-9/ci.yml
+++ b/scenarios/centos-9/ci.yml
@@ -3,7 +3,7 @@ ansible_user_dir: "{{ lookup('env', 'HOME') }}"
 cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
 
 cifmw_openshift_user: "kubeadmin"
-cifmw_openshift_password: "123456789"
+cifmw_openshift_password: "12345678"
 cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
 
 cifmw_openshift_setup_skip_internal_registry: true

--- a/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
+++ b/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
@@ -27,7 +27,7 @@ cifmw_rhol_crc_use_installyamls: true
 
 # openshift_login role vars
 cifmw_openshift_user: "kubeadmin"
-cifmw_openshift_password: "123456789"
+cifmw_openshift_password: "12345678"
 cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
 
 pre_deploy:

--- a/scenarios/centos-9/edpm_ci.yml
+++ b/scenarios/centos-9/edpm_ci.yml
@@ -18,7 +18,7 @@ cifmw_openshift_setup_skip_internal_registry: true
 
 # openshift_login role vars
 cifmw_openshift_user: "kubeadmin"
-cifmw_openshift_password: "123456789"
+cifmw_openshift_password: "12345678"
 cifmw_openshift_api: api.crc.testing:6443
 cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
 cifmw_openshift_skip_tls_verify: true


### PR DESCRIPTION
Nested crc image has changed its passwd back to 1..8 and now legacy jobs are failing. we need to switchover to old passwd to unblock jobs.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
