### PR TITLE
Fix the file name for check_reported_jobs taskfile

### DIFF
--- a/ci_framework/roles/dlrn_promote/tasks/check_reported_jobs.yml
+++ b/ci_framework/roles/dlrn_promote/tasks/check_reported_jobs.yml
@@ -23,7 +23,7 @@
 
 - name: Get the the DLRN output results
   ansible.builtin.slurp:
-    path: "{{ cifmw_dlrn_promote_workspace }}/cifmw_dlrn_promote_hash_report_status_output.txt"
+    path: "{{ cifmw_dlrn_promote_workspace }}/cifmw_dlrn_promote_repo_success_output.txt"
   register: cifmw_dlrn_promote_hash_report_status_output_from_slurp
 
 - name: Set fact for DLRN output results


### PR DESCRIPTION
dlrnapi agg-status command output is stored in
cifmw_dlrn_promote_repo_success_output.txt file but we are reading cifmw_dlrn_promote_hash_report_status_output.txt in the next task. But cifmw_dlrn_promote_hash_report_status_output.txt does not exists leading to task failure.

Fixing the file name fixes the issue.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

