### PR TITLE
Remove useless parameter

### DIFF
--- a/scenarios/reproducers/validated-architecture-1.yml
+++ b/scenarios/reproducers/validated-architecture-1.yml
@@ -21,7 +21,7 @@ cifmw_libvirt_manager_networks:
   osp_trunk:
     default: true
     range: "192.168.122.0/24"
-    mtu: 1500
+    mtu: 9000
     static_ip: true
   internal-api:
     range: "172.17.0.0/24"
@@ -55,6 +55,7 @@ cifmw_libvirt_manager_configuration:
         <name>osp_trunk</name>
         <forward mode='nat'/>
         <bridge name='osp_trunk' stp='on' delay='0'/>
+        <mtu size='{{ cifmw_libvirt_manager_networks.osp_trunk.mtu }}'/>
         <ip family='ipv4' address='{{ cifmw_libvirt_manager_networks.osp_trunk.range | ansible.utils.nthhost(1) }}' prefix='24'>
         </ip>
       </network>
@@ -114,12 +115,6 @@ cifmw_devscripts_config_overrides:
   worker_disk: 100
   worker_vcpu: 10
   num_extra_workers: 0
-
-cifmw_devscripts_extra_networks:
-  - name: osp_trunk
-    mtu: 9000
-    cidr: "192.168.122.0/24"
-    static_ip: true
 
 # Note: with that extra_network_names "osp_trunk", we instruct
 # devscripts role to create a new network, and associate it to


### PR DESCRIPTION
Now that we're leveraging libvirt_manager to start the actual OCP
workload, we don't need to pass the cifmw_devscripts_extra_networks
parameter anymore.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
