### PR TITLE
Trigger nova discover hosts after EDPM deploy

### DIFF
--- a/ci_framework/roles/edpm_deploy/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy/tasks/main.yml
@@ -80,6 +80,18 @@
           --for=condition=ready
           --timeout={{ cifmw_edpm_deploy_timeout }}m
 
+- name: Run nova-manage discover_hosts to ensure compute nodes are mapped
+  when:
+    - not cifmw_edpm_deploy_dryrun | bool
+  environment:
+    PATH: "{{ cifmw_path }}"
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+  ansible.builtin.command:
+    cmd: >-
+      oc rsh
+      --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+      nova-cell0-conductor-0 nova-manage cell_v2 discover_hosts --verbose
+
 - name: Validate EDPM
   when: cifmw_edpm_deploy_run_validation | bool
   vars:

--- a/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -193,3 +193,14 @@
       oc wait --timeout={{ cifmw_edpm_deploy_baremetal_wait_dataplane_timeout_mins }}m
       --for=condition=Ready openstackdataplane openstack-edpm
       -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+
+- name: Run nova-manage discover_hosts to ensure compute nodes are mapped
+  when: not cifmw_edpm_deploy_baremetal_dry_run
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: >-
+      oc rsh
+      -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+      nova-cell0-conductor-0 nova-manage cell_v2 discover_hosts --verbose


### PR DESCRIPTION
The periodic host discovery is now disabled in nova-scheduler as it is not scaling well. Instead after EDPM compute node deployment the nova-manage cell_v2 discover_hosts CLI is run to trigger the discovery.

Related-To: openstack-k8s-operators/nova-operator#519
Related: https://issues.redhat.com/browse/OSPRH-319

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
