### PR TITLE
Keep false default value under quotes

### DIFF
--- a/ci_framework/playbooks/06-deploy-edpm.yml
+++ b/ci_framework/playbooks/06-deploy-edpm.yml
@@ -59,7 +59,7 @@
             tasks_from: deploy_edpm_compute.yml
 
         - name: Prepare for HCI deploy phase 1
-          when: cifmw_edpm_deploy_hci | default(false) | bool
+          when: cifmw_edpm_deploy_hci | default('false') | bool
           ansible.builtin.import_role:
             name: hci_prepare
             tasks_from: phase1.yml
@@ -72,7 +72,7 @@
   hosts: edpm
   tasks:
     - name: Clear edpm hosts facts
-      when: cifmw_edpm_deploy_hci | default(false) | bool
+      when: cifmw_edpm_deploy_hci | default('false') | bool
       ansible.builtin.meta: clear_facts
 
 - name: Deploy Ceph on EDPM nodes
@@ -80,14 +80,14 @@
     storage_network_range: 172.18.0.0/24
     storage_mgmt_network_range: 172.20.0.0/24
   ansible.builtin.import_playbook: ceph.yml
-  when: cifmw_edpm_deploy_hci | default(false) | bool
+  when: cifmw_edpm_deploy_hci | default('false') | bool
 
 - name: Continue HCI deploy
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
     - name: Create Ceph secrets and retrieve FSID info
-      when: cifmw_edpm_deploy_hci | default(false) | bool
+      when: cifmw_edpm_deploy_hci | default('false') | bool
       block:
         - name: Prepare for HCI deploy phase 2
           ansible.builtin.import_role:


### PR DESCRIPTION
If we keep `cifmw_edpm_deploy_hci | default(false) | bool`. The conditional check fails and complains with following error:
```
"The conditional check 'cifmw_edpm_deploy_hci | default(false) | bool' failed.
The error was: unable to evaluate conditional: cifmw_edpm_deploy_hci | default(false) | bool
The error appears to be in '/src/ci-framework/ci_framework/playbooks/ceph.yml': line 24, column 7,
but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:
```

Adding it under quotes fixes the issue.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

