### PR TITLE
Add support to set concurrency value in tempest

### DIFF
--- a/ci_framework/roles/tempest/README.md
+++ b/ci_framework/roles/tempest/README.md
@@ -16,6 +16,7 @@ become - Required to install required rpm packages
 * `cifmw_tempest_tests_skipped`: (List) List of tests to be skipped. Setting this will not use the `list_skipped` plugin
 * `cifmw_tempest_tests_allowed`: (List) List of tests to be executed. Setting this will not use the `list_allowed` plugin
 * `cifmw_tempest_tempestconf_profile`: (Dictionary) List of settings to be overwritten in tempest.conf.
+* `cifmw_tempest_concurrency`: (Integer) Tempest concurrency value.
 
 ## Use of cifmw_tempest_tempestconf_profile
 

--- a/ci_framework/roles/tempest/defaults/main.yml
+++ b/ci_framework/roles/tempest/defaults/main.yml
@@ -26,3 +26,4 @@ cifmw_tempest_image: quay.io/podified-antelope-centos9/openstack-tempest
 cifmw_tempest_image_tag: current-podified
 cifmw_tempest_dry_run: false
 cifmw_tempest_remove_container: false
+cifmw_tempest_concurrency: 4

--- a/ci_framework/roles/tempest/tasks/main.yml
+++ b/ci_framework/roles/tempest/tasks/main.yml
@@ -48,6 +48,8 @@
     volume:
       - "{{ cifmw_tempest_artifacts_basedir }}/:/var/lib/tempest/external_files:Z"
     detach: false
+    env:
+      CONCURRENCY: "{{ cifmw_tempest_concurrency | default(omit) }}"
   when: not cifmw_tempest_dry_run | bool
   register: tempest_run_output
 


### PR DESCRIPTION
At this moment, tempest is using all cpus available, and in some test cases this leads to timeout in some resources. Adding the hability to set the proper concurrency will fix this problems.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
