### PR TITLE
Add tempest related vars for periodic jobs

### DIFF
--- a/scenarios/centos-9/edpm_periodic.yml
+++ b/scenarios/centos-9/edpm_periodic.yml
@@ -11,3 +11,5 @@ cifmw_set_openstack_containers_namespace: "podified-main-centos9"
 cifmw_edpm_deploy_baremetal_update_os_containers: true
 cifmw_run_tests: true
 cifmw_edpm_deploy_registry_url: "{{ cifmw_set_openstack_containers_registry }}/{{ cifmw_set_openstack_containers_namespace }}"
+cifmw_tempest_image: "{{ cifmw_set_openstack_containers_registry }}/{{ cifmw_set_openstack_containers_namespace }}/openstack-tempest"
+cifmw_tempest_image_tag: "{{ cifmw_repo_setup_full_hash }}"

--- a/zuul.d/edpm_periodic.yaml
+++ b/zuul.d/edpm_periodic.yaml
@@ -3,6 +3,8 @@
     name: periodic-podified-edpm-deployment-master-ocp-crc-1cs9
     parent: cifmw-crc-podified-edpm-deployment
     vars: &edpm_vars
+      cifmw_repo_setup_branch: master
+      cifmw_repo_setup_promotion: podified-ci-testing
       cifmw_extras:
         - '@scenarios/centos-9/nested_virt.yml'
         - '@scenarios/centos-9/edpm_periodic.yml'


### PR DESCRIPTION
Currently we were testing the current-podified container in
the periodic jobs, which is not correct. We need to use
podified-ci-testing tag for tempest container.
    
 This patch sets the correct tempest container related vars
 for the periodic line.


As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
