### PR TITLE
Add high level tags to deploy-edpm.yml playbook

### DIFF
--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -51,6 +51,8 @@
   ansible.builtin.include_role:
     name: 'install_yamls_makes'
     tasks_from: 'make_crc_storage'
+  tags:
+    - control-plane
 
 - name: Prepare inputs
   vars:
@@ -62,6 +64,8 @@
   ansible.builtin.include_role:
     name: 'install_yamls_makes'
     tasks_from: 'make_input'
+  tags:
+    - control-plane
 
 - name: OpenStack meta-operator installation
   vars:
@@ -71,8 +75,12 @@
   ansible.builtin.include_role:
     name: 'install_yamls_makes'
     tasks_from: 'make_openstack'
+  tags:
+    - control-plane
 
-- name: Wait for OpenStack control plane to be installed
+- name: Wait for OpenStack operators to be installed
+  tags:
+    - control-plane
   when:
     - not cifmw_edpm_prepare_dry_run
   block:
@@ -116,6 +124,8 @@
   ansible.builtin.include_role:
     name: 'install_yamls_makes'
     tasks_from: 'make_openstack_deploy_prep'
+  tags:
+    - control-plane
 
 - name: Deploy NetConfig
   vars:
@@ -124,8 +134,12 @@
   ansible.builtin.include_role:
     name: 'install_yamls_makes'
     tasks_from: 'make_netconfig_deploy'
+  tags:
+    - control-plane
 
 - name: Kustomize and deploy OpenStackControlPlane
+  tags:
+    - control-plane
   vars:
     cifmw_edpm_prepare_openstack_crs_path: >-
       {{
@@ -197,6 +211,8 @@
           --timeout={{ cifmw_edpm_prepare_timeout }}m
 
 - name: Wait for keystone to be ready
+  tags:
+    - control-plane
   when: not cifmw_edpm_prepare_dry_run
   block:
     - name: Extract keystone endpoint host

--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -19,25 +19,39 @@
 
 - name: Import infra entrypoint playbook
   ansible.builtin.import_playbook: ci_framework/playbooks/02-infra.yml
+  tags:
+    - infra
 
 - name: Import package build playbook
   ansible.builtin.import_playbook: ci_framework/playbooks/03-build-packages.yml
+  tags:
+    - build-packages
 
 - name: Import containers build playbook
   ansible.builtin.import_playbook: ci_framework/playbooks/04-build-containers.yml
+  tags:
+    - build-containers
 
 - name: Import operators build playbook
   ansible.builtin.import_playbook: ci_framework/playbooks/05-build-operators.yml
+  tags:
+    - build-operators
 
 - name: Import deploy edpm playbook
   ansible.builtin.import_playbook: ci_framework/playbooks/06-deploy-edpm.yml
+  tags:
+    - edpm
 
 - name: Import admin setup related playbook
   ansible.builtin.import_playbook: ci_framework/playbooks/07-admin-setup.yml
+  tags:
+    - admin-setup
 
 - name: Import run test playbook
   ansible.builtin.import_playbook: ci_framework/playbooks/08-run-tests.yml
   when: cifmw_run_tests | default('false') | bool
+  tags:
+    - run-tests
 
 - name: Inject status flag
   hosts: "{{ cifmw_target_host | default('localhost') }}"
@@ -49,4 +63,6 @@
 
 - name: Run log related tasks
   ansible.builtin.import_playbook: ci_framework/playbooks/99-logs.yml
-  when: not zuul_log_collection | default ('false') | bool
+  when: not zuul_log_collection | default('false') | bool
+  tags:
+    - logs

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -63,6 +63,7 @@ controlplane
 coreos
 cpus
 cr
+crs
 crashloopbackoff
 crb
 crc
@@ -257,6 +258,7 @@ openshift
 openshiftsdn
 openssl
 openstack
+openstackcontrolplane
 openstackdataplane
 openstackdataplanenodeset
 openstackprovisioner

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -125,6 +125,15 @@ or `--skip-tags`:
 * `bootstrap`: Run all of the package installation tasks as well as the potential system configuration depending on the options you set.
 * `packages`: Run all package installation tasks associated to the options you set.
 * `bootstrap_layout`: Run the [reproducer](../reproducers/01-considerations.md) bootstrap steps only.
+* `infra`: Denotes tasks to prepare host virtualization and Openshift Container Platform when deploy-edpm.yml playbook is run.
+* `build-packages`: Denotes tasks to call the role [pkg_build](../roles/pkg_build.md) when deploy-edpm.yml playbook is run.
+* `build-containers`: Denotes tasks to call the role [build_containers](../roles/build_containers.md) when deploy-edpm.yml playbook is run.
+* `build-operators`: Denotes tasks to call the role [operator_build](../roles/operator_build.md) when deploy-edpm.yml playbook is run.
+* `control-plane`: Deploys the control-plane on OpenShift by creating `OpenStackControlPlane` CRs when deploy-edpm.yml playbook is run.
+* `edpm`: Deploys the data-plane (External Data Plane Management) on RHEL nodes by creating `OpenStackDataPlane` CRs when deploy-edpm.yml playbook is run.
+* `admin-setup`: Denotes tasks to call the role [os_net_setup](../roles/os_net_setup.md) when deploy-edpm.yml playbook is run.
+* `run-tests`: Denotes tasks to call the role [tempest](../roles/tempest.md) when deploy-edpm.yml playbook is run.
+* `logs`: Denotes tasks which generate artifacts via the role [artifacts](../roles/artifacts.md) and when collect logs when deploy-edpm.yml playbook is run.
 
 For instance, if you want to bootstrap a hypervisor, and reuse it over and
 over, you'll run the following commands:
@@ -133,10 +142,17 @@ over, you'll run the following commands:
 $ ansible-playbook deploy-edpm.yml -K --tags bootstrap,packages [-e @scenarios/centos-9/some-environment -e <...>]
 $ ansible-playbook deploy-edpm.yml -K --skip-tags bootstrap,packages [-e @scenarios/centos-9/some-environment -e <...>]
 ```
-
 Running the command twice, with `--tags` and `--skip-tags` as only difference,
 will ensure your environment has the needed directories, packages and
 configurations with the first run, while skip all of those tasks in the
 following runs. That way, you will save time and resources.
+
+If you've already deployed OpenStack but it failed
+during [os_net_setup](../roles/os_net_setup.md) and you've taken steps
+to correct the problem and want to test if they resolved the issue,
+then use:
+```Bash
+ansible-playbook deploy-edpm.yml -K --tags admin-setup
+```
 
 More tags may show up according to the needs.


### PR DESCRIPTION
If the deploy-edpm.yml playbook fails it saves time to be able to re-run it and pass tags so certain steps can be skipped.

Tags are named their plays. The control-plane tag is the same as the edpm tag for now since the 06-deploy-edpm.yml playbook also deploys the control-plane. Further tagging can be done within the edpm_prepare role to differentiate the control-plane and data-plane.

Tags were not added to the 01-bootstrap.yml playbook call because the bootstrap tag already exists and the playbook has some tasks with an always tag.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
