### PR TITLE
Donot use pipe in os_must_gather command while using ci_script plugin

### DIFF
--- a/ci_framework/roles/os_must_gather/tasks/main.yml
+++ b/ci_framework/roles/os_must_gather/tasks/main.yml
@@ -42,7 +42,7 @@
         PATH: "{{ cifmw_path }}"
       ci_script:
         output_dir: "{{ cifmw_os_must_gather_output_dir }}/artifacts"
-        script: |
+        script: >-
           oc adm must-gather --image {{ cifmw_os_must_gather_image }}
           --timeout {{ cifmw_os_must_gather_timeout }}
           --host-network={{ cifmw_os_must_gather_host_network }}


### PR DESCRIPTION
Currently We are using | in the os_must_gather command with ci_script plugin. It treats each line as a single command to leading os-must-gather command failure saying `--timeout` command not found.

Replace | with >- fixes the issue.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running

