### PR TITLE
Improve reproducer role

### DIFF
--- a/ci_framework/roles/reproducer/tasks/ci_data.yml
+++ b/ci_framework/roles/reproducer/tasks/ci_data.yml
@@ -11,18 +11,18 @@
         job_id: "{{ cifmw_job_uri | regex_replace('/$', '') | basename }}"
       ansible.builtin.set_fact:
         cacheable: true
-        reproducer_basedir: "{{ basedir }}/ci-reproducer/{{ job_id }}"
+        _reproducer_basedir: "{{ basedir }}/ci-reproducer/{{ job_id }}"
         data_baseurl: "{{ cifmw_job_uri }}/controller/ci-framework-data/artifacts/"
         job_id: "{{ job_id }}"
 
     - name: Create local directory for parameters
       ansible.builtin.file:
-        path: "{{ reproducer_basedir }}/parameters"
+        path: "{{ _reproducer_basedir }}/parameters"
         state: directory
 
     - name: Fetch needed artifacts
       ansible.builtin.get_url:
-        dest: "{{ reproducer_basedir }}/{{ item }}"
+        dest: "{{ _reproducer_basedir }}/{{ item }}"
         url: "{{ data_baseurl }}/{{ item }}"
         force: true
       loop:
@@ -32,19 +32,19 @@
 
     - name: Fetch zuul inventory
       ansible.builtin.get_url:
-        dest: "{{ reproducer_basedir }}/zuul_inventory.yml"
+        dest: "{{ _reproducer_basedir }}/zuul_inventory.yml"
         url: "{{ cifmw_job_uri }}/zuul-info/inventory.yaml"
         force: true
 
     - name: Load parameters in current runtime
       ansible.builtin.include_vars:
-        dir: "{{ reproducer_basedir }}/parameters"
+        dir: "{{ _reproducer_basedir }}/parameters"
 
     - name: Extract compute count
       vars:
         zuul_inventory: >-
           {{
-            lookup('file', reproducer_basedir ~ '/zuul_inventory.yml') |
+            lookup('file', _reproducer_basedir ~ '/zuul_inventory.yml') |
             from_yaml
            }}
         compute_count: >-

--- a/ci_framework/roles/reproducer/tasks/ci_job.yml
+++ b/ci_framework/roles/reproducer/tasks/ci_job.yml
@@ -1,5 +1,7 @@
 ---
 - name: Extract playbook to run
+  when:
+    - cifmw_job_uri is defined
   vars:
     playbooks: "{{ zuul.playbook_context.playbooks }}"
     extracted: >-
@@ -30,6 +32,25 @@
   delegate_to: controller-0
   remote_user: zuul
   block:
+    - name: Ensure _reproducer_basedir is set
+      when:
+        - _reproducer_basedir is undefined
+      ansible.builtin.set_fact:
+        job_id: "reproducer"
+        _reproducer_basedir: >-
+          {{
+            (
+             '/home/zuul',
+             'ci-framework-data',
+             'artifacts'
+             ) | path_join
+          }}
+
+    - name: Ensure directory exists
+      ansible.builtin.file:
+        path: "{{ _reproducer_basedir }}"
+        state: directory
+
     - name: Create data directory on controller-0
       ansible.builtin.file:
         path: "ci-framework-data/artifacts/parameters"
@@ -71,19 +92,31 @@
           }}
         mode: "0644"
 
-    - name: Copy environment files to controller node
+    - name: CI reproducer dedicated tasks
       tags:
         - bootstrap
-      ansible.builtin.copy:
-        src: "{{ reproducer_basedir }}/parameters/"
-        dest: "./{{ job_id }}-params"
+      when:
+        - cifmw_job_uri is defined
+      block:
+        - name: Copy environment files to controller node
+          ansible.builtin.copy:
+            src: "{{ _reproducer_basedir }}/parameters/"
+            dest: "./{{ job_id }}-params"
 
-    - name: Inject reproducer dedicated parameter file
-      tags:
-        - bootstrap
-      ansible.builtin.template:
-        src: "reproducer_params.yml.j2"
-        dest: "./{{ job_id }}-params/reproducer_params.yml"
+        - name: Inject reproducer dedicated parameter file
+          ansible.builtin.template:
+            src: "reproducer_params.yml.j2"
+            dest: "./{{ job_id }}-params/reproducer_params.yml"
+
+        - name: Generate CI job playbook
+          ansible.builtin.template:
+            dest: "src/github.com/openstack-k8s-operators/ci-framework/{{ job_id }}_play.yml"
+            src: "play.yml.j2"
+
+        - name: Push extracted network data on controller-0
+          ansible.builtin.copy:
+            dest: zuul-network-data.yml
+            content: "{{ {'job_network': ci_job_networking} | to_nice_yaml}}"
 
     - name: Install collections
       tags:
@@ -101,20 +134,6 @@
           ci-framework-data/artifacts/zuul_inventory.yml
         creates: ci-framework-data/artifacts/zuul_inventory.yml
 
-    - name: Generate CI job playbook
-      tags:
-        - bootstrap
-      ansible.builtin.template:
-        dest: "src/github.com/openstack-k8s-operators/ci-framework/{{ job_id }}_play.yml"
-        src: "play.yml.j2"
-
-    - name: Push extracted network data on controller-0
-      tags:
-        - bootstrap
-      ansible.builtin.copy:
-        dest: zuul-network-data.yml
-        content: "{{ {'job_network': ci_job_networking} | to_nice_yaml}}"
-
     - name: Push pre-CI job playbook
       tags:
         - bootstrap
@@ -122,28 +141,6 @@
         dest: "src/github.com/openstack-k8s-operators/ci-framework/pre-ci-play.yml"
         src: "pre-ci-play.yml"
 
-    - name: Push zuul-params.yml to expected location
-      tags:
-        - bootstrap
-      block:
-        - name: Get content of zuul-params.yml
-          register: zuul_params
-          ansible.builtin.slurp:
-            path: "{{ job_id }}-params/zuul-params.yml"
-
-        - name: Push extracted content
-          vars:
-            zuul_params_filtered: >-
-              {{
-                (zuul_params['content'] | b64decode | from_yaml) |
-                dict2items |
-                rejectattr('key', 'equalto', 'cifmw_operator_build_output') |
-                rejectattr('key', 'equalto', 'content_provider_registry_ip') |
-                items2dict
-              }}
-          ansible.builtin.copy:
-            dest: "ci-framework-data/artifacts/parameters/zuul-params.yml"
-            content: "{{ zuul_params_filtered | to_nice_yaml }}"
 
     - name: Check for ansible logs file and rotate it
       tags:
@@ -167,27 +164,3 @@
           ansible-playbook
           -i ~/ci-framework-data/artifacts/zuul_inventory.yml
           pre-ci-play.yml
-
-    - name: Prepare environment for content-provider
-      when:
-        - cifmw_job_uri is defined
-      environment:
-        ANSIBLE_LOG_PATH: "~/ansible-content-provider-bootstrap.log"
-      ansible.builtin.command:
-        chdir: "src/github.com/openstack-k8s-operators/ci-framework"
-        cmd: >-
-          ansible-playbook
-          -i ~/ci-framework-data/artifacts/zuul_inventory.yml
-          ci_framework/playbooks/01-bootstrap.yml
-
-    - name: Run job
-      when:
-        - cifmw_reproducer_run_job | bool
-      environment:
-        ANSIBLE_LOG_PATH: "~/ansible-{{ job_id }}.log"
-      ansible.builtin.command:
-        chdir: "src/github.com/openstack-k8s-operators/ci-framework"
-        cmd: >-
-          ansible-playbook
-          -i ~/ci-framework-data/artifacts/zuul_inventory.yml
-          {{ job_id }}_play.yml

--- a/ci_framework/roles/reproducer/tasks/cleanup.yml
+++ b/ci_framework/roles/reproducer/tasks/cleanup.yml
@@ -18,8 +18,3 @@
   ansible.builtin.import_role:
     name: libvirt_manager
     tasks_from: clean_layout
-
-- name: Remove basedir
-  ansible.builtin.file:
-    path: "{{ cifmw_reproducer_basedir }}"
-    state: absent

--- a/ci_framework/roles/reproducer/tasks/devscripts_inventory.yml
+++ b/ci_framework/roles/reproducer/tasks/devscripts_inventory.yml
@@ -1,0 +1,33 @@
+---
+- name: Get devscripts extra_network XML
+  vars:
+    net_name: "{{ cifmw_devscripts_config_overrides.extra_network_names }}"
+  register: _osp_trunk_dump
+  community.libvirt.virt_net:
+    command: "get_xml"
+    name: "{{ net_name }}"
+    uri: "qemu:///system"
+
+- name: Extract static leases from extra_network
+  register: _leases
+  community.general.xml:
+    xmlstring: "{{ _osp_trunk_dump.get_xml }}"
+    xpath: "/network/ip/dhcp/host"
+    content: "attribute"
+
+- name: Ensure inventory directory exists
+  ansible.builtin.file:
+    path: >-
+      {{
+        (cifmw_reproducer_basedir,
+         'reproducer-inventory') |
+         path_join
+      }}
+    state: directory
+
+- name: Generate inventory for devscripts nodes
+  vars:
+    _data: "{{ _leases.matches }}"
+  ansible.builtin.template:
+    src: "devscripts_inventory.yml.j2"
+    dest: "{{ cifmw_reproducer_basedir }}/reproducer-inventory/devscripts-group.yml"

--- a/ci_framework/roles/reproducer/tasks/devscripts_layout.yml
+++ b/ci_framework/roles/reproducer/tasks/devscripts_layout.yml
@@ -1,0 +1,46 @@
+---
+- name: Run devscripts
+  tags:
+    - devscripts_layout
+  block:
+    - name: Deploy devscripts layout
+      ansible.builtin.import_role:
+        name: devscripts
+
+- name: Generate devscripts inventory
+  tags:
+    - devscripts_inventory
+  ansible.builtin.import_tasks: devscripts_inventory.yml
+
+- name: Slurp devscripts private key
+  register: _devscript_privkey
+  ansible.builtin.slurp:
+    path: >-
+      {{
+        (cifmw_reproducer_basedir,
+        'artifacts',
+         ansible_user_id ~ '_ed25519') |
+         path_join
+      }}
+
+- name: Slurp content of the devscripts kubeconfig
+  register: _devscripts_kubeconfig
+  ansible.builtin.slurp:
+    path: >-
+      {{
+        (ansible_user_dir,
+         'src/github.com/openshift-metal3',
+         'dev-scripts/ocp/ocp/auth/kubeconfig') |
+         path_join
+      }}
+
+- name: Slurp content of the devscripts kubeadmin-password
+  register: _devscripts_kubeadm
+  ansible.builtin.slurp:
+    path: >-
+      {{
+        (ansible_user_dir,
+         'src/github.com/openshift-metal3',
+         'dev-scripts/ocp/ocp/auth/kubeadmin-password') |
+         path_join
+      }}

--- a/ci_framework/roles/reproducer/tasks/epel.yml
+++ b/ci_framework/roles/reproducer/tasks/epel.yml
@@ -1,0 +1,39 @@
+---
+- name: Enable CRB repositories (CentOS)
+  when:
+    - ansible_facts['distribution'] == 'CentOS'
+  become: true
+  ansible.builtin.command:
+    cmd: dnf config-manager --set-enabled crb
+
+- name: Enable CRB repositories (RHEL)
+  when:
+    - ansible_facts['distribution'] == 'RedHat'
+  become: true
+  vars:
+    arch: "{{ ansible_facts['architecture'] }}"
+  ansible.builtin.command:
+    cmd: >-
+      subscription-manager repos
+      --enable codeready-builder-for-rhel-9-{{ arch }}-rpms
+
+- name: Install EPEL repositories
+  become: true
+  vars:
+    rhel_uri: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
+    pkg: "{{ (ansible_facts['distribution'] == 'RedHat') | ternary(rhel_uri, 'epel-release')}}"
+  ansible.builtin.dnf:
+    name: "{{ pkg }}"
+    disable_gpg_check: "{{ (pkg != 'epel-release') }}"
+
+- name: Deactivate all of EPEL repositories
+  become: true
+  ansible.builtin.shell:  # noqa: command-instead-of-module
+    cmd: sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/epel*
+
+- name: Install packages from EPEL
+  become: true
+  ansible.builtin.dnf:  # noqa: package-latest
+    enablerepo: epel
+    name: "{{ cifmw_reproducer_epel_pkgs }}"
+    state: latest

--- a/ci_framework/roles/reproducer/tasks/libvirt_layout.yml
+++ b/ci_framework/roles/reproducer/tasks/libvirt_layout.yml
@@ -1,0 +1,213 @@
+---
+- name: Deploy layout on target host
+  tags:
+    - libvirt_layout
+  ansible.builtin.import_role:
+    name: libvirt_manager
+    tasks_from: deploy_layout
+
+- name: Push generated inventory from hypervisor
+  ansible.builtin.command:  # noqa: command-instead-of-module
+    cmd: >-
+      rsync -r {{ cifmw_reproducer_basedir }}/reproducer-inventory/
+      zuul@controller-0:reproducer-inventory
+
+- name: Slurp ssh key for CRC access
+  when:
+    - _layout.vms.crc is defined
+  tags:
+    - bootstrap
+    - bootstrap_layout
+  register: crc_priv_key
+  ansible.builtin.slurp:
+    path: "{{ ansible_user_dir}}/.crc/machines/crc/id_ecdsa"
+
+- name: Configure CRC services
+  when:
+    - _layout.vms.crc is defined
+  tags:
+    - bootstrap
+    - bootstrap_layout
+  delegate_to: crc-0
+  remote_user: root
+  block:
+    - name: Ensure crc-0 knows about its second NIC
+      when:
+        - cifmw_job_uri is undefined
+      community.general.nmcli:
+        autoconnect: true
+        conn_name: private_net
+        dns4: 127.0.0.1
+        ifname: enp2s0
+        type: ethernet
+        ip4: "{{ cifmw_reproducer_crc_ip4 }}/24"
+        gw4: "{{ cifmw_reproducer_crc_gw4 }}"
+        state: present
+
+    - name: Ensure crc-0 does not get "public" DNS
+      community.general.nmcli:
+        autoconnect: true
+        conn_name: "Wired connection 1"
+        dns4_ignore_auto: true
+        state: present
+
+    - name: Configure dns forwarders
+      ansible.builtin.blockinfile:
+        path: "/var/srv/dnsmasq.conf"
+        block: |-
+          {% if cifmw_reproducer_dns_servers %}
+          {% for dns_server in cifmw_reproducer_dns_servers %}server={{ dns_server }}{% endfor %}
+          {% endif %}
+
+    - name: Configure local DNS for CRC pod
+      register: last_modification
+      ansible.builtin.replace:
+        path: "/var/srv/dnsmasq.conf"
+        regexp: "192.168.130.11"
+        replace: "{{ cifmw_reproducer_crc_ip4 }}"
+
+    - name: Reboot CRC node
+      when:
+        - last_modification is changed
+        - cifmw_job_uri is undefined
+      ansible.builtin.reboot:
+
+- name: Get kubeconfig file from crc directory
+  when:
+    - _layout.vms.crc is defined
+  tags:
+    - bootstrap
+    - bootstrap_layout
+  register: _crc_kubeconfig
+  ansible.builtin.slurp:
+    path: "{{ cifmw_reproducer_kubecfg }}"
+
+- name: Configure controller-0
+  tags:
+    - bootstrap
+    - bootstrap_layout
+  delegate_to: controller-0
+  delegate_facts: true
+  remote_user: root
+  block:
+    - name: Gather some facts
+      ansible.builtin.setup:
+        gather_subset:
+          - '!all'
+          - 'min'
+
+    - name: Ensure controller-0 has an IP in private network
+      when:
+        - cifmw_job_uri is undefined
+      community.general.nmcli:
+        autoconnect: true
+        conn_name: private_net
+        ifname: "{{ cifmw_reproducer_private_nic }}"
+        type: ethernet
+        ip4: "{{ cifmw_reproducer_ctl_ip4 }}/24"
+        gw4: "{{ cifmw_reproducer_ctl_gw4 }}"
+        state: present
+
+    - name: Create kube directory
+      ansible.builtin.file:
+        path: "/home/zuul/.kube"
+        state: directory
+        owner: zuul
+        group: zuul
+        mode: "0755"
+
+    - name: Inject kubeconfig content
+      when:
+        - _devscripts_kubeconfig is defined or _crc_kubeconfig is defined
+      ansible.builtin.copy:
+        dest: "/home/zuul/.kube/config"
+        content: >-
+          {{
+            (cifmw_use_devscripts | default(false) | bool) |
+            ternary(_devscripts_kubeconfig.content, _crc_kubeconfig.content) |
+            b64decode
+          }}
+        owner: zuul
+        group: zuul
+        mode: "0644"
+
+    - name: Inject kubeadmin-password if exists
+      when:
+        - _devscripts_kubeadm is defined
+      ansible.builtin.copy:
+        dest: "/home/zuul/.kube/kubeadmin-password"
+        content: "{{ _devscripts_kubeadm['content'] | b64decode }}"
+        owner: zuul
+        group: zuul
+        mode: "0600"
+
+    - name: Inject devscripts private key if set
+      when:
+        - _devscript_privkey is defined
+      ansible.builtin.copy:
+        dest: "/home/zuul/.ssh/devscripts_key"
+        content: "{{ _devscript_privkey['content'] | b64decode }}"
+        owner: "zuul"
+        group: "zuul"
+        mode: "0400"
+
+    - name: Inject CRC related content if needed
+      when:
+        - _layout.vms.crc is defined
+      block:
+        - name: Inject CRC ssh key
+          ansible.builtin.copy:
+            dest: "/home/zuul/.ssh/crc_key"
+            content: "{{ crc_priv_key['content'] | b64decode }}"
+            mode: "0400"
+            owner: zuul
+            group: zuul
+
+        - name: Inject crc related host entry
+          ansible.builtin.lineinfile:
+            path: /etc/hosts
+            line: >-
+              {{ cifmw_reproducer_crc_ip4 }} api.crc.testing
+              canary-openshift-ingress-canary.apps-crc.testing
+              console-openshift-console.apps-crc.testing
+              default-route-openshift-image-registry.apps-crc.testing
+              downloads-openshift-console.apps-crc.testing
+              oauth-openshift.apps-crc.testing
+
+    - name: RHEL repository setup for ansible-controller
+      when:
+        - ansible_facts['distribution'] == 'RedHat'
+      block:
+        - name: Get rhos-release
+          ansible.builtin.package:
+            name: "{{ cifmw_repo_setup_rhos_release_rpm }}"
+            state: present
+            disable_gpg_check: true
+
+        - name: Enable RHEL repos
+          ansible.builtin.command:
+            cmd: "rhos-release rhel"
+
+        - name: Install internal CA
+          ansible.builtin.package:
+            name: "{{ cifmw_reproducer_internal_ca }}"
+            disable_gpg_check: true
+
+    - name: Install some tools
+      ansible.builtin.package:
+        name:
+          - ansible-core
+          - bash-completion
+          - git-core
+          - make
+          - podman
+          - python3-jmespath
+          - python3-netaddr
+          - python3-pip
+          - tmux
+          - vim
+          - wget
+
+    - name: Install ansible dependencies
+      ansible.builtin.pip:
+        requirements: https://raw.githubusercontent.com/openstack-k8s-operators/ci-framework/main/ansible-requirements.txt

--- a/ci_framework/roles/reproducer/tasks/main.yml
+++ b/ci_framework/roles/reproducer/tasks/main.yml
@@ -31,164 +31,36 @@
     - artifacts
     - logs
 
+- name: Manage EPEL and related packages
+  tags:
+    - bootstrap
+    - packages
+  ansible.builtin.import_tasks: epel.yml
+
 - name: Load CI job environment
   when:
     - cifmw_job_uri is defined
+    - cifmw_job_uri != ''
   ansible.builtin.import_tasks: ci_data.yml
 
-- name: Deploy layout on target host
+# dev-scripts will create a bunch of resources, among them networks.
+# So we want to run this before libvirt_manager so that we can plug
+# our own VM onto the network.
+- name: Consume devscripts
+  when:
+    - cifmw_use_devscripts | default(false) | bool
   tags:
     - bootstrap
     - bootstrap_layout
-  ansible.builtin.import_role:
-    name: libvirt_manager
-    tasks_from: deploy_layout
+  ansible.builtin.import_tasks: devscripts_layout.yml
 
-- name: Push generated inventory from hypervisor
+- name: Consume libvirt_manager
+  when:
+    - cifmw_use_libvirt | default(false) | bool
   tags:
     - bootstrap
     - bootstrap_layout
-  ansible.builtin.command:  # noqa: command-instead-of-module
-    cmd: >-
-      rsync -r {{ cifmw_reproducer_basedir }}/reproducer-inventory/
-      zuul@controller-0:reproducer-inventory
-
-- name: Slurp ssh key for CRC access
-  tags:
-    - bootstrap
-    - bootstrap_layout
-  register: crc_priv_key
-  ansible.builtin.slurp:
-    path: "{{ ansible_user_dir}}/.crc/machines/crc/id_ecdsa"
-
-- name: Configure CRC services
-  tags:
-    - bootstrap
-    - bootstrap_layout
-  delegate_to: crc-0
-  remote_user: root
-  block:
-    - name: Ensure crc-0 knows about its second NIC
-      when:
-        - cifmw_job_uri is undefined
-      community.general.nmcli:
-        autoconnect: true
-        conn_name: private_net
-        dns4: 127.0.0.1
-        ifname: enp2s0
-        type: ethernet
-        ip4: "{{ cifmw_reproducer_crc_ip4 }}/24"
-        gw4: "{{ cifmw_reproducer_crc_gw4 }}"
-        state: present
-
-    - name: Ensure crc-0 does not get "public" DNS
-      community.general.nmcli:
-        autoconnect: true
-        conn_name: "Wired connection 1"
-        dns4_ignore_auto: true
-        state: present
-
-    - name: Configure dns forwarders
-      ansible.builtin.blockinfile:
-        path: "/var/srv/dnsmasq.conf"
-        block: |-
-          {% if cifmw_reproducer_dns_servers %}
-          {% for dns_server in cifmw_reproducer_dns_servers %}server={{ dns_server }}{% endfor %}
-          {% endif %}
-
-    - name: Configure local DNS for CRC pod
-      register: last_modification
-      ansible.builtin.replace:
-        path: "/var/srv/dnsmasq.conf"
-        regexp: "192.168.130.11"
-        replace: "{{ cifmw_reproducer_crc_ip4 }}"
-
-    - name: Reboot CRC node
-      when:
-        - last_modification is changed
-        - cifmw_job_uri is undefined
-      ansible.builtin.reboot:
-
-- name: Get kubeconfig file from crc directory
-  tags:
-    - bootstrap
-    - bootstrap_layout
-  register: kubeconfig
-  ansible.builtin.slurp:
-    path: "{{ cifmw_reproducer_kubecfg }}"
-
-- name: Configure controller-0
-  tags:
-    - bootstrap
-    - bootstrap_layout
-  delegate_to: controller-0
-  remote_user: root
-  block:
-    - name: Ensure controller-0 has an IP in private network
-      when:
-        - cifmw_job_uri is undefined
-      community.general.nmcli:
-        autoconnect: true
-        conn_name: private_net
-        ifname: "{{ cifmw_reproducer_private_nic }}"
-        type: ethernet
-        ip4: "{{ cifmw_reproducer_ctl_ip4 }}/24"
-        gw4: "{{ cifmw_reproducer_ctl_gw4 }}"
-        state: present
-
-    - name: Create kube directory
-      ansible.builtin.file:
-        path: "/home/zuul/.kube"
-        state: directory
-        owner: zuul
-        group: zuul
-        mode: "0755"
-
-    - name: Inject kubeconfig content
-      ansible.builtin.copy:
-        dest: "/home/zuul/.kube/config"
-        content: "{{ kubeconfig.content | b64decode }}"
-        owner: zuul
-        group: zuul
-        mode: "0644"
-
-    - name: Inject CRC ssh key
-      ansible.builtin.copy:
-        dest: "/home/zuul/.ssh/crc_key"
-        content: "{{ crc_priv_key['content'] | b64decode }}"
-        mode: "0400"
-        owner: zuul
-        group: zuul
-
-    - name: Inject crc related host entry
-      ansible.builtin.lineinfile:
-        path: /etc/hosts
-        line: >-
-          {{ cifmw_reproducer_crc_ip4 }} api.crc.testing
-          canary-openshift-ingress-canary.apps-crc.testing
-          console-openshift-console.apps-crc.testing
-          default-route-openshift-image-registry.apps-crc.testing
-          downloads-openshift-console.apps-crc.testing
-          oauth-openshift.apps-crc.testing
-
-    - name: Install some tools
-      ansible.builtin.package:
-        name:
-          - ansible-core
-          - bash-completion
-          - git-core
-          - make
-          - podman
-          - python3-jmespath
-          - python3-netaddr
-          - python3-pip
-          - tmux
-          - vim
-          - wget
-
-    - name: Install ansible dependencies
-      ansible.builtin.pip:
-        requirements: https://raw.githubusercontent.com/openstack-k8s-operators/ci-framework/main/ansible-requirements.txt
+  ansible.builtin.import_tasks: libvirt_layout.yml
 
 - name: Push local code
   tags:
@@ -196,7 +68,57 @@
     - bootstrap
   ansible.builtin.import_tasks: push_code.yml
 
-- name: Emulate CI job
+- name: Generate data
+  ansible.builtin.import_tasks: ci_job.yml
+
+- name: Run CI job if instructed
   when:
     - cifmw_job_uri is defined
-  ansible.builtin.import_tasks: ci_job.yml
+  delegate_to: controller-0
+  block:
+    - name: Push zuul-params.yml to expected location
+      tags:
+        - bootstrap
+      block:
+        - name: Get content of zuul-params.yml
+          register: zuul_params
+          ansible.builtin.slurp:
+            path: "{{ job_id }}-params/zuul-params.yml"
+
+        - name: Push extracted content
+          vars:
+            zuul_params_filtered: >-
+              {{
+                (zuul_params['content'] | b64decode | from_yaml) |
+                dict2items |
+                rejectattr('key', 'equalto', 'cifmw_operator_build_output') |
+                rejectattr('key', 'equalto', 'content_provider_registry_ip') |
+                items2dict
+              }}
+          ansible.builtin.copy:
+            dest: "ci-framework-data/artifacts/parameters/zuul-params.yml"
+            content: "{{ zuul_params_filtered | to_nice_yaml }}"
+
+    - name: Prepare environment for content-provider
+      when:
+        - cifmw_job_uri is defined
+      environment:
+        ANSIBLE_LOG_PATH: "~/ansible-content-provider-bootstrap.log"
+      ansible.builtin.command:
+        chdir: "src/github.com/openstack-k8s-operators/ci-framework"
+        cmd: >-
+          ansible-playbook
+          -i ~/ci-framework-data/artifacts/zuul_inventory.yml
+          ci_framework/playbooks/01-bootstrap.yml
+
+    - name: Run job
+      when:
+        - cifmw_reproducer_run_job | bool
+      environment:
+        ANSIBLE_LOG_PATH: "~/ansible-{{ job_id }}.log"
+      ansible.builtin.command:
+        chdir: "src/github.com/openstack-k8s-operators/ci-framework"
+        cmd: >-
+          ansible-playbook
+          -i ~/ci-framework-data/artifacts/zuul_inventory.yml
+          {{ job_id }}_play.yml

--- a/ci_framework/roles/reproducer/tasks/push_code.yml
+++ b/ci_framework/roles/reproducer/tasks/push_code.yml
@@ -40,7 +40,7 @@
     - name: Sync local repositories to ansible controller
       delegate_to: localhost
       when:
-        - item.src is abs or item.src is not match(':')
+        - item.src is abs or item.src is not match('.*:.*')
       ansible.builtin.command:  # noqa: command-instead-of-module
         cmd: "rsync -ar {{ item.src }} zuul@controller-0:{{ item.dest }}"
       loop: "{{ cifmw_reproducer_repositories }}"
@@ -52,7 +52,7 @@
       delegate_facts: true
       when:
         # will match github.com:org/project, but also https://github.com/...
-        - item.src is match(':')
+        - item.src is match('.*:.*')
       ansible.builtin.git:
         repo: "{{ item.src }}"
         dest: "{{ item.dest }}"

--- a/ci_framework/roles/reproducer/templates/devscripts_inventory.yml.j2
+++ b/ci_framework/roles/reproducer/templates/devscripts_inventory.yml.j2
@@ -1,0 +1,8 @@
+ocps:
+  hosts:
+{% for _host in _data %}
+    {{ _host.host.name }}:
+      ansible_host: {{ _host.host.ip }}
+      ansible_user: core
+      ansible_ssh_private_key_file: ~/.ssh/devscripts_key
+{% endfor %}

--- a/docs/source/reproducers/04-validated-architecture.md
+++ b/docs/source/reproducers/04-validated-architecture.md
@@ -1,0 +1,23 @@
+# Validated Architecture
+## Words of warning
+This feature is still under development and may change in the near future.
+
+## Purpose
+The Validated Architecture describes a deployment layout matching customer infrastructure.
+
+On the "hardware" part, it consist in a 3-node OCP service, and at least 3 compute nodes.
+
+## Supported environment
+This has been successfully tested on the following environments:
+
+* CentOS Stream 9 hypervisor, running CS-9 VMs
+* Red Hat Enterprise Linux 9.2 hypervisor, running RHEL-9.2 VMs
+
+Regarding hypervisor capacities, you have to get at least:
+
+* 64G of RAM
+* 130G of storage (/ must have over 80G of free space for dev-scripts, and /home must have at least 50G)
+* 24 CPUs
+
+## Deploy the layout
+(doc will be updated on due time once all the pieces are in the repository)

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -135,6 +135,8 @@ or `--skip-tags`:
 * `admin-setup`: Denotes tasks to call the role [os_net_setup](../roles/os_net_setup.md) when deploy-edpm.yml playbook is run.
 * `run-tests`: Denotes tasks to call the role [tempest](../roles/tempest.md) when deploy-edpm.yml playbook is run.
 * `logs`: Denotes tasks which generate artifacts via the role [artifacts](../roles/artifacts.md) and when collect logs when deploy-edpm.yml playbook is run.
+* `devscripts_layout`: Run the [devscripts](../roles/devscripts.md) parts of the [reproducer](../reproducer/04-validated-architecture.md) when dev-scripts is activated.
+* `libvirt_layout`: Run the [libvirt_manager](../roles/libvirt_manager.md) part of the [reproducer](../reproducer/04-validated-architecture.md) when libvirt is activated.
 
 For instance, if you want to bootstrap a hypervisor, and reuse it over and
 over, you'll run the following commands:


### PR DESCRIPTION
With this patch, we extend the reproducer role in such a way it will
properly integrate and support dev-scripts provided VMs, and properly
manage the ones we may want to inject using libvirt_manager.

With this change, we ensure that:
- devscripts is running first, so that it can create its networks

- libvirt_manager comes next, and is able to consume any existing
  networks provided by devscripts

- the reproducer is able to generate and provide mandatory files related
  to the inventory and network, even if we're not running a CI Job
  Reproducer

- we introduce a "light" EPEL management, in the wait of some formal
  inclusion in either ci_setup or repo_setup

- we correct a tiny issue in the `push_code.yml` that prevented correct
  matching of the "kind" of repository (remote or local), since `match()`
  is greedy.

This patch is a major refactoring of the reproducer role, allowing to
get extended features.

As a pull request owner and reviewers, I checked that:
- [X] It has been iterated over and over during the VA-1 introduction
