### PR TITLE
Ensure we clean ssh key from the authorized_keys

### DIFF
--- a/ci_framework/roles/devscripts/tasks/cleanup.yml
+++ b/ci_framework/roles/devscripts/tasks/cleanup.yml
@@ -55,3 +55,24 @@
   ansible.builtin.yum_repository:
     name: "crb"
     state: absent
+
+- name: Remove generated keypair and related accesses
+  block:
+    - name: Get public key
+      register: _pub_key
+      ansible.builtin.slurp:
+        path: >-
+          {{ cifmw_devscripts_artifacts_dir }}/{{ cifmw_devscripts_user }}_ed25519.pub
+
+    - name: Remove key from the authorized_keys
+      ansible.posix.authorized_key:
+        user: "{{ cifmw_devscripts_user }}"
+        key: "{{ _pub_key['content'] | b64decode }}"
+
+    - name: Remove ssh keypair
+      ansible.builtin.file:
+        path: "{{ cifmw_devscripts_artifacts_dir }}/{{ item }}"
+        state: absent
+      loop:
+        - "{{ cifmw_devscripts_user }}_ed25519"
+        - "{{ cifmw_devscripts_user }}_ed25519.pub"


### PR DESCRIPTION
Until now, in case we were iterating deploy and cleanup over and over,
with the removal of the `cifmw_devscripts_basedir`, we ended up with an
ever-growing authorized_keys.

This patch ensures, during the cleanup tasks, that we remove the
generated key. It won't have impact on the deployed nodes, since, at
this point, there won't be any node anymore.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
