### PR TITLE
Enable new parameter support for compute hook

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -41,5 +41,7 @@ gettext
 
 # Required for community.general.json_query usage
 python3-jmespath  [platform:rpm]
+# Required for ipaddr filter
+python3-netaddr   [platform:rpm]
 # Required for ansible-lint to not complain about python not found
 python-unversioned-command [platform:rpm]

--- a/ci_framework/hooks/playbooks/fetch_compute_facts.yml
+++ b/ci_framework/hooks/playbooks/fetch_compute_facts.yml
@@ -13,7 +13,7 @@
         label: "{{ item }}"
 
 - name: Push repositories hook
-  hosts: all
+  hosts: all,!crcs,!crc
   gather_facts: true
   tasks:
     - name: Copy repositories from controller to compute
@@ -65,6 +65,12 @@
       ansible.builtin.set_fact:
         cifmw_edpm_prepare_extra_vars:
           NNCP_INTERFACE: "{{ crc_ci_bootstrap_networks_out[_crc_hostname].default.iface }}"
+          NNCP_DNS_SERVER: >-
+            {{
+              crc_ci_bootstrap_networks_out[_crc_hostname].default.ip4 |
+              default(crc_ci_bootstrap_networks_out[_crc_hostname].default.ip) |
+              replace('/24', '')
+            }}
           NETWORK_MTU: "{{ crc_ci_bootstrap_networks_out[_crc_hostname].default.mtu }}"
 
     - name: Ensure the kustomizations dirs exists
@@ -109,7 +115,12 @@
             dns_servers: "{{ ((['192.168.122.10'] + ansible_facts['dns']['nameservers']) | unique)[0:2] }}"
             edpm_install_yamls_vars:
               SSH_KEY_FILE: "{{ ansible_user_dir }}/.ssh/id_ed25519"
-              DATAPLANE_COMPUTE_IP: "{{ crc_ci_bootstrap_networks_out['compute-0'].default.ip | ansible.utils.ipaddr('address') }}"
+              DATAPLANE_COMPUTE_IP: >-
+                {{
+                  crc_ci_bootstrap_networks_out['compute-0'].default.ip4 |
+                  default(crc_ci_bootstrap_networks_out['compute-0'].default.ip) |
+                  ansible.utils.ipaddr('address')
+                }}
               DATAPLANE_SSHD_ALLOWED_RANGES: "['0.0.0.0/0']"
               DATAPLANE_TOTAL_NODES: "{{ computes_len | int }}"
               DATAPLANE_SINGLE_NODE: "{{ (computes_len | int > 1) | ternary('false', 'true') }}"
@@ -160,11 +171,21 @@
               {% for compute_node in groups['computes'] if compute_node != 'compute-0' %}
                   - op: replace
                     path: /spec/nodes/edpm-{{ compute_node }}/ansible/ansibleHost
-                    value: {{ crc_ci_bootstrap_networks_out[compute_node].default.ip  | ansible.utils.ipaddr('address') }}
+                    value: >-
+                      {{
+                        crc_ci_bootstrap_networks_out[compute_node].default.ip4 |
+                        default(crc_ci_bootstrap_networks_out[compute_node].default.ip) |
+                        ansible.utils.ipaddr('address')
+                      }}
 
                   - op: replace
                     path: /spec/nodes/edpm-{{ compute_node }}/networks/0/fixedIP
-                    value: {{ crc_ci_bootstrap_networks_out[compute_node].default.ip  | ansible.utils.ipaddr('address') }}
+                    value: >-
+                      {{
+                        crc_ci_bootstrap_networks_out[compute_node].default.ip4 |
+                        default(crc_ci_bootstrap_networks_out[compute_node].default.ip) |
+                        ansible.utils.ipaddr('address')
+                      }}
               {% endfor %}
 
                   - op: add


### PR DESCRIPTION
Since we intend to support IPv6 sooner or later, it's better to be
consistent with the parameter names. Since the ci_network role
introduces the "ip6" and "ip4" as well as "dns6" and "dns4", let's make
the hook aware of them for the reproducer case.

This will also make the switch to ci_network role easier in the near
future.

Regarding the "!crc,!crc": those exclusions ensure we don't try to
deploy repositories on the CRC. Both names are mandatory:
- "crc" is the name in the CI
- "crcs" is a group name, present in the reproducer.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
