### PR TITLE
Split edpm_baremetal into 2 tasks

### DIFF
--- a/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -44,14 +44,23 @@
   ansible.builtin.include_role:
     name: set_openstack_containers
 
-- name: Install Dataplane with baremetal
+- name: Create virtual baremetal
   vars:
-    make_edpm_baremetal_env: "{{ cifmw_edpm_deploy_baremetal_common_env |
+    make_edpm_baremetal_compute_env: "{{ cifmw_edpm_deploy_baremetal_common_env |
       combine(cifmw_edpm_deploy_baremetal_make_openstack_env | from_yaml)}}"
-    make_edpm_baremetal_dryrun: "{{ cifmw_edpm_deploy_baremetal_dry_run }}"
+    make_edpm_baremetal_compute_dryrun: "{{ cifmw_edpm_deploy_baremetal_dry_run }}"
   ansible.builtin.include_role:
     name: 'install_yamls_makes'
-    tasks_from: 'make_edpm_baremetal'
+    tasks_from: 'make_edpm_baremetal_compute'
+
+- name: Deploy EDPM with baremetal
+  vars:
+    make_edpm_deploy_baremetal_env: "{{ cifmw_edpm_deploy_baremetal_common_env |
+      combine(cifmw_edpm_deploy_baremetal_make_openstack_env | from_yaml)}}"
+    make_edpm_deploy_baremetal_dryrun: "{{ cifmw_edpm_deploy_baremetal_dry_run }}"
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_edpm_deploy_baremetal'
 
 - name: Wait for Ironic to be ready
   when: not cifmw_edpm_deploy_baremetal_dry_run


### PR DESCRIPTION
The documented process is to call devsetup/Makefile
edpm_baremetal_compute and then Makefile edpm_deploy_baremetal. This
change does that, and also aligns the task names with the compute
tasks in 06-deploy-edpm.yml.

Once this has landed, target edpm_baremetal can be deleted so there is
no coupling between the 2 Makefiles.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
