### PR TITLE
Remove Devscript repo dir only if it exists

### DIFF
--- a/ci_framework/roles/devscripts/tasks/cleanup.yml
+++ b/ci_framework/roles/devscripts/tasks/cleanup.yml
@@ -23,8 +23,15 @@
       }}
     cacheable: true
 
+- name: Check for Devscripts repo directory
+  ansible.builtin.stat:
+    path: "{{ cifmw_devscripts_repo_dir }}"
+  register: devscript_repodir
+
 - name: Remove the deployed OpenShift platform.
-  when: not cifmw_devscripts_dry_run | bool
+  when:
+    - not cifmw_devscripts_dry_run | bool
+    - devscript_repodir.stat.exists
   community.general.make:
     chdir: "{{ cifmw_devscripts_repo_dir }}"
     target: clean


### PR DESCRIPTION
It will help to avoid these errors:
```
No rule to make target 'clean'.
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
