### PR TITLE
Ensure we fetch generated parameters

### DIFF
--- a/ci_framework/roles/artifacts/tasks/edpm.yml
+++ b/ci_framework/roles/artifacts/tasks/edpm.yml
@@ -72,6 +72,7 @@
           set -x
           sudo dnf install -y rsync
           mkdir -p /tmp/{{ host_ip }}
+          sudo test -d /etc/ci/env && sudo cp -r /etc/ci/env /tmp/{{ host_ip }}/ci-env
           sudo cp -a /var/log/ /tmp/{{ host_ip }}
           sudo test -d /var/lib/openstack && sudo cp -a /var/lib/openstack /tmp/{{ host_ip }}
           sudo test -d /var/lib/config-data && sudo cp -a /var/lib/config-data /tmp/{{ host_ip }}

--- a/ci_framework/roles/artifacts/tasks/environment.yml
+++ b/ci_framework/roles/artifacts/tasks/environment.yml
@@ -21,6 +21,7 @@
       cp -r /etc/NetworkManager/system-connections {{ cifmw_artifacts_basedir }}/artifacts/NetworkManager
       find {{ cifmw_artifacts_basedir }}/artifacts/NetworkManager -type f -exec chmod 0644 '{}' \;
       find {{ cifmw_artifacts_basedir }}/artifacts/NetworkManager -type d -exec chmod 0755 '{}' \;
+      test -d /etc/ci/env && cp -r /etc/ci/env {{ cifmw_artifacts_basedir }}/artifacts/ci-env
       ip ro ls > {{ cifmw_artifacts_basedir }}/artifacts/ip-network.txt
       ip rule ls >> {{ cifmw_artifacts_basedir }}/artifacts/ip-network.txt
       ip -j -p link ls >> {{ cifmw_artifacts_basedir }}/artifacts/ip-network.txt


### PR DESCRIPTION
Until now, we were missing an important piece of the CI job bootstrap,
generated by the bootstrap playbooks. Thost information describe the
network layout and are later consumed by a hook in the case of multinode
+ compute jobs.

Ensuring we get a hold on those data for later reference is important,
since it may help debugging networking related issues.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
