### PR TITLE
Fix Ceph Spec play to correctly map hostname to storage IP

### DIFF
--- a/ci_framework/playbooks/ceph.yml
+++ b/ci_framework/playbooks/ceph.yml
@@ -98,9 +98,18 @@
   pre_tasks:
     - name: Build a dict mapping hostname to its IP which is in storage network range
       ansible.builtin.set_fact:
-        host_to_ip: >-
-          {{ host_to_ip | default({}) | combine({hostvars['ansible_hostname']: hostvars | ipaddr(storage_network_range) | first}) }}
+        host_to_ip:
+          "{{ host_to_ip | default({}) |
+            combine(
+              {
+                hostvars[item]['ansible_hostname'] :
+                hostvars[item][all_addresses] | ipaddr(storage_network_range) | first
+              }
+            )
+           }}"
       delegate_to: "{{ item }}"
+      when:
+        - hostvars[item]['ansible_hostname'] is defined
       loop: "{{ groups['edpm'] }}"
   roles:
     - role: cifmw_ceph_spec


### PR DESCRIPTION
This patch updates the "Build a dict mapping hostname to its IP which is in storage network range" task to correctly retrieve the storage IP from the hostvars.

Fixes bug introduced by 2de93b92fc26f844b75681ddc7ec71f8279fb786

In breaking commit, `hostvars[item][all_addresses]` was changed to `hostvars['ansible_hostname']` which does not contain the same value. Runs of the play after then failed with "'bool' object is not iterable".

Also, add `when` to prevent an undefined key in the dictionary.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
