### PR TITLE
Add edpm multinode job with 3 computes

### DIFF
--- a/ci/playbooks/multinode-customizations.yml
+++ b/ci/playbooks/multinode-customizations.yml
@@ -157,7 +157,7 @@
         key: "{{ hostvars['controller']['persistent_ssh_key'] }}"
 
 - name: "Add cloud-admin user on Compute"
-  hosts: compute
+  hosts: computes
   tasks:
     - name: Create cloud-admin
       become: true

--- a/ci_framework/hooks/playbooks/fetch_compute_facts.yml
+++ b/ci_framework/hooks/playbooks/fetch_compute_facts.yml
@@ -40,14 +40,7 @@
 
     - name: Check we have some compute in inventory
       ansible.builtin.set_fact:
-        has_compute: >-
-          {% set ns = namespace(found=false) -%}
-          {% for host in hostvars.keys() -%}
-          {%   if host is match('^compute.*') -%}
-          {%     set ns.found = true -%}
-          {%   endif -%}
-          {% endfor -%}
-          {{ ns.found }}
+        computes_len: "{{ groups['computes'] | length }}"
 
     - name: Ensure that the isolated net was configured for crc
       ansible.builtin.assert:
@@ -58,11 +51,11 @@
 
     - name: Ensure we have needed bits for compute when needed
       when:
-        - has_compute | bool
+        - computes_len | int > 0
       ansible.builtin.assert:
         that:
-          - "'compute' in crc_ci_bootstrap_networks_out"
-          - "'default' in crc_ci_bootstrap_networks_out['compute']"
+          - "'compute-0' in crc_ci_bootstrap_networks_out"
+          - "'default' in crc_ci_bootstrap_networks_out['compute-0']"
 
     - name: Set facts for further usage within the framework
       ansible.builtin.set_fact:
@@ -105,14 +98,18 @@
 
     - name: Prepare EDPM deploy related facts and keys
       when:
-        - has_compute | bool
+        - computes_len | int > 0
       block:
         - name: Set specific fact for compute accesses
           vars:
+            dns_servers: "{{ ((['192.168.122.10'] + ansible_facts['dns']['nameservers']) | unique)[0:2] }}"
             edpm_install_yamls_vars:
               SSH_KEY_FILE: "{{ ansible_user_dir }}/.ssh/id_ed25519"
-              DATAPLANE_COMPUTE_IP: "{{ crc_ci_bootstrap_networks_out.compute.default.ip | ansible.utils.ipaddr('address') }}"
+              DATAPLANE_COMPUTE_IP: "{{ crc_ci_bootstrap_networks_out['compute-0'].default.ip | ansible.utils.ipaddr('address') }}"
               DATAPLANE_SSHD_ALLOWED_RANGES: "['0.0.0.0/0']"
+              DATAPLANE_TOTAL_NODES: "{{ computes_len | int }}"
+              DATAPLANE_SINGLE_NODE: "{{ (computes_len | int > 1) | ternary('false', 'true') }}"
+
           ansible.builtin.set_fact:
             cifmw_edpm_deploy_extra_vars: "{{ edpm_install_yamls_vars }}"
 
@@ -135,36 +132,46 @@
 
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleVars/neutron_public_interface_name
-                    value: "{{ crc_ci_bootstrap_networks_out.compute.default.iface | default('') }}"
+                    value: "{{ crc_ci_bootstrap_networks_out['compute-0'].default.iface | default('') }}"
 
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleVars/ctlplane_mtu
-                    value: {{ crc_ci_bootstrap_networks_out.compute.default.mtu | default(1500) }}
+                    value: {{ crc_ci_bootstrap_networks_out['compute-0'].default.mtu | default(1500) }}
 
-              {% if 'tenant' in crc_ci_bootstrap_networks_out.compute %}
+              {% if 'tenant' in crc_ci_bootstrap_networks_out['compute-0'] %}
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleVars/tenant_mtu
-                    value: {{ crc_ci_bootstrap_networks_out.compute['tenant'].mtu | default(1500) }}
+                    value: {{ crc_ci_bootstrap_networks_out['compute-0']['tenant'].mtu | default(1500) }}
               {% endif %}
 
-              {% if 'storage' in crc_ci_bootstrap_networks_out.compute %}
+              {% if 'storage' in crc_ci_bootstrap_networks_out['compute-0'] %}
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleVars/storage_mtu
-                    value: {{ crc_ci_bootstrap_networks_out.compute['storage'].mtu | default(1500) }}
+                    value: {{ crc_ci_bootstrap_networks_out['compute-0']['storage'].mtu | default(1500) }}
               {% endif %}
 
-              {% if 'internal-api' in crc_ci_bootstrap_networks_out.compute %}
+              {% if 'internal-api' in crc_ci_bootstrap_networks_out['compute-0'] %}
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleVars/internal_api_mtu
-                    value: {{ crc_ci_bootstrap_networks_out.compute['internal-api'].mtu | default(1500) }}
+                    value: {{ crc_ci_bootstrap_networks_out['compute-0']['internal-api'].mtu | default(1500) }}
               {% endif %}
+
+              {% for compute_node in groups['computes'] if compute_node != 'compute-0' %}
+                  - op: replace
+                    path: /spec/nodes/edpm-{{ compute_node }}/ansible/ansibleHost
+                    value: {{ crc_ci_bootstrap_networks_out[compute_node].default.ip  | ansible.utils.ipaddr('address') }}
+
+                  - op: replace
+                    path: /spec/nodes/edpm-{{ compute_node }}/networks/0/fixedIP
+                    value: {{ crc_ci_bootstrap_networks_out[compute_node].default.ip  | ansible.utils.ipaddr('address') }}
+              {% endfor %}
 
                   - op: add
                     path: /spec/nodeTemplate/ansible/ansibleVars/edpm_os_net_config_mappings
                     value:
                       net_config_data_lookup:
                         edpm-compute:
-                          nic2: "{{ crc_ci_bootstrap_networks_out.compute.default.iface | default('ens7') }}"
+                          nic2: "{{ crc_ci_bootstrap_networks_out['compute-0'].default.iface | default('ens7') }}"
 
                   - op: replace
                     path: /spec/nodeTemplate/networkConfig
@@ -205,7 +212,7 @@
 
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleUser
-                    value: "{{ hostvars.compute.ansible_user | default('zuul') }}"
+                    value: "{{ hostvars['compute-0'].ansible_user | default('zuul') }}"
 
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleVars/ctlplane_dns_nameservers

--- a/ci_framework/roles/artifacts/tasks/edpm.yml
+++ b/ci_framework/roles/artifacts/tasks/edpm.yml
@@ -47,7 +47,7 @@
             - cifmw_edpm_deploy_extra_vars is defined
           ansible.builtin.set_fact:
             ssh_key_file: "{{ cifmw_edpm_deploy_extra_vars.SSH_KEY_FILE }}"
-            ssh_user: "{{ hostvars.compute.ansible_user | default('zuul') }}"
+            ssh_user: "{{ hostvars['compute-0'].ansible_user | default('zuul') }}"
             edpm_vms: >-
               {{
                 crc_ci_bootstrap_networks_out | dict2items |

--- a/ci_framework/roles/edpm_kustomize/README.md
+++ b/ci_framework/roles/edpm_kustomize/README.md
@@ -33,18 +33,18 @@ None
 
            - op: replace
              path: /spec/nodeTemplate/ansible/ansibleUser
-             value: "{{ hostvars.compute.ansible_user | default('zuul') }}"
+             value: "{{ hostvars['compute-0'].ansible_user | default('zuul') }}"
 
            - op: replace
              path: /spec/nodeTemplate/ansible/ansibleVars/edpm_os_net_config_mappings
              value:
                net_config_data_lookup:
                  edpm-compute:
-                   nic1: "{{ crc_ci_bootstrap_networks_out.compute.default.iface }}"
+                   nic1: "{{ crc_ci_bootstrap_networks_out['compute-0'].default.iface }}"
 
            - op: replace
              path: /spec/nodeTemplate/ansible/ansibleUser
-             value: "{{ hostvars.compute.ansible_user | default('zuul') }}"
+             value: "{{ hostvars['compute-0'].ansible_user | default('zuul') }}"
   ansible.builtin.include_role:
     name: edpm_kustomize
 ```

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -97,10 +97,14 @@
       nodes:
         - name: controller
           label: cloud-centos-9-stream-tripleo-vexxhost
-        - name: compute
+        - name: compute-0
           label: cloud-centos-9-stream-tripleo-vexxhost
         - name: crc
           label: coreos-crc-extracted-xxl
+      groups:
+        - name: computes
+          nodes:
+            - compute-0
     irrelevant-files: *ir_files
     required-projects:
       - openstack-k8s-operators/ci-framework
@@ -162,7 +166,7 @@
                 ip: 172.18.0.5
               tenant:
                 ip: 172.19.0.5
-          compute:
+          compute-0:
             networks:
               default:
                 ip: 192.168.122.100

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -1,5 +1,96 @@
 ---
 - job:
+    name: podified-multinode-edpm-deployment-crc-3comp
+    parent: podified-multinode-edpm-deployment-crc
+    nodeset:
+      nodes:
+        - name: controller
+          label: cloud-centos-9-stream-tripleo-vexxhost
+        - name: compute-0
+          label: cloud-centos-9-stream-tripleo-vexxhost
+        - name: compute-1
+          label: cloud-centos-9-stream-tripleo-vexxhost
+        - name: compute-2
+          label: cloud-centos-9-stream-tripleo-vexxhost
+        - name: crc
+          label: coreos-crc-extracted-xxl
+      groups:
+        - name: computes
+          nodes:
+            - compute-0
+            - compute-1
+            - compute-2
+    vars:
+      crc_ci_bootstrap_networking:
+        networks:
+          default:
+            mtu: 1500
+            range: 192.168.122.0/24
+          internal-api:
+            vlan: 20
+            range: 172.17.0.0/24
+          storage:
+            vlan: 21
+            range: 172.18.0.0/24
+          tenant:
+            vlan: 22
+            range: 172.19.0.0/24
+        instances:
+          controller:
+            networks:
+              default:
+                ip: 192.168.122.11
+          crc:
+            networks:
+              default:
+                ip: 192.168.122.10
+              internal-api:
+                ip: 172.17.0.5
+              storage:
+                ip: 172.18.0.5
+              tenant:
+                ip: 172.19.0.5
+          compute-0:
+            networks:
+              default:
+                ip: 192.168.122.100
+              internal-api:
+                ip: 172.17.0.100
+                config_nm: false
+              storage:
+                ip: 172.18.0.100
+                config_nm: false
+              tenant:
+                ip: 172.19.0.100
+                config_nm: false
+          compute-1:
+            networks:
+              default:
+                ip: 192.168.122.101
+              internal-api:
+                ip: 172.17.0.101
+                config_nm: false
+              storage:
+                ip: 172.18.0.101
+                config_nm: false
+              tenant:
+                ip: 172.19.0.101
+                config_nm: false
+          compute-2:
+            networks:
+              default:
+                ip: 192.168.122.102
+              internal-api:
+                ip: 172.17.0.102
+                config_nm: false
+              storage:
+                ip: 172.18.0.102
+                config_nm: false
+              tenant:
+                ip: 172.19.0.102
+                config_nm: false
+
+- job:
     name: podified-multinode-edpm-deployment-crc
     parent: cifmw-podified-multinode-edpm-base-crc
     vars:


### PR DESCRIPTION
This patch adds a new multinode job which deploys
3 computes nodes. Some minor changes were needed to
get multiple nodes supported.
It also change compute name to a new pattern: compute-$INDEX,
where the first compute is always 'compute-0'

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
