### PR TITLE
Create Nova SSH migration secret in hci_prepare role

### DIFF
--- a/ci_framework/roles/hci_prepare/tasks/phase2.yml
+++ b/ci_framework/roles/hci_prepare/tasks/phase2.yml
@@ -60,6 +60,23 @@
         output_dir: "{{ cifmw_hci_prepare_basedir }}/artifacts"
         script: "oc apply -f {{ cifmw_hci_prepare_basedir }}/artifacts/dpservice-nova-custom-ceph.yml"
 
+    - name: Create Nova SSH Migration Key
+      ci_script:
+        output_dir: "{{ cifmw_hci_prepare_basedir }}/artifacts"
+        script: |
+          function create_migration_key {
+            pushd "$(mktemp -d)"
+            ssh-keygen -f ./id -t ed25519 -N ''
+            oc create secret generic nova-migration-ssh-key \
+              -n openstack \
+              --from-file=ssh-privatekey=id \
+              --from-file=ssh-publickey=id.pub \
+              --type kubernetes.io/ssh-auth
+            rm id*
+            popd
+          }
+          oc get secret nova-migration-ssh-key -n openstack || create_migration_key
+
 - name: Create configuration to finish HCI deployment
   ansible.builtin.copy:
     dest: "{{ cifmw_hci_prepare_dataplane_dir }}/87-hci-post-kustomization.yaml"

--- a/ci_framework/roles/hci_prepare/templates/dpservice-nova-custom-ceph.yml.j2
+++ b/ci_framework/roles/hci_prepare/templates/dpservice-nova-custom-ceph.yml.j2
@@ -10,4 +10,5 @@ spec:
     - ceph-nova
   secrets:
     - nova-cell1-compute-config
+    - nova-migration-ssh-key
   playbook: osp.edpm.nova


### PR DESCRIPTION
Add task to phase2 tasks list in hci_prepare role which prepares the Nova migration SSH key pair.

The podified-multinode-hci-deployment-crc job is failing ever since the Nova OpenStackDataPlaneSercice started requiring the Nova migration SSH key secret. The error was not seen in non-HCI jobs because install_yamls was updated to automatically handle it [1]. Because the HCI job is not as tightly coupled with install_yamls, we need to create this secret as part of the hci_prepare role.

[1] https://github.com/openstack-k8s-operators/install_yamls/pull/586/files

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
