### PR TITLE
Revert "Continue ci_script implementation"

### DIFF
--- a/ci_framework/roles/repo_setup/molecule/default/converge.yml
+++ b/ci_framework/roles/repo_setup/molecule/default/converge.yml
@@ -24,10 +24,6 @@
   tasks:
     - name: Ensure proper locations are created
       block:
-        - name: Create ci-framework-data logs dir if not exists
-          ansible.builtin.file:
-            path: "{{ ansible_user_dir }}/ci-framework-data/logs"
-            state: directory
         - name: Stat some files
           register: file_stats
           ansible.builtin.stat:

--- a/ci_framework/roles/repo_setup/tasks/artifacts.yml
+++ b/ci_framework/roles/repo_setup/tasks/artifacts.yml
@@ -1,8 +1,7 @@
 ---
 - name: Run repo-setup-get-hash
-  ci_script:
-    output_dir: "{{ cifmw_repo_setup_basedir }}/artifacts"
-    script: >-
+  ansible.builtin.command:
+    cmd: >-
       {{ cifmw_repo_setup_basedir }}/venv/bin/repo-setup-get-hash
       --dlrn-url {{ cifmw_repo_setup_dlrn_uri[:-1] }}
       --os-version {{ cifmw_repo_setup_os_release }}{{ cifmw_repo_setup_dist_major_version }}

--- a/ci_framework/roles/repo_setup/tasks/configure.yml
+++ b/ci_framework/roles/repo_setup/tasks/configure.yml
@@ -1,9 +1,8 @@
 ---
 - name: Run repo-setup
   become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"
-  ci_script:
-    output_dir: "{{ cifmw_repo_setup_basedir }}/artifacts"
-    script: >-
+  ansible.builtin.command:
+    cmd: >-
       {{ cifmw_repo_setup_basedir }}/venv/bin/repo-setup
       {{ cifmw_repo_setup_promotion }} {{ cifmw_repo_setup_additional_repos }}
       -d {{ cifmw_repo_setup_os_release }}{{ cifmw_repo_setup_dist_major_version }}

--- a/ci_framework/roles/repo_setup/tasks/install.yml
+++ b/ci_framework/roles/repo_setup/tasks/install.yml
@@ -6,7 +6,6 @@
   loop:
     - tmp
     - artifacts/repositories
-    - logs
 
 - name: Make sure git-core package is installed
   become: true
@@ -30,8 +29,7 @@
     virtualenv_command: "python3 -m venv"
 
 - name: Install repo-setup package
-  ci_script:
-    output_dir: "{{ cifmw_repo_setup_basedir }}/artifacts"
-    script: "{{ cifmw_repo_setup_basedir }}/venv/bin/python setup.py install"
+  ansible.builtin.command:
+    cmd: "{{ cifmw_repo_setup_basedir }}/venv/bin/python setup.py install"
     chdir: "{{ cifmw_repo_setup_basedir }}/tmp/repo-setup"
     creates: "{{ cifmw_repo_setup_basedir }}/venv/bin/repo-setup"

--- a/ci_framework/roles/repo_setup/tasks/rhos_release.yml
+++ b/ci_framework/roles/repo_setup/tasks/rhos_release.yml
@@ -16,8 +16,7 @@
 
 - name: "Generate repos using rhos-release {{ cifmw_repo_setup_rhos_release_args }}"
   become: true
-  ci_script:
-    output_dir: "{{ cifmw_repo_setup_basedir }}/artifacts"
-    script: >-
+  ansible.builtin.command:
+    cmd: >-
       rhos-release {{ cifmw_repo_setup_rhos_release_args }} \
         -t {{ cifmw_repo_setup_output }}


### PR DESCRIPTION
Reverts openstack-k8s-operators/ci-framework#506 since is breaking the jobs. https://logserver.rdoproject.org/70/49870/1/check/periodic-container-tcib-build-push-centos-9-antelope/4a694e4/job-output.txt 

As a pull request owner and reviewers, I checked that:
- [X] Nothing required to check.