### PR TITLE
Configure insecure registry on EDPM nodes

### DIFF
--- a/ci_framework/hooks/playbooks/fetch_compute_facts.yml
+++ b/ci_framework/hooks/playbooks/fetch_compute_facts.yml
@@ -229,6 +229,12 @@
                       - "{{ dns_server }}"
               {% endfor %}
 
+              {% if content_provider_registry_ip is defined %}
+                  - op: add
+                    path: /spec/nodeTemplate/ansible/ansibleVars/edpm_container_registry_insecure_registries
+                    value: ["{{ content_provider_registry_ip }}:5001"]
+              {% endif %}
+
 
         - name: Ensure we know about the private host keys
           ansible.builtin.shell:

--- a/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -182,6 +182,20 @@
           --type json
           -p '[{"op": "replace", "path": "/spec/services/0", "value": "repo-setup-downstream"}]'
 
+- name: Patch OpenStackDataPlaneNodeSet resource to include content provider insecure registry
+  when: content_provider_registry_ip is defined
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: >-
+      oc patch openstackdataplanenodeset openstack-edpm-ipam
+      -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+      --type json
+      -p '[{"op": "replace",
+            "path": "/spec/nodeTemplate/ansible/ansibleVars/edpm_container_registry_insecure_registries",
+            "value": "['{{ content_provider_registry_ip }}:5001']"}]'
+
 - name: Wait for OpenStackDataPlaneNodeSet to be Ready
   when: not cifmw_edpm_deploy_baremetal_dry_run
   environment:


### PR DESCRIPTION
In tcib project side, we build openstack-services containers in a content provider job. Then we pull these images in EDPM jobs.

On EDPM job side, EDPM telemetry service deployment is failing while pulling ceilometer image from content provider.

Content provider is an insecure registry for edpm node. We need to configure insecure registry setting to allow pulling the images otherwise it will fail[1].

This pr adds the same.

[1]. https://logserver.rdoproject.org/97/97/5399ecf516bf7375b76a26fe439288e8b31361f5/github-check/tcib-podified-multinode-edpm-deployment-crc/3ccfc05/controller/ci-framework-data/logs/crc/pods/openstack_dataplane-deployment-telemetry-openstack-edpm-bvb65_391f164a-eba4-4906-b80b-b2ee7d162e1a/openstackansibleee/0.log

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

