### PR TITLE
No cert validation in os_net_setup

### DIFF
--- a/ci_framework/roles/os_net_setup/README.md
+++ b/ci_framework/roles/os_net_setup/README.md
@@ -11,3 +11,4 @@ That is provided by `openshift_login` role.
 * `cifmw_os_net_setup_config`: See an example in ci_framework/roles/os_net_setup/defaults/main.yml
 * `cifmw_os_net_setup_osp_calls_retries`: (Integer) Number of attempts to retry an OSP action if it fails. Defaults to `10`.
 * `cifmw_os_net_setup_osp_calls_delay`: (Integer) Delay, in seconds, between failed OSP call retries. Defaults to `5`.
+* `cifmw_os_net_setup_verify_tls`: (Boolean) In case of TLS enabled for OpenStack endpoint, validates against the CA. Defaults to `false`.

--- a/ci_framework/roles/os_net_setup/defaults/main.yml
+++ b/ci_framework/roles/os_net_setup/defaults/main.yml
@@ -15,3 +15,4 @@ cifmw_os_net_setup_config:
         allocation_pool_end: 192.168.122.210
         gateway_ip: 192.168.122.1
         enable_dhcp: false
+cifmw_os_net_setup_verify_tls: false

--- a/ci_framework/roles/os_net_setup/tasks/main.yml
+++ b/ci_framework/roles/os_net_setup/tasks/main.yml
@@ -38,6 +38,7 @@
 - name: Get network information
   openstack.cloud.networks_info:
     auth: "{{ openstack_auth }}"
+    validate_certs: "{{ cifmw_os_net_setup_verify_tls }}"
   register: cifmw_os_net_setup_network_list_out
   until: cifmw_os_net_setup_network_list_out is not failed
   retries: "{{ cifmw_os_net_setup_osp_calls_retries }}"

--- a/ci_framework/roles/os_net_setup/tasks/subtask_net.yml
+++ b/ci_framework/roles/os_net_setup/tasks/subtask_net.yml
@@ -16,6 +16,7 @@
     region_name: '{{ region_name }}'
     state: present
     auth: "{{ openstack_auth }}"
+    validate_certs: "{{ cifmw_os_net_setup_verify_tls }}"
   register: cifmw_os_net_setup_net_fetch_out
   until: cifmw_os_net_setup_net_fetch_out is not failed
   retries: "{{ cifmw_os_net_setup_osp_calls_retries }}"
@@ -44,6 +45,7 @@
     region_name: '{{ region_name }}'
     state: present
     auth: "{{ openstack_auth }}"
+    validate_certs: "{{ cifmw_os_net_setup_verify_tls }}"
   loop: "{{ net_item.subnets | flatten(levels=1) }}"
   loop_control:
     loop_var: subnet_item


### PR DESCRIPTION
For now disable cert validation on os_net_setup role. In a follow up we fetch the CA from a CA bundle secret and can enable it. Disable it is a pre-req to allow integration of the TLS functionality for the public endpoints via the openstack-operator. The openstack-operator will create the required CA.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
