### PR TITLE
Allow to customize the inventory hostname for CRC

### DIFF
--- a/ci_framework/hooks/playbooks/fetch_compute_facts.yml
+++ b/ci_framework/hooks/playbooks/fetch_compute_facts.yml
@@ -38,6 +38,10 @@
       loop_control:
         label: "{{ item }}"
 
+    - name: Ensure CRC hostname is set
+      ansible.builtin.set_fact:
+        _crc_hostname: "{{ cifmw_crc_hostname | default('crc') }}"
+
     - name: Check we have some compute in inventory
       ansible.builtin.set_fact:
         computes_len: "{{ groups['computes'] | length }}"
@@ -46,8 +50,8 @@
       ansible.builtin.assert:
         that:
           - crc_ci_bootstrap_networks_out is defined
-          - "'crc' in crc_ci_bootstrap_networks_out"
-          - "'default' in crc_ci_bootstrap_networks_out['crc']"
+          - crc_ci_bootstrap_networks_out[_crc_hostname] is defined
+          - crc_ci_bootstrap_networks_out[_crc_hostname]['default'] is defined
 
     - name: Ensure we have needed bits for compute when needed
       when:
@@ -60,8 +64,8 @@
     - name: Set facts for further usage within the framework
       ansible.builtin.set_fact:
         cifmw_edpm_prepare_extra_vars:
-          NNCP_INTERFACE: "{{ crc_ci_bootstrap_networks_out.crc.default.iface }}"
-          NETWORK_MTU: "{{ crc_ci_bootstrap_networks_out.crc.default.mtu }}"
+          NNCP_INTERFACE: "{{ crc_ci_bootstrap_networks_out[_crc_hostname].default.iface }}"
+          NETWORK_MTU: "{{ crc_ci_bootstrap_networks_out[_crc_hostname].default.mtu }}"
 
     - name: Ensure the kustomizations dirs exists
       ansible.builtin.file:

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -15,6 +15,8 @@ The following parameters allow to set a common value for parameters that
 are shared among multiple roles:
 * `cifmw_basedir`: The base directory for all of the artifacts. Defaults to
 `~/ci-framework-data`
+* `cifmw_crc_hostname`: Allow to set the actual CRC inventory hostname. Mostly used in the fetch_compute_facts hook
+in the multinode layout, especially for the reproducer case.
 * `cifmw_edpm_deploy_baremetal`: (Bool) Toggle whether to deploy edpm on compute nodes
 provisioned with virtual baremetal vs pre-provisioned VM.
 * `cifmw_installyamls_repos`: install_yamls repository location. Defaults to `../..`


### PR DESCRIPTION
In order to properly support the CI Job reproducer, we have to ensure
we're able to customize a bit the "crc" inventory hostname.

This change allows to inject a custom parameter file in
artifacts/parameters containing `cifmw_crc_hostname: crc-0` we need,
while defaulting on the `crc` we have in current CI layout.t

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] Content of the docs/source is reflecting the changes
