### PR TITLE
Added the posibility to load OCP password from a file

### DIFF
--- a/ci_framework/roles/openshift_login/README.md
+++ b/ci_framework/roles/openshift_login/README.md
@@ -29,6 +29,7 @@ No privilege escalation needed.
 * `cifmw_openshift_login_user`: (String) Optional. Login user. If provided, the user that logins. Defaults to `cifmw_openshift_user` and to the logged in user after login.
 * `cifmw_openshift_login_provided_token`: (String) Optional. Initial login token. If provided, that token will be used to authenticate into OpenShift. Defaults to `cifmw_openshift_provided_token`.
 * `cifmw_openshift_login_password`: (String) Optional. Login password. If provided is the password used for login in. Defaults to `cifmw_openshift_password`.
+* `cifmw_openshift_login_password_file`: (String) Optional. Path to a file that contains the plain login password. If provided is the password used for login in.
 * `cifmw_openshift_login_force_refresh`: (Boolean) Disallow reusing already existing token. Defaults to `false`.
 * `cifmw_openshift_login_retries`: (Integer) Number of attempts to retry the login action if it fails. Defaults to `10`.
 * `cifmw_openshift_login_retries_delay`: (Integer) Delay, in seconds, between login retries. Defaults to `20`.

--- a/ci_framework/roles/openshift_login/molecule/login_file_pwd_no_kubeconfig/cleanup.yml
+++ b/ci_framework/roles/openshift_login/molecule/login_file_pwd_no_kubeconfig/cleanup.yml
@@ -1,0 +1,22 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Cleanup
+  hosts: all
+  tasks:
+    - name: Clean cached facts
+      ansible.builtin.meta: clear_facts

--- a/ci_framework/roles/openshift_login/molecule/login_file_pwd_no_kubeconfig/converge.yml
+++ b/ci_framework/roles/openshift_login/molecule/login_file_pwd_no_kubeconfig/converge.yml
@@ -1,0 +1,49 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  vars:
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+    cifmw_openshift_login_api: https://api.crc.testing:6443
+    cifmw_openshift_user: kubeadmin
+    cifmw_openshift_password_file: "{{ ansible_user_dir + '/ci-framework-data/.kube/kubeadmin-password' }}"
+    # Pass a known unexisting kubeconfig path
+    cifmw_openshift_kubeconfig: "{{ ansible_user_dir + '/ci-framework-data/.kube/kubeconfig-file-password' }}"
+    cifmw_openshift_login_skip_tls_verify: true
+    cifmw_install_yamls_environment: {}
+  tasks:
+
+    - name: Make sure the .kube dir exists
+      ansible.builtin.file:
+        path: "{{ cifmw_openshift_password_file | dirname }}"
+        state: directory
+
+    - name: Create the kubeadmin password file
+      ansible.builtin.copy:
+        dest: "{{ cifmw_openshift_password_file }}"
+        content: "123456789"
+        mode: "0600"
+
+    - name: Login
+      ansible.builtin.import_role:
+        name: openshift_login
+
+    - name: Assert variables are in place
+      vars:
+        kubeconfig_target_path: "{{ cifmw_openshift_kubeconfig }}"
+      ansible.builtin.import_tasks: "../default/tasks/validate_login_facts.yml"

--- a/ci_framework/roles/openshift_login/molecule/login_file_pwd_no_kubeconfig/molecule.yml
+++ b/ci_framework/roles/openshift_login/molecule/login_file_pwd_no_kubeconfig/molecule.yml
@@ -1,0 +1,9 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true

--- a/ci_framework/roles/openshift_login/molecule/login_file_pwd_no_kubeconfig/prepare.yml
+++ b/ci_framework/roles/openshift_login/molecule/login_file_pwd_no_kubeconfig/prepare.yml
@@ -1,0 +1,25 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps
+  tasks:
+    - name: Ensure CRC is started
+      ansible.builtin.command:
+        cmd: crc start

--- a/ci_framework/roles/openshift_login/tasks/login.yml
+++ b/ci_framework/roles/openshift_login/tasks/login.yml
@@ -14,6 +14,31 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Fetch user password from file in case is not provided by a variable
+  when:
+    - cifmw_openshift_login_password is not defined
+    - cifmw_openshift_password is not defined
+    - >-
+        (cifmw_openshift_login_password_file is defined) or
+        (cifmw_openshift_password_file is defined)
+  block:
+    - name: Check if the password file is present
+      ansible.builtin.stat:
+        path: "{{ cifmw_openshift_login_password_file | default(cifmw_openshift_password_file) }}"
+      register: cifmw_openshift_login_password_file_stat
+
+    - name: Fetch user password content
+      when: cifmw_openshift_login_password_file_stat.stat.exists
+      ansible.builtin.slurp:
+        src: "{{ cifmw_openshift_login_password_file | default(cifmw_openshift_password_file) }}"
+      register: cifmw_openshift_login_password_file_slurp
+
+    - name: Set user password as a fact
+      when: cifmw_openshift_login_password_file_slurp.content is defined
+      ansible.builtin.set_fact:
+        cifmw_openshift_login_password: "{{ cifmw_openshift_login_password_file_slurp.content | b64decode }}"
+        cacheable: true
+
 - name: Set role variables
   ansible.builtin.set_fact:
     cifmw_openshift_login_kubeconfig: >-

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -35,6 +35,7 @@ provisioned with virtual baremetal vs pre-provisioned VM.
 * `cifmw_openshift_user`: (String) Login user. If provided, the user that logins.
 * `cifmw_openshift_provided_token`: (String) Initial login token. If provided, that token will be used to authenticate into OpenShift.
 * `cifmw_openshift_password`: (String) Login password. If provided is the password used for login in.
+* `cifmw_openshift_password_file`: (String) Path to a file that contains the plain login password. If provided is the password used for login in.
 * `cifmw_openshift_skip_tls_verify`: (Boolean) Skip TLS verification to login. Defaults to `false`.
 * `cifmw_use_opn`: (Bool) toggle openshift provisioner node support.
 * `cifmw_use_hive`: (Bool) toggle OpenShift deployment using hive operator.


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
