### PR TITLE
New role: manage_secrets

### DIFF
--- a/ci_framework/roles/manage_secrets/README.md
+++ b/ci_framework/roles/manage_secrets/README.md
@@ -1,0 +1,72 @@
+# manage_secrets
+Copy secret content such as pull-secret and ci-token to a known location with appropriate rights.
+
+## Privilege escalation
+None
+
+## Parameters
+* `cifmw_manage_secrets_basedir`: (String) Base directory for the directory tree. Default to `cifmw_basedir` which defaults to `~/ci-framework-data`.
+* `cifmw_manage_secrets_pullsecret_dest`: (String) Destination file for pull-secret.json. Defaults to `{{ cifmw_manage_secrets_basedir }}/secrets/pull_secret.json`.
+* `cifmw_manage_secrets_pullsecret_file`: (String) Absolute path to the source pull-secret. Defaults to `null`.
+* `cifmw_manage_secrets_pullsecret_content`: (String) Content of the source pull-secret. Defaults to `null`.
+* `cifmw_manage_secrets_citoken_dest`: (String) Destination file for ci-token. Defaults to `{{ cifmw_manage_secrets_basedir }}/secrets/ci_token`.
+* `cifmw_manage_secrets_citoken_file`: (String) Absolute path to the source ci-token. Defaults to `null`.
+* `cifmw_manage_secrets_citoken_content`: (String) Content of the source ci-token. Defaults to `null`.
+* `cifmw_manage_secrets_kube_dest`: (String) Destination directory for kube configuration files. Defaults to `~/.kube`.
+* `cifmw_manage_secrets_kube_type`: (String) Type of kube configuration file. Must be either `config` or `kubeadmin-password`. Defaults to `null`.
+* `cifmw_manage_secrets_kube_file`: (String) Absolute path to the source kube configuration file. Defaults to `null`.
+* `cifmw_manage_secrets_kube_content:` (String) Content of the kube configuration file. Defaults to `null`.
+
+## File versus Content
+You can set either a file OR a content for the pull-secret and ci-token secrets. You can't set both.
+
+## Examples
+
+```YAML
+- name: Initialize manage_secrets
+  ansible.builtin.import_role:
+    name: manage_secrets
+
+- name: Push my local pull-secret
+  vars:
+    cifmw_manage_secrets_pullsecret_file: "{{ lookup('env', 'HOME') }}/pull-secret.txt"
+  ansible.builtin.include_role:
+    name: manage_secrets
+    tasks_from: pull_secret.yml
+
+- name: Create a ci-token with inline content
+  vars:
+    cifmw_manage_secrets_citoken_content: "sha256~AAABBCC123"
+  ansible.builtin.include_role:
+    name: manage_secrets
+    tasks_from: ci_token.yml
+```
+
+In some cases, you may want to copy some content from the hypervisor to a virtual machine - this is especially
+true for the kubeconfig and kubeadmin-password files. In such a case, the "easiest" way is to `slurp` the content
+and pass it down:
+
+```YAML
+- name: Get kubeaconfig content
+  register: _kubeconfig
+  ansible.builtin.slurp:
+    path: "{{ ansible_user_dir }}/ci-framework-data/artifacts/kubeconfig"
+
+- name: Delegate block to controller-0
+  delegate_to: controller-0
+  remote_user: zuul
+  vars:
+    cifmw_manage_secrets_basedir: "/home/zuul/ci-framework-data"
+  block:
+    - name: Initialize manage_secrets
+      ansible.builtin.import_role:
+        name: manage_secrets
+
+    - name: Inject kubeconfig
+      vars:
+        cifmw_manage_secrets_kube_type: "config"
+        cifmw_manage_secrets_kube_content: "{{ _kubeconfig.content | b64decode }}"
+      ansible.builtin.include_role:
+        name: manage_secrets
+        tasks_from: kube.yml
+```

--- a/ci_framework/roles/manage_secrets/defaults/main.yml
+++ b/ci_framework/roles/manage_secrets/defaults/main.yml
@@ -1,0 +1,48 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_manage_secrets"
+cifmw_manage_secrets_basedir: >-
+  {{
+    cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data')
+  }}
+
+# pull-secret management
+cifmw_manage_secrets_pullsecret_dest: >-
+  {{ (cifmw_manage_secrets_basedir,
+      'secrets', 'pull_secret.json') | path_join
+  }}
+cifmw_manage_secrets_pullsecret_file: null
+cifmw_manage_secrets_pullsecret_content: null
+
+# CI Token management
+cifmw_manage_secrets_citoken_dest: >-
+  {{ (cifmw_manage_secrets_basedir,
+      'secrets', 'ci_token') | path_join
+  }}
+cifmw_manage_secrets_citoken_file: null
+cifmw_manage_secrets_citoken_content: null
+
+# kubeconfig and kubeadmin-password file management
+cifmw_manage_secrets_kube_dest: >-
+  {{
+    (ansible_user_dir, '.kube') | path_join
+  }}
+cifmw_manage_secrets_kube_content: null
+cifmw_manage_secrets_kube_file: null
+cifmw_manage_secrets_kube_type: null

--- a/ci_framework/roles/manage_secrets/handlers/main.yml
+++ b/ci_framework/roles/manage_secrets/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.

--- a/ci_framework/roles/manage_secrets/meta/main.yml
+++ b/ci_framework/roles/manage_secrets/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- manage_secrets
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: edpm
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - edpm
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/ci_framework/roles/manage_secrets/molecule/ci_token/cleanup.yml
+++ b/ci_framework/roles/manage_secrets/molecule/ci_token/cleanup.yml
@@ -1,0 +1,29 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Remove yodel file
+      ansible.builtin.file:
+        path: /tmp/yodel
+        state: absent
+
+    - name: Clean created secret
+      ansible.builtin.import_role:
+        name: manage_secrets
+        tasks_from: cleanup.yml

--- a/ci_framework/roles/manage_secrets/molecule/ci_token/converge.yml
+++ b/ci_framework/roles/manage_secrets/molecule/ci_token/converge.yml
@@ -1,0 +1,76 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  roles:
+    - role: manage_secrets
+  tasks:
+    - name: Inject fake pull_secret
+      ansible.builtin.copy:
+        dest: "/tmp/yodel"
+        content: >-
+          sha256~abcdefg1234-ABEFGRsd3
+    - name: Expose ci_token to target location
+      vars:
+        _file: >-
+          {{ (ansible_user_dir,
+              'ci-framework-data',
+              'secrets',
+              'ci_token') | path_join
+          }}
+      block:
+        - name: Copy provided file
+          vars:
+            cifmw_manage_secrets_citoken_file: '/tmp/yodel'
+          ansible.builtin.include_role:
+            name: manage_secrets
+            tasks_from: ci_token.yml
+
+        - name: Check for file
+          register: cp_file
+          ansible.builtin.stat:
+            checksum_algorithm: sha256
+            get_checksum: true
+            get_attributes: false
+            get_mime: false
+            path: "{{ _file }}"
+
+        - name: Create file from content
+          vars:
+            cifmw_manage_secrets_citoken_content: |-
+              sha256~AABBCC-DDEE1232455
+          ansible.builtin.include_role:
+            name: manage_secrets
+            tasks_from: ci_token.yml
+
+        - name: Check for file
+          register: create_file
+          ansible.builtin.stat:
+            checksum_algorithm: sha256
+            get_checksum: true
+            get_attributes: false
+            get_mime: false
+            path: "{{ _file }}"
+
+        - name: Validate files
+          ansible.builtin.assert:
+            that:
+              - cp_file.stat.exists | bool
+              - cp_file.stat.checksum == '199432267350192a54c6a92869056386956732a5bf476fadfa9536adcc49285f'
+              - create_file.stat.exists | bool
+              - create_file.stat.checksum == '697bbc161f38c5173f4d6ac7340aac5e62719c3e2d734bbf700af4f7d4933662'

--- a/ci_framework/roles/manage_secrets/molecule/ci_token/molecule.yml
+++ b/ci_framework/roles/manage_secrets/molecule/ci_token/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/manage_secrets/molecule/ci_token/prepare.yml
+++ b/ci_framework/roles/manage_secrets/molecule/ci_token/prepare.yml
@@ -1,0 +1,21 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps

--- a/ci_framework/roles/manage_secrets/molecule/kube/cleanup.yml
+++ b/ci_framework/roles/manage_secrets/molecule/kube/cleanup.yml
@@ -1,0 +1,29 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Remove yodel file
+      ansible.builtin.file:
+        path: /tmp/yodel
+        state: absent
+
+    - name: Clean created secret
+      ansible.builtin.import_role:
+        name: manage_secrets
+        tasks_from: cleanup.yml

--- a/ci_framework/roles/manage_secrets/molecule/kube/converge.yml
+++ b/ci_framework/roles/manage_secrets/molecule/kube/converge.yml
@@ -1,0 +1,92 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  roles:
+    - role: manage_secrets
+  tasks:
+    - name: Inject fake kubeconfig
+      ansible.builtin.copy:
+        dest: "/tmp/yodel"
+        content: >-
+          - name: admin
+            user:
+              client-certificate-data: foobar
+              client-key-data: barfoo
+
+    - name: Expose kube to target location
+      vars:
+        _config_file: >-
+          {{ (ansible_user_dir,
+              '.kube',
+              'config') | path_join
+          }}
+        _adm_file: >-
+          {{ (ansible_user_dir,
+              '.kube',
+              'kubeadmin-password') | path_join
+          }}
+      block:
+        - name: Copy provided file
+          vars:
+            cifmw_manage_secrets_kube_file: '/tmp/yodel'
+            cifmw_manage_secrets_kube_type: "config"
+          ansible.builtin.include_role:
+            name: manage_secrets
+            tasks_from: kube.yml
+
+        - name: Check for file
+          register: cp_file
+          ansible.builtin.stat:
+            checksum_algorithm: sha256
+            get_checksum: true
+            get_attributes: false
+            get_mime: false
+            path: "{{ _config_file }}"
+
+        - name: Create file from content
+          vars:
+            cifmw_manage_secrets_kube_content: |-
+              E234-Jac45-UuvCD-X2BZ2
+            cifmw_manage_secrets_kube_type: kubeadmin-password
+          ansible.builtin.include_role:
+            name: manage_secrets
+            tasks_from: kube.yml
+
+        - name: Check for file
+          register: create_file
+          ansible.builtin.stat:
+            checksum_algorithm: sha256
+            get_checksum: true
+            get_attributes: false
+            get_mime: false
+            path: "{{ _adm_file }}"
+
+        - name: Expose file data
+          ansible.builtin.debug:
+            msg:
+              - "{{ cp_file }}"
+              - "{{ create_file }}"
+
+        - name: Validate files
+          ansible.builtin.assert:
+            that:
+              - cp_file.stat.exists | bool
+              - cp_file.stat.checksum == '5903097f988e969fc7d35578338cdbe4bd6c94bfa5e845c47ee4518c5d490bcc'
+              - create_file.stat.exists | bool
+              - create_file.stat.checksum == 'd87438c29fedd67024def70ef2eeaae5ac310aa119f35605e8411f46a258bb30'

--- a/ci_framework/roles/manage_secrets/molecule/kube/molecule.yml
+++ b/ci_framework/roles/manage_secrets/molecule/kube/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/manage_secrets/molecule/kube/prepare.yml
+++ b/ci_framework/roles/manage_secrets/molecule/kube/prepare.yml
@@ -1,0 +1,21 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps

--- a/ci_framework/roles/manage_secrets/molecule/pull_secret/cleanup.yml
+++ b/ci_framework/roles/manage_secrets/molecule/pull_secret/cleanup.yml
@@ -1,0 +1,29 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Remove yodel file
+      ansible.builtin.file:
+        path: /tmp/yodel
+        state: absent
+
+    - name: Clean created secret
+      ansible.builtin.import_role:
+        name: manage_secrets
+        tasks_from: cleanup.yml

--- a/ci_framework/roles/manage_secrets/molecule/pull_secret/converge.yml
+++ b/ci_framework/roles/manage_secrets/molecule/pull_secret/converge.yml
@@ -1,0 +1,83 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  roles:
+    - role: manage_secrets
+  tasks:
+    - name: Inject fake pull_secret
+      ansible.builtin.copy:
+        dest: "/tmp/yodel"
+        content: >-
+          {"auths": {"my_cloud":
+            {"auth": "starwars and startrek are on a boat",
+             "email": "foo@none.tld"}}}
+    - name: Expose pull_secret to target location
+      vars:
+        _file: >-
+          {{ (ansible_user_dir,
+              'ci-framework-data',
+              'secrets',
+              'pull_secret.json') | path_join
+          }}
+      block:
+        - name: Copy provided file
+          vars:
+            cifmw_manage_secrets_pullsecret_file: '/tmp/yodel'
+          ansible.builtin.include_role:
+            name: manage_secrets
+            tasks_from: pull_secret.yml
+
+        - name: Check for file
+          register: cp_file
+          ansible.builtin.stat:
+            checksum_algorithm: sha256
+            get_checksum: true
+            get_attributes: false
+            get_mime: false
+            path: "{{ _file }}"
+
+        - name: Create file from content
+          vars:
+            cifmw_manage_secrets_pullsecret_content: >-
+              {"auths": {
+                "your_cloud": {
+                  "auth": "complicated life isn't easy",
+                  "email": "nope@yodel.tld"
+                }
+              }}
+          ansible.builtin.include_role:
+            name: manage_secrets
+            tasks_from: pull_secret.yml
+
+        - name: Check for file
+          register: create_file
+          ansible.builtin.stat:
+            checksum_algorithm: sha256
+            get_checksum: true
+            get_attributes: false
+            get_mime: false
+            path: "{{ _file }}"
+
+        - name: Validate files
+          ansible.builtin.assert:
+            that:
+              - cp_file.stat.exists | bool
+              - cp_file.stat.checksum == '9295045617ece5e18e43a84bf8075d5a9cf8f956e493a3149d4d382f4f0badc3'
+              - create_file.stat.exists | bool
+              - create_file.stat.checksum == '5635f1ec0143515126da8dd9fedd80cd001954f4baafd94489718cc1dbba87d5'

--- a/ci_framework/roles/manage_secrets/molecule/pull_secret/molecule.yml
+++ b/ci_framework/roles/manage_secrets/molecule/pull_secret/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/manage_secrets/molecule/pull_secret/prepare.yml
+++ b/ci_framework/roles/manage_secrets/molecule/pull_secret/prepare.yml
@@ -1,0 +1,21 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps

--- a/ci_framework/roles/manage_secrets/tasks/_push_secret.yml
+++ b/ci_framework/roles/manage_secrets/tasks/_push_secret.yml
@@ -1,0 +1,45 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Manage file copy
+  when:
+    - _secret_file != None
+  block:
+    - name: Ensure parameter is an absolute path
+      ansible.builtin.assert:
+        that:
+          - _secret_file is ansible.builtin.abs
+        msg: |
+          {{ _secret_file }} must be an absolute path
+
+    - name: Copy file to location
+      ansible.builtin.copy:
+        dest: "{{ _secret_dest }}"
+        src: "{{ _secret_file }}"
+        mode: "0600"
+        owner: "{{ ansible_user_id }}"
+
+- name: Manage file creation from content
+  when:
+    - _secret_content != None
+  block:
+    - name: Create file from content
+      no_log: true
+      ansible.builtin.copy:
+        dest: "{{ _secret_dest }}"
+        content: "{{ _secret_content }}"
+        mode: "0600"
+        owner: "{{ ansible_user_id }}"

--- a/ci_framework/roles/manage_secrets/tasks/ci_token.yml
+++ b/ci_framework/roles/manage_secrets/tasks/ci_token.yml
@@ -1,0 +1,34 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Assert we get needed data
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - cifmw_manage_secrets_citoken_file != None or
+        cifmw_manage_secrets_citoken_content != None
+      - not (cifmw_manage_secrets_citoken_file != None and
+             cifmw_manage_secrets_citoken_content != None)
+    msg: |
+      Please provide EITHER cifmw_manage_secrets_citoken_file
+      OR cifmw_manage_secrets_citoken_content - not both.
+
+- name: Manage secret
+  vars:
+    _secret_dest: "{{ cifmw_manage_secrets_citoken_dest }}"
+    _secret_content: "{{ cifmw_manage_secrets_citoken_content }}"
+    _secret_file: "{{ cifmw_manage_secrets_citoken_file }}"
+  ansible.builtin.include_tasks: _push_secret.yml

--- a/ci_framework/roles/manage_secrets/tasks/cleanup.yml
+++ b/ci_framework/roles/manage_secrets/tasks/cleanup.yml
@@ -1,0 +1,23 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Remove all generated secrets
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ cifmw_manage_secrets_pullsecret_dest }}"
+    - "{{ cifmw_manage_secrets_citoken_dest }}"

--- a/ci_framework/roles/manage_secrets/tasks/kube.yml
+++ b/ci_framework/roles/manage_secrets/tasks/kube.yml
@@ -1,0 +1,48 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Assert we get needed data
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - cifmw_manage_secrets_kube_type is match('^(config|kubeadmin-password)$')
+      - cifmw_manage_secrets_kube_file != None or
+        cifmw_manage_secrets_kube_content != None
+      - not (cifmw_manage_secrets_kube_file != None and
+             cifmw_manage_secrets_kube_content != None)
+    msg: |
+      Please provide EITHER cifmw_manage_secrets_kube_file
+      OR cifmw_manage_secrets_kube_content - not both.
+
+      cifmw_manage_secrets_kube_type MUST be either config
+      or kubeadmin-password
+
+- name: Ensure destination directory exists
+  ansible.builtin.file:
+    path: "{{ cifmw_manage_secrets_kube_dest }}"
+    state: "directory"
+    mode: "0750"
+
+- name: Manage secret
+  vars:
+    _secret_dest: >-
+      {{
+        (cifmw_manage_secrets_kube_dest,
+         cifmw_manage_secrets_kube_type) | path_join
+      }}
+    _secret_content: "{{ cifmw_manage_secrets_kube_content }}"
+    _secret_file: "{{ cifmw_manage_secrets_kube_file }}"
+  ansible.builtin.include_tasks: _push_secret.yml

--- a/ci_framework/roles/manage_secrets/tasks/main.yml
+++ b/ci_framework/roles/manage_secrets/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure directory tree exist
+  ansible.builtin.file:
+    path: "{{ cifmw_manage_secrets_basedir }}/secrets"
+    state: directory
+    owner: "{{ ansible_user_id }}"
+    mode: "0700"

--- a/ci_framework/roles/manage_secrets/tasks/pull_secret.yml
+++ b/ci_framework/roles/manage_secrets/tasks/pull_secret.yml
@@ -1,0 +1,34 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Assert we get needed data
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - cifmw_manage_secrets_pullsecret_file != None or
+        cifmw_manage_secrets_pullsecret_content != None
+      - not (cifmw_manage_secrets_pullsecret_file != None and
+             cifmw_manage_secrets_pullsecret_content != None)
+    msg: |
+      Please provide EITHER cifmw_manage_secrets_pullsecret_file
+      OR cifmw_manage_secrets_pullsecret_content - not both.
+
+- name: Manage secret
+  vars:
+    _secret_dest: "{{ cifmw_manage_secrets_pullsecret_dest }}"
+    _secret_content: "{{ cifmw_manage_secrets_pullsecret_content }}"
+    _secret_file: "{{ cifmw_manage_secrets_pullsecret_file }}"
+  ansible.builtin.include_tasks: _push_secret.yml

--- a/ci_framework/roles/manage_secrets/vars/main.yml
+++ b/ci_framework/roles/manage_secrets/vars/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# While options found within the vars/ path can be overridden using extra
+# vars, items within this path are considered part of the role and not
+# intended to be modified.
+
+# All variables within this role should have a prefix of "cifmw_manage_secrets"

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -1,3 +1,4 @@
+aaabbcc
 abcdefghij
 addr
 ansible
@@ -49,6 +50,7 @@ chrony
 chronyc
 cidr
 cifmw
+citoken
 ciuser
 cjeanner
 ckcg

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -272,6 +272,16 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
+    - ^ci_framework/roles/manage_secrets/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    name: cifmw-molecule-manage_secrets
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: manage_secrets
+- job:
+    files:
+    - ^ansible-requirements.txt
+    - ^molecule-requirements.txt
     - ^ci_framework/roles/openshift_login/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-openshift_login

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -35,6 +35,7 @@
       - cifmw-molecule-install_yamls
       - cifmw-molecule-libvirt_manager
       - cifmw-molecule-local_env_vm
+      - cifmw-molecule-manage_secrets
       - cifmw-molecule-openshift_login
       - cifmw-molecule-openshift_provisioner_node
       - cifmw-molecule-openshift_setup


### PR DESCRIPTION
This role allows to copy pull-secret and ci-token to a relatively safe
location, with appropriate rights.

Follow-up patches will ensure this new role is put to use from the
needed places.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
