### PR TITLE
Fix include_role task

### DIFF
--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -250,7 +250,7 @@
       vars:
         cifmw_install_ca_bundle_src: "{{ cifmw_edpm_prepare_basedir }}/tls-ca-bundle.pem"
       ansible.builtin.include_role:
-        role: install_ca
+        name: install_ca
 
 - name: Wait for keystone to be ready
   tags:


### PR DESCRIPTION
include_role uses "name: [name of role]" as a way to import role.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
