### PR TITLE
 Replace ci_make invocations with ci_script to reduce maintenance

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,4 +1,7 @@
 # action_plugins/ci_make
+
+> **_NOTE:_** This module is deprecated and will be removed in a future version. Please consider using the ci_script module instead.
+
 This wraps `community.general.make` module, mostly. It requires an additional
 parameter, `output_dir`, in order to output the `make` generated command.
 It also adds a new optional parameter, `dry_run`, allowing to NOT run

--- a/plugins/modules/generate_make_tasks.py
+++ b/plugins/modules/generate_make_tasks.py
@@ -72,13 +72,12 @@ MAKE_TMPL = """---
   delay: "{{ make_%(target)s_delay | default(omit) }}"
   until: "{{ make_%(target)s_until | default(true) }}"
   register: "make_%(target)s_status"
-  ci_make:
+  ci_script:
     output_dir: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts"
     chdir: "%(chdir)s"
-    target: %(target)s
+    script: "make %(target)s"
     dry_run: "{{ make_%(target)s_dryrun|default(false)|bool }}"
-    params: "{{ make_%(target)s_params|default(omit) }}"
-  environment: "{{ make_%(target)s_env | default({}) }}"
+    extra_args: "{{ dict((make_%(target)s_env|default({})), **(make_%(target)s_params|default({}))) }}"
 """  # noqa
 
 NO_OUTDIR = "Directory %s does not exist. Please create it."

--- a/roles/devscripts/tasks/03_install.yml
+++ b/roles/devscripts/tasks/03_install.yml
@@ -26,10 +26,11 @@
   ansible.builtin.import_tasks: sub_tasks/32_params.yml
 
 - name: Deploying the OpenShift platform
+  when: cifmw_devscripts_make_target is defined
   tags:
     - bootstrap
-  ci_make:
+  ci_script:
     chdir: "{{ cifmw_devscripts_repo_dir }}"
     output_dir: "{{ cifmw_devscripts_output_dir }}"
     dry_run: "{{ cifmw_devscripts_dry_run | bool }}"
-    target: "{{ cifmw_devscripts_make_target | default(omit) }}"
+    script: " make {{ cifmw_devscripts_make_target }}"

--- a/roles/install_yamls/README.md
+++ b/roles/install_yamls/README.md
@@ -29,13 +29,12 @@ The created role directory contains multiple task files, similar to
   delay: "{{ make_crc_storage_delay | default(omit) }}"
   until: "{{ make_crc_storage_until | default(true) }}"
   register: "make_crc_storage_status"
-  ci_make:
+  ci_script:
     output_dir: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts"
     chdir: "/home/zuul/src/github.com/openstack-k8s-operators/install_yamls"
-    target: crc_storage
+    script: make crc_storage
     dry_run: "{{ make_crc_storage_dryrun|default(false)|bool }}"
-    params: "{{ make_crc_storage_params|default(omit) }}"
-  environment: "{{ make_crc_storage_env | default({}) }}"
+    extra_args: "{{ dict((make_crc_storage_env|default({})), **(make_crc_storage_params|default({}))) }}"
 ```
 
 The role can be imported and tasks can be executed like this

--- a/roles/operator_build/tasks/build.yml
+++ b/roles/operator_build/tasks/build.yml
@@ -118,30 +118,30 @@
       }}}, recursive=True)}}
 
 - name: "{{ operator.name }} - Call manifests"  # noqa: name[template]
-  ci_make:
+  ci_script:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
     chdir: "{{ operator.src }}"
     output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
-    target: manifests
+    script: make manifests
 
 - name: "{{ operator.name }} - Call docker-build"  # noqa: name[template]
-  ci_make:
+  ci_script:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
     chdir: "{{ operator.src }}"
     output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
-    target: docker-build
-    params:
+    script: make docker-build
+    extra_args:
       IMG: "{{ operator_img }}"
 
 - name: "{{ operator.name }} - Call docker-push"  # noqa: name[template]
   when:
     - cifmw_operator_build_push_ct|bool
-  ci_make:
+  ci_script:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
     chdir: "{{ operator.src }}"
     output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
-    target: docker-push
-    params:
+    script: make docker-push
+    extra_args:
       IMG: "{{ operator_img }}"
       VERIFY_TLS: "{{ cifmw_operator_build_push_registry_tls_verify }}"
   register: op_push_result
@@ -150,12 +150,12 @@
   delay: 10
 
 - name: "{{ operator.name }} - Call bundle"  # noqa: name[template]
-  ci_make:
+  ci_script:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
     chdir: "{{ operator.src }}"
     output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
-    target: bundle
-    params:
+    script: make bundle
+    extra_args:
       IMG: "{{ operator_img }}"
       IMAGENAMESPACE: "{{ cifmw_operator_build_push_org }}"
       IMAGEREGISTRY: "{{ cifmw_operator_build_push_registry }}"
@@ -163,12 +163,12 @@
       LOCAL_REGISTRY: "{{ cifmw_operator_build_local_registry | default (0) }}"
 
 - name: "{{ operator.name }} - Call bundle-build"  # noqa: name[template]
-  ci_make:
+  ci_script:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
     chdir: "{{ operator.src }}"
     output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
-    target: bundle-build
-    params:
+    script: make bundle-build
+    extra_args:
       IMG: "{{ operator_img }}"
       BUNDLE_IMG: "{{ operator_img_bundle }}"
       IMAGENAMESPACE: "{{ cifmw_operator_build_push_org }}"
@@ -189,12 +189,12 @@
   delay: 10
 
 - name: "{{ operator.name }} - Call catalog-build"  # noqa: name[template]
-  ci_make:
+  ci_script:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
     chdir: "{{ operator.src }}"
     output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
-    target: catalog-build
-    params:
+    script: make catalog-build
+    extra_args:
       CATALOG_IMG: "{{ operator_img_catalog }}"
       BUNDLE_IMG: "{{ operator_img_bundle }}"
       IMAGENAMESPACE: "{{ cifmw_operator_build_push_org }}"
@@ -206,12 +206,12 @@
 - name: "{{ operator.name }} - Call catalog-push"  # noqa: name[template]
   when:
     - cifmw_operator_build_push_ct|bool
-  ci_make:
+  ci_script:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
     chdir: "{{ operator.src }}"
     output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
-    target: catalog-push
-    params:
+    script: make catalog-push
+    extra_args:
       CATALOG_IMG: "{{ operator_img_catalog }}"
       VERIFY_TLS: "{{ cifmw_operator_build_push_registry_tls_verify }}"
   register: result

--- a/roles/operator_deploy/tasks/main.yml
+++ b/roles/operator_deploy/tasks/main.yml
@@ -15,9 +15,9 @@
 # under the License.
 
 - name: Deploy selected operators
-  ci_make:
+  ci_script:
     output_dir: "{{ cifmw_operator_deploy_basedir }}/artifacts"
     chdir: "{{ cifmw_operator_deploy_installyamls }}"
-    target: "{{ item.name }}"
-    params: "{{ item.params | default(omit) }}"
+    script: "make {{ item.name }}"
+    extra_args: "{{ item.params | default({}) }}"
   loop: "{{ cifmw_operator_deploy_list }}"

--- a/roles/os_must_gather/tasks/build_openstack-must-gather_image.yml
+++ b/roles/os_must_gather/tasks/build_openstack-must-gather_image.yml
@@ -25,21 +25,21 @@
     msg: "{{ openstack_must_gather_tag }}"
 
 - name: Build openstack-must-gather container
-  ci_make:
+  ci_script:
     chdir: "{{ cifmw_os_must_gather_repo_path }}"
     output_dir: "{{ cifmw_os_must_gather_output_dir }}/artifacts"
-    target: podman-build
-    params:
+    script: make podman-build
+    extra_args:
       IMAGE_TAG: "{{ openstack_must_gather_tag.stdout }}"
       IMAGE_REGISTRY: "{{ cifmw_os_must_gather_image_registry }}"
       MUST_GATHER_IMAGE: "openstack-must-gather"
 
 - name: Push openstack-must-gather container
-  ci_make:
+  ci_script:
     chdir: "{{ cifmw_os_must_gather_repo_path }}"
     output_dir: "{{ cifmw_os_must_gather_output_dir }}/artifacts"
-    target: podman-push
-    params:
+    script: make podman-push
+    extra_args:
       IMAGE_TAG: "{{ openstack_must_gather_tag.stdout }}"
       IMAGE_REGISTRY: "{{ cifmw_os_must_gather_image_registry }}"
       MUST_GATHER_IMAGE: "openstack-must-gather"

--- a/tests/integration/targets/make/tasks/ci_make.yml
+++ b/tests/integration/targets/make/tasks/ci_make.yml
@@ -20,10 +20,10 @@
       failing:
       > @exit 255
 
-- name: Run ci_make without any params
-  register: no_params
-  ci_make:
-    target: help
+- name: Run ci_script make without any extra_args
+  register: no_extra_args
+  ci_script:
+    script: make help
     chdir: /tmp/project_makefile
     output_dir: /tmp/artifacts
 
@@ -33,78 +33,81 @@
     content: |
       I'm a useless flag in here
 
-- name: Run ci_make with a param
-  register: with_params
-  ci_make:
-    target: help
+- name: Run ci_script make with extra_args
+  register: with_extra_args
+  ci_script:
+    script: make help
     chdir: /tmp/project_makefile
     output_dir: /tmp/artifacts
-    params:
+    extra_args:
       FOO_BAR: starwars
 
 - name: Ensure we have correct output
   ansible.builtin.assert:
     that:
-      - no_params.stdout == 'This is the help thing showing toto'
-      - with_params.stdout == 'This is the help thing showing starwars'
+      - "'This is the help thing showing toto' in no_extra_args.stdout"
+      - "'This is the help thing showing starwars' in with_extra_args.stdout"
 
 - name: Try dry_run parameter
-  ci_make:
+  ci_script:
     chdir: /tmp/project_makefile
     output_dir: /tmp/artifacts
-    params:
-      FOO_BAR: startrek
     dry_run: true
+    script: make
+    extra_args:
+      FOO_BAR: startrek
 
-- name: Test with environment parameters
-  environment:
-    MY_ENV_VAR: startrek
-    SOME_OTHER: jar-jar-binks
-  ci_make:
+
+- name: Test with extra_args
+  ci_script:
     chdir: /tmp/project_makefile
     output_dir: /tmp/artifacts
-    target: help
-    params:
-      FOO_BAR: "${MY_ENV_VAR}"
+    script: make help
+    extra_args:
+      FOO_BAR: startrek
+      SOME_OTHER: jar-jar-binks
 
-- name: Test with environment parameters passed as ansible variables
+
+- name: Test with extra_args passed as ansible variables and special chars /
   block:
     - name: Set env var
       ansible.builtin.set_fact:
         my_env_vars:
-          FOO_BAR: Muad-Dib
+          FOO_BAR: /=8GB /tmp=1GB /home=1GB /var=8GB
           SOME_OTHER: Dune
-    - name: Run ci_make with custom env variable
-      environment: "{{ my_env_vars }}"
-      ci_make:
+        other_env_vars:
+          ONE: 1
+          FOO_BAR: Baz
+    - name: Run ci_script make with custom env variable
+      ci_script:
         chdir: /tmp/project_makefile
         output_dir: /tmp/artifacts
-        target: help
-    - name: Run ci_make with custom env variable and default
-      environment: "{{ my_env_vars | default({}) }}"
-      ci_make:
+        script: make help
+        extra_args: "{{ dict((my_env_vars|default({})), **(other_env_vars|default({}))) }}"
+    - name: Run ci_script make custom env var and default
+      ci_script:
         chdir: /tmp/project_makefile
         output_dir: /tmp/artifacts
-        target: help
+        script: make help
+        extra_args: "{{ my_env_vars | default({}) }}"
 
-- name: Run ci_make with environment parameter and default
-  environment: "{{ other_env_vars | default({'FOO_BAR': 'titi'}) }}"
-  ci_make:
+- name: Run ci_script make with extra_args and default
+  ci_script:
     chdir: /tmp/project_makefile
     output_dir: /tmp/artifacts
-    target: help
+    script: make help
+    extra_args: "{{ other_env_vars | default({'FOO_BAR': 'titi'}) }}"
 
-- name: Run ci_make with a faulty command
+- name: Run ci_script make with a faulty command
   block:
     - name: Run failing target
       register: failing_make
       failed_when:
-        - failing_make.stderr is not match(".*Error 255.*")
-      ci_make:
+        - "'Error 255' not in failing_make.stdout"
+      ci_script:
         chdir: /tmp/project_makefile
         output_dir: /tmp/artifacts
-        target: failing
-
+        script: make failing
 
 - name: Check generated files
   tags:
@@ -113,32 +116,36 @@
     - name: Set files attributes
       ansible.builtin.set_fact:
         files_to_check:
-          "/tmp/artifacts/ci_make_000_run_ci_make_without_any_params.sh":
-            e6ec8bc41f8aa58ef72fb1d8e336dc9c8115d0e4
-          "/tmp/artifacts/ci_make_001_run_ci_make_with_a_param.sh":
-            79fe696cf7e0f3001e99fed22f5a2674f1f8c493
-          "/tmp/artifacts/ci_make_002_try_dry_run_parameter.sh":
-            4909f854ee1fc8e17c608ea0a7a2adb40101c825
-          "/tmp/artifacts/ci_make_003_test_with_environment_parameters.sh":
-            4ca6f838a71ab336f91f8775d684c3d8ccc0a89a
-          "/tmp/artifacts/ci_make_004_run_ci_make_with_custom_env_variable.sh":
-            2447a25f97c34a25c0ab3a6e67baf1d2c8817c78
-          "/tmp/logs/ci_make_000_run_ci_make_without_any_params.log":
-            8dcc15e2dd273dda4f7120efc059274bd8d50a89
-          "/tmp/logs/ci_make_001_run_ci_make_with_a_param.log":
-            fa1fd735445ca641270e630a00303b5816bafff3
-          "/tmp/logs/ci_make_003_test_with_environment_parameters.log":
-            3384b44a202d4f841781dff704276e0ae44484e7
-          "/tmp/logs/ci_make_004_run_ci_make_with_custom_env_variable.log":
-            f17389a98ce38f871c3b69f1ad8b9956b7f95958
-          "/tmp/logs/ci_make_005_run_ci_make_with_custom_env_variable_and_default.log":
-            f17389a98ce38f871c3b69f1ad8b9956b7f95958
-          "/tmp/logs/ci_make_006_run_ci_make_with_environment_parameter_and_default.log":
-            33d4f79ce503647c036a927bbf409189e79b1fd4
-          "/tmp/logs/ci_make_007_run_failing_target.log":
-            88aa7bc8f90b26effa2b0d6cc528530b7bc6f75f
-          "/tmp/artifacts/ci_make_007_run_failing_target.sh":
-            0294daf29cbd1b1a68268ae698d5e74a8c527632
+          "/tmp/artifacts/ci_script_000_run_ci_script_make_without_any_extra_args.sh":
+            e19e15e8c10461c54a40a0ce00296aa887cf7756
+          "/tmp/artifacts/ci_script_001_run_ci_script_make_with_extra_args.sh":
+            4bbb01aa527121b670dbf533cc0fbc6ff725e0ab
+          "/tmp/artifacts/ci_script_002_try_dry_run_parameter.sh":
+            33cca9289d8bcef9fe070d810151ad67b42adc35
+          "/tmp/artifacts/ci_script_003_test_with_extra_args.sh":
+            863730abb0e0edd3edcb025c8fe4d2d12ace9d2a
+          "/tmp/artifacts/ci_script_004_run_ci_script_make_with_custom_env_variable.sh":
+            2b6737616136a7b33dfabe4ef673dccc6c4e9acb
+          "/tmp/artifacts/ci_script_005_run_ci_script_make_custom_env_var_and_default.sh":
+            85ecd67eac4c873e8d3b120035415e7709a25e0f
+          "/tmp/artifacts/ci_script_006_run_ci_script_make_with_extra_args_and_default.sh":
+            0fe9a340527f84628bd2c8f655150403f3afb8d1
+          "/tmp/artifacts/ci_script_007_run_failing_target.sh":
+            7d9c6fab3c87b65b0e6db9f1211d5dcde9f6f8a1
+          "/tmp/logs/ci_script_000_run_ci_script_make_without_any_extra_args.log":
+            6147c30d7f99d803a8a2e5eb357017bf1146cea9
+          "/tmp/logs/ci_script_001_run_ci_script_make_with_extra_args.log":
+            2784a3a2ac54ee7787687153cefb78a920793efa
+          "/tmp/logs/ci_script_003_test_with_extra_args.log":
+            5cd9ccee64ea4d0babe042f72717dc97809e9b7b
+          "/tmp/logs/ci_script_004_run_ci_script_make_with_custom_env_variable.log":
+            7756df69bf6879216075c159e3e1f19b4d98126e
+          "/tmp/logs/ci_script_005_run_ci_script_make_custom_env_var_and_default.log":
+            7da4babbb838e956ab49e06573926c893375e34c
+          "/tmp/logs/ci_script_006_run_ci_script_make_with_extra_args_and_default.log":
+            7756df69bf6879216075c159e3e1f19b4d98126e
+          "/tmp/logs/ci_script_007_run_failing_target.log":
+            a2e12c228875d1606ae9980ac6390f76bc2cd066
 
     - name: Gather files
       register: reproducer_scripts

--- a/tests/integration/targets/script/tasks/main.yml
+++ b/tests/integration/targets/script/tasks/main.yml
@@ -73,25 +73,25 @@
 - name: Set files attributes
   ansible.builtin.set_fact:
     files_to_check:
-      "/tmp/artifacts/ci_script_000_run_simple_no_failing_script.sh":
-        720b8c4a647e187c6e9a676ac2c85b9755dacc48
-      "/tmp/artifacts/ci_script_001_run_simple_failing_script.sh":
-        708a7940875961edc336ad512eaf136da6f91b6e
-      "/tmp/artifacts/ci_script_002_run_with_global_debug_enabled.sh":
-        9e8fd25f66399fc8e599e9e4255cce1fd76f65e3
-      "/tmp/artifacts/ci_script_003_run_with_action_debug_enabled.sh":
-        b6b80308119960ffe15f78ec576b799af396a33b
-      "/tmp/artifacts/ci_script_004_run_using_chdir_option.sh":
-        07778093d31657c4728cc25bb7e217dd2a9e822b
-      "/tmp/logs/ci_script_000_run_simple_no_failing_script.log":
+      "/tmp/artifacts/ci_script_008_run_simple_no_failing_script.sh":
+        bc43101e80bb1eff0c49d572fb20527c7e3a9d0b
+      "/tmp/artifacts/ci_script_009_run_simple_failing_script.sh":
+        dba40c73eb61fbf09c40da7f66b67d78953f1fcf
+      "/tmp/artifacts/ci_script_010_run_with_global_debug_enabled.sh":
+        defedbe625d823d0d499bb8b2f8d893df15649b9
+      "/tmp/artifacts/ci_script_011_run_with_action_debug_enabled.sh":
+        009a5da41869d419c24c305ad6cbe4c644f9aea5
+      "/tmp/artifacts/ci_script_012_run_using_chdir_option.sh":
+        26a353fd5989a27902412fcd20891d584cb1050f
+      "/tmp/logs/ci_script_008_run_simple_no_failing_script.log":
         1382103331d56fa62a3f0b12388aad5cdb36389d
-      "/tmp/logs/ci_script_001_run_simple_failing_script.log":
+      "/tmp/logs/ci_script_009_run_simple_failing_script.log":
         67dd35c6c747cc9614633e32694fe9eb5e4a53d1
-      "/tmp/logs/ci_script_002_run_with_global_debug_enabled.log":
+      "/tmp/logs/ci_script_010_run_with_global_debug_enabled.log":
         b76a03852f2d614a63af5bc6ac3e9d61a113a34b
-      "/tmp/logs/ci_script_003_run_with_action_debug_enabled.log":
+      "/tmp/logs/ci_script_011_run_with_action_debug_enabled.log":
         bb7199b9b6842f10081dc307e0fe4cf9d0ef340a
-      "/tmp/logs/ci_script_004_run_using_chdir_option.log":
+      "/tmp/logs/ci_script_012_run_using_chdir_option.log":
         3588d48b41e8aa6b8e19f3507abfd8770aba7f6d
       "/tmp/dummy/test/test-file.txt":
         cff41d666ec6fd5404d5d2fd89136a40ba43671e

--- a/zuul.d/end-to-end.yaml
+++ b/zuul.d/end-to-end.yaml
@@ -65,4 +65,7 @@
       - ^roles/libvirt_manager/(?!meta|README).*
       - ^roles/cert_manager/(?!meta|README).*
       - scenarios/centos-9/edpm_baremetal_deployment_ci.yml
+      - ^plugins/action/ci_script.py
+      - ^plugins/modules/generate_make_tasks.py
+
     run: ci/playbooks/edpm_baremetal_deployment/run.yml


### PR DESCRIPTION
 Replace ci_make invocations with ci_script to reduce maintenance

The ci_make calls can be accommodated with ci_script. This replaces
all invocations of ci_make with ci_script and updates tests accordingly.

The removal of the ci_make module and associated files will come
in followup reviews.

https://issues.redhat.com/browse/OSPRH-1630 ([OSP-29266](https://issues.redhat.com//browse/OSP-29266))

As a pull request owner and reviewers, I checked that:

- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date: