### PR TITLE
Correct how we waited for VM SSH to be ready

### DIFF
--- a/ci_framework/roles/libvirt_manager/tasks/create_vms.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/create_vms.yml
@@ -52,7 +52,7 @@
 - name: "(localhost) Inject ssh jumpers for {{ vm_type }}"
   delegate_to: localhost
   vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] |replace('/24','') }}"
+    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
   ansible.builtin.blockinfile:
     create: true
     path: "~/.ssh/config"
@@ -71,7 +71,7 @@
 
 - name: "({{ inventory_hostname }}) Inject ssh jumpers for {{ vm_type }}"  # noqa: name[template]
   vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] |replace('/24','') }}"
+    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
   ansible.builtin.blockinfile:
     create: true
     path: "~/.ssh/config"
@@ -96,15 +96,16 @@
     src: inventory.yml.j2
 
 - name: "Wait for SSH on VMs type {{ vm_type }}"
-  delegate_to: localhost
+  vars:
+    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
   ansible.builtin.wait_for:
-    host: "{{ vm_ip.item }}"
+    host: "{{ extracted_ip }}"
     port: 22
     delay: 5
   loop: "{{ vm_ips.results }}"
   loop_control:
     loop_var: vm_ip
-    label: "{{ vm_ip.item }}"
+    label: "{{ extracted_ip }}"
 
 - name: "Configure ssh access on type {{ vm_type }}"
   when:

--- a/ci_framework/roles/reproducer/files/pre-ci-play.yml
+++ b/ci_framework/roles/reproducer/files/pre-ci-play.yml
@@ -1,6 +1,6 @@
 ---
 - name: Configure networking on all nodes
-  hosts: all
+  hosts: all,!localhost
   gather_facts: false
   become: true
   vars:
@@ -61,17 +61,30 @@
         path: "{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters"
         state: directory
 
-    - name: Copy zuul inventory in the artifacts
-      ansible.builtin.copy:
-        remote_src: true
-        src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/scenarios/centos-9/zuul_inventory.yml"
-        dest: "{{ ansible_user_dir }}/ci-framework-data/artifacts/zuul_inventory.yml"
-
     - name: Inject CRC hostname
       ansible.builtin.copy:
         dest: "{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/crc-hostname.yml"
         content: |-
           cifmw_crc_hostname: crc-0
+
+    - name: Ensure controller-0 knows about remote SSH key
+      block:
+        - name: Inject localhost key
+          ansible.builtin.shell:
+            cmd: >-
+              ssh-keyscan localhost > ~/.ssh/known_hosts
+
+        - name: Loop on all hosts to get their host SSH key
+          ansible.builtin.shell:
+            cmd: >-
+              ssh-keyscan {{ hostvars[item].ansible_host }}
+              >> ~/.ssh/known_hosts
+          loop: >-
+            {{
+              hostvars | dict2items |
+              selectattr("value.ansible_host", "defined") |
+              map(attribute="key")
+            }}
 
 - name: Wait for CRC services
   hosts: crc-0

--- a/ci_framework/roles/reproducer/tasks/ci_job.yml
+++ b/ci_framework/roles/reproducer/tasks/ci_job.yml
@@ -30,11 +30,30 @@
   delegate_to: controller-0
   remote_user: zuul
   block:
+    - name: Create data directory on controller-0
+      ansible.builtin.file:
+        path: "ci-framework-data/artifacts/parameters"
+        state: directory
+
+    - name: Fetch zuul.items repositories
+      tags:
+        - bootstrap
+      ansible.builtin.git:  # noqa: latest[git]
+        dest: "{{ repo.project.src_dir }}"
+        repo: "https://{{ repo.project.canonical_name }}"
+        refspec: "pull/{{ repo.change }}/head:{{ job_id }}"
+        force: true
+      loop: "{{ zuul['items'] }}"
+      loop_control:
+        loop_var: repo
+        label: "{{ repo.project.name }}"
+
     - name: Fetch zuul.projects repositories for dependencies
       tags:
         - bootstrap
       when:
         - repo.key is match('^github.com')
+        - "repo.key not in (zuul['items'] | map(attribute='project.canonical_name'))"
       ansible.builtin.git:
         dest: "{{ repo.value.src_dir }}"
         repo: "https://{{ repo.key }}"
@@ -44,19 +63,6 @@
       loop_control:
         loop_var: repo
         label: "{{ repo.key }}"
-
-    - name: Fetch zuul.items repositories
-      tags:
-        - bootstrap
-      ansible.builtin.git:
-        dest: "{{ repo.project.src_dir }}"
-        repo: "https://{{ repo.project.canonical_name }}"
-        version: "{{ repo.patchset }}"
-        force: true
-      loop: "{{ zuul['items'] }}"
-      loop_control:
-        loop_var: repo
-        label: "{{ repo.project.name }}"
 
     - name: Ensure ci-framework is here
       tags:
@@ -147,14 +153,14 @@
         chdir: "src/github.com/openstack-k8s-operators/ci-framework"
         cmd: ansible-galaxy collection install -r requirements.yml
 
-    - name: Build zuul_inventory for hook usage
+    - name: Build job inventory for hook usage
       tags:
         - bootstrap
       ansible.builtin.shell:
         cmd: >-
           cat reproducer-inventory/* >
-          src/github.com/openstack-k8s-operators/ci-framework/scenarios/centos-9/zuul_inventory.yml
-        creates: src/github.com/openstack-k8s-operators/ci-framework/scenarios/centos-9/zuul_inventory.yml
+          ci-framework-data/artifacts/zuul_inventory.yml
+        creates: ci-framework-data/artifacts/zuul_inventory.yml
 
     - name: Generate CI job playbook
       tags:
@@ -177,29 +183,38 @@
         dest: "src/github.com/openstack-k8s-operators/ci-framework/pre-ci-play.yml"
         src: "pre-ci-play.yml"
 
-    - name: Check for ansible log file and rotate it
+    - name: Push zuul-params.yml to expected location
+      tags:
+        - bootstrap
       block:
-        - name: Check ansible.log
-          register: ansible_log
-          ansible.builtin.stat:
-            path: ansible.log
+        - name: Get content of zuul-params.yml
+          register: zuul_params
+          ansible.builtin.slurp:
+            path: "{{ job_id }}-params/zuul-params.yml"
 
-        - name: Rotate log if present
-          when:
-            - ansible_log.stat.exists
-          ansible.builtin.shell:
-            cmd: mv ansible.log "ansible.log-$(date +%s)"
+        - name: Push extracted content
+          vars:
+            zuul_params_filtered: >-
+              {{
+                (zuul_params['content'] | b64decode | from_yaml) |
+                dict2items |
+                rejectattr('key', 'equalto', 'cifmw_operator_build_output') |
+                rejectattr('key', 'equalto', 'content_provider_registry_ip') |
+                items2dict
+              }}
+          ansible.builtin.copy:
+            dest: "ci-framework-data/artifacts/parameters/zuul-params.yml"
+            content: "{{ zuul_params_filtered | to_nice_yaml }}"
 
-        - name: Check pre-ci log
-          register: pre_ci_log
-          ansible.builtin.stat:
-            path: ansible-pre-ci.log
-
-        - name: Rotate pre-ci log if present
-          when:
-            - pre_ci_log.stat.exists
-          ansible.builtin.shell:
-            cmd: mv ansible-pre-ci.log "ansible-pre-ci.log-$(date +%s)"
+    - name: Check for ansible logs file and rotate it
+      tags:
+        - always
+      ansible.builtin.include_tasks: rotate_log.yml
+      loop:
+        - "ansible.log"
+        - "ansible-pre-ci.log"
+        - "ansible-{{ job_id }}.log"
+        - "ansible-content-provider-bootstrap.log"
 
     - name: Run pre-ci-play
       tags:
@@ -211,25 +226,29 @@
         chdir: "src/github.com/openstack-k8s-operators/ci-framework/"
         cmd: >-
           ansible-playbook
-          -i scenarios/centos-9/zuul_inventory.yml
+          -i ~/ci-framework-data/artifacts/zuul_inventory.yml
           pre-ci-play.yml
 
-    - name: Run reproducer preparation job
+    - name: Prepare environment for content-provider
       when:
         - cifmw_job_uri is defined
+      environment:
+        ANSIBLE_LOG_PATH: "~/ansible-content-provider-bootstrap.log"
       ansible.builtin.command:
         chdir: "src/github.com/openstack-k8s-operators/ci-framework"
         cmd: >-
           ansible-playbook
-          -i scenarios/centos-9/zuul_inventory.yml
+          -i ~/ci-framework-data/artifacts/zuul_inventory.yml
           ci_framework/playbooks/01-bootstrap.yml
 
     - name: Run job
       when:
         - cifmw_reproducer_run_job | bool
+      environment:
+        ANSIBLE_LOG_PATH: "~/ansible-{{ job_id }}.log"
       ansible.builtin.command:
         chdir: "src/github.com/openstack-k8s-operators/ci-framework"
         cmd: >-
           ansible-playbook
-          -i scenarios/centos-9/zuul_inventory.yml
+          -i ~/ci-framework-data/artifacts/zuul_inventory.yml
           {{ job_id }}_play.yml

--- a/ci_framework/roles/reproducer/tasks/rotate_log.yml
+++ b/ci_framework/roles/reproducer/tasks/rotate_log.yml
@@ -1,0 +1,13 @@
+---
+- name: "Check {{ item }}"
+  register: log_file
+  ansible.builtin.stat:
+    path: "{{ item }}"
+
+- name: Rotate log if present
+  vars:
+    timestamp: "{{ lookup('pipe', 'date +%s') }}"
+  when:
+    - log_file.stat.exists
+  ansible.builtin.command:
+    cmd: "mv {{ item }} {{ item }}-{{ timestamp }}"

--- a/ci_framework/roles/reproducer/templates/all-inventory.yml.j2
+++ b/ci_framework/roles/reproducer/templates/all-inventory.yml.j2
@@ -3,3 +3,7 @@ all:
 {% for vm in _layout.vms.keys() %}
     {{ vm }}s:
 {% endfor %}
+localhost:
+  hosts:
+    localhost:
+      ansible_connection: local

--- a/ci_framework/roles/reproducer/templates/play.yml.j2
+++ b/ci_framework/roles/reproducer/templates/play.yml.j2
@@ -24,7 +24,6 @@
         - "{{ ansible_user_dir }}/{{ job_id }}-params/zuul-params.yml"
         - "./scenarios/centos-9/base.yml"
         - "./scenarios/centos-9/content_provider.yml"
-        - "./scenarios/centos-9/zuul_inventory.yml"
 
     - name: Install necessary tools
       ansible.builtin.import_role:


### PR DESCRIPTION
Running the reproducer against a multi-compute scenario raised an issue
in the established logic in said step.

We now wait for SSH using the proper IP, and from the hypervisor instead
of some fancy localhost that wasn't configured until... next step.

We also take the opportunity to leverage a better filter for IP address
extraction.

This patch also corrects how repositories were cloned, especially when it
comes to github repository and the tested PR. Since most of the
repositories work with forks instead of dev-branches, the PR code/change
isn't usually known by the main repository - and we have to switch to
some specific reference instead.

We also take the opportunity to ensure the controller-0 knows the public
ssh key of all the hosts, even itself.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
