### PR TITLE
Make CI flake match the tox settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,9 @@ repos:
         # justified with relation to defaults.
         # W503 - line break before binary operator, ignored by default
         # E402 - Module level import not at top of file
+        # E203 - As per black doc to match PEP8
         # max-line-length increased to 88 as per blacks recommendation
-        entry: flake8 --ignore=W503,E402 --max-line-length=88
+        entry: flake8 --ignore=W503,E203,E402 --max-line-length=88
 
   - repo: https://github.com/openstack-dev/bashate.git
     rev: 2.1.1


### PR DESCRIPTION
In CI the E203 rule wasn't ignored, making flake8 not that aligned with PEP8 as it's in tox. This is crucial for black to work by default.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date: