### PR TITLE
Correct check for ca_bundle_file in edpm_prepare

### DIFF
--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -245,8 +245,8 @@
         content: "{{ ca_bundle }}"
       register: ca_bundle_file
 
-    - name: Inject OpenStackControlplane CA bundle
-      when: ca_bundle_file is defined
+    - name: Inject OpenStackControlplane CA bundle  # noqa: no-handler
+      when: ca_bundle_file is changed
       vars:
         cifmw_install_ca_bundle_src: "{{ cifmw_edpm_prepare_basedir }}/tls-ca-bundle.pem"
       ansible.builtin.include_role:


### PR DESCRIPTION
The task "Inject OpenStackControlplane CA bundle" checks whether the
ca_bundle contents was written to file, but in its current version will
run even if the previous task was skipped, and it was not written to
fail. Logically, the invocation of the install_ca role then fails.

This change modifies the condition of the task so it only runs if the
previous task was changed, so install_ca will not be called if it was
skipped.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
