### PR TITLE
Reproducer: add content-provider support

### DIFF
--- a/ci_framework/roles/reproducer/tasks/ci_data.yml
+++ b/ci_framework/roles/reproducer/tasks/ci_data.yml
@@ -55,6 +55,11 @@
       ansible.builtin.set_fact:
         cacheable: true
         ci_job_networking: "{{ zuul_inventory.all.hosts.crc.crc_ci_bootstrap_networking }}"
+        use_content_provider: >-
+          {{
+            zuul_inventory.all.hosts.crc.content_provider_registry_ip is defined and
+            zuul_inventory.all.hosts.crc.cifmw_operator_build_output is defined
+          }}
         updated_layout:
           vms:
             compute:

--- a/ci_framework/roles/reproducer/tasks/ci_job.yml
+++ b/ci_framework/roles/reproducer/tasks/ci_job.yml
@@ -30,13 +30,29 @@
   delegate_to: controller-0
   remote_user: zuul
   block:
-    - name: Fetch repositories from Zuul job
+    - name: Fetch zuul.projects repositories for dependencies
+      tags:
+        - bootstrap
+      when:
+        - repo.key is match('^github.com')
+      ansible.builtin.git:
+        dest: "{{ repo.value.src_dir }}"
+        repo: "https://{{ repo.key }}"
+        version: "{{ repo.value.commit }}"
+        force: true
+      loop: "{{ zuul['projects'] | dict2items }}"
+      loop_control:
+        loop_var: repo
+        label: "{{ repo.key }}"
+
+    - name: Fetch zuul.items repositories
       tags:
         - bootstrap
       ansible.builtin.git:
         dest: "{{ repo.project.src_dir }}"
         repo: "https://{{ repo.project.canonical_name }}"
         version: "{{ repo.patchset }}"
+        force: true
       loop: "{{ zuul['items'] }}"
       loop_control:
         loop_var: repo
@@ -197,6 +213,16 @@
           ansible-playbook
           -i scenarios/centos-9/zuul_inventory.yml
           pre-ci-play.yml
+
+    - name: Run reproducer preparation job
+      when:
+        - cifmw_job_uri is defined
+      ansible.builtin.command:
+        chdir: "src/github.com/openstack-k8s-operators/ci-framework"
+        cmd: >-
+          ansible-playbook
+          -i scenarios/centos-9/zuul_inventory.yml
+          ci_framework/playbooks/01-bootstrap.yml
 
     - name: Run job
       when:

--- a/ci_framework/roles/reproducer/tasks/main.yml
+++ b/ci_framework/roles/reproducer/tasks/main.yml
@@ -17,10 +17,13 @@
 - name: Discover latest image for CS9
   tags:
     - bootstrap
+    - bootstrap_layout
   ansible.builtin.import_role:
     name: discover_latest_image
 
 - name: Ensure directories are present
+  tags:
+    - always
   ansible.builtin.file:
     path: "{{ cifmw_reproducer_basedir }}"
     state: directory
@@ -36,6 +39,7 @@
 - name: Deploy layout on target host
   tags:
     - bootstrap
+    - bootstrap_layout
   ansible.builtin.import_role:
     name: libvirt_manager
     tasks_from: deploy_layout
@@ -43,6 +47,7 @@
 - name: Push generated inventory from hypervisor
   tags:
     - bootstrap
+    - bootstrap_layout
   ansible.builtin.command:  # noqa: command-instead-of-module
     cmd: >-
       rsync -r {{ cifmw_reproducer_basedir }}/reproducer-inventory/
@@ -51,6 +56,7 @@
 - name: Slurp ssh key for CRC access
   tags:
     - bootstrap
+    - bootstrap_layout
   register: crc_priv_key
   ansible.builtin.slurp:
     path: ".crc/machines/crc/id_ecdsa"
@@ -58,6 +64,7 @@
 - name: Configure CRC services
   tags:
     - bootstrap
+    - bootstrap_layout
   delegate_to: crc-0
   remote_user: root
   block:
@@ -104,6 +111,7 @@
 - name: Get kubeconfig file from crc directory
   tags:
     - bootstrap
+    - bootstrap_layout
   register: kubeconfig
   ansible.builtin.slurp:
     path: "{{ cifmw_reproducer_kubecfg }}"
@@ -111,6 +119,7 @@
 - name: Configure controller-0
   tags:
     - bootstrap
+    - bootstrap_layout
   delegate_to: controller-0
   remote_user: root
   block:

--- a/ci_framework/roles/reproducer/templates/play.yml.j2
+++ b/ci_framework/roles/reproducer/templates/play.yml.j2
@@ -1,4 +1,83 @@
 ---
+{% if use_content_provider | default(false) | bool -%}
+- name: Configure CRC for insecure registry
+  hosts: crcs
+  vars:
+    content_provider_registry_ip: {{ cifmw_reproducer_ctl_ip4 }}
+  tasks:
+    - name: Set insecure registry on crc node
+      ansible.builtin.import_tasks: ci/playbooks/tasks/set_crc_insecure_registry.yml
+
+- name: "Content Provider"
+  hosts: localhost
+  gather_facts: true
+  vars:
+    cifmw_rp_registry_ip: {{ cifmw_reproducer_ctl_ip4 }}
+    cifmw_rp_registry_firewall: false
+    job_id: "{{ job_id }}"
+  tasks:
+{% raw %}
+    - name: Load env variables
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop:
+        - "{{ ansible_user_dir }}/{{ job_id }}-params/zuul-params.yml"
+        - "./scenarios/centos-9/base.yml"
+        - "./scenarios/centos-9/content_provider.yml"
+        - "./scenarios/centos-9/zuul_inventory.yml"
+
+    - name: Install necessary tools
+      ansible.builtin.import_role:
+        name: install_yamls_makes
+        tasks_from: make_download_tools
+
+    - name: Deploy registry
+      ansible.builtin.import_role:
+        name: registry_deploy
+
+    # Imported from the ci/playbooks/content_provider/content_provider.yml play
+    # Ensure we get consistent name for the operator, linked to
+    # https://github.com/openstack-k8s-operators/ci-framework/pull/621
+    - name: Set var for cifmw_operator_build_operators var
+      when:
+        - zuul is defined
+        - "'project' in zuul"
+        - "'short_name' in zuul.project"
+      ansible.builtin.set_fact:
+        cifmw_operator_build_operators:
+          - name: "openstack-operator"
+            src: "~/src/github.com/{{ cifmw_operator_build_org }}/openstack-operator"
+            image_base: >-
+              {{ zuul.project.short_name | split('-') | reject('search','operator') | join('-') }}
+
+    - name: Build Operators
+      ansible.builtin.include_role:
+        name: operator_build
+
+    - name: Get the containers list from container registry
+      ansible.builtin.uri:
+        url: "http://{{ cifmw_rp_registry_ip }}:5001/v2/_catalog"
+        return_content: true
+      register: cp_imgs
+
+    - name: Add the container list to file
+      ansible.builtin.copy:
+        content: "{{ cp_imgs.content }}"
+        dest: "{{ ansible_user_dir }}/local_registry.log"
+        mode: "0644"
+
+    - name: Output needed content into consumable environment
+      ansible.builtin.copy:
+        dest: "{{ ansible_user_dir }}/{{ job_id }}-params/content-provider.yml"
+        content: |-
+          {{
+            {'cifmw_operator_build_output': cifmw_operator_build_output,
+             'content_provider_registry_ip': cifmw_rp_registry_ip
+            } | to_nice_yaml
+          }}
+{% endraw %}
+{% endif %}
+
 {% for play in zuul_plays %}
 - name: "Reproducer for {{ job_id }}: {{ play }}"
   vars:
@@ -6,6 +85,9 @@
       - '@~/{{ job_id }}-params/custom-params.yml'
       - '@~/{{ job_id }}-params/install-yamls-params.yml'
       - '@~/{{ job_id }}-params/reproducer_params.yml'
+{% if use_content_provider | bool %}
+      - '@~/{{ job_id }}-params/content-provider.yml'
+{% endif %}
       - cifmw_zuul_target_host=controller-0
       - cifmw_openshift_user=kubeadmin
       - cifmw_openshift_kubeconfig=/home/zuul/.crc/machines/crc/kubeconfig


### PR DESCRIPTION
This patch introduce content-provider job-like support.

The goal here is to enable job reproduction in cases such as the
podified-multinode-edpm-deployment-crc.
This specific job requires a content-provider job in order to build and
provide the operator/container images.

With this patch, such a need is detected by the role, and a step to get
the content-provider running on the ansible controller node is then
launched.

This patch also corrects some wrong assumption with the way zuul
clones/manages the dependency repositories, and is closer to its
behavior than before.

Finaly, we also introduce a new tag, "boostrap_layout" in order to
re-run only specific steps.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/637

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Proper documentation update is in place