### PR TITLE
Fix dataplane repo-setup injection to not overwrite bootstrap

### DIFF
--- a/ci_framework/roles/deploy_va_tmp/tasks/deploy-dataplane.yml
+++ b/ci_framework/roles/deploy_va_tmp/tasks/deploy-dataplane.yml
@@ -89,7 +89,7 @@
             path: /metadata/name
             value: deployment-pre-ceph
       {% if _custom_repo_setup_name != '' %}
-          - op: replace
+          - op: add
             path: /spec/servicesOverride/0
             value: "{{ _custom_repo_setup_name }}"
       {% endif %}


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
