### PR TITLE
Duplicate network-config-{override,template} functionality

### DIFF
--- a/ci_framework/hooks/playbooks/fetch_compute_facts.yml
+++ b/ci_framework/hooks/playbooks/fetch_compute_facts.yml
@@ -171,6 +171,42 @@
                           nic2: "{{ crc_ci_bootstrap_networks_out['compute-0'].default.iface | default('ens7') }}"
 
                   - op: replace
+                    path: /spec/nodeTemplate/ansible/ansibleVars/edpm_network_config_template
+                    value: |-
+                        {%- raw %}
+                        ---
+                        {% set mtu_list = [ctlplane_mtu] %}
+                        {% for network in role_networks %}
+                        {{ mtu_list.append(lookup("vars", networks_lower[network] ~ "_mtu")) }}
+                        {%- endfor %}
+                        {% set min_viable_mtu = mtu_list | max %}
+                        network_config:
+                        - type: ovs_bridge
+                          name: {{ neutron_physical_bridge_name }}
+                          mtu: {{ min_viable_mtu }}
+                          use_dhcp: false
+                          dns_servers: {{ ctlplane_dns_nameservers }}
+                          domain: {{ dns_search_domains }}
+                          addresses:
+                          - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+                          members:
+                          - type: interface
+                            name: nic2
+                            mtu: {{ min_viable_mtu }}
+                            # force the MAC address of the bridge to this interface
+                            primary: true
+                        {% for network in role_networks %}
+                          - type: vlan
+                            mtu: 1496
+                            vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+                            addresses:
+                            - ip_netmask:
+                                {{ lookup("vars", networks_lower[network] ~ "_ip") }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+                            routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+                        {% endfor %}
+                        {% endraw %}
+
+                  - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleVars/edpm_network_config_override
                     value: |-
                         {%- raw %}


### PR DESCRIPTION
This change duplicates the kustomize for edpm_network_config_override and edpm_network_config_template. This will allow for backwards compatibility while we remove the _override variable. Similar functionality is implemented in edpm-ansible via:
https://github.com/openstack-k8s-operators/edpm-ansible/pull/362

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
