### PR TITLE
Increasing default ip range

### DIFF
--- a/ci_framework/roles/os_net_setup/defaults/main.yml
+++ b/ci_framework/roles/os_net_setup/defaults/main.yml
@@ -12,7 +12,7 @@ cifmw_os_net_setup_config:
       - name: public_subnet
         cidr: 192.168.122.0/24
         allocation_pool_start: 192.168.122.200
-        allocation_pool_end: 192.168.122.210
+        allocation_pool_end: 192.168.122.240
         gateway_ip: 192.168.122.1
         enable_dhcp: false
 cifmw_os_net_setup_verify_tls: false


### PR DESCRIPTION
The current renge too small for parallel runs.
The default range might bo moved to different subnet in the
future, but for know only the range should be increased
in case of no overlapping known.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
