### PR TITLE
[cifmw_cephadm] Enable the usage of custom `haproxy` and `keepalived` container images

### DIFF
--- a/ci_framework/roles/cifmw_cephadm/tasks/cephadm_config_set.yml
+++ b/ci_framework/roles/cifmw_cephadm/tasks/cephadm_config_set.yml
@@ -47,6 +47,26 @@
     {{ cifmw_cephadm_container_ns }}/{{ cifmw_cephadm_container_image }}
   changed_when: false
 
+- name: Set haproxy container image in ceph configuration
+  when:
+    - cifmw_cephadm_haproxy_container_image is defined
+    - not (cifmw_cephadm_default_container | default(false) | bool)
+  become: true
+  ansible.builtin.command: |
+    {{ cifmw_cephadm_ceph_cli }} config set mgr mgr/cephadm/container_image_haproxy \
+    {{ cifmw_cephadm_haproxy_container_image }}
+  changed_when: false
+
+- name: Set keepalived container image in ceph configuration
+  when:
+    - cifmw_cephadm_keepalived_container_image is defined
+    - not (cifmw_cephadm_default_container | default(false) | bool)
+  become: true
+  ansible.builtin.command: |
+    {{ cifmw_cephadm_ceph_cli }} config set mgr mgr/cephadm/container_image_keepalived \
+    {{ cifmw_cephadm_keepalived_container_image }}
+  changed_when: false
+
 - name: Set dashboard container image in ceph mgr configuration
   when:
     - cifmw_cephadm_dashboard_enabled | bool


### PR DESCRIPTION
This PR replace https://github.com/openstack-k8s-operators/ci-framework/pull/765

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
