### PR TITLE
FQCN fix for calls to ansible.utils.ipaddr in ceph playbook

### DIFF
--- a/ci_framework/playbooks/ceph.yml
+++ b/ci_framework/playbooks/ceph.yml
@@ -103,7 +103,7 @@
             combine(
               {
                 hostvars[item]['ansible_hostname'] :
-                hostvars[item][all_addresses] | ipaddr(storage_network_range) | first
+                hostvars[item][all_addresses] | ansible.utils.ipaddr(storage_network_range) | first
               }
             )
            }}"
@@ -182,7 +182,7 @@
 
     - name: Get already assigned IP addresses
       ansible.builtin.set_fact:
-        ips: "{{ ips | default([]) + [ hostvars[item][all_addresses] | ipaddr(cifmw_cephadm_rgw_network) | first ] }}"
+        ips: "{{ ips | default([]) + [ hostvars[item][all_addresses] | ansible.utils.ipaddr(cifmw_cephadm_rgw_network) | first ] }}"
       loop: "{{ groups['edpm'] }}"
 
     # cifmw_cephadm_vip is the VIP reserved in the Storage network

--- a/ci_framework/roles/cifmw_ceph_spec/README.md
+++ b/ci_framework/roles/cifmw_ceph_spec/README.md
@@ -66,7 +66,7 @@ storage network IP range.
     - name: Build a dict mapping hostname to its IP which is in storage network range
       ansible.builtin.set_fact:
         host_to_ip: "{{ host_to_ip | default({}) | combine({ hostvars[item]['ansible_hostname'] :
-          hostvars[item][all_addresses] | ipaddr(storage_network_range) | first }) }}"
+          hostvars[item][all_addresses] | ansible.utils.ipaddr(storage_network_range) | first }) }}"
       loop: "{{ groups['edpm'] }}"
   roles:
     - role: cifmw_ceph_spec

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -318,6 +318,7 @@ undefine
 unittest
 uri
 usr
+utils
 uuid
 vbibob
 vcgvuc


### PR DESCRIPTION
Update ceph playbook to use ansible.utils.ipaddr in place of just ipaddr.

As a pull request owner and reviewers, I checked that:
- [x ] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
