### PR TITLE
Improve reproducer and reproduer-clean playbooks

### DIFF
--- a/reproducer-clean.yml
+++ b/reproducer-clean.yml
@@ -6,3 +6,18 @@
       ansible.builtin.import_role:
         name: reproducer
         tasks_from: cleanup.yml
+
+    - name: Clean up devscripts related content
+      when:
+        - cifmw_use_devscripts | default(false) | bool
+      ansible.builtin.import_role:
+        name: devscripts
+        tasks_from: cleanup.yml
+
+    - name: Remove basedir
+      ansible.builtin.file:
+        path: "{{ cifmw_reproducer_basedir }}"
+        state: absent
+
+    - name: Clear all facts
+      ansible.builtin.meta: clear_facts

--- a/reproducer.yml
+++ b/reproducer.yml
@@ -4,5 +4,6 @@
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: true
   roles:
+    - role: ci_setup
     - role: libvirt_manager
     - role: reproducer


### PR DESCRIPTION
Since we're introducing devscripts in the reproducer, we have to ensure
we're able to clean it up.

We also ensure some basic setup steps are done on the target host.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
