### PR TITLE
Revert "Pin tempest container to last known good tag"

### DIFF
--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -118,8 +118,6 @@
     vars:
       cifmw_extras:
         - '@scenarios/centos-9/multinode-ci.yml'
-      # Revert once tempest container is fixed
-      cifmw_tempest_image_tag: "e8f50e92676531d00f857753024c2f57"
     run:
       - ci/playbooks/edpm/run.yml
 
@@ -130,8 +128,6 @@
       cifmw_extras:
         - '@scenarios/centos-9/ci.yml'
         - '@scenarios/centos-9/multinode-ci.yml'
-      # Revert once tempest container is fixed
-      cifmw_tempest_image_tag: "e8f50e92676531d00f857753024c2f57"
     run:
       - ci/playbooks/e2e-run.yml
     irrelevant-files:


### PR DESCRIPTION
Reverts openstack-k8s-operators/ci-framework#555

Latest promoted tempest container has the fix.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
