### PR TITLE
[TLS] To update env bundle, check for ca_bundle_file got created

### DIFF
--- a/ci_framework/roles/edpm_prepare/tasks/main.yml
+++ b/ci_framework/roles/edpm_prepare/tasks/main.yml
@@ -243,10 +243,14 @@
       ansible.builtin.copy:
         dest: "{{ cifmw_edpm_prepare_basedir }}/tls-ca-bundle.pem"
         content: "{{ ca_bundle }}"
+
+    - name: Check if ca_bundle_file exists
       register: ca_bundle_file
+      ansible.builtin.stat:
+        path: "{{ cifmw_edpm_prepare_basedir }}/tls-ca-bundle.pem"
 
     - name: Inject OpenStackControlplane CA bundle  # noqa: no-handler
-      when: ca_bundle_file is changed
+      when: ca_bundle_file.stat.exists
       vars:
         cifmw_install_ca_bundle_src: "{{ cifmw_edpm_prepare_basedir }}/tls-ca-bundle.pem"
       ansible.builtin.include_role:


### PR DESCRIPTION
In jobs it was seen that the ca bundle got not updated with the current condition and CA validation failed [1]. This updates to check for the extracted bundle file to exist and then injects the OpenStackControlplane CA bundle

[1] https://logserver.rdoproject.org/37/737/dbe17d96f1096433445e9851e9f3ee0d1be478d1/github-check/podified-multinode-edpm-e2e-nobuild-tagged-crc/018ee98/controller/ci-framework-data/tests/tempest/podman_tempest.log

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
