### PR TITLE
Moving to nodeset coreos-crc-extracted-3xl which has 12vcpus

### DIFF
--- a/zuul.d/kuttl_multinode.yaml
+++ b/zuul.d/kuttl_multinode.yaml
@@ -9,7 +9,7 @@
         - name: controller
           label: cloud-centos-9-stream-tripleo-vexxhost
         - name: crc
-          label: coreos-crc-extracted-xxl
+          label: coreos-crc-extracted-3xl
     vars:
       zuul_log_collection: true
     extra-vars:


### PR DESCRIPTION
Nodeset is added here: https://softwarefactory-project.io/r/c/config/+/29784

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
