### PR TITLE
[set_openstack_containers] Also update env for dataplane operator

### DIFF
--- a/ci_framework/roles/set_openstack_containers/templates/update_env_vars.sh.j2
+++ b/ci_framework/roles/set_openstack_containers/templates/update_env_vars.sh.j2
@@ -32,6 +32,9 @@ oc get csv -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} \
    -l operators.coreos.com/{{ operator_name }}-operator.openstack-operators -o=jsonpath='{.items[0]}' \
    {% for key, value in containers_dict.items() -%}
    | jq '(.spec.install.spec.deployments[0].spec.template.spec.containers[1].env[] | select(.name=={{ '\"' + key + '\"' }})) |= (.value={{ '\"' + value + '\"' }})' \
+   {% if operator_name == 'openstack' -%}
+   | jq '(.spec.install.spec.deployments[1].spec.template.spec.containers[1].env[] | select(.name=={{ '\"' + key + '\"' }})) |= (.value={{ '\"' + value + '\"' }})' \
+   {% endif -%}
    {% endfor -%}
    > {{ cifmw_set_openstack_containers_basedir }}/artifacts/update_containers_patch.out
 


### PR DESCRIPTION
dataplane operator is bundled in openstack-operator, so need to update it too when updating openstack-operator.

Fixes: https://issues.redhat.com/browse/OSPCIX-105

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
