### PR TITLE
Fix loading of commits.yaml using slurp

### DIFF
--- a/ci_framework/roles/dlrn_promote/tasks/get_hash_from_commit.yaml
+++ b/ci_framework/roles/dlrn_promote/tasks/get_hash_from_commit.yaml
@@ -12,9 +12,13 @@
   delay: 50
 
 - name: Load data from commit.yaml file
-  ansible.builtin.include_vars:
-    file: "{{ cifmw_dlrn_promote_workspace }}/commit.yaml"
-    name: _hashes
+  ansible.builtin.slurp:
+    path: "{{ cifmw_dlrn_promote_workspace }}/commit.yaml"
+  register: _commit_data
+
+- name: Filter slurp data from commit.yaml
+  ansible.builtin.set_fact:
+    _hashes: "{{ _commit_data['content'] | b64decode | from_yaml }}"
 
 - name: Get individual commit/distro hashes
   ansible.builtin.set_fact:


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

