### PR TITLE
Fix typo in hive role

### DIFF
--- a/ci_framework/roles/hive/tasks/baremetal_delete_cluster.yml
+++ b/ci_framework/roles/hive/tasks/baremetal_delete_cluster.yml
@@ -22,7 +22,7 @@
   vars:
     resource_type: "{{ item.type }}"
     resource: "{{ item.name }}"
-  ansible.builtin.include_task:
+  ansible.builtin.include_tasks:
     file: oc_delete.yml
   loop:
     - {'type': 'clusterdeployment', 'name': "{{ cifmw_hive_baremetal.cluster_name }}" }


### PR DESCRIPTION
This PR fixes a warning reported by ansible-lint [1]

[1] `WARNING  Unable to resolve FQCN for module ansible.builtin.include_task`

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
