### PR TITLE
Ignore operator related images

### DIFF
--- a/ci_framework/roles/set_openstack_containers/templates/update_env_vars.sh.j2
+++ b/ci_framework/roles/set_openstack_containers/templates/update_env_vars.sh.j2
@@ -19,7 +19,7 @@ export PATH="{{ cifmw_path }}"
 {%     endif -%}
 {#   All the openstack services containers contain /openstack- prefix #}
 {#   It filters out the same and update the container address with new url #}
-{%   elif cifmw_set_openstack_containers_prefix in _container -%}
+{%   elif (cifmw_set_openstack_containers_prefix in _container) and ('operator' not in _container) -%}
 {%     set _container_data = _container.split(cifmw_set_openstack_containers_prefix)[-1] -%}
 {%     set _container_name = _container_data.split('@sha256')[0] -%}
 {%     set _container_address = _container_registry + '/' + cifmw_set_openstack_containers_prefix + _container_name + ':' + cifmw_set_openstack_containers_tag -%}


### PR DESCRIPTION
Currently set_openstack_containers role filter the openstack services images based on openstack or downstream_prefix name.

But openstack-baremetal-operator-agent is not a openstack service image. It needs to be ignored by set_openstack_containers role.

In order to do that, we are adding another conditional check to skip operator image.

It will fix the job.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
