### PR TITLE
Add support for dlrn_hash_tag in repo-setup role

### DIFF
--- a/ci_framework/roles/dlrn_report/tasks/dlrn_report_results.yml
+++ b/ci_framework/roles/dlrn_report/tasks/dlrn_report_results.yml
@@ -22,7 +22,9 @@
       --server-principal {{ cifmw_dlrn_report_dlrnapi_host_principal }} --auth-method kerberosAuth
       {% endif -%}
       report-result
-      {% if (cifmw_repo_setup_full_hash is defined) and (cifmw_repo_setup_full_hash | length > 0) -%}
+      {% if (cifmw_repo_setup_dlrn_hash_tag is defined) and (cifmw_repo_setup_dlrn_hash_tag | length > 0) -%}
+      --agg-hash {{ cifmw_repo_setup_dlrn_hash_tag }}
+      {% elif (cifmw_repo_setup_full_hash is defined) and (cifmw_repo_setup_full_hash | length > 0) -%}
       --agg-hash {{ cifmw_repo_setup_full_hash }}
       {% endif -%}
       {% if (cifmw_repo_setup_extended_hash is defined) and (cifmw_repo_setup_extended_hash | length > 0) -%}

--- a/ci_framework/roles/repo_setup/README.md
+++ b/ci_framework/roles/repo_setup/README.md
@@ -16,6 +16,7 @@ Please explain the role purpose.
 * `cifmw_repo_setup_additional_repos`: (String) Additional repos(ceph, deps) to enable. Defaults to `''`.
 * `cifmw_repo_setup_env`: (Dict) Environment variables to be passed to repo_setup cli . Defaults to `'{}'`.
 * `cifmw_repo_setup_enable_rhos_release`: (Boolean) Toggle `rhos-release` support. Defaults to `False`.
+* `cifmw_repo_setup_dlrn_hash_tag`: (String) repo-setup dlrn-hash-tag. Defaults to `{}`.
 
 ### Optional parameters for rhos-release
 * `cifmw_repo_setup_rhos_release_rpm`: (String) URL to rhos-release RPM.

--- a/ci_framework/roles/repo_setup/defaults/main.yml
+++ b/ci_framework/roles/repo_setup/defaults/main.yml
@@ -31,6 +31,7 @@ cifmw_repo_setup_src: "https://github.com/openstack-k8s-operators/repo-setup"
 cifmw_repo_setup_output: "{{ cifmw_repo_setup_basedir }}/artifacts/repositories"
 cifmw_repo_setup_env: {}
 cifmw_repo_setup_additional_repos: ''
+cifmw_repo_setup_dlrn_hash_tag: ''
 
 # Variables related to rhos-release tools
 # rhos-release is used in downstream to populate downstream base os repos

--- a/ci_framework/roles/repo_setup/tasks/artifacts.yml
+++ b/ci_framework/roles/repo_setup/tasks/artifacts.yml
@@ -10,6 +10,9 @@
       {% if cifmw_repo_setup_component is defined -%}
       --component {{ cifmw_repo_setup_component }}
       {% endif -%}
+      {% if cifmw_repo_setup_dlrn_hash_tag | length > 0 -%}
+      --dlrn-hash-tag {{ cifmw_repo_setup_dlrn_hash_tag }}
+      {% endif -%}
       --json
   environment: "{{ cifmw_repo_setup_env | default({}) }}"
   register: _get_hash

--- a/ci_framework/roles/repo_setup/tasks/configure.yml
+++ b/ci_framework/roles/repo_setup/tasks/configure.yml
@@ -8,5 +8,8 @@
       -d {{ cifmw_repo_setup_os_release }}{{ cifmw_repo_setup_dist_major_version }}
       -b {{ cifmw_repo_setup_branch }}
       --rdo-mirror {{ cifmw_repo_setup_rdo_mirror }}
+      {% if cifmw_repo_setup_dlrn_hash_tag | length > 0 %}
+      --dlrn-hash-tag {{ cifmw_repo_setup_dlrn_hash_tag }}
+      {% endif %}
       -o {{ cifmw_repo_setup_output }}
   environment: "{{ cifmw_repo_setup_env | default ({}) }}"

--- a/zuul.d/edpm_build_images.yaml
+++ b/zuul.d/edpm_build_images.yaml
@@ -17,6 +17,7 @@
       cifmw_repo_setup_branch: antelope
       cifmw_repo_setup_output: "/etc/yum.repos.d/"
       ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+      cifmw_repo_setup_src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/repo-setup"
 
 - job:
     name: cifmw-edpm-build-images


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/repo-setup/pull/20 adds the support of passing dlrn hash and generate the repos using that hash.

This pr adds the support for the same and it will be useful to re-run the job at particular hash and report it to dlrn.

Depends-On: https://github.com/openstack-k8s-operators/repo-setup/pull/20

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
