### PR TITLE
Disable gpgcheck during rhos-release rpm installation

### DIFF
--- a/ci_framework/roles/repo_setup/README.md
+++ b/ci_framework/roles/repo_setup/README.md
@@ -21,6 +21,7 @@ Please explain the role purpose.
 ### Optional parameters for rhos-release
 * `cifmw_repo_setup_rhos_release_rpm`: (String) URL to rhos-release RPM.
 * `cifmw_repo_setup_rhos_release_args`: (String) Parameters to pass down to `rhos-release`.
+* `cifmw_repo_setup_rhos_release_gpg_check`: (Bool) Skips the gpg check during rhos-release rpm installation. Defaults to `True`.
 
 ## Notes
 

--- a/ci_framework/roles/repo_setup/defaults/main.yml
+++ b/ci_framework/roles/repo_setup/defaults/main.yml
@@ -38,3 +38,4 @@ cifmw_repo_setup_dlrn_hash_tag: ''
 # cifmw_repo_setup_rhos_release_rpm: <full url of rhos-release rpm>
 # cifmw_repo_setup_rhos_release_args: <arguments for rhos-release utility>
 cifmw_repo_setup_enable_rhos_release: false
+cifmw_repo_setup_rhos_release_gpg_check: true

--- a/ci_framework/roles/repo_setup/tasks/rhos_release.yml
+++ b/ci_framework/roles/repo_setup/tasks/rhos_release.yml
@@ -4,6 +4,7 @@
   ansible.builtin.package:
     name: "{{ cifmw_repo_setup_rhos_release_rpm }}"
     state: present
+    disable_gpg_check: "{{ cifmw_repo_setup_rhos_release_gpg_check | bool }}"
 
 - name: Get rhos-release tool version
   become: true

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -123,6 +123,7 @@ githooks
 github
 golang
 gowork
+gpg
 gpsbwcm
 groupinstall
 gw


### PR DESCRIPTION
On RHEL system, if we install rhos-release from rpm. It gives
```
Failed to validate GPG signature for rhos-release-1.6.15-1.noarch:
Package rhos-release-latest.noarchj1qd2t_h.rpm is not signed
```
These rpms are not shipped to customers and if the machine is subscribed subscription manager, we hit the above issue. The only way to overcome the issue is to disable the gpgcheck during rhos-release rpm installation.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

