### PR TITLE
Add cinder to the list of kuttl tests

### DIFF
--- a/zuul.d/kuttl_multinode.yaml
+++ b/zuul.d/kuttl_multinode.yaml
@@ -63,6 +63,7 @@
       cifmw_kuttl_tests_operator_list:
         - ansibleee
         - keystone
+        - cinder
       commands_before_kuttl_run:
         - oc get pv
         - oc get all


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
