### PR TITLE
Fixed the arguments of dlrnapi repo-promote

### DIFF
--- a/ci_framework/roles/dlrn_promote/tasks/promote_hash.yml
+++ b/ci_framework/roles/dlrn_promote/tasks/promote_hash.yml
@@ -8,13 +8,13 @@
       {% endif -%}
       repo-promote
       {% if (cifmw_dlrn_promote_extended_hash is defined) and (cifmw_repo_setup_extended_hash | length > 0) -%}
-      --extended_hash {{ cifmw_dlrn_promote_extended_hash }}
+      --extended-hash {{ cifmw_dlrn_promote_extended_hash }}
       {% endif -%}
       {% if cifmw_dlrn_promote_commit_hash | length > 0 -%}
-      --commit_hash {{ cifmw_dlrn_promote_commit_hash }}
+      --commit-hash {{ cifmw_dlrn_promote_commit_hash }}
       {% endif -%}
       {% if cifmw_dlrn_promote_distro_hash | length > 0 -%}
-      --distro_hash {{ cifmw_dlrn_promote_distro_hash }}
+      --distro-hash {{ cifmw_dlrn_promote_distro_hash }}
       {% endif -%}
       --promote-name {{ cifmw_dlrn_promote_promotion_target }}
   environment: |


### PR DESCRIPTION
Below are the options of dlrnapi repo-promote
```
lrnapi repo-promote --help
usage: dlrnapi repo-promote [-h] --commit-hash COMMIT_HASH --distro-hash DISTRO_HASH [--extended-hash EXTENDED_HASH] --promote-name PROMOTE_NAME

options:
  -h, --help            show this help message and exit
  --commit-hash COMMIT_HASH
                        commit_hash of the repo to be promoted
  --distro-hash DISTRO_HASH
                        distro_hash of the repo to be promoted
  --extended-hash EXTENDED_HASH
                        extended_hash of the repo to be promoted
  --promote-name PROMOTE_NAME
                        Name to be used for the promotion
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

