### PR TITLE
Add switch config role from ansible NFV

### DIFF
--- a/ci_framework/hooks/playbooks/switch_config.yml
+++ b/ci_framework/hooks/playbooks/switch_config.yml
@@ -1,0 +1,5 @@
+- name: Switches configuration
+  hosts: switches
+  gather_facts: false
+  roles:
+    - switch_config

--- a/ci_framework/roles/switch_config/README.md
+++ b/ci_framework/roles/switch_config/README.md
@@ -1,0 +1,175 @@
+# Switches config
+
+## Description
+The switches config role performs the following tasks:
+- VLAN configuration access/trunk on the switch port.
+- MTU configuration on the switch port.
+- LACP configuration on interface and members attach.
+- IGMP Snooping configuration
+
+Supported switch platforms:
+- Cisco
+- Juniper
+- Mellanox MLNX-OS (ONYX with JSON API is not supported due to not having access to a compatible switch)
+
+**For Juniper switches, Ansible modules use the `netconf` capability `lock`, which is equivalent to the CLI command `configure exclusive`,
+which means parallel execution is impossible.**.
+We are doing a check to avoid this if the configuration database is open.
+It will automatically retry 3 times every 15 minutes if it is not open (by default).
+This hack might not be stable.
+
+## Inventory
+The play requires an inventory file that will describe switches that the playbook should run on.
+**Note** - Switches are static resources that not changing frequently.
+As a result the inventory could be static and not generated dynamically.
+The inventory for this playbook should be created by the user.
+
+```
+[ios]
+cisco_switch01 ansible_host=10.10.10.120
+
+[junos]
+juniper_switch01 ansible_host=10.10.10.100
+juniper_switch02 ansible_host=10.10.10.101
+
+[onyx]
+mlx_switch01 ansible_host=10.10.10.131
+
+[switches:children]
+ios
+junos
+onyx
+
+[switches:vars]
+ansible_user=root
+
+[ios:vars]
+ansible_network_os=ios
+ansible_connection=network_cli
+ansible_become=yes
+ansible_become_method=enable
+
+[junos:vars]
+ansible_network_os=junos
+ansible_connection=netconf
+
+[onyx:vars]
+ansible_user=admin
+ansible_password=admin
+ansible_become_password=admin
+ansible_connection=network_cli
+ansible_network_os=onyx
+ansible_become=yes
+ansible_become_method=enable
+```
+
+## Variables
+The names of the switches in the variables should represent the name of the switch in the inventory.
+
+```YAML
+juniper_switch01:
+  switch_banner: |
+    MOTD can
+    span multiple lines
+  vlans:
+    - start: 10
+      end: 20
+    - start: 50
+      end: 55
+  interfaces:
+    - { description: 'host1_port1', iface: 'xe-0/0/0', iface_mode: 'access', vlan: '10', mtu: '9000' }
+    - { description: 'host2_port3', iface: 'xe-0/0/1', iface_mode: 'trunk', vlan: '15-20', mtu: '9000' }
+    - { description: 'host3_port1', iface: 'xe-0/0/4', iface_mode: 'trunk', vlan: '50-53' }
+    - { description: 'aggregation', iface: 'ae2', iface_mode: 'trunk', vlan: '53-55', mtu: '9192', aggr_members: ['xe-0/0/12', 'xe-0/0/13'] }
+  igmp_snooping:
+    - { vlan: '55', ip_address: '10.20.155.5', interfaces: ['ae2'] }
+
+juniper_switch02:
+  vlans:
+    - start: 25
+      end: 30
+    - start: 70
+      end: 75
+  interfaces:
+    - { description: 'host1_port1', iface: 'xe-0/0/0', iface_mode: 'trunk', vlan: '25-27', mtu: '9000' }
+    - { description: 'host2_port3', iface: 'xe-0/0/1', iface_mode: 'access', vlan: '29', mtu: '9000' }
+    - { description: 'host3_port1', iface: 'xe-0/0/4', iface_mode: 'trunk', vlan: '70-75' }
+    - { description: 'host3_port1', iface: 'xe-0/0/5', iface_mode: 'trunk', vlan: '70' }
+  # The play assumes that all layer3 interfaces are of type 'irb'
+  # 'vlan_interface' name is <vlan><vlan_id>
+  layer3_interfaces:
+    - unit: '110'
+      ipv4_address: '192.168.110.254/24'
+      vlan_interface: 'vlan110'
+    - unit: '199'
+      ipv4_address: '192.168.199.254/24'
+      vlan_interface: 'vlan999'
+
+cisco_switch01:
+  switch_banner: |
+    MOTD can
+    span multiple lines
+  # Generates the following commands:
+  # route-map Test-RouteMap permit 10
+  #   match ip address Test-RouteMap-ACL
+  #   set ip next-hop 192.168.20.1
+  # interface vlan 21
+  #   ip policy route-map Test-RouteMap
+  route_maps:
+    - route_map_name: Test-RouteMap
+      match_ip_address: Test-RouteMap-ACL
+      ip_next_hop: 192.168.20.1
+      interface: vlan21
+  vlans:
+    - start: 100
+      end: 105
+  interfaces:
+     - { description: 'tigon15', iface: 'GigabitEthernet5/0/6', iface_mode: 'access', vlan: '20' }
+     - { description: 'tigon16', iface: 'GigabitEthernet5/0/7', iface_mode: 'access', vlan: '20' }
+     - { description: 'tigon17', iface: 'GigabitEthernet5/0/8', iface_mode: 'access', vlan: '90' }
+     - { description: 'uplink_port', iface: 'GigabitEthernet5/0/9', iface_mode: 'trunk', vlan: '', encapsulation: true }
+  vlan_interfaces:
+    - iface: vlan20
+      ip_address: 192.168.20.200
+      netmask: 255.255.255.0
+    - iface: vlan21
+      ip_address: 192.168.21.254
+      netmask: 255.255.255.0
+      ip_helper_address:
+        - 192.168.20.1
+        - 192.168.20.5
+
+mlx_switch01:
+  switch_banner: |
+    "MOTD is in double quotes"
+  vlans:
+    - start: 110
+      end: 119
+  interfaces:
+    - description: "{'host': 'tigon15', 'nic_biosdevname': 'p6p1', 'nic_kernel_predictable_name': 'enp7s0f0', 'description': 'Mellanox NIC1 port0'}"
+      iface: 'ethernet 1/1'
+      iface_mode: 'trunk'
+      vlan: '110-115'
+      mtu: 9192
+    - description: "{'host': 'tigon16', 'nic_biosdevname': 'p6p2', 'nic_kernel_predictable_name': 'enp7s0f1', 'description': 'Mellanox NIC1 port1'}"
+      iface: 'ethernet 1/2'
+      iface_mode: 'trunk'
+      vlan: '110-114, 116'
+      mtu: 9192
+    - description: "{'host': 'kodkod01', 'nic_biosdevname': 'p6p2', 'nic_kernel_predictable_name': 'enp7s0f1', 'description': 'Mellanox NIC1 port0'}"
+      iface: 'ethernet 1/3'
+      iface_mode: 'acess'
+      vlan: 118
+      mtu: 9192
+```
+
+* `cifmw_switch_config_task_retry_delay`: (int) The delay time between retries when DB is locked, defaults to `900`.
+* `cifmw_switch_config_task_retries`: (int) Number of retries when DB is locked, defaults to `3`.
+
+
+## Example
+Example on applying switch configuration
+
+```
+ ansible-playbook -i /path/to/inventory switch_config.yml -e @vars_file_config.yml
+```

--- a/ci_framework/roles/switch_config/defaults/main.yml
+++ b/ci_framework/roles/switch_config/defaults/main.yml
@@ -1,0 +1,3 @@
+# Amount of retries to supported tasks
+cifmw_switch_config_task_retries: 3
+cifmw_switch_config_task_retry_delay: 900

--- a/ci_framework/roles/switch_config/molecule/default/converge.yml
+++ b/ci_framework/roles/switch_config/molecule/default/converge.yml
@@ -1,0 +1,25 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Do not do anything
+      ansible.builtin.debug:
+        msg: |
+          This role exclusively relies on running physical switches.
+          Molecule cannot run and mimic it in an environment without a switch to test on.

--- a/ci_framework/roles/switch_config/molecule/default/molecule.yml
+++ b/ci_framework/roles/switch_config/molecule/default/molecule.yml
@@ -1,0 +1,9 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true

--- a/ci_framework/roles/switch_config/tasks/ios_config.yml
+++ b/ci_framework/roles/switch_config/tasks/ios_config.yml
@@ -1,0 +1,114 @@
+---
+- name: Set login banner
+  cisco.ios.ios_banner:
+    banner: motd
+    text: "{{ switch_vars['switch_banner'] }}"
+    state: present
+  when: "'switch_banner' in switch_vars"
+
+- name: Configure DHCP Relay
+  cisco.ios.ios_config:
+    lines:
+      - ip dhcp relay information option
+      - ip dhcp relay information {{ switch_vars['dhcp_relay'] }}
+  when: "'dhcp_relay' in switch_vars"
+
+- name: Set VLANs
+  cisco.ios.ios_vlan:
+    name: "vlan{{ item }}"
+    vlan_id: "{{ item }}"
+    state: present
+  loop: "{{ vlan_list }}"
+
+- name: Advanced VLAN Interface Configuration
+  when: "'vlan_interfaces' in switch_vars"
+  block:
+    - name: Configure IP Address For Vlan Interface
+      cisco.ios.ios_config:
+        lines: ip address {{ item['ip_address'] }} {{ item['netmask'] }}
+        parents: "interface {{ item['iface'] }}"
+      loop: "{{ switch_vars['vlan_interfaces'] }}"
+      when:
+        - "'ip_address' in item"
+        - "'netmask' in item"
+    - name: Configure IP Helper Address For Vlan Interface
+      cisco.ios.ios_config:
+        lines: |
+          {%- set commands = [] -%}
+          {%- if item['ip_helper_address'] | type_debug == 'string' -%}
+          {{ commands.append('ip helper-address ' + item['ip_helper_address']) }}
+          {%- elif item['ip_helper_address'] | type_debug == 'list' -%}
+          {%- for helper in item['ip_helper_address'] -%}
+          {{ commands.append('ip helper-address ' + helper) }}
+          {%- endfor -%}
+          {%- endif -%}
+          {{ commands }}
+        parents: "interface {{ item['iface'] }}"
+      loop: "{{ switch_vars['vlan_interfaces'] }}"
+      when: "'ip_helper_address' in item"
+
+- name: Configure route-maps
+  when: "'route_maps' in switch_vars"
+  block:
+    # Native Ansible module 'ios_route_maps' shipped with collection
+    # 'cisco.ios' did not appear to work on tested Cisco switch
+    # (Catalyst 3750)
+    # We support a specific scenario for route-map
+    - name: Assign route-map To Interface
+      cisco.ios.ios_config:
+        lines:
+          - match ip address {{ item['match_ip_address'] }}
+          - set ip next-hop {{ item['ip_next_hop'] }}
+        parents: "route-map {{ item['route_map_name'] }} permit 10"
+      loop: "{{ switch_vars['route_maps'] }}"
+    - name: Assign route-map To Interface
+      cisco.ios.ios_config:
+        lines: ip policy route-map {{ item['route_map_name'] }}
+        parents: "interface {{ item['interface'] }}"
+      loop: "{{ switch_vars['route_maps'] }}"
+
+- name: Set interface description and MTU
+  cisco.ios.ios_interface:
+    name: "{{ item.iface }}"
+    description: "{{ item.description }}"
+    mtu: "{{ item.mtu |default(omit) }}"
+    # state: present
+  loop: "{{ switch_vars.interfaces }}"
+
+- name: Configure interfaces - mode (access/trunk), vlans
+  vars:
+    iface_vlans: "{%- if item.iface_mode == 'trunk' and '-' in item.vlan -%}
+                  {{ item.vlan.split('-') }}
+                  {%- endif -%}"
+    iface_vlan_range: "{%- if iface_vlans -%}
+                       {{ range(iface_vlans.0 | int, iface_vlans.1 | int + 1) | list }}
+                       {%- endif -%}"
+    trunk_vlans_list: "{%- if iface_vlan_range[0] is defined -%}
+                       {{ iface_vlan_range.split() }}{% else %}{{ item.vlan }}{% endif %}"
+    access_vlan: "{% if item.iface_mode == 'access' %}{{ item.vlan }}{% endif %}"
+  cisco.ios.ios_l2_interface:
+    name: "{{ item.iface }}"
+    mode: "{{ item.iface_mode }}"
+    access_vlan: "{%- if item.iface_mode == 'access' -%}
+                  {{ access_vlan }}{% else %}{{ omit }}{% endif %}"
+    trunk_vlans: "{%- if item.iface_mode == 'trunk' -%}
+                  {{ trunk_vlans_list }}{% else %}{{ omit }}{% endif %}"
+    native_vlan: "{%- if item.iface_mode == 'trunk' and 'native_vlan' in item -%}
+                  {{ item.native_vlan | int }}{% else %}{{ omit }}{% endif %}"
+    state: present
+  loop: "{{ switch_vars.interfaces }}"
+
+# TODO: Once moving to 2.9 version, replace the task below with the new ios_l2_interface
+# module and merge with the task above.
+- name: Set encapsulation on the interface
+  cisco.ios.ios_config:
+    lines:
+      - switchport trunk encapsulation dot1q
+      - switchport mode trunk
+    parents: "interface {{ item.iface }}"
+  loop: "{{ switch_vars.interfaces }}"
+  when: item.encapsulation is defined and item.encapsulation
+
+- name: Save configuration
+  cisco.ios.ios_config:
+    save_when: always

--- a/ci_framework/roles/switch_config/tasks/junos_config.yml
+++ b/ci_framework/roles/switch_config/tasks/junos_config.yml
@@ -1,0 +1,162 @@
+---
+
+# Workaround since Ansible modules lock the database similar to `configure exclusive`
+- name: "Random Duraion Pause"
+  ansible.builtin.pause:
+    seconds: "{{ 90 | random(step=6) }}"
+
+- name: "Check If Junos Database Is Open"
+  junipernetworks.junos.junos_config:
+    lines:
+      - set system license keys
+  register: junos_config_db_check
+  retries: "{{ cifmw_switch_config_task_retries }}"
+  delay: "{{ cifmw_switch_config_task_retry_delay }}"
+  # Not filtering specific database issue or taking into account other errors
+  until: (junos_config_db_check['msg'] is not defined)
+
+- name: Junos configuration block
+  block:
+    - name: Set login banner
+      junipernetworks.junos.junos_banner:
+        banner: motd
+        text: "{{ switch_vars['switch_banner'] }}"
+        state: present
+      when: "'switch_banner' in switch_vars"
+
+    - name: Set VLANs
+      junipernetworks.junos.junos_vlan:
+        name: "vlan{{ item }}"
+        vlan_id: "{{ item }}"
+        state: present
+      loop: "{{ vlan_list }}"
+
+    - name: Configure interfaces - description, mode (access/trunk), vlans
+      vars:
+        iface_vlans: "{%- set iface_vlans = [] -%}
+                      {%- set helper_var = [] -%}
+                      {%- if item.iface_mode == 'trunk'-%}
+                      {%- if ',' in item.vlan -%}
+                      {%- for vlan in item.vlan.replace(' ', '').split(',') -%} {{ helper_var.append(vlan) }} {%- endfor -%}
+                      {%- else -%}
+                      {{ helper_var.append(item.vlan) }}
+                      {%- endif -%}
+                      {%- for vlan in helper_var -%}
+                      {%- if '-' in vlan -%}
+                      {%- for v in range(vlan.split('-')[0] | int, vlan.split('-')[1] | int + 1) -%}
+                      {{ iface_vlans.append(v) }}
+                      {%- endfor -%}
+                      {%- else -%}
+                      {{ iface_vlans.append(vlan | int) }}
+                      {%- endif -%}
+                      {%- endfor -%}
+                      {%- endif -%}
+                      {{ iface_vlans | unique }}"
+        vlans_string: "{%- if iface_vlans -%}
+                       {% for item in iface_vlans %}vlan{{ item }} {% endfor %}
+                       {%- elif item.vlan == 'all' -%}{{ item.vlan }}
+                       {%- else -%}vlan{{ item.vlan }}{% endif %}"
+        trunk_vlans_list: "{%- if vlans_string[0] is defined -%}
+                           {{ vlans_string.split() }}{% else %}{{ item.vlan }}{% endif %}"
+        access_vlan: "{%- if item.iface_mode == 'access' -%}
+                      {{ item.vlan |regex_replace('^(.*)$', 'vlan\\1') }}
+                      {%- endif -%}"
+      junipernetworks.junos.junos_l2_interface:
+        name: "{{ item.iface }}"
+        description: "{{ item.description }}"
+        mode: "{{ item.iface_mode }}"
+        access_vlan: "{%- if item.iface_mode == 'access' -%}
+                      {{ access_vlan }}{% else %}{{ omit }}{% endif %}"
+        trunk_vlans: "{%- if item.iface_mode == 'trunk' -%}
+                      {{ trunk_vlans_list }}{% else %}{{ omit }}{% endif %}"
+        native_vlan: "{%- if item.iface_mode == 'trunk' and 'native_vlan' in item -%}
+                      {{ item.native_vlan | int }}{% else %}{{ omit }}{% endif %}"
+        unit: 0
+        state: present
+      loop: "{{ switch_vars.interfaces }}"
+      when: "'interfaces' in switch_vars"
+
+    - name: Set MTU value on the interface
+      junipernetworks.junos.junos_interface:
+        name: "{{ item.iface }}"
+        mtu: "{{ item.mtu }}"
+        state: present
+      loop: "{{ switch_vars.interfaces }}"
+      when: item.mtu is defined
+
+    # LACP aggregation can't override existing configuration
+    # that is not LACP related on the memeber interfaces.
+    # Required to delete the config before setting the LACP dependency interface.
+    - name: Reset LACP member interface
+      junipernetworks.junos.junos_interface:
+        name: "{{ item.1 }}"
+        state: absent
+      loop: "{{ switch_vars.interfaces | subelements('aggr_members', 'skip_missing=True') }}"
+      when: item.0.aggr_members is defined
+
+    - name: Set aggregation for the interface
+      junipernetworks.junos.junos_linkagg:
+        name: "{{ item.iface }}"
+        description: "{{ item.description }}"
+        members: "{{ item.aggr_members }}"
+        mode: active
+      loop: "{{ switch_vars.interfaces }}"
+      when: item.aggr_members is defined
+
+    # For each vlan for which igmp snooping is configured, remove previous
+    # configuration if it exists to ensure that applied configuration is
+    # as specified in configuration file
+    - name: Configure IGMP snooping
+      when: switch_vars.igmp_snooping is defined
+      block:
+        - name: Reset IGMP snooping for each defined vlan
+          junipernetworks.junos.junos_config:
+            lines:
+              - delete protocols igmp-snooping vlan vlan{{ item.vlan }}
+          loop: "{{ switch_vars.igmp_snooping }}"
+          when: item.vlan is defined
+
+        - name: Create IGMP querier for each defined vlan
+          junipernetworks.junos.junos_config:
+            lines:
+              - "set protocols igmp-snooping vlan vlan{{ item.vlan }}
+                 l2-querier source-address {{ item.ip_address }}"
+          loop: "{{ switch_vars.igmp_snooping }}"
+          when: item.vlan is defined and item.ip_address is defined
+
+        - name: Configure interfaces in which IGMP queries are broadcasted
+          junipernetworks.junos.junos_config:
+            lines:
+              - "set protocols igmp-snooping vlan vlan{{ item.0.vlan }}
+                 interface {{ item.1 }}"
+          loop: "{{ switch_vars.igmp_snooping | default([]) |
+                 subelements('interfaces', 'skip_missing=True') }}"
+          when: item.0.vlan is defined and item.0.interfaces is defined
+
+    - name: Configure Layer3(irb) Interfaces
+      when: "'layer3_interfaces' in switch_vars"
+      block:
+        - name: Ensure irb Interfae is configured
+          junipernetworks.junos.junos_l3_interface:
+            name: irb
+            unit: "{{ item['unit'] }}"
+            ipv4: "{{ item['ipv4_address'] }}"
+          loop: "{{ switch_vars['layer3_interfaces'] }}"
+        - name: Assign irb Interface To VLAN Interface
+          junipernetworks.junos.junos_vlan:
+            name: "{{ item['vlan_interface'] }}"
+            l3_interface: "irb.{{ item['unit'] }}"
+          loop: "{{ switch_vars['layer3_interfaces'] }}"
+
+    - name: Save configuration
+      junipernetworks.junos.junos_config:
+        confirm_commit: true
+
+  rescue:
+    - name: Configuration rollback
+      junipernetworks.junos.junos_config:
+        rollback: 1
+
+    - name: Fail Play
+      ansible.builtin.fail:
+        msg: "Configuration was rollbacked, failing play."

--- a/ci_framework/roles/switch_config/tasks/main.yml
+++ b/ci_framework/roles/switch_config/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Load switch configuration
+  ansible.builtin.set_fact:
+    switch_vars: "{{ (lookup('vars', inventory_hostname, default='')) }}"
+
+- name: Create VLANs list
+  ansible.builtin.set_fact:
+    vlan_list: "{{ vlan_list | default([]) + range(item.start, item.end + 1) | list }}"
+  loop: "{{ switch_vars.vlans }}"
+  when: "'vlans' in switch_vars"
+
+- name: "Include tasks: {{ ansible_network_os }}"
+  ansible.builtin.include_tasks: "{{ ansible_network_os }}_config.yml"
+  when: switch_vars

--- a/ci_framework/roles/switch_config/tasks/onyx_config.yml
+++ b/ci_framework/roles/switch_config/tasks/onyx_config.yml
@@ -1,0 +1,109 @@
+---
+- name: Collect switch facts
+  mellanox.onyx.onyx_facts:
+  register: onyx_facts
+  failed_when: false
+
+- name: Check if JSON API is supported in switch
+  ansible.builtin.set_fact:
+    json_api_support: |-
+      {%- if onyx_facts['rc'] == 1 and 'command \"json-print\"' in onyx_facts['module_stderr'] -%}
+        {{ False | bool }}
+      {%- else -%}
+        {{ True | bool }}
+      {%- endif -%}
+
+- name: Quit if JSON API is supported
+  ansible.builtin.fail:
+    msg: "This playbook was tested on non JSON API enabled switch and not using native onyx modules to perform actions"
+  when: json_api_support
+
+- name: MLNX-OS non JSON API enabled configuration block
+  become: true
+  when: not json_api_support
+  block:
+    - name: Set Login Banner If Required
+      mellanox.onyx.onyx_config:
+        lines: |
+          {%- set commands = [] -%}
+          {%- if 'switch_banner' in switch_vars -%}
+            {{ commands.append('banner motd ' + switch_vars['switch_banner'] | string ) }}
+          {%- endif -%}
+          {{ commands }}
+    # Generate all required commands using jinja2 template instead of looping
+    # If we loop, unnecessary SSH connections will run which will increase execution time significantly
+    - name: Create vlans
+      mellanox.onyx.onyx_config:
+        lines: |
+          {%- set commands = [] -%}
+          {%- for vlan_id in vlan_list -%}
+            {{ commands.append('vlan ' + vlan_id | string + ' name vlan' + vlan_id | string) }}
+          {%- endfor -%}
+          {{ commands }}
+
+    # Generate all required commands using jinja2 template instead of looping
+    # If we loop, unnecessary SSH connections will run which will increase execution time significantly
+    # If using `hybrid` mode, please exclude the native VLAN from trunk list
+    - name: Configure interfaces - description, mode (access/trunk/hybrid), vlans
+      mellanox.onyx.onyx_config:
+        lines: |
+          {%- set commands = [] -%}
+          {%- for interface in switch_vars['interfaces'] -%}
+            {%- if interface['description'] -%}
+              {{ commands.append('interface ' + interface['iface'] + ' description ' + interface['description']) }}
+            {%- endif -%}
+            {%- if interface['mtu'] -%}
+            {%- set mtu_commands = ['interface ' + interface['iface'] + ' shutdown', 'interface ' + interface['iface'] + ' mtu ' + interface['mtu'] | string ,'interface ' + interface['iface'] + ' no shutdown'] -%}
+            {%- for command in mtu_commands -%}
+              {{ commands.append(command) }}
+            {%- endfor -%}
+            {%- endif -%}
+            {%- if interface['iface_mode'] and interface['vlan'] -%}
+              {{ commands.append('interface ' + interface['iface'] + ' switchport mode ' + interface['iface_mode']) }}
+              {%- if interface['iface_mode'] == 'trunk' -%}
+                {%- if 'native_vlan' in interface -%}
+                  {%- set mode = 'hybrid' -%}
+                  {%- set native_commands = ['interface ' + interface['iface'] + ' switchport mode hybrid', 'interface ' + interface['iface'] + ' switchport access vlan ' + interface['native_vlan'] | string] -%}
+                  {%- for command in native_commands -%}
+                    {{ commands.append(command) }}
+                  {%- endfor -%}
+                {%- else -%}
+                  {%- set mode = 'trunk' -%}
+                {%- endif -%}
+                {{ commands.append('interface ' + interface['iface'] + ' switchport ' + mode + ' allowed-vlan none') }}
+                {%- set helper_vlans = [] -%}
+                {%- set vlans = [] -%}
+                {%- if 'all' in interface['vlan'] -%}
+                  {{ commands.append('interface ' + interface['iface'] + ' switchport' + mode + 'allowed-vlan all') }}
+                {%- elif ',' in interface['vlan'] -%}
+                  {%- for vlan in interface['vlan'].replace(' ', '').split(',') -%}
+                    {{ helper_vlans.append(vlan) }}
+                  {%- endfor -%}
+                {%- else -%}
+                  {{ helper_vlans.append(interface['vlan']) }}
+                {%- endif -%}
+                {%- for entry in helper_vlans | unique -%}
+                  {%- if '-' in entry -%}
+                    {%- for v in range(entry.split('-')[0] | int, entry.split('-')[1] | int + 1) -%}
+                      {{ vlans.append(v) }}
+                    {%- endfor -%}
+                  {%- else -%}
+                    {{ vlans.append(entry) }}
+                  {%- endif -%}
+                {%- endfor -%}
+                {%- for vlan in vlans | unique -%}
+                  {{ commands.append('interface ' + interface['iface'] + ' switchport ' + mode + ' allowed-vlan add ' + vlan | string) }}
+                {%- endfor -%}
+                {{ commands.append('interface ' + interface['iface'] + ' switchport ' + mode + ' allowed-vlan remove 1') }}
+              {%- elif interface['iface_mode'] == 'access' -%}
+                {%- if interface['vlan'] | int -%}
+                  {{ commands.append('interface ' + interface['iface'] + ' switchport access vlan ' + interface['vlan'] | string) }}
+                {%- endif -%}
+              {%- endif -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{ commands }}
+
+    - name: Save configuration
+      mellanox.onyx.onyx_config:
+        save: true

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -165,6 +165,7 @@ icokicagy
 idrac
 iface
 igfsbg
+IGMP
 igogicbjyxbzig
 ihbyb
 img
@@ -209,6 +210,7 @@ kustomize
 kustomized
 kuttl
 kvm
+LACP
 ldp
 libguestfs
 libvirt
@@ -238,11 +240,13 @@ manpage
 mawxlihjizaogicbjyxbzig
 mawxlihjizcbwb
 maxdepth
+Mellanox
 metallb
 metalsmith
 mgmt
 mins
 minsizegigabytes
+MLNX
 modprobe
 mountpoints
 mtcylje

--- a/requirements.yml
+++ b/requirements.yml
@@ -33,3 +33,11 @@ collections:
     type: git
   - name: https://github.com/openstack/ansible-config_template
     type: git
+  - name: https://github.com/ansible-collections/junipernetworks.junos
+    version: 2.10.0
+    type: git
+  - name: https://github.com/ansible-collections/cisco.ios
+    version: 3.3.2
+    type: git
+  - name: https://github.com/ansible-collections/mellanox.onyx
+    type: git

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -462,6 +462,16 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
+    - ^ci_framework/roles/switch_config/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    name: cifmw-molecule-switch_config
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: switch_config
+- job:
+    files:
+    - ^ansible-requirements.txt
+    - ^molecule-requirements.txt
     - ^ci_framework/roles/tempest/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-tempest

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -52,6 +52,7 @@
       - cifmw-molecule-rhol_crc
       - cifmw-molecule-run_hook
       - cifmw-molecule-set_openstack_containers
+      - cifmw-molecule-switch_config
       - cifmw-molecule-tempest
       - cifmw-molecule-test_deps
     name: openstack-k8s-operators/ci-framework


### PR DESCRIPTION

- added roles for switch configuration from NFV ansible repo
- added a playbook to run the sw config role

Those role allow configuring switches with OS such as: Onyx, IOS, Junos

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
