### PR TITLE
Avoid warning the user about oc not found

### DIFF
--- a/ci_framework/roles/ci_setup/README.md
+++ b/ci_framework/roles/ci_setup/README.md
@@ -15,6 +15,7 @@ Ensure you have the needed directories and packages for the rest of the tasks.
   stable release of the client.
 - `cifmw_ci_setup_rhel_rhsm_default_repos` (List) List of repos to be enabled via Red Hat Subscription Manager.
 - `cifmw_ci_setup_yum_repos` (list) List of dicts holding information on the repos to be enabled.
+- `cifmw_ci_setup_oc_install_path`: (String) Path where the OCP client binary should be placed. Defaults to `~/bin`.
 
 ## Example of cifmw_ci_setup_yum_repos
 

--- a/ci_framework/roles/ci_setup/defaults/main.yml
+++ b/ci_framework/roles/ci_setup/defaults/main.yml
@@ -20,3 +20,4 @@
 
 cifmw_ci_setup_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_ci_setup_openshift_client_version: "stable"
+cifmw_ci_setup_oc_install_path: "{{ ansible_user_dir ~ '/bin' }}"

--- a/ci_framework/roles/ci_setup/tasks/packages.yml
+++ b/ci_framework/roles/ci_setup/tasks/packages.yml
@@ -15,46 +15,62 @@
     name: "{{ cifmw_ci_setup_packages }}"
     state: latest
 
+- name: Gather version of openshift client
+  register: _oc_version
+  environment: >-
+    {{
+      {'PATH': cifmw_path}
+      if cifmw_path is defined else
+      {}
+    }}
+  ansible.builtin.command:
+    cmd: "oc version --client -o yaml"
+  changed_when: false
+  failed_when: false
+
 - name: Install openshift client
   tags:
     - bootstrap
     - packages
+  when: >-
+    _oc_version.rc != 0 or
+    (
+      ((_oc_version.stdout | from_yaml).releaseClientVersion | split('.') | first | int) >=
+      cifmw_ci_setup_openshift_minimum_version
+    )
   block:
-    - name: Gather version of openshift client if it exists
-      register: oc_version
-      environment:
-        PATH: "{{ cifmw_path }}"
-      ansible.builtin.command:
-        cmd: "oc version -o yaml"
-
-    - name: Check if version of openshift client is supported
-      vars:
-        oc_version_data: "{{ oc_version.stdout | from_yaml }}"
-        oc_major_version: "{{ oc_version_data.releaseClientVersion | split('.') | first }}"
-      ansible.builtin.assert:
-        that:
-          - oc_major_version | int >= cifmw_ci_setup_openshift_minimum_version
-  rescue:
     - name: Ensure openshift client install path is present
       ansible.builtin.file:
-        path: "{{ cifmw_ci_setup_openshift_client_install_path }}"
+        path: "{{ cifmw_ci_setup_oc_install_path }}"
         state: directory
         mode: "0755"
 
     - name: Install openshift client
       ansible.builtin.unarchive:
         src: "{{ cifmw_ci_setup_openshift_client_download_uri }}/{{ cifmw_ci_setup_openshift_client_version }}/openshift-client-linux.tar.gz"
-        dest: "{{ cifmw_ci_setup_openshift_client_install_path }}"
+        dest: "{{ cifmw_ci_setup_oc_install_path }}"
         remote_src: true
         mode: "0755"
-        creates: "{{ cifmw_ci_setup_openshift_client_install_path }}/oc"
+        creates: "{{ cifmw_ci_setup_oc_install_path }}/oc"
+
+- name: Add the OC path to cifmw_path if needed
+  vars:
+    _cifmw_paths_list: >-
+      {{
+        cifmw_path | split(':')
+        if cifmw_path is defined else []
+      }}
+  when: cifmw_ci_setup_oc_install_path not in _cifmw_paths_list
+  ansible.builtin.set_fact:
+    cifmw_path: "{{ cifmw_ci_setup_oc_install_path }}:{{ ansible_env.PATH }}"
+    cacheable: true
 
 - name: Inject oc completion in local profile
   block:
     - name: Create completion file
       ansible.builtin.shell:  # noqa: risky-shell-pipe
         cmd: >-
-          {{ cifmw_ci_setup_openshift_client_install_path }} completion bash |
+          {{ cifmw_ci_setup_oc_install_path }}/oc completion bash |
           tee -a ~/.oc_completion
         creates: "{{ ansible_user_dir }}/.oc_completion"
 

--- a/ci_framework/roles/ci_setup/vars/main.yml
+++ b/ci_framework/roles/ci_setup/vars/main.yml
@@ -25,4 +25,3 @@ cifmw_ci_setup_packages:
 # openshift client
 cifmw_ci_setup_openshift_client_download_uri: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp"
 cifmw_ci_setup_openshift_minimum_version: 4
-cifmw_ci_setup_openshift_client_install_path: "{{ ansible_user_dir }}/bin"


### PR DESCRIPTION
The approach we took for choose if oc needs to be installed or not is to call it, and if it fails, rescue the task and install it. That yields an error that a user is usually interpreting as a real one. We should not pass that error to the user, and ignore it.

At the same time, it seems that under certain circumstances, the fact catching mechanism is capturing the variable that holds where oc should be installed, what's a problem if the previous run was done with a different user, like root, as the extraction of oc will fail because of lack of permission.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
