### PR TITLE
Fix the SSH proxy hostname used in the localhost controller

### DIFF
--- a/ci_framework/roles/libvirt_manager/tasks/create_vms.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/create_vms.yml
@@ -202,6 +202,7 @@
   delegate_to: localhost
   vars:
     extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
+    proxy_hostname: "{{ ansible_host | default(inventory_hostname) }}"
   ansible.builtin.blockinfile:
     create: true
     path: "{{ lookup('env', 'HOME') }}/.ssh/config"
@@ -209,7 +210,7 @@
     mode: "0600"
     block: |-
       Host {{ vm_ip.nic.host }} cifmw-{{ vm_ip.nic.host }} {{ extracted_ip }}
-        ProxyJump {{ ansible_user | default(lookup('env', 'USER')) }}@{{ inventory_hostname }}
+        ProxyJump {{ ansible_user | default(lookup('env', 'USER')) }}@{{ proxy_hostname }}
         Hostname {{ extracted_ip }}
         User zuul
         StrictHostKeyChecking no


### PR DESCRIPTION
Right now we are using the inventory_hostname, that may not be a valid hostname, that's why now we default to the ansible_host.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
