### PR TITLE
Install tcib from RPM

### DIFF
--- a/ci/playbooks/tcib/tcib.yml
+++ b/ci/playbooks/tcib/tcib.yml
@@ -15,6 +15,15 @@
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: true
   tasks:
+    - name: Copy repo-setup generated repos to yum.repos.d directory
+      tags:
+        - container_img_build
+      become: true
+      ansible.builtin.copy:
+        remote_src: true
+        src: "{{ cifmw_build_containers_repo_dir }}/"
+        dest: "/etc/yum.repos.d/"
+
     - name: Build tcib package
       vars:
         cifmw_bop_dlrn_target: centos9-stream

--- a/ci_framework/roles/build_containers/README.md
+++ b/ci_framework/roles/build_containers/README.md
@@ -34,3 +34,4 @@ become - Required to install and execute tcib
 * `cifmw_build_containers_hotfix_rpms_paths`: (List) The full path to a directory where RPMs exist.
 * `cifmw_build_containers_hotfix_tag`: (String) The tag of the container image.
 * `cifmw_build_containers_run_hotfix`: (boolean) conditional variable for executing build_containers.
+* `cifmw_build_containers_install_from_source`: (boolean) Install tcib from RPM.

--- a/ci_framework/roles/build_containers/defaults/main.yml
+++ b/ci_framework/roles/build_containers/defaults/main.yml
@@ -49,3 +49,6 @@ cifmw_build_containers_repo_dir: "{{ cifmw_build_containers_basedir }}/artifacts
 cifmw_build_containers_image_tag: current-podified
 cifmw_build_containers_containers_base_image: quay.io/centos/centos:stream9
 cifmw_build_containers_cleanup: false
+
+# Install tcib from source
+cifmw_build_containers_install_from_source: false

--- a/ci_framework/roles/build_containers/molecule/default/converge.yml
+++ b/ci_framework/roles/build_containers/molecule/default/converge.yml
@@ -19,6 +19,7 @@
   hosts: all
   vars:
     cifmw_build_containers_cleanup: true
+    cifmw_build_containers_install_from_source: true
     cifmw_build_containers_config_file: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/roles/build_containers/files/containers.yaml"
   roles:
     - role: "build_containers"

--- a/ci_framework/roles/build_containers/tasks/install.yml
+++ b/ci_framework/roles/build_containers/tasks/install.yml
@@ -11,17 +11,26 @@
       - buildah
     state: latest  # noqa: package-latest
 
-- name: Get tcib from repository  # noqa: latest[git]
-  ansible.builtin.git:
-    accept_hostkey: true
-    dest: "{{ cifmw_build_containers_basedir }}/tmp/tcib"
-    repo: "{{ cifmw_build_containers_tcib_src }}"
+- name: Install tcib from source
+  when: cifmw_build_containers_install_from_source | bool
+  block:
+    - name: Get tcib from repository  # noqa: latest[git]
+      ansible.builtin.git:
+        accept_hostkey: true
+        dest: "{{ cifmw_build_containers_basedir }}/tmp/tcib"
+        repo: "{{ cifmw_build_containers_tcib_src }}"
 
-  # FIXME(Chandan/arxcruz): Skip usage of sudo installation
-- name: Install tcib package
+      # FIXME(Chandan/arxcruz): Skip usage of sudo installation
+    - name: Install tcib package
+      become: true
+      ansible.builtin.shell: |
+        pip install -r requirements.txt
+        python setup.py install
+      args:
+        chdir: "{{ cifmw_build_containers_basedir }}/tmp/tcib"
+
+- name: Install tcib from RPM
+  when: not cifmw_build_containers_install_from_source | bool
   become: true
-  ansible.builtin.shell: |
-    pip install -r requirements.txt
-    python setup.py install
-  args:
-    chdir: "{{ cifmw_build_containers_basedir }}/tmp/tcib"
+  ansible.builtin.package:
+    name: python3-tcib


### PR DESCRIPTION
tcib is used in periodic line to build openstack services containers.

Periodic line should be instaling the tcib package itself from podified-ci-testing via rpm. But it is installed via github source. The tcib content in podified-ci-testing is different from source (New commit might merged and dlrn have not picked it up.)

So, it diverges the testing and causes unwanted issues.

This pr adds the support for installing the tcib content from rpm. It will help to install the correct content.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

https://issues.redhat.com/browse/OSPCIX-101