### PR TITLE
Add custom RHEL 8 dependency packages

### DIFF
--- a/ci_framework/roles/libvirt_manager/tasks/main.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/main.yml
@@ -27,6 +27,13 @@
     - bootstrap_layout
   ansible.builtin.import_tasks: virtualization_prerequisites.yml
 
+- name: Set RHEL 8 dependency packages
+  set_fact:
+    cifmw_libvirt_manager_dependency_packages:
+      "{{ cifmw_libvirt_manager_dependency_packages_rhel8 }}"
+  when: ansible_distribution == 'RedHat' and
+        ansible_distribution_major_version == '8'
+
 - name: Install packages and dependencies
   tags:
     - packages

--- a/ci_framework/roles/libvirt_manager/vars/main.yml
+++ b/ci_framework/roles/libvirt_manager/vars/main.yml
@@ -31,5 +31,15 @@ cifmw_libvirt_manager_dependency_packages:
   - libguestfs
   - guestfs-tools
 
+cifmw_libvirt_manager_dependency_packages_rhel8:
+  - libvirt
+  - libvirt-client
+  - libvirt-daemon
+  - libvirt-daemon-kvm
+  - virt-install
+  - qemu-kvm
+  - libguestfs
+  - libguestfs-tools
+
 cifmw_libvirt_manager_polkit_rules_dir: /etc/polkit-1/rules.d
 cifmw_libvirt_manager_polkit_rules_file: "{{ cifmw_libvirt_manager_polkit_rules_dir }}/80-libvirt-manage.rules"


### PR DESCRIPTION
Some package names have different names for RHEL 8 compared to RHEL/CentOS 9 (e.g. libguestfs-tools instead of guestfs-tools)

As a pull request owner and reviewers, I checked that:
- [ x] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
