### PR TITLE
Replace lookup() by slurp calls

### DIFF
--- a/ci_framework/roles/devscripts/tasks/sub_tasks/41_set_facts.yml
+++ b/ci_framework/roles/devscripts/tasks/sub_tasks/41_set_facts.yml
@@ -31,7 +31,7 @@
     src: "{{ kube_pass_file }}"
   register: kubeadmin_password
 
-- name: Loading the kubeconfig information
+- name: Slurp kubeconfig
   vars:
     kube_file: >-
       {{
@@ -43,9 +43,14 @@
           'kubeconfig'
         ) | path_join
       }}
+  register: _kubeconfig
+  ansible.builtin.slurp:
+    path: "{{ kube_file }}"
+
+- name: Loading the kubeconfig information
   ansible.builtin.set_fact:
-    kubeconfig: "{{ kube_file }}"
-    kubeconf: "{{ lookup('ansible.builtin.file', kube_file) | from_yaml }}"
+    kubeconfig: "{{ _kubeconfig['source'] }}"
+    kubeconf: "{{ _kubeconfig['content'] | b64decode | from_yaml }}"
 
 - name: Set the OpenShift platform access information.
   ansible.builtin.set_fact:

--- a/ci_framework/roles/devscripts/tasks/sub_tasks/42_add_bmh.yml
+++ b/ci_framework/roles/devscripts/tasks/sub_tasks/42_add_bmh.yml
@@ -22,9 +22,22 @@
   block:
     - name: Collecting the extra baremetal hosts information.
       vars:
-        nodes_file: "{{ cifmw_devscripts_repo_dir }}/ocp/{{ cifmw_devscripts_config.cluster_name }}/extra_baremetalhosts.json"
+        nodes_file: >-
+          {{
+            [
+              cifmw_devscripts_repo_dir,
+               'ocp',
+               cifmw_devscripts_config.cluster_name,
+               'extra_baremetalhosts.json'
+            ] | path_join
+          }}
+      register: _bm_info
+      ansible.builtin.slurp:
+        path: "{{ node_files }}"
+
+    - name: Expose nodes as a fact
       ansible.builtin.set_fact:
-        nodes: "{{ lookup('ansible.builtin.file', nodes_file) | from_json }}"
+        nodes: "{{ _bm_info['content'] | b64decode | from_json }}"
 
     - name: Add devscripts extra nodes
       ansible.builtin.include_tasks: _get_node.yml


### PR DESCRIPTION
File lookup() is running locally on the ansible controller, preventing
remote execution of the role.
This change switches to `ansible.builtin.slurp` in order to ensure we
can run the role against a remote hypervisor.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
