### PR TITLE
Parameterize EDPM compute VM memory, cpu and disk size

### DIFF
--- a/ci_framework/roles/libvirt_manager/README.md
+++ b/ci_framework/roles/libvirt_manager/README.md
@@ -23,3 +23,6 @@ Used for checking if:
 * `cifmw_libvirt_manager_installyamls`: (String) install_yamls repository location. Defaults to `cifmw_installyamls_repos` which defaults to `../..`
 * `cifmw_libvirt_manager_dryrun`: (Boolean) Toggle ci_make `dry_run` parameter. Defaults to `false`.
 * `cifmw_libvirt_manager_compute_amount`: (Integer) State the amount of computes you want. Defaults to `1`.
+* `cifmw_libvirt_manager_compute_memory`: (Integer) The amount of memory in GB per compute. Defaults to `4`.
+* `cifmw_libvirt_manager_compute_disksize`: (Integer) The size of the disk in GB per compute. Defaults to `20`.
+* `cifmw_libvirt_manager_compute_cpus`: (Integer) The amount of vCPUs per compute. Defaults to `1`.

--- a/ci_framework/roles/libvirt_manager/defaults/main.yml
+++ b/ci_framework/roles/libvirt_manager/defaults/main.yml
@@ -24,6 +24,9 @@ cifmw_libvirt_manager_user: "{{ ansible_user | default(lookup('env', 'USER')) }}
 cifmw_libvirt_manager_images_url: https://cloud.centos.org/centos/9-stream/x86_64/images
 
 cifmw_libvirt_manager_compute_amount: 1
+cifmw_libvirt_manager_compute_disksize: 20
+cifmw_libvirt_manager_compute_memory: 4
+cifmw_libvirt_manager_compute_cpus: 1
 cifmw_libvirt_manager_configuration:
   networks:
     - default
@@ -35,10 +38,10 @@ cifmw_libvirt_manager_configuration:
       image_local_dir: "{{ cifmw_libvirt_manager_basedir }}/images/"
       disk_file_name: "centos-9-stream.qcow2"
       # GB
-      disksize: 20
+      disksize: "{{ cifmw_libvirt_manager_compute_disksize }}"
       # GB
-      memory: 4
-      cpus: 1
+      memory: "{{ cifmw_libvirt_manager_compute_memory }}"
+      cpus: "{{ cifmw_libvirt_manager_compute_cpus }}"
       start_ip: 192.168.122.100
       subnet_mask: 255.255.255.0
 

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -90,6 +90,7 @@ dhcp
 dib
 dir
 disablecertificateverification
+disksize
 distro
 dlrn
 dlrnapi


### PR DESCRIPTION
Introduce the following parameters into the libvirt_manager role:

  cifmw_libvirt_manager_compute_memory
  cifmw_libvirt_manager_compute_cpus
  cifmw_libvirt_manager_compute_disksize

The intent of this PR is to make it easy for a user to set these parameters without needing to redefine the entire cifmw_libvirt_manager_configuration structure in an override.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
