### PR TITLE
Fix: DNS forwarders condition is always resulting in true

### DIFF
--- a/ci_framework/roles/ci_network/tasks/apply-dns.yml
+++ b/ci_framework/roles/ci_network/tasks/apply-dns.yml
@@ -35,8 +35,8 @@
 - name: Ensure existing nameservers are DNS forwarders.
   become: true
   when: >
-    "'127.0.0.1' not in ansible_dns.nameservers" or
-    "'forwarders' in cifmw_network_local_dns"
+    ("'127.0.0.1' not in ansible_dns.nameservers") or
+    ("'forwarders' in cifmw_network_local_dns")
   vars:
     dns_servers: >-
       {{


### PR DESCRIPTION
In this patch, the checks done for checking whether to update the local DNS forwarders is corrected. The fix enables us to update the forwarder records only when required.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running