### PR TITLE
Make sure parameters directory exists on install_yamls role

### DIFF
--- a/ci_framework/roles/install_yamls/tasks/main.yml
+++ b/ci_framework/roles/install_yamls/tasks/main.yml
@@ -23,6 +23,7 @@
   loop:
     - "{{ cifmw_install_yamls_out_dir }}"
     - "{{ cifmw_install_yamls_tasks_out }}"
+    - "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts/parameters"
 
 - name: Set environment override cifmw_install_yamls_environment fact
   tags:


### PR DESCRIPTION
When we call install_yamls role seperately, It fails with parameters directory does not exist. This pr makes sure the directory exists before copying files in parameters directory.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

