### PR TITLE
Drop current tags from install_ca role

### DIFF
--- a/ci_framework/roles/install_ca/tasks/main.yml
+++ b/ci_framework/roles/install_ca/tasks/main.yml
@@ -15,9 +15,6 @@
 # under the License.
 
 - name: Execute all as root
-  tags:
-    - bootstrap
-    - packages
   become: true
   block:
     - name: Ensure target directory exists


### PR DESCRIPTION
podified-multinode-edpm-e2e-nobuild-tagged-crc use: --skip-tags bootstrap,packages
which result in the install_ca role not be triggered when the created ca bundle got extracted from the deployed env. As a result the cert validation of the keystone public endpoint fails.

We should be able to add CAs at any time. Therefore this drops the current tags from the role.

Jira: https://issues.redhat.com/browse/OSPCIX-104

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
