### PR TITLE
Correctly set OS container image override

### DIFF
--- a/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -31,7 +31,7 @@
 - name: Set facts for baremetal UEFI image url
   ansible.builtin.set_fact:
     cifmw_set_openstack_containers_overrides:
-      OS_CONTAINER_IMAGE_URL_DEFAULT: "{{ cifmw_build_images_output['images']['edpm-hardened-uefi']['image'] }}"
+      RELATED_IMAGE_OS_CONTAINER_IMAGE_URL_DEFAULT: "{{ cifmw_build_images_output['images']['edpm-hardened-uefi']['image'] }}"
     cacheable: true
   when: cifmw_build_images_output is defined
 


### PR DESCRIPTION
The name of this env variable was changed[1] so needs to be updated here so that built images are actually tested in the job.

[1] https://github.com/openstack-k8s-operators/openstack-baremetal-operator/commit/e51b9770ce5cbc6084b35dec7174be2a4e24cea0

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
