### PR TITLE
Add tempest.api.network.admin.test_dhcp_agent_scheduler test to skip …

### DIFF
--- a/ci_framework/roles/tempest/files/list_skipped.yml
+++ b/ci_framework/roles/tempest/files/list_skipped.yml
@@ -1,5 +1,14 @@
 known_failures:
   # Neutron operator
+  - test: 'tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestJSON'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - neutron-operator
   - test: 'tempest.api.network.admin.test_ports.PortsAdminExtendedAttrsIpV6TestJSON'
     deployment:
       - 'overcloud'


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:

- [x] Appropriate testing is done and actually running

- [x] Appropriate documentation exists and/or is up-to-date:

  