### PR TITLE
Add some tags in the devscripts role

### DIFF
--- a/ci_framework/roles/devscripts/README.md
+++ b/ci_framework/roles/devscripts/README.md
@@ -9,6 +9,14 @@ libvirt/kvm virtual machines.
 Yes, requires privilege escalation to install dependant packages on the system. Along with performing
 network configuration, repository setup and libvirt networks.
 
+## Exposed tags
+
+* `devscripts_prepare`: Selects tasks related to "preparing the host" and building the various
+needed files.
+* `devscripts_deploy`: Overlaps with the previous tag, and adds the actual deployment of devscripts
+managed services.
+* `devscripts_post`: Only runs the post-installation tasks.
+
 ## Parameters
 
 * `cifmw_devscripts_artifacts_dir` (str) path to the directory to store the role artifacts.

--- a/ci_framework/roles/devscripts/tasks/main.yml
+++ b/ci_framework/roles/devscripts/tasks/main.yml
@@ -16,6 +16,8 @@
 
 
 - name: Gather the configurations to be passed to dev-scripts.
+  tags:
+    - always
   ansible.builtin.set_fact:
     cifmw_devscripts_config: >-
       {{
@@ -25,6 +27,8 @@
     cacheable: true
 
 - name: Ensure the required folders are present.
+  tags:
+    - always
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
@@ -35,14 +39,24 @@
     - "{{ cifmw_devscripts_output_dir }}"
 
 - name: Prepare the host for execution of dev-scripts.
+  tags:
+    - devscripts_prepare
+    - devscripts_deploy
   ansible.builtin.import_tasks: 01_prepare_host.yml
 
 - name: Gather the host and dev-scripts required information.
+  tags:
+    - devscripts_prepare
+    - devscripts_deploy
   ansible.builtin.import_tasks: 02_gather_env_details.yml
 
 - name: Running dev-scripts.
+  tags:
+    - devscripts_deploy
   ansible.builtin.import_tasks: 03_install.yml
 
 - name: Executing dev-scripts post-install tasks.
+  tags:
+    - devscripts_post
   when: not cifmw_devscripts_dry_run | bool
   ansible.builtin.import_tasks: 04_post.yml


### PR DESCRIPTION
This should allow people to re-start a failed run without needing to
re-run the whole role.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
   [X] README in the role
