### PR TITLE
Remove virt-net default only when requested

### DIFF
--- a/ci_framework/roles/devscripts/README.md
+++ b/ci_framework/roles/devscripts/README.md
@@ -40,8 +40,9 @@ managed services.
 * `cifmw_devscripts_pull_secret_file` (str) Path to pull-secret for pulling OCP component images.
   We can use `cifmw_devscripts_pull_secret` or `cifmw_devscripts_pull_secret_file` for passing pull_secrets
 * `cifmw_devscripts_src_dir` (str) The parent folder of dev-scripts repository.
-* `cifmw_devscripts_use_layers`: (bool) Toggle overlay support. Specifically, this boolean will instruct the role to
+* `cifmw_devscripts_use_layers` (bool) Toggle overlay support. Specifically, this boolean will instruct the role to
   shutdown the whole OCP cluster, dump the XML, undefine the nodes, and prevents running the "post" tasks. Defaults to `false`.
+* `cifmw_devscripts_remove_default_net` (bool) Remove the default virtual network. Defaults to `false`.
 
 ### Supported keys in cifmw_devscripts_config_overrides
 

--- a/ci_framework/roles/devscripts/defaults/main.yml
+++ b/ci_framework/roles/devscripts/defaults/main.yml
@@ -29,9 +29,9 @@ cifmw_devscripts_repo_dir: "{{ (ansible_user_dir, 'src/github.com/openshift-meta
 
 cifmw_devscripts_user: "{{ ansible_user_id }}"
 cifmw_devscripts_restart_virtproxyd: true
+cifmw_devscripts_use_layers: false
+cifmw_devscripts_remove_default_net: false
 
 cifmw_devscripts_osp_compute_nodes: []
 
 cifmw_devscripts_config_overrides: {}
-
-cifmw_devscripts_use_layers: false

--- a/ci_framework/roles/devscripts/tasks/sub_tasks/13_network.yml
+++ b/ci_framework/roles/devscripts/tasks/sub_tasks/13_network.yml
@@ -15,7 +15,8 @@
 # under the License.
 
 
-- name: Ensure the default network is removed.
+- name: Remove default virt-net from the system.
+  when: cifmw_devscripts_remove_default_net | bool
   vars:
     net_name: "default"
   ansible.builtin.include_role:


### PR DESCRIPTION
As part of this PR, the default virtual network is not removed by default. This network is removed only when the user passes `cifmw_devscripts_remove_default_net: true`.

Fixes: #760

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
