### PR TITLE
Copy ci_token_file file to the devscript directory

### DIFF
--- a/ci_framework/roles/devscripts/molecule/default/converge.yml
+++ b/ci_framework/roles/devscripts/molecule/default/converge.yml
@@ -106,9 +106,15 @@
         content: "hello world"
         dest: '/tmp/pull-secret'
 
+    - name: Create a dummy pull secret file
+      ansible.builtin.copy:
+        content: "hello world"
+        dest: '/tmp/ci_token'
+
     - name: Set fact for cifmw_devscripts_pull_secret_file
       ansible.builtin.set_fact:
         cifmw_devscripts_pull_secret_file: '/tmp/pull-secret'
+        cifmw_devscripts_ci_token_file: '/tmp/pull-secret'
 
     - name: Re-run devscripts role
       ansible.builtin.include_role:
@@ -122,6 +128,16 @@
     - name: Verify the content of pull-secret
       ansible.builtin.assert:
         that: ps_data['content'] | b64decode == 'hello world'
+
+    - name: Collect stat of ci_token file
+      ansible.builtin.stat:
+        path: "{{ cifmw_devscripts_repo_dir }}/config_{{ cifmw_devscripts_user }}.sh"
+      register: ci_token_results
+
+    - name: Test ci_token file stat information
+      ansible.builtin.assert:
+        that:
+          - ci_token_results.stat is defined
 
     - name: Perform cleanup
       ansible.builtin.include_role:

--- a/ci_framework/roles/devscripts/tasks/03_install.yml
+++ b/ci_framework/roles/devscripts/tasks/03_install.yml
@@ -53,6 +53,17 @@
     regexp: "^    address_v4(.+)$"
     replace: "    address_v4: {{ ansible_default_ipv4.address }}"
 
+- name: Copy the CI token file in devscript repo directory
+  when: cifmw_devscripts_ci_token_file is defined
+  tags:
+    - bootstrap
+  ansible.builtin.copy:
+    src: "{{ cifmw_devscripts_ci_token_file }}"
+    dest: "{{ cifmw_devscripts_repo_dir }}/ci_token"
+    owner: "{{ cifmw_devscripts_user }}"
+    group: "{{ cifmw_devscripts_user }}"
+    mode: "0600"
+
 - name: Copy the OCP config file.
   tags:
     - bootstrap

--- a/ci_framework/roles/devscripts/templates/conf_ciuser.sh.j2
+++ b/ci_framework/roles/devscripts/templates/conf_ciuser.sh.j2
@@ -5,7 +5,7 @@
 #
 set +x
 {% if cifmw_devscripts_ci_token_file is defined %}
-export CI_TOKEN=$(cat {{ cifmw_devscripts_ci_token }})
+export CI_TOKEN=$(cat {{ cifmw_devscripts_repo_dir }}/ci_token)
 {% else %}
 export CI_TOKEN="{{ cifmw_devscripts_ci_token }}"
 {% endif %}


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/ci-framework/pull/678 added the support for pull secret and ci-token var. It also introduces a typo in the ci_token file conditional.

This patch first copy the ci_token_file in the devscript (if devscript role is used via reproducer) and then cat the output of ci_token to avoid unwanted failure.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

