### PR TITLE
Fix network authold logic

### DIFF
--- a/ci/playbooks/multinode-autohold.yml
+++ b/ci/playbooks/multinode-autohold.yml
@@ -3,13 +3,20 @@
   hosts: controller
   gather_facts: true
   tasks:
-    - name: Check if the current run is an authold target
+    - name: Verify if "success" flag exists after successful tests execution
+      register: cifmw_success_flag
+      ansible.builtin.stat:
+        path: "{{ ansible_user_dir }}/cifmw-success"
+
+    - name: Check if the current run is an autohold target
       when:
+        - not cifmw_success_flag.stat.exists
         - zuul is defined
         - "'ref' in zuul"
         - "'tenant' in zuul"
         - "'job' in zuul"
         - "'project' in zuul"
+        - "'canonical_name' in zuul.project"
       block:
         - name: Fetch existing autoholds from zuul
           vars:
@@ -21,7 +28,7 @@
                   'api',
                   'tenant',
                   zuul.tenant,
-                  'autoholds'
+                  'autohold'
                 ] | join('/')
               }}
           ansible.builtin.uri:
@@ -43,7 +50,7 @@
             - "autoholds_response.content_type.startswith('application/json')"
           ignore_errors: true
 
-        - name: Check if any authold matches
+        - name: Check if any autohold matches
           vars:
             autoholds_returned_data: >-
               {{
@@ -67,7 +74,7 @@
                 selectattr('current_count', 'defined') |
                 selectattr('max_count', 'defined') |
                 selectattr('tenant', 'equalto', zuul.tenant) |
-                selectattr('project', 'equalto', zuul.project) |
+                selectattr('project', 'equalto', zuul.project.canonical_name) |
                 selectattr('job', 'equalto', zuul.job)
               }}
             matching_candidates: >-

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -124,7 +124,7 @@
     post-run:
       - ci/playbooks/e2e-collect-logs.yml
       - ci/playbooks/collect-logs.yml
-      - ci/playbooks/multinode-authold.yml
+      - ci/playbooks/multinode-autohold.yml
     vars:
       zuul_log_collection: true
       registry_login_enabled: true


### PR DESCRIPTION
Some changed to fix how the network autohold mechanism works. The API URL was wrong and the field used to compare the project name should be the canonical one. Fixed a typo in the filename too. As successful runs don't tigger the instances hold we now skip holding the network for successful runs.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date: