### PR TITLE
Pin tempest container to last known good tag

### DIFF
--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -118,6 +118,8 @@
     vars:
       cifmw_extras:
         - '@scenarios/centos-9/multinode-ci.yml'
+      # Revert once tempest container is fixed
+      cifmw_tempest_image_tag: "e8f50e92676531d00f857753024c2f57"
     run:
       - ci/playbooks/edpm/run.yml
 
@@ -128,6 +130,8 @@
       cifmw_extras:
         - '@scenarios/centos-9/ci.yml'
         - '@scenarios/centos-9/multinode-ci.yml'
+      # Revert once tempest container is fixed
+      cifmw_tempest_image_tag: "e8f50e92676531d00f857753024c2f57"
     run:
       - ci/playbooks/e2e-run.yml
     irrelevant-files:


### PR DESCRIPTION
Tempest tests are failing with the following error: "error: argument --concurrency/-w: expected one argument" We need to pin a previous version to skip that bug

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
