### PR TITLE
Correctly handle types in kustomize_compute template

### DIFF
--- a/ci_framework/roles/libvirt_manager/templates/kustomize_compute.yml.j2
+++ b/ci_framework/roles/libvirt_manager/templates/kustomize_compute.yml.j2
@@ -1,4 +1,4 @@
-{%- set ip_suffix = item + 100 -%}
+{%- set ip_suffix = (item|int + 100)|string -%}
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneNode
 metadata:


### PR DESCRIPTION
Without this patch, a 3 node edpm-compute deployment fails with "can only concatenate str (not \"int\") to str".

Update the kustomize_compute.yml.j2 template in the libvirt_manager role to explicitly cast the item to an int so that addition can take place and then cast the result to a string so that concatenation can take place.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
