### PR TITLE
No cert validation on keystone endpoint check

### DIFF
--- a/ci_framework/roles/edpm_prepare/README.md
+++ b/ci_framework/roles/edpm_prepare/README.md
@@ -14,3 +14,4 @@ This role doesn't need privilege escalation.
 * `cifmw_edpm_prepare_oc_delay`: (Integer) Delay, in seconds, between failed oc call retries. Defaults to `30`.
 * `cifmw_edpm_prepare_update_os_containers`: (Boolean) Updates the openstack services containers env variable. Defaults to `false`.
 * `cifmw_edpm_prepare_timeout`: (Integer) Time, in minutes to wait for the deployment to be ready. Defaults to `30`.
+* `cifmw_edpm_prepare_verify_tls`: (Boolean) In case of TLS enabled for OpenStack endpoint, validates against the CA. Defaults to `false`.

--- a/ci_framework/roles/edpm_prepare/defaults/main.yml
+++ b/ci_framework/roles/edpm_prepare/defaults/main.yml
@@ -25,3 +25,4 @@ cifmw_edpm_prepare_dry_run: false
 cifmw_edpm_prepare_skip_crc_storage_creation: false
 cifmw_edpm_prepare_update_os_containers: false
 cifmw_edpm_prepare_timeout: 30
+cifmw_edpm_prepare_verify_tls: false

--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -220,6 +220,7 @@
       ansible.builtin.uri:
         url: "{{ _cifmw_edpm_prepare_keystone_endpoint_out.stdout | trim }}"
         status_code: "{{ _keystone_response_codes }}"  # noqa: args[module]
+        validate_certs: "{{ cifmw_edpm_prepare_verify_tls }}"
       retries: 20
       delay: 10
       until:


### PR DESCRIPTION
The task is only used to check when keystone is available. No need for now to have cert validation by fetching the CA.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
