### PR TITLE
Allow to gather passed hooks in the custom params

### DIFF
--- a/ci_framework/playbooks/01-bootstrap.yml
+++ b/ci_framework/playbooks/01-bootstrap.yml
@@ -19,7 +19,7 @@
           {{
             hostvars[inventory_hostname] |
             dict2items |
-            selectattr("key", "match", "^cifmw_(?!install_yamls|openshift).*") |
+            selectattr("key", "match", "^(cifmw|pre|post)_(?!install_yamls|openshift).*") |
             list | items2dict
           }}
 


### PR DESCRIPTION
This would make the whole reproducer easier: we'll only need to inject
the custom-params.yml file in the environment instead of having to
gather the scenario contents.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
