### PR TITLE
[set_openstack_containers] filter os containers based on prefix

### DIFF
--- a/ci_framework/roles/set_openstack_containers/README.md
+++ b/ci_framework/roles/set_openstack_containers/README.md
@@ -15,7 +15,7 @@ The role will generate two 2 files in ~/ci-framework-data/artifacts/ directory a
 * `cifmw_set_openstack_containers_tag_from_md5`: Get the tag from delorean.repo.md5. Defaults to `false`.
 * `cifmw_set_openstack_containers_dlrn_md5_path`: Full path of delorean.repo.md5. Defaults to `/etc/yum.repos.d/delorean.repo.md5`.
 * `cifmw_set_openstack_containers_overrides`: Extra container overrides. Defaults to `{}`
-* `cifmw_set_openstack_containers_tag_filter`: Update container tags ending with. Defaults to `current-podified`
+* `cifmw_set_openstack_containers_prefix`: Update container containing. Defaults to `openstack`
 
 ## Examples
 

--- a/ci_framework/roles/set_openstack_containers/defaults/main.yml
+++ b/ci_framework/roles/set_openstack_containers/defaults/main.yml
@@ -21,7 +21,7 @@ cifmw_set_openstack_containers_basedir: "{{ cifmw_basedir | default(ansible_user
 cifmw_set_openstack_containers_registry: quay.io
 cifmw_set_openstack_containers_namespace: podified-antelope-centos9
 cifmw_set_openstack_containers_tag: current-podified
-cifmw_set_openstack_containers_tag_filter: current-podified
+cifmw_set_openstack_containers_prefix: openstack
 cifmw_set_openstack_containers_operator_name: openstack
 cifmw_set_openstack_containers_tag_from_md5: false
 cifmw_set_openstack_containers_dlrn_md5_path: "/etc/yum.repos.d/delorean.repo.md5"

--- a/ci_framework/roles/set_openstack_containers/templates/update_env_vars.sh.j2
+++ b/ci_framework/roles/set_openstack_containers/templates/update_env_vars.sh.j2
@@ -17,12 +17,12 @@ export PATH="{{ cifmw_path }}"
 {%     if _container_env in cifmw_set_openstack_containers_overrides.keys() -%}
 {%       set _ = containers_dict.update({_container_env: cifmw_set_openstack_containers_overrides[_container_env]}) -%}
 {%     endif -%}
-{#   All the openstack services containers ends with current-podified tag #}
+{#   All the openstack services containers contain /openstack- prefix #}
 {#   It filters out the same and update the container address with new url #}
-{%   elif _container.endswith(cifmw_set_openstack_containers_tag_filter) -%}
-{%     set _container_data = _container.split('/')[-1] -%}
-{%     set _container_name = _container_data.split(':')[0] -%}
-{%     set _container_address = _container_registry + '/' + _container_name + ':' + cifmw_set_openstack_containers_tag -%}
+{%   elif cifmw_set_openstack_containers_prefix in _container -%}
+{%     set _container_data = _container.split(cifmw_set_openstack_containers_prefix)[-1] -%}
+{%     set _container_name = _container_data.split('@sha256')[0] -%}
+{%     set _container_address = _container_registry + '/' + cifmw_set_openstack_containers_prefix + _container_name + ':' + cifmw_set_openstack_containers_tag -%}
 {%     set _ = containers_dict.update({_container_env: _container_address}) -%}
 {%   endif -%}
 {% endfor -%}


### PR DESCRIPTION
Openstack operators got the support for disconnected environment. It changes the openstack services container url to use sha instead of tag.

It breaks the set_openstack_containers role as we were filtering the containers based on tags.

With this pr, it removes the filter var and replace it with image prefix and also allow user to use the image prefix in the image name.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

