### PR TITLE
Fixing missing comma in autohold URI

### DIFF
--- a/ci/playbooks/multinode-authold.yml
+++ b/ci/playbooks/multinode-authold.yml
@@ -18,7 +18,7 @@
                 [
                   ('https://'+ (zuul.executor.hostname | split('.'))[1:] | join('.')),
                   'zuul',
-                  'api'
+                  'api',
                   'tenant',
                   zuul.tenant,
                   'autoholds'


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date: