### PR TITLE
Correct Layout reproducer

### DIFF
--- a/ci_framework/roles/reproducer/tasks/main.yml
+++ b/ci_framework/roles/reproducer/tasks/main.yml
@@ -36,6 +36,35 @@
     - cifmw_job_uri is defined
   ansible.builtin.import_tasks: ci_data.yml
 
+- name: Deploy CRC if needed
+  when:
+    - cifmw_libvirt_manager_configuration.vms.crc is defined
+  block:
+    - name: Check for CRC availability in known path
+      register: _crc_available
+      vars:
+        _img: >-
+          {{
+            (cifmw_libvirt_manager_configuration.vms.crc.image_local_dir,
+             cifmw_libvirt_manager_configuration.vms.crc.disk_file_name) |
+             path_join
+          }}
+      ansible.builtin.stat:
+        path: "{{ _img }}"
+
+    - name: Prepare CRC for later usage
+      when:
+        - not _crc_available.stat.exists
+      block:
+        - name: Deploy CRC
+          ansible.builtin.import_role:
+            name: rhol_crc
+
+        - name: Ensure CRC is stopped
+          ansible.builtin.import_role:
+            name: rhol_crc
+            tasks_from: undefine.yml
+
 - name: Deploy layout on target host
   tags:
     - bootstrap
@@ -93,7 +122,9 @@
         path: "/var/srv/dnsmasq.conf"
         block: |-
           {% if cifmw_reproducer_dns_servers %}
-          {% for dns_server in cifmw_reproducer_dns_servers %}server={{ dns_server }}{% endfor %}
+          {%   for dns_server in cifmw_reproducer_dns_servers %}
+          server={{ dns_server }}
+          {%   endfor %}
           {% endif %}
 
     - name: Configure local DNS for CRC pod

--- a/ci_framework/roles/rhol_crc/tasks/binary.yml
+++ b/ci_framework/roles/rhol_crc/tasks/binary.yml
@@ -35,7 +35,7 @@
   ansible.builtin.unarchive:
     src: "{{ rhol_crc_download_tmp_directory.path }}/{{ cifmw_rhol_crc_tarball_name }}"
     dest: "{{ cifmw_rhol_crc_binary_folder }}"
-    remote_src: false
+    remote_src: true
     extra_opts:
       - --strip=1
       - --no-anchored

--- a/ci_framework/roles/rhol_crc/tasks/undefine.yml
+++ b/ci_framework/roles/rhol_crc/tasks/undefine.yml
@@ -1,0 +1,34 @@
+---
+# These tasks will ensure CRC is stopped, undefined, and nothing
+# like danging network are around.
+# This is mostly used in the reproducer case.
+
+- name: Stop CRC VM
+  failed_when: false
+  community.libvirt.virt:
+    command: destroy
+    name: crc
+
+- name: Undefine CRC VM
+  failed_when: false
+  community.libvirt.virt:
+    command: undefine
+    name: crc
+
+- name: Destroy CRC network
+  failed_when: false
+  community.libvirt.virt_net:
+    command: destroy
+    name: crc
+
+- name: Undefine CRC network
+  failed_when: false
+  community.libvirt.virt_net:
+    command: undefine
+    name: crc
+
+- name: Destroy default network
+  failed_when: false
+  community.libvirt.virt_net:
+    command: destroy
+    name: default

--- a/docs/source/reproducers/01-considerations.md
+++ b/docs/source/reproducers/01-considerations.md
@@ -10,32 +10,9 @@ configuration, but it **wasn't tested** (yet).
 
 ## Prerequisites
 ### CRC
-The CRC VM has to be properly set up prior to running the reproducer play. You
-may get to that leveraging either the rhol_crc role from the CI Framework, or
-manually by calling `crc setup && crc start -p pull-secret`.
-
-Note: make sure to create the CRC with proper disk size, e.g. 100G, it won't
-be resized during reproducer create.
-
-Once the CRC VM is properly started, you can then stop it and undefine it as
-follows:
-```Bash
-$ virsh -c qemu:///system destroy crc
-$ virsh -c qemu:///system undefine crc
-```
-
-Since most of the ranges are hard-coded for now, please ensure no network is
-pre-existing:
-```Bash
-$ virsh -c qemu:///system net-list --all
-$ virsh -c qemu:///system net-destroy <NETWORK>
-$ virsh -c qemu:///system net-undefine <NETWORK>
-```
-
-You then have to ensure you have the following content on the target hypervisor:
-- ~/.crc/machine/crc/crc.qcow2
-- ~/.crc/machine/crc/id_*
-- ~/.crc/machine/crc/kubeconfig
+For now, you have to ensure your `pull-secret` is present on the target host (in the case
+of a remote deployment). A proper way to copy and manage it is in the pipe, but for now,
+this is your responsibility to get it on the remote node.
 
 ### Ssh authorized_keys
 On the target hypervisor, you have to ensure the ~/.ssh/authorized_keys has all

--- a/scenarios/reproducers/3-nodes.yml
+++ b/scenarios/reproducers/3-nodes.yml
@@ -7,6 +7,33 @@ cifmw_install_yamls_repo: "~/src/github.com/openstack-k8s-operators/install_yaml
 cifmw_basedir: "{{ ansible_user_dir }}/ci-framework-data"
 cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
 
+cifmw_rhol_crc_config:
+  pull-secret-file: "{{ ansible_user_dir }}/pull-secret"
+  disk-size: 100
+  memory: 24000
+
+# Since we don't have zuul data, we have to provide some
+# networking information to the libvirt_manager so that it will be able to
+# generate the needed content for later usage
+cifmw_libvirt_manager_networks:
+  osp_trunk:
+    default: true
+    range: "192.168.122.0/24"
+    mtu: 1500
+    static_ip: true
+  internal-api:
+    range: "172.17.0.0/24"
+    vlan: 20
+  storage:
+    range: "172.18.0.0/24"
+    vlan: 21
+  tenant:
+    range: "172.19.0.0/24"
+    vlan: 22
+  storage-mgmt:
+    range: "172.20.0.0/24"
+    vlan: 23
+
 cifmw_libvirt_manager_configuration:
   vms:
     compute:


### PR DESCRIPTION
When the CI Job reproducer was introduced, we missed the need of a new
parameter in order to inject the actual network layout we're consuming
in a non-CI job case.

This patch also allows to bootstrap CRC directly during the reproducer
run, provided we define it in the layout (it's usually the case).

As a follow-up, we may want to properly manage pull-secret copy from the
host running the playbook onto the hypervisor, in case those are two
distinct nodes. Since this is a feature shared with devscripts, we may
want to get a common role for that.

We also update the doc to reflect this change, since we don't need to
have a CRC pre-provisionned anymore. You still may have it ready, but
it's not mandatory anymore.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] Content of the docs/source is reflecting the changes
