### PR TITLE
Improvements to dlrn_promote playbook

### DIFF
--- a/ci_framework/roles/dlrn_promote/tasks/check_promotion_criteria.yml
+++ b/ci_framework/roles/dlrn_promote/tasks/check_promotion_criteria.yml
@@ -23,6 +23,6 @@
 
     - name: Query to match promotion criteria
       ansible.builtin.include_tasks: query_criteria.yml
-      with_items: "{{ criteria[promote_target] }}"
+      with_items: "{{ criteria[cifmw_dlrn_promote_promotion_target] }}"
       loop_control:
         loop_var: "cifmw_dlrn_promote_criteria_job"

--- a/ci_framework/roles/dlrn_promote/tasks/check_reported_jobs.yml
+++ b/ci_framework/roles/dlrn_promote/tasks/check_reported_jobs.yml
@@ -29,7 +29,7 @@
 - name: Set fact for DLRN output results
   ansible.builtin.set_fact:
     cifmw_dlrn_promote_hash_report_status_output:
-      "{{ cifmw_dlrn_promote_hash_report_status_output_from_slurp['content'] | b64decode | from_yaml }}"
+      "{{ cifmw_dlrn_promote_hash_report_status_output_from_slurp['content'] | b64decode | from_yaml | map(attribute='job_id') }}"
     cacheable: true
 
 - name: Debug reported jobs from dlrnapi output

--- a/ci_framework/roles/dlrn_promote/tasks/query_criteria.yml
+++ b/ci_framework/roles/dlrn_promote/tasks/query_criteria.yml
@@ -3,28 +3,18 @@
   block:
     - name: Debug criteria job
       ansible.builtin.debug:
-        msg: "DEBUG: criteria job --->{{ criteria_job }}<---"
+        msg: "DEBUG: criteria job --->{{ cifmw_dlrn_promote_criteria_job }}<---"
 
     - name: Debug reported jobs
       ansible.builtin.debug:
-        msg: "DEBUG: dlrnapi reported jobs --->{{ reported_jobs.stdout | from_json }}<---"
-
-    - name: Debug json query result
-      vars:
-        query: "[?contains(job_id, '{{ criteria_job }}')]"
-      ansible.builtin.debug:
-        msg: "DEBUG: json query result --->{{ reported_jobs.stdout | from_json | json_query(query) }}<---"
+        msg: "DEBUG: dlrnapi reported jobs --->{{ cifmw_dlrn_promote_hash_report_status_output }}<---"
 
     - name: Criteria failed?
       ansible.builtin.fail:
         msg: "FAILURE! :( Promotion criteria failed to match."
-      vars:
-        query: "[?contains(job_id, '{{ criteria_job }}')]"
-      when: reported_jobs.stdout | from_json | json_query(query) == []
+      when: cifmw_dlrn_promote_criteria_job not in cifmw_dlrn_promote_hash_report_status_output
 
     - name: Criteria match?
       ansible.builtin.debug:
         msg: "SUCCESS! :) Promotion criteria match!"
-      vars:
-        query: "[?contains(job_id, '{{ criteria_job }}')]"
-      when: reported_jobs.stdout | from_json | json_query(query) != []
+      when: cifmw_dlrn_promote_criteria_job in cifmw_dlrn_promote_hash_report_status_output


### PR DESCRIPTION
- Fixes the criteria var names used in query_criteria playbook
- Make the checking criteria logic simple by filtering the reported jobs from dlrn agg hash and checking the criteria job in reported job and then promote the content.
- Drop unwanted noise of playbook

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

