### PR TITLE
ceph save spec initila config as artifact

### DIFF
--- a/ci_framework/playbooks/ceph.yml
+++ b/ci_framework/playbooks/ceph.yml
@@ -135,8 +135,8 @@
   gather_facts: false
   vars:
     ansible_ssh_private_key_file: "{{ lookup('env', 'ANSIBLE_SSH_PRIVATE_KEY') }}"
-    cifmw_cephadm_spec_ansible_host: /tmp/ceph_spec.yml
-    cifmw_cephadm_bootstrap_conf: /tmp/initial_ceph.conf
+    cifmw_cephadm_spec_ansible_host: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts/ceph_spec/ceph_spec.yml"
+    cifmw_cephadm_bootstrap_conf: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts/ceph_spec/initial_ceph.conf"
     cifmw_ceph_client_vars: /tmp/ceph_client.yml
     cifmw_cephadm_default_container: true
     all_addresses: ansible_all_ipv4_addresses # change if you need IPv6

--- a/ci_framework/roles/cifmw_ceph_spec/README.md
+++ b/ci_framework/roles/cifmw_ceph_spec/README.md
@@ -27,7 +27,7 @@ None
   Ceph spec data devices (defaults to the path `/dev/ceph_vg/ceph_lv_data`
   which is created by the `cifmw_block_device` role)
 * `cifmw_ceph_spec_path`: path of the rendered spec file (default
-  `/tmp/ceph_spec.yml`)
+  `ci-framework-data/artifacts/ceph_spec/ceph_spec.yml`)
 
 ## Examples
 

--- a/ci_framework/roles/cifmw_ceph_spec/defaults/main.yml
+++ b/ci_framework/roles/cifmw_ceph_spec/defaults/main.yml
@@ -31,10 +31,13 @@ cifmw_ceph_spec_data_devices: >-
     - /dev/ceph_vg/ceph_lv_data
 
 # The path of the rendered spec file
-cifmw_ceph_spec_path: /tmp/ceph_spec.yml
+cifmw_ceph_spec_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+cifmw_ceph_spec_configs_dir: "{{ cifmw_ceph_spec_basedir }}/artifacts/ceph_spec"
+
+cifmw_ceph_spec_path: "{{ cifmw_ceph_spec_configs_dir }}/ceph_spec.yml"
 
 # The path of the rendered initial ceph conf file
-cifmw_ceph_spec_path_initial_conf: /tmp/initial_ceph.conf
+cifmw_ceph_spec_path_initial_conf: "{{ cifmw_ceph_spec_configs_dir }}/initial_ceph.conf"
 
 # Defaults set so role works without network isolation
 cifmw_ceph_spec_public_network: 192.168.122.0/24

--- a/ci_framework/roles/cifmw_ceph_spec/tasks/main.yml
+++ b/ci_framework/roles/cifmw_ceph_spec/tasks/main.yml
@@ -14,6 +14,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: "Ensures ceph spec dir exists"
+  file:
+    path: "{{ cifmw_ceph_spec_configs_dir }}"
+    state: directory
+
 - name: Create a Ceph spec
   ansible.builtin.template:
     src: templates/ceph_spec.yml.j2


### PR DESCRIPTION
These files should be saved for troubleshooting.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
