### PR TITLE
Pass extra install_yamls variables to the set_openstack_containers role

### DIFF
--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -102,6 +102,8 @@
 
 - name: Update OpenStack Services containers Env
   when: cifmw_edpm_prepare_update_os_containers | bool
+  vars:
+    cifmw_set_openstack_containers_extra_vars: "{{ cifmw_edpm_prepare_extra_vars }}"
   ansible.builtin.include_role:
     name: set_openstack_containers
 

--- a/ci_framework/roles/set_openstack_containers/tasks/main.yml
+++ b/ci_framework/roles/set_openstack_containers/tasks/main.yml
@@ -33,9 +33,15 @@
         cifmw_set_openstack_containers_tag: "{{ dlrn_md5['content'] | b64decode | trim }}"
         cacheable: true
 
-- name: Set the operator name
+- name: Set common facts for the role
   ansible.builtin.set_fact:
     operator_name: "{{ cifmw_set_openstack_containers_operator_name }}"
+    cifmw_set_openstack_containers_common_env: >-
+      {{
+        cifmw_install_yamls_environment |
+        combine({'PATH': cifmw_path}) |
+        combine(cifmw_set_openstack_containers_extra_vars | default({}))
+      }}
     cacheable: true
 
 - name: Get all openstack pods
@@ -81,7 +87,7 @@
 
 - name: Wait for reinstallation of meta operator
   vars:
-    make_openstack_wait_env: "{{ cifmw_install_yamls_environment | combine({'PATH': cifmw_path}) }}"
+    make_openstack_wait_env: "{{ cifmw_set_openstack_containers_common_env }}"
   ansible.builtin.include_role:
     name: 'install_yamls_makes'
     tasks_from: 'make_openstack_wait'
@@ -89,7 +95,7 @@
 
 - name: Wait for reinstallation of operator
   vars:
-    make_wait_env: "{{ cifmw_install_yamls_environment | combine({'PATH': cifmw_path}) }}"
+    make_wait_env: "{{ cifmw_set_openstack_containers_common_env }}"
     make_wait_params:
       OPERATOR_NAME: "{{ operator_name }}"
   ansible.builtin.include_role:


### PR DESCRIPTION
Since the introduction of the multinode layout the defaults set by install_yamls refering to networking are no longer valid. In the edpm_prepare role we are since then passing custom variables for the MTU and the interface name using my NMstate, but till this PR set_openstack_containers is not passing them.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date
