### PR TITLE
Update ceph roles for cloud-admin

### DIFF
--- a/ci_framework/playbooks/ceph.yml
+++ b/ci_framework/playbooks/ceph.yml
@@ -55,18 +55,19 @@
   gather_facts: false
   become: true
   vars:
+    cifmw_admin_user: ceph-admin
     ansible_ssh_private_key_file: "{{ lookup('env', 'ANSIBLE_SSH_PRIVATE_KEY') }}"
   pre_tasks:
     - name: Get local private key
       ansible.builtin.slurp:
-        src: "{{ hostvars['localhost']['private_key'] }}"
+        src: "{{ lookup('env', 'HOME') }}/.ssh/{{ cifmw_admin_user }}-id_rsa"
       register: private_key_get
       delegate_to: localhost
       no_log: true
 
     - name: Get local public key
       ansible.builtin.slurp:
-        src: "{{ hostvars['localhost']['public_key'] }}"
+        src: "{{ lookup('env', 'HOME') }}/.ssh/{{ cifmw_admin_user }}-id_rsa.pub"
       register: public_key_get
       delegate_to: localhost
   roles:

--- a/ci_framework/roles/cifmw_cephadm/README.md
+++ b/ci_framework/roles/cifmw_cephadm/README.md
@@ -25,7 +25,7 @@ a three EDPM node deployment from
 [install_yamls](https://github.com/openstack-k8s-operators/install_yamls).
 
 ## Privilege escalation
-Requires root to install Ceph server.
+Requires an Ansible user who can become root to install Ceph server.
 
 ## Parameters
 
@@ -158,7 +158,7 @@ generates an SSH key `install_yamls/out/edpm/ansibleee-ssh-key-id_rsa`
 for root on every EDPM node. Configure the Ansible environment to use
 this user and key.
 ```
-export ANSIBLE_REMOTE_USER=root
+export ANSIBLE_REMOTE_USER=cloud-admin
 export ANSIBLE_SSH_PRIVATE_KEY=~/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa
 export ANSIBLE_HOST_KEY_CHECKING=False
 ```

--- a/ci_framework/roles/cifmw_cephadm/tasks/keys.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/keys.yml
@@ -35,8 +35,8 @@
   ansible.builtin.command:
     cmd: >-
       {{ cifmw_cephadm_ceph_cli }} auth import
-      -i {{ cifmw_cephadm_config_home | default('/etc/ceph') }}/
-      {{ cifmw_cephadm_cluster | default('ceph') }}.{{ item.name }}.keyring"
+      -i {{ cifmw_cephadm_config_home | default('/etc/ceph')
+      }}/{{ cifmw_cephadm_cluster | default('ceph') }}.{{ item.name }}.keyring
   become: true
   loop: "{{ cifmw_cephadm_keys| default([]) }}"
   changed_when: false


### PR DESCRIPTION
Update the ceph roles in ci-framework so that they work when cloud-admin is the Ansible user instead of root. Related to a84652db296f2a329002068ae59a837b4dfc539e

Also, fix Import cephx keys task which was broken by commit f2f62f729e37d17d14daa903320ca207c50d1b18

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
