### PR TITLE
Mark nested virt related doc as deprecated

### DIFF
--- a/docs/source/quickstart/02_nested_virt.md
+++ b/docs/source/quickstart/02_nested_virt.md
@@ -1,5 +1,8 @@
 # Virtualized environment setup
 
+> ⚠️ Warning
+> This is **deprecated** - please refer to [run on your own hardware](./04_non-virt.md) documentation.
+
 In this section, you will learn how to set up your local development environment.
 
 > ⚠️ **Warning**

--- a/docs/source/quickstart/03_psi.md
+++ b/docs/source/quickstart/03_psi.md
@@ -1,5 +1,8 @@
 # Create a PSI instance
 
+> ⚠️ Warning
+> This is **deprecated** since it uses nested virtualization. Please refer to [run on your own hardware](./04_non-virt.md) documentation.
+
 ## Steps
 
 1. **Download openrc.sh**


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [X] Appropriate documentation exists and/or is up-to-date:
