### PR TITLE
Remove nobuild-tagged from PR runs

### DIFF
--- a/ci/templates/projects.yaml
+++ b/ci/templates/projects.yaml
@@ -15,5 +15,4 @@
         - cifmw-multinode-kuttl
         - cifmw-edpm-build-images
         - cifmw-content-provider-build-images
-        - podified-multinode-edpm-e2e-nobuild-tagged-crc
 # Start generated content

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -211,27 +211,6 @@
       - ci/playbooks/edpm/run.yml
 
 - job:
-    name: podified-multinode-edpm-e2e-nobuild-tagged-crc
-    parent: cifmw-podified-multinode-edpm-base-crc
-    vars:
-      cifmw_extras:
-        - '@scenarios/centos-9/ci.yml'
-        - '@scenarios/centos-9/multinode-ci.yml'
-    run:
-      - ci/playbooks/e2e-run.yml
-    irrelevant-files:
-      - ^ci_framework/roles/.*_build
-      - ^ci_framework/roles/build.*
-      - ^ci_framework/roles/local_env_vm
-      - ^ci_framework/roles/dlrn_report
-      - ^ci_framework/roles/dlrn_promote
-      - ^ci/templates
-      - ^docs
-      - ^.*/*.md
-      - ^OWNERS
-      - ^.github
-
-- job:
     name: podified-multinode-hci-deployment-crc
     parent: podified-multinode-hci-deployment-crc-3comp
     files:

--- a/zuul.d/edpm_periodic.yaml
+++ b/zuul.d/edpm_periodic.yaml
@@ -37,6 +37,16 @@
       registry_login_enabled: true
       cifmw_dlrn_report_result: true
 
+- job:
+    name: podified-multinode-edpm-e2e-nobuild-tagged-crc
+    parent: cifmw-podified-multinode-edpm-base-crc
+    vars:
+      cifmw_extras:
+        - '@scenarios/centos-9/ci.yml'
+        - '@scenarios/centos-9/multinode-ci.yml'
+    run:
+      - ci/playbooks/e2e-run.yml
+
 # Antelope jobs
 - job:
     name: periodic-podified-edpm-deployment-antelope-ocp-crc-1cs9

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -8,7 +8,6 @@
       - cifmw-multinode-kuttl
       - cifmw-edpm-build-images
       - cifmw-content-provider-build-images
-      - podified-multinode-edpm-e2e-nobuild-tagged-crc
       - cifmw-molecule-artifacts
       - cifmw-molecule-build_containers
       - cifmw-molecule-build_openstack_packages


### PR DESCRIPTION
This job is consuming "what's available" in the registry and may fail
due to a missing image bump.

Let's move it to periodic, and avoid random issues.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
