### PR TITLE
Ensure we can get Tempest image before running tests

### DIFF
--- a/ci_framework/roles/tempest/tasks/main.yml
+++ b/ci_framework/roles/tempest/tasks/main.yml
@@ -37,6 +37,14 @@
     cmd: "podman unshare chown 42480:42480 -R {{ cifmw_tempest_artifacts_basedir }}"
   when: not cifmw_tempest_dry_run | bool
 
+- name: Ensure we have tempest container image
+  register: _tempest_fetch_img
+  containers.podman.podman_image:
+    name: "{{ cifmw_tempest_image }}:{{ cifmw_tempest_image_tag }}"
+  retries: 5
+  delay: 5
+  until: _tempest_fetch_img is success
+
 - name: Run tempest
   ignore_errors: true
   containers.podman.podman_container:


### PR DESCRIPTION
This new task should ensure we're able to fetch the tempest image, since
it may happen image registry has some hiccups.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
