### PR TITLE
Speed up build_containers molecule job

### DIFF
--- a/ci_framework/roles/build_containers/files/containers.yaml
+++ b/ci_framework/roles/build_containers/files/containers.yaml
@@ -1,0 +1,3 @@
+container_images:
+  - imagename: quay.io/podified-master-centos9/openstack-base:current-podified
+  - imagename: quay.io/podified-master-centos9/openstack-keystone:current-podified

--- a/ci_framework/roles/build_containers/molecule/default/converge.yml
+++ b/ci_framework/roles/build_containers/molecule/default/converge.yml
@@ -19,5 +19,6 @@
   hosts: all
   vars:
     cifmw_build_containers_cleanup: true
+    cifmw_build_containers_config_file: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/roles/build_containers/files/containers.yaml"
   roles:
     - role: "build_containers"


### PR DESCRIPTION
It will build only keystone containers to validate the build_containers role.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

