### PR TITLE
Do not code any NIC related data in domain XML

### DIFF
--- a/ci_framework/roles/libvirt_manager/molecule/deploy_layout/converge.yml
+++ b/ci_framework/roles/libvirt_manager/molecule/deploy_layout/converge.yml
@@ -26,6 +26,8 @@
         range: "192.168.140.0/24"
         mtu: 1500
         static_ip: true
+      public:
+        range: "192.168.100.0/24"
       internal-api:
         range: "172.17.0.0/24"
         vlan: 20
@@ -49,9 +51,10 @@
             <name>public</name>
             <forward mode='nat'/>
             <bridge name='public' stp='on' delay='0'/>
-            <ip family='ipv4' address='192.168.100.1' prefix='24'>
+            <ip family='ipv4' address='{{ cifmw_libvirt_manager_networks.public.range | ansible.utils.nthhost(1) }}' prefix='24'>
               <dhcp>
-                <range start='192.168.100.10' end='192.168.100.100'/>
+                <range start='{{ cifmw_libvirt_manager_networks.public.range | ansible.utils.nthhost(10) }}'
+                end='{{ cifmw_libvirt_manager_networks.public.range | ansible.utils.nthhost(100) }}'/>
               </dhcp>
             </ip>
           </network>
@@ -60,7 +63,7 @@
             <name>osp_trunk</name>
             <forward mode='nat'/>
             <bridge name='osp_trunk' stp='on' delay='0'/>
-            <ip family='ipv4' address='192.168.140.1' prefix='24'>
+            <ip family='ipv4' address='{{ cifmw_libvirt_manager_networks.osp_trunk.range | ansible.utils.nthhost(1) }}' prefix='24'>
             </ip>
           </network>
   roles:

--- a/ci_framework/roles/libvirt_manager/tasks/attach_interface.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/attach_interface.yml
@@ -32,6 +32,7 @@
 
     - name: Extract networks from XML
       register: _extracted_xml
+      failed_when: false
       community.general.xml:
         xmlstring: "{{ _domain_xml.get_xml }}"
         xpath: "/domain/devices/interface/source"
@@ -46,7 +47,7 @@
       }}
     _attached_nets: >-
       {{
-        _extracted_xml.matches |
+        _extracted_xml.matches | default([]) |
         selectattr('source.bridge', 'equalto', _net_name)
       }}
   when:

--- a/ci_framework/roles/libvirt_manager/tasks/create_vms.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/create_vms.yml
@@ -105,6 +105,16 @@
     index_var: vm_id
     label: "{{ vm_type }}-{{ vm_id }}"
 
+- name: Attach listed networks to the VMs
+  vars:
+    vm_item: "{{ vm_type }}-{{ vm_id }}"
+    networks: "{{ vm_data.value.nets }}"
+  ansible.builtin.include_tasks: net_to_vms.yml
+  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
+  loop_control:
+    index_var: vm_id
+    label: "{{ vm_type }}-{{ vm_id }}"
+
 - name: Fetch per-vm ports
   register: _vm_ports
   ansible.builtin.command:
@@ -223,6 +233,11 @@
 - name: "({{ inventory_hostname }}) Inject ssh jumpers for {{ vm_type }}"  # noqa: name[template]
   vars:
     extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
+    identity_file: >-
+      {{
+        cifmw_reproducer_basedir ~ '/artifacts/cifmw_ocp_access_key' if vm_type == 'ocp' else
+        ansible_user_dir ~ '/.ssh/cifmw_reproducer_key'
+      }}
   ansible.builtin.blockinfile:
     create: true
     path: "{{ ansible_user_dir }}/.ssh/config"
@@ -232,7 +247,7 @@
       Host {{ vm_ip.nic.host }} cifmw-{{ vm_ip.nic.host }} {{ extracted_ip }}
         Hostname {{ extracted_ip }}
         User zuul
-        IdentityFile {{ ansible_user_dir }}/.ssh/cifmw_reproducer_key
+        IdentityFile {{ identity_file }}
         StrictHostKeyChecking no
         UserKnownHostsFile /dev/null
   loop: "{{ vm_ips.results }}"
@@ -275,7 +290,7 @@
 
 - name: "Configure ssh access on type {{ vm_type }}"
   when:
-    - vm_type is not match('^crc.*$')
+    - vm_type is not match('^(crc|ocp).*$')
   delegate_to: "{{ vm_ip.nic.host }}"
   remote_user: "{{ _init_admin_user }}"
   ansible.posix.authorized_key:

--- a/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -103,7 +103,7 @@
     vm_type: "{{ vm_data.key }}"
     pub_key: "{{ pub_ssh_key.content | b64decode }}"
     priv_key: "{{ priv_ssh_key.content | b64decode }}"
-    _init_admin_user: "{{ item.value.admin_user | default('root') }}"
+    _init_admin_user: "{{ vm_data.value.admin_user | default('root') }}"
   ansible.builtin.include_tasks:
     file: create_vms.yml
   loop: "{{ _layout.vms | dict2items }}"

--- a/ci_framework/roles/libvirt_manager/tasks/net_to_vms.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/net_to_vms.yml
@@ -1,0 +1,30 @@
+---
+# Mostly called from the create_vms.yml tasks, from
+# within a loop on the VMs.
+# It will then loop on the listed networks and attach
+# them to the current "item", which is an actual VM.o
+- name: "Attach {{ vm_item }} to {{ net_item }}"  # noqa: name[template]
+  vars:
+    cifmw_libvirt_manager_net_prefix_add: >-
+      {{
+        net_item is not match('^ocp.*')
+      }}
+    vm_name: "cifmw-{{ vm_item }}"
+    network:
+      name: "{{ net_item }}"
+      cidr: >-
+        {{
+          cifmw_libvirt_manager_networks[net_item]['range']
+        }}
+      mtu: >-
+        {{
+          cifmw_libvirt_manager_networks[net_item]['mtu'] | default(1500)
+        }}
+      static_ip: >-
+        {{
+          cifmw_libvirt_manager_networks[net_item]['static_ip'] | default(false)
+        }}
+  ansible.builtin.include_tasks: attach_interface.yml
+  loop: "{{ networks }}"
+  loop_control:
+    loop_var: net_item

--- a/ci_framework/roles/libvirt_manager/tasks/reserve_ip.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/reserve_ip.yml
@@ -30,26 +30,74 @@
 #   extraworker     100
 #   compute         100      # Has the same index of extraworker
 
-
-- name: Generate the IP address
+- name: "Dump net XML for {{ network.name }}"
   vars:
-    _vm_name: "{{ vm_name | replace('-', '_') | split('_') }}"
-    _ip_index: >-
+    _net_name: >-
       {{
-        cifmw_libvirt_manager_vm_net_ip_set[_vm_name[1]] +
-        _vm_name[2] | int
+        (network.name is match('^ocp')) |
+        ternary(network.name, 'cifmw-' ~ network.name)
+      }}
+  register: _net_xml
+  community.libvirt.virt_net:
+    command: "get_xml"
+    name: "{{ _net_name }}"
+
+- name: "Parse XML for {{ network.name }}"
+  failed_when: false
+  register: _reserved
+  community.general.xml:
+    xmlstring: "{{ _net_xml.get_xml }}"
+    xpath: "/network/ip/dhcp/host"
+    content: "attribute"
+
+- name: "Check for existing reservation for {{ vm_name }} in {{ network.name }}"  # noqa: name[template]
+  vars:
+    _reservation: >-
+      {{
+        _reserved.matches | default([]) |
+        selectattr('host.name', 'equalto', vm_name) |
+        first
       }}
   ansible.builtin.set_fact:
-    _lm_ip_address: "{{ network.cidr | ansible.utils.nthhost(_ip_index) }}"
+    reserved: >-
+      {{
+        _reservation.host.mac | default('')
+      }}
 
-- name: Reserve static IP address for the node.
-  vars:
-    _vm_name: "{{ vm_name | replace('^cifmw-', '') }}"
-  community.libvirt.virt_net:
-    command: modify
-    name: "cifmw-{{ network.name }}"
-    uri: "qemu:///system"
-    xml: |
-      <host mac='{{ mac_address }}' name='{{ _vm_name }}' ip='{{ _lm_ip_address }}'>
-        <lease expiry='60' unit='minutes'/>
-      </host>
+- name: "Override MAC for {{ vm_name }} on {{ network.name }}"  # noqa: name[template]
+  when:
+    - reserved != ''
+  ansible.builtin.set_fact:
+    mac_address: "{{ reserved }}"
+
+- name: Reserve IP address
+  when:
+    - reserved == ''
+  block:
+    - name: "Generate IP address for {{ vm_name }}"
+      vars:
+        _vm_name: "{{ vm_name | replace('-', '_') | split('_') }}"
+        _ip_index: >-
+          {{
+            cifmw_libvirt_manager_vm_net_ip_set[_vm_name[1]] +
+            _vm_name[2] | int
+          }}
+      ansible.builtin.set_fact:
+        _lm_ip_address: "{{ network.cidr | ansible.utils.nthhost(_ip_index) }}"
+
+    - name: "Reserve IP for {{ vm_name }} on {{ network.name }}"  # noqa: name[template]
+      vars:
+        _vm_name: "{{ vm_name | replace('^cifmw-', '') }}"
+        _net_name: >-
+          {{
+            (network.name is match('^ocp')) |
+            ternary(network.name, 'cifmw-' ~ network.name)
+          }}
+      community.libvirt.virt_net:
+        command: modify
+        name: "{{ _net_name }}"
+        uri: "qemu:///system"
+        xml: |
+          <host mac='{{ mac_address }}' name='{{ _vm_name }}' ip='{{ _lm_ip_address }}'>
+            <lease expiry='60' unit='minutes'/>
+          </host>

--- a/ci_framework/roles/libvirt_manager/templates/domain.xml.j2
+++ b/ci_framework/roles/libvirt_manager/templates/domain.xml.j2
@@ -24,19 +24,6 @@
       <source file='{{ cifmw_libvirt_manager_basedir }}/workload/{{ vm_type }}-{{ vm_id }}.qcow2'/>
       <target dev='sda' bus='sata'/>
     </disk>
-    {% for network in vm_data.value.nets %}
-    <interface type='network'>
-{% if _layout.networks is defined and network in _layout.networks.keys() %}
-      <source network='cifmw-{{ network }}'/>
-{% elif cifmw_devscripts_extra_networks is defined and (cifmw_devscripts_extra_networks | selectattr('name', 'equalto', network)) | length > 0 %}
-      <source network='cifmw-{{ network }}'/>
-{% else %}
-      <source network='{{ network }}'/>
-{% endif %}
-      <mac address='{{ '24:42:%02i'|format(vm_id|int) |random_mac }}'/>
-      <model type="virtio"/>
-    </interface>
-    {% endfor %}
     <controller type='usb' index='0' model='ich9-ehci1'>
       <alias name='usb'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x7'/>

--- a/ci_framework/roles/libvirt_manager/templates/network-data.yml.j2
+++ b/ci_framework/roles/libvirt_manager/templates/network-data.yml.j2
@@ -36,7 +36,7 @@ crc_ci_bootstrap_networks_out:
       mtu: {{ default_mtu }}
 {% if vm_type != 'controller' %}
 {% for networking in cifmw_libvirt_manager_networks | dict2items %}
-{%   if networking.value.default is undefined or not networking.value.default | bool %}
+{%   if networking.value.vlan is defined %}
     {{ networking.key }}:
       iface: {{ ns.iface }}.{{ networking.value.vlan }}
       connection: {{ networking.key }}

--- a/ci_framework/roles/reproducer/defaults/main.yml
+++ b/ci_framework/roles/reproducer/defaults/main.yml
@@ -23,7 +23,7 @@ cifmw_reproducer_ctl_gw4: 192.168.122.1
 cifmw_reproducer_crc_ip4: 192.168.122.10
 cifmw_reproducer_crc_gw4: 192.168.122.1
 cifmw_reproducer_private_nic: eth1
-cifmw_reproducer_crc_private_nic: enp2s0
+cifmw_reproducer_crc_private_nic: enp5s0
 cifmw_reproducer_kubecfg: "{{ cifmw_libvirt_manager_configuration.vms.crc.image_local_dir }}/kubeconfig"
 cifmw_reproducer_params: {}
 cifmw_reproducer_run_job: true

--- a/ci_framework/roles/reproducer/molecule/crc_layout/converge.yml
+++ b/ci_framework/roles/reproducer/molecule/crc_layout/converge.yml
@@ -23,6 +23,8 @@
     cifmw_install_yamls_repo: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
     cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
     cifmw_libvirt_manager_networks:
+      public:
+        range: "192.168.100.0/24"
       osp_trunk:
         default: true
         range: "192.168.140.0/24"
@@ -85,9 +87,10 @@
             <forward mode='nat'/>
             <bridge name='public' stp='on' delay='0'/>
             <mac address='52:54:00:6a:f2:dc'/>
-            <ip family='ipv4' address='192.168.100.1' prefix='24'>
+            <ip family='ipv4' address='{{ cifmw_libvirt_manager_networks.public.range | ansible.utils.nthhost(1) }}' prefix='24'>
               <dhcp>
-                <range start='192.168.100.10' end='192.168.100.100'/>
+                <range start='{{ cifmw_libvirt_manager_networks.public.range | ansible.utils.nthhost(10) }}'
+                end='{{ cifmw_libvirt_manager_networks.public.range | ansible.utils.nthhost(100) }}'/>
               </dhcp>
             </ip>
           </network>

--- a/ci_framework/roles/reproducer/tasks/configure_crc.yml
+++ b/ci_framework/roles/reproducer/tasks/configure_crc.yml
@@ -16,7 +16,7 @@
         autoconnect: true
         conn_name: private_net
         dns4: 127.0.0.1
-        ifname: enp2s0
+        ifname: "{{ cifmw_reproducer_crc_private_nic }}"
         type: ethernet
         ip4: "{{ cifmw_reproducer_crc_ip4 }}/24"
         gw4: "{{ cifmw_reproducer_crc_gw4 }}"

--- a/scenarios/reproducers/3-nodes.yml
+++ b/scenarios/reproducers/3-nodes.yml
@@ -16,6 +16,8 @@ cifmw_rhol_crc_config:
 # networking information to the libvirt_manager so that it will be able to
 # generate the needed content for later usage
 cifmw_libvirt_manager_networks:
+  public:
+    range: "192.168.100.0/24"
   osp_trunk:
     default: true
     range: "192.168.122.0/24"


### PR DESCRIPTION
This change allows to use attach_network tasks in all cases instead of
trying to be too smart.

Converging like this will ensure a far happier path for OCP cluster
integration.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
