### PR TITLE
Add HCI dataplane deployment

### DIFF
--- a/ci_framework/playbooks/06-deploy-edpm.yml
+++ b/ci_framework/playbooks/06-deploy-edpm.yml
@@ -49,7 +49,43 @@
             name: libvirt_manager
             tasks_from: deploy_edpm_compute.yml
 
+        - name: Prepare for HCI deploy phase 1
+          when: cifmw_edpm_deploy_hci | default(false) | bool
+          ansible.builtin.import_role:
+            name: hci_prepare
+            tasks_from: phase1.yml
+
         - name: Deploy EDPM
+          ansible.builtin.import_role:
+            name: edpm_deploy
+
+- name: Clear edpm hosts facts to force refreshing in HCI deployments
+  hosts: edpm
+  tasks:
+    - name: Clear edpm hosts facts
+      when: cifmw_edpm_deploy_hci | default(false) | bool
+      ansible.builtin.meta: clear_facts
+
+- name: Deploy Ceph on EDPM nodes
+  vars:
+    storage_network_range: 172.18.0.0/24
+    storage_mgmt_network_range: 172.20.0.0/24
+  ansible.builtin.import_playbook: ceph.yml
+  when: cifmw_edpm_deploy_hci | default(false) | bool
+
+- name: Continue HCI deploy
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Create Ceph secrets and retrieve FSID info
+      when: cifmw_edpm_deploy_hci | default(false) | bool
+      block:
+        - name: Prepare for HCI deploy phase 2
+          ansible.builtin.import_role:
+            name: hci_prepare
+            tasks_from: phase2.yml
+
+        - name: Continue HCI deployment
           ansible.builtin.import_role:
             name: edpm_deploy
 

--- a/ci_framework/playbooks/ceph.yml
+++ b/ci_framework/playbooks/ceph.yml
@@ -104,14 +104,14 @@
           "{{ host_to_ip | default({}) |
             combine(
               {
-                hostvars[item]['ansible_hostname'] :
+                hostvars[item]['ansible_fqdn'] :
                 hostvars[item][all_addresses] | ansible.utils.ipaddr(ssh_network_range) | first
               }
             )
            }}"
       delegate_to: "{{ item }}"
       when:
-        - hostvars[item]['ansible_hostname'] is defined
+        - hostvars[item]['ansible_fqdn'] is defined
       loop: "{{ groups['edpm'] }}"
   roles:
     - role: cifmw_ceph_spec
@@ -128,7 +128,7 @@
     cifmw_cephadm_spec_ansible_host: /tmp/ceph_spec.yml
     cifmw_cephadm_bootstrap_conf: /tmp/initial_ceph.conf
     cifmw_ceph_client_vars: /tmp/ceph_client.yml
-    cifmw_cephadm_bootstrap_host: "{{ ansible_hostname }}"
+    cifmw_cephadm_bootstrap_host: "{{ ansible_fqdn }}"
     cifmw_cephadm_default_container: true
     all_addresses: ansible_all_ipv4_addresses # change if you need IPv6
     cifmw_cephadm_pools:

--- a/ci_framework/roles/cifmw_cephadm/tasks/rgw.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/rgw.yml
@@ -16,7 +16,7 @@
 
 - name: Collect the host and build the resulting host list
   ansible.builtin.set_fact:
-    _hosts: "{{ _hosts|default([]) + [ hostvars[item]['ansible_hostname'] ] }}"
+    _hosts: "{{ _hosts|default([]) + [ hostvars[item]['ansible_fqdn'] ] }}"
   loop: "{{ groups['edpm'] }}"
 
 - name: Create a Ceph RGW spec

--- a/ci_framework/roles/edpm_deploy/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy/tasks/main.yml
@@ -117,6 +117,7 @@
 - name: Run nova-manage discover_hosts to ensure compute nodes are mapped
   when:
     - not cifmw_edpm_deploy_dryrun | bool
+    - not cifmw_edpm_deploy_skip_nova_discover_hosts | default(false) | bool
   environment:
     PATH: "{{ cifmw_path }}"
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"

--- a/ci_framework/roles/hci_prepare/README.md
+++ b/ci_framework/roles/hci_prepare/README.md
@@ -1,0 +1,42 @@
+# hci_prepare
+Prepare steps and files needed when deploying Ceph services alongside with compute nodes using `edpm_deploy` role.
+
+## Privilege escalation
+None.
+
+## Parameters
+* `cifmw_hci_prepare_basedir`: (String) Base directory. Defaults to `cifmw_basedir` which defaults to `~/ci-framework-data`.
+* `cifmw_hci_prepare_dataplane_dir`: (String) Directory in where `edpm_deploy` role will search for DataPlane kustomizations. Defaults to `"{{ cifmw_basedir }}/artifacts/manifests/kustomizations/dataplane"`.
+* `cifmw_hci_prepare_dryrun`: (Boolean) Perform a dry run on a set of commands. Defaults to `False`.
+* `cifmw_hci_prepare_skip_load_parameters`: Skip the initial `load_parameters` step, which load vars to gather network information. Defaults to `False`.
+* `cifmw_hci_prepare_ceph_secret_path`: "/tmp/k8s_ceph_secret.yml"
+* `cifmw_hci_prepare_enable_storage_mgmt`: (Boolean) Creates a kustomization file to include `storage-mgmt` network in DataPlane deployment. Defaults to `True`.
+* `cifmw_hci_prepare_storage_mgmt_mtu`: (Int) Storage-Management network MTU. Defaults to `1500`.
+* `cifmw_hci_prepare_storage_mgmt_vlan`: (Int) Storage-Management network VLAn. Defaults to `23`.
+
+## Examples
+### 1 - How to deploy HCI using hci_prepare and edpm_deploy
+```yaml
+- hosts: localhost
+  tasks:
+    - name: Prepare for HCI deploy phase 1
+      ansible.builtin.import_role:
+        name: hci_prepare
+        tasks_from: phase1.yml
+
+    - name: Deploy EDPM using edpm_deploy role
+      ansible.builtin.import_role:
+        name: edpm_deploy
+
+    - name: Deploy Ceph on edpm nodes
+      ansible.builtin.import_playbook: ceph.yml
+
+    - name: Prepare for HCI deploy phase 2
+      ansible.builtin.import_role:
+        name: hci_prepare
+        tasks_from: phase2.yml
+
+    - name: Continue HCI deployment using edpm_deploy role
+      ansible.builtin.import_role:
+        name: edpm_deploy
+```

--- a/ci_framework/roles/hci_prepare/defaults/main.yml
+++ b/ci_framework/roles/hci_prepare/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+cifmw_hci_prepare_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+cifmw_hci_prepare_dataplane_dir: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/dataplane"
+cifmw_hci_prepare_dryrun: false
+cifmw_hci_prepare_skip_load_parameters: false
+cifmw_hci_prepare_ceph_secret_path: "/tmp/k8s_ceph_secret.yml"
+cifmw_hci_prepare_enable_storage_mgmt: true
+cifmw_hci_prepare_storage_mgmt_mtu: 1500
+cifmw_hci_prepare_storage_mgmt_vlan: 23

--- a/ci_framework/roles/hci_prepare/meta/main.yml
+++ b/ci_framework/roles/hci_prepare/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- hci_prepare
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: edpm
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - edpm
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/ci_framework/roles/hci_prepare/molecule/default/converge.yml
+++ b/ci_framework/roles/hci_prepare/molecule/default/converge.yml
@@ -1,0 +1,92 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: all
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_basedir: "{{ ansible_user_dir }}/ci-framework-data"
+    cifmw_path: "/path/to/bin"
+    cifmw_openshift_kubeconfig: "path/to/kubeconfig"
+    cifmw_hci_prepare_dryrun: true
+    cifmw_install_yamls_defaults:
+      NAMESPACE: openstack
+  tasks:
+    - name: Add compute-0 to inventory
+      ansible.builtin.add_host:
+        name: compute-0
+        ansible_connection: local
+        groups: computes
+
+    - name: Ensure minimal dirs exists
+      become: true
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0777"
+      loop:
+        - "{{ cifmw_basedir }}/artifacts/parameters"
+        - /etc/ci/env
+
+    - name: Expected network info
+      vars:
+        file_content:
+          crc_ci_bootstrap_networks_out:
+            compute-0:
+              storage-mgmt:
+                mtu: 9000
+                vlan: 10
+      ansible.builtin.copy:
+        dest: "{{ cifmw_basedir }}/artifacts/parameters/network_info.yml"
+        content: "{{ file_content | to_nice_yaml }}"
+
+    - name: Run phase1
+      ansible.builtin.import_role:
+        name: hci_prepare
+        tasks_from: phase1
+
+    - name: Assert mtu and vlan values were set
+      ansible.builtin.assert:
+        that:
+          - cifmw_hci_prepare_storage_mgmt_mtu | int == 9000
+          - cifmw_hci_prepare_storage_mgmt_vlan | int == 10
+
+    - name: Check expected kustomizations
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      loop:
+        - "{{ cifmw_hci_prepare_dataplane_dir }}/89-storage-mgmt-kustomization.yaml"
+        - "{{ cifmw_hci_prepare_dataplane_dir }}/88-hci-pre-kustomization.yaml"
+      register: phase1_files
+
+    - name: Check if expected files where created
+      ansible.builtin.assert:
+        that: item.stat.exists
+      loop: "{{ phase1_files.results }}"
+
+    - name: Run phase2
+      ansible.builtin.import_role:
+        name: hci_prepare
+        tasks_from: phase2
+
+    - name: Check expected kustomizations - phase 2
+      ansible.builtin.stat:
+        path: "{{ cifmw_hci_prepare_dataplane_dir }}/87-hci-post-kustomization.yaml"
+      register: phase2_files
+
+    - name: Check if expected files where created - phase 2
+      ansible.builtin.assert:
+        that: phase2_files.stat.exists

--- a/ci_framework/roles/hci_prepare/molecule/default/molecule.yml
+++ b/ci_framework/roles/hci_prepare/molecule/default/molecule.yml
@@ -1,0 +1,9 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true

--- a/ci_framework/roles/hci_prepare/molecule/default/prepare.yml
+++ b/ci_framework/roles/hci_prepare/molecule/default/prepare.yml
@@ -1,0 +1,21 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps

--- a/ci_framework/roles/hci_prepare/tasks/load_parameters.yml
+++ b/ci_framework/roles/hci_prepare/tasks/load_parameters.yml
@@ -1,0 +1,40 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Load parameters
+  ansible.builtin.include_vars:
+    dir: "{{ item }}"
+  loop:
+    - "{{ cifmw_basedir }}/artifacts/parameters"
+    - "/etc/ci/env"
+  loop_control:
+    label: "{{ item }}"
+
+- name: Ensure we have needed bits for compute when needed
+  ansible.builtin.assert:
+    that:
+      - "'compute-0' in crc_ci_bootstrap_networks_out"
+      - "'storage-mgmt' in crc_ci_bootstrap_networks_out['compute-0']"
+
+- name: Set mtu value from crc_ci_bootstrap_networks_out
+  when: "'mtu' in crc_ci_bootstrap_networks_out['compute-0']['storage-mgmt']"
+  ansible.builtin.set_fact:
+    cifmw_hci_prepare_storage_mgmt_mtu: "{{ crc_ci_bootstrap_networks_out['compute-0']['storage-mgmt'].mtu }}"
+
+- name: Set vlan value from crc_ci_bootstrap_networks_out
+  when: "'vlan' in crc_ci_bootstrap_networks_out['compute-0']['storage-mgmt']"
+  ansible.builtin.set_fact:
+    cifmw_hci_prepare_storage_mgmt_vlan: "{{ crc_ci_bootstrap_networks_out['compute-0']['storage-mgmt'].vlan }}"

--- a/ci_framework/roles/hci_prepare/tasks/main.yml
+++ b/ci_framework/roles/hci_prepare/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.

--- a/ci_framework/roles/hci_prepare/tasks/phase1.yml
+++ b/ci_framework/roles/hci_prepare/tasks/phase1.yml
@@ -1,0 +1,89 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Load parameters
+  ansible.builtin.include_tasks: load_parameters.yml
+  when: not cifmw_hci_prepare_skip_load_parameters | bool
+
+- name: Ensure the kustomizations dirs exists
+  ansible.builtin.file:
+    path: "{{ cifmw_hci_prepare_dataplane_dir }}"
+    state: directory
+
+- name: Prepare EDPM netowork for HCI deployment
+  when:
+    - cifmw_hci_prepare_enable_storage_mgmt
+  ansible.builtin.copy:
+    dest: "{{ cifmw_hci_prepare_dataplane_dir }}/89-storage-mgmt-kustomization.yaml"
+    content: |-
+      apiVersion: kustomize.config.k8s.io/v1beta1
+      kind: Kustomization
+      resources:
+      namespace: {{ cifmw_install_yamls_defaults.NAMESPACE }}
+      patches:
+      - target:
+          kind: OpenStackDataPlaneNodeSet
+        patch: |-
+          - op: replace
+            path: /spec/nodeTemplate/ansible/ansibleVars/storage_mgmt_mtu
+            value: {{ cifmw_hci_prepare_storage_mgmt_mtu }}
+
+          - op: replace
+            path: /spec/nodeTemplate/ansible/ansibleVars/storage_mgmt_vlan_id
+            value: {{ cifmw_hci_prepare_storage_mgmt_vlan }}
+
+          - op: add
+            path: /spec/nodeTemplate/ansible/ansibleVars/role_networks/-
+            value: StorageMgmt
+
+          - op: add
+            path: /spec/nodeTemplate/ansible/ansibleVars/networks_lower/StorageMgmt
+            value: storage_mgmt
+
+      {% for compute_node in groups['computes'] %}
+          - op: add
+            path: /spec/nodes/edpm-{{ compute_node }}/networks/-
+            value:
+              name: StorageMgmt
+              subnetName: subnet1
+      {% endfor %}
+
+- name: Enable services needed to deploy Ceph
+  ansible.builtin.copy:
+    dest: "{{ cifmw_hci_prepare_dataplane_dir }}/88-hci-pre-kustomization.yaml"
+    content: |-
+      apiVersion: kustomize.config.k8s.io/v1beta1
+      kind: Kustomization
+      resources:
+      namespace: {{ cifmw_install_yamls_defaults.NAMESPACE }}
+      patches:
+      - target:
+          kind: OpenStackDataPlaneNodeSet
+        patch: |-
+          - op: replace
+            path: /spec/services
+            value:
+              - download-cache
+              - configure-network
+              - validate-network
+              - install-os
+              - ceph-hci-pre
+              - configure-os
+              - run-os
+
+- name: Disable discover_hosts when deploying hci on phase1
+  ansible.builtin.set_fact:
+    cifmw_edpm_deploy_skip_nova_discover_hosts: true

--- a/ci_framework/roles/hci_prepare/tasks/phase2.yml
+++ b/ci_framework/roles/hci_prepare/tasks/phase2.yml
@@ -1,0 +1,104 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+  loop:
+    - "{{ cifmw_hci_prepare_basedir }}/artifacts"
+    - "{{ cifmw_hci_prepare_dataplane_dir }}"
+
+- name: Create Ceph secrets and configure Nova
+  environment:
+    PATH: "{{ cifmw_path }}"
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+  when: not cifmw_hci_prepare_dryrun
+  block:
+    - name: Create ceph config secret
+      ci_script:
+        output_dir: "{{ cifmw_hci_prepare_basedir }}/artifacts"
+        script: "oc apply -f {{ cifmw_hci_prepare_ceph_secret_path }}"
+
+    - name: Set Ceph FSID fact
+      ansible.builtin.set_fact:
+        cifmw_hci_prepare_ceph_fsid: "{{ (lookup('template', cifmw_hci_prepare_ceph_secret_path)|from_yaml).data['ceph.conf'] \
+        | b64decode | regex_search('fsid = (.*)', '\\1') | first | trim }}"
+
+    - name: Generate nova config map
+      ansible.builtin.template:
+        src: templates/configmap-ceph-nova.yml.j2
+        dest: "{{ cifmw_hci_prepare_basedir }}/artifacts/configmap-ceph-nova.yml"
+        mode: "0644"
+
+    - name: Create nova config map
+      ci_script:
+        output_dir: "{{ cifmw_hci_prepare_basedir }}/artifacts"
+        script: "oc apply -f {{ cifmw_hci_prepare_basedir }}/artifacts/configmap-ceph-nova.yml"
+
+    - name: Generate Ceph-Nova Dataplane Service
+      ansible.builtin.template:
+        src: templates/dpservice-nova-custom-ceph.yml.j2
+        dest: "{{ cifmw_hci_prepare_basedir }}/artifacts/dpservice-nova-custom-ceph.yml"
+        mode: "0644"
+
+    - name: Create Ceph-Nova Dataplane Service
+      ci_script:
+        output_dir: "{{ cifmw_hci_prepare_basedir }}/artifacts"
+        script: "oc apply -f {{ cifmw_hci_prepare_basedir }}/artifacts/dpservice-nova-custom-ceph.yml"
+
+- name: Create configuration to finish HCI deployment
+  ansible.builtin.copy:
+    dest: "{{ cifmw_hci_prepare_dataplane_dir }}/87-hci-post-kustomization.yaml"
+    content: |-
+      apiVersion: kustomize.config.k8s.io/v1beta1
+      kind: Kustomization
+      resources:
+      namespace: {{ cifmw_install_yamls_defaults.NAMESPACE }}
+      patches:
+      - target:
+          kind: OpenStackDataPlaneNodeSet
+        patch: |-
+          - op: add
+            path: /spec/nodeTemplate/extraMounts
+            value:
+              - extraVolType: Ceph
+                volumes:
+                - name: ceph
+                  secret:
+                    secretName: ceph-conf-files
+                mounts:
+                - name: ceph
+                  mountPath: "/etc/ceph"
+                  readOnly: true
+          - op: replace
+            path: /spec/services
+            value:
+              - download-cache
+              - configure-network
+              - validate-network
+              - install-os
+              - configure-os
+              - ceph-hci-pre
+              - run-os
+              - ceph-client
+              - ovn
+              - libvirt
+              - nova-custom-ceph
+
+- name: Enabled nova discover_hosts after deployment
+  ansible.builtin.set_fact:
+    cifmw_edpm_deploy_skip_nova_discover_hosts: false

--- a/ci_framework/roles/hci_prepare/templates/configmap-ceph-nova.yml.j2
+++ b/ci_framework/roles/hci_prepare/templates/configmap-ceph-nova.yml.j2
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: ConfigMap
+namespace: {{ cifmw_install_yamls_defaults.NAMESPACE }}
+metadata:
+  name: ceph-nova
+data:
+  03-ceph-nova.conf: |
+    [libvirt]
+    images_type=rbd
+    images_rbd_pool=vms
+    images_rbd_ceph_conf=/etc/ceph/ceph.conf
+    images_rbd_glance_store_name=default_backend
+    images_rbd_glance_copy_poll_interval=15
+    images_rbd_glance_copy_timeout=600
+    rbd_user=openstack
+    rbd_secret_uuid={{ cifmw_hci_prepare_ceph_fsid }}

--- a/ci_framework/roles/hci_prepare/templates/dpservice-nova-custom-ceph.yml.j2
+++ b/ci_framework/roles/hci_prepare/templates/dpservice-nova-custom-ceph.yml.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+namespace: {{ cifmw_install_yamls_defaults.NAMESPACE }}
+metadata:
+  name: nova-custom-ceph
+spec:
+  label: dataplane-deployment-nova-custom-ceph
+  configMaps:
+    - ceph-nova
+  secrets:
+    - nova-cell1-compute-config
+  playbook: osp.edpm.nova

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -91,6 +91,117 @@
                 config_nm: false
 
 - job:
+    name: podified-multinode-hci-deployment-crc-3comp
+    parent: podified-multinode-edpm-deployment-crc
+    nodeset:
+      nodes:
+        - name: controller
+          label: cloud-centos-9-stream-tripleo-vexxhost
+        - name: compute-0
+          label: cloud-centos-9-stream-tripleo-vexxhost
+        - name: compute-1
+          label: cloud-centos-9-stream-tripleo-vexxhost
+        - name: compute-2
+          label: cloud-centos-9-stream-tripleo-vexxhost
+        - name: crc
+          label: coreos-crc-extracted-xxl
+      groups:
+        - name: computes
+          nodes:
+            - compute-0
+            - compute-1
+            - compute-2
+        - name: edpm
+          nodes:
+            - compute-0
+            - compute-1
+            - compute-2
+    vars:
+      cifmw_edpm_deploy_hci: true
+      crc_ci_bootstrap_networking:
+        networks:
+          default:
+            mtu: 1500
+            range: 192.168.122.0/24
+          internal-api:
+            vlan: 20
+            range: 172.17.0.0/24
+          storage:
+            vlan: 21
+            range: 172.18.0.0/24
+          tenant:
+            vlan: 22
+            range: 172.19.0.0/24
+          storage-mgmt:
+            vlan: 23
+            range: 172.20.0.0/24
+        instances:
+          controller:
+            networks:
+              default:
+                ip: 192.168.122.11
+          crc:
+            networks:
+              default:
+                ip: 192.168.122.10
+              internal-api:
+                ip: 172.17.0.5
+              storage:
+                ip: 172.18.0.5
+              tenant:
+                ip: 172.19.0.5
+              storage-mgmt:
+                ip: 172.20.0.5
+          compute-0:
+            networks:
+              default:
+                ip: 192.168.122.100
+              internal-api:
+                ip: 172.17.0.100
+                config_nm: false
+              storage:
+                ip: 172.18.0.100
+                config_nm: false
+              tenant:
+                ip: 172.19.0.100
+                config_nm: false
+              storage-mgmt:
+                ip: 172.20.0.100
+                config_nm: false
+          compute-1:
+            networks:
+              default:
+                ip: 192.168.122.101
+              internal-api:
+                ip: 172.17.0.101
+                config_nm: false
+              storage:
+                ip: 172.18.0.101
+                config_nm: false
+              tenant:
+                ip: 172.19.0.101
+                config_nm: false
+              storage-mgmt:
+                ip: 172.20.0.101
+                config_nm: false
+          compute-2:
+            networks:
+              default:
+                ip: 192.168.122.102
+              internal-api:
+                ip: 172.17.0.102
+                config_nm: false
+              storage:
+                ip: 172.18.0.102
+                config_nm: false
+              tenant:
+                ip: 172.19.0.102
+                config_nm: false
+              storage-mgmt:
+                ip: 172.20.0.102
+                config_nm: false
+
+- job:
     name: podified-multinode-edpm-deployment-crc
     parent: cifmw-podified-multinode-edpm-base-crc
     vars:

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -202,6 +202,16 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
+    - ^ci_framework/roles/hci_prepare/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    name: cifmw-molecule-hci_prepare
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: hci_prepare
+- job:
+    files:
+    - ^ansible-requirements.txt
+    - ^molecule-requirements.txt
     - ^ci_framework/roles/hive/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-hive

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -29,6 +29,7 @@
       - cifmw-molecule-edpm_deploy_baremetal
       - cifmw-molecule-edpm_kustomize
       - cifmw-molecule-edpm_prepare
+      - cifmw-molecule-hci_prepare
       - cifmw-molecule-hive
       - cifmw-molecule-install_ca
       - cifmw-molecule-install_yamls


### PR DESCRIPTION
This patch adds:
* A new multinode job which deploy 3 HCI nodes
* Adds a new role to assist hci deployment.
  This role has 2 main phases, for pre and post ceph deploy:
  * in pre-ceph(phase1), a new storageMgmt network is added, and services
    limited to not deploy: ovn, libvirt and nova
  * in post-ceph(phase2) all other services + ceph_client are added
    back. A new nova service is creted to include ceph backend
    configuration.
* Update deploy-edpm playbook to deploy Ceph and run deploy_edpm role
  twice with differen configuration.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
