### PR TITLE
Ensure "patch" is available on the system

### DIFF
--- a/ci_framework/roles/devscripts/vars/main.yml
+++ b/ci_framework/roles/devscripts/vars/main.yml
@@ -24,6 +24,7 @@
 cifmw_devscripts_packages:
   - ipmitool
   - NetworkManager-initscripts-updown
+  - patch
   - python3-jmespath
 
 cifmw_devscripts_repo: "https://github.com/openshift-metal3/dev-scripts.git"


### PR DESCRIPTION
It seems this binary isn't in the base system - let's ensure it's
available before trying to patch dev-scripts.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
