### PR TITLE
Remove ci_script call from devscripts role

### DIFF
--- a/ci_framework/roles/devscripts/tasks/sub_tasks/15_network.yml
+++ b/ci_framework/roles/devscripts/tasks/sub_tasks/15_network.yml
@@ -33,9 +33,9 @@
     - ansible_default_ipv4['type'] != 'bridge'
   block:
     - name: "Ensure no ifcfg script for interface {{ iface_name }}"
-      ci_script:
-        script: "rm -f /etc/sysconfig/network-scripts/ifcfg-{{ iface_name }}"
-        output_dir: "{{ cifmw_devscripts_output_dir }}"
+      ansible.builtin.file:
+        path: "/etc/sysconfig/network-scripts/ifcfg-{{ iface_name }}"
+        state: absent
 
     - name: Ensure external bridge exists
       community.general.nmcli:

--- a/ci_framework/roles/devscripts/tasks/sub_tasks/_get_node.yml
+++ b/ci_framework/roles/devscripts/tasks/sub_tasks/_get_node.yml
@@ -27,9 +27,8 @@
         else 'pr'
       }}
     vm_name: "{{ node.name | replace('-', '_') }}"
-  ci_script:
-    output_dir: "{{ cifmw_devscripts_output_dir }}"
-    script: >-
+  ansible.builtin.shell:  # noqa: risky-shell-pipe
+    cmd: >-
       virsh -q domiflist {{ vm_name }} |
       grep {{ cifmw_devscripts_config.cluster_name }}{{ bridge_suffix }}
   register: boot_mac_out


### PR DESCRIPTION
One of them should be a `file`, since it's ensuring a file is absent.

Second one prevents running the role against a remote node.

We'll need to rework the `ci_script` action plugin to properly support
remote run before using it.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
