### PR TITLE
Allow auth file to be null

### DIFF
--- a/ci_framework/roles/build_containers/README.md
+++ b/ci_framework/roles/build_containers/README.md
@@ -8,7 +8,7 @@ become - Required to install and execute tcib
 
 * `cifmw_build_containers_tcib_src`: (String) Repository of tcib to be installed
 * `cifmw_build_containers_basedir`: (String) Directory where we will hold all tcib files. Default to `cifmw_basedir/artifacts/containers_build` which defaults to `~/ci-framework-data/`.
-* `cifmw_build_containers_authfile_path`: (String) Authorization file to push containers to registry. Default to `${XDG_RUNTIME_DIR}/containers/auth.json`.
+* `cifmw_build_containers_authfile_path`: (String or Null) Authorization file to push containers to registry. Default to `${XDG_RUNTIME_DIR}/containers/auth.json`.
 * `cifmw_build_containers_push_containers`: (Boolean) Whether push containers after build or not. Default to `false`.
 * `cifmw_build_containers_timestamper_cmd`: (String) Timestamp to be added in the logs
 * `cifmw_build_containers_container_name_prefix`: (String) Prefix to be added in the name of the containers. Default to `openstack`.

--- a/ci_framework/roles/build_containers/tasks/main.yml
+++ b/ci_framework/roles/build_containers/tasks/main.yml
@@ -49,7 +49,7 @@
 
 - name: Make sure authfile exists
   when:
-    - cifmw_build_containers_authfile_path is defined
+    - cifmw_build_containers_authfile_path != None
     - cifmw_build_containers_push_containers | bool
   block:
     - name: Check for authfile
@@ -57,7 +57,7 @@
         path: '{{ cifmw_build_containers_authfile_path }}'
       register: authfile_exist
 
-    - name: Make sure autfile exists
+    - name: Make sure authfile exists
       ansible.builtin.assert:
         that:
           - authfile_exist.stat.exists | bool

--- a/ci_framework/roles/build_containers/templates/build_containers.sh.j2
+++ b/ci_framework/roles/build_containers/templates/build_containers.sh.j2
@@ -4,7 +4,7 @@ openstack tcib container image build \
 {%   if cifmw_build_containers_push_containers|bool %}
      --push \
 {%   endif %}
-{%   if cifmw_build_containers_authfile_path is defined %}
+{%   if cifmw_build_containers_authfile_path != None %}
      --authfile {{ cifmw_build_containers_authfile_path }} \
 {%   endif %}
 {%   if  cifmw_build_containers_distro is defined %}


### PR DESCRIPTION
Currently the `cifmw_build_containers_authfile_path` variable has a default string value and because of that it is impossible to unset it in Ansible. However, when deploying local registry with `registry_deploy` role, the authentication is not necessary while pushing the built containers images. Instead of supplying a dummy empty file as workaround, it would be nice to just set the authfile_path variable to Null/None.

Additionally, a minor typo in task name is corrected.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes