### PR TITLE
Fix ci_nmstate to work without cifmw_ci_nmstate_network_layout

### DIFF
--- a/ci_framework/roles/ci_nmstate/tasks/main.yml
+++ b/ci_framework/roles/ci_nmstate/tasks/main.yml
@@ -92,7 +92,12 @@
         _custom_instances_config[item.key]
       }}
     cacheable: true
-  loop: "{{ cifmw_ci_nmstate_network_layout | dict2items }}"
+  loop: >-
+    {{
+      cifmw_ci_nmstate_network_layout |
+      combine(_custom_instances_config)|
+      dict2items
+    }}
   loop_control:
     label: "{{ item.key }}"
 


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date
