### PR TITLE
Run test_server_basic_ops tests on multinode crc job

### DIFF
--- a/scenarios/centos-9/multinode-ci.yml
+++ b/scenarios/centos-9/multinode-ci.yml
@@ -20,3 +20,5 @@ cifmw_run_tests: true
 
 # Deploy EDPM in multinode scenario
 cifmw_deploy_edpm: true
+cifmw_tempest_tests_allowed:
+  - tempest.scenario.test_network_basic_ops.TestNetworkBasicOps


### PR DESCRIPTION
Currently we are running keystone api tests which comes from default tempest role. It does not provide enough testing to edpm deployment. Switching to test_server_basic_ops will test the whole EDPM deployment.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/583
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/582
