### PR TITLE
Support custom XML and multiple base image for overlays

### DIFF
--- a/ci_framework/roles/libvirt_manager/tasks/attach_interface.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/attach_interface.yml
@@ -22,7 +22,7 @@
 #     mtu           MTU applied on the interface.
 #     static_ip     boolean if static address is required.
 
-- name: Check ports attached to the domain
+- name: "Check ports attached to the domain {{ vm_name }}"
   block:
     - name: Dump domain xml
       register: _domain_xml
@@ -48,17 +48,19 @@
   when:
     - _attached_nets | length == 0
   block:
-    - name: Generate a random MAC address
+    - name: "Generate a random MAC address for {{ vm_name }}"
       ansible.builtin.set_fact:
         _lm_mac_address: "{{ '0A:02' | community.general.random_mac }}"
 
-    - name: Reserve an IP address
+    - name: "Reserve an IP address for {{ vm_name }}"
       when: network.static_ip | bool
       vars:
         mac_address: "{{ _lm_mac_address }}"
       ansible.builtin.import_tasks: reserve_ip.yml
 
-    - name: Attach interface to the virtual machine.
+    - name: "Attach interface {{ network.name }} on {{ vm_name }}"  # noqa: name[template]
+      when:
+        - _lm_mac_address is defined
       vars:
         _net_name: >
           {{
@@ -69,7 +71,7 @@
         cmd: >-
           virsh -c qemu:///system
           attach-interface "{{ vm_name }}"
-          --source "{{ _net_name }}"
+          --source "cifmw-{{ _net_name }}"
           --type bridge
           --mac "{{ _lm_mac_address }}"
           --model virtio

--- a/ci_framework/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/clean_layout.yml
@@ -27,6 +27,8 @@
 - name: Undefine machine
   community.libvirt.virt:
     command: undefine
+    flags:
+      - keep_nvram
     name: "{{ item }}"
     uri: "qemu:///system"
   loop: "{{ cleanup_vms }}"
@@ -82,3 +84,11 @@
         user: "{{ ansible_user_id }}"
         key: "{{ _pub_key['content'] | b64decode }}"
         state: absent
+
+- name: Remove data directories
+  ansible.builtin.file:
+    path: "{{ cifmw_libvirt_manager_basedir }}/{{ item }}"
+    state: absent
+  loop:
+    - workload
+    - images

--- a/ci_framework/roles/libvirt_manager/tasks/create_vms.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/create_vms.yml
@@ -1,11 +1,26 @@
 ---
 - name: "Create VM overlays for {{ vm_type }}"
+  become: true
+  vars:
+    _base_img_name: >-
+      {{
+        (vm_data.value.image_local_dir,
+         vm_data.value.disk_file_name) |
+         path_join
+      }}
+    _img: >-
+      {{
+        (vm_type is match('.*ocp.*')) |
+        ternary(_base_img_name ~ "_" ~ vm_id ~ ".qcow2",
+                _base_img_name)
+      }}
   ansible.builtin.command:
     cmd: >-
       qemu-img create
-      -o backing_file={{ vm_data.value.image_local_dir }}/{{ vm_data.value.disk_file_name }},backing_fmt=qcow2
+      -o backing_file={{ _img }},backing_fmt=qcow2
       -f qcow2
-      "{{ vm_type }}-{{ vm_id }}.qcow2" "{{ vm_data.value.disksize|default ('40') }}G"
+      "{{ vm_type }}-{{ vm_id }}.qcow2"
+      "{{ vm_data.value.disksize|default ('40') }}G"
     creates: "{{ vm_type }}-{{ vm_id }}.qcow2"
     chdir: "{{ cifmw_reproducer_basedir }}/workload"
   loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
@@ -13,7 +28,61 @@
     index_var: vm_id
     label: "{{ vm_type }}-{{ vm_id }}"
 
-- name: "Define VMs for type {{ vm_type }}"
+- name: Manipulate XMLs and load them if provided
+  when:
+    vm_data.value.xml_paths is defined
+  block:
+    - name: "Set disk path for {{ vm_type }}"
+      community.general.xml:
+        path: "{{ _xml }}"
+        xpath: "/domain/devices/disk/source"
+        attribute: "file"
+        value: >-
+          {{ (cifmw_reproducer_basedir,
+              'workload',
+              vm_type ~ '-' ~ _xml_id ~ '.qcow2') |
+              path_join
+          }}
+      loop: "{{ vm_data.value.xml_paths }}"
+      loop_control:
+        loop_var: "_xml"
+        index_var: "_xml_id"
+        label: "{{ vm_type }}-{{ _xml_id }}"
+
+    - name: "Remove document description header for type ${{ vm_type }}"
+      ansible.builtin.replace:
+        path: "{{ _xml }}"
+        regexp: "<\\?xml version='1.0' encoding='UTF-8'\\?>\n"
+        replace: ""
+      loop: "{{ vm_data.value.xml_paths }}"
+      loop_control:
+        loop_var: "_xml"
+        index_var: "_xml_id"
+        label: "{{ vm_type }}-{{ _xml_id }}"
+    - name: "Load VM XMLs for type {{ vm_type }}"
+      register: _vm_xmls
+      ansible.builtin.slurp:
+        path: "{{ item }}"
+      loop: "{{ vm_data.value.xml_paths }}"
+      loop_control:
+        index_var: "_xml_id"
+        label: "{{ vm_type }}-{{ _xml_id }}"
+
+    - name: "Define VMs with custom XML for type {{ vm_type }}"
+      community.libvirt.virt:
+        command: define
+        xml: "{{ _xml['content'] | b64decode }}"
+        uri: "qemu:///system"
+      loop: "{{ _vm_xmls.results }}"
+      loop_control:
+        index_var: vm_id
+        label: "{{ vm_type }}-{{ vm_id }}"
+        loop_var: '_xml'
+
+
+- name: "Define VMs with default template for type {{ vm_type }}"
+  when:
+    - vm_data.value.xml_paths is undefined
   community.libvirt.virt:
     command: define
     xml: "{{ lookup('template', 'domain.xml.j2') }}"
@@ -38,7 +107,9 @@
   vars:
     _fixed_net_name: >-
       {{
-        _fixed_ip_nets | dict2items | map(attribute='key')
+        _fixed_ip_nets | dict2items |
+        map(attribute='key') |
+        map('regex_replace', '^', 'cifmw-')
       }}
     _vals: >-
       {{
@@ -60,6 +131,13 @@
         (macs | default([]) + _macs) |
         selectattr('network', 'in', _fixed_net_name)
       }}
+    ocpbm_nics: >-
+      {{
+        (ocpbm_nics | default([]) + _macs) |
+        selectattr('network', 'equalto', 'ocpbm') |
+        selectattr('host', 'match', '.*' ~ vm_type ~ '.*')
+      }}
+
   loop: "{{ _vm_ports.results }}"
   loop_control:
     index_var: index
@@ -67,9 +145,10 @@
 - name: Fix IPs for selected networks and VMs
   vars:
     vm_name: "cifmw-{{ mac_node.host }}"
+    net_name: "{{ mac_node.network | replace('cifmw-', '') }}"
     network:
-      cidr: "{{ _fixed_ip_nets[mac_node.network]['range'] }}"
-      name: "{{ mac_node.network }}"
+      cidr: "{{ _fixed_ip_nets[net_name]['range'] }}"
+      name: "{{ net_name }}"
     mac_address: "{{ mac_node.mac }}"
   ansible.builtin.include_tasks: reserve_ip.yml
   loop: "{{ macs }}"
@@ -92,11 +171,12 @@
   ansible.builtin.shell:
     cmd: >-
       virsh -c qemu:///system -q
-      domifaddr cifmw-{{ vm_type }}-{{ vm_id }} | head -1
-  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
+      domifaddr --source arp
+      cifmw-{{ nic.host }} | grep "{{ nic.mac }}"
+  loop: "{{ ocpbm_nics }}"
   loop_control:
-    index_var: vm_id
-    label: "{{ vm_type }}-{{ vm_id }}"
+    index_var: nic
+    label: "{{ nic.host }}"
   retries: 20
   delay: 5
   until:
@@ -112,9 +192,9 @@
   ansible.builtin.blockinfile:
     create: true
     path: "~/.ssh/config"
-    marker: "## {mark} {{ vm_type }}-{{ vm_ip.item }}"
+    marker: "## {mark} {{ vm_ip.nic.host }}"
     block: |-
-      Host {{ vm_type }}-{{ vm_ip.item }} cifmw-{{ vm_type }}-{{ vm_ip.item }} {{ extracted_ip }}
+      Host {{ vm_ip.nic.host }} cifmw-{{ vm_ip.nic.host }} {{ extracted_ip }}
         ProxyJump {{ ansible_user | default(lookup('env', 'USER')) }}@{{ inventory_hostname }}
         Hostname {{ extracted_ip }}
         User zuul
@@ -123,7 +203,7 @@
   loop: "{{ vm_ips.results }}"
   loop_control:
     loop_var: vm_ip
-    label: "{{ vm_ip.item }}"
+    label: "{{ vm_ip.nic.host }}"
 
 - name: "({{ inventory_hostname }}) Inject ssh jumpers for {{ vm_type }}"  # noqa: name[template]
   vars:
@@ -131,9 +211,9 @@
   ansible.builtin.blockinfile:
     create: true
     path: "~/.ssh/config"
-    marker: "## {mark} {{ vm_type }}-{{ vm_ip.item }}"
+    marker: "## {mark} {{ vm_ip.nic.host }}"
     block: |-
-      Host {{ vm_type }}-{{ vm_ip.item }} cifmw-{{ vm_type }}-{{ vm_ip.item }} {{ extracted_ip }}
+      Host {{ vm_ip.nic.host }} cifmw-{{ vm_ip.nic.host }} {{ extracted_ip }}
         Hostname {{ extracted_ip }}
         User zuul
         IdentityFile ~/.ssh/cifmw_reproducer_key
@@ -142,20 +222,20 @@
   loop: "{{ vm_ips.results }}"
   loop_control:
     loop_var: vm_ip
-    label: "{{ vm_ip.item }}"
+    label: "{{ vm_ip.nic.host }}"
 
 - name: Inject nodes in the ansible inventory
   delegate_to: localhost
   vars:
     extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
   ansible.builtin.add_host:
-    name: "{{ vm_type }}-{{ vm_ip.item }}"
+    name: "{{ vm_ip.nic.host }}"
     groups: "{{ vm_type }}"
     ansible_host: "{{ extracted_ip }}"
   loop: "{{ vm_ips.results }}"
   loop_control:
     loop_var: vm_ip
-    label: "{{ vm_ip.item }}"
+    label: "{{ vm_ip.nic.host }}"
 
 - name: "Create group inventory for {{ vm_type }}"
   vars:
@@ -193,7 +273,7 @@
 
 - name: "Configure VMs type {{ vm_type }}"
   when:
-    - vm_type is not match('^crc.*$')
+    - vm_type is not match('^(crc|ocp).*$')
   delegate_to: "{{ vm_type }}-{{ vm_id }}"
   remote_user: "{{ vm_data.value.admin_user | default('root') }}"
   ansible.builtin.shell:

--- a/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -19,6 +19,8 @@
   ansible.builtin.import_tasks: create_networks.yml
 
 - name: Ensure images are present
+  when:
+    - item.key is not match('.*(ocp|crc).*')
   vars:
     image_data: "{{ item.value }}"
   ansible.builtin.include_tasks:
@@ -31,7 +33,8 @@
   delegate_facts: true
   ansible.builtin.command:
     cmd: >-
-      ssh-keygen -t ed25519 -f {{ ansible_user_dir }}/.ssh/cifmw_reproducer_key -P '' -q
+      ssh-keygen -t ed25519
+      -f {{ ansible_user_dir }}/.ssh/cifmw_reproducer_key -P '' -q
     creates: "{{ ansible_user_dir }}/.ssh/cifmw_reproducer_key"
 
 - name: Slurp public key for later use
@@ -51,16 +54,17 @@
     user: "{{ ansible_user_id }}"
     key: "{{ pub_ssh_key['content'] | b64decode }}"
 
-- name: Prepare base image with user and ssh accesses  # noqa: risky-shell-pipe
+- name: Prepare disk image with SSH and growing volume  # noqa: risky-shell-pipe
   when:
-    - item.key is not match('^crc.*$')
+    - item.key is not match('^(crc|ocp).*$')
   vars:
     _admin_user: "{{ item.value.admin_user | default('root') }}"
+    _root_part: "{{ item.value.root_part_id | default('1') }}"
   ansible.builtin.shell:
     cmd: >-
       virt-sysprep -a "{{ item.value.image_local_dir }}/{{ item.value.disk_file_name }}"
       --selinux-relabel
-      --firstboot-command "growpart /dev/sda 1"
+      --firstboot-command "growpart /dev/sda {{ _root_part }}"
       --firstboot-command "xfs_growfs /"
       --root-password "password:{{ item.value.password | default('fooBar') }}"
       --ssh-inject {{ _admin_user }}:file:{{ ansible_user_dir }}/.ssh/authorized_keys
@@ -88,6 +92,7 @@
     vm_type: "{{ vm_data.key }}"
     pub_key: "{{ pub_ssh_key.content | b64decode }}"
     priv_key: "{{ priv_ssh_key.content | b64decode }}"
+    _admin_user: "{{ item.value.admin_user | default('root') }}"
   ansible.builtin.include_tasks:
     file: create_vms.yml
   loop: "{{ _layout.vms | dict2items }}"

--- a/ci_framework/roles/libvirt_manager/tasks/reserve_ip.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/reserve_ip.yml
@@ -25,10 +25,10 @@
 #     cidr        network notation
 
 # The nth host is determined by looking to the vm_name
-#   master          20
+#   master/crc/ocp  10
 #   worker          23
-#   extraworker     26
-#   compute         26      # Has the same index of extraworker
+#   extraworker     100
+#   compute         100      # Has the same index of extraworker
 
 
 - name: Generate the IP address
@@ -43,11 +43,13 @@
     _lm_ip_address: "{{ network.cidr | ansible.utils.nthhost(_ip_index) }}"
 
 - name: Reserve static IP address for the node.
+  vars:
+    _vm_name: "{{ vm_name | replace('^cifmw-', '') }}"
   community.libvirt.virt_net:
     command: modify
     name: "cifmw-{{ network.name }}"
     uri: "qemu:///system"
     xml: |
-      <host mac='{{ mac_address }}' name='{{ vm_name }}' ip='{{ _lm_ip_address }}'>
+      <host mac='{{ mac_address }}' name='{{ _vm_name }}' ip='{{ _lm_ip_address }}'>
         <lease expiry='60' unit='minutes'/>
       </host>

--- a/ci_framework/roles/libvirt_manager/templates/domain.xml.j2
+++ b/ci_framework/roles/libvirt_manager/templates/domain.xml.j2
@@ -28,6 +28,8 @@
     <interface type='network'>
 {% if _layout.networks is defined and network in _layout.networks.keys() %}
       <source network='cifmw-{{ network }}'/>
+{% elif cifmw_devscripts_extra_networks is defined and (cifmw_devscripts_extra_networks | selectattr('name', 'equalto', network)) | length > 0 %}
+      <source network='cifmw-{{ network }}'/>
 {% else %}
       <source network='{{ network }}'/>
 {% endif %}

--- a/ci_framework/roles/libvirt_manager/vars/main.yml
+++ b/ci_framework/roles/libvirt_manager/vars/main.yml
@@ -36,7 +36,10 @@ cifmw_libvirt_manager_polkit_rules_file: "{{ cifmw_libvirt_manager_polkit_rules_
 
 # It is either compute or extraworker and not both hence the numbers are reused
 cifmw_libvirt_manager_vm_net_ip_set:
+  controller: 5
+  crc: 10
   master: 10
+  ocp: 10
   worker: 13
   extraworker: 100
   compute: 100


### PR DESCRIPTION
Following #766, we have now to add a feature in libvirt_manager to
support:
- user provided XML (note: those are *remote* - on the hypervisor)
- multiple base image for the same VM family

With these features, we're getting closer to a good and nice support of
overlays for the OCP cluster, allowing faster re-deploy.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
