### PR TITLE
Remove the namespace in the NMstate resources as is cluster wide

### DIFF
--- a/ci_framework/roles/ci_nmstate/defaults/main.yml
+++ b/ci_framework/roles/ci_nmstate/defaults/main.yml
@@ -55,7 +55,6 @@ cifmw_ci_nmstate_operator_config:
   kind: NMState
   metadata:
     name: nmstate
-    namespace: "{{ cifmw_ci_nmstate_namespace }}"
 
 cifmw_ci_nmstate_nncp_config_template:
   apiVersion: nmstate.io/v1


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
