### PR TITLE
Add hooks and new scenario to kuttl-multinode job

### DIFF
--- a/ci/playbooks/kuttl/e2e-kuttl.yml
+++ b/ci/playbooks/kuttl/e2e-kuttl.yml
@@ -11,6 +11,21 @@
         ] | ansible.builtin.path_join
     }}
 
+- name: Run pre_kuttl hooks
+  vars:
+    hooks: "{{ pre_kuttl | default([]) }}"
+    step: pre_kuttl
+  ansible.builtin.import_playbook: >-
+    {{
+        [
+          ansible_user_dir,
+          zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
+          'ci_framework',
+          'playbooks',
+          'hooks.yml'
+        ] | ansible.builtin.path_join
+    }}
+
 - name: Deploy and run KUTTL operator tests
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   tasks:
@@ -35,6 +50,21 @@
       loop: "{{ cifmw_kuttl_tests_operator_list | default(['cinder' 'keystone']) }}"
       loop_control:
         loop_var: operator
+
+- name: Run post_kuttl hooks
+  vars:
+    hooks: "{{ post_kuttl | default([]) }}"
+    step: post_kuttl
+  ansible.builtin.import_playbook: >-
+    {{
+        [
+          ansible_user_dir,
+          zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
+          'ci_framework',
+          'playbooks',
+          'hooks.yml'
+        ] | ansible.builtin.path_join
+    }}
 
 - name: Run log related tasks
   ansible.builtin.import_playbook: >-

--- a/ci/playbooks/kuttl/run-kuttl-tests.yml
+++ b/ci/playbooks/kuttl/run-kuttl-tests.yml
@@ -1,4 +1,7 @@
 ---
+- name: Load parameters
+  ansible.builtin.include_vars:
+    dir: "{{ cifmw_basedir }}/artifacts/parameters"
 
 - name: Set environment vars for kuttl test
   ansible.builtin.set_fact:
@@ -6,6 +9,7 @@
       {{
         cifmw_install_yamls_environment |
         combine(cifmw_kuttl_tests_env_vars | default({})) |
+        combine(cifmw_kuttl_openstack_prep_vars | default({})) |
         combine({'PATH': cifmw_path})
       }}
 

--- a/ci_framework/hooks/playbooks/README.md
+++ b/ci_framework/hooks/playbooks/README.md
@@ -27,6 +27,14 @@ This path should be relative to hook playbook directory.
 * `kustomized_{{ cifmw_kustomize_cr_file_name }}`: Kustomized file which is
 available at *cifmw_kustomize_cr_artifact_dir* to be consumed by the deployment.
 
+## kuttl_openstack_prep.yml
+This hook provides openstack_prep variables for kuttl tests.
+### Input
+None
+### Output
+* `cifmw_kuttl_openstack_prep_vars`: Environment variable to be used during openstack_prep
+step in install_yamls.
+
 ## noop.yml
 Just a dummy hook, mostly used as a demonstrator of the hook workflow.
 

--- a/ci_framework/hooks/playbooks/fetch_compute_facts.yml
+++ b/ci_framework/hooks/playbooks/fetch_compute_facts.yml
@@ -31,7 +31,7 @@
 
     - name: Check we have some compute in inventory
       ansible.builtin.set_fact:
-        computes_len: "{{ groups['computes'] | length }}"
+        computes_len: "{{ groups['computes'] | default([]) | length }}"
 
     - name: Ensure that the isolated net was configured for crc
       ansible.builtin.assert:

--- a/ci_framework/hooks/playbooks/kuttl_openstack_prep.yml
+++ b/ci_framework/hooks/playbooks/kuttl_openstack_prep.yml
@@ -1,0 +1,44 @@
+- name: Get crc network info
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Load parameters
+      ansible.builtin.include_vars:
+        dir: "{{ item }}"
+      loop:
+        - "{{ cifmw_basedir }}/artifacts/parameters"
+        - "/etc/ci/env"
+      loop_control:
+        label: "{{ item }}"
+
+    - name: Ensure CRC hostname is set
+      ansible.builtin.set_fact:
+        _crc_hostname: "{{ cifmw_crc_hostname | default('crc') }}"
+
+    - name: Ensure that the isolated net was configured for crc
+      ansible.builtin.assert:
+        that:
+          - crc_ci_bootstrap_networks_out is defined
+          - crc_ci_bootstrap_networks_out[_crc_hostname] is defined
+          - crc_ci_bootstrap_networks_out[_crc_hostname]['default'] is defined
+
+    - name: Set facts for further usage within the framework
+      ansible.builtin.set_fact:
+        cifmw_kuttl_openstack_prep_vars:
+          NNCP_INTERFACE: "{{ crc_ci_bootstrap_networks_out[_crc_hostname].default.iface }}"
+          NNCP_DNS_SERVER: >-
+            {{
+              crc_ci_bootstrap_networks_out[_crc_hostname].default.ip4 |
+              default(crc_ci_bootstrap_networks_out[_crc_hostname].default.ip) |
+              replace('/24', '')
+            }}
+          NETWORK_MTU: "{{ crc_ci_bootstrap_networks_out[_crc_hostname].default.mtu }}"
+
+    - name: Save content into artifact directory
+      vars:
+        file_content:
+          cifmw_kuttl_openstack_prep_vars: "{{ cifmw_kuttl_openstack_prep_vars }}"
+      ansible.builtin.copy:
+        dest: "{{ cifmw_basedir }}/artifacts/parameters/{{ step }}_{{ hook_name }}.yml"
+        content: "{{ file_content | to_nice_yaml }}"

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -180,6 +180,7 @@ kustomization
 kustomizations
 kustomize
 kustomized
+kuttl
 kvm
 ldp
 libguestfs

--- a/scenarios/centos-9/kuttl_multinode.yml
+++ b/scenarios/centos-9/kuttl_multinode.yml
@@ -1,0 +1,9 @@
+---
+pre_kuttl:
+  - name: Fetch crc facts and save them as parameters for kuttl jobs
+    type: playbook
+    inventory: "{{ ansible_user_dir }}/ci-framework-data/artifacts/zuul_inventory.yml"
+    source: kuttl_openstack_prep.yml
+
+cifmw_kuttl_tests_env_vars:
+  PV_NUM: 20

--- a/zuul.d/kuttl_multinode.yaml
+++ b/zuul.d/kuttl_multinode.yaml
@@ -60,10 +60,13 @@
       - ^scenarios/centos-9/kuttl.yml
       - ^zuul.d/kuttl.yaml
     vars:
+      cifmw_extras:
+        - '@scenarios/centos-9/kuttl_multinode.yml'
       cifmw_kuttl_tests_operator_list:
         - ansibleee
-        - keystone
         - cinder
+        - keystone
+        - openstack
       commands_before_kuttl_run:
         - oc get pv
         - oc get all


### PR DESCRIPTION
We need to run multinode-ci scenario hooks to get/set some additional network configuration for the crc node.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
  
Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/518