### PR TITLE
Add test dir under irrelevant_files list

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -17,14 +17,12 @@
       - ^PROJECT$
       - ^README.md$
       - ^renovate.json$
-      - ^tests/.*$
       - ^kuttl-test.yaml$
       - molecule/.*
       - molecule-requirements.txt
       - .github/workflows
       - docs/.*
       - contribute/.*
-      - tests
       - roles/.*/molecule/.*
       # ci-framework
       - .readthedocs.yaml
@@ -35,6 +33,7 @@
       - .gitignore
       - .golangci.yaml
       - .pre-commit-config.yaml
+      - tests?\/functional
       # openstack-ansibleee-operator
       - examples
       - mkdocs.yml


### PR DESCRIPTION
test dir in operator codebase contains tests. We donot want to run content provider on it. Adding it under irrelevant_files skips the content provider job.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

