### PR TITLE
Ensure we deploy EDPM

### DIFF
--- a/ci_framework/roles/edpm_deploy/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy/tasks/main.yml
@@ -15,6 +15,9 @@
 # under the License.
 
 - name: Set EDPM related vars
+  when:
+    - cifmw_install_yamls_environment is defined
+    - cifmw_install_yamls_defaults is defined
   tags:
     - always
   ansible.builtin.set_fact:

--- a/scenarios/centos-9/multinode-ci.yml
+++ b/scenarios/centos-9/multinode-ci.yml
@@ -17,3 +17,6 @@ post_ctlplane_deploy:
 
 # Enable tempest
 cifmw_run_tests: true
+
+# Deploy EDPM in multinode scenario
+cifmw_deploy_edpm: true


### PR DESCRIPTION
While we thought this job was deploying EDPM, it actually doesn't.

This patch is correcting this situation, and ensures things are running
as they should with proper tag "split".

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
