### PR TITLE
Add repo-setup service in hci edpm job

### DIFF
--- a/ci_framework/roles/hci_prepare/tasks/phase1.yml
+++ b/ci_framework/roles/hci_prepare/tasks/phase1.yml
@@ -76,6 +76,7 @@
           - op: replace
             path: /spec/services
             value:
+              - repo-setup
               - download-cache
               - configure-network
               - validate-network


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/ci-framework/pull/800 avoid copying repositories generated by repo-setup to compute nodes.

in HCI edpm job, download-cache service was failing to install packages because there is no repos configured on the edpm node.

Adding repo-setup service to the edpm service list will fix the issue.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

