### PR TITLE
Continue ci_script implementation for ceph roles

### DIFF
--- a/ci_framework/roles/cifmw_cephadm/defaults/main.yml
+++ b/ci_framework/roles/cifmw_cephadm/defaults/main.yml
@@ -64,3 +64,4 @@ cifmw_cephadm_single_host_defaults: false
 cifmw_cephadm_extra_args: ""
 cifmw_cephadm_pacific_filter: "16.*"
 cifmw_cephadm_dashboard_enabled: false
+cifmw_cephadm_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"

--- a/ci_framework/roles/cifmw_cephadm/tasks/bootstrap.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/bootstrap.yml
@@ -43,28 +43,30 @@
 - name: Bootstrap Ceph if there are no running Ceph Daemons
   block:
     - name: Run cephadm bootstrap
-      ansible.builtin.shell: |
-        {{ cifmw_cephadm_bin }} \
-        {% if not cifmw_cephadm_default_container %}--image {{ cifmw_cephadm_container_ns + '/' + cifmw_cephadm_container_image + ':' + cifmw_cephadm_container_tag|string }} \{% endif %}
-        bootstrap \
-        --skip-firewalld \
-        --skip-prepare-host \
-        --ssh-private-key /home/{{ cifmw_cephadm_ssh_user }}/.ssh/id_rsa \
-        --ssh-public-key /home/{{ cifmw_cephadm_ssh_user }}/.ssh/id_rsa.pub \
-        --ssh-user {{ cifmw_cephadm_ssh_user }} \
-        --allow-fqdn-hostname \
-        --output-keyring {{ cifmw_cephadm_admin_keyring }} \
-        --output-config {{ cifmw_cephadm_conf }} \
-        --fsid {{ cifmw_cephadm_fsid }} \
-        {% if cifmw_cephadm_registry_url|length > 0 %}--registry-url {{ cifmw_cephadm_registry_url }} \{% endif %}
-        {% if cifmw_cephadm_registry_username|length > 0 %}--registry-username {{ cifmw_cephadm_registry_username }} \{% endif %}
-        {% if cifmw_cephadm_registry_password|length > 0 %}--registry-password {{ cifmw_cephadm_registry_password }} \{% endif %}
-        {% if cifmw_cephadm_spec_on_bootstrap %}--apply-spec {{ cifmw_cephadm_spec }} \{% endif %}
-        {% if cifmw_cephadm_assimilate_conf_stat.stat.exists %}--config {{ cifmw_cephadm_assimilate_conf }} \{% endif %}
-        {% if cifmw_cephadm_single_host_defaults %}--single-host-defaults \{% endif %}
-        --skip-monitoring-stack --skip-dashboard \
-        {% if cifmw_cephadm_extra_args|length > 0 %}{{ cifmw_cephadm_extra_args }} \{% endif %}
-        --mon-ip {{ cifmw_cephadm_first_mon_ip }}
+      ci_script:
+        output_dir: "{{ cifmw_cephadm_basedir }}/artifacts"
+        script: |
+          {{ cifmw_cephadm_bin }} \
+          {% if not cifmw_cephadm_default_container %}--image {{ cifmw_cephadm_container_ns + '/' + cifmw_cephadm_container_image + ':' + cifmw_cephadm_container_tag|string }} \{% endif %}
+          bootstrap \
+          --skip-firewalld \
+          --skip-prepare-host \
+          --ssh-private-key /home/{{ cifmw_cephadm_ssh_user }}/.ssh/id_rsa \
+          --ssh-public-key /home/{{ cifmw_cephadm_ssh_user }}/.ssh/id_rsa.pub \
+          --ssh-user {{ cifmw_cephadm_ssh_user }} \
+          --allow-fqdn-hostname \
+          --output-keyring {{ cifmw_cephadm_admin_keyring }} \
+          --output-config {{ cifmw_cephadm_conf }} \
+          --fsid {{ cifmw_cephadm_fsid }} \
+          {% if cifmw_cephadm_registry_url|length > 0 %}--registry-url {{ cifmw_cephadm_registry_url }} \{% endif %}
+          {% if cifmw_cephadm_registry_username|length > 0 %}--registry-username {{ cifmw_cephadm_registry_username }} \{% endif %}
+          {% if cifmw_cephadm_registry_password|length > 0 %}--registry-password {{ cifmw_cephadm_registry_password }} \{% endif %}
+          {% if cifmw_cephadm_spec_on_bootstrap %}--apply-spec {{ cifmw_cephadm_spec }} \{% endif %}
+          {% if cifmw_cephadm_assimilate_conf_stat.stat.exists %}--config {{ cifmw_cephadm_assimilate_conf }} \{% endif %}
+          {% if cifmw_cephadm_single_host_defaults %}--single-host-defaults \{% endif %}
+          --skip-monitoring-stack --skip-dashboard \
+          {% if cifmw_cephadm_extra_args|length > 0 %}{{ cifmw_cephadm_extra_args }} \{% endif %}
+          --mon-ip {{ cifmw_cephadm_first_mon_ip }}
       register: cephadm_bootstrap
       become: true
     - name: Show results of bootstrap


### PR DESCRIPTION
Continue ci_script implementation replacing shell and command built-in modules
Roles: cifmw_cephadm
Some command builti-in hasn't been ported since they don't give any important or relevant info that can be useful in logs. @fmount can you please check if some of the changes aren't necessary and if some of the other commands should have it? I didn't change the ones that set simple changes for example. Thx.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate documentation exists and/or is up-to-date:

