### PR TITLE
Use kustomize add operation for setting insecure registry

### DIFF
--- a/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -192,9 +192,9 @@
       oc patch openstackdataplanenodeset openstack-edpm-ipam
       -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
       --type json
-      -p '[{"op": "replace",
+      -p '[{"op": "add",
             "path": "/spec/nodeTemplate/ansible/ansibleVars/edpm_container_registry_insecure_registries",
-            "value": "['{{ content_provider_registry_ip }}:5001']"}]'
+            "value": [{{ content_provider_registry_ip }}:5001]}]'
 
 - name: Wait for OpenStackDataPlaneNodeSet to be Ready
   when: not cifmw_edpm_deploy_baremetal_dry_run

--- a/zuul.d/tcib.yaml
+++ b/zuul.d/tcib.yaml
@@ -2,7 +2,7 @@
 - job:
     name: cifmw-tcib-base
     parent: container-tcib-build-base
-    timeout: 3000
+    timeout: 3500
     nodeset: centos-stream-9
     required-projects:
       - opendev.org/zuul/zuul-jobs


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/ci-framework/pull/785 adds the support for setting insecure registry on EDPM nodes.

It works for EDPM. In BM job, we used replace operation which does not work as the key `edpm_container_registry_insecure_registries` does not exists in CR.

We need to use `add` as used in EDPM in order to make it working.

Note: It also bumps the timeout for tcib jobs as new containers got added and we need more then an hour to build all containers.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
