### PR TITLE
Introduce new tag in libvirt_manager

### DIFF
--- a/ci_framework/roles/libvirt_manager/tasks/main.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/main.yml
@@ -24,20 +24,24 @@
 - name: Virtualization check and configuration tasks
   tags:
     - bootstrap
+    - bootstrap_layout
   ansible.builtin.import_tasks: virtualization_prerequisites.yml
 
 - name: Install packages and dependencies
   tags:
     - packages
     - bootstrap
+    - bootstrap_layout
   ansible.builtin.import_tasks: packages.yml
 
 - name: Add polkit rules
   tags:
     - bootstrap
+    - bootstrap_layout
   ansible.builtin.import_tasks: polkit_rules.yml
 
 - name: Check Virsh usage
   tags:
     - bootstrap
+    - bootstrap_layout
   ansible.builtin.import_tasks: virsh_checks.yml

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -109,6 +109,7 @@ or `--skip-tags`:
 
 * `bootstrap`: Run all of the package installation tasks as well as the potential system configuration depending on the options you set.
 * `packages`: Run all package installation tasks associated to the options you set.
+* `bootstrap_layout`: Run the [reproducer](../reproducers/01-considerations.md) bootstrap steps only.
 
 For instance, if you want to bootstrap a hypervisor, and reuse it over and
 over, you'll run the following commands:


### PR DESCRIPTION
This tag is mostly used in the reproducer case, when we want to iterate
on a deploy without having to wait for the libvirt steps to pass again
(when it's already deployed). It's allowing a faster run.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
