### PR TITLE
[tempest] allow set of dns servers for tempest pod

### DIFF
--- a/ci_framework/roles/tempest/defaults/main.yml
+++ b/ci_framework/roles/tempest/defaults/main.yml
@@ -27,3 +27,5 @@ cifmw_tempest_image_tag: current-podified
 cifmw_tempest_dry_run: false
 cifmw_tempest_remove_container: false
 cifmw_tempest_concurrency: 4
+cifmw_tempest_dns_servers:
+  - "192.168.122.10"

--- a/ci_framework/roles/tempest/tasks/main.yml
+++ b/ci_framework/roles/tempest/tasks/main.yml
@@ -56,6 +56,7 @@
     volume:
       - "{{ cifmw_tempest_artifacts_basedir }}/:/var/lib/tempest/external_files:Z"
     detach: false
+    dns: "{{ cifmw_tempest_dns_servers }}"
     env:
       CONCURRENCY: "{{ cifmw_tempest_concurrency | default(omit) }}"
   when: not cifmw_tempest_dry_run | bool


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
