### PR TITLE
Remove disable_default_gw flag

### DIFF
--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -82,7 +82,6 @@
               tenant:
                 ip: 172.19.0.5
           compute:
-            disable_default_gw: false
             networks:
               default:
                 ip: 192.168.122.100


### PR DESCRIPTION
As the base jobs already removed that functionality the skip flag can be deleted.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date