### PR TITLE
Replace copy with slurp in dlrn_promote check criteria tasks

### DIFF
--- a/ci_framework/roles/dlrn_promote/molecule/check_criteria/converge.yml
+++ b/ci_framework/roles/dlrn_promote/molecule/check_criteria/converge.yml
@@ -1,0 +1,30 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: all
+  vars:
+    cifmw_dlrn_promote_hash_report_status_output:
+      - periodic-podified-edpm-baremetal-antelope-ocp-crc
+      - periodic-podified-edpm-deployment-antelope-ocp-crc-1cs9
+      - periodic-data-plane-adoption-github-rdo-centos-9-crc-single-node-antelope
+    cifmw_dlrn_promote_criteria_file: '~/src/github.com/openstack-k8s-operators/ci-framework/roles/dlrn_promote/files/centos9_antelope.yaml'
+    cifmw_dlrn_promote_promotion_target: current-podified
+  tasks:
+    - name: Check check_promotion_criteria playbook
+      ansible.builtin.include_role:
+        name: dlrn_promote
+        tasks_from: check_promotion_criteria.yml

--- a/ci_framework/roles/dlrn_promote/molecule/check_criteria/molecule.yml
+++ b/ci_framework/roles/dlrn_promote/molecule/check_criteria/molecule.yml
@@ -1,0 +1,9 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true

--- a/ci_framework/roles/dlrn_promote/molecule/check_criteria/prepare.yml
+++ b/ci_framework/roles/dlrn_promote/molecule/check_criteria/prepare.yml
@@ -1,0 +1,28 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps
+  tasks:
+    - name: Get the zuul/zuul-jobs repo
+      ansible.builtin.git:
+        repo: https://opendev.org/zuul/zuul-jobs
+        dest: "{{ ansible_user_dir }}/zuul-jobs"
+        version: master
+        force: true

--- a/ci_framework/roles/dlrn_promote/tasks/check_promotion_criteria.yml
+++ b/ci_framework/roles/dlrn_promote/tasks/check_promotion_criteria.yml
@@ -20,17 +20,15 @@
       ansible.builtin.fail:
         msg: "{{ cifmw_dlrn_promote_criteria_file }} does not exists."
 
-    - name: Copy criteria file
+    - name: Slurp criteria file
       when: criteria_file.stat.exists
-      ansible.builtin.copy:
-        dest: "{{ cifmw_dlrn_promote_workspace }}/"
-        src: "{{ cifmw_dlrn_promote_criteria_file }}"
-        remote_src: true
+      ansible.builtin.slurp:
+        path: "{{ cifmw_dlrn_promote_criteria_file }}"
+      register: criteria_data
 
-    - name: Load criteria for promotion
-      ansible.builtin.include_vars:
-        file: "{{ cifmw_dlrn_promote_workspace }}/{{ cifmw_dlrn_promote_criteria_file | basename }}"
-        name: "criteria"
+    - name: Set fact for criteria
+      ansible.builtin.set_fact:
+        criteria: "{{ criteria_data['content'] | b64decode | from_yaml }}"
 
     - name: Query to match promotion criteria
       ansible.builtin.include_tasks: query_criteria.yml


### PR DESCRIPTION
Currently the dlrn_promote jobs are failing with following error:
```
TASK [dlrn_promote : Load criteria for promotion]
2023-10-16 04:02:33.078956 | primary | ERROR
2023-10-16 04:02:33.079200 | primary | {
2023-10-16 04:02:33.079236 | primary |   "ansible_facts": {
2023-10-16 04:02:33.079262 | primary |     "criteria": {}
2023-10-16 04:02:33.079286 | primary |   },
2023-10-16 04:02:33.079308 | primary |   "ansible_included_var_files": [],
2023-10-16 04:02:33.079348 | primary |   "message": "Could not find or access '/home/zuul/ci-framework-data/antelope.yaml' on the Ansible Controller.\nIf you are using a module and expect the file to exist on the remote, see the remote_src option"
```

The Criteria file exists in the workspace. But it is failing to load. In order to fix the issue. We can slurp the criteria file and store the needed data in criteria var. It will fix the issue.

This pr adds molecule tests for check_criteria taskfile.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

