### PR TITLE
Correct pyspell configuration file indentation

### DIFF
--- a/.spellcheck.yml
+++ b/.spellcheck.yml
@@ -9,7 +9,7 @@ matrix:
       - ./**/*.md
     pipelines:
       - pyspelling.filters.markdown:
-        dictionary:
-          wordlists:
-            - docs/dictionary/en-custom.txt
-        output: docs/_build/en-custom.dic
+    dictionary:
+      wordlists:
+        - docs/dictionary/en-custom.txt
+      output: docs/_build/en-custom.dic


### PR DESCRIPTION
The indentation was broken in [1] so pyspell is unable to find the
custom words defined in `docs/dictionary/en-custom.txt`

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/515

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
