### PR TITLE
Revert adding black CI check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,12 +48,6 @@ repos:
         args: ['check_zuul_files']
         pass_filenames: false
 
-  # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.9.1
-    hooks:
-      - id: black
-
   - repo: https://github.com/ansible/ansible-lint
     rev: v6.18.0
     hooks:


### PR DESCRIPTION
Black addition was unintendedly merged. Remove it till we can include it properly with a line-length and line breaking setting that are good in local and CI.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date: