### PR TITLE
Run ansibleee kuttl tests as default

### DIFF
--- a/zuul.d/kuttl.yaml
+++ b/zuul.d/kuttl.yaml
@@ -27,7 +27,6 @@
       - ^zuul.d/kuttl.yaml
     vars:
       cifmw_kuttl_tests_operator_list:
-        - keystone
         - ansibleee
       commands_before_kuttl_run:
         - oc get pv


### PR DESCRIPTION
Currently kuttl tests are failing on Keystone. Removing it for now and run only ansibleee to unblock the patches.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

