### PR TITLE
Add a simple retries mechanism for os_net_config

### DIFF
--- a/ci_framework/roles/os_net_setup/README.md
+++ b/ci_framework/roles/os_net_setup/README.md
@@ -9,3 +9,5 @@ That is provided by `openshift_login` role.
 
 ### Parameters
 * `cifmw_os_net_setup_config`: See an example in ci_framework/roles/os_net_setup/defaults/main.yml
+* `cifmw_os_net_setup_osp_calls_retries`: (Integer) Number of attempts to retry an OSP action if it fails. Defaults to `10`.
+* `cifmw_os_net_setup_osp_calls_delay`: (Integer) Delay, in seconds, between failed OSP call retries. Defaults to `5`.

--- a/ci_framework/roles/os_net_setup/defaults/main.yml
+++ b/ci_framework/roles/os_net_setup/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_os_net_setup"
+cifmw_os_net_setup_osp_calls_retries: 10
+cifmw_os_net_setup_osp_calls_delay: 5
 cifmw_os_net_setup_config:
   - name: public
     external: true

--- a/ci_framework/roles/os_net_setup/tasks/main.yml
+++ b/ci_framework/roles/os_net_setup/tasks/main.yml
@@ -38,7 +38,10 @@
 - name: Get network information
   openstack.cloud.networks_info:
     auth: "{{ openstack_auth }}"
-  register: net_info
+  register: cifmw_os_net_setup_network_list_out
+  until: cifmw_os_net_setup_network_list_out is not failed
+  retries: "{{ cifmw_os_net_setup_osp_calls_retries }}"
+  delay: "{{ cifmw_os_net_setup_osp_calls_delay }}"
 
 - name: Process network list element
   ansible.builtin.include_tasks:

--- a/ci_framework/roles/os_net_setup/tasks/subtask_net.yml
+++ b/ci_framework/roles/os_net_setup/tasks/subtask_net.yml
@@ -16,7 +16,10 @@
     region_name: '{{ region_name }}'
     state: present
     auth: "{{ openstack_auth }}"
-  register: net_info
+  register: cifmw_os_net_setup_net_fetch_out
+  until: cifmw_os_net_setup_net_fetch_out is not failed
+  retries: "{{ cifmw_os_net_setup_osp_calls_retries }}"
+  delay: "{{ cifmw_os_net_setup_osp_calls_delay }}"
 
 - name: Process subnet list elements
   openstack.cloud.subnet:
@@ -34,7 +37,7 @@
     ipv6_ra_mode: '{{ subnet_item.ipv6_ra_mode | default(omit) }}'
     is_dhcp_enabled: '{{ subnet_item.is_dhcp_enabled | default(omit) }}'
     name: '{{ subnet_item.name | default(omit) }}'
-    network: "{{ net_info.id }}"
+    network: "{{ cifmw_os_net_setup_net_fetch_out.id }}"
     prefix_length: '{{ subnet_item.prefix_length | default(omit) }}'
     subnet_pool: '{{ subnet_item.subnet_pool | default(omit) }}'
     use_default_subnet_pool: '{{ subnet_item.use_default_subnet_pool | default(omit) }}'
@@ -44,3 +47,7 @@
   loop: "{{ net_item.subnets | flatten(levels=1) }}"
   loop_control:
     loop_var: subnet_item
+  register: cifmw_os_net_setup_subnet_fetch_out
+  until: cifmw_os_net_setup_subnet_fetch_out is not failed
+  retries: "{{ cifmw_os_net_setup_osp_calls_retries }}"
+  delay: "{{ cifmw_os_net_setup_osp_calls_delay }}"

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -236,6 +236,7 @@ opn
 orchestrator
 os
 osd
+osp
 param
 params
 passwd


### PR DESCRIPTION
Seems that sometimes OSP call may fail, so we can try to alleviate those issues by retrying.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
