### PR TITLE
Correct parameter value

### DIFF
--- a/scenarios/centos-9/edpm_ci.yml
+++ b/scenarios/centos-9/edpm_ci.yml
@@ -45,6 +45,6 @@ post_ctlplane_deploy:
     source: validate_podified_deployment.yml
     extra_vars:
       podified_validation: "{{ podified_validation | default ('false') | bool }}"
-      cifmw_openshift_login_kubeconfig: "{{ cifmw_openshift_login_kubeconfig }}"
+      cifmw_openshift_kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
       cifmw_path: "{{ cifmw_path }}"
       openstack_namespace: "{{ cifmw_install_yamls_defaults['NAMESPACE'] }}"


### PR DESCRIPTION
This is the "quick-fix", the "right" way would be to modify the hook in
order to `include_vars` on the generated environment file, allowing to
access all of the data such as the path, namespace and so on.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
