### PR TITLE
[artifacts]Gather the whole /etc

### DIFF
--- a/ci_framework/roles/artifacts/tasks/edpm.yml
+++ b/ci_framework/roles/artifacts/tasks/edpm.yml
@@ -77,8 +77,7 @@
           sudo test -d /var/lib/openstack && sudo cp -a /var/lib/openstack /tmp/{{ host_ip }}
           sudo test -d /var/lib/config-data && sudo cp -a /var/lib/config-data /tmp/{{ host_ip }}
           sudo test -d /var/lib/cloud && sudo cp -a /var/lib/cloud /tmp/{{ host_ip }}
-          sudo test -d /etc/nftables && sudo cp -a /etc/nftables /tmp/{{ host_ip }}
-          sudo test -d /etc/os-net-config && sudo cp -a /etc/os-net-config /tmp/{{ host_ip }}
+          sudo test -d /etc && sudo cp -RP /etc /tmp/{{ host_ip }}
           sudo find /tmp/{{ host_ip }} -type d -exec chmod ugoa+rx '{}' \;
           sudo find /tmp/{{ host_ip }} -type f -exec chmod ugoa+r '{}' \;
           command -v ovs-vsctl && sudo ovs-vsctl list Open_vSwitch > /tmp/{{ host_ip }}/ovs_vsctl_list_openvswitch.txt


### PR DESCRIPTION
There are many places in /etc the EDPM ansible roles are modifying like tuned config or ssh_known_hosts file. To be able to troubleshoot such configuration in CI runs this PR switch to gather the whole /etc directory from the EDPM nodes.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running