### PR TITLE
Better service management for libvirt components

### DIFF
--- a/ci_framework/roles/libvirt_manager/tasks/virsh_checks.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/virsh_checks.yml
@@ -14,47 +14,64 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Start and enable libvirt service
-  become: true
-  ansible.builtin.service:
-    name: "{{ cifmw_libvirt_manager_daemon }}"
-    state: started
-    enabled: true
 
-# stabilize libvirt accesses
-# We hit a fair amount of failures with the libvirt sockets over the
-# past iteration. After many tests, it seems that removing the timeout
-# of the virtproxyd service and ensuring it's enabled and started
-# corrects this issue. With this hack, we could successfully deploy the
-# whole VA-1 layout without any issue.
-- name: Hack in the virtproxyd service
+- name: Clean hacky service override
   become: true
-  when: cifmw_libvirt_manager_apply_virtproxy_patch | bool
   block:
-    - name: Create service override directory
+    - name: Remove directory for service override
       ansible.builtin.file:
         path: "/etc/systemd/system/virtproxyd.service.d"
-        state: directory
-        owner: root
-        group: root
-        mode: "0755"
-
-    - name: Create service override
-      ansible.builtin.copy:
-        dest: "/etc/systemd/system/virtproxyd.service.d/override.conf"
-        content: |
-          # Managed by the CI Framework
-          # Remove timeout to service to ensure it's persistent
-          [Service]
-          Environment=
-          Environment=VIRTPROXYD_ARGS=""
+        state: absent
 
     - name: Reload systemctl and start/enable virtproxyd.service
       ansible.builtin.systemd_service:
         daemon_reload: true
-        name: virtproxyd.service
-        state: restarted
+
+- name: Ensure proper services are enabled on newer OS
+  become: true
+  when:
+    - ansible_facts['distribution'] in ['CentOS', 'RedHat']
+    - ansible_facts['distribution_major_version'] >= '9'
+  vars:
+    _services:
+      - qemu
+      - network
+      - nodedev
+      - nwfilter
+      - secret
+      - storage
+      - interface
+  block:
+    - name: Ensure main sockets are enabled
+      ansible.builtin.service:
+        name: "virt{{ item }}d.socket"
+        state: started
         enabled: true
+      loop: "{{ _services }}"
+
+    - name: Ensure read-only sockets are enabled
+      ansible.builtin.service:
+        name: "virt{{ item }}d-ro.socket"
+        state: started
+        enabled: true
+      loop: "{{ _services }}"
+
+    - name: Ensure admin sockets are enabled
+      ansible.builtin.service:
+        name: "virt{{ item }}d-admin.socket"
+        state: started
+        enabled: true
+      loop: "{{ _services }}"
+
+- name: Manage service for older releases
+  become: true
+  when:
+    - ansible_facts['distribution'] in ['CentOS', 'RedHat']
+    - ansible_facts['distribution_major_version'] < '9'
+  ansible.builtin.service:
+    name: "{{ cifmw_libvirt_manager_daemon }}"
+    state: started
+    enabled: true
 
 - name: Get libvirt group users
   ansible.builtin.getent:


### PR DESCRIPTION
With EL-9 and CS-9, libvirt has moved to modular, socket activated
services.
We therefore must ensure proper services are enabled depending on the
release - and with the modular approach, we now have multiple sockets to
control.

Fixes: #751

Co-Authored-By: @knoha-rh

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
