### PR TITLE
Modify libvirt_manager role for proper reproducer capabilities

### DIFF
--- a/ci/playbooks/e2e-run.yml
+++ b/ci/playbooks/e2e-run.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Run ci/playbooks/e2e-run.yml"
-  hosts: controller
+  hosts: "{{ cifmw_zuul_target_host | default('controller') }}"
   gather_facts: true
   vars:
     ci_framework_src_dir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
@@ -19,6 +19,12 @@
           {%- endif %}
           -e @scenarios/centos-9/zuul_inventory.yml
           --tags packages
+
+    - name: Clean ansible cache
+      ansible.builtin.file:
+        path: "{{ ansible_user_dir }}/ansible_facts_cache"
+        state: absent
+
     - name: Tagged bootstrap - no packages
       ansible.builtin.command:
         chdir: "{{ ci_framework_src_dir }}"
@@ -34,6 +40,12 @@
           -e @scenarios/centos-9/zuul_inventory.yml
           --tags bootstrap
           --skip-tags packages
+
+    - name: Clean ansible cache
+      ansible.builtin.file:
+        path: "{{ ansible_user_dir }}/ansible_facts_cache"
+        state: absent
+
     - name: Not tagged bootstrap nor packages
       ansible.builtin.command:
         chdir: "{{ ci_framework_src_dir }}"

--- a/ci_framework/roles/libvirt_manager/tasks/create_vms.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/create_vms.yml
@@ -1,15 +1,14 @@
 ---
 - name: "Create VM overlays for {{ vm_type }}"
-  ci_script:
-    output_dir: "{{ cifmw_libvirt_manager_basedir }}/artifacts"
-    script: >-
+  ansible.builtin.command:
+    cmd: >-
       qemu-img create
       -o backing_file={{ vm_data.value.image_local_dir }}/{{ vm_data.value.disk_file_name }},backing_fmt=qcow2
       -f qcow2
       "{{ vm_type }}-{{ vm_id }}.qcow2" "{{ vm_data.value.disksize|default ('40') }}G"
     creates: "{{ vm_type }}-{{ vm_id }}.qcow2"
     chdir: "{{ cifmw_reproducer_basedir }}/workload"
-  loop: "{{ range(0, vm_data.value.amount|default(1)) }}"
+  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
   loop_control:
     index_var: vm_id
     label: "{{ vm_type }}-{{ vm_id }}"
@@ -19,7 +18,7 @@
     command: define
     xml: "{{ lookup('template', 'domain.xml.j2') }}"
     uri: "qemu:///system"
-  loop: "{{ range(0, vm_data.value.amount|default(1)) }}"
+  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
   loop_control:
     index_var: vm_id
     label: "{{ vm_type }}-{{ vm_id }}"
@@ -29,19 +28,18 @@
     state: running
     name: "cifmw-{{ vm_type }}-{{ vm_id }}"
     uri: "qemu:///system"
-  loop: "{{ range(0, vm_data.value.amount|default(1)) }}"
+  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
   loop_control:
     index_var: vm_id
     label: "{{ vm_type }}-{{ vm_id }}"
 
 - name: "Grab IPs for nodes type {{ vm_type }}"  # noqa: risky-shell-pipe
   register: vm_ips
-  ci_script:
-    output_dir: "{{ cifmw_libvirt_manager_basedir }}/artifacts"
-    script: >-
+  ansible.builtin.shell:
+    cmd: >-
       virsh -c qemu:///system -q
       domifaddr cifmw-{{ vm_type }}-{{ vm_id }} | head -1
-  loop: "{{ range(0, vm_data.value.amount|default(1)) }}"
+  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
   loop_control:
     index_var: vm_id
     label: "{{ vm_type }}-{{ vm_id }}"
@@ -89,6 +87,14 @@
     loop_var: vm_ip
     label: "{{ vm_ip.item }}"
 
+- name: "Create group inventory for {{ vm_type }}"
+  vars:
+    hosts: "{{ vm_ips.results }}"
+    admin_user: "{{ vm_data.value.admin_user | default('zuul') }}"
+  ansible.builtin.template:
+    dest: "{{ cifmw_reproducer_basedir }}/reproducer-inventory/{{ vm_type }}-group.yml"
+    src: inventory.yml.j2
+
 - name: "Wait for SSH on VMs type {{ vm_type }}"
   delegate_to: localhost
   ansible.builtin.wait_for:
@@ -100,15 +106,28 @@
     loop_var: vm_ip
     label: "{{ vm_ip.item }}"
 
+- name: "Configure ssh access on type {{ vm_type }}"
+  when:
+    - vm_type is not match('^crc.*$')
+  delegate_to: "{{ vm_type }}-{{ vm_id }}"
+  remote_user: "{{ vm_data.value.admin_user | default('root') }}"
+  ansible.posix.authorized_key:
+    user: "{{ vm_data.value.admin_user | default('root') }}"
+    state: present
+    key: "{{ pub_key }}"
+  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
+  loop_control:
+    index_var: vm_id
+    label: "{{ vm_type }}-{{ vm_id }}"
+
 - name: "Configure VMs type {{ vm_type }}"
   when:
     - vm_type is not match('^crc.*$')
   delegate_to: "{{ vm_type }}-{{ vm_id }}"
   remote_user: "{{ vm_data.value.admin_user | default('root') }}"
-  ci_script:
-    output_dir: "{{ cifmw_libvirt_manager_basedir }}/artifacts"
+  ansible.builtin.shell:
     executable: /bin/bash
-    script: |-
+    cmd: |-
       test -d /home/zuul && exit 0;
       set -xe -o pipefail;
       echo "{{ vm_type }}-{{ vm_id }}" | sudo tee /etc/hostname;
@@ -118,7 +137,49 @@
       sudo -u zuul mkdir -p /home/zuul/.ssh /home/zuul/src/github.com/openstack-k8s-operators;
       sudo cp ${HOME}/.ssh/authorized_keys /home/zuul/.ssh/;
       chown -R zuul: /home/zuul/.ssh;
-  loop: "{{ range(0, vm_data.value.amount|default(1)) }}"
+  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
+  loop_control:
+    index_var: vm_id
+    label: "{{ vm_type }}-{{ vm_id }}"
+
+- name: "Inject private key on hosts {{ vm_type }}"
+  when:
+    - vm_type is match('^controller.*$')
+  delegate_to: "{{ vm_type }}-{{ vm_id }}"
+  remote_user: "{{ vm_data.value.admin_user | default('root') }}"
+  ansible.builtin.copy:
+    dest: "/home/zuul/.ssh/id_ed25519"
+    content: "{{ priv_key }}"
+    owner: zuul
+    group: zuul
+    mode: "0400"
+  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
+  loop_control:
+    index_var: vm_id
+    label: "{{ vm_type }}-{{ vm_id }}"
+
+- name: "Inject public key on hosts {{ vm_type }}"
+  when:
+    - vm_type is match('^controller.*$')
+  delegate_to: "{{ vm_type }}-{{ vm_id }}"
+  remote_user: "{{ vm_data.value.admin_user | default('root') }}"
+  ansible.builtin.copy:
+    dest: "/home/zuul/.ssh/id_ed25519.pub"
+    content: "{{ pub_key }}"
+    owner: zuul
+    group: zuul
+    mode: "0444"
+  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
+  loop_control:
+    index_var: vm_id
+    label: "{{ vm_type }}-{{ vm_id }}"
+
+- name: "Inject network configuration file on {{ vm_type }}"
+  ansible.builtin.template:
+    dest: "{{ cifmw_reproducer_basedir }}/reproducer-network-env/{{ vm_type }}-{{ vm_id }}.yml"
+    src: "network-data.yml.j2"
+    mode: "0644"
+  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
   loop_control:
     index_var: vm_id
     label: "{{ vm_type }}-{{ vm_id }}"

--- a/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -1,8 +1,17 @@
 ---
 - name: Create needed worload directory
   ansible.builtin.file:
-    path: "{{ cifmw_reproducer_basedir }}/workload"
+    path: "{{ cifmw_reproducer_basedir }}/{{ item }}"
     state: directory
+  loop:
+    - workload
+    - reproducer-inventory
+    - reproducer-network-env
+
+- name: Chose right parameter for layout definition
+  ansible.builtin.set_fact:
+    cacheable: true
+    _layout: "{{ cifmw_libvirt_manager_configuration_gen | default(cifmw_libvirt_manager_configuration) }}"
 
 - name: Ensure networks are defined
   community.libvirt.virt_net:
@@ -10,7 +19,7 @@
     name: "cifmw-{{ item.key }}"
     xml: "{{ item.value | replace(item.key, 'cifmw-' ~ item.key) }}"
     uri: "qemu:///system"
-  loop: "{{ cifmw_libvirt_manager_configuration.networks | dict2items }}"
+  loop: "{{ _layout.networks | dict2items }}"
   loop_control:
     label: "{{ item.key }}"
 
@@ -19,7 +28,7 @@
     command: create
     name: "cifmw-{{ item.key }}"
     uri: "qemu:///system"
-  loop: "{{ cifmw_libvirt_manager_configuration.networks | dict2items }}"
+  loop: "{{ _layout.networks | dict2items }}"
   loop_control:
     label: "{{ item.key }}"
 
@@ -28,7 +37,7 @@
     state: active
     name: "cifmw-{{ item.key }}"
     uri: "qemu:///system"
-  loop: "{{ cifmw_libvirt_manager_configuration.networks | dict2items }}"
+  loop: "{{ _layout.networks | dict2items }}"
   loop_control:
     label: "{{ item.key }}"
 
@@ -37,7 +46,7 @@
     image_data: "{{ item.value }}"
   ansible.builtin.include_tasks:
     file: get_image.yml
-  loop: "{{ cifmw_libvirt_manager_configuration.vms | dict2items }}"
+  loop: "{{ _layout.vms | dict2items }}"
   loop_control:
     label: "{{ item.key }}"
 
@@ -56,23 +65,51 @@
       --ssh-inject {{ _admin_user }}:file:{{ ansible_user_dir }}/.ssh/authorized_keys
       | tee -a {{ item.value.image_local_dir }}/{{ item.value.disk_file_name }}.log
     creates: "{{ item.value.image_local_dir }}/{{ item.value.disk_file_name }}.log"
-  loop: "{{ cifmw_libvirt_manager_configuration.vms | dict2items }}"
+  loop: "{{ _layout.vms | dict2items }}"
   loop_control:
     label: "{{ item.key }}"
+
+- name: Create temporary ssh keypair
+  ansible.builtin.command:
+    cmd: >-
+      ssh-keygen -t ed25519 -f .ssh/cifmw_reproducer_key -P '' -q
+    creates: .ssh/cifmw_reproducer_key
+
+- name: Slurp public key for later use
+  register: pub_ssh_key
+  ansible.builtin.slurp:
+    path: .ssh/cifmw_reproducer_key.pub
+
+- name: Slurp private key for later use
+  register: priv_ssh_key
+  ansible.builtin.slurp:
+    path: .ssh/cifmw_reproducer_key
+
+- name: Create fact holding network data for VMs
+  ansible.builtin.set_fact:
+    cacheable: true
+    cifmw_reproducer_network_data: {}
 
 - name: Create and run VMs
   vars:
     vm_type: "{{ vm_data.key }}"
+    pub_key: "{{ pub_ssh_key.content | b64decode }}"
+    priv_key: "{{ priv_ssh_key.content | b64decode }}"
   ansible.builtin.include_tasks:
     file: create_vms.yml
-  loop: "{{ cifmw_libvirt_manager_configuration.vms | dict2items }}"
+  loop: "{{ _layout.vms | dict2items }}"
   loop_control:
     label: "{{ vm_data.key }}"
     loop_var: vm_data
 
+- name: Create "all" group inventory file
+  ansible.builtin.template:
+    dest: "{{ cifmw_reproducer_basedir }}/reproducer-inventory/all-group.yml"
+    src: "all-inventory.yml.j2"
+
 - name: Ensure we get proper access to CRC
   vars:
-    crc_private_key: "{{ cifmw_libvirt_manager_configuration.vms.crc.image_local_dir }}/id_ecdsa"
+    crc_private_key: "{{ _layout.vms.crc.image_local_dir }}/id_ecdsa"
   block:
     - name: Copy authorized_keys
       ansible.builtin.command:

--- a/ci_framework/roles/libvirt_manager/templates/domain.xml.j2
+++ b/ci_framework/roles/libvirt_manager/templates/domain.xml.j2
@@ -1,7 +1,7 @@
 <domain type='kvm'>
   <name>cifmw-{{ vm_type }}-{{ vm_id }}</name>
   <memory unit='GB'>{{ vm_data.value.memory | default(2) }}</memory>
-  <vcpu placement='static'>{{ vm_data.value.cpu | default(2) }}</vcpu>
+  <vcpu placement='static'>{{ vm_data.value.cpus | default(2) }}</vcpu>
   <os>
     <type arch='x86_64' machine='q35'>hvm</type>
     <boot dev='hd'/>

--- a/ci_framework/roles/libvirt_manager/templates/inventory.yml.j2
+++ b/ci_framework/roles/libvirt_manager/templates/inventory.yml.j2
@@ -1,0 +1,10 @@
+{{ vm_type }}s:
+  hosts:
+{% for host in hosts %}
+    {{ vm_type }}-{{ host.item }}:
+      ansible_host: {{ (host.stdout.split())[3] | replace('/24','') }}
+      ansible_user: {{ admin_user }}
+{% if admin_user == 'core' %}
+      ansible_ssh_private_key_file: ~/.ssh/crc_key
+{% endif %}
+{% endfor %}

--- a/ci_framework/roles/libvirt_manager/templates/network-data.yml.j2
+++ b/ci_framework/roles/libvirt_manager/templates/network-data.yml.j2
@@ -1,0 +1,50 @@
+{#
+The ci_job_networking is exposed by the reproducer role. It namely exposes
+the CI job configuration passed down to zuul so that we can ensure we're
+using the same networks.
+#}
+{% set ns = namespace(
+    ip4='',
+    gw4='',
+    iface=cifmw_reproducer_private_nic,
+    config_nm=false, ip_suffix=0)
+-%}
+{% if vm_type == 'controller' -%}
+{%   set ns.gw4 = cifmw_reproducer_ctl_gw4 -%}
+{%   set ns.ip4 =  ci_job_networking['instances']['controller']['networks']['default']['ip'] %}
+{% elif vm_type == 'crc' -%}
+{%   set ns.ip_suffix = 10 -%}
+{%   set ns.iface = cifmw_reproducer_crc_private_nic -%}
+{%   set ns.gw4 = cifmw_reproducer_crc_gw4 -%}
+{%   set ns.config_nm = true -%}
+{%   set ns.ip4 =  ci_job_networking['instances']['crc']['networks']['default']['ip'] %}
+{% else -%}
+{%   set ns.ip_suffix = 100+vm_id -%}
+{%   set ns.ip4 = ci_job_networking['instances']['compute-' ~ vm_id]['networks']['default']['ip']%}
+{%   set ns.gw4 = cifmw_reproducer_ctl_gw4 -%}
+{% endif -%}
+{% set default_mtu = ci_job_networking.networks['default'].mtu | default('1500') -%}
+{% set vlan_mtu = default_mtu - 4 -%}
+crc_ci_bootstrap_networks_out:
+  {{ vm_type }}-{{ vm_id }}:
+    default:
+      iface: {{ ns.iface }}
+      connection: ci-private-network
+      ip4: {{ ns.ip4 }}/24
+      gw4: {{ ns.gw4 }}
+      dns4: {{ ci_job_networking['instances']['crc']['networks']['default']['ip'] }}
+      mtu: {{ ci_job_networking.networks['default'].mtu | default(default_mtu) }}
+{% if vm_type != 'controller' %}
+{% for networking in ci_job_networking.networks | dict2items %}
+{%   if networking.key != 'default' %}
+    {{ networking.key }}:
+      iface: {{ ns.iface }}.{{ networking.value.vlan }}
+      connection: {{ networking.key }}
+      vlan: {{ networking.value.vlan }}
+      parent_iface: {{ ns.iface }}
+      ip4: {{ networking.value.range | ansible.utils.ipaddr('net') | ansible.utils.ipmath(ns.ip_suffix) }}/24
+      config_nm: {{ ns.config_nm }}
+      mtu: {{ networking.value.mtu | default(vlan_mtu) }}
+{%    endif %}
+{%  endfor %}
+{% endif %}


### PR DESCRIPTION
This patch extend the libvirt_manager role in order to create the full
reproducer job layout.
In such a case, there are some extended needs compared to the "deploy a
layout" easy use-case: we need to inject some keys, create network
layout files/configuration and so on.

This patch, in conjuction with some others coming later, will allow
users to reproduce a 1:1 CI job, with the layout and networking.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
