### PR TITLE
Remove network_config_override variable

### DIFF
--- a/ci_framework/hooks/playbooks/fetch_compute_facts.yml
+++ b/ci_framework/hooks/playbooks/fetch_compute_facts.yml
@@ -211,42 +211,6 @@
                         {% endraw %}
 
                   - op: replace
-                    path: /spec/nodeTemplate/ansible/ansibleVars/edpm_network_config_override
-                    value: |-
-                        {%- raw %}
-                        ---
-                        {% set mtu_list = [ctlplane_mtu] %}
-                        {% for network in role_networks %}
-                        {{ mtu_list.append(lookup("vars", networks_lower[network] ~ "_mtu")) }}
-                        {%- endfor %}
-                        {% set min_viable_mtu = mtu_list | max %}
-                        network_config:
-                        - type: ovs_bridge
-                          name: {{ neutron_physical_bridge_name }}
-                          mtu: {{ min_viable_mtu }}
-                          use_dhcp: false
-                          dns_servers: {{ ctlplane_dns_nameservers }}
-                          domain: {{ dns_search_domains }}
-                          addresses:
-                          - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
-                          members:
-                          - type: interface
-                            name: nic2
-                            mtu: {{ min_viable_mtu }}
-                            # force the MAC address of the bridge to this interface
-                            primary: true
-                        {% for network in role_networks %}
-                          - type: vlan
-                            mtu: 1496
-                            vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
-                            addresses:
-                            - ip_netmask:
-                                {{ lookup("vars", networks_lower[network] ~ "_ip") }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
-                            routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
-                        {% endfor %}
-                        {% endraw %}
-
-                  - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleUser
                     value: "{{ hostvars['compute-0'].ansible_user | default('zuul') }}"
 


### PR DESCRIPTION
This change removes all use of the edpm_network_config_override variable in ci-framework. This variable has been removed from the network_config role.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
