### PR TITLE
Automatically skip bootstrapped network cleanup if autohold

### DIFF
--- a/ci/playbooks/multinode-authold.yml
+++ b/ci/playbooks/multinode-authold.yml
@@ -1,0 +1,84 @@
+---
+- name: "Run ci/playbooks/multinode-autohold.yml"
+  hosts: controller
+  gather_facts: true
+  tasks:
+    - name: Check if the current run is an authold target
+      when:
+        - zuul is defined
+        - "'ref' in zuul"
+        - "'tenant' in zuul"
+        - "'job' in zuul"
+        - "'project' in zuul"
+      block:
+        - name: Fetch existing autoholds from zuul
+          vars:
+            _zuul_api_url: >-
+              {{
+                [
+                  ('https://'+ (zuul.executor.hostname | split('.'))[1:] | join('.')),
+                  'zuul',
+                  'api'
+                  'tenant',
+                  zuul.tenant,
+                  'autoholds'
+                ] | join('/')
+              }}
+          ansible.builtin.uri:
+            url: "{{ _zuul_api_url }}"
+            method: GET
+            headers:
+              Content-Type: "application/json"
+              Accept: "application/json"
+            return_content: yes
+            status_code: 200
+            body_format: json
+          register: autoholds_response
+          retries: 2
+          delay: 10
+          until:
+            - autoholds_response.status is defined
+            - autoholds_response.content_type is defined
+            - autoholds_response.status == 200
+            - "autoholds_response.content_type.startswith('application/json')"
+          ignore_errors: true
+
+        - name: Check if any authold matches
+          vars:
+            autoholds_returned_data: >-
+              {{
+                (
+                  autoholds_response.content |
+                  default('[]') |
+                  from_json
+                ) if
+                  (
+                    (not autoholds_response.failed) and
+                    autoholds_response.content_type.startswith('application/json')
+                  )
+                else []
+              }}
+            autohold_candidates: >-
+              {{
+                autoholds_returned_data |
+                selectattr('tenant', 'defined') |
+                selectattr('project', 'defined') |
+                selectattr('job', 'defined') |
+                selectattr('current_count', 'defined') |
+                selectattr('max_count', 'defined') |
+                selectattr('tenant', 'equalto', zuul.tenant) |
+                selectattr('project', 'equalto', zuul.project) |
+                selectattr('job', 'equalto', zuul.job)
+              }}
+            matching_candidates: >-
+              {% set matching_holds = [] -%}
+              {% for candidate in autohold_candidates -%}
+              {%   if zuul.ref | regex_search(candidate.ref_filter) and (candidate.max_count > candidate.current_count) -%}
+              {%     set _ = matching_holds.append(candidate) -%}
+              {%   endif -%}
+              {% endfor -%}
+              {{ matching_holds }}
+          when: matching_candidates | length > 0
+          ansible.builtin.file:
+            path: "{{ ansible_user_dir }}/crc-ci-bootstrap-skip-cleanup"
+            state: touch

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -120,6 +120,7 @@
     post-run:
       - ci/playbooks/e2e-collect-logs.yml
       - ci/playbooks/collect-logs.yml
+      - ci/playbooks/multinode-authold.yml
     vars:
       zuul_log_collection: true
       registry_login_enabled: true


### PR DESCRIPTION
Allows automatically skipping the cleanup of the bootstrapped network if there is an autohold for the current job.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date