### PR TITLE
[devscripts] Add file related vars for pull secrets and ci-token

### DIFF
--- a/ci_framework/roles/devscripts/README.md
+++ b/ci_framework/roles/devscripts/README.md
@@ -13,6 +13,8 @@ network configuration, repository setup and libvirt networks.
 
 * `cifmw_devscripts_artifacts_dir` (str) path to the directory to store the role artifacts.
 * `cifmw_devscripts_ci_token` (str) oAuth token required for accessing console.redhat.com.
+* `cifmw_devscripts_ci_token_file` (str) oAuth token file required for accessing console.redhat.com.
+   We can use `cifmw_devscripts_ci_token` or `cifmw_devscripts_ci_token_file` for passing OAuth token.
 * `cifmw_devscripts_config_overrides` (dict) key/value pairs to be used for overriding the default
   configuration. Refer [section](#supported-keys-in-cifmw_devscripts_config_overrides) for more information.
 * `cifmw_devscripts_crb_repo` (str) Repo URL of code ready builder.
@@ -23,6 +25,8 @@ network configuration, repository setup and libvirt networks.
   containing details about OpenStack compute nodes. Refer
   [section](#supported-keys-in-cifmw_devscripts_osp_compute_nodes) for more information.
 * `cifmw_devscripts_pull_secret` (str) Access secret for pulling OCP component images.
+* `cifmw_devscripts_pull_secret_file` (str) Path to pull-secret for pulling OCP component images.
+  We can use `cifmw_devscripts_pull_secret` or `cifmw_devscripts_pull_secret_file` for passing pull_secrets
 * `cifmw_devscripts_src_dir` (str) The parent folder of dev-scripts repository.
 
 ### Supported keys in cifmw_devscripts_config_overrides

--- a/ci_framework/roles/devscripts/molecule/default/converge.yml
+++ b/ci_framework/roles/devscripts/molecule/default/converge.yml
@@ -101,6 +101,28 @@
           - cifmw_devscripts_config.extra_network_names == 'osp_trunk'
           - cifmw_devscripts_config.num_extra_workers | int == 2
 
+    - name: Create a dummy pull secret file
+      ansible.builtin.copy:
+        content: "hello world"
+        dest: '/tmp/pull-secret'
+
+    - name: Set fact for cifmw_devscripts_pull_secret_file
+      ansible.builtin.set_fact:
+        cifmw_devscripts_pull_secret_file: '/tmp/pull-secret'
+
+    - name: Re-run devscripts role
+      ansible.builtin.include_role:
+        name: devscripts
+
+    - name: Slurp the content of pull secret file
+      ansible.builtin.slurp:
+        path: "{{ cifmw_devscripts_repo_dir }}/pull_secret.json"
+      register: ps_data
+
+    - name: Verify the content of pull-secret
+      ansible.builtin.assert:
+        that: ps_data['content'] | b64decode == 'hello world'
+
     - name: Perform cleanup
       ansible.builtin.include_role:
         name: devscripts

--- a/ci_framework/roles/devscripts/tasks/03_install.yml
+++ b/ci_framework/roles/devscripts/tasks/03_install.yml
@@ -51,12 +51,24 @@
     dest: >-
       {{ cifmw_devscripts_repo_dir }}/config_{{ cifmw_devscripts_user }}.sh
 
-- name: Copy the user pull secret
+- name: Copy the user pull secret from cifmw_devscripts_pull_secret var
+  when: cifmw_devscripts_pull_secret is defined
   tags:
     - bootstrap
   ansible.builtin.copy:
     dest: "{{ cifmw_devscripts_repo_dir }}/pull_secret.json"
     content: "{{ cifmw_devscripts_pull_secret }}"
+    owner: "{{ cifmw_devscripts_user }}"
+    group: "{{ cifmw_devscripts_user }}"
+    mode: "0644"
+
+- name: Copy the user pull secret from cifmw_devscripts_pull_secret_file var
+  when: cifmw_devscripts_pull_secret_file is defined
+  tags:
+    - bootstrap
+  ansible.builtin.copy:
+    dest: "{{ cifmw_devscripts_repo_dir }}/pull_secret.json"
+    src: "{{ cifmw_devscripts_pull_secret_file }}"
     owner: "{{ cifmw_devscripts_user }}"
     group: "{{ cifmw_devscripts_user }}"
     mode: "0644"

--- a/ci_framework/roles/devscripts/templates/conf_ciuser.sh.j2
+++ b/ci_framework/roles/devscripts/templates/conf_ciuser.sh.j2
@@ -4,7 +4,11 @@
 # Refer https://github.com/openshift-metal3/dev-scripts/blob/master/config_example.sh
 #
 set +x
+{% if cifmw_devscripts_ci_token_file is defined %}
+export CI_TOKEN=$(cat {{ cifmw_devscripts_ci_token }})
+{% else %}
 export CI_TOKEN="{{ cifmw_devscripts_ci_token }}"
+{% endif %}
 set -x
 
 {% for item in cifmw_devscripts_config %}


### PR DESCRIPTION
Currently we are passing pull secrets and ci-token content as a string in the ansible var. In order to consume it in CI, we need to slurp the content of pull secret and ci-token in these vars.

If somehow the these vars are passed via var files through command line, it might expose the secrets on failures.

This pr adds two new vars to pass the pull secrets and ci-token as file also.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

