### PR TITLE
Expose a userfriendly container env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,8 @@ ansible_test_nodeps: ## Run ansible-test without installing dependencies
 ci_ctx: ## Build CI container with podman
 	if [ "x$(BUILD_VENV_CTX)" == 'xyes' ]; then \
 		podman image exists localhost/cifmw-build:latest || \
-		podman build -t localhost/cifmw-build:latest -f containerfiles/Containerfile.ci .; \
-		buildah bud -t ${CI_CTX_NAME} -f containerfiles/Containerfile.tests .; \
+		podman build --security-opt label=disable -t localhost/cifmw-build:latest -f containerfiles/Containerfile.ci .; \
+		podman build --security-opt label=disable -t ${CI_CTX_NAME} -f containerfiles/Containerfile.tests .; \
 	fi
 
 .PHONY: run_ctx_all_tests

--- a/containerfiles/Containerfile.tests
+++ b/containerfiles/Containerfile.tests
@@ -4,14 +4,16 @@ ENV USE_VENV=no
 ENV MOLECULE_CONFIG=.config/molecule/config_local.yml
 
 RUN adduser -d / -M prow
+RUN mkdir -p /home/prow && chown prow: /home/prow
 RUN echo "prow ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/prow
 
-COPY ../ /opt/sources
+RUN --mount=type=bind,source=../,destination=/tmp/project-code cp -ra /tmp/project-code /opt/sources
 RUN chown -R prow: /opt/sources
 WORKDIR /opt/sources
 RUN find . -type d -exec chmod g+rwx {} \;
 RUN find . -type f -exec chmod g+rw {} \;
 RUN /usr/bin/make setup_molecule USE_VENV=${USE_VENV}
+RUN dnf clean all
 
 USER prow
 RUN git config core.fileMode false

--- a/containerfiles/README.md
+++ b/containerfiles/README.md
@@ -1,0 +1,72 @@
+# Available containers
+
+The project provides two types of containers:
+
+- Containerfile.ci: builds a really basic container, mostly used in Prow, exposing needed tools
+- Containerfile.tests: based upon the previous one, allows to run some tests locally, or run the framework
+
+## Build containers
+
+Leveraging make, you can build the container on your own:
+```Bash
+$ make ci_ctx
+```
+
+## Using the container
+
+In the examples bellow, the options will do:
+
+- `-w /home/prow`: change the working directory to /home/prow
+- `-e HOME=/home/prow`: switch *prow* user home directory location.
+- `-v ~/.ssh/id_ed25519:/home/prow/.ssh/id_ed25519`: exposes your private SSH key.
+- `-v .:/home/prow/ci-framework`: exposes the project content in /home/prow/ci-framework in the container.
+- `-v ~/inventory.yml:/home/prow/ci-framework/inventory.yml`: an example of how you can override the inventory.yml.
+- `--security-opt label=disable`: needed for SELinux environment.
+
+### Inventory considerations
+
+By default, the CI Framework runs against `localhost`. If you intend to run the framework against `localhost` from
+within the container, you **must** provide a custom inventory in order to let ansible use the network connection
+instead of the `local` default set in the provided inventory. For instance, you want an inventory like this:
+
+```YAML
+all:
+  hosts:
+    localhost:
+      ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+```
+
+And then mount it in the container, as shown bellow.
+
+### Commands
+
+#### UNIX systems
+
+Depending on your Linux version, you may or may not need to pass the `--security-opt`. This mostly depends
+on your SELinux status.
+
+##### On RHEL based systems (CentOS, RHEL, Fedora, ...):
+```Bash
+podman run --rm -ti \
+    -w /home/prow \
+    -e HOME=/home/prow \
+    -v ~/.ssh/id_ed25519:/home/prow/.ssh/id_ed25519 \
+    -v .:/home/prow/ci-framework \
+    -v ~/inventory.yml:/home/prow/ci-framework/inventory.yml \
+    --security-opt label=disable \
+    localhost/cifmw:latest bash
+```
+
+##### On non-SELinux systems (Debian, Ubuntu, Mint, MacOS, ...):
+```Bash
+podman run --rm -ti \
+    -w /home/prow \
+    -e HOME=/home/prow \
+    -v ~/.ssh/id_ed25519:/home/prow/.ssh/id_ed25519 \
+    -v .:/home/prow/ci-framework \
+    -v ~/inventory.yml:/home/prow/ci-framework/inventory.yml \
+    --security-opt label=disable \
+    localhost/cifmw:latest bash
+```
+
+Note that you can replace `podman` command by `docker` with the same flags.

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -188,8 +188,8 @@ kvm
 ldp
 libguestfs
 libvirt
-libvirt's
 libvirtd
+libvirt's
 ljaumtawojy
 ljaumtaxojy
 ljaumtayojy
@@ -204,6 +204,7 @@ lv
 lvm
 lweyzmmtmji
 machinenetwork
+macos
 makefile
 makefiles
 manpage
@@ -323,6 +324,7 @@ rpmss
 rsa
 rsync
 runtime
+selinux
 sha
 skbg
 specificities
@@ -331,6 +333,7 @@ src
 sshkey
 ssl
 str
+stricthostkeychecking
 subnet
 sudo
 sudoers


### PR DESCRIPTION
ALlowing people to consume the framework via a container seems to be
mandatory.

This change allows to get rid of `buildah` call (not available on MacOS
for instance), while allowing some more friendly usage of the
ci-framework.

The embedded documentation will be added to the readthedocs one once we
finish the deep refacroring.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate documentation exists and/or is up-to-date
