### PR TITLE
Fix unversioned python for RHEL 8

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -11,3 +11,4 @@ fact_caching = jsonfile
 fact_caching_connection = ~/ansible_facts_cache
 fact_caching_timeout = 0
 inventory = inventory.yml
+interpreter_python = /usr/bin/python

--- a/bindep.txt
+++ b/bindep.txt
@@ -44,4 +44,4 @@ python3-jmespath  [platform:rpm]
 # Required for ipaddr filter
 python3-netaddr   [platform:rpm]
 # Required for ansible-lint to not complain about python not found
-python-unversioned-command [platform:rpm]
+python-unversioned-command [platform:rpm !platform:rhel-8]


### PR DESCRIPTION
python-unversioned-command package does not exist for RHEL 8 so it has been removed from bindep for it.

In order to have unversioned python in RHEL 8 run this: 
~~~
sudo alternatives --set python3 /usr/bin/python3.9 sudo alternatives --set python /usr/bin/python3
~~~

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
