### PR TITLE
Add Multinode job to run Tempest tests

### DIFF
--- a/ci_framework/roles/tempest/README.md
+++ b/ci_framework/roles/tempest/README.md
@@ -17,6 +17,8 @@ become - Required to install required rpm packages
 * `cifmw_tempest_tests_allowed`: (List) List of tests to be executed. Setting this will not use the `list_allowed` plugin
 * `cifmw_tempest_tempestconf_profile`: (Dictionary) List of settings to be overwritten in tempest.conf.
 * `cifmw_tempest_concurrency`: (Integer) Tempest concurrency value.
+* `cifmw_tempest_tests_allowed_override_scenario`: (Boolean) Whether to override the scenario `cifmw_tempest_tests_allowed` definition. Default to `false`
+* `cifmw_tempest_tests_skipped_override_scenario`: (Boolean) Whether to override the scenario `cifmw_tempest_tests_skipped` definition. Default to `false`
 
 ## Use of cifmw_tempest_tempestconf_profile
 

--- a/ci_framework/roles/tempest/defaults/main.yml
+++ b/ci_framework/roles/tempest/defaults/main.yml
@@ -27,3 +27,7 @@ cifmw_tempest_image_tag: current-podified
 cifmw_tempest_dry_run: false
 cifmw_tempest_remove_container: false
 cifmw_tempest_concurrency: 4
+cifmw_tempest_dns_servers:
+  - "192.168.122.10"
+cifmw_tempest_tests_allowed_override_scenario: false
+cifmw_tempest_tests_skipped_override_scenario: false

--- a/ci_framework/roles/tempest/tasks/tempest-tests.yml
+++ b/ci_framework/roles/tempest/tasks/tempest-tests.yml
@@ -15,7 +15,9 @@
 # under the License.
 #
 - name: Configuring tests to be executed via skiplist
-  when: cifmw_tempest_tests_allowed is not defined
+  when: >
+   cifmw_tempest_tests_allowed is not defined or
+   cifmw_tempest_tests_allowed_override_scenario | bool
   block:
     - name: Copy list_allowed to artifacts dir
       ansible.builtin.copy:
@@ -40,7 +42,9 @@
         msg: "{{ list_allowed }}"
 
 - name: Configuring tests to be skipped via skiplist
-  when: cifmw_tempest_tests_skipped is not defined
+  when: >
+    cifmw_tempest_tests_skipped is not defined or
+    cifmw_tempest_tests_skipped_override_scenario | bool
   block:
     - name: Copy list_skipped to artifacts dir
       ansible.builtin.copy:
@@ -65,7 +69,9 @@
 
 
 - name: Configuring tests to be executed via cifmw_tempest_tests_allowed
-  when: cifmw_tempest_tests_allowed is defined
+  when: >
+   cifmw_tempest_tests_allowed is defined and
+   not cifmw_tempest_tests_allowed_override_scenario | bool
   block:
     - name: Creating include.txt
       ansible.builtin.copy:
@@ -77,7 +83,9 @@
         msg: "{{ cifmw_tempest_tests_allowed }}"
 
 - name: Configuring tests to be skipped via cifmw_tempest_tests_skipped
-  when: cifmw_tempest_tests_skipped is defined
+  when: >
+   cifmw_tempest_tests_skipped is defined and
+   not cifmw_tempest_tests_skipped_override_scenario | bool
   block:
     - name: Creating exclude.txt
       ansible.builtin.copy:

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -45,7 +45,8 @@
       - openstack-k8s-operators/ci-framework
       - openstack-k8s-operators/cinder-operator
       - openstack-k8s-operators/dataplane-operator
-      - openstack-k8s-operators/designate-operator
+      - name: openstack-k8s-operators/designate-operator
+        override-checkout: main
       - openstack-k8s-operators/glance-operator
       - openstack-k8s-operators/heat-operator
       - openstack-k8s-operators/horizon-operator
@@ -63,7 +64,8 @@
       - openstack-k8s-operators/openstack-operator
       - openstack-k8s-operators/ovn-operator
       - openstack-k8s-operators/placement-operator
-      - openstack-k8s-operators/repo-setup
+      - name: openstack-k8s-operators/repo-setup
+        override-checkout: main
       - openstack-k8s-operators/swift-operator
       - openstack-k8s-operators/tcib
       - openstack-k8s-operators/telemetry-operator
@@ -114,7 +116,8 @@
       - openstack-k8s-operators/infra-operator
       - openstack-k8s-operators/openstack-baremetal-operator
       - openstack-k8s-operators/openstack-operator
-      - openstack-k8s-operators/repo-setup
+      - name: openstack-k8s-operators/repo-setup
+        override-checkout: main
       - openstack-k8s-operators/edpm-ansible
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
@@ -210,7 +213,8 @@
       - openstack-k8s-operators/infra-operator
       - openstack-k8s-operators/openstack-baremetal-operator
       - openstack-k8s-operators/openstack-operator
-      - openstack-k8s-operators/repo-setup
+      - name: openstack-k8s-operators/repo-setup
+        override-checkout: main
       - openstack-k8s-operators/edpm-ansible
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -40,3 +40,14 @@
           - controller
       - name: peers
         nodes: []
+
+- nodeset:
+    name: multinode-centos-9-stream-crc
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-vexxhost
+      - name: crc
+        label: coreos-crc-extracted-xxl
+    groups:
+      - name: computes
+        nodes: []

--- a/zuul.d/tcib.yaml
+++ b/zuul.d/tcib.yaml
@@ -7,7 +7,8 @@
     required-projects:
       - opendev.org/zuul/zuul-jobs
       - github.com/openstack-k8s-operators/ci-framework
-      - github.com/openstack-k8s-operators/repo-setup
+      - name: github.com/openstack-k8s-operators/repo-setup
+        override-checkout: main
       - github.com/openstack-k8s-operators/tcib
       - github.com/openstack-k8s-operators/install_yamls
     pre-run:

--- a/zuul.d/tempest_multinode.yaml
+++ b/zuul.d/tempest_multinode.yaml
@@ -1,0 +1,73 @@
+---
+- job:
+    name: cifmw-base-multinode-tempest
+    parent: cifmw-podified-multinode-edpm-base-crc
+    timeout: 5400
+    abstract: true
+    nodeset: multinode-centos-9-stream-crc
+    vars:
+      zuul_log_collection: true
+      cifmw_deploy_edpm: false
+      openstack_release: antelope
+      # disable operator build
+      cifmw_operator_build_meta_build: false
+      cifmw_operator_build_operators: []
+      cifmw_tempest_tests_allowed_override_scenario: true
+    extra-vars:
+      crc_ci_bootstrap_networking:
+        networks:
+          default:
+            range: 192.168.122.0/24
+            mtu: 1500
+          internal-api:
+            vlan: 20
+            range: 172.17.0.0/24
+          storage:
+            vlan: 21
+            range: 172.18.0.0/24
+          tenant:
+            vlan: 22
+            range: 172.19.0.0/24
+        instances:
+          controller:
+            networks:
+              default:
+                ip: 192.168.122.11
+          crc:
+            networks:
+              default:
+                ip: 192.168.122.10
+              internal-api:
+                ip: 172.17.0.5
+              storage:
+                ip: 172.18.0.5
+              tenant:
+                ip: 172.19.0.5
+      cifmw_extras:
+        - '@scenarios/centos-9/ci.yml'
+        - '@scenarios/centos-9/multinode-ci.yml'
+        - '@scenarios/centos-9/ceph_backends.yml'
+    pre-run:
+      - ci/playbooks/e2e-prepare.yml
+    run:
+      - ci/playbooks/e2e-run.yml
+    required-projects:
+      - github.com/openstack-k8s-operators/install_yamls
+      - openstack-k8s-operators/ci-framework
+      - openstack-k8s-operators/dataplane-operator
+      - openstack-k8s-operators/infra-operator
+      - openstack-k8s-operators/openstack-baremetal-operator
+      - openstack-k8s-operators/openstack-operator
+      - name: openstack-k8s-operators/repo-setup
+        override-checkout: main
+      - openstack-k8s-operators/edpm-ansible
+
+- job:
+    name: cifmw-multinode-tempest
+    parent: cifmw-base-multinode-tempest
+    files:
+      - ^ci_framework/roles/tempest
+      - ^scenarios/centos-9/multinode-ci.yml
+      - ^scenarios/centos-9/ci.yml
+      - ^scenarios/centos-9/ceph_backends.yml
+      - ^zuul.d/tempest_multinode.yaml


### PR DESCRIPTION
Also includes vars to override a passed
scenario definition of which tests to run
or skip.

Note: two additional files had to be modified in this backport:
- zuul.d/tcib.yaml
- zuul.d/base.yaml
in order to override the branch to "main", since some repositories don't
have the dev-preview2 branch.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
