### PR TITLE
Generate gating.repo to install built packages

### DIFF
--- a/ci_framework/roles/build_openstack_packages/tasks/create_repo.yml
+++ b/ci_framework/roles/build_openstack_packages/tasks/create_repo.yml
@@ -30,8 +30,19 @@
 
 - name: Run createrepo on generated rpms
   ansible.builtin.command:
-    cmd: createrepo gating_repo
-    chdir: '{{ cifmw_bop_gating_repo | ansible.builtin.dirname }}'
+    cmd: createrepo .
+    chdir: '{{ cifmw_bop_gating_repo }}'
+
+- name: Add gating.repo file to install the required built packages
+  ansible.builtin.copy:
+    content: |
+      [gating-repo]
+      # All gating repo contents must be present in distro.repos.d directory
+      baseurl=file:///etc/distro.repos.d
+      enabled=1
+      gpgcheck=0
+      priority=1
+    dest: "{{ cifmw_bop_gating_repo }}/gating.repo"
 
 - name: Compress the repo
   ansible.builtin.command:  # noqa: command-instead-of-module


### PR DESCRIPTION
build_openstack_packages is building the rpm package and creating the repo metadata in a directory. In order to install the package from metadata, we need to add .repo file so that dnf install the package.

This patch adds the gating.repo to install the built packages.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
