### PR TITLE
Add management networks for Ceph SSH and OSD replication

### DIFF
--- a/ci_framework/playbooks/ceph.yml
+++ b/ci_framework/playbooks/ceph.yml
@@ -88,23 +88,24 @@
   roles:
     - role: cifmw_block_device
 
-- name: Build Ceph spec from gathered IP addresses of EDPM inventory group
+- name: Build Ceph spec and conf from gathered IPs of EDPM inventory group
   tags: spec
   hosts: localhost
   gather_facts: true
   vars:
+    ssh_network_range: 192.168.122.0/24
     # storage_network_range: 172.18.0.0/24
-    storage_network_range: 192.168.122.0/24
+    # storage_mgmt_network_range: 172.20.0.0/24
     all_addresses: ansible_all_ipv4_addresses # change if you need IPv6
   pre_tasks:
-    - name: Build a dict mapping hostname to its IP which is in storage network range
+    - name: Build a dict mapping hostname to its IP which is in management network range
       ansible.builtin.set_fact:
         host_to_ip:
           "{{ host_to_ip | default({}) |
             combine(
               {
                 hostvars[item]['ansible_hostname'] :
-                hostvars[item][all_addresses] | ansible.utils.ipaddr(storage_network_range) | first
+                hostvars[item][all_addresses] | ansible.utils.ipaddr(ssh_network_range) | first
               }
             )
            }}"
@@ -115,7 +116,8 @@
   roles:
     - role: cifmw_ceph_spec
       cifmw_ceph_spec_host_to_ip: "{{ host_to_ip }}"
-      cifmw_ceph_spec_public_network: "{{ storage_network_range }}"
+      cifmw_ceph_spec_public_network: "{{ storage_network_range | default(ssh_network_range) }}"
+      cifmw_ceph_spec_private_network: "{{ storage_mgmt_network_range | default('') }}"
 
 - name: Bootstrap Ceph and apply spec
   tags: cephadm

--- a/ci_framework/roles/cifmw_ceph_spec/defaults/main.yml
+++ b/ci_framework/roles/cifmw_ceph_spec/defaults/main.yml
@@ -35,3 +35,7 @@ cifmw_ceph_spec_path: /tmp/ceph_spec.yml
 
 # The path of the rendered initial ceph conf file
 cifmw_ceph_spec_path_initial_conf: /tmp/initial_ceph.conf
+
+# Defaults set so role works without network isolation
+cifmw_ceph_spec_public_network: 192.168.122.0/24
+cifmw_ceph_spec_private_network: ''

--- a/ci_framework/roles/cifmw_ceph_spec/molecule/default/converge.yml
+++ b/ci_framework/roles/cifmw_ceph_spec/molecule/default/converge.yml
@@ -15,7 +15,33 @@
 # under the License.
 
 
-- name: Converge
+- name: Converge without network isolation
   hosts: all
   roles:
     - role: "cifmw_ceph_spec"
+  post_tasks:
+    - name: Verify spec (always uses SSH network so only tested once)
+      ansible.builtin.include_tasks: tasks/verify_spec.yml
+    - name: Verify conf
+      ansible.builtin.include_tasks: tasks/verify_conf.yml
+
+- name: Converge with isolated storage network
+  hosts: all
+  vars:
+    cifmw_ceph_spec_public_network: 172.18.0.0/24
+  roles:
+    - role: "cifmw_ceph_spec"
+  post_tasks:
+    - name: Verify conf
+      ansible.builtin.include_tasks: tasks/verify_conf.yml
+
+- name: Converge with isolated storage and storage management networks
+  hosts: all
+  vars:
+    cifmw_ceph_spec_public_network: 172.18.0.0/24
+    cifmw_ceph_spec_private_network: 172.20.0.0/24
+  roles:
+    - role: "cifmw_ceph_spec"
+  post_tasks:
+    - name: Verify conf
+      ansible.builtin.include_tasks: tasks/verify_conf.yml

--- a/ci_framework/roles/cifmw_ceph_spec/molecule/default/tasks/verify_conf.yml
+++ b/ci_framework/roles/cifmw_ceph_spec/molecule/default/tasks/verify_conf.yml
@@ -1,0 +1,41 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Stat ceph.conf file
+  ansible.builtin.stat:
+    path: "{{ cifmw_ceph_spec_path_initial_conf }}"
+  register: cifmw_ceph_spec_path_initial_conf_stat
+  become: true
+
+- name: Fail if ceph.conf file is missing
+  ansible.builtin.fail:
+    msg: "{{ cifmw_ceph_spec_path_initial_conf }} does not exist according to stat"
+  when:
+    - cifmw_ceph_spec_path_initial_conf_stat.stat.exists is not defined
+
+- name: Extract public_network
+  ansible.builtin.set_fact:
+    found_public_network: "{{ lookup('ansible.builtin.ini', 'public_network section=global file=' ~ cifmw_ceph_spec_path_initial_conf) }}"
+
+- name: Extract private_network
+  ansible.builtin.set_fact:
+    found_private_network: "{{ lookup('ansible.builtin.ini', 'private_network section=global file=' ~ cifmw_ceph_spec_path_initial_conf) }}"
+
+- name: Assert expected values about public and private network
+  ansible.builtin.assert:
+    that:
+      - found_public_network == cifmw_ceph_spec_public_network
+      - found_private_network == cifmw_ceph_spec_private_network

--- a/ci_framework/roles/cifmw_ceph_spec/molecule/default/tasks/verify_spec.yml
+++ b/ci_framework/roles/cifmw_ceph_spec/molecule/default/tasks/verify_spec.yml
@@ -1,0 +1,71 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Stat ceph spec file
+  ansible.builtin.stat:
+    path: "{{ cifmw_ceph_spec_path }}"
+  register: cifmw_ceph_spec_path_stat
+  become: true
+
+- name: Fail if ceph spec file is missing
+  ansible.builtin.fail:
+    msg: "{{ cifmw_ceph_spec_path }} does not exist according to stat"
+  when:
+    - cifmw_ceph_spec_path_stat.stat.exists is not defined
+
+- name: Read the ceph spec file
+  ansible.builtin.command: "cat {{ cifmw_ceph_spec_path }}"
+  register: cat_ceph_spec
+  delegate_to: localhost
+
+- name: Assert expected values about hosts entries
+  ansible.builtin.assert:
+    that:
+      - item.hostname is match("edpm-compute-0")
+      - item.addr is match("192.168.122.100")
+      - (item.labels | join(' ')) is match ("mgr|mon|osd|_admin")
+  when:
+    - item.service_type == 'host'
+  loop: "{{ cat_ceph_spec.stdout | from_yaml_all | list }}"
+
+- name: Assert expected values about mon and mgr daemon entries
+  ansible.builtin.assert:
+    that:
+      - item.placement.hosts == expected_hosts
+      - item.service_id == item.service_name
+  when:
+    - item.service_type == 'mon' or item.service_type == 'mgr'
+  loop: "{{ cat_ceph_spec.stdout | from_yaml_all | list }}"
+  vars:
+    expected_hosts:
+      - edpm-compute-0
+
+- name: Assert expected values about osd daemon entries
+  ansible.builtin.assert:
+    that:
+      - item.placement.hosts == expected_hosts
+      - item.service_id == 'default_drive_group'
+      - item.service_name == 'osd.default_drive_group'
+      - item.data_devices == expected_devices
+  when:
+    - item.service_type == 'osd'
+  loop: "{{ cat_ceph_spec.stdout | from_yaml_all | list }}"
+  vars:
+    expected_hosts:
+      - edpm-compute-0
+    expected_devices:
+      paths:
+        - /dev/ceph_vg/ceph_lv_data

--- a/ci_framework/roles/cifmw_ceph_spec/tasks/main.yml
+++ b/ci_framework/roles/cifmw_ceph_spec/tasks/main.yml
@@ -22,9 +22,6 @@
     force: true
 
 - name: Create an initial Ceph conf file
-  when:
-    - cifmw_ceph_spec_public_network is defined
-    - cifmw_ceph_spec_public_network | length > 0
   ansible.builtin.template:
     src: templates/initial_ceph.conf.j2
     dest: "{{ cifmw_ceph_spec_path_initial_conf }}"

--- a/ci_framework/roles/cifmw_ceph_spec/templates/initial_ceph.conf.j2
+++ b/ci_framework/roles/cifmw_ceph_spec/templates/initial_ceph.conf.j2
@@ -1,5 +1,10 @@
 [global]
 osd pool default size = 1
+{% if cifmw_ceph_spec_public_network %}
 public_network = {{ cifmw_ceph_spec_public_network }}
+{% endif %}
+{% if cifmw_ceph_spec_private_network %}
+private_network = {{ cifmw_ceph_spec_private_network }}
+{% endif %}
 [mon]
 mon_warn_on_pool_no_redundancy = false


### PR DESCRIPTION
Introduce ssh_network_range (default 192.168.122.0/24) to ceph.yaml playbook for building the Ceph spec. The Ceph orchestrator will use this network to SSH into hosts as the ceph-admin user. This network should be used in the Ceph spec for adding hosts.

Introduce storage_mgmt_network_range to ceph.yaml playbook. If storage_network_range and storage_mgmt_network_range are undefined, then their respective cifmw_ceph_spec_public_network and cifmw_ceph_spec_private_network, in the cifmw_ceph_spec role, will be set to the ssh_network_range for the public network and omitted for the private network respectively in the initial ceph.conf. This ensures that a public network can always be looked up by other plays from the initial ceph.conf while keeping the ceph playbook working without network isolation by default. However, values for these networks can be easily uncommented in the ceph.yaml playbook (or passed as overrides) for when network isolation is used. Commented out values for these networks are based on the project defaults [1].

Molecule tests have been added to cifmw_ceph_spec role to ensure this desired behavior is enforced.

[1] https://github.com/openstack-k8s-operators/docs/blob/main/networking.md

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
