### PR TITLE
Ensure default repositories are always present

### DIFF
--- a/ci_framework/roles/reproducer/tasks/default_repositories.yml
+++ b/ci_framework/roles/reproducer/tasks/default_repositories.yml
@@ -1,0 +1,15 @@
+---
+- name: "Ensure repository is present: {{ repository.src | basename }}"
+  delegate_to: controller-0
+  block:
+    - name: "Check repository availability: {{ repository.src | basename }}"
+      register: _repo_clone
+      ansible.builtin.stat:
+        path: "{{ repository.dest }}"
+
+    - name: "Clone repository if needed: {{ repository.src | basename}}"
+      when:
+        - not _repo_clone.stat.exists
+      ansible.builtin.git:  # noqa: latest[git]
+        dest: "{{ repository.dest }}"
+        repo: "{{ repository.src }}"

--- a/ci_framework/roles/reproducer/tasks/push_code.yml
+++ b/ci_framework/roles/reproducer/tasks/push_code.yml
@@ -63,33 +63,9 @@
       loop_control:
         label: "{{ item.src | basename }}"
 
-    - name: Ensure ci-framework is here
-      delegate_to: controller-0
-      block:
-        - name: Check ci-framework availability
-          register: ci_framework_clone
-          ansible.builtin.stat:
-            path: "{{ repo_base_dir }}/github.com/openstack-k8s-operators/ci-framework"
-
-        - name: Clone ci-framework if needed
-          when:
-            - not ci_framework_clone.stat.exists
-          ansible.builtin.git:  # noqa: latest[git]
-            dest: "{{ repo_base_dir }}/github.com/openstack-k8s-operators/ci-framework"
-            repo: "https://github.com/openstack-k8s-operators/ci-framework"
-
-    - name: Ensure install_yamls is here
-      delegate_to: controller-0
-      delegate_facts: true
-      block:
-        - name: Check install_yamls availability
-          register: install_yamls_clone
-          ansible.builtin.stat:
-            path: "{{ repo_base_dir }}/github.com/openstack-k8s-operators/install_yamls"
-
-        - name: Clone install_yamls if needed
-          when:
-            - not install_yamls_clone.stat.exists
-          ansible.builtin.git:  # noqa: latest[git]
-            dest: "{{ repo_base_dir }}/github.com/openstack-k8s-operators/install_yamls"
-            repo: "https://github.com/openstack-k8s-operators/install_yamls"
+    - name: Ensure default repositories are present
+      ansible.builtin.include_tasks: default_repositories.yml
+      loop: "{{ cifmw_reproducer_default_repositories }}"
+      loop_control:
+        loop_var: repository
+        label: "{{ repository.src | basename }}"

--- a/ci_framework/roles/reproducer/vars/main.yml
+++ b/ci_framework/roles/reproducer/vars/main.yml
@@ -1,0 +1,9 @@
+---
+# Default repositories we always want to have
+cifmw_reproducer_default_repositories:
+  - src: "https://github.com/openstack-k8s-operators/ci-framework"
+    dest: "/home/zuul/src/github.com/openstack-k8s-operators/ci-framework"
+  - src: "https://github.com/openstack-k8s-operators/install_yamls"
+    dest: "/home/zuul/src/github.com/openstack-k8s-operators/install_yamls"
+  - src: "https://github.com/openstack-k8s-operators/architecture"
+    dest: "/home/zuul/src/github.com/openstack-k8s-operators/architecture"


### PR DESCRIPTION
Since we may get a growing list of default repositories, let's use some
proper loop and avoid code duplication

As a pull request owner and reviewers, I checked that:
- [X] tested while running the VA-1 reproducer - working just fine with latest iteration