### PR TITLE
Patch dev-scripts on the fly for virtproxyd.socket

### DIFF
--- a/ci_framework/roles/devscripts/files/virtproxyd.patch
+++ b/ci_framework/roles/devscripts/files/virtproxyd.patch
@@ -1,0 +1,12 @@
+--- a/ocp_install_env.sh
++++ b/ocp_install_env.sh
+@@ -288,7 +288,8 @@ function generate_ocp_install_config() {
+         exit 1
+       fi
+     fi
+-
++    # Try to fix libvirt stability before running bootstrap VM
++    sudo systemctl restart virtproxyd.socket
+     cat > "${outdir}/install-config.yaml" << EOF
+ apiVersion: v1
+ baseDomain: ${BASE_DOMAIN}

--- a/ci_framework/roles/devscripts/tasks/03_install.yml
+++ b/ci_framework/roles/devscripts/tasks/03_install.yml
@@ -30,6 +30,16 @@
   delay: 15
   until: "clone_out is not failed"
 
+# This is the same patch as proposed upstream with
+# https://github.com/openshift-metal3/dev-scripts/pull/1595
+# Even if it gets merged, the patch here won't fail.
+- name: Patch dev-scripts for libvirt stability
+  tags:
+    - bootstrap
+  ansible.posix.patch:
+    src: virtproxyd.patch
+    dest: "{{ cifmw_devscripts_repo_dir }}/ocp_install_env.sh"
+
 # Note: Override When external network is being reused.
 - name: Verify dev-scripts vm_setup_vars to reflects external network address
   tags:


### PR DESCRIPTION
This patch was proposed on the upstream dev-scripts repository - but
some environment would need it now.
So let's apply it directly - we can remove that block once it's merged
upstream.

The task won't fail even if the patch is merged, so it's safe. Unless we
have to modify the upstream patch, of course.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
