### PR TITLE
Revert "[tls] Add CA bundle from OpenStackCtlplane to controller"

### DIFF
--- a/ci_framework/roles/edpm_prepare/README.md
+++ b/ci_framework/roles/edpm_prepare/README.md
@@ -14,5 +14,5 @@ This role doesn't need privilege escalation.
 * `cifmw_edpm_prepare_oc_delay`: (Integer) Delay, in seconds, between failed oc call retries. Defaults to `30`.
 * `cifmw_edpm_prepare_update_os_containers`: (Boolean) Updates the openstack services containers env variable. Defaults to `false`.
 * `cifmw_edpm_prepare_timeout`: (Integer) Time, in minutes to wait for the deployment to be ready. Defaults to `30`.
-* `cifmw_edpm_prepare_verify_tls`: (Boolean) In case of TLS enabled for OpenStack endpoint, validates against the CA. Defaults to `true`.
+* `cifmw_edpm_prepare_verify_tls`: (Boolean) In case of TLS enabled for OpenStack endpoint, validates against the CA. Defaults to `false`.
 * `cifmw_edpm_prepare_skip_patch_ansible_runner`: (Boolean) Intentionally skips setting ansible runner image to `latest` from quay.io. Defaults to `False`.

--- a/ci_framework/roles/edpm_prepare/defaults/main.yml
+++ b/ci_framework/roles/edpm_prepare/defaults/main.yml
@@ -25,5 +25,5 @@ cifmw_edpm_prepare_dry_run: false
 cifmw_edpm_prepare_skip_crc_storage_creation: false
 cifmw_edpm_prepare_update_os_containers: false
 cifmw_edpm_prepare_timeout: 30
-cifmw_edpm_prepare_verify_tls: true
+cifmw_edpm_prepare_verify_tls: false
 cifmw_edpm_prepare_skip_patch_ansible_runner: false

--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -229,7 +229,11 @@
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
       ansible.builtin.command:
-        cmd: 'oc get secret combined-ca-bundle -n openstack -o "jsonpath={.data.tls-ca-bundle\.pem}" --ignore-not-found'
+        cmd: >-
+          oc get secret combined-ca-bundle
+          -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+          -o "jsonpath={.data.tls-ca-bundle\.pem}"
+          --ignore-not-found
       register: ca_bundle_data
 
     - name: Get CA bundle
@@ -251,6 +255,7 @@
         cifmw_install_ca_bundle_src: "{{ cifmw_edpm_prepare_basedir }}/tls-ca-bundle.pem"
       ansible.builtin.include_role:
         role: install_ca
+
 
 - name: Wait for keystone to be ready
   tags:

--- a/ci_framework/roles/os_net_setup/README.md
+++ b/ci_framework/roles/os_net_setup/README.md
@@ -11,4 +11,4 @@ That is provided by `openshift_login` role.
 * `cifmw_os_net_setup_config`: See an example in ci_framework/roles/os_net_setup/defaults/main.yml
 * `cifmw_os_net_setup_osp_calls_retries`: (Integer) Number of attempts to retry an OSP action if it fails. Defaults to `10`.
 * `cifmw_os_net_setup_osp_calls_delay`: (Integer) Delay, in seconds, between failed OSP call retries. Defaults to `5`.
-* `cifmw_os_net_setup_verify_tls`: (Boolean) In case of TLS enabled for OpenStack endpoint, validates against the CA. Defaults to `true`.
+* `cifmw_os_net_setup_verify_tls`: (Boolean) In case of TLS enabled for OpenStack endpoint, validates against the CA. Defaults to `false`.

--- a/ci_framework/roles/os_net_setup/defaults/main.yml
+++ b/ci_framework/roles/os_net_setup/defaults/main.yml
@@ -15,4 +15,4 @@ cifmw_os_net_setup_config:
         allocation_pool_end: 192.168.122.240
         gateway_ip: 192.168.122.1
         enable_dhcp: false
-cifmw_os_net_setup_verify_tls: true
+cifmw_os_net_setup_verify_tls: false

--- a/ci_framework/roles/tempest/vars/main.yml
+++ b/ci_framework/roles/tempest/vars/main.yml
@@ -1,3 +1,5 @@
 cifmw_tempest_tempestconf_profile_default:
   overrides:
     identity.v3_endpoint_type: public
+    identity.disable_ssl_certificate_validation: true
+    dashboard.disable_ssl_certificate_validation: true


### PR DESCRIPTION
This is a *partial* revert of https://github.com/openstack-k8s-operators/ci-framework/commit/00e8d245d522fdf906b593a7d912e19e438542a9.

We've seen constant failures in a CI job, linked to certificate
validation:
https://review.rdoproject.org/zuul/builds?job_name=podified-multinode-edpm-e2e-nobuild-tagged-crc&project=openstack-k8s-operators/ci-framework

An example:
FAILED - RETRYING: [localhost]: Wait for keystone endpoint to exist in DNS (1 retries left).
fatal: [localhost]: FAILED! => {"attempts": 20, "changed": false, "elapsed": 0, "msg": "Status code was -1 and not [200, 300, 301, 302, 401, 402, 403]: Request failed: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:1129)>", "redirected": false, "status": -1, "url": "https://keystone-public-openstack.apps-crc.testing/"}

Reverting the CA verification toggle patch seems the safest way to get
back to a green CI.
It's still supposed to fetch and install the CA at this point.

We're seeing tempest failures when we do a complete reverse.

Note: the new failure may be related to a recent patch:
https://github.com/openstack-k8s-operators/openstack-operator/pull/502


As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
