### PR TITLE
Use copy instead of fetch in pulling dlrn_promote criteria file

### DIFF
--- a/ci_framework/roles/dlrn_promote/tasks/check_promotion_criteria.yml
+++ b/ci_framework/roles/dlrn_promote/tasks/check_promotion_criteria.yml
@@ -10,11 +10,22 @@
     - cifmw_dlrn_promote_hash_report_status_output | length > 0
     - cifmw_dlrn_promote_hash_report_status_output  != '[]'
   block:
-    - name: Fetch criteria file
-      ansible.builtin.fetch:
+    - name: Check for criteria file before copying
+      ansible.builtin.stat:
+        path: "{{ cifmw_dlrn_promote_criteria_file }}"
+      register: criteria_file
+
+    - name: Abort the role on missing criteria file
+      when: not criteria_file.stat.exists
+      ansible.builtin.fail:
+        msg: "{{ cifmw_dlrn_promote_criteria_file }} does not exists."
+
+    - name: Copy criteria file
+      when: criteria_file.stat.exists
+      ansible.builtin.copy:
         dest: "{{ cifmw_dlrn_promote_workspace }}/"
         src: "{{ cifmw_dlrn_promote_criteria_file }}"
-        flat: true
+        remote_src: true
 
     - name: Load criteria for promotion
       ansible.builtin.include_vars:

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -112,6 +112,8 @@
       - ^ci_framework/roles/.*_build
       - ^ci_framework/roles/build.*
       - ^ci_framework/roles/local_env_vm
+      - ^ci_framework/roles/dlrn_report
+      - ^ci_framework/roles/dlrn_promote
       - ^ci/templates
       - ^docs
       - ^.*/*.md


### PR DESCRIPTION
Currently Zuul dlrn check job is failing with following error:
```
023-10-13 12:03:10.421553 | TASK [dlrn_promote : Criteria failed?]
2023-10-13 12:03:10.472932 | primary | ERROR
2023-10-13 12:03:10.473128 | primary | {
2023-10-13 12:03:10.473164 | primary |   "msg": "FAILURE! :( Promotion criteria failed to match."
2023-10-13 12:03:10.473191 | primary | }
2023-10-13 12:03:10.474690 |
```

This pr first checks for criteria file and then copy it to workspace instead of fetching the file to avoid above issue.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
