### PR TITLE
Add role to collect operator images used in the environment

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -33,4 +33,3 @@
 - job:
     name: cifmw-molecule-env_op_images
     nodeset: centos-9-crc-xl
-    timeout: 5400

--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -30,3 +30,7 @@
 - job:
     name: cifmw-molecule-cert_manager
     nodeset: centos-9-crc-xxl
+- job:
+    name: cifmw-molecule-env_op_images
+    nodeset: centos-9-crc-xl
+    timeout: 5400

--- a/ci_framework/playbooks/99-logs.yml
+++ b/ci_framework/playbooks/99-logs.yml
@@ -32,6 +32,10 @@
       ansible.builtin.import_role:
         name: artifacts
 
+    - name: Collect container images used in the environment
+      ansible.builtin.import_role:
+        name: env_op_images
+
     - name: Ensure ansible.log is at the expected location
       register: ansible_log_state
       ansible.builtin.stat:

--- a/ci_framework/roles/env_op_images/README.md
+++ b/ci_framework/roles/env_op_images/README.md
@@ -1,0 +1,13 @@
+# env_op_images
+A role to gather the container images used in the openstack deployment with specific tags.
+
+## Parameters
+* `cifmw_env_op_images_dir`: (String) Directory where the operator_images.yaml will be stored. Defaults to `~/ci-framework-data/artifacts`
+* `cifmw_env_op_images_file`: (String) Name of the file storing the operator images and tags. Defaults to `operator_images.yaml`
+
+## Examples
+```YAML
+- name: Collect container images used in the environment
+  ansible.builtin.import_role:
+    name: env_op_images
+```

--- a/ci_framework/roles/env_op_images/defaults/main.yml
+++ b/ci_framework/roles/env_op_images/defaults/main.yml
@@ -1,0 +1,23 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_env_op_images"
+
+cifmw_env_op_images_dir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+cifmw_env_op_images_file: operator_images.yaml
+cifmw_env_op_images_dryrun: false

--- a/ci_framework/roles/env_op_images/meta/main.yml
+++ b/ci_framework/roles/env_op_images/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- env_op_images
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: edpm
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - edpm
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/ci_framework/roles/env_op_images/molecule/default/converge.yml
+++ b/ci_framework/roles/env_op_images/molecule/default/converge.yml
@@ -1,0 +1,67 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  vars:
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+    cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+    cifmw_env_op_images_dir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+    cifmw_env_op_images_file: operator_images.yaml
+    cifmw_env_op_images_dryrun: true
+    cifmw_install_yamls_environment:
+      KUBECONFIG: "{{ cifmw_openshift_kubeconfig  }}"
+      BMO_SETUP: false
+      NETWORK_ISOLATION: false
+    cifmw_install_yamls_defaults:
+      OPERATOR_NAMESPACE: openstack-operators
+
+  pre_tasks:
+    - name: Make download_tools
+      ansible.builtin.include_role:
+        name: 'install_yamls_makes'
+        tasks_from: 'make_download_tools'
+
+    - name: Wait for openstack-operator to be deployed
+      vars:
+        make_openstack_wait_env: "{{ cifmw_install_yamls_environment | combine({'PATH': cifmw_path}) }}"
+      ansible.builtin.include_role:
+        name: 'install_yamls_makes'
+        tasks_from: 'make_openstack_wait'
+
+  tasks:
+    - name: Gather operator images from setup
+      ansible.builtin.include_role:
+        name: env_op_images
+
+    - name: Read YAML file
+      ansible.builtin.include_vars:
+        file: "{{ cifmw_env_op_images_dir }}/artifacts/{{ cifmw_env_op_images_file }}"
+
+    - name: Verify entries under cifmw_csv_images key
+      ansible.builtin.assert:
+        that:
+          - "cifmw_csv_images is defined"
+          - "cifmw_csv_images | length > 0"
+        fail_msg: "cifmw_csv_images are missing."
+
+    - name: Verify entries under cifmw_openstack_operator_index_image key
+      ansible.builtin.assert:
+        that:
+          - "cifmw_openstack_operator_index_image is defined"
+          - "cifmw_openstack_operator_index_image | length > 0"
+        fail_msg: "cifmw_openstack_operator_index_image key is missing or empty."

--- a/ci_framework/roles/env_op_images/molecule/default/molecule.yml
+++ b/ci_framework/roles/env_op_images/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/env_op_images/molecule/default/prepare.yml
+++ b/ci_framework/roles/env_op_images/molecule/default/prepare.yml
@@ -1,0 +1,29 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  vars:
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+  roles:
+    - role: test_deps
+    - role: ci_setup
+    - role: install_yamls
+  tasks:
+    - name: Ensure CRC is started
+      ansible.builtin.command:
+        cmd: crc start --memory 14000 --disk-size 80 --cpus 6

--- a/ci_framework/roles/env_op_images/tasks/main.yml
+++ b/ci_framework/roles/env_op_images/tasks/main.yml
@@ -1,0 +1,102 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure directory is present
+  ansible.builtin.file:
+    path: "{{ cifmw_env_op_images_dir }}/{{ item }}"
+    state: directory
+  loop:
+    - artifacts
+    - logs
+
+- name: Check if OpenStackControlPlane is setup
+  when:
+    - cifmw_openshift_kubeconfig is defined
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: oc get OpenStackControlPlane -o=jsonpath='{.items[*].status.conditions[?(@.type=="Ready")].status}'
+  register: openstack_installed
+  failed_when: false
+
+- name: Get openstack operator images
+  when:
+    - ( openstack_installed.stdout is defined and
+        openstack_installed.rc == 0 and
+        openstack_installed.stdout == "True"
+      ) or
+      cifmw_env_op_images_dryrun
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  block:
+    - name: Get images from the csv
+      ansible.builtin.shell: |
+        csv_name=$(oc get csv -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} -l operators.coreos.com/openstack-operator.openstack-operators -o=jsonpath='{.items[*].metadata.name}')
+        oc get csv -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} ${csv_name} -o=jsonpath='{.spec.install.spec.deployments[*].spec.template.spec.containers[?(@.name=="manager")].env}'
+      register: csv_images
+
+    - name: Extract env variable name and images
+      ansible.builtin.set_fact:
+        cifmw_openstack_service_images_content: "{{ cifmw_openstack_service_images_content | default({}) | combine({(item | from_json).name: (item | from_json).value}) }}"
+      loop: "{{ csv_images.stdout| regex_findall('\\{[^}]+\\}') }}"
+
+    - name: Get all the pods in openstack-operator namespace
+      kubernetes.core.k8s_info:
+        kind: Pod
+        namespace: "{{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }}"
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit)}}"
+        context: "{{ cifmw_openshift_context | default(omit)}}"
+        field_selectors:
+          - status.phase=Running
+      register: pod_list
+
+    - name: Retrieve openstack-operator-index pod
+      vars:
+        selected_pod: "{{ pod_list.resources| selectattr('metadata.generateName', 'equalto', 'openstack-operator-index-') | list | first }}"
+      ansible.builtin.set_fact:
+        cifmw_install_yamls_vars_content:
+          OPENSTACK_IMG: "{{ selected_pod.status.containerStatuses[0].imageID }}"
+
+    - name: Get operator images and pods
+      when: not cifmw_env_op_images_dryrun
+      vars:
+        selected_pod: "{{ pod_list.resources | selectattr('metadata.generateName', 'contains', 'rabbitmq-cluster-operator-') | list | first }}"
+      ansible.builtin.set_fact:
+        cifmw_openstack_operator_images_content:
+          RABBITMQ_OP_IMG: "{{ selected_pod.status.containerStatuses[0].imageID }}"
+        selected_pods: "{{ pod_list.resources |
+                           rejectattr('metadata.generateName', 'contains', 'openstack-operator-index-') |
+                           rejectattr('metadata.generateName', 'contains', 'rabbitmq-cluster-operator-')
+                        }}"
+
+    - name: Add operator images to the dictionary
+      when: not cifmw_env_op_images_dryrun
+      ansible.builtin.set_fact:
+        cifmw_openstack_operator_images_content: "{{ cifmw_openstack_operator_images_content | combine({ item.metadata.labels['openstack.org/operator-name'] | upper ~ '_OP_IMG': item.status.containerStatuses[1].imageID}) }}"
+      loop: "{{ selected_pods }}"
+
+    - name: Write images to file
+      vars:
+        _content:
+          cifmw_openstack_operator_index_image: "{{ cifmw_install_yamls_vars_content | default({}) }}"
+          cifmw_operator_images: "{{ cifmw_openstack_operator_images_content | default({}) }}"
+          cifmw_csv_images: "{{ cifmw_openstack_service_images_content | default({}) }}"
+      ansible.builtin.copy:
+        dest: "{{ cifmw_env_op_images_dir }}/artifacts/{{ cifmw_env_op_images_file }}"
+        content: "{{ _content | to_nice_yaml }}"

--- a/ci_framework/roles/env_op_images/tasks/main.yml
+++ b/ci_framework/roles/env_op_images/tasks/main.yml
@@ -39,7 +39,7 @@
         openstack_installed.rc == 0 and
         openstack_installed.stdout == "True"
       ) or
-      cifmw_env_op_images_dryrun
+      cifmw_env_op_images_dryrun | bool
   environment:
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
     PATH: "{{ cifmw_path }}"
@@ -74,7 +74,7 @@
           OPENSTACK_IMG: "{{ selected_pod.status.containerStatuses[0].imageID }}"
 
     - name: Get operator images and pods
-      when: not cifmw_env_op_images_dryrun
+      when: not cifmw_env_op_images_dryrun | bool
       vars:
         selected_pod: "{{ pod_list.resources | selectattr('metadata.generateName', 'contains', 'rabbitmq-cluster-operator-') | list | first }}"
       ansible.builtin.set_fact:
@@ -86,7 +86,7 @@
                         }}"
 
     - name: Add operator images to the dictionary
-      when: not cifmw_env_op_images_dryrun
+      when: not cifmw_env_op_images_dryrun | bool
       ansible.builtin.set_fact:
         cifmw_openstack_operator_images_content: "{{ cifmw_openstack_operator_images_content | combine({ item.metadata.labels['openstack.org/operator-name'] | upper ~ '_OP_IMG': item.status.containerStatuses[1].imageID}) }}"
       loop: "{{ selected_pods }}"

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -76,6 +76,7 @@ creds
 cri
 crio
 crs
+csv
 ctl
 ctlplane
 ctx
@@ -379,6 +380,7 @@ subnet
 subnets
 sudo
 sudoers
+svc
 svg
 svgrepo
 svm

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -223,6 +223,18 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
+    - ^ci_framework/roles/env_op_images/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    name: cifmw-molecule-env_op_images
+    nodeset: centos-9-crc-xl
+    parent: cifmw-molecule-base
+    timeout: 5400
+    vars:
+      TEST_RUN: env_op_images
+- job:
+    files:
+    - ^ansible-requirements.txt
+    - ^molecule-requirements.txt
     - ^ci_framework/roles/hci_prepare/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-hci_prepare

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -228,7 +228,6 @@
     name: cifmw-molecule-env_op_images
     nodeset: centos-9-crc-xl
     parent: cifmw-molecule-base
-    timeout: 5400
     vars:
       TEST_RUN: env_op_images
 - job:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -31,6 +31,7 @@
       - cifmw-molecule-edpm_deploy_baremetal
       - cifmw-molecule-edpm_kustomize
       - cifmw-molecule-edpm_prepare
+      - cifmw-molecule-env_op_images
       - cifmw-molecule-hci_prepare
       - cifmw-molecule-hive
       - cifmw-molecule-install_ca


### PR DESCRIPTION
Generate artifacts containing images used in the current deployment
Linked to task [OSP-25630](https://issues.redhat.com//browse/OSP-25630)

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
