### PR TITLE
Fix the var name for cifmw_dlrn_promote_kerberos_auth

### DIFF
--- a/ci_framework/roles/dlrn_promote/tasks/promote_hash.yml
+++ b/ci_framework/roles/dlrn_promote/tasks/promote_hash.yml
@@ -3,7 +3,7 @@
   ansible.builtin.shell:
     cmd: >-
       dlrnapi --url {{ cifmw_repo_setup_dlrn_api_url }}
-      {% if cifmw_dlrn_report_kerberos_auth|bool -%}
+      {% if cifmw_dlrn_promote_kerberos_auth|bool -%}
       --server-principal {{ cifmw_dlrn_report_dlrnapi_host_principal }} --auth-method kerberosAuth
       {% endif -%}
       repo-promote


### PR DESCRIPTION
It should be cifmw_dlrn_promote_kerberos_auth not
cifmw_dlrn_report_kerberos_auth.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

