### PR TITLE
Fix the way we call ini lookup on the `initial.ceph` config file

### DIFF
--- a/ci_framework/playbooks/ceph.yml
+++ b/ci_framework/playbooks/ceph.yml
@@ -163,7 +163,7 @@
     # public network always exist because is provided by the ceph_spec role
     - name: Get Storage network range
       ansible.builtin.set_fact:
-        cifmw_cephadm_rgw_network: "{{ lookup('ansible.builtin.ini', 'public_network', section='global',  file=cifmw_cephadm_bootstrap_conf) }}"
+        cifmw_cephadm_rgw_network: "{{ lookup('ansible.builtin.ini', 'public_network section=global file=' ~ cifmw_cephadm_bootstrap_conf) }}"
 
     - name: Get already assigned IP addresses
       ansible.builtin.set_fact:


### PR DESCRIPTION
With the old syntax we experienced some failures that seem to be fixed by this way of doing the lookup.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
- [x] README in the role
- [x] Content of the docs/source is reflecting the changes
