### PR TITLE
Append `-` in the container prefix name

### DIFF
--- a/ci_framework/roles/set_openstack_containers/templates/update_env_vars.sh.j2
+++ b/ci_framework/roles/set_openstack_containers/templates/update_env_vars.sh.j2
@@ -7,6 +7,9 @@ export PATH="{{ cifmw_path }}"
 {% set containers_dict = {} -%}
 {# Set the container registry url with namespace #}
 {% set _container_registry = cifmw_set_openstack_containers_registry + '/' + cifmw_set_openstack_containers_namespace -%}
+{#   Add `-` to the cifmw_set_openstack_containers_prefix to avoid issues with #}
+{#   openstack-openstackclient image name #}
+{% set _container_prefix = cifmw_set_openstack_containers_prefix + '-' -%}
 {# Environment variables contains = sign, Based on that we need to split with key and value #}
 {% for container in containers_env_list.stdout_lines if '=' in container -%}
 {%   set container_data = container.split('=') -%}
@@ -19,10 +22,10 @@ export PATH="{{ cifmw_path }}"
 {%     endif -%}
 {#   All the openstack services containers contain /openstack- prefix #}
 {#   It filters out the same and update the container address with new url #}
-{%   elif (cifmw_set_openstack_containers_prefix in _container) and ('operator' not in _container) -%}
-{%     set _container_data = _container.split(cifmw_set_openstack_containers_prefix)[-1] -%}
+{%   elif (_container_prefix in _container) and ('operator' not in _container) -%}
+{%     set _container_data = _container.split(_container_prefix)[-1] -%}
 {%     set _container_name = _container_data.split('@sha256')[0] -%}
-{%     set _container_address = _container_registry + '/' + cifmw_set_openstack_containers_prefix + _container_name + ':' + cifmw_set_openstack_containers_tag -%}
+{%     set _container_address = _container_registry + '/' + _container_prefix + _container_name + ':' + cifmw_set_openstack_containers_tag -%}
 {%     set _ = containers_dict.update({_container_env: _container_address}) -%}
 {%   endif -%}
 {% endfor -%}


### PR DESCRIPTION
Currently set_openstack_containers role filters the openstack services container images based on container prefix name e.g. openstack and then regenerate the container url.

openstack-openstackclient service image contains two openstack. In this case the generated container image will `openstackclient`.

And this image does not exists on content provider leading to ImgPullErr issue.

Adding `-` in the container prefix name fixes the issue and returns the correct url for such images.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

