### PR TITLE
Add more project template and improve it

### DIFF
--- a/zuul.d/content_provider.yaml
+++ b/zuul.d/content_provider.yaml
@@ -21,6 +21,18 @@
       - contribute/.*
       - tests
       - roles/.*/molecule/.*
+      # ci-framework
+      - .readthedocs.yaml
+      # Other openstack operators
+      - containers/ci
+      - .ci-operator.yaml
+      - .dockerignore
+      - .gitignore
+      - .golangci.yaml
+      - .pre-commit-config.yaml
+      # openstack-ansibleee-operator
+      - examples
+      - mkdocs.yml
     required-projects:
       - opendev.org/zuul/zuul-jobs
       - openstack-k8s-operators/barbican-operator

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1,11 +1,25 @@
 ---
 # Zuul Job template to avoid repetition of calling jobs in multiple repos
 - project-template:
-    name: podified-multinode-edpm-pipeline
+    name: podified-multinode-edpm-baremetal-pipeline
+    description: |
+      Project template to run content provider with EDPM and
+      baremetal job.
     github-check:
       jobs:
         - openstack-k8s-operators-content-provider
         - podified-multinode-edpm-deployment-crc: &content_provider
             dependencies:
               - openstack-k8s-operators-content-provider
-        - ci-framework-crc-podified-edpm-baremetal: *content_provider
+        - cifmw-crc-podified-edpm-baremetal: *content_provider
+
+- project-template:
+    name: podified-multinode-edpm-pipeline
+    description: |
+      Project template to run content provider with EDPM job.
+    github-check:
+      jobs:
+        - openstack-k8s-operators-content-provider
+        - podified-multinode-edpm-deployment-crc:
+            dependencies:
+              - openstack-k8s-operators-content-provider


### PR DESCRIPTION
This patch renames the existing project-template podified-multinode-edpm-pipeline to podified-multinode-edpm-baremetal-pipeline (It will be used for run both edpm and baremetal jobs). It updates the baremetal job name to use cifmw-crc-podified-edpm-baremetal.

It also adds a seperate template podified-multinode-edpm-pipeline to run only EDPM jobs.

Both will be useful where both jobs or only EDPM jobs are runned.

Note: It also updates the missing irrelevant-files list from dataplane-operator and ansibleee-operator.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

