### PR TITLE
Provide a default safe tempest profile definition by default

### DIFF
--- a/ci_framework/roles/tempest/tasks/configure-tempest.yml
+++ b/ci_framework/roles/tempest/tasks/configure-tempest.yml
@@ -32,8 +32,16 @@
 
 # Check README to see examples of how to set cifmw_tempest_tempestconf_profile
 - name: Create profile.yaml file
-  when: cifmw_tempest_tempestconf_profile is defined
+  vars:
+    _cifmw_tempest_tempestconf_profile_content: >-
+      {{
+        cifmw_tempest_tempestconf_profile_default |
+        combine(
+          cifmw_tempest_tempestconf_profile | default({})
+          ,recursive=True
+        )
+      }}
   ansible.builtin.copy:
-    content: "{{ cifmw_tempest_tempestconf_profile | to_nice_yaml }}"
+    content: "{{ _cifmw_tempest_tempestconf_profile_content | to_nice_yaml }}"
     dest: "{{ cifmw_tempest_artifacts_basedir }}/profile.yaml"
     mode: "0644"

--- a/ci_framework/roles/tempest/vars/main.yml
+++ b/ci_framework/roles/tempest/vars/main.yml
@@ -1,0 +1,3 @@
+cifmw_tempest_tempestconf_profile_default:
+  overrides:
+    identity.v3_endpoint_type: public


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
