### PR TITLE
Remove all bashism

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,10 +12,7 @@ build:
     python: "3.11"
   jobs:
     pre_build:
-      - >-
-        pushd docs/source/ &&
-        ansible-doc-extractor ./plugins ../../plugins/modules/*.py
-        && popd
+      - ansible-doc-extractor docs/source/plugins plugins/modules/*.py
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Apparently the shell running the build on RTD is really limited, let's
remove all of the fancy things and hit directly the hard knot.

As a pull request owner and reviewers, I checked that:
- [X] we can't really test until we merge.
