### PR TITLE
[reproducer] allow customize dns server via cifmw_reproducer_dns_servers

### DIFF
--- a/ci_framework/roles/reproducer/README.md
+++ b/ci_framework/roles/reproducer/README.md
@@ -16,6 +16,7 @@ None
 * `cifmw_reproducer_params`: (Dict) Specific parameters you want to pass to the reproducer. Defaults to `{}`.
 * `cifmw_reproducer_private_nic`: (String) Private NIC for compute and controller. Defaults to `eth1`.
 * `cifmw_reproducer_crc_private_nic`: (String) Private NIC for CRC node. Defaults to `enp2s0`.
+* `cifmw_reproducer_dns_servers`: List of dns servers which should be used by the CRC VM as upstream dns servers. Defaults to 1.1.1.1, 8.8.8.8.
 
 ## Warning
 This role isn't intended to be called outside of the `reproducer.yml` playbook.

--- a/ci_framework/roles/reproducer/defaults/main.yml
+++ b/ci_framework/roles/reproducer/defaults/main.yml
@@ -27,3 +27,6 @@ cifmw_reproducer_crc_private_nic: enp2s0
 cifmw_reproducer_kubecfg: "{{ cifmw_libvirt_manager_configuration.vms.crc.image_local_dir }}/kubeconfig"
 cifmw_reproducer_params: {}
 cifmw_reproducer_run_job: true
+cifmw_reproducer_dns_servers:
+  - 1.1.1.1
+  - 8.8.8.8

--- a/ci_framework/roles/reproducer/tasks/main.yml
+++ b/ci_framework/roles/reproducer/tasks/main.yml
@@ -92,8 +92,9 @@
       ansible.builtin.blockinfile:
         path: "/var/srv/dnsmasq.conf"
         block: |-
-          server=1.1.1.1
-          server=8.8.8.8
+          {% if cifmw_reproducer_dns_servers %}
+          {% for dns_server in cifmw_reproducer_dns_servers %}server={{ dns_server }}{% endfor %}
+          {% endif %}
 
     - name: Configure local DNS for CRC pod
       register: last_modification


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running