### PR TITLE
Checkout PR branch

### DIFF
--- a/ci_framework/roles/reproducer/tasks/ci_job.yml
+++ b/ci_framework/roles/reproducer/tasks/ci_job.yml
@@ -38,10 +38,11 @@
     - name: Fetch zuul.items repositories
       tags:
         - bootstrap
-      ansible.builtin.git:  # noqa: latest[git]
+      ansible.builtin.git:
         dest: "{{ repo.project.src_dir }}"
         repo: "https://{{ repo.project.canonical_name }}"
         refspec: "pull/{{ repo.change }}/head:{{ job_id }}"
+        version: "{{ job_id }}"
         force: true
       loop: "{{ zuul['items'] }}"
       loop_control:


### PR DESCRIPTION
Until now, the cloned repository got the branch containing the pull
request, but it was still in the `main` branch.

This patch ensures we switch branch to the proper content.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
