### PR TITLE
Add option to kustomize within target path

### DIFF
--- a/ci_framework/plugins/action/ci_kustomize.py
+++ b/ci_framework/plugins/action/ci_kustomize.py
@@ -367,9 +367,13 @@ class CifmwKustomizeWrapper:
         self.__target_workspace_file = self.__workspace_dir.joinpath(
             self.__CI_KUSTOMIZE_DEFAULT_RESULT_FILE_NAME
         )
-        self.__kustomization_scan_paths = [target_base_path] + [
+        self.__kustomization_scan_paths = [
             pathlib.Path(path) for path in (kustomizations_paths or [])
         ]
+        self.__run_kustomize_in_target_directory_first = run_kustomize_in_target_directory_first
+        if not self.__run_kustomize_in_target_directory_first:
+            self.__kustomization_scan_paths.insert(0, target_base_path)
+
         self.__kustomization_files_goes_first = kustomization_files_goes_first
         self.__preserve_workspace = preserve_workspace
         self.__sort_ascending = sort_ascending


### PR DESCRIPTION
Add the option to execute the initial kustomize within the target path. This allows end users the option to leverage the overlay workflow when using kustomize. Using the below directory structure below as an example, end users can have multiple sub-directories that can inherit from a base and apply CRD kustomizations specific to their job needs.

```
|-- base
    OpenStackControlPlane.yaml
    glance.yaml
    keystone.yaml
    infra.yaml
    kustomization.yaml
|-- ci
    storage.yaml
    kustomization.yaml
```

If ci/kustomization.yaml had the following:

```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
namespace: openstack
patches:
- path: storage.yaml
resources:
- ../base
```


The generated CRD will inherit from base while also overwriting the storage provided by _base_ with the definition in the _ci_ (storage.yaml). An example of this directory structure can be found in the nova-operator repo. [1]

In order to accurately map out all the relative paths and inherit from the proper base, kustomize needs to be applied to the appropriate path. This update adds a parameter that will execute kustomize in the target path first and all subsequent kustomize calls will be applied to the result in the workspace. If the parameter is left as False the original default kustomization actions are done.

[1] https://github.com/openstack-k8s-operators/nova-operator/tree/main/ci/nova-operator-compute-kit/topology/ci

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
