### PR TITLE
Handle ceph orch stuck issues

### DIFF
--- a/ci_framework/playbooks/ceph.yml
+++ b/ci_framework/playbooks/ceph.yml
@@ -208,6 +208,11 @@
         name: cifmw_cephadm
         tasks_from: bootstrap
 
+    - name: Ensure that Ceph orchestrator is responsive
+      ansible.builtin.import_role:
+        name: cifmw_cephadm
+        tasks_from: monitor_ceph_orch
+
     - name: Apply Ceph spec
       ansible.builtin.import_role:
         name: cifmw_cephadm
@@ -235,6 +240,11 @@
       ansible.builtin.import_role:
         name: cifmw_cephadm
         tasks_from: export
+
+    - name: Ensure that Ceph orchestrator is responsive
+      ansible.builtin.import_role:
+        name: cifmw_cephadm
+        tasks_from: monitor_ceph_orch
 
     - name: Show the Ceph cluster status
       ansible.builtin.import_role:


### PR DESCRIPTION
This patches ensures to call monitor_ceph_orch task before apply_spec and post operations where 'orch status' command is used.

The task monitor_ceph_orch will exit the command execution after a timeout and restarts the current active mgr to fix it.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
