### PR TITLE
Ensure we build the plugin documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,18 +10,16 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-    # You can also specify other tool versions:
-    # nodejs: "19"
-    # rust: "1.64"
-    # golang: "1.19"
+  jobs:
+    pre_build:
+      - >-
+        pushd docs/source/ &&
+        ansible-doc-extractor ./plugins ../../plugins/modules/*.py
+        && popd
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py
-
-        # If using Sphinx, optionally build your docs in additional formats such as PDF
-        # formats:
-        #    - pdf
 
 # Optionally declare the Python requirements required to build your docs
 python:


### PR DESCRIPTION
It seems RTD doesn't consume the Makefile, meaning it didn't build the
plugin documentation.

This patch adds a jobs.pre_build entry in order to make RTD builder
aware of that step, according the official documentation[1] (using their
example for doxygen pre-build).

[1] https://docs.readthedocs.io/en/stable/build-customization.html#generate-documentation-from-annotated-sources-with-doxygen

As a pull request owner and reviewers, I checked that:
- [X] no checkbox available for it, we must merge before seeing if it breaks or works
