### PR TITLE
Gather "zuul" parameter

### DIFF
--- a/ci_framework/playbooks/01-bootstrap.yml
+++ b/ci_framework/playbooks/01-bootstrap.yml
@@ -61,3 +61,10 @@
       ansible.builtin.copy:
         dest: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts/parameters/custom-params.yml"
         content: "{{ ci_framework_params | to_nice_yaml }}"
+
+    - name: Save zuul parameter if exists
+      when:
+        - zuul is defined
+      ansible.builtin.copy:
+        dest: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts/parameters/zuul-params.yml"
+        content: "{{ {'zuul': zuul} | to_nice_yaml }}"


### PR DESCRIPTION
This parameter will provide the needed data for dependencies and needed
builds, especially the `zuul.items` listing the patches under test. This
will be consumed as-is by the operator_build role.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
