### PR TITLE
Move create network set of tasks out

### DIFF
--- a/ci_framework/roles/libvirt_manager/tasks/create_networks.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/create_networks.yml
@@ -1,0 +1,53 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Ensure networks are defined
+  community.libvirt.virt_net:
+    command: define
+    name: "cifmw-{{ item.key }}"
+    xml: "{{ item.value | replace(item.key, 'cifmw-' ~ item.key) }}"
+    uri: "qemu:///system"
+  loop: "{{ _layout.networks | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+
+- name: Ensure networks are created/started
+  community.libvirt.virt_net:
+    command: create
+    name: "cifmw-{{ item.key }}"
+    uri: "qemu:///system"
+  loop: "{{ _layout.networks | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+
+- name: Ensure networks are active
+  community.libvirt.virt_net:
+    state: active
+    name: "cifmw-{{ item.key }}"
+    uri: "qemu:///system"
+  loop: "{{ _layout.networks | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+
+- name: Ensure networks enabled to autostart
+  community.libvirt.virt_net:
+    autostart: true
+    name: "cifmw-{{ item.key }}"
+    uri: "qemu:///system"
+  loop: "{{ _layout.networks | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"

--- a/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -16,34 +16,7 @@
 - name: Manage networks if needed
   when:
     - _layout.networks is defined
-  block:
-    - name: Ensure networks are defined
-      community.libvirt.virt_net:
-        command: define
-        name: "cifmw-{{ item.key }}"
-        xml: "{{ item.value | replace(item.key, 'cifmw-' ~ item.key) }}"
-        uri: "qemu:///system"
-      loop: "{{ _layout.networks | dict2items }}"
-      loop_control:
-        label: "{{ item.key }}"
-
-    - name: Ensure networks are created/started
-      community.libvirt.virt_net:
-        command: create
-        name: "cifmw-{{ item.key }}"
-        uri: "qemu:///system"
-      loop: "{{ _layout.networks | dict2items }}"
-      loop_control:
-        label: "{{ item.key }}"
-
-    - name: Ensure networks are active
-      community.libvirt.virt_net:
-        state: active
-        name: "cifmw-{{ item.key }}"
-        uri: "qemu:///system"
-      loop: "{{ _layout.networks | dict2items }}"
-      loop_control:
-        label: "{{ item.key }}"
+  ansible.builtin.import_tasks: create_networks.yml
 
 - name: Ensure images are present
   vars:


### PR DESCRIPTION
In this PR, we are moving the tasks related to virtual network creation to it's own module. This helps in reusing the new module by other roles.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
