### PR TITLE
Allow ci_kustomize to filter discovered content by using regexes

### DIFF
--- a/ci_framework/tests/integration/targets/kustomize/tasks/run_test_case.yml
+++ b/ci_framework/tests/integration/targets/kustomize/tasks/run_test_case.yml
@@ -157,6 +157,8 @@
     kustomization_files_goes_first: "{{ kustomize_tc_kustomization_files_goes_first | default(omit) }}"
     preserve_workspace: "{{ kustomize_tc_preserve_workspace | default(omit) }}"
     sort_ascending: "{{ kustomize_tc_sort_ascending | default(omit) }}"
+    skip_regexes: "{{ kustomize_tc_skip_regexes | default(omit) }}"
+    include_regexes: "{{ kustomize_tc_include_regexes | default(omit) }}"
   register: _ci_kustomize_last_output
   ignore_errors: true
   loop: "{{ range(1, (3 if kustomize_tc_idempotence | default(false) else 2)) | list }}"

--- a/ci_framework/tests/integration/targets/kustomize/tasks/run_test_case_validate_success.yml
+++ b/ci_framework/tests/integration/targets/kustomize/tasks/run_test_case_validate_success.yml
@@ -31,21 +31,52 @@
       {% endfor -%}
       {{ expected }}
 
-- name: "[{{ kustomize_tc_name }}] Assert that the expected number of kustomization has been applied" # noqa: name[template]
-  when: "kustomize_tc_should_apply_kustomizations_count is defined"
+- name: "[{{ kustomize_tc_name }}] Assert that the expected number of resources has been outputed" # noqa: name[template]
+  when: "kustomize_tc_should_output_count is defined"
   ansible.builtin.assert:
-    that: "output['count'] == (kustomize_tc_should_apply_kustomizations_count | int)"
+    that: "output['result'] | length == (kustomize_tc_should_output_count | int)"
     quiet: true
 
-- name: "[{{ kustomize_tc_name }}] Assert that the expected kustomization files have been discovered" # noqa: name[template]
+- name: "[{{ kustomize_tc_name }}] Set the expected kustomization files" # noqa: name[template]
   vars:
-    kustomizations_paths: >-
+    _kustomizations_all_paths: >-
       {{
         (_ci_kustomize_extra_kustomizations.keys() | list) +
         (_ci_kustomize_kustomizations.keys() | list)
       }}
+  ansible.builtin.set_fact:
+    _ci_kustomize_expected_kustomization_files: >-
+      {% set included_paths = [] if kustomize_tc_include_regexes is defined else _kustomizations_all_paths -%}
+      {% for include_regex in kustomize_tc_include_regexes | default([]) -%}
+      {%   for kustomization_path in _kustomizations_all_paths -%}
+      {%     if (kustomization_path | regex_search(include_regex)) -%}
+      {%       set _ = included_paths.append(kustomization_path) -%}
+      {%     endif -%}
+      {%   endfor -%}
+      {% endfor -%}
+      {% set expected_paths = included_paths | list | unique -%}
+      {% for kustomization_path in included_paths -%}
+      {%   set should_skip = false -%}
+      {%   for skip_regex in kustomize_tc_skip_regexes | default([]) -%}
+      {%     if (kustomization_path | regex_search(skip_regex)) -%}
+      {%       set _ = expected_paths.remove(kustomization_path) -%}
+      {%     endif -%}
+      {%   endfor -%}
+      {% endfor -%}
+      {{ expected_paths }}
+    cacheable: true
+
+- name: "[{{ kustomize_tc_name }}] Assert that the expected number of kustomization has been applied" # noqa: name[template]
+  when: "kustomize_tc_should_apply_kustomizations_count is defined"
   ansible.builtin.assert:
-    that: "(output['kustomizations_paths'] | sort) == (kustomizations_paths | sort)" # noqa: name[template]
+    that:
+      - "output['count'] == (kustomize_tc_should_apply_kustomizations_count | int)"
+      - " output['count'] >= (_ci_kustomize_expected_kustomization_files | length)"
+    quiet: true
+
+- name: "[{{ kustomize_tc_name }}] Assert that the expected kustomization files have been discovered" # noqa: name[template]
+  ansible.builtin.assert:
+    that: "(output['kustomizations_paths'] | sort) == (_ci_kustomize_expected_kustomization_files | sort)" # noqa: name[template]
     quiet: true
 
 - name: "[{{ kustomize_tc_name }}] Assert the output points to an output path" # noqa: name[template]

--- a/ci_framework/tests/integration/targets/kustomize/tasks/scenarios/ci_kustomize_file_input_scenario.yml
+++ b/ci_framework/tests/integration/targets/kustomize/tasks/scenarios/ci_kustomize_file_input_scenario.yml
@@ -190,3 +190,78 @@
       -
         - "b-sorting-kustomization.yml"
   ansible.builtin.include_tasks: run_test_case.yml
+
+- name: Apply the files based kustomizations to a filtered set of resources (skip regex)
+  vars:
+    kustomize_tc_idempotence: true
+    # Define the kustomization parameters
+    kustomize_tc_extra_path: "{{ ci_kustomize_oc_bin_path }}"
+    kustomize_tc_name: "tc-success-files-dir-target-extras-skip-regex-kustomization"
+    kustomize_tc_target_dir_paths:
+      - "testing-deployment.yaml"
+      - "testing-cm.yml"
+    kustomize_tc_skip_regexes:
+      - "cm-kustomization-(.).yml$"
+      - "testing-cm.yml$"
+      - "kustomization.yaml$"
+    # Define assertions
+    kustomize_tc_should_fail: false
+    kustomize_tc_should_change: true
+    kustomize_tc_should_have_labels:
+      - apiVersion: apps/v1
+        kind: Deployment
+        name: testing-deployment
+        labels:
+          cifmw-label-2: "cifmw-label-2-value"
+          cifmw-label-4: "cifmw-label-4-value"
+          cifmw-label-5: "cifmw-label-5-value"
+    kustomize_tc_should_apply_kustomizations_count: 3
+    kustomize_tc_should_output_count: 1
+    # Define kustomization that needs to be copied to the TC temporal folder:
+    kustomize_tc_copy_kustomization_files:
+      - "kustomization.yml"
+      - "kustomization.yaml"
+      - "cm-kustomization-1.yml"
+    kustomize_tc_copy_kustomization_paths:
+      # Non-list of list paths points ci_kustomize directly to a kustomization,
+      # otherwise, the path to the dir containing the kustomizations is passed
+      - "cm-kustomization-2.yml"
+      -
+        - "multiple-kustomizations-in-one-file.yml"
+  ansible.builtin.include_tasks: run_test_case.yml
+
+- name: Apply the files based kustomizations to a filtered set of resources (include regex)
+  vars:
+    kustomize_tc_idempotence: true
+    # Define the kustomization parameters
+    kustomize_tc_extra_path: "{{ ci_kustomize_oc_bin_path }}"
+    kustomize_tc_name: "tc-success-files-dir-target-extras-inc-regex-kustomization"
+    kustomize_tc_target_dir_paths:
+      - "testing-deployment.yaml"
+      - "testing-cm.yml"
+    kustomize_tc_include_regexes:
+      - "cm-kustomization-1.yml$"
+      - "testing-cm.yml$"
+    # Define assertions
+    kustomize_tc_should_fail: false
+    kustomize_tc_should_change: true
+    kustomize_tc_should_have_labels:
+      - apiVersion: v1
+        kind: ConfigMap
+        name: testing-cm
+        labels:
+          cifmw-label-1: "cifmw-label-1-value"
+    kustomize_tc_should_apply_kustomizations_count: 1
+    kustomize_tc_should_output_count: 1
+    # Define kustomization that needs to be copied to the TC temporal folder:
+    kustomize_tc_copy_kustomization_files:
+      - "kustomization.yml"
+      - "kustomization.yaml"
+      - "cm-kustomization-1.yml"
+    kustomize_tc_copy_kustomization_paths:
+      # Non-list of list paths points ci_kustomize directly to a kustomization,
+      # otherwise, the path to the dir containing the kustomizations is passed
+      - "cm-kustomization-2.yml"
+      -
+        - "multiple-kustomizations-in-one-file.yml"
+  ansible.builtin.include_tasks: run_test_case.yml


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] Content of the docs/source is reflecting the changes