### PR TITLE
Make ci_network role aware of crc_ci_bootstrap_networks_out

### DIFF
--- a/ci_framework/roles/ci_network/README.md
+++ b/ci_framework/roles/ci_network/README.md
@@ -41,3 +41,7 @@ cifmw_network_layout:
       gw6:  # Optional. IPv6 gateway.
       dns6:  # Optional. IPV6 DNS servers list.
 ```
+
+## Bootstrap CI
+It will also look for a specific parameter from the CI Bootstrap steps: `crc_ci_bootstrap_networks_out`.
+If it finds it, it will consume it instead of `cifmw_network_layout`.

--- a/ci_framework/roles/ci_network/molecule/default/prepare.yml
+++ b/ci_framework/roles/ci_network/molecule/default/prepare.yml
@@ -34,7 +34,7 @@
         dest: "/etc/ci/env/network-layout.yml"
         mode: "0644"
         content: |
-          cifmw_network_layout_gen:
+          crc_ci_bootstrap_networks_out:
             {{ inventory_hostname }}:
               vlan20:
                 iface: "eth0.20"

--- a/ci_framework/roles/ci_network/tasks/main.yml
+++ b/ci_framework/roles/ci_network/tasks/main.yml
@@ -29,7 +29,7 @@
   vars:
     _net_layout: >-
       {{
-        cifmw_network_layout_gen | default(cifmw_network_layout)
+        crc_ci_bootstrap_networks_out | default(cifmw_network_layout)
       }}
   ansible.builtin.import_tasks: validate.yml
 
@@ -64,7 +64,7 @@
   vars:
     _net_layout: >-
       {{
-        cifmw_network_layout_gen | default(cifmw_network_layout)
+        crc_ci_bootstrap_networks_out | default(cifmw_network_layout)
       }}
   ansible.builtin.include_tasks: apply.yml
   loop: "{{ _net_layout[inventory_hostname] | dict2items }}"


### PR DESCRIPTION
Consuming that parameter will allow a smoother transition to that role,
and will help converging the reproducer.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/615

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
