### PR TITLE
[tls] Add CA bundle from OpenStackCtlplane to controller

### DIFF
--- a/ci_framework/roles/edpm_prepare/README.md
+++ b/ci_framework/roles/edpm_prepare/README.md
@@ -14,4 +14,4 @@ This role doesn't need privilege escalation.
 * `cifmw_edpm_prepare_oc_delay`: (Integer) Delay, in seconds, between failed oc call retries. Defaults to `30`.
 * `cifmw_edpm_prepare_update_os_containers`: (Boolean) Updates the openstack services containers env variable. Defaults to `false`.
 * `cifmw_edpm_prepare_timeout`: (Integer) Time, in minutes to wait for the deployment to be ready. Defaults to `30`.
-* `cifmw_edpm_prepare_verify_tls`: (Boolean) In case of TLS enabled for OpenStack endpoint, validates against the CA. Defaults to `false`.
+* `cifmw_edpm_prepare_verify_tls`: (Boolean) In case of TLS enabled for OpenStack endpoint, validates against the CA. Defaults to `true`.

--- a/ci_framework/roles/edpm_prepare/defaults/main.yml
+++ b/ci_framework/roles/edpm_prepare/defaults/main.yml
@@ -25,4 +25,4 @@ cifmw_edpm_prepare_dry_run: false
 cifmw_edpm_prepare_skip_crc_storage_creation: false
 cifmw_edpm_prepare_update_os_containers: false
 cifmw_edpm_prepare_timeout: 30
-cifmw_edpm_prepare_verify_tls: false
+cifmw_edpm_prepare_verify_tls: true

--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -210,6 +210,34 @@
           --for=condition=ready
           --timeout={{ cifmw_edpm_prepare_timeout }}m
 
+    - name: Get CA bundle data
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.command:
+        cmd: 'oc get secret combined-ca-bundle -n openstack -o "jsonpath={.data.tls-ca-bundle\.pem}" --ignore-not-found'
+      register: ca_bundle_data
+
+    - name: Get CA bundle
+      when: ca_bundle_data.stdout | length > 0
+      ansible.builtin.set_fact:
+        ca_bundle: >-
+          {{ ca_bundle_data.stdout | ansible.builtin.b64decode }}
+
+    - name: Creating tls-ca-bundle.pem
+      when: (ca_bundle is defined) and (ca_bundle | length > 0)
+      ansible.builtin.copy:
+        dest: "{{ cifmw_edpm_prepare_basedir }}/tls-ca-bundle.pem"
+        content: "{{ ca_bundle }}"
+      register: ca_bundle_file
+
+    - name: Inject OpenStackControlplane CA bundle
+      when: ca_bundle_file is defined
+      vars:
+        cifmw_install_ca_bundle_src: "{{ cifmw_edpm_prepare_basedir }}/tls-ca-bundle.pem"
+      ansible.builtin.include_role:
+        role: install_ca
+
 - name: Wait for keystone to be ready
   tags:
     - control-plane

--- a/ci_framework/roles/os_net_setup/README.md
+++ b/ci_framework/roles/os_net_setup/README.md
@@ -11,4 +11,4 @@ That is provided by `openshift_login` role.
 * `cifmw_os_net_setup_config`: See an example in ci_framework/roles/os_net_setup/defaults/main.yml
 * `cifmw_os_net_setup_osp_calls_retries`: (Integer) Number of attempts to retry an OSP action if it fails. Defaults to `10`.
 * `cifmw_os_net_setup_osp_calls_delay`: (Integer) Delay, in seconds, between failed OSP call retries. Defaults to `5`.
-* `cifmw_os_net_setup_verify_tls`: (Boolean) In case of TLS enabled for OpenStack endpoint, validates against the CA. Defaults to `false`.
+* `cifmw_os_net_setup_verify_tls`: (Boolean) In case of TLS enabled for OpenStack endpoint, validates against the CA. Defaults to `true`.

--- a/ci_framework/roles/os_net_setup/defaults/main.yml
+++ b/ci_framework/roles/os_net_setup/defaults/main.yml
@@ -15,4 +15,4 @@ cifmw_os_net_setup_config:
         allocation_pool_end: 192.168.122.240
         gateway_ip: 192.168.122.1
         enable_dhcp: false
-cifmw_os_net_setup_verify_tls: false
+cifmw_os_net_setup_verify_tls: true

--- a/ci_framework/roles/tempest/tasks/main.yml
+++ b/ci_framework/roles/tempest/tasks/main.yml
@@ -32,6 +32,15 @@
   ansible.builtin.include_tasks: configure-tempest.yml
   when: not cifmw_tempest_dry_run | bool
 
+- name: Copy CA bundle to cifmw_tempest_artifacts_basedir
+  ansible.builtin.copy:
+    src: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+    dest: "{{ cifmw_tempest_artifacts_basedir }}"
+    mode: '0444'
+    owner: "{{ lookup('env', 'USER') }}"
+    group: "{{ lookup('env', 'USER') }}"
+    remote_src: true
+
 - name: Set proper permission for tempest directory
   ansible.builtin.command:
     cmd: "podman unshare chown 42480:42480 -R {{ cifmw_tempest_artifacts_basedir }}"
@@ -55,6 +64,7 @@
     network: host
     volume:
       - "{{ cifmw_tempest_artifacts_basedir }}/:/var/lib/tempest/external_files:Z"
+      - "{{ cifmw_tempest_artifacts_basedir }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:Z"
     detach: false
     dns: "{{ cifmw_tempest_dns_servers }}"
     env:

--- a/ci_framework/roles/tempest/vars/main.yml
+++ b/ci_framework/roles/tempest/vars/main.yml
@@ -1,5 +1,3 @@
 cifmw_tempest_tempestconf_profile_default:
   overrides:
     identity.v3_endpoint_type: public
-    identity.disable_ssl_certificate_validation: true
-    dashboard.disable_ssl_certificate_validation: true


### PR DESCRIPTION
Gets the ca bundle generated by the openstack-operator to the controller and imports to the system wide bundle. The controller host ca bundle will be attached to the tempest container to be able to verify the API and points.

Jira: [OSP-26299](https://issues.redhat.com//browse/OSP-26299)

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
