### PR TITLE
Allow to NOT affect network on nodes

### DIFF
--- a/ci_framework/roles/ci_network/tasks/validate.yml
+++ b/ci_framework/roles/ci_network/tasks/validate.yml
@@ -11,6 +11,11 @@
     loop_var: "network"
     label: "{{ network.key }}"
 
+- name: Abort host if not in the provided net_layout
+  when:
+    - _net_layout['inventory_hostname'] is undefined
+  ansible.builtin.meta: end_host
+
 - name: Mandatory parameters are defined
   ansible.builtin.assert:
     that:


### PR DESCRIPTION
Until now, it was mandatory to get network layout for every single node
we have in the inventory. This change allows to not be so strict, and
will just end the play on the hosts that don't show up in the provided
layout.

As a pull request owner and reviewers, I checked that:
- [X] Successfully tested in the VA-1 patch
