### PR TITLE
[libvirt_manager] make sure ssh keys get created in {{ ansible_user_d…

### DIFF
--- a/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -70,20 +70,23 @@
     label: "{{ item.key }}"
 
 - name: Create temporary ssh keypair
+  delegate_facts: true
   ansible.builtin.command:
     cmd: >-
-      ssh-keygen -t ed25519 -f .ssh/cifmw_reproducer_key -P '' -q
-    creates: .ssh/cifmw_reproducer_key
+      ssh-keygen -t ed25519 -f {{ ansible_user_dir }}/.ssh/cifmw_reproducer_key -P '' -q
+    creates: "{{ ansible_user_dir }}/.ssh/cifmw_reproducer_key"
 
 - name: Slurp public key for later use
+  delegate_facts: true
   register: pub_ssh_key
   ansible.builtin.slurp:
-    path: .ssh/cifmw_reproducer_key.pub
+    path: "{{ ansible_user_dir }}/.ssh/cifmw_reproducer_key.pub"
 
 - name: Slurp private key for later use
+  delegate_facts: true
   register: priv_ssh_key
   ansible.builtin.slurp:
-    path: .ssh/cifmw_reproducer_key
+    path: "{{ ansible_user_dir }}/.ssh/cifmw_reproducer_key"
 
 - name: Create fact holding network data for VMs
   ansible.builtin.set_fact:


### PR DESCRIPTION
…ir }}/.ssh

As a pull request owner and reviewers, I checked that:
- [X] No CI for the reproducer yet