### PR TITLE
Pass debug and create by default to tempestconf

### DIFF
--- a/ci_framework/roles/tempest/vars/main.yml
+++ b/ci_framework/roles/tempest/vars/main.yml
@@ -1,3 +1,5 @@
 cifmw_tempest_tempestconf_profile_default:
+  create: true
+  debug: true
   overrides:
     identity.v3_endpoint_type: public


### PR DESCRIPTION
--debug and --create arguments are hardcoded in run_tempest.sh
script in TCIB [1]. To avoid too many levels with default values,
I propose to have it defaulted here in ci-framework as the consumer
of the image defined in TCIB. That will allows us to remove the
hardcoded default values from TCIB.

[1] https://github.com/openstack-k8s-operators/tcib/blob/41a73ab686826c4fc2095cbe3f76b0dc2d61147f/container-images/tcib/base/os/tempest/run_tempest.sh

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
