### PR TITLE
Deploy ceph dashboard and monitoring stack

### DIFF
--- a/ci_framework/playbooks/ceph.yml
+++ b/ci_framework/playbooks/ceph.yml
@@ -251,6 +251,8 @@
       ansible.builtin.import_role:
         name: cifmw_cephadm
         tasks_from: monitoring
+      vars:
+        cifmw_cephadm_monitoring_network: "{{ lookup('ansible.builtin.ini', 'public_network section=global file=' ~ cifmw_cephadm_bootstrap_conf) }}"
 
     - name: Create cephfs volume
       ansible.builtin.import_role:

--- a/ci_framework/playbooks/ceph.yml
+++ b/ci_framework/playbooks/ceph.yml
@@ -247,6 +247,11 @@
         # cifmw_cephadm_vip is computed or passed as an override via -e @extra.yml
         cifmw_cephadm_rgw_vip: "{{ cifmw_cephadm_vip }}/24"
 
+    - name: Configure Monitoring Stack
+      ansible.builtin.import_role:
+        name: cifmw_cephadm
+        tasks_from: monitoring
+
     - name: Create cephfs volume
       ansible.builtin.import_role:
         name: cifmw_cephadm

--- a/ci_framework/roles/cifmw_cephadm/README.md
+++ b/ci_framework/roles/cifmw_cephadm/README.md
@@ -54,6 +54,24 @@ need to be changed for a typical EDPM deployment.
 
 * `cifmw_cephadm_keys`: see below
 
+ `cifmw_cephadm_certs`: The path on the ceph host where TLS/SSL certificates
+   are located. It points to '/etc/pki/tls'
+
+* `cifmw_cephadm_dashboard_crt`: The SSL/TLS certificate signed by CA which is
+   an optional parameter. If it is provided, ceph dashabord will be configured
+   for SSL automatically. Certficate should be made available in
+   `cifmw_cephadm_certs` path only. To enable SSL for dashabord, both
+   `cifmw_cephadm_dashboard_crt` and `cifmw_cephadm_dashboard_key` are needed.
+
+* `cifmw_cephadm_dashboard_key`: The SSL/TLS certificate key which is an
+   optional parameter. If it is provided, ceph dashabord will be configured
+   for SSL automatically.
+
+* `cifmw_cephadm_monitoring_network`: the Ceph `public_network` where the
+   dashboard monitoring stack instances should be bound. The network range
+   is gathered from the `cifmw_cephadm_bootstrap_conf` file, which represents
+   the initial Ceph configuration file passed at bootstrap time.
+
 * `cifmw_cephadm_rgw_network`: the Ceph `public_network` where the `radosgw`
    instances should be bound. The network range is gathered from the
    `cifmw_cephadm_bootstrap_conf` file, which represents the initial Ceph
@@ -76,7 +94,7 @@ need to be changed for a typical EDPM deployment.
 Use the `cifmw_cephadm_pools` list of dictionaries to define pools for
 Nova (vms), Cinder (volumes), Cinder-backups (backups), and Glance (images).
 ```
-fmw_cephadm_pools:
+cifmw_cephadm_pools:
 - name: vms
   pg_autoscale_mode: True
   target_size_ratio: 0.3

--- a/ci_framework/roles/cifmw_cephadm/README.md
+++ b/ci_framework/roles/cifmw_cephadm/README.md
@@ -58,13 +58,13 @@ need to be changed for a typical EDPM deployment.
    are located. It points to '/etc/pki/tls'
 
 * `cifmw_cephadm_dashboard_crt`: The SSL/TLS certificate signed by CA which is
-   an optional parameter. If it is provided, ceph dashabord will be configured
-   for SSL automatically. Certficate should be made available in
-   `cifmw_cephadm_certs` path only. To enable SSL for dashabord, both
+   an optional parameter. If it is provided, ceph dashboard will be configured
+   for SSL automatically. Certificate should be made available in
+   `cifmw_cephadm_certs` path only. To enable SSL for dashboard, both
    `cifmw_cephadm_dashboard_crt` and `cifmw_cephadm_dashboard_key` are needed.
 
 * `cifmw_cephadm_dashboard_key`: The SSL/TLS certificate key which is an
-   optional parameter. If it is provided, ceph dashabord will be configured
+   optional parameter. If it is provided, ceph dashboard will be configured
    for SSL automatically.
 
 * `cifmw_cephadm_monitoring_network`: the Ceph `public_network` where the

--- a/ci_framework/roles/cifmw_cephadm/defaults/main.yml
+++ b/ci_framework/roles/cifmw_cephadm/defaults/main.yml
@@ -92,8 +92,6 @@ cifmw_cephadm_ceph_spec_fqdn: "{{ ceph_spec_fqdn | default(false) | bool }}"
 cifmw_ceph_dashboard_spec_path: /tmp/ceph_dashboard.yml
 cifmw_cephadm_dashboard_crt: ""
 cifmw_cephadm_dashboard_key: ""
-cifmw_cephadm_grafana_crt: ""
-cifmw_cephadm_grafana_key: ""
 cifmw_cephadm_dashboard_port: 8444
 cifmw_cephadm_grafana_admin_user: 'admin'
 cifmw_cephadm_grafana_admin_password: '/home/grafana_password.yml'

--- a/ci_framework/roles/cifmw_cephadm/defaults/main.yml
+++ b/ci_framework/roles/cifmw_cephadm/defaults/main.yml
@@ -92,5 +92,19 @@ cifmw_cephadm_cephfs_name: "cephfs"
 cifmw_cephadm_ceph_spec_fqdn: "{{ ceph_spec_fqdn | default(false) | bool }}"
 cifmw_ceph_dashboard_spec_path: /tmp/ceph_dashboard.yml
 cifmw_cephadm_dashboard_protocol: http
+cifmw_cephadm_dashboard_crt: '/etc/pki/tls/certs/ceph_dashboard.crt'
+cifmw_cephadm_dashboard_key: '/etc/pki/tls/private/ceph_dashboard.key'
 cifmw_cephadm_grafana_crt: '/etc/pki/tls/certs/ceph_grafana.crt'
 cifmw_cephadm_grafana_key: '/etc/pki/tls/private/ceph_grafana.key'
+cifmw_cephadm_dashboard_enabled: true
+cifmw_cephadm_dashboard_port: 8444
+cifmw_cephadm_dashboard_admin_user: 'admin'
+cifmw_cephadm_dashboard_admin_password: 'admin'
+cifmw_cephadm_dashboard_admin_user_ro: 'read-only'
+#cifmw_dashboard_pwd_file: '/etc/ceph/dashboard_password.yml'
+#cifmw_container_dashboard_pwd_file: '/home/dashboard_password.yml'
+cifmw_cephadm_grafana_admin_user: 'admin'
+cifmw_cephadm_grafana_admin_password: '/home/grafana_password.yml'
+cifmw_cephadm_prometheus_port:  9092
+cifmw_cephadm_grafana_port: 3100
+cifmw_cephadm_dashboard_frontend_vip:

--- a/ci_framework/roles/cifmw_cephadm/defaults/main.yml
+++ b/ci_framework/roles/cifmw_cephadm/defaults/main.yml
@@ -95,5 +95,5 @@ cifmw_cephadm_dashboard_key: ""
 cifmw_cephadm_dashboard_port: 8444
 cifmw_cephadm_grafana_admin_user: 'admin'
 cifmw_cephadm_grafana_admin_password: '/home/grafana_password.yml'
-cifmw_cephadm_prometheus_port:  9092
+cifmw_cephadm_prometheus_port: 9092
 cifmw_cephadm_grafana_port: 3100

--- a/ci_framework/roles/cifmw_cephadm/defaults/main.yml
+++ b/ci_framework/roles/cifmw_cephadm/defaults/main.yml
@@ -91,3 +91,6 @@ cifmw_ceph_rgw_config:
 cifmw_cephadm_cephfs_name: "cephfs"
 cifmw_cephadm_ceph_spec_fqdn: "{{ ceph_spec_fqdn | default(false) | bool }}"
 cifmw_ceph_dashboard_spec_path: /tmp/ceph_dashboard.yml
+cifmw_cephadm_dashboard_protocol: http
+cifmw_cephadm_grafana_crt: '/etc/pki/tls/certs/ceph_grafana.crt'
+cifmw_cephadm_grafana_key: '/etc/pki/tls/private/ceph_grafana.key'

--- a/ci_framework/roles/cifmw_cephadm/defaults/main.yml
+++ b/ci_framework/roles/cifmw_cephadm/defaults/main.yml
@@ -90,3 +90,4 @@ cifmw_ceph_rgw_config:
   rgw_max_attr_size: 1024
 cifmw_cephadm_cephfs_name: "cephfs"
 cifmw_cephadm_ceph_spec_fqdn: "{{ ceph_spec_fqdn | default(false) | bool }}"
+cifmw_ceph_dashboard_spec_path: /tmp/ceph_dashboard.yml

--- a/ci_framework/roles/cifmw_cephadm/defaults/main.yml
+++ b/ci_framework/roles/cifmw_cephadm/defaults/main.yml
@@ -63,7 +63,6 @@ cifmw_cephadm_default_container: false
 cifmw_cephadm_single_host_defaults: false
 cifmw_cephadm_extra_args: ""
 cifmw_cephadm_pacific_filter: "16.*"
-cifmw_cephadm_dashboard_enabled: false
 # The path of the rendered rgw spec file
 cifmw_ceph_rgw_spec_path: /tmp/ceph_rgw.yml
 cifmw_ceph_rgw_keystone_ep: "keystone-internal.openstack.svc:5000"
@@ -91,20 +90,12 @@ cifmw_ceph_rgw_config:
 cifmw_cephadm_cephfs_name: "cephfs"
 cifmw_cephadm_ceph_spec_fqdn: "{{ ceph_spec_fqdn | default(false) | bool }}"
 cifmw_ceph_dashboard_spec_path: /tmp/ceph_dashboard.yml
-cifmw_cephadm_dashboard_protocol: http
-cifmw_cephadm_dashboard_crt: '/etc/pki/tls/certs/ceph_dashboard.crt'
-cifmw_cephadm_dashboard_key: '/etc/pki/tls/private/ceph_dashboard.key'
-cifmw_cephadm_grafana_crt: '/etc/pki/tls/certs/ceph_grafana.crt'
-cifmw_cephadm_grafana_key: '/etc/pki/tls/private/ceph_grafana.key'
-cifmw_cephadm_dashboard_enabled: true
+cifmw_cephadm_dashboard_crt: ""
+cifmw_cephadm_dashboard_key: ""
+cifmw_cephadm_grafana_crt: ""
+cifmw_cephadm_grafana_key: ""
 cifmw_cephadm_dashboard_port: 8444
-cifmw_cephadm_dashboard_admin_user: 'admin'
-cifmw_cephadm_dashboard_admin_password: 'admin'
-cifmw_cephadm_dashboard_admin_user_ro: 'read-only'
-#cifmw_dashboard_pwd_file: '/etc/ceph/dashboard_password.yml'
-#cifmw_container_dashboard_pwd_file: '/home/dashboard_password.yml'
 cifmw_cephadm_grafana_admin_user: 'admin'
 cifmw_cephadm_grafana_admin_password: '/home/grafana_password.yml'
 cifmw_cephadm_prometheus_port:  9092
 cifmw_cephadm_grafana_port: 3100
-cifmw_cephadm_dashboard_frontend_vip:

--- a/ci_framework/roles/cifmw_cephadm/tasks/cephadm_config_set.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/cephadm_config_set.yml
@@ -69,7 +69,6 @@
 
 - name: Set dashboard container image in ceph mgr configuration
   when:
-    - cifmw_cephadm_dashboard_enabled | bool
     - not (cifmw_cephadm_default_container | default(false) | bool)
   become: true
   block:

--- a/ci_framework/roles/cifmw_cephadm/tasks/dashboard/configure_dashboard_backends.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/dashboard/configure_dashboard_backends.yml
@@ -15,14 +15,14 @@
 # under the License.
 
 - name: Get the current mgr
-  command: |
+  ansible.builtin.command: |
     {{ cifmw_cephadm_container_cli }} ps -a -f 'name=ceph-?(.*)-mgr.*' --format \{\{\.Command\}\} --no-trunc
   register: ceph_mgr
   become: true
   delegate_to: "{{ dashboard_backend }}"
 
 - name: Check the resulting mgr container instance
-  set_fact:
+  ansible.builtin.set_fact:
     current_mgr: "{{ ceph_mgr.stdout | regex_replace('^-n mgr.(.*)(?P<inst>) -f (.*)+$', '\\1') }}"
 
 - name: Check the resulting mgr container instance
@@ -31,7 +31,7 @@
   when: cifmw_cephadm_verbose | bool
 
 - name: config the current dashboard backend
-  command: |
+  ansible.builtin.command: |
     {{ cifmw_cephadm_ceph_cli }} config set \
     mgr mgr/dashboard/{{ current_mgr }}/server_addr \
     {{ hostvars[item][all_addresses] | ansible.utils.ipaddr(cifmw_cephadm_rgw_network) | first }}

--- a/ci_framework/roles/cifmw_cephadm/tasks/dashboard/configure_dashboard_backends.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/dashboard/configure_dashboard_backends.yml
@@ -26,14 +26,13 @@
     current_mgr: "{{ ceph_mgr.stdout | regex_replace('^-n mgr.(.*)(?P<inst>) -f (.*)+$', '\\1') }}"
 
 - name: Check the resulting mgr container instance
-  debug:
+  ansible.builtin.debug:
     msg: "{{ current_mgr }}"
   when: cifmw_cephadm_verbose | bool
 
-- name: config the current dashboard backend
+- name: Config the current dashboard backend
   ansible.builtin.command: |
     {{ cifmw_cephadm_ceph_cli }} config set \
     mgr mgr/dashboard/{{ current_mgr }}/server_addr \
     {{ hostvars[item][all_addresses] | ansible.utils.ipaddr(cifmw_cephadm_rgw_network) | first }}
   become: true
- 

--- a/ci_framework/roles/cifmw_cephadm/tasks/dashboard/configure_dashboard_backends.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/dashboard/configure_dashboard_backends.yml
@@ -1,0 +1,39 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Get the current mgr
+  command: |
+    {{ cifmw_cephadm_container_cli }} ps -a -f 'name=ceph-?(.*)-mgr.*' --format \{\{\.Command\}\} --no-trunc
+  register: ceph_mgr
+  become: true
+  delegate_to: "{{ dashboard_backend }}"
+
+- name: Check the resulting mgr container instance
+  set_fact:
+    current_mgr: "{{ ceph_mgr.stdout | regex_replace('^-n mgr.(.*)(?P<inst>) -f (.*)+$', '\\1') }}"
+
+- name: Check the resulting mgr container instance
+  debug:
+    msg: "{{ current_mgr }}"
+  when: cifmw_cephadm_verbose | bool
+
+- name: config the current dashboard backend
+  command: |
+    {{ cifmw_cephadm_ceph_cli }} config set \
+    mgr mgr/dashboard/{{ current_mgr }}/server_addr \
+    {{ hostvars[item][all_addresses] | ansible.utils.ipaddr(cifmw_cephadm_rgw_network) | first }}
+  become: true
+ 

--- a/ci_framework/roles/cifmw_cephadm/tasks/dashboard/dashboard.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/dashboard/dashboard.yml
@@ -24,35 +24,36 @@
 - name: Configure the Ceph Dashboard port
   become: true
   block:
-    - name: "set the dashboard port ({{ cifmw_cephadm_dashboard_port }})"
+    - name: "Set the dashboard port ({{ cifmw_cephadm_dashboard_port }})"
       ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config set mgr mgr/dashboard/server_port {{ cifmw_cephadm_dashboard_port }}"
       changed_when: false
-    - name: "set the dashboard SSL port ({{ cifmw_cephadm_dashboard_port }})"
+    - name: "Set the dashboard SSL port ({{ cifmw_cephadm_dashboard_port }})"
       ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config set mgr mgr/dashboard/ssl_server_port {{ cifmw_cephadm_dashboard_port }}"
       run_once: true
 
-- name: disable SSL for dashboard
+- name: Disable SSL for dashboard
   become: true
   ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config set mgr mgr/dashboard/ssl false"
 
 - name: Configure SSL key/cert for the Ceph Dashboard if provided
   become: true
+  when: cifmw_cephadm_dashboard_crt | length > 0 and
+        cifmw_cephadm_dashboard_key | length > 0
   block:
-    - name: enable SSL for dashboard
+    - name: Enable SSL for dashboard
       ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config set mgr mgr/dashboard/ssl true"
       run_once: true
 
-    - name: import dashboard certificate file
+    - name: Import dashboard certificate file
       ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config-key set mgr/dashboard/crt -i {{ cifmw_cephadm_dashboard_crt }}"
       changed_when: false
 
-    - name: import dashboard certificate key
+    - name: Import dashboard certificate key
       ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config-key set mgr/dashboard/key -i {{ cifmw_cephadm_dashboard_key }}"
       changed_when: false
-  when: cifmw_cephadm_dashboard_crt | length > 0 and
-        cifmw_cephadm_dashboard_key | length > 0
 
-- include_tasks: configure_dashboard_backends.yml
+- name: Configure dashboard backends
+  ansible.builtin.include_tasks: configure_dashboard_backends.yml
   with_items: "{{ groups['edpm'] }}"
   vars:
     dashboard_backend: '{{ item }}'
@@ -60,41 +61,41 @@
 - name: Restart the Ceph dashboard
   become: true
   block:
-    - name: disable mgr dashboard module (restart)
+    - name: Disable mgr dashboard module (restart)
       ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} mgr module disable dashboard"
-    - name: enable mgr dashboard module (restart)
+    - name: Enable mgr dashboard module (restart)
       ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} mgr module enable dashboard"
 
 - name: Configure Monitoring Stack
   become: true
   vars:
-    grafana_host:  "{{ groups['edpm'][0] }}"
+    grafana_host: "{{ groups['edpm'][0] }}"
   block:
-    - name: get Grafana instance address
+    - name: Get Grafana instance address
       ansible.builtin.set_fact:
         grafana_server_addr: "{{ hostvars[grafana_host][all_addresses] | ansible.utils.ipaddr(cifmw_cephadm_monitoring_network) | first }}"
-    - name: set grafana api user
+    - name: Set grafana api user
       ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} dashboard set-grafana-api-username {{ cifmw_cephadm_grafana_admin_user }}"
-    - name: set grafana api password
+    - name: Set grafana api password
       ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} dashboard set-grafana-api-password -i -"
       args:
         stdin: "{{ cifmw_cephadm_grafana_admin_password }}"
-        stdin_add_newline: no
-    - name: disable ssl verification for grafana
+        stdin_add_newline: "no"
+    - name: Disable ssl verification for grafana
       ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} dashboard set-grafana-api-ssl-verify False"
       changed_when: false
       when:
         - cifmw_cephadm_dashboard_crt | length > 0 and
           cifmw_cephadm_dashboard_key | length > 0
 
-    - name: set alertmanager host
+    - name: Set alertmanager host
       ansible.builtin.command: |
         {{ cifmw_cephadm_ceph_cli }} dashboard set-alertmanager-api-host http://{{ grafana_server_addr }}:9093
-    - name: set prometheus host
+    - name: Set prometheus host
       ansible.builtin.command: |
         {{ cifmw_cephadm_ceph_cli }} dashboard set-prometheus-api-host \
         http://{{ grafana_server_addr }}:{{ cifmw_cephadm_prometheus_port }}
-    - name: config grafana api url
+    - name: Config grafana api url
       ansible.builtin.command: |
         {{ cifmw_cephadm_ceph_cli }} dashboard set-grafana-api-url \
         http://{{ grafana_server_addr }}:{{ cifmw_cephadm_grafana_port }}
@@ -102,7 +103,7 @@
 - name: Restart the Ceph dashboard
   become: true
   block:
-    - name: disable mgr dashboard module (restart)
+    - name: Disable mgr dashboard module (restart)
       ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} mgr module disable dashboard"
-    - name: enable mgr dashboard module (restart)
+    - name: Enable mgr dashboard module (restart)
       ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} mgr module enable dashboard"

--- a/ci_framework/roles/cifmw_cephadm/tasks/dashboard/dashboard.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/dashboard/dashboard.yml
@@ -1,0 +1,112 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Get ceph_cli
+  ansible.builtin.include_tasks: ceph_cli.yml
+  vars:
+    mount_spec: true
+    sensitive_data: true
+    mount_certs: "{{ (cifmw_cephadm_dashboard_protocol == 'https' and cifmw_cephadm_dashboard_crt | length > 0 and cifmw_cephadm_dashboard_key | length > 0) | bool }}"
+
+- name: Configure the Ceph Dashboard port
+  become: true
+  block:
+    - name: "set the dashboard port ({{ cifmw_cephadm_dashboard_port }})"
+      command: "{{ cifmw_cephadm_ceph_cli }} config set mgr mgr/dashboard/server_port {{ cifmw_cephadm_dashboard_port }}"
+      changed_when: false
+    - name: "set the dashboard SSL port ({{ cifmw_cephadm_dashboard_port }})"
+      command: "{{ cifmw_cephadm_ceph_cli }} config set mgr mgr/dashboard/ssl_server_port {{ cifmw_cephadm_dashboard_port }}"
+      run_once: true
+
+- name: disable SSL for dashboard
+  become: true
+  command: "{{ cifmw_cephadm_ceph_cli }} config set mgr mgr/dashboard/ssl false"
+  when: cifmw_cephadm_dashboard_protocol == "http"
+
+- name: Configure SSL key/cert for the Ceph Dashboard if provided
+  become: true
+  block:
+    - name: enable SSL for dashboard
+      command: "{{ cifmw_cephadm_ceph_cli }} config set mgr mgr/dashboard/ssl true"
+      run_once: true
+
+    - name: import dashboard certificate file
+      command: "{{ cifmw_cephadm_ceph_cli }} config-key set mgr/dashboard/crt -i {{ cifmw_cephadm_dashboard_crt }}"
+      changed_when: false
+
+    - name: import dashboard certificate key
+      command: "{{ cifmw_cephadm_ceph_cli }} config-key set mgr/dashboard/key -i {{ cifmw_cephadm_dashboard_key }}"
+      changed_when: false
+  when: cifmw_cephadm_dashboard_protocol == "https" and
+        cifmw_cephadm_dashboard_crt | length > 0 and
+        cifmw_cephadm_dashboard_key | length > 0
+
+- include_tasks: configure_dashboard_backends.yml
+  with_items: "{{ groups['edpm'] }}"
+  vars:
+    dashboard_backend: '{{ item }}'
+
+- name: Restart the Ceph dashboard
+  become: true
+  block:
+    - name: disable mgr dashboard module (restart)
+      command: "{{ cifmw_cephadm_ceph_cli }} mgr module disable dashboard"
+    - name: enable mgr dashboard module (restart)
+      command: "{{ cifmw_cephadm_ceph_cli }} mgr module enable dashboard"
+
+      #ToDo : skipped dashboard admin user creation task for CI, we shall add it if needed. 
+- name: Configure Monitoring Stack
+  become: true
+  block:
+    - name: get Grafana instance(s) addresses
+      set_fact:
+        grafana_server_addrs: "{{ (grafana_server_addrs | default([])) | union(hostvars[item][all_addresses] | ansible.utils.ipaddr(cifmw_cephadm_rgw_network)) }}"
+      loop: "{{ groups['edpm'] | list }}"
+    - name: set grafana api user
+      command: "{{ cifmw_cephadm_ceph_cli }} dashboard set-grafana-api-username {{ cifmw_cephadm_grafana_admin_user }}"
+    - name: set grafana api password
+      command: "{{ cifmw_cephadm_ceph_cli }} dashboard set-grafana-api-password -i -"
+      args:
+        stdin: "{{ cifmw_cephadm_grafana_admin_password }}"
+        stdin_add_newline: no
+    - name: disable ssl verification for grafana
+      command: "{{ cifmw_cephadm_ceph_cli }} dashboard set-grafana-api-ssl-verify False"
+      changed_when: false
+      when:
+        - cifmw_cephadm_dashboard_protocol == "https"
+    - name: set alertmanager host
+      command: |
+        {{ cifmw_cephadm_ceph_cli }} dashboard set-alertmanager-api-host http://{{ grafana_server_addrs | first }}:9093
+    - name: set prometheus host
+      command: |
+        {{ cifmw_cephadm_ceph_cli }} dashboard set-prometheus-api-host \
+        http://{{ grafana_server_addrs | first }}:{{ cifmw_cephadm_prometheus_port }}
+    - name: config grafana api url vip
+      command: |
+        {{ cifmw_cephadm_ceph_cli }} dashboard set-grafana-api-url \
+        {{ cifmw_cephadm_dashboard_protocol }}://{{ cifmw_cephadm_dashboard_frontend_vip }}:{{ cifmw_cephadm_grafana_port }}
+      changed_when: false
+      when:
+        - cifmw_cephadm_dashboard_frontend_vip is defined
+        - cifmw_cephadm_dashboard_frontend_vip | length > 0
+
+- name: Restart the Ceph dashboard
+  become: true
+  block:
+    - name: disable mgr dashboard module (restart)
+      command: "{{ cifmw_cephadm_ceph_cli }} mgr module disable dashboard"
+    - name: enable mgr dashboard module (restart)
+      command: "{{ cifmw_cephadm_ceph_cli }} mgr module enable dashboard"

--- a/ci_framework/roles/cifmw_cephadm/tasks/dashboard/dashboard.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/dashboard/dashboard.yml
@@ -19,39 +19,37 @@
   vars:
     mount_spec: true
     sensitive_data: true
-    mount_certs: "{{ (cifmw_cephadm_dashboard_protocol == 'https' and cifmw_cephadm_dashboard_crt | length > 0 and cifmw_cephadm_dashboard_key | length > 0) | bool }}"
+    mount_certs: "{{ (cifmw_cephadm_dashboard_crt | length > 0 and cifmw_cephadm_dashboard_key | length > 0) | bool }}"
 
 - name: Configure the Ceph Dashboard port
   become: true
   block:
     - name: "set the dashboard port ({{ cifmw_cephadm_dashboard_port }})"
-      command: "{{ cifmw_cephadm_ceph_cli }} config set mgr mgr/dashboard/server_port {{ cifmw_cephadm_dashboard_port }}"
+      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config set mgr mgr/dashboard/server_port {{ cifmw_cephadm_dashboard_port }}"
       changed_when: false
     - name: "set the dashboard SSL port ({{ cifmw_cephadm_dashboard_port }})"
-      command: "{{ cifmw_cephadm_ceph_cli }} config set mgr mgr/dashboard/ssl_server_port {{ cifmw_cephadm_dashboard_port }}"
+      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config set mgr mgr/dashboard/ssl_server_port {{ cifmw_cephadm_dashboard_port }}"
       run_once: true
 
 - name: disable SSL for dashboard
   become: true
-  command: "{{ cifmw_cephadm_ceph_cli }} config set mgr mgr/dashboard/ssl false"
-  when: cifmw_cephadm_dashboard_protocol == "http"
+  ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config set mgr mgr/dashboard/ssl false"
 
 - name: Configure SSL key/cert for the Ceph Dashboard if provided
   become: true
   block:
     - name: enable SSL for dashboard
-      command: "{{ cifmw_cephadm_ceph_cli }} config set mgr mgr/dashboard/ssl true"
+      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config set mgr mgr/dashboard/ssl true"
       run_once: true
 
     - name: import dashboard certificate file
-      command: "{{ cifmw_cephadm_ceph_cli }} config-key set mgr/dashboard/crt -i {{ cifmw_cephadm_dashboard_crt }}"
+      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config-key set mgr/dashboard/crt -i {{ cifmw_cephadm_dashboard_crt }}"
       changed_when: false
 
     - name: import dashboard certificate key
-      command: "{{ cifmw_cephadm_ceph_cli }} config-key set mgr/dashboard/key -i {{ cifmw_cephadm_dashboard_key }}"
+      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config-key set mgr/dashboard/key -i {{ cifmw_cephadm_dashboard_key }}"
       changed_when: false
-  when: cifmw_cephadm_dashboard_protocol == "https" and
-        cifmw_cephadm_dashboard_crt | length > 0 and
+  when: cifmw_cephadm_dashboard_crt | length > 0 and
         cifmw_cephadm_dashboard_key | length > 0
 
 - include_tasks: configure_dashboard_backends.yml
@@ -63,47 +61,49 @@
   become: true
   block:
     - name: disable mgr dashboard module (restart)
-      command: "{{ cifmw_cephadm_ceph_cli }} mgr module disable dashboard"
+      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} mgr module disable dashboard"
     - name: enable mgr dashboard module (restart)
-      command: "{{ cifmw_cephadm_ceph_cli }} mgr module enable dashboard"
+      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} mgr module enable dashboard"
 
-      #ToDo : skipped dashboard admin user creation task for CI, we shall add it if needed. 
 - name: Configure Monitoring Stack
   become: true
+  vars:
+    grafana_host:  "{{ groups['edpm'][0] }}"
   block:
-    - name: get Grafana instance(s) addresses
-      set_fact:
-        grafana_server_addrs: "{{ (grafana_server_addrs | default([])) | union(hostvars[item][all_addresses] | ansible.utils.ipaddr(cifmw_cephadm_rgw_network)) }}"
-      loop: "{{ groups['edpm'] | list }}"
+    - name: get Grafana instance address
+      ansible.builtin.set_fact:
+        grafana_server_addr: "{{ hostvars[grafana_host][all_addresses] | ansible.utils.ipaddr(cifmw_cephadm_monitoring_network) }}"
     - name: set grafana api user
-      command: "{{ cifmw_cephadm_ceph_cli }} dashboard set-grafana-api-username {{ cifmw_cephadm_grafana_admin_user }}"
+      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} dashboard set-grafana-api-username {{ cifmw_cephadm_grafana_admin_user }}"
     - name: set grafana api password
-      command: "{{ cifmw_cephadm_ceph_cli }} dashboard set-grafana-api-password -i -"
+      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} dashboard set-grafana-api-password -i -"
       args:
         stdin: "{{ cifmw_cephadm_grafana_admin_password }}"
         stdin_add_newline: no
     - name: disable ssl verification for grafana
-      command: "{{ cifmw_cephadm_ceph_cli }} dashboard set-grafana-api-ssl-verify False"
+      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} dashboard set-grafana-api-ssl-verify False"
       changed_when: false
       when:
-        - cifmw_cephadm_dashboard_protocol == "https"
+        - cifmw_cephadm_dashboard_crt | length > 0 and
+          cifmw_cephadm_dashboard_key | length > 0
+
+
     - name: set alertmanager host
-      command: |
-        {{ cifmw_cephadm_ceph_cli }} dashboard set-alertmanager-api-host http://{{ grafana_server_addrs | first }}:9093
+      ansible.builtin.command: |
+        {{ cifmw_cephadm_ceph_cli }} dashboard set-alertmanager-api-host http://{{ grafana_server_addr | first }}:9093
     - name: set prometheus host
-      command: |
+      ansible.builtin.command: |
         {{ cifmw_cephadm_ceph_cli }} dashboard set-prometheus-api-host \
-        http://{{ grafana_server_addrs | first }}:{{ cifmw_cephadm_prometheus_port }}
-    #ToDo: We may need to use cifmw_cephadm_dashboard_frontend_vip similar to tripleo
-    - name: config grafana api url vip
-      command: |
+        http://{{ grafana_server_addr | first }}:{{ cifmw_cephadm_prometheus_port }}
+    - name: config grafana api url
+      ansible.builtin.command: |
         {{ cifmw_cephadm_ceph_cli }} dashboard set-grafana-api-url \
-        {{ cifmw_cephadm_dashboard_protocol }}://{{ grafana_server_addrs | first }}:{{ cifmw_cephadm_grafana_port }}
+        http://{{ grafana_server_addr | first }}:{{ cifmw_cephadm_grafana_port }}
 
 - name: Restart the Ceph dashboard
   become: true
   block:
     - name: disable mgr dashboard module (restart)
-      command: "{{ cifmw_cephadm_ceph_cli }} mgr module disable dashboard"
+      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} mgr module disable dashboard"
     - name: enable mgr dashboard module (restart)
-      command: "{{ cifmw_cephadm_ceph_cli }} mgr module enable dashboard"
+      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} mgr module enable dashboard"

--- a/ci_framework/roles/cifmw_cephadm/tasks/dashboard/dashboard.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/dashboard/dashboard.yml
@@ -72,7 +72,7 @@
   block:
     - name: get Grafana instance address
       ansible.builtin.set_fact:
-        grafana_server_addr: "{{ hostvars[grafana_host][all_addresses] | ansible.utils.ipaddr(cifmw_cephadm_monitoring_network) }}"
+        grafana_server_addr: "{{ hostvars[grafana_host][all_addresses] | ansible.utils.ipaddr(cifmw_cephadm_monitoring_network) | first }}"
     - name: set grafana api user
       ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} dashboard set-grafana-api-username {{ cifmw_cephadm_grafana_admin_user }}"
     - name: set grafana api password
@@ -87,18 +87,17 @@
         - cifmw_cephadm_dashboard_crt | length > 0 and
           cifmw_cephadm_dashboard_key | length > 0
 
-
     - name: set alertmanager host
       ansible.builtin.command: |
-        {{ cifmw_cephadm_ceph_cli }} dashboard set-alertmanager-api-host http://{{ grafana_server_addr | first }}:9093
+        {{ cifmw_cephadm_ceph_cli }} dashboard set-alertmanager-api-host http://{{ grafana_server_addr }}:9093
     - name: set prometheus host
       ansible.builtin.command: |
         {{ cifmw_cephadm_ceph_cli }} dashboard set-prometheus-api-host \
-        http://{{ grafana_server_addr | first }}:{{ cifmw_cephadm_prometheus_port }}
+        http://{{ grafana_server_addr }}:{{ cifmw_cephadm_prometheus_port }}
     - name: config grafana api url
       ansible.builtin.command: |
         {{ cifmw_cephadm_ceph_cli }} dashboard set-grafana-api-url \
-        http://{{ grafana_server_addr | first }}:{{ cifmw_cephadm_grafana_port }}
+        http://{{ grafana_server_addr }}:{{ cifmw_cephadm_grafana_port }}
 
 - name: Restart the Ceph dashboard
   become: true

--- a/ci_framework/roles/cifmw_cephadm/tasks/dashboard/dashboard.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/dashboard/dashboard.yml
@@ -94,14 +94,11 @@
       command: |
         {{ cifmw_cephadm_ceph_cli }} dashboard set-prometheus-api-host \
         http://{{ grafana_server_addrs | first }}:{{ cifmw_cephadm_prometheus_port }}
+    #ToDo: We may need to use cifmw_cephadm_dashboard_frontend_vip similar to tripleo
     - name: config grafana api url vip
       command: |
         {{ cifmw_cephadm_ceph_cli }} dashboard set-grafana-api-url \
-        {{ cifmw_cephadm_dashboard_protocol }}://{{ cifmw_cephadm_dashboard_frontend_vip }}:{{ cifmw_cephadm_grafana_port }}
-      changed_when: false
-      when:
-        - cifmw_cephadm_dashboard_frontend_vip is defined
-        - cifmw_cephadm_dashboard_frontend_vip | length > 0
+        {{ cifmw_cephadm_dashboard_protocol }}://{{ grafana_server_addrs | first }}:{{ cifmw_cephadm_grafana_port }}
 
 - name: Restart the Ceph dashboard
   become: true

--- a/ci_framework/roles/cifmw_cephadm/tasks/monitoring.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/monitoring.yml
@@ -1,8 +1,18 @@
-
-- name: Collect the host and build the resulting host list
-  ansible.builtin.set_fact:
-    _hosts: "{{ _hosts|default([]) + [ hostvars[item]['ansible_hostname'] ] }}"
-  loop: "{{ groups['edpm'] }}"
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
 
 - name: Create dashboard spec
   ansible.builtin.template:
@@ -38,4 +48,3 @@
 - name: Apply spec
   ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} orch apply --in-file {{ cifmw_cephadm_container_spec }}"
   become: true
-

--- a/ci_framework/roles/cifmw_cephadm/tasks/monitoring.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/monitoring.yml
@@ -48,3 +48,7 @@
 - name: Apply spec
   ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} orch apply --in-file {{ cifmw_cephadm_container_spec }}"
   become: true
+
+- include_tasks: dashboard/dashboard.yml
+  when:
+    - cifmw_cephadm_dashboard_enabled | bool

--- a/ci_framework/roles/cifmw_cephadm/tasks/monitoring.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/monitoring.yml
@@ -25,16 +25,16 @@
   become: true
   block:
     - name: Get ceph_cli
-      include_tasks: ceph_cli.yaml
+      ansible.builtin.include_tasks: ceph_cli.yml
       vars:
         mount_certs: true
 
     - name: import grafana certificate file
-      command: "{{ tripleo_cephadm_ceph_cli }} config-key set mgr/cephadm/grafana_crt -i {{ tripleo_cephadm_grafana_crt }}"
+      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config-key set mgr/cephadm/grafana_crt -i {{ cifmw_cephadm_grafana_crt }}"
       changed_when: false
 
     - name: import grafana certificate key
-      command: "{{ tripleo_cephadm_ceph_cli }} config-key set mgr/cephadm/grafana_key -i {{ tripleo_cephadm_grafana_key }}"
+      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config-key set mgr/cephadm/grafana_key -i {{ cifmw_cephadm_grafana_key }}"
       changed_when: false
   when: cifmw_cephadm_dashboard_protocol == "https" and
         cifmw_cephadm_grafana_crt | length > 0 and cifmw_cephadm_grafana_key | length > 0

--- a/ci_framework/roles/cifmw_cephadm/tasks/monitoring.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/monitoring.yml
@@ -16,7 +16,7 @@
 
 - name: Create dashboard spec
   ansible.builtin.template:
-    src: templates/ceph_dashboard.yml.j2
+    src: templates/ceph_monitoring_stack.yml.j2
     dest: "{{ cifmw_ceph_dashboard_spec_path }}"
     mode: '0644'
     force: true
@@ -36,8 +36,8 @@
     - name: import grafana certificate key
       ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config-key set mgr/cephadm/grafana_key -i {{ cifmw_cephadm_grafana_key }}"
       changed_when: false
-  when: cifmw_cephadm_dashboard_protocol == "https" and
-        cifmw_cephadm_grafana_crt | length > 0 and cifmw_cephadm_grafana_key | length > 0
+  when: cifmw_cephadm_grafana_crt | length > 0 and
+        cifmw_cephadm_grafana_key | length > 0
 
 - name: Get ceph_cli
   ansible.builtin.include_tasks: ceph_cli.yml
@@ -50,5 +50,3 @@
   become: true
 
 - include_tasks: dashboard/dashboard.yml
-  when:
-    - cifmw_cephadm_dashboard_enabled | bool

--- a/ci_framework/roles/cifmw_cephadm/tasks/monitoring.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/monitoring.yml
@@ -30,14 +30,14 @@
         mount_certs: true
 
     - name: import grafana certificate file
-      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config-key set mgr/cephadm/grafana_crt -i {{ cifmw_cephadm_grafana_crt }}"
+      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config-key set mgr/cephadm/grafana_crt -i {{ cifmw_cephadm_dashboard_crt }}"
       changed_when: false
 
     - name: import grafana certificate key
-      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config-key set mgr/cephadm/grafana_key -i {{ cifmw_cephadm_grafana_key }}"
+      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config-key set mgr/cephadm/grafana_key -i {{ cifmw_cephadm_dashboard_key }}"
       changed_when: false
-  when: cifmw_cephadm_grafana_crt | length > 0 and
-        cifmw_cephadm_grafana_key | length > 0
+  when: cifmw_cephadm_dashboard_crt | length > 0 and
+        cifmw_cephadm_dashboard_key | length > 0
 
 - name: Get ceph_cli
   ansible.builtin.include_tasks: ceph_cli.yml

--- a/ci_framework/roles/cifmw_cephadm/tasks/monitoring.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/monitoring.yml
@@ -23,21 +23,21 @@
 
 - name: Config ssl cert(s) and key(s) for the exposed components
   become: true
+  when: cifmw_cephadm_dashboard_crt | length > 0 and
+        cifmw_cephadm_dashboard_key | length > 0
   block:
     - name: Get ceph_cli
       ansible.builtin.include_tasks: ceph_cli.yml
       vars:
         mount_certs: true
 
-    - name: import grafana certificate file
+    - name: Import grafana certificate file
       ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config-key set mgr/cephadm/grafana_crt -i {{ cifmw_cephadm_dashboard_crt }}"
       changed_when: false
 
-    - name: import grafana certificate key
+    - name: Import grafana certificate key
       ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config-key set mgr/cephadm/grafana_key -i {{ cifmw_cephadm_dashboard_key }}"
       changed_when: false
-  when: cifmw_cephadm_dashboard_crt | length > 0 and
-        cifmw_cephadm_dashboard_key | length > 0
 
 - name: Get ceph_cli
   ansible.builtin.include_tasks: ceph_cli.yml
@@ -49,4 +49,5 @@
   ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} orch apply --in-file {{ cifmw_cephadm_container_spec }}"
   become: true
 
-- include_tasks: dashboard/dashboard.yml
+- name: Run dashboard tasks
+  ansible.builtin.include_tasks: dashboard/dashboard.yml

--- a/ci_framework/roles/cifmw_cephadm/tasks/monitoring.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/monitoring.yml
@@ -1,0 +1,41 @@
+
+- name: Collect the host and build the resulting host list
+  ansible.builtin.set_fact:
+    _hosts: "{{ _hosts|default([]) + [ hostvars[item]['ansible_hostname'] ] }}"
+  loop: "{{ groups['edpm'] }}"
+
+- name: Create dashboard spec
+  ansible.builtin.template:
+    src: templates/ceph_dashboard.yml.j2
+    dest: "{{ cifmw_ceph_dashboard_spec_path }}"
+    mode: '0644'
+    force: true
+
+- name: Config ssl cert(s) and key(s) for the exposed components
+  become: true
+  block:
+    - name: Get ceph_cli
+      include_tasks: ceph_cli.yaml
+      vars:
+        mount_certs: true
+
+    - name: import grafana certificate file
+      command: "{{ tripleo_cephadm_ceph_cli }} config-key set mgr/cephadm/grafana_crt -i {{ tripleo_cephadm_grafana_crt }}"
+      changed_when: false
+
+    - name: import grafana certificate key
+      command: "{{ tripleo_cephadm_ceph_cli }} config-key set mgr/cephadm/grafana_key -i {{ tripleo_cephadm_grafana_key }}"
+      changed_when: false
+  when: cifmw_cephadm_dashboard_protocol == "https" and
+        cifmw_cephadm_grafana_crt | length > 0 and cifmw_cephadm_grafana_key | length > 0
+
+- name: Get ceph_cli
+  ansible.builtin.include_tasks: ceph_cli.yml
+  vars:
+    mount_spec: true
+    cifmw_cephadm_spec: "{{ cifmw_ceph_dashboard_spec_path }}"
+
+- name: Apply spec
+  ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} orch apply --in-file {{ cifmw_cephadm_container_spec }}"
+  become: true
+

--- a/ci_framework/roles/cifmw_cephadm/templates/ceph_dashboard.yml.j2
+++ b/ci_framework/roles/cifmw_cephadm/templates/ceph_dashboard.yml.j2
@@ -2,7 +2,6 @@
 service_type: node-exporter
 service_id: node-exporter
 service_name: node-exporter
-placement: *
 ---
 service_type: grafana
 service_id: grafana

--- a/ci_framework/roles/cifmw_cephadm/templates/ceph_dashboard.yml.j2
+++ b/ci_framework/roles/cifmw_cephadm/templates/ceph_dashboard.yml.j2
@@ -1,0 +1,38 @@
+---
+service_type: node-exporter
+service_id: node-exporter
+service_name: node-exporter
+placement: *
+---
+service_type: grafana
+service_id: grafana
+service_name: grafana
+placement:
+  hosts:
+{% for host in _hosts %}
+  - {{ host }}
+{% endfor %}
+networks:
+- {{ cifmw_cephadm_rgw_network }}
+---
+service_type: prometheus 
+service_id: prometheus
+service_name: prometheus
+placement:
+  hosts:
+{% for host in _hosts %}
+  - {{ host }}
+{% endfor %}
+networks:
+- {{ cifmw_cephadm_rgw_network }}
+---
+service_type: alertmanager
+service_id: alertmanager
+service_name: alertmanager
+placement:
+  hosts:
+{% for host in _hosts %}
+  - {{ host }}
+{% endfor %}
+networks:
+- {{ cifmw_cephadm_rgw_network }}

--- a/ci_framework/roles/cifmw_cephadm/templates/ceph_monitoring_stack.yml.j2
+++ b/ci_framework/roles/cifmw_cephadm/templates/ceph_monitoring_stack.yml.j2
@@ -8,20 +8,18 @@ service_id: grafana
 service_name: grafana
 placement:
   hosts:
-{% for host in _hosts %}
-  - {{ host }}
-{% endfor %}
+  - {{ _hosts[0] }}
+  count: 1
 networks:
 - {{ cifmw_cephadm_rgw_network }}
 ---
-service_type: prometheus 
+service_type: prometheus
 service_id: prometheus
 service_name: prometheus
 placement:
   hosts:
-{% for host in _hosts %}
-  - {{ host }}
-{% endfor %}
+  - {{ _hosts[0] }}
+  count: 1
 networks:
 - {{ cifmw_cephadm_rgw_network }}
 ---
@@ -30,8 +28,7 @@ service_id: alertmanager
 service_name: alertmanager
 placement:
   hosts:
-{% for host in _hosts %}
-  - {{ host }}
-{% endfor %}
+  - {{ _hosts[0] }}
+  count: 1
 networks:
 - {{ cifmw_cephadm_rgw_network }}

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -1,6 +1,7 @@
 aaabbcc
 abcdefghij
 addr
+alertmanager
 ansible
 ansibleee
 ansibleuser
@@ -82,6 +83,7 @@ csv
 ctl
 ctlplane
 ctx
+dashboard
 dataplane
 dataplanenodeset
 dd'd
@@ -146,6 +148,7 @@ gpg
 gpgcheck
 gpsbwcm
 gracefulrestart
+grafana
 groupinstall
 gw
 gzwu
@@ -325,6 +328,7 @@ polkit
 pre
 prikey
 projectquay
+prometheus
 provisioner
 provisioningdhcprange
 provisioningnetwork


### PR DESCRIPTION
ceph playbook is updated to run dashboard task which deploys montioring stack daemons like prometheus, alert-manager and grafana.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
