### PR TITLE
WIP: Improvements to devscripts role

### DIFF
--- a/ci_framework/roles/ci_setup/README.md
+++ b/ci_framework/roles/ci_setup/README.md
@@ -8,9 +8,10 @@ Ensure you have the needed directories and packages for the rest of the tasks.
 
 ## Parameters
 
-- `cifmw_ci_setup_basedir`: (String) Base directory for the directory tree. Default to `~/ci-framework-data`.
-- `cifmw_ci_setup_packages`: (List) List of packages to install.
-- `cifmw_ci_setup_openshift_client_version`: (String) Version of openshift
+
+- `cifmw_ci_setup_basedir` (String) Base directory for the directory tree. Default to `~/ci-framework-data`.
+- `cifmw_ci_setup_packages` (List) List of packages to install.
+- `cifmw_ci_setup_openshift_client_version` (String) Version of openshift
   client to be installed on the system. Defaults to `stable` i.e. the latest
   stable release of the client.
 - `cifmw_ci_setup_rhel_rhsm_default_repos` (List) List of repos to be enabled via Red Hat Subscription Manager.

--- a/ci_framework/roles/ci_setup/tasks/main.yml
+++ b/ci_framework/roles/ci_setup/tasks/main.yml
@@ -19,6 +19,11 @@
     - always
   ansible.builtin.import_tasks: load_vars.yml
 
+- name: Enable repos
+  tags:
+    - always
+  ansible.builtin.import_tasks: repos.yml
+
 - name: Install packages
   tags:
     - always

--- a/ci_framework/roles/devscripts/README.md
+++ b/ci_framework/roles/devscripts/README.md
@@ -22,16 +22,17 @@ managed services.
 * `cifmw_devscripts_artifacts_dir` (str) path to the directory to store the role artifacts.
 * `cifmw_devscripts_ci_token` (str) oAuth token required for accessing
   [openshift-console](https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/).
-* `cifmw_devscripts_ci_token_file` (str) oAuth token required for accessing
+* `cifmw_devscripts_ci_token_file` (str) oAuth token file required for accessing
   [openshift-console](https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/).
   We can use `cifmw_devscripts_ci_token` or `cifmw_devscripts_ci_token_file` for passing OAuth token.
 * `cifmw_devscripts_config_overrides` (dict) key/value pairs to be used for overriding the default
   configuration. Refer [section](#supported-keys-in-cifmw_devscripts_config_overrides) for more information.
-* `cifmw_devscripts_crb_repo` (str) Repo URL of code ready builder.
 * `cifmw_devscripts_dry_run` (bool) If enabled, the workflow is evaluated.
 * `cifmw_devscripts_restart_virtproxyd` (bool) Optional, if libvirt's virtproxy service should be restarted via
   a dev-scripts patch. By default this is enabled for stability.
 * `cifmw_devscripts_make_target` (str) Optional, the target to be used with dev-scripts.
+* `cifmw_devscripts_restart_virtproxyd` (bool) Optional, if libvirt's virtproxyd service should be restarted.
+  By default, the service is restarted.
 * `cifmw_devscripts_ocp_version` (str) The version of OpenShift to be deployed.
 * `cifmw_devscripts_osp_compute_nodes` (list) A list of nodes which has key/value pairs
   containing details about OpenStack compute nodes. Refer
@@ -146,7 +147,6 @@ Additional information can be found [here](https://github.com/metal3-io/baremeta
   cifmw_devscripts_src_dir: "/home/ciuser/src/dev-scripts"
 
   cifmw_devscripts_ocp_version: '4.13.13'
-  cifmw_devscripts_crb_repo: 'https://mirror.stream.centos.org/9-stream/CRB/x86_64/os/'
   ...
   ```
 

--- a/ci_framework/roles/devscripts/defaults/main.yml
+++ b/ci_framework/roles/devscripts/defaults/main.yml
@@ -21,11 +21,32 @@
 cifmw_devscripts_dry_run: false
 cifmw_devscripts_debug: false
 
-cifmw_devscripts_data_dir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
-cifmw_devscripts_artifacts_dir: "{{ (cifmw_devscripts_data_dir, 'artifacts') | path_join }}"
-cifmw_devscripts_logs_dir: "{{ (cifmw_devscripts_data_dir, 'devscripts', 'logs') | path_join }}"
-cifmw_devscripts_output_dir: "{{ (cifmw_devscripts_data_dir, 'devscripts', 'output') | path_join }}"
-cifmw_devscripts_repo_dir: "{{ (ansible_user_dir, 'src/github.com/openshift-metal3/dev-scripts') | path_join }}"
+cifmw_devscripts_data_dir: >-
+  {{
+    cifmw_basedir |
+    default(ansible_user_dir ~ '/ci-framework-data')
+  }}
+cifmw_devscripts_artifacts_dir: >-
+  {{
+    (cifmw_devscripts_data_dir, 'artifacts') |
+    path_join
+  }}
+cifmw_devscripts_logs_dir: >-
+  {{
+    (cifmw_devscripts_data_dir, 'devscripts', 'logs') |
+    path_join
+  }}
+cifmw_devscripts_output_dir: >-
+  {{
+    (cifmw_devscripts_data_dir, 'devscripts', 'output') |
+    path_join
+  }}
+cifmw_devscripts_repo_dir: >-
+  {{
+    (
+      ansible_user_dir, 'src', 'github.com', 'openshift-metal3', 'dev-scripts'
+    ) | path_join
+  }}
 
 cifmw_devscripts_user: "{{ ansible_user_id }}"
 cifmw_devscripts_restart_virtproxyd: true
@@ -33,3 +54,5 @@ cifmw_devscripts_restart_virtproxyd: true
 cifmw_devscripts_osp_compute_nodes: []
 
 cifmw_devscripts_config_overrides: {}
+
+cifmw_devscripts_extra_networks: []

--- a/ci_framework/roles/devscripts/molecule/default/converge.yml
+++ b/ci_framework/roles/devscripts/molecule/default/converge.yml
@@ -28,8 +28,6 @@
     cifmw_devscripts_dry_run: true
     cifmw_devscripts_ci_token: "random value"
     cifmw_devscripts_pull_secret: "should be a json"
-    cifmw_devscripts_ocp_version: "4.13.12"
-    cifmw_devscripts_user: "{{ ansible_user_id }}"
     cifmw_devscripts_repo_dir: "{{ (ansible_user_dir, 'src', 'dev-scripts') | path_join }}"
     cifmw_devscripts_data_dir: "{{ (ansible_user_dir, 'ci-framework-data') | path_join }}"
     cifmw_devscripts_artifacts_dir: "{{ (cifmw_devscripts_data_dir, 'devscripts', 'artifacts') | path_join }}"

--- a/ci_framework/roles/devscripts/tasks/cleanup.yml
+++ b/ci_framework/roles/devscripts/tasks/cleanup.yml
@@ -54,7 +54,11 @@
 - name: Cleanup the devscripts working directory.
   become: true
   ansible.builtin.file:
-    path: "{{ cifmw_devscripts_config.working_dir }}"
+    path: >-
+      {{
+        cifmw_devscripts_config.working_dir |
+        default('/home/dev-scripts')
+      }}
     state: absent
     force: true
 

--- a/ci_framework/roles/devscripts/tasks/sub_tasks/11_packages.yml
+++ b/ci_framework/roles/devscripts/tasks/sub_tasks/11_packages.yml
@@ -14,6 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+
 - name: Ensure the required packages for executing dev-scripts exists.
   become: true
   ansible.builtin.package:

--- a/ci_framework/roles/devscripts/tasks/sub_tasks/43_add_bmh.yml
+++ b/ci_framework/roles/devscripts/tasks/sub_tasks/43_add_bmh.yml
@@ -61,7 +61,7 @@
     dest: "{{ cifmw_devscripts_artifacts_dir }}/bmh/{{ item.name }}.yaml"
     owner: "{{ cifmw_devscripts_user }}"
     group: "{{ cifmw_devscripts_user }}"
-    mode: "0644"
+    mode: "0640"
   loop: "{{ cifmw_devscripts_osp_compute_nodes }}"
 
 - name: Apply the baremetal host definitions

--- a/ci_framework/roles/devscripts/tasks/sub_tasks/_421_gather.yml
+++ b/ci_framework/roles/devscripts/tasks/sub_tasks/_421_gather.yml
@@ -30,6 +30,7 @@
             cifmw_ci_nmstate_instance_config[inventory_hostname]['interfaces'] |
             community.general.json_query(_query)
           }}
+
     - name: Add the details to extra networks
       vars:
         _nets_data:

--- a/ci_framework/roles/devscripts/vars/main.yml
+++ b/ci_framework/roles/devscripts/vars/main.yml
@@ -47,6 +47,9 @@ cifmw_devscripts_config_defaults:
   master_disk: 100
   master_vcpu: 10
   num_workers: 0
+  worker_disk: 80
+  worker_memory: 32768
+  worker_vcpu: 10
   num_extra_workers: 0
   extra_worker_memory: 16384
   extra_worker_disk: 80

--- a/ci_framework/roles/libvirt_manager/defaults/main.yml
+++ b/ci_framework/roles/libvirt_manager/defaults/main.yml
@@ -19,6 +19,7 @@
 # All variables within this role should have a prefix of "cifmw_libvirt_manager"
 
 cifmw_libvirt_manager_basedir: "{{ cifmw_basedir | default( ansible_user_dir ~ '/ci-framework-data') }}"
+cifmw_libvirt_manager_artifacts_dir: "{{ cifmw_libvirt_manager_basedir }}/artifacts"
 cifmw_libvirt_manager_enable_virtualization_module: false
 cifmw_libvirt_manager_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
 cifmw_libvirt_manager_images_url: https://cloud.centos.org/centos/9-stream/x86_64/images

--- a/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -14,8 +14,7 @@
     _layout: "{{ cifmw_libvirt_manager_configuration_gen | default(cifmw_libvirt_manager_configuration) }}"
 
 - name: Manage networks if needed
-  when:
-    - _layout.networks is defined
+  when: _layout.networks is defined
   ansible.builtin.import_tasks: create_networks.yml
 
 - name: Ensure images are present

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -255,6 +255,7 @@ olm
 opendev
 openrc
 openshift
+openshiftapps
 openshiftsdn
 openssl
 openstack
@@ -368,6 +369,7 @@ venv
 vexxhost
 virsh
 virt
+virthost
 virthosts
 virtproxy
 virtproxyd

--- a/docs/source/roles/devscripts.md
+++ b/docs/source/roles/devscripts.md
@@ -1,0 +1,1 @@
+../../../ci_framework/roles/devscripts/README.md


### PR DESCRIPTION
Below are some of the optimizations carried out

- Supports Hybrid test environment.
- No longer supports creating of user instead opts to use existing executor.
- Improved way of inserting the default ipv4 address
- Integrated with `ci_nmstate`
-- Support attaching of extra networks to worker nodes
-- Support for extending virtual network into the physical layer
- Extra networks managed outside of dev-scripts
- Firewall configuration for all extra networks
- Forwarding rule for all extra networks.
- The default number of extra worker nodes created is set to `0`

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
