### PR TITLE
Move ssh-keyscan to zuul pre playbook

### DIFF
--- a/ci/playbooks/multinode-customizations.yml
+++ b/ci/playbooks/multinode-customizations.yml
@@ -102,6 +102,19 @@
           - make
         state: present
 
+    - name: Ensure we know compute host keys
+      ansible.builtin.shell:
+        cmd: |
+          ssh-keyscan {{ hostvars[item].ansible_host }} >> ~/.ssh/known_hosts
+      loop: >-
+        {{
+          hostvars | dict2items |
+          selectattr("value.ansible_host", "defined") |
+          map(attribute="key")
+        }}
+      loop_control:
+        label: "{{ item }}"
+
     - name: Generate an ssh keypair
       ansible.builtin.command:
         cmd: ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -P ''

--- a/ci_framework/hooks/playbooks/fetch_compute_facts.yml
+++ b/ci_framework/hooks/playbooks/fetch_compute_facts.yml
@@ -1,22 +1,4 @@
 ---
-- name: Gather ssh host keys hook
-  hosts: localhost
-  gather_facts: false
-  connection: local
-  tasks:
-    - name: Ensure we know compute host keys
-      ansible.builtin.shell:
-        cmd: |
-          ssh-keyscan {{ hostvars[item].ansible_host }} >> ~/.ssh/known_hosts
-      loop: >-
-        {{
-          hostvars | dict2items |
-          selectattr("value.ansible_host", "defined") |
-          map(attribute="key")
-        }}
-      loop_control:
-        label: "{{ item }}"
-
 - name: Push repositories hook
   hosts: all,!crcs,!crc
   gather_facts: true


### PR DESCRIPTION
As we now need to connect to each host from the controller we need to ensure from the very beggining that we are able to SSH each node since start.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date: