### PR TITLE
Refine the openshift variables to not dump to openshift_login only

### DIFF
--- a/ci_framework/playbooks/01-bootstrap.yml
+++ b/ci_framework/playbooks/01-bootstrap.yml
@@ -19,7 +19,7 @@
           {{
             hostvars[inventory_hostname] |
             dict2items |
-            selectattr("key", "match", "^(cifmw|pre|post)_(?!install_yamls|openshift).*") |
+            selectattr("key", "match", "^(cifmw|pre|post)_(?!install_yamls|openshift_token|openshift_login).*") |
             list | items2dict
           }}
 


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date: