### PR TITLE
Fix kuttl playbook order

### DIFF
--- a/ci/playbooks/kuttl/e2e-kuttl.yml
+++ b/ci/playbooks/kuttl/e2e-kuttl.yml
@@ -11,22 +11,7 @@
         ] | ansible.builtin.path_join
     }}
 
-- name: Run pre_kuttl hooks
-  vars:
-    hooks: "{{ pre_kuttl | default([]) }}"
-    step: pre_kuttl
-  ansible.builtin.import_playbook: >-
-    {{
-        [
-          ansible_user_dir,
-          zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
-          'ci_framework',
-          'playbooks',
-          'hooks.yml'
-        ] | ansible.builtin.path_join
-    }}
-
-- name: Deploy and run KUTTL operator tests
+- name: Install deps and prepare for KUTTL run
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   tasks:
     - name: Download install_yamls deps
@@ -45,6 +30,24 @@
         name: "install_yamls_makes"
         tasks_from: "make_crc_attach_default_interface"
 
+- name: Run pre_kuttl hooks
+  vars:
+    hooks: "{{ pre_kuttl | default([]) }}"
+    step: pre_kuttl
+  ansible.builtin.import_playbook: >-
+    {{
+        [
+          ansible_user_dir,
+          zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
+          'ci_framework',
+          'playbooks',
+          'hooks.yml'
+        ] | ansible.builtin.path_join
+    }}
+
+- name: Run KUTTL operator tests
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  tasks:
     - name: Run kuttl tests
       ansible.builtin.include_tasks: run-kuttl-tests.yml
       loop: "{{ cifmw_kuttl_tests_operator_list | default(['cinder' 'keystone']) }}"


### PR DESCRIPTION
Some pre_hooks need to reach OCP cluster using the kubeconfig generated by openshift_login. So we need to move pre_hook right before running kuttl tests.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
