### PR TITLE
Improve dlrn_promote role

### DIFF
--- a/ci_framework/roles/dlrn_promote/README.md
+++ b/ci_framework/roles/dlrn_promote/README.md
@@ -18,6 +18,7 @@ This role does not need privilege escalation.
 * `cifmw_dlrn_promote_hash`: (boolean) Whether to run DLRN promote hash. Default: `false`
 * `cifmw_dlrn_promote_ssl_ca_bundle`: (string) Path to SSL CA cert. Default: `"/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt"`
 * `cifmw_dlrn_promote_hash_promote_content`: (boolean) Whether to promote DLRN content. Default: `false`
+* `cifmw_dlrn_promote_dlrnrepo_path`: (String) Path tp delorean.repo file Default: `{{ cifmw_dlrn_promote_workspace }}/artifacts/repositories/delorean.repo`
 
 ### Notes
 

--- a/ci_framework/roles/dlrn_promote/defaults/main.yml
+++ b/ci_framework/roles/dlrn_promote/defaults/main.yml
@@ -26,3 +26,4 @@ cifmw_dlrn_promote_criteria_file: ""
 cifmw_dlrn_promote_hash: false
 cifmw_dlrn_promote_hash_promote_content: false
 cifmw_dlrn_promote_ssl_ca_bundle: "/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt"
+cifmw_dlrn_promote_dlrnrepo_path: "{{ cifmw_dlrn_promote_workspace }}/artifacts/repositories/delorean.repo"

--- a/ci_framework/roles/dlrn_promote/molecule/default/converge.yml
+++ b/ci_framework/roles/dlrn_promote/molecule/default/converge.yml
@@ -18,5 +18,13 @@
   hosts: all
   vars:
     cifmw_dlrn_promote_hash: false
-  roles:
-    - role: "dlrn_promote"
+    cifmw_repo_setup_os_release: centos
+  tasks:
+    - name: Run repo-setup role
+      ansible.builtin.include_role:
+        name: repo_setup
+
+    - name: Check get_hashes playbook
+      ansible.builtin.include_role:
+        name: dlrn_promote
+        tasks_from: get_hashes.yml

--- a/ci_framework/roles/dlrn_promote/tasks/get_hash_from_commit.yaml
+++ b/ci_framework/roles/dlrn_promote/tasks/get_hash_from_commit.yaml
@@ -1,0 +1,55 @@
+---
+- name: Get commit.yaml file
+  ansible.builtin.get_url:
+    url: "{{ commit_url }}/commit.yaml"
+    dest: "{{ cifmw_dlrn_promote_workspace }}/commit.yaml"
+    force: true
+  register: result
+  until: result is success
+  retries: 6
+  delay: 50
+
+- name: Load data from commit.yaml file
+  ansible.builtin.include_vars:
+    file: "{{ cifmw_dlrn_promote_workspace }}/commit.yaml"
+    name: _hashes
+
+- name: Get individual commit/distro hashes
+  ansible.builtin.set_fact:
+    cifmw_dlrn_promote_distro_hash: "{{ _hashes['commits'][0]['distro_hash'] }}"
+    cifmw_dlrn_promote_commit_hash: "{{ _hashes['commits'][0]['commit_hash'] }}"
+
+- name: Get individual extended hash - if it is not None
+  ansible.builtin.set_fact:
+    cifmw_dlrn_promote_extended_hash: "{{ _hashes['commits'][0]['extended_hash'] }}"
+  when: _hashes['commits'][0]['extended_hash'] != 'None'
+
+- name: Print out commit_hash
+  ansible.builtin.debug:
+    var: cifmw_dlrn_promote_commit_hash
+
+- name: Print out distro_hash
+  ansible.builtin.debug:
+    var: cifmw_dlrn_promote_distro_hash
+
+- name: Print out extended_hash
+  ansible.builtin.debug:
+    var: cifmw_dlrn_promote_extended_hash
+  when: cifmw_dlrn_promote_extended_hash is defined
+
+- name: Converge commit/distro hashes into full_hash
+  ansible.builtin.set_fact:
+    cifmw_dlrn_promote_full_hash: "{{ cifmw_dlrn_promote_commit_hash }}_{{ cifmw_dlrn_promote_distro_hash[:8] }}"
+
+- name: Add extended_hash to full_hash if defined
+  ansible.builtin.set_fact:
+    cifmw_dlrn_promote_full_hash: "{{ cifmw_dlrn_promote_full_hash }}_{{ cifmw_dlrn_promote_extended_hash.split('_')[0][:8] }}_{{ cifmw_dlrn_promote_extended_hash.split('_')[1][:8] }}"
+  when: cifmw_dlrn_promote_extended_hash is defined
+
+- name: Print out full_hash
+  ansible.builtin.debug:
+    var: cifmw_dlrn_promote_full_hash
+
+- name: Run promotion
+  ansible.builtin.include_tasks: promote_hash.yml
+  when: cifmw_dlrn_promote_hash_promote_content | bool

--- a/ci_framework/roles/dlrn_promote/tasks/get_hashes.yml
+++ b/ci_framework/roles/dlrn_promote/tasks/get_hashes.yml
@@ -1,0 +1,21 @@
+---
+- name: Copy delorean.repo to dlrn_promote workspace
+  ansible.builtin.fetch:
+    src: "{{ cifmw_dlrn_promote_dlrnrepo_path }}"
+    dest: "{{ cifmw_dlrn_promote_workspace }}/"
+    flat: true
+
+- name: Get baseurls from delorean.repo
+  ansible.builtin.shell:
+    cmd: >-
+      set -o pipefail;
+      cat {{ cifmw_dlrn_promote_workspace }}/delorean.repo
+      | grep  'baseurl=' | cut -d '=' -f 2
+  register: base_urls
+  changed_when: true
+
+- name: Run promotion for each base component urls
+  ansible.builtin.include_tasks: get_hash_from_commit.yaml
+  with_items: "{{ base_urls.stdout_lines }}"
+  loop_control:
+    loop_var: "commit_url"

--- a/ci_framework/roles/dlrn_promote/tasks/main.yml
+++ b/ci_framework/roles/dlrn_promote/tasks/main.yml
@@ -37,5 +37,5 @@
       ansible.builtin.import_tasks: check_promotion_criteria.yml
 
     - name: Promote promote_source to target_source
-      ansible.builtin.import_tasks: promote_hash.yml
+      ansible.builtin.import_tasks: get_hashes.yml
       when: cifmw_dlrn_promote_hash_promote_content | bool

--- a/ci_framework/roles/dlrn_promote/tasks/promote_hash.yml
+++ b/ci_framework/roles/dlrn_promote/tasks/promote_hash.yml
@@ -7,19 +7,14 @@
       --server-principal {{ cifmw_dlrn_report_dlrnapi_host_principal }} --auth-method kerberosAuth
       {% endif -%}
       repo-promote
-      {% if (cifmw_repo_setup_dlrn_hash_tag is defined) and (cifmw_repo_setup_dlrn_hash_tag | length > 0) -%}
-      --agg-hash {{ cifmw_repo_setup_dlrn_hash_tag }}
-      {% elif (cifmw_repo_setup_full_hash is defined) and (cifmw_repo_setup_full_hash | length > 0) -%}
-      --agg-hash {{ cifmw_repo_setup_full_hash }}
+      {% if (cifmw_dlrn_promote_extended_hash is defined) and (cifmw_repo_setup_extended_hash | length > 0) -%}
+      --extended_hash {{ cifmw_dlrn_promote_extended_hash }}
       {% endif -%}
-      {% if (cifmw_repo_setup_extended_hash is defined) and (cifmw_repo_setup_extended_hash | length > 0) -%}
-      --extended_hash {{ cifmw_repo_setup_extended_hash }}
+      {% if cifmw_dlrn_promote_commit_hash | length > 0 -%}
+      --commit_hash {{ cifmw_dlrn_promote_commit_hash }}
       {% endif -%}
-      {% if (cifmw_repo_setup_commit_hash is defined) and (cifmw_repo_setup_commit_hash | length > 0) -%}
-      --commit_hash {{ cifmw_repo_setup_commit_hash }}
-      {% endif -%}
-      {% if (cifmw_repo_setup_distro_hash is defined) and (cifmw_repo_setup_distro_hash | length > 0) -%}
-      --distro_hash {{ cifmw_repo_setup_distro_hash }}
+      {% if cifmw_dlrn_promote_distro_hash | length > 0 -%}
+      --distro_hash {{ cifmw_dlrn_promote_distro_hash }}
       {% endif -%}
       --promote-name { cifmw_dlrn_promote_promotion_target }}
   environment: |

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -1,3 +1,4 @@
+
 abcdefghij
 addr
 ansible
@@ -87,6 +88,7 @@ disablecertificateverification
 distro
 dlrn
 dlrnapi
+dlrnrepo
 dm
 dnf
 dns
@@ -311,6 +313,7 @@ tldca
 tls
 tmp
 todo
+tp
 tripleo
 txt
 uefi

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -28,6 +28,8 @@
       - roles/.*/molecule/.*
       # ci-framework
       - .readthedocs.yaml
+      - ci_framework/roles/dlrn_report
+      - ci_framework/roles/dlrn_promote
       # Other openstack operators
       - containers/ci
       - .ci-operator.yaml


### PR DESCRIPTION
dlrnapi repo-promote works on distro hash and commit hash. Delorean.repo contains a list of base urls for each component. Each component base_url/commit.yaml contains distro, commit and extended hash.

This pr adds the taskfiles to fetch all base_urls from delorean.repo and then get commits.yaml, extract the distro, commit and extended hash and pass it promote_hash.yml taskfiles and do the promotion.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

