### PR TITLE
Change the way how `image_base` var is built

### DIFF
--- a/ci/playbooks/content_provider/content_provider.yml
+++ b/ci/playbooks/content_provider/content_provider.yml
@@ -27,7 +27,7 @@
     - name: Set var for cifmw_operator_build_operators var
       # It handles the case of setting image_base for
       # openstack-ansibleee-operator and openstack-operator project
-      # for openstack-ansibleee-operator, it will return ansibleee
+      # for openstack-ansibleee-operator, it will return openstack-ansibleee
       # and for openstack-operator, openstack will be returned
       when:
         - zuul is defined
@@ -38,13 +38,7 @@
           - name: "openstack-operator"
             src: "~/src/github.com/{{ cifmw_operator_build_org }}/openstack-operator"
             image_base: >-
-              {%- if zuul.project.short_name | split('-') | length > 2 -%}
-              {{ zuul.project.short_name | split('-', 1) | last | split('-') | first }}
-              {%- else -%}
-              {{ zuul.project.short_name | split('-') | first }}
-              {%- endif -%}
-
-
+              {{ zuul.project.short_name | split('-') | reject('search','operator') | join('-') }}
 
     - name: Build Operators
       ansible.builtin.include_role:


### PR DESCRIPTION
For repo name like `openstack-ansibleee-operator` it should be used `openstack-ansibleee` as `image_base` name, otherwise it can create issues while pushing images in the registries.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
