### PR TITLE
Revert "Continue ci_script implementation replacing shell and command built-in modules"

### DIFF
--- a/ci_framework/roles/cifmw_cephadm/defaults/main.yml
+++ b/ci_framework/roles/cifmw_cephadm/defaults/main.yml
@@ -64,7 +64,6 @@ cifmw_cephadm_single_host_defaults: false
 cifmw_cephadm_extra_args: ""
 cifmw_cephadm_pacific_filter: "16.*"
 cifmw_cephadm_dashboard_enabled: false
-cifmw_cephadm_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 # The path of the rendered rgw spec file
 cifmw_ceph_rgw_spec_path: /tmp/ceph_rgw.yml
 cifmw_ceph_rgw_keystone_ep: "keystone-public-openstack.apps-crc.testing"

--- a/ci_framework/roles/cifmw_cephadm/tasks/bootstrap.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/bootstrap.yml
@@ -43,30 +43,28 @@
 - name: Bootstrap Ceph if there are no running Ceph Daemons
   block:
     - name: Run cephadm bootstrap
-      ci_script:
-        output_dir: "{{ cifmw_cephadm_basedir }}/artifacts"
-        script: |
-          {{ cifmw_cephadm_bin }} \
-          {% if not cifmw_cephadm_default_container %}--image {{ cifmw_cephadm_container_ns + '/' + cifmw_cephadm_container_image + ':' + cifmw_cephadm_container_tag|string }} \{% endif %}
-          bootstrap \
-          --skip-firewalld \
-          --skip-prepare-host \
-          --ssh-private-key /home/{{ cifmw_cephadm_ssh_user }}/.ssh/id_rsa \
-          --ssh-public-key /home/{{ cifmw_cephadm_ssh_user }}/.ssh/id_rsa.pub \
-          --ssh-user {{ cifmw_cephadm_ssh_user }} \
-          --allow-fqdn-hostname \
-          --output-keyring {{ cifmw_cephadm_admin_keyring }} \
-          --output-config {{ cifmw_cephadm_conf }} \
-          --fsid {{ cifmw_cephadm_fsid }} \
-          {% if cifmw_cephadm_registry_url|length > 0 %}--registry-url {{ cifmw_cephadm_registry_url }} \{% endif %}
-          {% if cifmw_cephadm_registry_username|length > 0 %}--registry-username {{ cifmw_cephadm_registry_username }} \{% endif %}
-          {% if cifmw_cephadm_registry_password|length > 0 %}--registry-password {{ cifmw_cephadm_registry_password }} \{% endif %}
-          {% if cifmw_cephadm_spec_on_bootstrap %}--apply-spec {{ cifmw_cephadm_spec }} \{% endif %}
-          {% if cifmw_cephadm_assimilate_conf_stat.stat.exists %}--config {{ cifmw_cephadm_assimilate_conf }} \{% endif %}
-          {% if cifmw_cephadm_single_host_defaults %}--single-host-defaults \{% endif %}
-          --skip-monitoring-stack --skip-dashboard \
-          {% if cifmw_cephadm_extra_args|length > 0 %}{{ cifmw_cephadm_extra_args }} \{% endif %}
-          --mon-ip {{ cifmw_cephadm_first_mon_ip }}
+      ansible.builtin.shell: |
+        {{ cifmw_cephadm_bin }} \
+        {% if not cifmw_cephadm_default_container %}--image {{ cifmw_cephadm_container_ns + '/' + cifmw_cephadm_container_image + ':' + cifmw_cephadm_container_tag|string }} \{% endif %}
+        bootstrap \
+        --skip-firewalld \
+        --skip-prepare-host \
+        --ssh-private-key /home/{{ cifmw_cephadm_ssh_user }}/.ssh/id_rsa \
+        --ssh-public-key /home/{{ cifmw_cephadm_ssh_user }}/.ssh/id_rsa.pub \
+        --ssh-user {{ cifmw_cephadm_ssh_user }} \
+        --allow-fqdn-hostname \
+        --output-keyring {{ cifmw_cephadm_admin_keyring }} \
+        --output-config {{ cifmw_cephadm_conf }} \
+        --fsid {{ cifmw_cephadm_fsid }} \
+        {% if cifmw_cephadm_registry_url|length > 0 %}--registry-url {{ cifmw_cephadm_registry_url }} \{% endif %}
+        {% if cifmw_cephadm_registry_username|length > 0 %}--registry-username {{ cifmw_cephadm_registry_username }} \{% endif %}
+        {% if cifmw_cephadm_registry_password|length > 0 %}--registry-password {{ cifmw_cephadm_registry_password }} \{% endif %}
+        {% if cifmw_cephadm_spec_on_bootstrap %}--apply-spec {{ cifmw_cephadm_spec }} \{% endif %}
+        {% if cifmw_cephadm_assimilate_conf_stat.stat.exists %}--config {{ cifmw_cephadm_assimilate_conf }} \{% endif %}
+        {% if cifmw_cephadm_single_host_defaults %}--single-host-defaults \{% endif %}
+        --skip-monitoring-stack --skip-dashboard \
+        {% if cifmw_cephadm_extra_args|length > 0 %}{{ cifmw_cephadm_extra_args }} \{% endif %}
+        --mon-ip {{ cifmw_cephadm_first_mon_ip }}
       register: cephadm_bootstrap
       become: true
     - name: Show results of bootstrap


### PR DESCRIPTION
Revert ceph playbook move to ci_script.

This reverts commit 0df6fa4cef78a8147405e40d3ebaa9672040846b.

Please see https://github.com/openstack-k8s-operators/ci-framework/issues/531

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
- [x] README in the role
- [x] Content of the docs/source is reflecting the changes
