### PR TITLE
Add cert-manager role

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -27,3 +27,6 @@
     name: cifmw-molecule-reproducer
     nodeset: centos-9-crc-xxl
     timeout: 5400
+- job:
+    name: cifmw-molecule-cert_manager
+    nodeset: centos-9-crc-xxl

--- a/ci_framework/roles/cert_manager/README.md
+++ b/ci_framework/roles/cert_manager/README.md
@@ -1,0 +1,32 @@
+# cert_manager
+
+Ansible role to install cert-manager operator
+
+## Privilege escalation
+If apply, please explain the privilege escalation done in this role.
+
+## Parameters
+* `cifmw_cert_manager_basedir`: (String) Base directory. Defaults to `cifmw_basedir` which defaults to `~/ci-framework-data`.
+* `cifmw_cert_manager_manifests_dir`: (String) Directory in where OCP manifests will be placed. Defaults to `"{{ cifmw_manifests | default(cifmw_cert_manager_basedir ~ '/artifacts/manifests') }}"`.
+* `cifmw_cert_manager_namespace`: (String) The namespace where OCP resources will be installed. Defaults to `cert-manager-operator`.
+* `cifmw_cert_manager_olm_operator_group`: (Dict) The `OperatorGroup` resource to be used to install the cert-manager operator.
+* `cifmw_cert_manager_olm_subscription`: (Dict) The `Subscription` resource to be used to install the cert-manager operator.
+* `cifmw_cert_manager_subscription_source`: (String) The Source of `Subscription` resource to pull cert-manager operator content.
+* `cifmw_cert_manager_subscription_sourcenamespace`: (String) The Source namespace of `Subscription` resource to pull cert-manager operator content.
+* `cifmw_cert_manager_validate`: (Bool) Validate the cert-manager api. Default to `True`.
+* `cifmw_cert_manager_version`: (String) Version of cert_manager tool. Default to `latest`.
+
+## Examples
+```YAML
+---
+- hosts: localhost
+  vars:
+    cifmw_openshift_user: "kubeadmin"
+    cifmw_openshift_password: "12345678"
+    cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+  tasks:
+    - ansible.builtin.include_role:
+        name: cert_manager
+```

--- a/ci_framework/roles/cert_manager/defaults/main.yml
+++ b/ci_framework/roles/cert_manager/defaults/main.yml
@@ -1,0 +1,60 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_cert_manager"
+
+cifmw_cert_manager_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+cifmw_cert_manager_manifests_dir: "{{ cifmw_manifests | default(cifmw_cert_manager_basedir ~ '/artifacts/manifests') }}/cert-manager"
+cifmw_cert_manager_operator_namespace: cert-manager-operator
+cifmw_cert_manager_openshift_version: stable-v1
+
+cifmw_cert_manager_olm_operator_group:
+  apiVersion: operators.coreos.com/v1
+  kind: OperatorGroup
+  metadata:
+    annotations:
+      olm.providedAPIs: CertManager.v1alpha1.operator.openshift.io,Certificate.v1.cert-manager.io,CertificateRequest.v1.cert-manager.io,Challenge.v1.acme.cert-manager.io,ClusterIssuer.v1.cert-manager.io,Issuer.v1.cert-manager.io,Order.v1.acme.cert-manager.io
+    generateName: "{{ cifmw_cert_manager_operator_namespace }}-"
+    name: "{{ cifmw_cert_manager_operator_namespace }}-bccwx"
+    namespace: "{{ cifmw_cert_manager_operator_namespace }}"
+  spec:
+    targetNamespaces:
+      - "{{ cifmw_cert_manager_operator_namespace }}"
+    upgradeStrategy: Default
+
+cifmw_cert_manager_subscription_source: redhat-operators
+cifmw_cert_manager_subscription_sourcenamespace: openshift-marketplace
+
+cifmw_cert_manager_olm_subscription:
+  apiVersion: operators.coreos.com/v1alpha1
+  kind: Subscription
+  metadata:
+    labels:
+      operators.coreos.com/openshift-cert-manager-operator.cert-manager-operator: ""
+    name: openshift-cert-manager-operator
+    namespace: "{{ cifmw_cert_manager_operator_namespace }}"
+  spec:
+    channel: "{{ cifmw_cert_manager_openshift_version }}"
+    installPlanApproval: Automatic
+    name: openshift-cert-manager-operator
+    source: "{{ cifmw_cert_manager_subscription_source }}"
+    sourceNamespace: "{{ cifmw_cert_manager_subscription_sourcenamespace }}"
+
+cifmw_cert_manager_version: latest
+cifmw_cert_manager_validate: true
+cifmw_cert_manager_cleanup: false

--- a/ci_framework/roles/cert_manager/meta/main.yml
+++ b/ci_framework/roles/cert_manager/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- cert_manager
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: edpm
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - edpm
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/ci_framework/roles/cert_manager/molecule/default/converge.yml
+++ b/ci_framework/roles/cert_manager/molecule/default/converge.yml
@@ -1,0 +1,119 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: all
+  gather_facts: true
+  vars:
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+    cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+    cifmw_cert_manager_operator_namespace: cert-manager-operator
+    cifmw_cert_manager_cleanup: true
+  tasks:
+    - name: Deploy cert-manager role
+      ansible.builtin.include_role:
+        name: "cert_manager"
+
+    - name: Store self signed ca file
+      vars:
+        _ca_content: |
+          ---
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: sandbox
+          ---
+          apiVersion: cert-manager.io/v1
+          kind: ClusterIssuer
+          metadata:
+            name: selfsigned-issuer
+          spec:
+            selfSigned: {}
+          ---
+          apiVersion: cert-manager.io/v1
+          kind: Certificate
+          metadata:
+            name: my-selfsigned-ca
+            namespace: cert-manager
+          spec:
+            isCA: true
+            commonName: my-selfsigned-ca
+            secretName: root-secret
+            privateKey:
+              algorithm: ECDSA
+              size: 256
+            issuerRef:
+              name: selfsigned-issuer
+              kind: ClusterIssuer
+              group: cert-manager.io
+          ---
+          apiVersion: cert-manager.io/v1
+          kind: ClusterIssuer
+          metadata:
+            name: my-ca-issuer
+          spec:
+            ca:
+              secretName: root-secret
+      ansible.builtin.copy:
+        dest: "/tmp/cmtest.yaml"
+        content: "{{ _ca_content }}"
+
+    - name: Apply cmtest.yaml
+      kubernetes.core.k8s:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        state: present
+        src: /tmp/cmtest.yaml
+
+    - name: Get clusterissuer my-ca-issuer
+      kubernetes.core.k8s_info:
+        api_version: cert-manager.io/v1
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        namespace: sandbox
+        name: my-ca-issuer
+        kind: clusterissuer
+      register: _data
+
+    - name: Assert the length of returned resources
+      ansible.builtin.assert:
+        that:
+          - '_data.resources | length > 0'
+
+    - name: Verify the presence of my-ca-issuer
+      ansible.builtin.assert:
+        that:
+          - '_data.resources[0]["metadata"]["name"] == "my-ca-issuer"'
+
+    - name: Cleanup cert manager resources
+      ansible.builtin.include_role:
+        name: "cert_manager"
+        tasks_from: cleanup.yml
+
+    - name: Get all namespaces
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        kind: Namespace
+      register: _cert_manager_ns
+
+    - name: Assert that the cert-manager ns is deleted
+      vars:
+        ns_names: >-
+          {{
+            _cert_manager_ns.resources |
+            default([]) |
+            map(attribute='metadata.name')
+          }}
+      ansible.builtin.assert:
+        that: "cifmw_cert_manager_operator_namespace not in ns_names"

--- a/ci_framework/roles/cert_manager/molecule/default/molecule.yml
+++ b/ci_framework/roles/cert_manager/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/cert_manager/molecule/default/prepare.yml
+++ b/ci_framework/roles/cert_manager/molecule/default/prepare.yml
@@ -1,0 +1,25 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps
+  tasks:
+    - name: Ensure CRC is started
+      ansible.builtin.command:
+        cmd: crc start

--- a/ci_framework/roles/cert_manager/tasks/cleanup.yml
+++ b/ci_framework/roles/cert_manager/tasks/cleanup.yml
@@ -1,0 +1,29 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Remove the cert-manager-operator namespace
+  when: cifmw_cert_manager_cleanup | bool
+  kubernetes.core.k8s:
+    state: absent
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    kind: Namespace
+    name: "{{ item }}"
+    wait: true
+  loop:
+    - cert-manager
+    - "{{ cifmw_cert_manager_operator_namespace }}"

--- a/ci_framework/roles/cert_manager/tasks/main.yml
+++ b/ci_framework/roles/cert_manager/tasks/main.yml
@@ -1,0 +1,116 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Create role needed directories
+  ansible.builtin.file:
+    path: "{{ cifmw_cert_manager_manifests_dir }}"
+    state: directory
+
+- name: Create the cifmw_cert_manager_operator_namespace namespace"
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    name: "{{ cifmw_cert_manager_operator_namespace }}"
+    kind: Namespace
+    state: present
+
+- name: Save k8s cert-manager OLM manifests as artifacts
+  ansible.builtin.copy:
+    dest: "{{ cifmw_cert_manager_manifests_dir }}/cert-manager-{{ item.kind | lower }}-olm.yaml"
+    content: "{{ item | to_nice_yaml }}"
+  loop:
+    - "{{ cifmw_cert_manager_olm_operator_group }}"
+    - "{{ cifmw_cert_manager_olm_subscription }}"
+  loop_control:
+    label: "{{ item.metadata.name }}"
+
+- name: Create the cert-manager OLM subscription resources
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    definition: "{{ item }}"
+    state: present
+  loop:
+    - "{{ cifmw_cert_manager_olm_operator_group }}"
+    - "{{ cifmw_cert_manager_olm_subscription }}"
+  loop_control:
+    label: "{{ item.metadata.name }}"
+
+- name: Get the operator name
+  ansible.builtin.set_fact:
+    _operator_name: "{{ cifmw_cert_manager_olm_subscription.metadata.name }}"
+
+- name: Wait for the cert-manager operator deployment to be Ready
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    namespace: "{{ cifmw_cert_manager_operator_namespace }}"
+    kind: Deployment
+    name: "{{ _operator_name }}"
+    wait_sleep: 10
+    wait_timeout: 360
+    wait_condition:
+      type: Ready
+      status: "True"
+
+- name: Wait for the cert-manager operator csv to be Ready
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    namespace: "{{ cifmw_cert_manager_operator_namespace }}"
+    kind: ClusterServiceVersion
+    wait_sleep: 10
+    wait_timeout: 360
+    field_selectors:
+      - status.phase=Succeeded
+
+- name: Check for cert-manager namspeace existance
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    name: cert-manager
+    kind: Namespace
+    field_selectors:
+      - status.phase=Active
+
+- name: Wait for cert-manager pods to be ready
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    namespace: cert-manager
+    kind: Pod
+    wait: true
+    wait_sleep: 10
+    wait_timeout: 600
+    wait_condition:
+      type: Ready
+      status: "True"
+    label_selectors:
+      - "app = {{ item }}"
+  loop:
+    - cainjector
+    - webhook
+    - cert-manager
+
+- name: Validate cert-manager installation
+  when: cifmw_cert_manager_validate | bool
+  ansible.builtin.import_tasks: validate_certs.yml

--- a/ci_framework/roles/cert_manager/tasks/validate_certs.yml
+++ b/ci_framework/roles/cert_manager/tasks/validate_certs.yml
@@ -1,0 +1,34 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Create $HOME/bin dir
+  ansible.builtin.file:
+    path: "{{ lookup('env', 'HOME') }}/bin"
+    state: directory
+    mode: '0755'
+
+- name: Install cert-manager cmctl CLI
+  ansible.builtin.unarchive:
+    src:
+      "https://github.com/cert-manager/cert-manager/releases/{{ cifmw_cert_manager_version }}/download/cmctl-linux-amd64.tar.gz"
+    dest: "{{ lookup('env', 'HOME') }}/bin/"
+    remote_src: true
+
+- name: Verify cert_manager api
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command: "{{ lookup('env', 'HOME') }}/bin/cmctl check api --wait=2m"

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -32,6 +32,17 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
+    - ^ci_framework/roles/cert_manager/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    name: cifmw-molecule-cert_manager
+    nodeset: centos-9-crc-xxl
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: cert_manager
+- job:
+    files:
+    - ^ansible-requirements.txt
+    - ^molecule-requirements.txt
     - ^ci_framework/roles/ci_network/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-ci_network

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -11,6 +11,7 @@
       - cifmw-molecule-artifacts
       - cifmw-molecule-build_containers
       - cifmw-molecule-build_openstack_packages
+      - cifmw-molecule-cert_manager
       - cifmw-molecule-ci_network
       - cifmw-molecule-ci_nmstate
       - cifmw-molecule-ci_setup


### PR DESCRIPTION
This role will take care of installing cert-manager operator.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
