### PR TITLE
Add data-plane adoption job to ci-framework PRs

### DIFF
--- a/ci/templates/projects.yaml
+++ b/ci/templates/projects.yaml
@@ -6,6 +6,7 @@
     name: openstack-k8s-operators/ci-framework
     templates:
       - podified-multinode-edpm-pipeline
+      - data-plane-adoption-pipeline
     github-check:
       jobs:
         - noop

--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -74,3 +74,21 @@
                 ip: 172.18.0.5
               tenant:
                 ip: 172.19.0.5
+
+- job:
+    name: cifmw-data-plane-adoption-github-rdo-centos-9-extracted-crc
+    parent: content-provider-data-plane-adoption-github-rdo-centos-9-extracted-crc
+    files:
+      - ^ci_framework/playbooks/01-bootstrap.yml
+      - ^ci_framework/playbooks/02-infra.yml
+      - ^ci_framework/playbooks/06-deploy-edpm.yml
+      - ^ci_framework/roles/discover_latest_image/(?!meta|README|molecule).*
+      - ^ci_framework/roles/edpm_prepare/(?!meta|README|molecule).*
+      - ^ci_framework/roles/install_ca/(?!meta|README|molecule).*
+      - ^ci_framework/roles/install_yamls/(?!meta|README|molecule).*
+      - ^ci_framework/roles/libvirt_manager/(?!meta|README|molecule).*
+      - ^ci_framework/roles/openshift_login/(?!meta|README|molecule).*
+      - ^ci_framework/roles/openshift_setup/(?!meta|README|molecule).*
+      - ^ci_framework/roles/repo_setup/(?!meta|README|molecule).*
+      - ^ci_framework/hooks/playbooks/fetch_compute_facts.yml
+      - ^zuul.d/adoption.yaml

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -24,3 +24,14 @@
             dependencies:
               - openstack-k8s-operators-content-provider
         - podified-multinode-hci-deployment-crc: *content_providere_edpm
+
+- project-template:
+    name: data-plane-adoption-pipeline
+    description: |
+      Project template to run content provider with data-plane adoption job.
+    github-check:
+      jobs:
+        - openstack-k8s-operators-content-provider
+        - cifmw-data-plane-adoption-github-rdo-centos-9-extracted-crc: &content_provider_adoption
+            dependencies:
+              - openstack-k8s-operators-content-provider

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -55,3 +55,4 @@
     name: openstack-k8s-operators/ci-framework
     templates:
     - podified-multinode-edpm-pipeline
+    - data-plane-adoption-pipeline


### PR DESCRIPTION
Run data-plane adoption job in those ci-framework PRs that could affect
it.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/608

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
