### PR TITLE
Use dlrnapi agg-status to fetch the CI results for a particular hash

### DIFF
--- a/ci_framework/roles/dlrn_promote/tasks/check_reported_jobs.yml
+++ b/ci_framework/roles/dlrn_promote/tasks/check_reported_jobs.yml
@@ -7,20 +7,11 @@
       {% if cifmw_dlrn_promote_kerberos_auth|bool -%}
       --server-principal {{ cifmw_dlrn_promote_dlrnapi_host_principal }} --auth-method kerberosAuth --force-auth
       {% endif -%}
-      repo-status
+      agg-status
       {% if (cifmw_repo_setup_full_hash is defined) and (cifmw_repo_setup_full_hash | length > 0) -%}
       --agg-hash {{ cifmw_repo_setup_full_hash }}
       {% endif -%}
-      {% if (cifmw_repo_setup_extended_hash is defined) and (cifmw_repo_setup_extended_hash | length > 0) -%}
-      --extended_hash {{ cifmw_repo_setup_extended_hash }}
-      {% endif -%}
-      {% if (cifmw_repo_setup_commit_hash is defined) and (cifmw_repo_setup_commit_hash | length > 0) -%}
-      --commit_hash {{ cifmw_repo_setup_commit_hash }}
-      {% endif -%}
-      {% if (cifmw_repo_setup_distro_hash is defined) and (cifmw_repo_setup_distro_hash | length > 0) -%}
-      --distro_hash {{ cifmw_repo_setup_distro_hash }}
-      {% endif -%}
-       --success true
+      --success true
       | tee -a {{ cifmw_dlrn_promote_workspace }}/cifmw_dlrn_promote_repo_success_output.txt
   environment: |
     {{ zuul | zuul_legacy_vars | combine({


### PR DESCRIPTION
dlrnapi repo-status depends on commit hash and distro hash which is generated when we query repo-status for a particular component with the full hash.

Here component is not in play during antelope/master promotion. So we use agg-status option to get the results.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

