### PR TITLE
Bump flavor for EDPM baremetal job.

### DIFF
--- a/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
+++ b/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
@@ -6,7 +6,9 @@ cifmw_install_yamls_vars:
   STORAGE_CLASS: crc-csi-hostpath-provisioner
   DATAPLANE_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/dataplane-operator"
   INFRA_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/infra-operator"
-  BMAAS_INSTANCE_MEMORY: 6144
+  BMAAS_INSTANCE_MEMORY: 8192
+  BMAAS_INSTANCE_VCPUS: 6
+  BMAAS_INSTANCE_DISK_SIZE: 40
 
 pre_infra:
   - name: Download needed tools

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -11,11 +11,11 @@
 # Virtual Baremetal job with CRC and single compute node.
 - job:
     name: cifmw-crc-podified-edpm-baremetal
-    nodeset: centos-9-crc-4xlarge
+    nodeset: centos-9-crc-6xlarge
     parent: cifmw-base-crc-openstack
     run: ci/playbooks/edpm_baremetal_deployment/run.yml
     vars:
-      crc_parameters: "--memory 32000 --disk-size 120 --cpus 10"
+      crc_parameters: "--memory 32000 --disk-size 240 --cpus 12"
 
 # Podified galera job
 - job:

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -24,6 +24,12 @@
         label: centos-9-stream-crc-4xlarge
 
 - nodeset:
+    name: centos-9-crc-6xlarge
+    nodes:
+      - name: controller
+        label: centos-9-stream-crc-6xlarge
+
+- nodeset:
     name: centos-stream-9
     nodes:
       - name: controller


### PR DESCRIPTION
For baremetal job, We are moving to a new flavor with spec:
24vcpu/48GB ram/ 400 GB disk.

Bumping cpus of crc to 12, and edpm node
cpu to 6 and ram to 8GB.


Depends-On: https://softwarefactory-project.io/r/c/config/+/29561

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running