### PR TITLE
Fix RGW default value

### DIFF
--- a/ci_framework/roles/cifmw_cephadm/defaults/main.yml
+++ b/ci_framework/roles/cifmw_cephadm/defaults/main.yml
@@ -66,7 +66,7 @@ cifmw_cephadm_pacific_filter: "16.*"
 cifmw_cephadm_dashboard_enabled: false
 # The path of the rendered rgw spec file
 cifmw_ceph_rgw_spec_path: /tmp/ceph_rgw.yml
-cifmw_ceph_rgw_keystone_ep: "keystone-public-openstack.apps-crc.testing"
+cifmw_ceph_rgw_keystone_ep: "keystone-internal.openstack.svc:5000"
 cifmw_ceph_rgw_keystone_psw: 12345678
 cifmw_ceph_rgw_keystone_user: "swift"
 cifmw_ceph_rgw_config:


### PR DESCRIPTION
When Ceph is deployed using the HCI model in the EDPM nodes, we need to point by default to the keystone-internal service instead of the public Route.
This value can be overriden in all the other use cases and a doc patch aligned with this change has already been proposed [1].

[1] https://github.com/openstack-k8s-operators/docs/pull/63

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
- [x] README in the role
- [x] Content of the docs/source is reflecting the changes
