### PR TITLE
New role: ci_network

### DIFF
--- a/ci_framework/roles/ci_network/README.md
+++ b/ci_framework/roles/ci_network/README.md
@@ -1,0 +1,43 @@
+# ci_network
+Apply and manage connection in NetworkManager. This role is especially important for CI
+and CI Job reproducer, since we have to prepare most of the network beforehand.
+
+## Privilege escalation
+It needs sudo access to edit Network Manager connections.
+
+## Parameters
+* `cifmw_network_generated_layout`: (Str) Path to the generated layout you want to apply. Defaults to `/etc/ci/env/network-layout.yml`.
+* `cifmw_network_pre_cleanup`: (Bool) Clean existing ethernet connections before applying configuration. Defaults to `true`.
+* `cifmw_network_layout`: (Dict) Network layout you want to apply.
+* `cifmw_network_nm_config_file`: (Str) Path to NetworkManager configuration file. Defaults to `/etc/NetworkManager/NetworkManager.conf`.
+* `cifmw_network_nm_config`: (List(dict)) List of editions to do in the NetworkManager.conf. Defaults to `[]`
+
+## NetworkManager configuration layout
+The list must be as follow:
+
+```YAML
+cifmw_network_nm_config:
+  - state: present|absent  # Optional. Defaults to present
+    section:  # Mandatory. Section name in the ini file
+    option:  # Mandatory. Option name in the ini file
+    value:  # Mandatory. Value of the option
+```
+
+## Network configuration layout
+This dict has to represent all of the networks as follow:
+
+```YAML
+cifmw_network_layout:
+  <hostname>:
+    <network-name>:
+      iface:  # Mandatory. Interface name on the host.
+      mac:  # Optional. MAC address of the interface.
+      mtu:  # Optional. Defaults to 1500.
+      connection:  # Optional. Connection name. Defaults to "network-name" key value.
+      ip4:  # Mandatory. IPv4 address.
+      dns4:  # Optional. IPv4 DNS servers list.
+      gw4:  # Optional. IPv4 gateway for that network.
+      ip6:  # Optional. IPv6 address.
+      gw6:  # Optional. IPv6 gateway.
+      dns6:  # Optional. IPV6 DNS servers list.
+```

--- a/ci_framework/roles/ci_network/defaults/main.yml
+++ b/ci_framework/roles/ci_network/defaults/main.yml
@@ -1,0 +1,106 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+cifmw_network_pre_cleanup: true
+cifmw_network_nm_config: []
+cifmw_network_nm_config_file: "/etc/NetworkManager/NetworkManager.conf"
+cifmw_network_generated_layout: "/etc/ci/env/network-layout.yml"
+# This parameter is provided as an exemple of the expected content.
+# Usually it will be generated in Zuul job, and the reproducer role
+# will generate it accordingly and inject it in the environment.
+cifmw_network_layout:
+  controller:
+    default:
+      iface: "eth1"
+      mac: omit
+      mtu: 1500
+      connection: "ci-private-network"
+      ip4: "192.168.122.10/24"
+      gw4: "192.168.122.1"
+      dns: omit
+  crc:
+    default:
+      iface: "enp2s0"
+      mac: omit
+      mtu: 1500
+      connection: "ci-private-network"
+      ip4: "192.168.122.11/24"
+      gw4: "192.168.122.1"
+      dns: omit
+    vlan19:
+      iface: "eth1.vlan20"
+      vlan: "19"
+      parent_iface: "eth1"
+      connection: "tenant"
+      mac: omit
+      mtu: 1500
+      ip4: "172.19.0.11/24"
+      dns: omit
+    vlan20:
+      iface: "eth1.vlan20"
+      vlan: "20"
+      parent_iface: "eth1"
+      connection: "internal-api"
+      mac: omit
+      mtu: 1500
+      ip4: "172.20.0.11/24"
+      dns: omit
+    vlan21:
+      iface: "eth1.vlan21"
+      vlan: "21"
+      parent_iface: "eth1"
+      connection: "storage"
+      mac: omit
+      mtu: 1500
+      ip4: "172.21.0.11/24"
+      dns: omit
+  compute-0:
+    default:
+      iface: "eth1"
+      mac: omit
+      mtu: 1500
+      connection: "ci-private-network"
+      ip4: "192.168.122.100/24"
+      gw4: "192.168.122.1"
+      dns: omit
+    vlan19:
+      iface: "eth1.vlan20"
+      vlan: "19"
+      parent_iface: "eth1"
+      connection: "tenant"
+      mac: omit
+      mtu: 1500
+      ip4: "172.19.0.100/24"
+      dns: omit
+    vlan20:
+      iface: "eth1.vlan20"
+      vlan: "20"
+      parent_iface: "eth1"
+      connection: "internal-api"
+      mac: omit
+      mtu: 1500
+      ip4: "172.20.0.100/24"
+      dns: omit
+    vlan21:
+      iface: "eth1.vlan21"
+      vlan: "21"
+      parent_iface: "eth1"
+      connection: "storage"
+      mac: omit
+      mtu: 1500
+      ip4: "172.21.0.100/24"
+      dns: omit

--- a/ci_framework/roles/ci_network/meta/main.yml
+++ b/ci_framework/roles/ci_network/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- ci_network
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: edpm
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - edpm
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/ci_framework/roles/ci_network/molecule/default/converge.yml
+++ b/ci_framework/roles/ci_network/molecule/default/converge.yml
@@ -1,0 +1,51 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  roles:
+    - role: "ci_network"
+  tasks:
+    - name: Get nmcli connections
+      register: nmcli_existing_connections
+      ansible.builtin.command:
+        cmd: nmcli -t -f NAME,DEVICE,ACTIVE con show
+
+    - name: Debug existing connections
+      ansible.builtin.debug:
+        var: nmcli_existing_connections.stdout_lines
+
+    - name: Ensure we have the expected vlan20
+      ansible.builtin.assert:
+        that:
+          - "'molecule-test:eth0.20:yes' in nmcli_existing_connections.stdout_lines"
+
+    - name: Get network interface configuration
+      register: nmcli_interface_conf
+      ansible.builtin.command:
+        cmd: nmcli -t -f vlan,IP4 con show molecule-test
+
+    - name: Debug connection settings
+      ansible.builtin.debug:
+        var: nmcli_interface_conf.stdout_lines
+
+    - name: Ensure interface configuration is correct
+      ansible.builtin.assert:
+        that:
+          - "'IP4.ADDRESS[1]:172.20.0.100/24' in nmcli_interface_conf.stdout_lines"
+          - "'vlan.id:20' in nmcli_interface_conf.stdout_lines"
+          - "'vlan.parent:eth0' in nmcli_interface_conf.stdout_lines"

--- a/ci_framework/roles/ci_network/molecule/default/molecule.yml
+++ b/ci_framework/roles/ci_network/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/ci_network/molecule/default/prepare.yml
+++ b/ci_framework/roles/ci_network/molecule/default/prepare.yml
@@ -1,0 +1,44 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps
+
+  tasks:
+    - name: Create directory for generated params
+      become: true
+      ansible.builtin.file:
+        path: "/etc/ci/env"
+        state: directory
+        mode: "0755"
+
+    - name: Push a dummy file
+      become: true
+      ansible.builtin.copy:
+        dest: "/etc/ci/env/network-layout.yml"
+        mode: "0644"
+        content: |
+          cifmw_network_layout_gen:
+            {{ inventory_hostname }}:
+              vlan20:
+                iface: "eth0.20"
+                vlan: 20
+                parent_iface: "eth0"
+                connection: "molecule-test"
+                ip4: "172.20.0.100/24"

--- a/ci_framework/roles/ci_network/tasks/apply.yml
+++ b/ci_framework/roles/ci_network/tasks/apply.yml
@@ -1,0 +1,41 @@
+---
+- name: Assert network configuration is valid
+  block:
+    - name: VLAN data are present
+      when:
+        - network.value.vlan is defined
+      ansible.builtin.assert:
+        that:
+          - network.value.parent_iface is defined
+        msg: "parent_iface is needed for VLAN interface"
+
+    - name: Mandatory parameters are defined
+      ansible.builtin.assert:
+        that:
+          - network.value.ip4 is defined
+          - network.value.iface is defined
+        msg: "ip4 and iface are needed for any interface"
+
+- name: "Apply network {{ network.key }}"
+  become: true
+  when:
+    - network.value.config_nm | default(true) | bool
+  community.general.nmcli:
+    autoconnect: true
+    state: "{{ network.value.state | default('present') }}"
+    conn_name: "{{ network.value.connection | default(network.key) }}"
+    ifname: "{{ network.value.iface }}"
+    type: "{{ network.value.vlan is defined | ternary('vlan', 'ethernet') }}"
+    ip4: "{{ network.value.ip4 }}"
+    mac: "{{ network.value.mac | default(omit) }}"
+    dns4: "{{ network.value.dns4 | default(omit) }}"
+    # Needed for some specific infra
+    mtu: "{{ network.value.mtu | default(1500) }}"
+    gw4: "{{ network.value.gw4 | default(omit) }}"
+    # Needed only for IPv6 support
+    ip6: "{{ network.value.ip6 | default(omit) }}"
+    gw6: "{{ network.value.gw6 | default(omit) }}"
+    dns6: "{{ network.value.dns6 | default(omit) }}"
+    # Needed for VLAN interface
+    vlandev: "{{ network.value.parent_iface | default(omit)}}"
+    vlanid: "{{ network.value.vlan | default(omit) }}"

--- a/ci_framework/roles/ci_network/tasks/main.yml
+++ b/ci_framework/roles/ci_network/tasks/main.yml
@@ -1,0 +1,65 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Check if environment file exists
+  register: env_file
+  ansible.builtin.stat:
+    path: "{{ cifmw_network_generated_layout }}"
+
+- name: Load generated network if exists
+  when:
+    - env_file.stat.exists
+  ansible.builtin.include_vars:
+    file: "{{  cifmw_network_generated_layout }}"
+
+- name: Configure NetworkManager service
+  register: nm_config_update
+  community.general.ini_file:
+    path: "{{ cifmw_network_nm_config_file }}"
+    state: "{{ nm_conf.state | default('present') }}"
+    no_extra_spaces: true
+    section: "{{ nm_conf.section }}"
+    option: "{{ nm_conf.option }}"
+    value: "{{ nm_conf.value }}"
+  loop: "{{ cifmw_network_nm_config }}"
+  loop_control:
+    loop_var: nm_conf
+    label: "{{ nm_conf.section }}-{{ nm_conf.option }}"
+
+- name: Reload NetworkManager service if needed
+  when:
+    - nm_config_update is defined
+    - nm_config_update is changed
+  ansible.builtin.systemd:
+    name: NetworkManager
+    state: reloaded
+
+- name: Clean all ethernet connection
+  when:
+    - cifmw_network_pre_cleanup | bool
+  ansible.builtin.import_tasks: nm-cleanup.yml
+
+- name: "Apply network configuration on {{ inventory_hostname }}"
+  vars:
+    _net_layout: >-
+      {{
+        cifmw_network_layout_gen | default(cifmw_network_layout)
+      }}
+  ansible.builtin.include_tasks: apply.yml
+  loop: "{{ _net_layout[inventory_hostname] | dict2items }}"
+  loop_control:
+    loop_var: "network"
+    label: "{{ network.key }}"

--- a/ci_framework/roles/ci_network/tasks/nm-cleanup.yml
+++ b/ci_framework/roles/ci_network/tasks/nm-cleanup.yml
@@ -1,0 +1,35 @@
+---
+- name: Fetch routes as a json
+  register: ip_routes
+  ansible.builtin.command:
+    cmd: ip -j ro ls
+
+- name: Get nm existing ethernet connections
+  register: nm_ethernet
+  ansible.builtin.command:
+    cmd: nmcli -t -f TYPE,DEVICE,NAME con show --active
+
+- name: Remove non-default ethernet connections
+  vars:
+    default_route_dev: >-
+      {{
+        ip_routes.stdout |
+        from_json |
+        selectattr("dst", "equalto", "default") |
+        map(attribute="dev") | first
+      }}
+    nm_con_list: >-
+      {{
+        nm_ethernet.stdout_lines |
+        select('search', 'ethernet') |
+        map('split', ':')
+      }}
+  become: true
+  when:
+    - item[1] != default_route_dev
+  community.general.nmcli:
+    conn_name: "{{ item[2] }}"
+    state: absent
+  loop: "{{ nm_con_list }}"
+  loop_control:
+    label: "{{ item[1] }}"

--- a/ci_framework/roles/ci_network/vars/main.yml
+++ b/ci_framework/roles/ci_network/vars/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# While options found within the vars/ path can be overridden using extra
+# vars, items within this path are considered part of the role and not
+# intended to be modified.
+
+# All variables within this role should have a prefix of "cifmw_ci_network"

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -142,6 +142,7 @@ igogicbjyxbzig
 ihbyb
 img
 ingressvips
+ini
 installyamls
 ipaddr
 ipi
@@ -209,6 +210,7 @@ namespaces
 ncia
 ndczmditnzbhni
 networkconfig
+networkmanager
 networktype
 nic
 nigzpbgugpsavdmfyl

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -32,6 +32,16 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
+    - ^ci_framework/roles/ci_network/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    name: cifmw-molecule-ci_network
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: ci_network
+- job:
+    files:
+    - ^ansible-requirements.txt
+    - ^molecule-requirements.txt
     - ^ci_framework/roles/ci_setup/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-ci_setup

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -12,6 +12,7 @@
       - cifmw-molecule-artifacts
       - cifmw-molecule-build_containers
       - cifmw-molecule-build_openstack_packages
+      - cifmw-molecule-ci_network
       - cifmw-molecule-ci_setup
       - cifmw-molecule-cifmw_block_device
       - cifmw-molecule-cifmw_ceph_client


### PR DESCRIPTION
This role will apply network configuration on the hosts.

While it has a default network layout, it is expected to
get data from a previous step, such as the Zuul job bootstrap,
in a specific format matching the default layout.

In the case of the job reproducer, the data will be generated by mixing
data from the actual CI job, and the ones matching the reproducer
infra.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
