### PR TITLE
Set default-branch for ci-framework to main

### DIFF
--- a/ci/templates/projects.yaml
+++ b/ci/templates/projects.yaml
@@ -4,6 +4,7 @@
 # ** /ci/templates/project.yaml **
 - project:
     name: openstack-k8s-operators/ci-framework
+    default-branch: main
     templates:
       - podified-multinode-edpm-pipeline
     github-check:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,4 +1,5 @@
 - project:
+    default-branch: main
     github-check:
       jobs:
       - noop


### PR DESCRIPTION
Zuul assumes a master branch is none is set.
Default this branch to 'main' as if the
convention now used in openstack-k8s-operators
repos.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
