### PR TITLE
Allow to not manage firewall

### DIFF
--- a/ci_framework/roles/registry_deploy/README.md
+++ b/ci_framework/roles/registry_deploy/README.md
@@ -7,3 +7,4 @@ An Ansible role to deploy local registry using registry:2 container image
 * `cifmw_rp_registry_image_fallback`: (String) Alternate registry2 container image url. It will be used when `cifmw_rp_registry_image` fails. Defaults to `quay.rdoproject.org/openstack-k8s-operators/registry:2`
 * `cifmw_rp_registry_ip:` (String) The registry IP address. Defaults to `0.0.0.0`.
 * `cifmw_rp_registry_port:`: (Integer) The registry port. Defaults to `5001`.
+* `cifmw_rp_registry_firewall`: (Bool) Configure nftables.

--- a/ci_framework/roles/registry_deploy/defaults/main.yml
+++ b/ci_framework/roles/registry_deploy/defaults/main.yml
@@ -22,3 +22,4 @@ cifmw_rp_registry_image: docker.io/library/registry:2
 cifmw_rp_registry_image_fallback: quay.rdoproject.org/openstack-k8s-operators/registry:2
 cifmw_rp_registry_ip: 0.0.0.0
 cifmw_rp_registry_port: 5001
+cifmw_rp_registry_firewall: true

--- a/ci_framework/roles/registry_deploy/tasks/main.yml
+++ b/ci_framework/roles/registry_deploy/tasks/main.yml
@@ -48,6 +48,8 @@
   become: true
   tags:
     - bootstrap
+  when:
+    - cifmw_rp_registry_firewall | bool
   ansible.builtin.command: >-
     nft insert rule ip filter INPUT tcp dport {{ cifmw_rp_registry_port }} counter accept
   changed_when: true

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -217,6 +217,7 @@ networkconfig
 networkmanager
 networktype
 nfs
+nftables
 nic
 nigzpbgugpsavdmfyl
 nlcggvjgnsdxn


### PR DESCRIPTION
In the reproducer, we don't have any nftables deployed. We therefore
don't need to allow anything.
More over, since the firewall isn't configured at all, the rule
insertion is leading to an error, because the INPUT chain doesn't exist.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role

