### PR TITLE
Enable patching of virtproxyd optional

### DIFF
--- a/ci_framework/roles/libvirt_manager/README.md
+++ b/ci_framework/roles/libvirt_manager/README.md
@@ -4,7 +4,6 @@ Used for checking if:
     - there's SVM/VMX virtualization, enable it if not
     - install libvirt packages and dependencies and add group and user to libvirt group if necessary,
 
-
 ## Privilege escalation
 
 `become` - Required in:
@@ -14,6 +13,7 @@ Used for checking if:
     - `polkit_rules.yml`: Add polkit rules under `/etc/`.
 
 ## Parameters
+
 * `cifmw_libvirt_manager_basedir`: (String) Base directory. Defaults to `cifmw_basedir` which defaults to `~/ci-framework-data`.
 * `cifmw_libvirt_manager_enable_virtualization_module`: (Boolean) If `true` it will enable the virtualization module in case it's not already and if the hosts allow it. Defaults to `false`.
 * `cifmw_libvirt_manager_user`: (String) User used for libvirt. Default: the one in the environment variable `USER`.
@@ -26,3 +26,4 @@ Used for checking if:
 * `cifmw_libvirt_manager_compute_memory`: (Integer) The amount of memory in GB per compute. Defaults to `4`.
 * `cifmw_libvirt_manager_compute_disksize`: (Integer) The size of the disk in GB per compute. Defaults to `20`.
 * `cifmw_libvirt_manager_compute_cpus`: (Integer) The amount of vCPUs per compute. Defaults to `1`.
+* `cifmw_libvirt_manager_apply_virtproxy_patch` (Boolean) Apply patch virtproxy patch for improved libvirt stability. This is set to `true` by default.

--- a/ci_framework/roles/libvirt_manager/defaults/main.yml
+++ b/ci_framework/roles/libvirt_manager/defaults/main.yml
@@ -50,3 +50,4 @@ cifmw_libvirt_manager_pool:
 cifmw_libvirt_manager_installyamls: "{{ cifmw_installyamls_repos | default('../..') }}"
 cifmw_libvirt_manager_dryrun: false
 cifmw_libvirt_manager_daemon: libvirtd.service
+cifmw_libvirt_manager_apply_virtproxy_patch: true

--- a/ci_framework/roles/libvirt_manager/tasks/virsh_checks.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/virsh_checks.yml
@@ -25,10 +25,11 @@
 # We hit a fair amount of failures with the libvirt sockets over the
 # past iteration. After many tests, it seems that removing the timeout
 # of the virtproxyd service and ensuring it's enabled and started
-# corrects this issue. With this hack, we could successfuly deploy the
+# corrects this issue. With this hack, we could successfully deploy the
 # whole VA-1 layout without any issue.
 - name: Hack in the virtproxyd service
   become: true
+  when: cifmw_libvirt_manager_apply_virtproxy_patch | bool
   block:
     - name: Create service override directory
       ansible.builtin.file:

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -364,6 +364,8 @@ vexxhost
 virsh
 virt
 virthosts
+virtproxy
+virtproxyd
 virtualized
 virtualmedia
 virtuser


### PR DESCRIPTION
As part of this patch, a new flag is being added so that users can opt out of applying the virtproxyd patch. This is introduced as in some cases a system reboot is required after applying the patch.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
