### PR TITLE
Add a simple retries mechanism to the keystone-public route fetch

### DIFF
--- a/ci_framework/roles/edpm_prepare/README.md
+++ b/ci_framework/roles/edpm_prepare/README.md
@@ -9,6 +9,8 @@ This role doesn't need privilege escalation.
 * `cifmw_edpm_prepare_dry_run`: (Boolean) Skips resources installations and waits. Defaults to false.
 * `cifmw_edpm_prepare_manifests_dir`: (String) Directory in where install_yamls output manifests will be placed. Defaults to `"{{ cifmw_edpm_prepare_basedir }}/artifacts/manifests"`
 * `cifmw_edpm_prepare_skip_crc_storage_creation`: (Boolean) Intentionally skips the deployment of the CRC storage related resources. Defaults to `False`.
-* `cifmw_edpm_prepare_wait_subscription_retries`: (Integer) Number of retries, with 5 seconds delays, waiting for the OpenStack subscription to come up. Defaults to `5`.
+* `cifmw_edpm_prepare_oc_retries`: (Integer) Number of retries, with 5 seconds delays, waiting for the OpenStack subscription to come up. Defaults to `5`.
+* `cifmw_edpm_prepare_oc_retries`: (Integer) Number of attempts to retry an oc command if it fails. Defaults to `10`.
+* `cifmw_edpm_prepare_oc_delay`: (Integer) Delay, in seconds, between failed oc call retries. Defaults to `30`.
 * `cifmw_edpm_prepare_update_os_containers`: (Boolean) Updates the openstack services containers env variable. Defaults to `false`.
 * `cifmw_edpm_prepare_timeout`: (Integer) Time, in minutes to wait for the deployment to be ready. Defaults to `30`.

--- a/ci_framework/roles/edpm_prepare/defaults/main.yml
+++ b/ci_framework/roles/edpm_prepare/defaults/main.yml
@@ -19,7 +19,8 @@
 # All variables within this role should have a prefix of "cifmw_edpm_prepare"
 cifmw_edpm_prepare_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_edpm_prepare_manifests_dir: "{{ cifmw_manifests | default(cifmw_edpm_prepare_basedir ~ '/artifacts/manifests') }}"
-cifmw_edpm_prepare_wait_subscription_retries: 30
+cifmw_edpm_prepare_oc_retries: 30
+cifmw_edpm_prepare_oc_delay: 30
 cifmw_edpm_prepare_dry_run: false
 cifmw_edpm_prepare_skip_crc_storage_creation: false
 cifmw_edpm_prepare_update_os_containers: false

--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -87,8 +87,8 @@
           -o=jsonpath='{.status.installplan.name}'
       until: cifmw_edpm_prepare_wait_installplan_out.rc == 0 and cifmw_edpm_prepare_wait_installplan_out.stdout != ""
       register: cifmw_edpm_prepare_wait_installplan_out
-      retries: "{{ cifmw_edpm_prepare_wait_subscription_retries }}"
-      delay: 10
+      retries: "{{ cifmw_edpm_prepare_oc_retries }}"
+      delay: "{{ cifmw_edpm_prepare_oc_delay }}"
 
     - name: Wait for OpenStack operator to get installed
       environment:
@@ -172,7 +172,6 @@
   when: not cifmw_edpm_prepare_dry_run
   block:
     - name: Extract keystone endpoint host
-      register: _keystone_endpoint
       environment:
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
@@ -181,13 +180,17 @@
           oc get route keystone-public
           --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
           -o jsonpath='{ .spec.host }'
+      register: _cifmw_edpm_prepare_keystone_endpoint_out
+      until: _cifmw_edpm_prepare_keystone_endpoint_out.rc == 0 and _cifmw_edpm_prepare_keystone_endpoint_out.stdout != ""
+      retries: "{{ cifmw_edpm_prepare_oc_retries }}"
+      delay: "{{ cifmw_edpm_prepare_oc_delay }}"
 
     - name: Wait for keystone endpoint to exist in DNS
       register: _cifmw_edpm_prepare_check_keystone_dns
       vars:
         _keystone_response_codes: [200, 300, 301, 302, 401, 402, 403]
       ansible.builtin.uri:
-        url: "http://{{ _keystone_endpoint.stdout | trim }}"
+        url: "http://{{ _cifmw_edpm_prepare_keystone_endpoint_out.stdout | trim }}"
         status_code: "{{ _keystone_response_codes }}"  # noqa: args[module]
       retries: 20
       delay: 10


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
