### PR TITLE
Fix small nits in run_ansible_test

### DIFF
--- a/scripts/run_ansible_test
+++ b/scripts/run_ansible_test
@@ -39,7 +39,7 @@ case ${USE_VENV} in
 esac
 
 mkdir -p ${HOME}/code/ansible_collections/cifmw/general
-cp -ra ${PROJECT_DIR}ci_framework/* ${HOME}/code/ansible_collections/cifmw/general/
+rsync -a --delete ${PROJECT_DIR}ci_framework/* ${HOME}/code/ansible_collections/cifmw/general/
 ln -fs ${collection_path}/* ${HOME}/code/ansible_collections/
 
 # Create/append the sanity exceptions for the current ansible version
@@ -52,6 +52,6 @@ ${ansible_test} sanity --test validate-modules
 if [ -d tests/integration ]; then
     ${ansible_test} integration --color=yes
 fi
-if [ -d tests/units ]; then
-    ${ansible_test} units --color=yes
+if [ -d tests/unit ]; then
+    ${ansible_test} units --color=yes --requirements
 fi


### PR DESCRIPTION
The current run_ansible_test scripts doesn't point to the proper unitest directory, that is 'unit', not 'units'.

Some dependencies, needed by ansible-test to run pytest, like pytest-forked need to be installed. To ensure the needed dependencies are installed, we should let ansible-test install the required ones.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date: