### PR TITLE
[reproducer] take ssh key from {{ ansible_user_dir}}/.crc

### DIFF
--- a/ci_framework/roles/reproducer/tasks/main.yml
+++ b/ci_framework/roles/reproducer/tasks/main.yml
@@ -59,7 +59,7 @@
     - bootstrap_layout
   register: crc_priv_key
   ansible.builtin.slurp:
-    path: ".crc/machines/crc/id_ecdsa"
+    path: "{{ ansible_user_dir}}/.crc/machines/crc/id_ecdsa"
 
 - name: Configure CRC services
   tags:


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
