### PR TITLE
Path ansibleee runner image to use correct image

### DIFF
--- a/ci_framework/roles/edpm_prepare/README.md
+++ b/ci_framework/roles/edpm_prepare/README.md
@@ -15,3 +15,4 @@ This role doesn't need privilege escalation.
 * `cifmw_edpm_prepare_update_os_containers`: (Boolean) Updates the openstack services containers env variable. Defaults to `false`.
 * `cifmw_edpm_prepare_timeout`: (Integer) Time, in minutes to wait for the deployment to be ready. Defaults to `30`.
 * `cifmw_edpm_prepare_verify_tls`: (Boolean) In case of TLS enabled for OpenStack endpoint, validates against the CA. Defaults to `true`.
+* `cifmw_edpm_prepare_skip_patch_ansible_runner`: (Boolean) Intentionally skips setting ansible runner image to `latest` from quay.io. Defaults to `False`.

--- a/ci_framework/roles/edpm_prepare/defaults/main.yml
+++ b/ci_framework/roles/edpm_prepare/defaults/main.yml
@@ -26,3 +26,4 @@ cifmw_edpm_prepare_skip_crc_storage_creation: false
 cifmw_edpm_prepare_update_os_containers: false
 cifmw_edpm_prepare_timeout: 30
 cifmw_edpm_prepare_verify_tls: true
+cifmw_edpm_prepare_skip_patch_ansible_runner: false

--- a/ci_framework/roles/edpm_prepare/molecule/default/converge.yml
+++ b/ci_framework/roles/edpm_prepare/molecule/default/converge.yml
@@ -21,6 +21,7 @@
     cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
     cifmw_operator_build_meta_name: openstack
     cifmw_edpm_prepare_dry_run: true
+    cifmw_edpm_prepare_skip_patch_ansible_runner: true
     cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
     cifmw_openshift_user: "kubeadmin"
     cifmw_openshift_password: "123456789"

--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -115,6 +115,20 @@
   ansible.builtin.include_role:
     name: set_openstack_containers
 
+- name: Patch ansible runner image temporarily
+  when:
+    - not cifmw_edpm_prepare_update_os_containers | bool
+    - not cifmw_edpm_prepare_skip_patch_ansible_runner | bool
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: >-
+      oc patch csv -n openstack-operators openstack-ansibleee-operator.v0.0.1
+      --type='json' -p='[{
+      "op":"replace", "path":"/spec/install/spec/deployments/0/spec/template/spec/containers/1/env/0",
+      "value": {"name": "RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT", "value": "quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest"}}]'
+
 # Prepare and kustomize the OpenStackControlPlane CR
 - name: Prepare OpenStack control plane CR
   vars:


### PR DESCRIPTION
Currently ansiblee runner image is not using the proper image. We need to force patch it to use the latest image.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

