### PR TITLE
Add OpenStackDataPlaneDeployment deploy step

### DIFF
--- a/ci_framework/roles/edpm_deploy/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy/tasks/main.yml
@@ -55,6 +55,16 @@
           (cifmw_install_yamls_defaults['DATAPLANE_NODESET_CR'] | basename)
         ] | ansible.builtin.path_join
       }}
+    cifmw_edpm_deploy_openstack_deployment_cr_path: >-
+      {{
+        [
+          cifmw_edpm_deploy_manifests_dir,
+          cifmw_install_yamls_defaults['NAMESPACE'],
+          'dataplane',
+          'cr',
+          (cifmw_install_yamls_defaults['DATAPLANE_DEPLOYMENT_CR'] | basename)
+        ] | ansible.builtin.path_join
+      }}
   environment:
     PATH: "{{ cifmw_path }}"
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
@@ -85,6 +95,12 @@
       ci_script:
         output_dir: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
         script: "oc apply -f {{ cifmw_edpm_deploy_openstack_cr_path }}"
+    
+    - name: Apply the OpenStackDataPlaneDeployment CR
+      when: not cifmw_edpm_deploy_dryrun
+      ci_script:
+        output_dir: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
+        script: "oc apply -f {{ cifmw_edpm_deploy_openstack_deployment_cr_path }}"
 
     - name: Wait for OpenStackDataplaneNodeSet to be deployed
       ansible.builtin.command:


### PR DESCRIPTION
This change adds a task to deploy the OpenStackDataPlaneDeployment CR as described by this PR:
https://github.com/openstack-k8s-operators/dataplane-operator/pull/378

This CR is required for the NodeSet to be deployed as of the above mentioned PR.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
