### PR TITLE
[ci_script] Create logs directory if missing

### DIFF
--- a/ci_framework/plugins/action/ci_script.py
+++ b/ci_framework/plugins/action/ci_script.py
@@ -145,7 +145,7 @@ class ActionModule(ActionBase):
 
         logs_dir = output_dir.parent.joinpath("logs")
         if not logs_dir.is_dir():
-            raise AnsibleActionFail(f"logs dir, {logs_dir} doesn't exist")
+            logs_dir.mkdir()
 
         # Remove cmd if not passed, we are going to use _raw_params
         # to pass the cmd we create here


### PR DESCRIPTION
Since the directory is relative to the output_dir
which is ensured to exist, should be fine to create the logs directory.

Faced issue with missing logs directory while running Token fetch task during the tempest run.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
