### PR TITLE
Ensure we fetch bmaas console log

### DIFF
--- a/ci_framework/roles/artifacts/tasks/environment.yml
+++ b/ci_framework/roles/artifacts/tasks/environment.yml
@@ -22,6 +22,7 @@
       find {{ cifmw_artifacts_basedir }}/artifacts/NetworkManager -type f -exec chmod 0644 '{}' \;
       find {{ cifmw_artifacts_basedir }}/artifacts/NetworkManager -type d -exec chmod 0755 '{}' \;
       test -d /etc/ci/env && cp -r /etc/ci/env {{ cifmw_artifacts_basedir }}/artifacts/ci-env
+      test -d /var/log/bmaas_console_logs && cp -r /var/log/bmaas_console_logs {{ cifmw_artifacts_basedir }}/logs
       ip ro ls > {{ cifmw_artifacts_basedir }}/artifacts/ip-network.txt
       ip rule ls >> {{ cifmw_artifacts_basedir }}/artifacts/ip-network.txt
       ip -j -p link ls >> {{ cifmw_artifacts_basedir }}/artifacts/ip-network.txt

--- a/ci_framework/roles/artifacts/tasks/main.yml
+++ b/ci_framework/roles/artifacts/tasks/main.yml
@@ -31,8 +31,11 @@
   tags:
     - always
   ansible.builtin.file:
-    path: "{{ cifmw_artifacts_basedir }}/artifacts"
+    path: "{{ cifmw_artifacts_basedir }}/{{ item }}"
     state: directory
+  loop:
+    - artifacts
+    - logs
 
 - name: Load generated hook environment for further usage
   ignore_errors: true  # noqa: ignore-errors


### PR DESCRIPTION
Such logs were introduced in install_yamls via this PR:
https://github.com/openstack-k8s-operators/install_yamls/pull/592

Since we're still using nested virt, we'll end with that new log
directory.
And, once we switch to multinode layout, nested virt shall still be
used, so we should benefit of this new location as well.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
