### PR TITLE
Add rsync to CI-framework Prow jobs

### DIFF
--- a/containerfiles/Containerfile.ci
+++ b/containerfiles/Containerfile.ci
@@ -4,4 +4,4 @@ LABEL summary="Provides root image for openstack-k8s-operators projects in Prow"
 USER root
 # workaround for RHBZ#2184640
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
-RUN dnf update -y && dnf install -y git python3-pip make gcc sudo && yum clean all
+RUN dnf update -y && dnf install -y git python3-pip make gcc sudo rsync && yum clean all


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date: