### PR TITLE
Create cephfs volume that can be consumed by Manila

### DIFF
--- a/ci_framework/playbooks/ceph.yml
+++ b/ci_framework/playbooks/ceph.yml
@@ -230,6 +230,14 @@
         # cifmw_cephadm_vip is computed or passed as an override via -e @extra.yml
         cifmw_cephadm_rgw_vip: "{{ cifmw_cephadm_vip }}/24"
 
+    - name: Create cephfs volume
+      ansible.builtin.import_role:
+        name: cifmw_cephadm
+        tasks_from: cephfs
+      vars:
+        # we reuse the same VIP reserved for rgw
+        cifmw_cephadm_nfs_vip: "{{ cifmw_cephadm_vip }}/24"
+
     - name: Create Cephx Keys for OpenStack
       ansible.builtin.import_role:
         name: cifmw_cephadm

--- a/ci_framework/roles/cifmw_cephadm/README.md
+++ b/ci_framework/roles/cifmw_cephadm/README.md
@@ -67,6 +67,12 @@ need to be changed for a typical EDPM deployment.
    requires a `VIP` that will be owned by `keepalived`. This IP address will
    be used as entry point to reach the `radosgw backends` through `haproxy`.
 
+* `cifmw_cephadm_nfs_vip`: the ingress daemon deployed along with the `nfs`
+   cluster requires a `VIP` that will be owned by `keepalived`. This IP
+   address is the same used for rgw unless an override is passed, and it's
+   used as entry point to reach the `ganesha backends` through an `haproxy`
+   instance where proxy-protocol is enabled.
+
 Use the `cifmw_cephadm_pools` list of dictionaries to define pools for
 Nova (vms), Cinder (volumes), Cinder-backups (backups), and Glance (images).
 ```

--- a/ci_framework/roles/cifmw_cephadm/defaults/main.yml
+++ b/ci_framework/roles/cifmw_cephadm/defaults/main.yml
@@ -88,3 +88,4 @@ cifmw_ceph_rgw_config:
   rgw_max_attr_name_len: 128
   rgw_max_attrs_num_in_req: 90
   rgw_max_attr_size: 1024
+cifmw_cephadm_cephfs_name: "cephfs"

--- a/ci_framework/roles/cifmw_cephadm/tasks/cephfs.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/cephfs.yml
@@ -1,0 +1,48 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Build placement string
+  block:
+    - name: Collect the host and build the resulting host list
+      ansible.builtin.set_fact:
+        _hosts: "{{ _hosts|default([]) + [ hostvars[item]['ansible_hostname'] ] }}"
+      with_items: "{{ groups['edpm'] }}"
+
+    - name: Collect the edpm hosts
+      ansible.builtin.set_fact:
+        placement: "{{ ''.join((placement|default(''), (item+' '))) }}"
+      with_items: "{{ _hosts | unique }}"
+
+- name: Get ceph_cli
+  ansible.builtin.include_tasks: ceph_cli.yml
+
+- name: Apply cephfs volume
+  ansible.builtin.command: |
+    {{ cifmw_cephadm_ceph_cli }} fs volume create {{ cifmw_cephadm_cephfs_name }} '--placement={{ placement }}'
+  changed_when: false
+  become: true
+
+# waiting for https://github.com/ceph/ceph/pull/53108
+# to appear in the next Ceph container build
+# disabling this task by default for now
+- name: Apply cephfs volume
+  when: ceph_nfs | default(false)
+  ansible.builtin.command: |
+    {{ cifmw_cephadm_ceph_cli }} nfs cluster create {{ cifmw_cephadm_cephfs_name }} \
+    --ingress --virtual-ip={{ cifmw_cephadm_nfs_vip }} \
+    --ingress-mode=haproxy-protocol '--placement={{ placement }}'
+  changed_when: false
+  become: true

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -212,6 +212,7 @@ ndczmditnzbhni
 networkconfig
 networkmanager
 networktype
+nfs
 nic
 nigzpbgugpsavdmfyl
 nlcggvjgnsdxn


### PR DESCRIPTION
This patch applies a cephfs volume and creates a ceph-nfs cluster that can be consumed by Manila.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
- [x] README in the role
- [x] Content of the docs/source is reflecting the changes
