### PR TITLE
Switch ssh key to our own custom one, create cloud-admin

### DIFF
--- a/ci/playbooks/multinode-customizations.yml
+++ b/ci/playbooks/multinode-customizations.yml
@@ -155,3 +155,26 @@
       ansible.posix.authorized_key:
         user: "root"
         key: "{{ hostvars['controller']['persistent_ssh_key'] }}"
+
+- name: "Add cloud-admin user on Compute"
+  hosts: compute
+  tasks:
+    - name: Create cloud-admin
+      become: true
+      ansible.builtin.user:
+        name: cloud-admin
+        shell: /bin/bash
+
+    - name: Inject key in cloud-admin
+      become: true
+      ansible.posix.authorized_key:
+        user: "cloud-admin"
+        key: "{{ hostvars['controller']['persistent_ssh_key'] }}"
+
+    - name: Allow cloud-admin on sudo
+      become: true
+      ansible.builtin.copy:
+        dest: "/etc/sudoers.d/cloud-admin"
+        content: |-
+          cloud-admin ALL=(ALL) NOPASSWD:ALL
+        mode: "0640"

--- a/ci_framework/hooks/playbooks/fetch_compute_facts.yml
+++ b/ci_framework/hooks/playbooks/fetch_compute_facts.yml
@@ -161,7 +161,7 @@
                                 {{ '{{' }} lookup("vars", networks_lower[network] ~ "_ip") {{ '}}' }}/{{ '{{' }} lookup('vars', networks_lower[network] ~ '_cidr') {{ '}}' }}
                             routes: {{ '{{' }} lookup('vars', networks_lower[network] ~ '_host_routes') }}
                         {{ '{%' }} endfor {{ '%}' }}
-                        {% endraw -%}
+                        {% endraw %}
 
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleUser

--- a/ci_framework/hooks/playbooks/fetch_compute_facts.yml
+++ b/ci_framework/hooks/playbooks/fetch_compute_facts.yml
@@ -88,46 +88,46 @@
               namespace: {{ cifmw_install_yamls_defaults.NAMESPACE }}
               patches:
               - target:
-                  kind: OpenStackDataPlane
+                  kind: OpenStackDataPlaneNodeSet
                 patch: |-
                   - op: remove
-                    path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/edpm_network_config_template
+                    path: /spec/nodeTemplate/ansible/ansibleVars/edpm_network_config_template
 
                   - op: replace
-                    path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/neutron_public_interface_name
+                    path: /spec/nodeTemplate/ansible/ansibleVars/neutron_public_interface_name
                     value: "{{ crc_ci_bootstrap_networks_out.compute.default.iface | default('') }}"
 
                   - op: replace
-                    path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/ctlplane_mtu
+                    path: /spec/nodeTemplate/ansible/ansibleVars/ctlplane_mtu
                     value: "{{ crc_ci_bootstrap_networks_out.compute.default.mtu | default('') }}"
 
               {% if 'tenant' in crc_ci_bootstrap_networks_out.compute %}
                   - op: replace
-                    path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/tenant_mtu
+                    path: /spec/nodeTemplate/ansible/ansibleVars/tenant_mtu
                     value: "{{ crc_ci_bootstrap_networks_out.compute['tenant'].mtu | default('') }}"
               {% endif %}
 
               {% if 'storage' in crc_ci_bootstrap_networks_out.compute %}
                   - op: replace
-                    path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/storage_mtu
+                    path: /spec/nodeTemplate/ansible/ansibleVars/storage_mtu
                     value: "{{ crc_ci_bootstrap_networks_out.compute['storage'].mtu | default('') }}"
               {% endif %}
 
               {% if 'internal-api' in crc_ci_bootstrap_networks_out.compute %}
                   - op: replace
-                    path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/internal_api_mtu
+                    path: /spec/nodeTemplate/ansible/ansibleVars/internal_api_mtu
                     value: "{{ crc_ci_bootstrap_networks_out.compute['internal-api'].mtu | default('') }}"
               {% endif %}
 
                   - op: add
-                    path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/edpm_os_net_config_mappings
+                    path: /spec/nodeTemplate/ansible/ansibleVars/edpm_os_net_config_mappings
                     value:
                       net_config_data_lookup:
                         edpm-compute:
                           nic2: "{{ crc_ci_bootstrap_networks_out.compute.default.iface | default('') }}"
 
                   - op: replace
-                    path: /spec/roles/edpm-compute/nodeTemplate/networkConfig
+                    path: /spec/nodeTemplate/networkConfig
                     value:
                       template: |-
                         {% raw %}
@@ -164,11 +164,11 @@
                         {% endraw %}
 
                   - op: replace
-                    path: /spec/roles/edpm-compute/nodeTemplate/ansibleUser
+                    path: /spec/nodeTemplate/ansible/ansibleUser
                     value: "{{ hostvars.compute.ansible_user | default('zuul') }}"
 
                   - op: replace
-                    path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/ctlplane_dns_nameservers
+                    path: /spec/nodeTemplate/ansible/ansibleVars/ctlplane_dns_nameservers
                     value:
               {% for dns_server in dns_servers %}
                       - "{{ dns_server }}"

--- a/ci_framework/hooks/playbooks/fetch_compute_facts.yml
+++ b/ci_framework/hooks/playbooks/fetch_compute_facts.yml
@@ -75,7 +75,7 @@
           vars:
             dns_servers: "{{ ((['192.168.122.10'] + ansible_facts['dns']['nameservers']) | unique)[0:2] }}"
             edpm_install_yamls_vars:
-              SSH_KEY_FILE: "{{ ansible_user_dir }}/.ssh/id_rsa"
+              SSH_KEY_FILE: "{{ ansible_user_dir }}/.ssh/id_ed25519"
               DATAPLANE_COMPUTE_IP: "{{ crc_ci_bootstrap_networks_out.compute.default.ip | ansible.utils.ipaddr('address') }}"
               DATAPLANE_SSHD_ALLOWED_RANGES: "['0.0.0.0/0']"
 
@@ -99,24 +99,24 @@
 
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleVars/ctlplane_mtu
-                    value: "{{ crc_ci_bootstrap_networks_out.compute.default.mtu | default('') }}"
+                    value: {{ crc_ci_bootstrap_networks_out.compute.default.mtu | default(1500) }}
 
               {% if 'tenant' in crc_ci_bootstrap_networks_out.compute %}
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleVars/tenant_mtu
-                    value: "{{ crc_ci_bootstrap_networks_out.compute['tenant'].mtu | default('') }}"
+                    value: {{ crc_ci_bootstrap_networks_out.compute['tenant'].mtu | default(1500) }}
               {% endif %}
 
               {% if 'storage' in crc_ci_bootstrap_networks_out.compute %}
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleVars/storage_mtu
-                    value: "{{ crc_ci_bootstrap_networks_out.compute['storage'].mtu | default('') }}"
+                    value: {{ crc_ci_bootstrap_networks_out.compute['storage'].mtu | default(1500) }}
               {% endif %}
 
               {% if 'internal-api' in crc_ci_bootstrap_networks_out.compute %}
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleVars/internal_api_mtu
-                    value: "{{ crc_ci_bootstrap_networks_out.compute['internal-api'].mtu | default('') }}"
+                    value: {{ crc_ci_bootstrap_networks_out.compute['internal-api'].mtu | default(1500) }}
               {% endif %}
 
                   - op: add
@@ -124,13 +124,13 @@
                     value:
                       net_config_data_lookup:
                         edpm-compute:
-                          nic2: "{{ crc_ci_bootstrap_networks_out.compute.default.iface | default('') }}"
+                          nic2: "{{ crc_ci_bootstrap_networks_out.compute.default.iface | default('ens7') }}"
 
                   - op: replace
                     path: /spec/nodeTemplate/networkConfig
                     value:
                       template: |-
-                        {% raw %}
+                        {%- raw %}
                         ---
                         {{ '{%' }} set mtu_list = [ctlplane_mtu] {{ '%}' }}
                         {{ '{%' }} for network in role_networks {{ '%}' }}
@@ -161,7 +161,7 @@
                                 {{ '{{' }} lookup("vars", networks_lower[network] ~ "_ip") {{ '}}' }}/{{ '{{' }} lookup('vars', networks_lower[network] ~ '_cidr') {{ '}}' }}
                             routes: {{ '{{' }} lookup('vars', networks_lower[network] ~ '_host_routes') }}
                         {{ '{%' }} endfor {{ '%}' }}
-                        {% endraw %}
+                        {% endraw -%}
 
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleUser

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -61,7 +61,7 @@
       registry_login_enabled: true
       push_registry: quay.rdoproject.org
       quay_login_secret_name: quay_nextgen_zuulgithubci
-      cifmw_artifacts_crc_sshkey: "~/.ssh/id_rsa"
+      cifmw_artifacts_crc_sshkey: "~/.ssh/id_ed25519"
       cifmw_openshift_user: kubeadmin
       cifmw_openshift_password: "123456789"
       cifmw_openshift_api: api.crc.testing:6443


### PR DESCRIPTION
It seems that "cloud-admin" is the user to use in a really close
future[1],so let's ensure it's present on the compute. Also, it
seems "root" is being used for now, and it's probably good to use
our own key, since we ensure it's present in all the needed users.

[1] https://github.com/openstack-k8s-operators/dataplane-operator/pull/398/files

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/523
