### PR TITLE
Add notice that framework can't be ran as root user.

### DIFF
--- a/docs/source/quickstart/01_requirements.md
+++ b/docs/source/quickstart/01_requirements.md
@@ -16,6 +16,8 @@ must be present on your system:
 * sudo
 
 # Needed specific configurations
+You must run the deployment as a **non root user**.
+
 Your user must have full `sudo` access in order to:
 
 * install packages


### PR DESCRIPTION
This is due to [1] and fails in a rather silent way.

[1] https://github.com/openstack-k8s-operators/install_yamls/blob/main/devsetup/scripts/crc-setup.sh#L5

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
