### PR TITLE
Avoid copying repositories generated by repo-setup

### DIFF
--- a/ci_framework/hooks/playbooks/fetch_compute_facts.yml
+++ b/ci_framework/hooks/playbooks/fetch_compute_facts.yml
@@ -1,16 +1,4 @@
 ---
-- name: Push repositories hook
-  hosts: all,!crcs,!crc
-  gather_facts: true
-  tasks:
-    - name: Copy repositories from controller to compute
-      when:
-        - inventory_hostname is match('^compute.*')
-      become: true
-      ansible.builtin.copy:
-        dest: "/etc/yum.repos.d/"
-        src: "{{ cifmw_basedir }}/artifacts/repositories/"
-
 - name: Build dataset hook
   hosts: localhost
   gather_facts: false


### PR DESCRIPTION
On computes, repo-setup is now run using an EDPM service. No need to copy repositories manually from the controller.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date: