### PR TITLE
Fix indentation issues in the read-the-docs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,25 +5,25 @@
 # Required
 version: 2
 
-  # Set the version of Python and other tools you might need
+# Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-      # You can also specify other tool versions:
-      # nodejs: "19"
-      # rust: "1.64"
-      # golang: "1.19"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
 
-      # Build documentation in the docs/ directory with Sphinx
-    sphinx:
-      configuration: docs/source/conf.py
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
 
         # If using Sphinx, optionally build your docs in additional formats such as PDF
         # formats:
         #    - pdf
 
-        # Optionally declare the Python requirements required to build your docs
-      python:
-        install:
-          - requirements: docs/doc-requirements.txt
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+    - requirements: docs/doc-requirements.txt


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date