### PR TITLE
Rename ee image var to RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT

### DIFF
--- a/ci/playbooks/build_runner_image.yml
+++ b/ci/playbooks/build_runner_image.yml
@@ -45,5 +45,5 @@
           cifmw_edpm_prepare_update_os_containers: true
           cifmw_set_openstack_containers_operator_name: openstack-ansibleee
           cifmw_set_openstack_containers_overrides:
-            ANSIBLEEE_IMAGE_URL_DEFAULT: "{{ ansibleee_runner_img }}"
+            RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT: "{{ ansibleee_runner_img }}"
         dest: "{{ ansible_user_dir }}/ci-framework-data/artifacts/edpm-ansible.yml"


### PR DESCRIPTION
ee-runner image env var got changed to RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT var by
https://github.com/openstack-k8s-operators/openstack-ansibleee-operator/pull/226.

We need to update the same to update the proper edpm image during deployment.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
