### PR TITLE
Continue ci_script implementation replacing shell and command built-i…

### DIFF
--- a/ci_framework/roles/install_ca/defaults/main.yml
+++ b/ci_framework/roles/install_ca/defaults/main.yml
@@ -20,3 +20,4 @@
 cifmw_install_ca_trust_dir: '/etc/pki/ca-trust/source/anchors/'
 cifmw_install_ca_bundle_inline: ''
 cifmw_install_ca_bundle_src: ''
+cifmw_install_ca_output_dir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"

--- a/ci_framework/roles/install_ca/molecule/default/prepare.yml
+++ b/ci_framework/roles/install_ca/molecule/default/prepare.yml
@@ -19,6 +19,7 @@
   hosts: all
   vars:
     ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_install_ca_basedir: "{{ cifmw_basedir | default( ansible_user_dir ~ '/ci-framework-data') }}"
     cifmw_install_yamls_defaults:
       NAMESPACE: openstack
   roles:
@@ -26,15 +27,17 @@
     - role: ci_setup
   tasks:
     - name: Create first dummy CA
-      ansible.builtin.command:
-        cmd: >-
+      ci_script:
+        output_dir: "{{ cifmw_install_ca_basedir }}/artifacts"
+        script: >-
           openssl req -x509 -sha256 -days 1 -nodes -newkey rsa:2048
           -subj "/CN=osp.test.redhat.testing/C=US/L=Raleigh"
           -keyout {{ ansible_user_dir }}/CA-one.key -out {{ ansible_user_dir }}/CA-one.crt
 
     - name: Create second dummy CA
-      ansible.builtin.command:
-        cmd: >-
+      ci_script:
+        output_dir: "{{ cifmw_install_ca_basedir }}/artifacts"
+        script: >-
           openssl req -x509 -sha256 -days 1 -nodes -newkey rsa:2048
           -subj "/CN=osp1.test.redhat.testing/C=US/L=Raleigh"
           -keyout {{ ansible_user_dir }}/CA-two.key -out {{ ansible_user_dir }}/CA-two.crt

--- a/ci_framework/roles/install_ca/tasks/main.yml
+++ b/ci_framework/roles/install_ca/tasks/main.yml
@@ -48,5 +48,6 @@
     - name: Update ca bundle
       when:
         - (ca_bundle is defined and ca_bundle is changed) or (ca_inline is defined and ca_inline is changed)
-      ansible.builtin.command:
-        cmd: update-ca-trust
+      ci_script:
+        output_dir: "{{ cifmw_install_ca_output_dir }}/artifacts"
+        script: update-ca-trust


### PR DESCRIPTION
Continue ci_script implementation replacing shell and command built-in modules.
Role: install_ca

As a pull request owner and reviewers, I checked that:
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
