### PR TITLE
Introduce cifmw_cephadm_ceph_spec_fqdn

### DIFF
--- a/ci_framework/roles/cifmw_cephadm/README.md
+++ b/ci_framework/roles/cifmw_cephadm/README.md
@@ -69,6 +69,10 @@ need to be changed for a typical EDPM deployment.
    used as entry point to reach the `ganesha backends` through an `haproxy`
    instance where proxy-protocol is enabled.
 
+* `cifmw_cephadm_ceph_spec_fqdn`: When true, the Ceph spec should use
+  a fully qualified domain name (e.g. server1.bar.com). When false, the
+  Ceph spec should use a short hostname (e.g. server1).
+
 Use the `cifmw_cephadm_pools` list of dictionaries to define pools for
 Nova (vms), Cinder (volumes), Cinder-backups (backups), and Glance (images).
 ```

--- a/ci_framework/roles/cifmw_cephadm/defaults/main.yml
+++ b/ci_framework/roles/cifmw_cephadm/defaults/main.yml
@@ -89,3 +89,4 @@ cifmw_ceph_rgw_config:
   rgw_max_attrs_num_in_req: 90
   rgw_max_attr_size: 1024
 cifmw_cephadm_cephfs_name: "cephfs"
+cifmw_cephadm_ceph_spec_fqdn: "{{ ceph_spec_fqdn | default(false) | bool }}"

--- a/ci_framework/roles/cifmw_cephadm/tasks/rgw.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/rgw.yml
@@ -14,9 +14,19 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Use ansible_fqdn when ceph_spec_fqdn parameter is true
+  when: cifmw_cephadm_ceph_spec_fqdn
+  ansible.builtin.set_fact:
+    ceph_hostname_var: 'ansible_fqdn'
+
+- name: Use ansible_hostname when ceph_spec_fqdn parameter is false
+  when: not cifmw_cephadm_ceph_spec_fqdn
+  ansible.builtin.set_fact:
+    ceph_hostname_var: 'ansible_hostname'
+
 - name: Collect the host and build the resulting host list
   ansible.builtin.set_fact:
-    _hosts: "{{ _hosts|default([]) + [ hostvars[item]['ansible_fqdn'] ] }}"
+    _hosts: "{{ _hosts|default([]) + [ hostvars[item][ceph_hostname_var] ] }}"
   loop: "{{ groups['edpm'] }}"
 
 - name: Create a Ceph RGW spec

--- a/ci_framework/roles/hci_prepare/templates/dpservice-nova-custom-ceph.yml.j2
+++ b/ci_framework/roles/hci_prepare/templates/dpservice-nova-custom-ceph.yml.j2
@@ -10,4 +10,5 @@ spec:
     - ceph-nova
   secrets:
     - nova-cell1-compute-config
+    - nova-migration-ssh-key
   playbook: osp.edpm.nova


### PR DESCRIPTION
Follow up to 2e69dd4c4e53b1ebdb65efac8b8e20914b04d969

The above patch fixed local RBD deployment but not local RGW deployment. This follow up patch fixes RGW deployment too. It supports the `ceph_spec_fqdn` parameter the same way and extneds it into the `cifmw_cephadm_ceph_spec_fqdn` which is a role var.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
