### PR TITLE
Do not set cifmw_cephadm_first_mon_ip from Ceph spec

### DIFF
--- a/ci_framework/playbooks/ceph.yml
+++ b/ci_framework/playbooks/ceph.yml
@@ -169,19 +169,16 @@
         pools: "{{ cifmw_cephadm_pools | map(attribute='name') | list }}"
       no_log: true
 
-    - name: Set IP address of first monitor
-      ansible.builtin.set_fact:
-        cifmw_cephadm_first_mon_ip: "{{ item.addr }}"
-      when:
-        - item.service_type == 'host'
-        - item.hostname == "{{ cifmw_cephadm_bootstrap_host }}"  # noqa: no-jinja-when
-      loop: "{{ lookup('file', cifmw_cephadm_spec_ansible_host) | from_yaml_all | list }}"
-      delegate_to: localhost
-
     # public network always exist because is provided by the ceph_spec role
     - name: Get Storage network range
       ansible.builtin.set_fact:
         cifmw_cephadm_rgw_network: "{{ lookup('ansible.builtin.ini', 'public_network section=global file=' ~ cifmw_cephadm_bootstrap_conf) }}"
+
+    - name: Set IP address of first monitor
+      ansible.builtin.set_fact:
+        cifmw_cephadm_first_mon_ip: "{{ hostvars[this_host][all_addresses] | ansible.utils.ipaddr(cifmw_cephadm_rgw_network) | first }}"
+      vars:
+        this_host: "{{ groups['edpm'][0] }}"
 
     - name: Get already assigned IP addresses
       ansible.builtin.set_fact:


### PR DESCRIPTION
Fixes bug from e23977349353fad521dd4ded0f149d3cab18c6fd

The "Set IP address of first monitor" task broke when the Ceph spec was changed to always use the ssh_network because that network is not necessarily the same as the storage_network_range. Update this task to get the first monitor IP not from the spec but from the hostvars of the host where the play is run after filtering for only the storage network.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
