### PR TITLE
Remove the 3-replicas Galera configuration

### DIFF
--- a/scenarios/centos-9/ci.yml
+++ b/scenarios/centos-9/ci.yml
@@ -31,7 +31,6 @@ post_ctlplane_deploy:
 
 cifmw_install_yamls_vars:
   BMO_SETUP: false
-  GALERA_REPLICAS: 3
 
 # Enable tempest
 cifmw_run_tests: true

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -26,8 +26,6 @@
       cifmw_use_libvirt: false
       podified_validation: true
       cifmw_run_tests: false
-      make_openstack_deploy_params:
-        GALERA_REPLICAS: 3
 
 # Install Yamls specific job
 - job:


### PR DESCRIPTION
There's no sense to deploy a 3-replicas galera on a single CRC node.
This is more a layout for the Validated Architecture.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running