### PR TITLE
Grant OpenStack CephX key access to CephFS pools

### DIFF
--- a/ci_framework/playbooks/ceph.yml
+++ b/ci_framework/playbooks/ceph.yml
@@ -134,7 +134,7 @@
     cifmw_cephadm_pools:
       - name: vms
         pg_autoscale_mode: true
-        target_size_ratio: 0.3
+        target_size_ratio: 0.2
         application: rbd
       - name: volumes
         pg_autoscale_mode: true
@@ -142,12 +142,20 @@
         application: rbd
       - name: backups
         pg_autoscale_mode: true
-        target_size_ratio: 0.2
+        target_size_ratio: 0.1
         application: rbd
       - name: images
         target_size_ratio: 0.2
         pg_autoscale_mode: true
         application: rbd
+      - name: cephfs.cephfs.meta
+        target_size_ratio: 0.1
+        pg_autoscale_mode: true
+        application: cephfs
+      - name: cephfs.cephfs.data
+        target_size_ratio: 0.1
+        pg_autoscale_mode: true
+        application: cephfs
   pre_tasks:
     - name: Generate a cephx key
       cephx_key:

--- a/ci_framework/roles/cifmw_ceph_spec/molecule/default/tasks/verify_conf.yml
+++ b/ci_framework/roles/cifmw_ceph_spec/molecule/default/tasks/verify_conf.yml
@@ -30,12 +30,12 @@
   ansible.builtin.set_fact:
     found_public_network: "{{ lookup('ansible.builtin.ini', 'public_network section=global file=' ~ cifmw_ceph_spec_path_initial_conf) }}"
 
-- name: Extract private_network
+- name: Extract cluster_network
   ansible.builtin.set_fact:
-    found_private_network: "{{ lookup('ansible.builtin.ini', 'private_network section=global file=' ~ cifmw_ceph_spec_path_initial_conf) }}"
+    found_cluster_network: "{{ lookup('ansible.builtin.ini', 'cluster_network section=global file=' ~ cifmw_ceph_spec_path_initial_conf) }}"
 
 - name: Assert expected values about public and private network
   ansible.builtin.assert:
     that:
       - found_public_network == cifmw_ceph_spec_public_network
-      - found_private_network == cifmw_ceph_spec_private_network
+      - found_cluster_network == cifmw_ceph_spec_private_network

--- a/ci_framework/roles/cifmw_ceph_spec/templates/initial_ceph.conf.j2
+++ b/ci_framework/roles/cifmw_ceph_spec/templates/initial_ceph.conf.j2
@@ -4,7 +4,7 @@ osd pool default size = 1
 public_network = {{ cifmw_ceph_spec_public_network }}
 {% endif %}
 {% if cifmw_ceph_spec_private_network %}
-private_network = {{ cifmw_ceph_spec_private_network }}
+cluster_network = {{ cifmw_ceph_spec_private_network }}
 {% endif %}
 [mon]
 mon_warn_on_pool_no_redundancy = false

--- a/ci_framework/roles/cifmw_cephadm/tasks/pools.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/pools.yml
@@ -23,7 +23,8 @@
     - name: Get ceph_cli
       ansible.builtin.include_tasks: ceph_cli.yml
 
-    - name: Create pool
+    - name: Create RBD pools
+      when: item.application == 'rbd'
       ansible.builtin.command:
         cmd: >-
           {{ cifmw_cephadm_ceph_cli }}
@@ -34,7 +35,8 @@
       loop: "{{ cifmw_cephadm_pools | default([]) }}"
       changed_when: false
 
-    - name: Enable application on Ceph pools
+    - name: Enable application on Ceph RBD pools
+      when: item.application == 'rbd'
       ansible.builtin.command:
         cmd: >-
           {{ cifmw_cephadm_ceph_cli }}


### PR DESCRIPTION
Since CephFS is now deployed by default by the ceph.yml playbook, include the CephFS `meta` and `data` pools by default.

Add CephFS pools to `cifmw_cephadm_pools` in Ceph playbook so that they will be included when `cifmw_cephadm_keys` fact is set. Update pools task in `cifmw_cephadm` role to only create RBD pools since commands to deploy RGW and CephFS (e.g. `ceph fs volume create`) create their own pools.

Also fix typo with cluster_network in initial ceph.conf.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
