### PR TITLE
Fix Baremetal EDPM logging

### DIFF
--- a/ci_framework/roles/artifacts/tasks/edpm.yml
+++ b/ci_framework/roles/artifacts/tasks/edpm.yml
@@ -4,9 +4,9 @@
     - not ansible_facts.services is defined
   ansible.builtin.service_facts:
 
-- name: Check for virtualized compute
+- name: Check for virtualized compute in Baremetal jobs
   when:
-    - "'libvirtd' in ansible_facts.services"
+    - "'libvirtd.service' in ansible_facts.services"
   block:
     - name: List all of the existing virtual machines
       register: vms_list
@@ -17,7 +17,7 @@
     - name: Filter out edpm vm
       ansible.builtin.set_fact:
         ssh_key_file: "{{ cifmw_artifacts_basedir }}/artifacts/edpm/ansibleee-ssh-key-id_rsa"
-        ssh_user: root
+        ssh_user: cloud-admin
         edpm_vms: >-
           {%- set listing=vms_list.list_vms | select('match', '^edpm-.*$') -%}
           {%- if listing | length == 1 -%}


### PR DESCRIPTION
    Currently `Check for virtualized compute` task is getting skipped
    due to wrong conditional.
    
    This patch fixes the conditional for libvirt services checking.
    
    In Baremetal Job, the default user with ssh access is cloud-admin
    not root user. It fixes the user for the same.


As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
