### PR TITLE
Fix the value for cifmw_dlrn_promote_hash_in_promote_target

### DIFF
--- a/ci_framework/roles/dlrn_promote/tasks/check_for_previous_promotions.yml
+++ b/ci_framework/roles/dlrn_promote/tasks/check_for_previous_promotions.yml
@@ -35,8 +35,12 @@
     path: "{{ cifmw_dlrn_promote_workspace }}/cifmw_dlrn_promote_hash_promote_target_output.txt"
   register: cifmw_dlrn_promote_hash_in_promote_target_from_slurp
 
-- name: Set fact for  promotion target output
+- name: Set fact for promotion target output
   ansible.builtin.set_fact:
     cifmw_dlrn_promote_hash_in_promote_target:
-      "{{ cifmw_dlrn_promote_hash_in_promote_target_from_slurp['content'] | b64decode }}"
+      "{{ cifmw_dlrn_promote_hash_in_promote_target_from_slurp['content'] | b64decode | from_yaml }}"
     cacheable: true
+
+- name: Print the cifmw_dlrn_promote_hash_in_promote_target value
+  ansible.builtin.debug:
+    var: cifmw_dlrn_promote_hash_in_promote_target

--- a/ci_framework/roles/dlrn_promote/tasks/main.yml
+++ b/ci_framework/roles/dlrn_promote/tasks/main.yml
@@ -28,8 +28,7 @@
 - name: Run DLRN promote hash
   when:
     - cifmw_dlrn_promote_hash_in_promote_target is defined
-    - "'stdout' in cifmw_dlrn_promote_hash_in_promote_target"
-    - cifmw_dlrn_promote_hash_in_promote_target.stdout == '[]'
+    - cifmw_dlrn_promote_hash_in_promote_target |length == 0
   block:
     - name: Check reported jobs
       ansible.builtin.import_tasks: check_reported_jobs.yml


### PR DESCRIPTION
Since we use slurp so there is no stdout key in the above var. It skips the resulting tasks where it is used as a conditional.

This patch fixes the same for the conditionals.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

