### PR TITLE
Fix fqcn for check_vip set_facts

### DIFF
--- a/ci_framework/playbooks/ceph.yml
+++ b/ci_framework/playbooks/ceph.yml
@@ -172,7 +172,7 @@
 
     # cifmw_cephadm_vip is the VIP reserved in the Storage network
     - name: Set VIP var as empty string
-      set_fact:
+      ansible.builtin.set_fact:
         cifmw_cephadm_vip: ""
 
     - name: Process VIP

--- a/ci_framework/roles/cifmw_cephadm/tasks/check_vip.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/check_vip.yml
@@ -15,19 +15,18 @@
 # under the License.
 
 - name: Process VIP
+  when:
+    - cifmw_cephadm_vip | default() | length == 0
   block:
     - name: Increment the retry count
-      set_fact:
+      ansible.builtin.set_fact:
         count: "{{ 2 if count is undefined else count | int + 2 }}"
 
     - name: Get an IP address from the Storage network
-      set_fact:
+      ansible.builtin.set_fact:
         cur_ip: "{{ cifmw_cephadm_rgw_network | ansible.utils.next_nth_usable(count) }}"
 
     - name: Reserve VIP if the address is available
-      set_fact:
+      ansible.builtin.set_fact:
         cifmw_cephadm_vip: "{{ cur_ip }}"
       when: cur_ip not in ips | default([])
-  when:
-    # cifmw_cephadm_vip is always defined in the ceph.yml playbook
-    - cifmw_cephadm_vip | default() | length == 0

--- a/ci_framework/roles/cifmw_cephadm/tasks/rgw.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/rgw.yml
@@ -23,7 +23,7 @@
   ansible.builtin.template:
     src: templates/ceph_rgw.yml.j2
     dest: "{{ cifmw_ceph_rgw_spec_path }}"
-    mode: 0644
+    mode: '0644'
     force: true
 
 - name: Get ceph_cli


### PR DESCRIPTION
We missed some fqcn fixes in the last minute updates of the RGW patch. This change fixes it and improves the name/when/block order.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
- [x] README in the role
- [x] Content of the docs/source is reflecting the changes
