### PR TITLE
Add missing interfaces for adoption base job

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -60,6 +60,10 @@
                 ip: 192.168.122.11
               internal-api:
                 ip: 172.17.0.4
+              storage:
+                ip: 172.18.0.4
+              tenant:
+                ip: 172.19.0.4
           crc:
             networks:
               default:


### PR DESCRIPTION
The controller node in the adoption base job nodeset does not have
interfaces for the storage and tenant networks. The storage network is
needed to use ceph.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
