### PR TITLE
Preset cifmw_devscripts_config var before running cleanup

### DIFF
--- a/ci_framework/roles/devscripts/tasks/cleanup.yml
+++ b/ci_framework/roles/devscripts/tasks/cleanup.yml
@@ -14,6 +14,15 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Gather the configurations to be passed to dev-scripts.
+  ansible.builtin.set_fact:
+    cifmw_devscripts_config: >-
+      {{
+        cifmw_devscripts_config_defaults |
+        combine(cifmw_devscripts_config_overrides, recursive=true)
+      }}
+    cacheable: true
+
 - name: Remove the deployed OpenShift platform.
   when: not cifmw_devscripts_dry_run | bool
   ci_make:


### PR DESCRIPTION
The cleanup task fails with cifmw_devscripts_config undefined var.
    It needs to be set before running the actual cleanup tasks.


As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

