### PR TITLE
Ensure destination directory for output CR exsits

### DIFF
--- a/ci_framework/roles/libvirt_manager/tasks/deploy_edpm_compute.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/deploy_edpm_compute.yml
@@ -27,6 +27,7 @@
   loop:
     - "{{ cifmw_libvirt_manager_basedir }}/workload"
     - "{{ cifmw_libvirt_manager_basedir }}/artifacts/edpm_compute"
+    - "{{ cifmw_libvirt_manager_basedir }}/artifacts/{{ cifmw_install_yamls_defaults['NAMESPACE'] }}/cr/"
 
 - name: Ensure image is available
   vars:


### PR DESCRIPTION
Without this patch a fresh deployment on hardware with >1 EDPM node fails on the libvirt_manager role task "Output CR for extra computes" with a message that the destination directory does not exist.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
