### PR TITLE
Do not call edpm_compute_repos

### DIFF
--- a/ci_framework/roles/hive/README.md
+++ b/ci_framework/roles/hive/README.md
@@ -84,7 +84,6 @@ cifmw_repo_setup_os_release: 'centos'
 cifmw_repo_setup_dist_major_version: 9
 
 cifmw_libvirt_manager_user: root
-cifmw_libvirt_manager_skip_edpm_compute_repos: true
 
 cifmw_opn_host: REDACTED
 cifmw_opn_external_network_iface: eno3

--- a/ci_framework/roles/libvirt_manager/README.md
+++ b/ci_framework/roles/libvirt_manager/README.md
@@ -23,4 +23,3 @@ Used for checking if:
 * `cifmw_libvirt_manager_installyamls`: (String) install_yamls repository location. Defaults to `cifmw_installyamls_repos` which defaults to `../..`
 * `cifmw_libvirt_manager_dryrun`: (Boolean) Toggle ci_make `dry_run` parameter. Defaults to `false`.
 * `cifmw_libvirt_manager_compute_amount`: (Integer) State the amount of computes you want. Defaults to `1`.
-* `cifmw_libvirt_manager_skip_edpm_compute_repos`: (Boolean) Intentionally skips the configuration of repos on EDPM compute nodes. Defaults to `False`.

--- a/ci_framework/roles/libvirt_manager/defaults/main.yml
+++ b/ci_framework/roles/libvirt_manager/defaults/main.yml
@@ -46,5 +46,4 @@ cifmw_libvirt_manager_crc_pool: "{{ cifmw_crc_pool | default(lookup('env', 'HOME
 cifmw_libvirt_manager_pool:
 cifmw_libvirt_manager_installyamls: "{{ cifmw_installyamls_repos | default('../..') }}"
 cifmw_libvirt_manager_dryrun: false
-cifmw_libvirt_manager_skip_edpm_compute_repos: false
 cifmw_libvirt_manager_daemon: libvirtd.service

--- a/ci_framework/roles/libvirt_manager/tasks/deploy_edpm_compute.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/deploy_edpm_compute.yml
@@ -74,23 +74,6 @@
         timeout: 60
       loop: "{{ edpm_vms_ips.results }}"
 
-- name: Configure repositories on external computes
-  when: not cifmw_libvirt_manager_skip_edpm_compute_repos
-  vars:
-    make_edpm_compute_repos_dryrun: "{{ cifmw_libvirt_manager_dryrun }}"
-    make_edpm_compute_repos_params:
-      EDPM_COMPUTE_SUFFIX: "{{ item }}"
-    make_edpm_compute_repos_env: >-
-      {{ cifmw_libvirt_manager_common_env |
-        combine({
-          'CMDS_FILE': cifmw_libvirt_manager_basedir + "/artifacts/edpm_compute/compute_repo-" + item + ".sh"
-        })
-      }}
-  ansible.builtin.include_role:
-    name: 'install_yamls_makes'
-    tasks_from: 'make_edpm_compute_repos.yml'
-  with_sequence: start=0 end={{ compute_config.amount - 1 }}
-
 - name: Output CR for extra computes
   when:
     - compute_config.amount > 2

--- a/scenarios/centos-9/edpm_periodic.yml
+++ b/scenarios/centos-9/edpm_periodic.yml
@@ -1,8 +1,6 @@
 ---
 cifmw_repo_setup_branch: master
 cifmw_repo_setup_promotion: podified-ci-testing
-make_edpm_compute_repos_params:
-  REPO_SETUP_CMD: "{{ cifmw_repo_setup_promotion }} -b {{ cifmw_repo_setup_branch }}"
 cifmw_set_openstack_containers_registry: quay.rdoproject.org
 cifmw_set_openstack_containers_tag_from_md5: true
 cifmw_set_openstack_containers_dlrn_md5_path: "{{ cifmw_basedir }}/artifacts/repositories/delorean.repo.md5"


### PR DESCRIPTION
This make target is now a noop since the ansible service `repo-setup` is responsible for setting up repos for install_yamls environments.

edpm_compute_repos can be deleted once this stops calling it.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
