### PR TITLE
Skip EDPM jobs on content provider irrelevant_files

### DIFF
--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -19,10 +19,25 @@
           label: cloud-centos-9-stream-tripleo-vexxhost
         - name: crc
           label: coreos-crc-extracted-xxl
+    # Note: Always sync irrelevant-files from content provider base job
     irrelevant-files:
       - .*/*.md
-      - .*/*.svg
-      - docs/source/*
+      - ^.github/.*$
+      - ^LICENSE$
+      - ^OWNERS$
+      - ^OWNERS_ALIASES$
+      - ^PROJECT$
+      - ^renovate.json$
+      - ^tests/.*$
+      - ^kuttl-test.yaml$
+      - molecule/.*
+      - molecule-requirements.txt
+      - .github/workflows
+      - scripts/.*
+      - docs/.*
+      - contribute/.*
+      - tests
+      - roles/.*/molecule/.*
     required-projects:
       - openstack-k8s-operators/ci-framework
       - openstack-k8s-operators/dataplane-operator


### PR DESCRIPTION
We are seeing Zuul job freeze issue against different operator changes due to difference in irrelevant_files on content provider and EDPM job.

Keeping the same irrelevant_files list fixes the following issue.
```
Unable to freeze job graph: Job podified-multinode-edpm-deployment-crc
depends on openstack-k8s-operators-content-provider which was not run.
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running