### PR TITLE
Update pyspell.yml

### DIFF
--- a/.github/workflows/pyspell.yml
+++ b/.github/workflows/pyspell.yml
@@ -18,6 +18,6 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Spellcheck
-      - uses: actions/checkout@v2
-      - uses: igsekor/pyspelling-any@v0.0.2
+      - uses: actions/checkout@v3
+      - uses: igsekor/pyspelling-any@v1.0.4
         name: Spellcheck


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

===
If you check any of the pyspell tests you can see them failing with a warning: `The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. ` [1], updating to Checkout V3 fixes this as it's based on node16 [2]

I also updated pyspell action as well as there has been some minor improvements and bug fixes between release [v0.0.2](https://github.com/igsekor/pyspelling-any/tree/v0.0.2) and [1.0.4](https://github.com/igsekor/pyspelling-any/tree/v1.0.4)

Checking the manual run I triggered you can see the warning is gone [3]

[1] https://github.com/openstack-k8s-operators/ci-framework/actions/runs/6089821798
[2] https://github.com/marketplace/actions/checkout
[3] https://github.com/openstack-k8s-operators/ci-framework/actions/runs/6090964704