### PR TITLE
Continue ci_script implementation

### DIFF
--- a/ci_framework/roles/openshift_login/tasks/main.yml
+++ b/ci_framework/roles/openshift_login/tasks/main.yml
@@ -14,6 +14,13 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Ensure output directory exists
+  tags:
+    - always
+  ansible.builtin.file:
+    path: "{{ cifmw_openshift_login_basedir }}/artifacts"
+    state: directory
+
 - name: OpenShift login
   ansible.builtin.include_tasks:
     file: "login.yml"

--- a/ci_framework/roles/openshift_login/tasks/try_login.yml
+++ b/ci_framework/roles/openshift_login/tasks/try_login.yml
@@ -34,8 +34,9 @@
   environment:
     PATH: "{{ cifmw_path }}"
     KUBECONFIG: "{{ cifmw_openshift_login_kubeconfig }}"
-  ansible.builtin.command:
-    cmd: >-
+  ci_script:
+    output_dir: "{{ cifmw_openshift_login_basedir }}/artifacts"
+    script: >-
       oc login
       {%- if cifmw_openshift_login_provided_token is not defined %}
       {%- if cifmw_openshift_login_user is defined %}

--- a/ci_framework/roles/openshift_setup/defaults/main.yml
+++ b/ci_framework/roles/openshift_setup/defaults/main.yml
@@ -17,6 +17,7 @@
 
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_openshift_setup"
+cifmw_openshift_setup_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_openshift_setup_dry_run: false
 cifmw_openshift_setup_create_namespaces: []
 cifmw_openshift_setup_skip_internal_registry: false

--- a/ci_framework/roles/openshift_setup/tasks/main.yml
+++ b/ci_framework/roles/openshift_setup/tasks/main.yml
@@ -14,6 +14,13 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Ensure output directory exists
+  tags:
+    - always
+  ansible.builtin.file:
+    path: "{{ cifmw_openshift_setup_basedir }}/artifacts"
+    state: directory
+
 - name: Fetch namespaces to create
   ansible.builtin.set_fact:
     cifmw_openshift_setup_namespaces: >-
@@ -95,8 +102,9 @@
           status: "True"
 
     - name: Login into OpenShift internal registry
-      ansible.builtin.command:
-        cmd: >-
+      ci_script:
+        output_dir: "{{ cifmw_openshift_setup_basedir }}/artifacts"
+        script: >-
           podman login
           -u {{ cifmw_openshift_user }}
           -p {{ cifmw_openshift_token }}


### PR DESCRIPTION
Continue ci_script implementation replacing shell and command built-in modules
Roles: **openshift_setup**, **openshift_login**
Some command builti-in hasn't been ported since they don't give any important or relevant info that can be useful in logs.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role

