### PR TITLE
Remove edpm-e2e-nobuild job from dev-preview2

### DIFF
--- a/ci/templates/projects.yaml
+++ b/ci/templates/projects.yaml
@@ -15,5 +15,4 @@
         - cifmw-multinode-kuttl
         - cifmw-edpm-build-images
         - cifmw-content-provider-build-images
-        - podified-multinode-edpm-e2e-nobuild-tagged-crc
 # Start generated content

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -8,7 +8,6 @@
       - cifmw-multinode-kuttl
       - cifmw-edpm-build-images
       - cifmw-content-provider-build-images
-      - podified-multinode-edpm-e2e-nobuild-tagged-crc
       - cifmw-molecule-artifacts
       - cifmw-molecule-build_containers
       - cifmw-molecule-build_openstack_packages


### PR DESCRIPTION
This job will always using the latest openstack-operator. In dev-preview2 it doesn't make sense
to run the job in it current form.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
