### PR TITLE
rgw respect ceph_spec_fqdn too

### DIFF
--- a/ci_framework/roles/cifmw_cephadm/tasks/rgw.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/rgw.yml
@@ -15,8 +15,11 @@
 # under the License.
 
 - name: Collect the host and build the resulting host list
+  vars:
+    use_fqdn: "{{ ceph_spec_fqdn | default(false) }}"
+    ceph_hostname_var: "{{ use_fqdn | ternary( 'ansible_fqdn', 'ansible_hostname') }}"
   ansible.builtin.set_fact:
-    _hosts: "{{ _hosts|default([]) + [ hostvars[item]['ansible_fqdn'] ] }}"
+    _hosts: "{{ _hosts|default([]) + [ hostvars[item][ceph_hostname_var] ] }}"
   loop: "{{ groups['edpm'] }}"
 
 - name: Create a Ceph RGW spec


### PR DESCRIPTION
This variable recently introduced and only had
effect to first phase of the ceph deployment,
extending it to the rgw part.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
