### PR TITLE
Use make for running devscript clean target

### DIFF
--- a/ci_framework/roles/devscripts/tasks/cleanup.yml
+++ b/ci_framework/roles/devscripts/tasks/cleanup.yml
@@ -25,9 +25,8 @@
 
 - name: Remove the deployed OpenShift platform.
   when: not cifmw_devscripts_dry_run | bool
-  ci_make:
+  community.general.make:
     chdir: "{{ cifmw_devscripts_repo_dir }}"
-    output_dir: "{{ cifmw_devscripts_output_dir }}"
     target: clean
 
 - name: Cleanup the devscripts repo directory.


### PR DESCRIPTION
When we run devscripts cleanup taskfile. It fails with two errors.
- Destination directory /home/zuul/ci-framework-data/devscripts/output does not exist
```
TASK [devscripts : Remove the deployed OpenShift platform. chdir={{ cifmw_devscripts_repo_dir }}, output_dir={{ cifmw_devscripts_output_dir }}, target=clean] ***
Friday 20 October 2023  08:13:51 +0530 (0:00:00.038)       0:00:25.710 ********
fatal: [baremetal]: FAILED! => {"changed": false, "checksum": "d5346cde73422919cfc291944c2903ec5c43d71d", "cmd": "/usr/bin/gmake clean", "msg": "Destination directory /home/zuul/ci-framework-data/devscripts/output does not exist", "rc": 2, "stderr": "gmake: *** No rule to make target 'clean'.  Stop.\n", "stderr_lines": ["gmake: *** No rule to make target 'clean'.  Stop."], "stdout": "", "stdout_lines": []}
```

- We run cleanup taskfile when /home/zuul/ci-framework-data/devscripts/output exists but ci_make clean task fails with long errors. But if i run make clean manually, it works fine without error.

  On switching to ansible make plugin, the cleanup playbook works fine.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

