### PR TITLE
Correct libvirt_manager

### DIFF
--- a/ci_framework/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/clean_layout.yml
@@ -62,3 +62,23 @@
     name: "{{ item }}"
     uri: "qemu:///system"
   loop: "{{ cleanup_nets }}"
+
+- name: Get temporary key status
+  register: _tmp_key
+  ansible.builtin.stat:
+    path: "{{ ansible_user_dir }}/.ssh/cifmw_reproducer_key.pub"
+
+- name: Remove temporary ssh key from authorized_keys
+  when:
+    - _tmp_key.stat.exists
+  block:
+    - name: Get public key
+      register: _pub_key
+      ansible.builtin.slurp:
+        path: "{{ ansible_user_dir }}/.ssh/cifmw_reproducer_key.pub"
+
+    - name: Remove public key
+      ansible.posix.authorized_key:
+        user: "{{ ansible_user_id }}"
+        key: "{{ _pub_key['content'] | b64decode }}"
+        state: absent

--- a/ci_framework/roles/libvirt_manager/tasks/create_vms.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/create_vms.yml
@@ -50,6 +50,8 @@
     - vm_ips.stdout != ''
 
 - name: "(localhost) Inject ssh jumpers for {{ vm_type }}"
+  when:
+    - inventory_hostname != 'localhost'
   delegate_to: localhost
   vars:
     extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
@@ -80,8 +82,22 @@
       Host {{ vm_type }}-{{ vm_ip.item }} cifmw-{{ vm_type }}-{{ vm_ip.item }} {{ extracted_ip }}
         Hostname {{ extracted_ip }}
         User zuul
+        IdentityFile ~/.ssh/cifmw_reproducer_key
         StrictHostKeyChecking no
         UserKnownHostsFile /dev/null
+  loop: "{{ vm_ips.results }}"
+  loop_control:
+    loop_var: vm_ip
+    label: "{{ vm_ip.item }}"
+
+- name: Inject nodes in the ansible inventory
+  delegate_to: localhost
+  vars:
+    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
+  ansible.builtin.add_host:
+    name: "{{ vm_type }}-{{ vm_ip.item }}"
+    groups: "{{ vm_type }}"
+    ansible_host: "{{ extracted_ip }}"
   loop: "{{ vm_ips.results }}"
   loop_control:
     loop_var: vm_ip
@@ -178,7 +194,11 @@
 - name: "Inject network configuration file on {{ vm_type }}"
   ansible.builtin.template:
     dest: "{{ cifmw_reproducer_basedir }}/reproducer-network-env/{{ vm_type }}-{{ vm_id }}.yml"
-    src: "network-data.yml.j2"
+    src: >-
+      {{
+        (ci_job_networking is defined)
+        | ternary('ci-network-data.yml.j2', 'network-data.yml.j2')
+      }}
     mode: "0644"
   loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
   loop_control:

--- a/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -13,58 +13,43 @@
     cacheable: true
     _layout: "{{ cifmw_libvirt_manager_configuration_gen | default(cifmw_libvirt_manager_configuration) }}"
 
-- name: Ensure networks are defined
-  community.libvirt.virt_net:
-    command: define
-    name: "cifmw-{{ item.key }}"
-    xml: "{{ item.value | replace(item.key, 'cifmw-' ~ item.key) }}"
-    uri: "qemu:///system"
-  loop: "{{ _layout.networks | dict2items }}"
-  loop_control:
-    label: "{{ item.key }}"
+- name: Manage networks if needed
+  when:
+    - _layout.networks is defined
+  block:
+    - name: Ensure networks are defined
+      community.libvirt.virt_net:
+        command: define
+        name: "cifmw-{{ item.key }}"
+        xml: "{{ item.value | replace(item.key, 'cifmw-' ~ item.key) }}"
+        uri: "qemu:///system"
+      loop: "{{ _layout.networks | dict2items }}"
+      loop_control:
+        label: "{{ item.key }}"
 
-- name: Ensure networks are created/started
-  community.libvirt.virt_net:
-    command: create
-    name: "cifmw-{{ item.key }}"
-    uri: "qemu:///system"
-  loop: "{{ _layout.networks | dict2items }}"
-  loop_control:
-    label: "{{ item.key }}"
+    - name: Ensure networks are created/started
+      community.libvirt.virt_net:
+        command: create
+        name: "cifmw-{{ item.key }}"
+        uri: "qemu:///system"
+      loop: "{{ _layout.networks | dict2items }}"
+      loop_control:
+        label: "{{ item.key }}"
 
-- name: Ensure networks are active
-  community.libvirt.virt_net:
-    state: active
-    name: "cifmw-{{ item.key }}"
-    uri: "qemu:///system"
-  loop: "{{ _layout.networks | dict2items }}"
-  loop_control:
-    label: "{{ item.key }}"
+    - name: Ensure networks are active
+      community.libvirt.virt_net:
+        state: active
+        name: "cifmw-{{ item.key }}"
+        uri: "qemu:///system"
+      loop: "{{ _layout.networks | dict2items }}"
+      loop_control:
+        label: "{{ item.key }}"
 
 - name: Ensure images are present
   vars:
     image_data: "{{ item.value }}"
   ansible.builtin.include_tasks:
     file: get_image.yml
-  loop: "{{ _layout.vms | dict2items }}"
-  loop_control:
-    label: "{{ item.key }}"
-
-- name: Prepare base image with user and ssh accesses  # noqa: risky-shell-pipe
-  when:
-    - item.key is not match('^crc.*$')
-  vars:
-    _admin_user: "{{ item.value.admin_user | default('root') }}"
-  ansible.builtin.shell:
-    cmd: >-
-      virt-sysprep -a "{{ item.value.image_local_dir }}/{{ item.value.disk_file_name }}"
-      --selinux-relabel
-      --firstboot-command "growpart /dev/sda 1"
-      --firstboot-command "xfs_growfs /"
-      --root-password "password:{{ item.value.password | default('fooBar') }}"
-      --ssh-inject {{ _admin_user }}:file:{{ ansible_user_dir }}/.ssh/authorized_keys
-      | tee -a {{ item.value.image_local_dir }}/{{ item.value.disk_file_name }}.log
-    creates: "{{ item.value.image_local_dir }}/{{ item.value.disk_file_name }}.log"
   loop: "{{ _layout.vms | dict2items }}"
   loop_control:
     label: "{{ item.key }}"
@@ -87,6 +72,30 @@
   register: priv_ssh_key
   ansible.builtin.slurp:
     path: "{{ ansible_user_dir }}/.ssh/cifmw_reproducer_key"
+
+- name: Inject cifmw_reproducer_key.pub in hypervisor authorized_keys
+  ansible.posix.authorized_key:
+    user: "{{ ansible_user_id }}"
+    key: "{{ pub_ssh_key['content'] | b64decode }}"
+
+- name: Prepare base image with user and ssh accesses  # noqa: risky-shell-pipe
+  when:
+    - item.key is not match('^crc.*$')
+  vars:
+    _admin_user: "{{ item.value.admin_user | default('root') }}"
+  ansible.builtin.shell:
+    cmd: >-
+      virt-sysprep -a "{{ item.value.image_local_dir }}/{{ item.value.disk_file_name }}"
+      --selinux-relabel
+      --firstboot-command "growpart /dev/sda 1"
+      --firstboot-command "xfs_growfs /"
+      --root-password "password:{{ item.value.password | default('fooBar') }}"
+      --ssh-inject {{ _admin_user }}:file:{{ ansible_user_dir }}/.ssh/authorized_keys
+      | tee -a {{ item.value.image_local_dir }}/{{ item.value.disk_file_name }}.log
+    creates: "{{ item.value.image_local_dir }}/{{ item.value.disk_file_name }}.log"
+  loop: "{{ _layout.vms | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
 
 - name: Create fact holding network data for VMs
   ansible.builtin.set_fact:
@@ -111,6 +120,8 @@
     src: "all-inventory.yml.j2"
 
 - name: Ensure we get proper access to CRC
+  when:
+    - _layout.vms.crc is defined
   vars:
     crc_private_key: "{{ _layout.vms.crc.image_local_dir }}/id_ecdsa"
   block:

--- a/ci_framework/roles/libvirt_manager/tasks/virsh_checks.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/virsh_checks.yml
@@ -21,6 +21,40 @@
     state: started
     enabled: true
 
+# stabilize libvirt accesses
+# We hit a fair amount of failures with the libvirt sockets over the
+# past iteration. After many tests, it seems that removing the timeout
+# of the virtproxyd service and ensuring it's enabled and started
+# corrects this issue. With this hack, we could successfuly deploy the
+# whole VA-1 layout without any issue.
+- name: Hack in the virtproxyd service
+  become: true
+  block:
+    - name: Create service override directory
+      ansible.builtin.file:
+        path: "/etc/systemd/system/virtproxyd.service.d"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Create service override
+      ansible.builtin.copy:
+        dest: "/etc/systemd/system/virtproxyd.service.d/override.conf"
+        content: |
+          # Managed by the CI Framework
+          # Remove timeout to service to ensure it's persistent
+          [Service]
+          Environment=
+          Environment=VIRTPROXYD_ARGS=""
+
+    - name: Reload systemctl and start/enable virtproxyd.service
+      ansible.builtin.systemd_service:
+        daemon_reload: true
+        name: virtproxyd.service
+        state: restarted
+        enabled: true
+
 - name: Get libvirt group users
   ansible.builtin.getent:
     database: group
@@ -34,3 +68,18 @@
     name: "{{ cifmw_libvirt_manager_user }}"
     groups: libvirt
     append: true
+
+- name: Allow QEMU on home directory for the storage access
+  become: true
+  ansible.posix.acl:
+    path: "{{ ansible_user_dir }}"
+    entity: "qemu"
+    etype: "user"
+    permissions: rx
+    state: present
+
+- name: Inject system connection parameters in bashrc
+  ansible.builtin.blockinfile:
+    dest: "{{ ansible_user_dir }}/.bashrc"
+    block: |-
+      export LIBVIRT_DEFAULT_URI="qemu:///system"

--- a/ci_framework/roles/libvirt_manager/templates/ci-network-data.yml.j2
+++ b/ci_framework/roles/libvirt_manager/templates/ci-network-data.yml.j2
@@ -1,0 +1,51 @@
+{#
+The ci_job_networking is exposed by the reproducer role. It namely exposes
+the CI job configuration passed down to zuul so that we can ensure we're
+using the same networks.
+#}
+{% set ns = namespace(
+    ip4='',
+    gw4='',
+    iface=cifmw_reproducer_private_nic,
+    config_nm=false,
+    ip_suffix=0)
+-%}
+{% set default_mtu = ci_job_networking.networks['default'].mtu | default('1500') -%}
+{% set vlan_mtu = default_mtu - 4 -%}
+{% if vm_type == 'controller' -%}
+{%   set ns.ip4 = ci_job_networking['instances']['controller']['networks']['default']['ip'] %}
+{%   set ns.gw4 = cifmw_reproducer_ctl_gw4 -%}
+{% elif vm_type == 'crc' -%}
+{%   set ns.ip4 =  ci_job_networking['instances']['crc']['networks']['default']['ip'] %}
+{%   set ns.gw4 = cifmw_reproducer_crc_gw4 -%}
+{%   set ns.iface = cifmw_reproducer_crc_private_nic -%}
+{%   set ns.config_nm = true -%}
+{%   set ns.ip_suffix = 10 -%}
+{% else -%}
+{%   set ns.ip4 = ci_job_networking['instances']['compute-' ~ vm_id]['networks']['default']['ip']%}
+{%   set ns.gw4 = cifmw_reproducer_ctl_gw4 -%}
+{%   set ns.ip_suffix = 100+vm_id -%}
+{% endif -%}
+crc_ci_bootstrap_networks_out:
+  {{ vm_type }}-{{ vm_id }}:
+    default:
+      iface: {{ ns.iface }}
+      connection: ci-private-network
+      ip4: {{ ns.ip4 }}/24
+      gw4: {{ ns.gw4 }}
+      dns4: {{ ci_job_networking['instances']['crc']['networks']['default']['ip'] }}
+      mtu: {{ default_mtu }}
+{% if vm_type != 'controller' %}
+{% for networking in ci_job_networking.networks | dict2items %}
+{%   if networking.key != 'default' %}
+    {{ networking.key }}:
+      iface: {{ ns.iface }}.{{ networking.value.vlan }}
+      connection: {{ networking.key }}
+      vlan: {{ networking.value.vlan }}
+      parent_iface: {{ ns.iface }}
+      ip4: {{ networking.value.range | ansible.utils.ipaddr('net') | ansible.utils.ipmath(ns.ip_suffix) }}/24
+      config_nm: {{ ns.config_nm }}
+      mtu: {{ networking.value.mtu | default(vlan_mtu) }}
+{%    endif %}
+{%  endfor %}
+{% endif %}

--- a/ci_framework/roles/libvirt_manager/templates/domain.xml.j2
+++ b/ci_framework/roles/libvirt_manager/templates/domain.xml.j2
@@ -26,7 +26,11 @@
     </disk>
     {% for network in vm_data.value.nets %}
     <interface type='network'>
+{% if _layout.networks is defined and network in _layout.networks.keys() %}
       <source network='cifmw-{{ network }}'/>
+{% else %}
+      <source network='{{ network }}'/>
+{% endif %}
       <mac address='{{ '24:42:%02i'|format(vm_id|int) |random_mac }}'/>
       <model type="virtio"/>
     </interface>

--- a/ci_framework/roles/libvirt_manager/templates/network-data.yml.j2
+++ b/ci_framework/roles/libvirt_manager/templates/network-data.yml.j2
@@ -1,29 +1,29 @@
 {#
-The ci_job_networking is exposed by the reproducer role. It namely exposes
-the CI job configuration passed down to zuul so that we can ensure we're
-using the same networks.
+This file is mostly used in the validated-architecture context.
+With that VA, we get an OCP cluster deployed, and libvirt_manager
+only takes care of the actual compute (and ansible-controller).
+
+Networks are managed by devscripts role (which deploys OCP), so we have to
+mostly generate all the things on our own.
+
+For now, we'll hardcode most of the things such as subnet and some IPs
 #}
 {% set ns = namespace(
     ip4='',
     gw4='',
     iface=cifmw_reproducer_private_nic,
-    config_nm=false, ip_suffix=0)
+    config_nm=false,
+    ip_suffix=0)
 -%}
 {% if vm_type == 'controller' -%}
+{%   set ns.ip4 = cifmw_reproducer_ctl_ip4 -%}
 {%   set ns.gw4 = cifmw_reproducer_ctl_gw4 -%}
-{%   set ns.ip4 =  ci_job_networking['instances']['controller']['networks']['default']['ip'] %}
-{% elif vm_type == 'crc' -%}
-{%   set ns.ip_suffix = 10 -%}
-{%   set ns.iface = cifmw_reproducer_crc_private_nic -%}
-{%   set ns.gw4 = cifmw_reproducer_crc_gw4 -%}
-{%   set ns.config_nm = true -%}
-{%   set ns.ip4 =  ci_job_networking['instances']['crc']['networks']['default']['ip'] %}
 {% else -%}
 {%   set ns.ip_suffix = 100+vm_id -%}
-{%   set ns.ip4 = ci_job_networking['instances']['compute-' ~ vm_id]['networks']['default']['ip']%}
+{%   set ns.ip4 = '192.168.122.0/24' | ansible.utils.ipmath(ns.ip_suffix) -%}
 {%   set ns.gw4 = cifmw_reproducer_ctl_gw4 -%}
 {% endif -%}
-{% set default_mtu = ci_job_networking.networks['default'].mtu | default('1500') -%}
+{% set default_mtu = 1500 -%}
 {% set vlan_mtu = default_mtu - 4 -%}
 crc_ci_bootstrap_networks_out:
   {{ vm_type }}-{{ vm_id }}:
@@ -32,11 +32,11 @@ crc_ci_bootstrap_networks_out:
       connection: ci-private-network
       ip4: {{ ns.ip4 }}/24
       gw4: {{ ns.gw4 }}
-      dns4: {{ ci_job_networking['instances']['crc']['networks']['default']['ip'] }}
-      mtu: {{ ci_job_networking.networks['default'].mtu | default(default_mtu) }}
+      dns4: {{ cifmw_reproducer_dns_servers }}
+      mtu: {{ default_mtu }}
 {% if vm_type != 'controller' %}
-{% for networking in ci_job_networking.networks | dict2items %}
-{%   if networking.key != 'default' %}
+{% for networking in cifmw_libvirt_manager_networks | dict2items %}
+{%   if networking.value.default is undefined or not networking.value.default | bool %}
     {{ networking.key }}:
       iface: {{ ns.iface }}.{{ networking.value.vlan }}
       connection: {{ networking.key }}


### PR DESCRIPTION
This patch corrects some major issues in the role.

- cifmw_reproducer_key wasn't used at all, and generated at the wrong
  time
  This lead to issues where, if a user wasn't forwarding the SSH Agent,
  accesses to the virtual machines weren't working in a remote
  deployment.
  We now generate the key at the right time, inject it in the VM, and
  ensure the hypervisor is consuming the private key for the accesses.

- localhost deployment support
  It may happen users want to deploy on localhost instead of a remote
  hypervisor. This wasn't properly supported, because we were adding two
  kind of SSH configuration, leading to hiccups.
  We now prevent the ProxyJump config to appear in the localhost case.

- cifmw_reproducer_key cleanup
  Since we're injecting the public key in the authorized_keys, we take
  care to clean it up during the cleanup step.

- inject nodes in the ansible inventory
  In order to make things a bit easier to handle on the ansible side, we
  ensure the new VMs are all added to the current inventory (in-memory).
  This ensures we're using the correct data, and the nodes are properly
  known by the current play. It's NOT mandatory, but just ensures things
  are cleaner.

- allow to not define any networks in the configuration
  Until now, we had to provide a `networks` entry in the configuration
  parameter. This lead to issues when we were re-using existing
  networks.

- allow to reuse existing virtual networks
  It may happen we just want to reuse existing networks. In such case,
  they will probably don't get the `cifmw-` prefix. This patch takes
  care of this specific case.

- stabilize libvirt accesses
  We hit a fair amount of failures with the libvirt sockets over the
  past iteration. After many tests, it seems that removing the timeout
  of the virtproxyd service and ensuring it's enabled and started
  corrects this issue. With this hack, we could successfuly deploy the
  whole VA-1 layout without any issue.

- ensure correct ACLs are applied to home directory
  Since we're usually consuming disk images from within the home
  directory, we have to ensure `qemu` user has proper access.

- new network-data template
  Since we may not reproduce a CI run, we have to generate some content
  instead when it comes to network data pushed on the nodes.

-

As a pull request owner and reviewers, I checked that:
- [X] Successfully tested in the VA-1 deployment.
