### PR TITLE
Update host's authorized_keys before injecting into base image

### DIFF
--- a/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -50,6 +50,20 @@
   loop_control:
     label: "{{ item.key }}"
 
+- name: Find all public key in the default user directory
+  ansible.builtin.find:
+    paths: "{{ ansible_user_dir }}/.ssh"
+    file_type: file
+    patterns: '*.pub'
+  register: users_pub_key
+
+- name: Update authorized keys for all users
+  ansible.posix.authorized_key:
+    user: zuul
+    state: present
+    key: '{{ item }}'
+  with_file: "{{ users_pub_key.files | map(attribute='path') }}"
+
 - name: Prepare base image with user and ssh accesses  # noqa: risky-shell-pipe
   when:
     - item.key is not match('^crc.*$')


### PR DESCRIPTION
In libvirt manager role, We create a base image for deploying compute vms based on layout. We use user's authorized keys while creating the image.

Devscripts role is used for deploy openshift. DevScripts itself generates two ssh keys[1] at user and root level.

All the users on the host does not ssh into the vms created from above base image as used authorized keys does not have all the pub keys added.

This pr finds all the authorized keys at user's level and update the authorized key. It will allow user's to ssh into the
machine. It will also allow all non-root users to ssh into the compute vms.

[1]. https://github.com/openshift-metal3/dev-scripts/blob/1de0dc213e9f23820a915cbe85ff8afa820f34d8/02_configure_host.sh#L13

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

