### PR TITLE
Allow to retry tempest run

### DIFF
--- a/ci_framework/roles/tempest/README.md
+++ b/ci_framework/roles/tempest/README.md
@@ -17,6 +17,8 @@ become - Required to install required rpm packages
 * `cifmw_tempest_tests_allowed`: (List) List of tests to be executed. Setting this will not use the `list_allowed` plugin
 * `cifmw_tempest_tempestconf_profile`: (Dictionary) List of settings to be overwritten in tempest.conf.
 * `cifmw_tempest_concurrency`: (Integer) Tempest concurrency value.
+* `cifmw_tempest_retries`: (Integer) Number of retries of tempest run.
+* `cifmw_tempest_retries_delay`: (Integer) Delay between retries.
 
 ## Use of cifmw_tempest_tempestconf_profile
 

--- a/ci_framework/roles/tempest/defaults/main.yml
+++ b/ci_framework/roles/tempest/defaults/main.yml
@@ -27,3 +27,5 @@ cifmw_tempest_image_tag: current-podified
 cifmw_tempest_dry_run: false
 cifmw_tempest_remove_container: false
 cifmw_tempest_concurrency: 4
+cifmw_tempest_retries: 2
+cifmw_tempest_retries_delay: 10

--- a/ci_framework/roles/tempest/tasks/main.yml
+++ b/ci_framework/roles/tempest/tasks/main.yml
@@ -37,40 +37,45 @@
     cmd: "podman unshare chown 42480:42480 -R {{ cifmw_tempest_artifacts_basedir }}"
   when: not cifmw_tempest_dry_run | bool
 
-- name: Run tempest
-  ignore_errors: true
-  containers.podman.podman_container:
-    name: tempest
-    image: "{{ cifmw_tempest_image }}:{{ cifmw_tempest_image_tag }}"
-    state: started
-    auto_remove: "{{ cifmw_tempest_remove_container | default(false) }}"
-    network: host
-    volume:
-      - "{{ cifmw_tempest_artifacts_basedir }}/:/var/lib/tempest/external_files:Z"
-    detach: false
-    env:
-      CONCURRENCY: "{{ cifmw_tempest_concurrency | default(omit) }}"
-  when: not cifmw_tempest_dry_run | bool
-  register: tempest_run_output
+- name: Wrap tempest run
+  block:
+    - name: Run tempest
+      when: not cifmw_tempest_dry_run | bool
+      register: tempest_run_output
+      retries: "{{ cifmw_tempest_retries | int}}"
+      delay: "{{ cifmw_tempest_retries_delay | int }}"
+      until: not tempest_run_output.failed
+      containers.podman.podman_container:
+        name: tempest
+        image: "{{ cifmw_tempest_image }}:{{ cifmw_tempest_image_tag }}"
+        state: started
+        auto_remove: "{{ cifmw_tempest_remove_container | default(false) }}"
+        network: host
+        volume:
+          - "{{ cifmw_tempest_artifacts_basedir }}/:/var/lib/tempest/external_files:Z"
+        detach: false
+        env:
+          CONCURRENCY: "{{ cifmw_tempest_concurrency | default(omit) }}"
 
-- name: Change tempest directory permission back to original
-  become: true
-  ansible.builtin.file:
-    path: "{{ cifmw_tempest_artifacts_basedir }}"
-    state: directory
-    recurse: true
-    owner: "{{ lookup('env', 'USER') }}"
-    group: "{{ lookup('env', 'USER') }}"
+  always:
+    - name: Change tempest directory permission back to original
+      become: true
+      ansible.builtin.file:
+        path: "{{ cifmw_tempest_artifacts_basedir }}"
+        state: directory
+        recurse: true
+        owner: "{{ lookup('env', 'USER') }}"
+        group: "{{ lookup('env', 'USER') }}"
 
-- name: Save logs from podman
-  when: not cifmw_tempest_dry_run | bool
-  ansible.builtin.copy:
-    dest: "{{ cifmw_tempest_artifacts_basedir }}/podman_tempest.log"
-    content: |
-      "{{ tempest_run_output.stdout }}"
+    - name: Save logs from podman
+      when: not cifmw_tempest_dry_run | bool
+      ansible.builtin.copy:
+        dest: "{{ cifmw_tempest_artifacts_basedir }}/podman_tempest.log"
+        content: |
+          "{{ tempest_run_output.stdout }}"
 
-- name: Fail if podman container did not succeed
-  when: not cifmw_tempest_dry_run | bool
-  ansible.builtin.assert:
-    that:
-      - "tempest_run_output.failed == false"
+    - name: Fail if podman container did not succeed
+      when: not cifmw_tempest_dry_run | bool
+      ansible.builtin.assert:
+        that:
+          - "tempest_run_output.failed == false"


### PR DESCRIPTION
From time to time, tempest fails due to OpenStack API going down. Let's
allow it to re-run after a small delay to see if it can avoid a full
"recheck" in RDO.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
