### PR TITLE
Support reserving of IP address

### DIFF
--- a/ci_framework/roles/libvirt_manager/tasks/attach_interface.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/attach_interface.yml
@@ -14,21 +14,39 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
 # This task requires
 #   vm_name         Domain name to which the interface needs to be attached.
-#   interface_name  source of the device
-#   interface_type  bridge or network
+#   network
+#     name          Name of the network bridge
+#     cidr          network notation
+#     mtu           MTU applied on the interface.
+#     static_ip     boolean if static address is required.
+
+
+- name: Generate a random MAC address
+  ansible.builtin.set_fact:
+    _lm_mac_address: "{{ '0A:02' | community.general.random_mac }}"
+
+- name: Reserve an IP address
+  when: network.static_ip | bool
+  vars:
+    mac_address: "{{ _lm_mac_address }}"
+  ansible.builtin.import_tasks: reserve_ip.yml
 
 - name: Attach interface to the virtual machine.
-  ci_script:
-    output_dir: "{{ cifmw_libvirt_manager_basedir }}/artifacts"
-    script: >-
+  vars:
+    _net_name: >
+      {{
+        (network.static_ip | bool) |
+        ternary(network.name, 'cifmw-net_' + network.name)
+      }}
+  ansible.builtin.command:
+    cmd: >-
       virsh -c qemu:///system
       attach-interface "{{ vm_name }}"
-      --source "{{ interface_name }}"
-      --type "{{ interface_type }}"
-      --mac "{{ '0A:02' | community.general.random_mac }}"
+      --source "{{ _net_name }}"
+      --type bridge
+      --mac "{{ _lm_mac_address }}"
       --model virtio
       --config
       --persistent

--- a/ci_framework/roles/libvirt_manager/tasks/reserve_ip.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/reserve_ip.yml
@@ -1,0 +1,53 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# The below tasks reserves an IP from the dhcp range and assigns it to the
+# specified mac address and vm
+
+# The below information are required
+#   vm_name       Name of the virtual machine/domain
+#   mac_address   Associated MAC address
+#   network
+#     name        virtual network name
+#     cidr        network notation
+
+# The nth host is determined by looking to the vm_name
+#   master          20
+#   worker          23
+#   extraworker     26
+#   compute         26      # Has the same index of extraworker
+
+
+- name: Generate the IP address
+  vars:
+    _vm_name: "{{ vm_name | replace('-', '_') | split('_') }}"
+    _ip_index: >-
+      {{
+        cifmw_libvirt_manager_vm_net_ip_set[_vm_name[1]] +
+        _vm_name[2] | int
+      }}
+  ansible.builtin.set_fact:
+    _lm_ip_address: "{{ network.cidr | ansible.utils.nthhost(_ip_index) }}"
+
+- name: Reserve static IP address for the node.
+  community.libvirt.virt_net:
+    command: modify
+    name: "{{ network.name }}"
+    uri: "qemu:///system"
+    xml: |
+      <host mac='{{ mac_address }}' name='{{ vm_name }}' ip='{{ _lm_ip_address }}'>
+        <lease expiry='60' unit='minutes'/>
+      </host>

--- a/ci_framework/roles/libvirt_manager/vars/main.yml
+++ b/ci_framework/roles/libvirt_manager/vars/main.yml
@@ -33,3 +33,10 @@ cifmw_libvirt_manager_dependency_packages:
 
 cifmw_libvirt_manager_polkit_rules_dir: /etc/polkit-1/rules.d
 cifmw_libvirt_manager_polkit_rules_file: "{{ cifmw_libvirt_manager_polkit_rules_dir }}/80-libvirt-manage.rules"
+
+# It is either compute or extraworker and not both hence the numbers are reused
+cifmw_libvirt_manager_vm_net_ip_set:
+  master: 10
+  worker: 13
+  extraworker: 100
+  compute: 100


### PR DESCRIPTION
This PR adds support of reserving IP addresses against a virtual machines MAC address. It enables the system to have a static IP address.

This feature is supported for those virtual networks managed by libvirt and has DHCP enabled.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] Content of the docs/source is reflecting the changes
