### PR TITLE
Set DATAPLANE_GROWVOLS_ARGS for baremetal job

### DIFF
--- a/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
+++ b/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
@@ -9,6 +9,7 @@ cifmw_install_yamls_vars:
   BMAAS_INSTANCE_MEMORY: 8192
   BMAAS_INSTANCE_VCPUS: 6
   BMAAS_INSTANCE_DISK_SIZE: 40
+  DATAPLANE_GROWVOLS_ARGS: "/=8GB /tmp=1GB /home=1GB /var=8GB"
 
 pre_infra:
   - name: Download needed tools


### PR DESCRIPTION
Now that DATAPLANE_GROWVOLS_ARGS is a variable the current value should be set in the job, since the value is specific to the BMAAS_INSTANCE_DISK_SIZE in this job.

The value in install_yamls[1] can be set to an empty string after this is merged, so that developers can install with the default.

[1] https://github.com/openstack-k8s-operators/install_yamls/blob/main/devsetup/Makefile#L34

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
