### PR TITLE
Get keystone endpoint from keystoneapi status

### DIFF
--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -205,9 +205,9 @@
         PATH: "{{ cifmw_path }}"
       ansible.builtin.command:
         cmd: >-
-          oc get route keystone-public
+          oc get keystoneapi keystone
           --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
-          -o jsonpath='{ .spec.host }'
+          -o jsonpath='{ .status.apiEndpoints.public }'
       register: _cifmw_edpm_prepare_keystone_endpoint_out
       until: _cifmw_edpm_prepare_keystone_endpoint_out.rc == 0 and _cifmw_edpm_prepare_keystone_endpoint_out.stdout != ""
       retries: "{{ cifmw_edpm_prepare_oc_retries }}"
@@ -218,7 +218,7 @@
       vars:
         _keystone_response_codes: [200, 300, 301, 302, 401, 402, 403]
       ansible.builtin.uri:
-        url: "http://{{ _cifmw_edpm_prepare_keystone_endpoint_out.stdout | trim }}"
+        url: "{{ _cifmw_edpm_prepare_keystone_endpoint_out.stdout | trim }}"
         status_code: "{{ _keystone_response_codes }}"  # noqa: args[module]
       retries: 20
       delay: 10


### PR DESCRIPTION
We should get the keystoneendpoint url with proto from keystoneapi instead of checking a route. When enable TLS we get the proto with out having to check any TLS settings of the route.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
