### PR TITLE
Introduce Zuul Project template

### DIFF
--- a/ci/templates/projects.yaml
+++ b/ci/templates/projects.yaml
@@ -4,10 +4,11 @@
 # ** /ci/templates/project.yaml **
 - project:
     name: openstack-k8s-operators/ci-framework
+    templates:
+      - podified-multinode-edpm-pipeline
     github-check:
       jobs:
         - noop
-        - ci-framework-crc-podified-edpm-baremetal
         - cifmw-tcib
         - cifmw-dev-prepare
         - cifmw-doc
@@ -15,5 +16,4 @@
         - cifmw-edpm-build-images
         - cifmw-content-provider-build-images
         - podified-multinode-edpm-e2e-nobuild-tagged-crc
-        - podified-multinode-edpm-deployment-crc
 # Start generated content

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1,0 +1,11 @@
+---
+# Zuul Job template to avoid repetition of calling jobs in multiple repos
+- project-template:
+    name: podified-multinode-edpm-pipeline
+    github-check:
+      jobs:
+        - openstack-k8s-operators-content-provider
+        - podified-multinode-edpm-deployment-crc: &content_provider
+            dependencies:
+              - openstack-k8s-operators-content-provider
+        - ci-framework-crc-podified-edpm-baremetal: *content_provider

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -2,7 +2,6 @@
     github-check:
       jobs:
       - noop
-      - ci-framework-crc-podified-edpm-baremetal
       - cifmw-tcib
       - cifmw-dev-prepare
       - cifmw-doc
@@ -10,7 +9,6 @@
       - cifmw-edpm-build-images
       - cifmw-content-provider-build-images
       - podified-multinode-edpm-e2e-nobuild-tagged-crc
-      - podified-multinode-edpm-deployment-crc
       - cifmw-molecule-artifacts
       - cifmw-molecule-build_containers
       - cifmw-molecule-build_openstack_packages
@@ -51,3 +49,5 @@
       - cifmw-molecule-tempest
       - cifmw-molecule-test_deps
     name: openstack-k8s-operators/ci-framework
+    templates:
+    - podified-multinode-edpm-pipeline


### PR DESCRIPTION
Project template allows us to define common jobs
at one place and calls them in another projects via template name.

It will help to update the job definition at one place and avoid sending multiple prs to update the same job.

Note: This patch also adds content provider job to ci-framework allowing developers to test dependent patches at any place.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

