### PR TITLE
Run content provider on script changes

### DIFF
--- a/zuul.d/content_provider.yaml
+++ b/zuul.d/content_provider.yaml
@@ -17,7 +17,6 @@
       - molecule/.*
       - molecule-requirements.txt
       - .github/workflows
-      - scripts/.*
       - docs/.*
       - contribute/.*
       - tests


### PR DESCRIPTION
In Install_yamls, we have scripts directory. Since scripts is in irrelevant_files under content_provider job which skips the content provider job leading to job freeze issue.

Removing it from there fixes the issue.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

