### PR TITLE
Kustomize EDPM containers using set_openstack_containers role

### DIFF
--- a/ci_framework/roles/edpm_deploy/defaults/main.yml
+++ b/ci_framework/roles/edpm_deploy/defaults/main.yml
@@ -23,4 +23,3 @@ cifmw_edpm_deploy_retries: 100
 cifmw_edpm_deploy_run_validation: false
 cifmw_edpm_deploy_dryrun: false
 cifmw_edpm_deploy_timeout: 40
-cifmw_edpm_deploy_registry_url: "{{ cifmw_install_yamls_defaults['DATAPLANE_REGISTRY_URL'] }}"

--- a/ci_framework/roles/edpm_deploy/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy/tasks/main.yml
@@ -25,8 +25,6 @@
       {{
         cifmw_install_yamls_environment |
         combine({'PATH': cifmw_path}) |
-        combine({'DATAPLANE_REGISTRY_URL': cifmw_edpm_deploy_registry_url }) |
-        combine({'DATAPLANE_CONTAINER_TAG': cifmw_repo_setup_full_hash | default(cifmw_install_yamls_defaults['DATAPLANE_CONTAINER_TAG']) }) |
         combine(cifmw_edpm_deploy_extra_vars | default({}))
       }}
     cacheable: true

--- a/ci_framework/roles/set_openstack_containers/README.md
+++ b/ci_framework/roles/set_openstack_containers/README.md
@@ -16,6 +16,7 @@ The role will generate two 2 files in ~/ci-framework-data/artifacts/ directory a
 * `cifmw_set_openstack_containers_dlrn_md5_path`: Full path of delorean.repo.md5. Defaults to `/etc/yum.repos.d/delorean.repo.md5`.
 * `cifmw_set_openstack_containers_overrides`: Extra container overrides. Defaults to `{}`
 * `cifmw_set_openstack_containers_prefix`: Update container containing. Defaults to `openstack`
+* `cifmw_set_openstack_containers_edpm`: Update EDPM containers. Defaults to `false`
 
 ## Examples
 

--- a/ci_framework/roles/set_openstack_containers/defaults/main.yml
+++ b/ci_framework/roles/set_openstack_containers/defaults/main.yml
@@ -26,5 +26,8 @@ cifmw_set_openstack_containers_operator_name: openstack
 cifmw_set_openstack_containers_tag_from_md5: false
 cifmw_set_openstack_containers_dlrn_md5_path: "/etc/yum.repos.d/delorean.repo.md5"
 
+# Update EDPM containers
+cifmw_set_openstack_containers_edpm: false
+
 # Set custom image url for non-openstack images
 cifmw_set_openstack_containers_overrides: {}

--- a/ci_framework/roles/set_openstack_containers/tasks/kustomize_edpm.yml
+++ b/ci_framework/roles/set_openstack_containers/tasks/kustomize_edpm.yml
@@ -1,0 +1,75 @@
+---
+- name: Make EDPM manifests directory exists
+  ansible.builtin.file:
+    path: "{{ cifmw_set_openstack_containers_basedir }}/artifacts/manifests/kustomizations/dataplane"
+    state: directory
+    recurse: true
+
+- name: Construct container registry
+  ansible.builtin.set_fact:
+    _container_registry: "{{ cifmw_set_openstack_containers_registry }}/{{ cifmw_set_openstack_containers_namespace }}"
+
+- name: Construct container url
+  ansible.builtin.set_fact:
+    _container_url: "{{ _container_registry }}/{{ cifmw_set_openstack_containers_prefix }}"
+
+- name: Create EDPM Container CR customization
+  ansible.builtin.copy:
+    dest: "{{ cifmw_set_openstack_containers_basedir }}/artifacts/manifests/kustomizations/dataplane/100-kustomization.yaml"
+    content: |-
+      apiVersion: kustomize.config.k8s.io/v1beta1
+      kind: Kustomization
+      resources:
+      namespace: {{ cifmw_install_yamls_defaults.NAMESPACE }}
+      patches:
+      - target:
+          kind: OpenStackDataPlaneNodeSet
+        patch: |-
+
+          - op: add
+            path: /spec/nodeTemplate/ansible/ansibleVars/edpm_ovn_controller_agent_image
+            value: {{ _container_url }}-ovn-controller:{{ cifmw_set_openstack_containers_tag }}
+
+          - op: add
+            path: /spec/nodeTemplate/ansible/ansibleVars/edpm_iscsid_image
+            value: {{ _container_url }}-iscsid:{{ cifmw_set_openstack_containers_tag }}
+
+          - op: add
+            path: /spec/nodeTemplate/ansible/ansibleVars/edpm_logrotate_crond_image
+            value: {{ _container_url }}-cron:{{ cifmw_set_openstack_containers_tag }}
+
+          - op: add
+            path: /spec/nodeTemplate/ansible/ansibleVars/edpm_nova_compute_image
+            value: {{ _container_url }}-nova-compute:{{ cifmw_set_openstack_containers_tag }}
+
+          - op: add
+            path: /spec/nodeTemplate/ansible/ansibleVars/edpm_libvirt_image
+            value: {{ _container_url }}-nova-libvirt:{{ cifmw_set_openstack_containers_tag }}
+
+          - op: add
+            path: /spec/nodeTemplate/ansible/ansibleVars/edpm_neutron_metadata_agent_image
+            value: {{ _container_url }}-neutron-metadata-agent-ovn:{{ cifmw_set_openstack_containers_tag }}
+
+          - op: add
+            path: /spec/nodeTemplate/ansible/ansibleVars/edpm_neutron_ovn_agent_image
+            value: {{ _container_url }}-neutron-ovn-agent:{{ cifmw_set_openstack_containers_tag }}
+
+          - op: add
+            path: /spec/nodeTemplate/ansible/ansibleVars/edpm_ovn_bgp_agent_image
+            value: {{ _container_url }}-ovn-bgp-agent:{{ cifmw_set_openstack_containers_tag }}
+
+          - op: add
+            path: /spec/nodeTemplate/ansible/ansibleVars/edpm_neutron_dhcp_image
+            value: {{ _container_url }}-neutron-dhcp-agent:{{ cifmw_set_openstack_containers_tag }}
+
+          - op: add
+            path: /spec/nodeTemplate/ansible/ansibleVars/edpm_neutron_sriov_image
+            value: {{ _container_url }}-neutron-sriov-agent:{{ cifmw_set_openstack_containers_tag }}
+
+          - op: add
+            path: /spec/nodeTemplate/ansible/ansibleVars/edpm_frr_image
+            value: {{ _container_url }}-frr:{{ cifmw_set_openstack_containers_tag }}
+
+          - op: add
+            path: /spec/nodeTemplate/ansible/ansibleVars/edpm_multipathd_image
+            value: {{ _container_url }}-multipathd:{{ cifmw_set_openstack_containers_tag }}

--- a/ci_framework/roles/set_openstack_containers/tasks/main.yml
+++ b/ci_framework/roles/set_openstack_containers/tasks/main.yml
@@ -130,3 +130,7 @@
     script: "oc set env {{ operator_pod_name }} -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} --list > operator_env.txt"
     chdir: "{{ cifmw_set_openstack_containers_basedir }}/artifacts"
     creates: operator_env.txt
+
+- name: Kustomize EDPM containers
+  ansible.builtin.import_tasks: kustomize_edpm.yml
+  when: cifmw_set_openstack_containers_edpm | bool

--- a/scenarios/centos-9/edpm_periodic.yml
+++ b/scenarios/centos-9/edpm_periodic.yml
@@ -8,6 +8,6 @@ cifmw_edpm_prepare_update_os_containers: true
 cifmw_set_openstack_containers_namespace: "podified-master-centos9"
 cifmw_edpm_deploy_baremetal_update_os_containers: true
 cifmw_run_tests: true
-cifmw_edpm_deploy_registry_url: "{{ cifmw_set_openstack_containers_registry }}/{{ cifmw_set_openstack_containers_namespace }}"
+cifmw_set_openstack_containers_edpm: true
 cifmw_tempest_image: "{{ cifmw_set_openstack_containers_registry }}/{{ cifmw_set_openstack_containers_namespace }}/openstack-tempest"
 cifmw_tempest_image_tag: "{{ cifmw_repo_setup_full_hash }}"


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/dataplane-operator/pull/512 drops the openstack services containers ansible vars from dataplane cr.

The above change is going to break the periodic line. In order to avoid breakage, It moves the image customization on set_openstack_containers side.

Depends-On: https://github.com/openstack-k8s-operators/dataplane-operator/pull/512

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

