### PR TITLE
Add task to include a component-based repo

### DIFF
--- a/ci_framework/roles/repo_setup/README.md
+++ b/ci_framework/roles/repo_setup/README.md
@@ -17,6 +17,8 @@ Please explain the role purpose.
 * `cifmw_repo_setup_env`: (Dict) Environment variables to be passed to repo_setup cli . Defaults to `'{}'`.
 * `cifmw_repo_setup_enable_rhos_release`: (Boolean) Toggle `rhos-release` support. Defaults to `False`.
 * `cifmw_repo_setup_dlrn_hash_tag`: (String) repo-setup dlrn-hash-tag. Defaults to `{}`.
+* `cifmw_repo_setup_component_name`: (String) component repo to setup. Used in component lines. Defaults to ''.
+* `cifmw_repo_setup_component_promotion_tag`: (String) DLRN hash tag to use for component repo setup. Defaults to `component-ci-testing`.
 
 ### Optional parameters for rhos-release
 * `cifmw_repo_setup_rhos_release_rpm`: (String) URL to rhos-release RPM.

--- a/ci_framework/roles/repo_setup/defaults/main.yml
+++ b/ci_framework/roles/repo_setup/defaults/main.yml
@@ -32,6 +32,8 @@ cifmw_repo_setup_output: "{{ cifmw_repo_setup_basedir }}/artifacts/repositories"
 cifmw_repo_setup_env: {}
 cifmw_repo_setup_additional_repos: ''
 cifmw_repo_setup_dlrn_hash_tag: ''
+cifmw_repo_setup_component_name: ''
+cifmw_repo_setup_component_promotion_tag: component-ci-testing
 
 # Variables related to rhos-release tools
 # rhos-release is used in downstream to populate downstream base os repos

--- a/ci_framework/roles/repo_setup/molecule/default/converge.yml
+++ b/ci_framework/roles/repo_setup/molecule/default/converge.yml
@@ -19,6 +19,8 @@
   hosts: all
   vars:
     cifmw_repo_setup_os_release: centos
+    cifmw_repo_setup_component_name: baremetal
+    cifmw_repo_setup_component_promotion_tag: consistent
   roles:
     - role: "repo_setup"
   tasks:
@@ -30,6 +32,7 @@
             path: "{{ ansible_user_dir }}/ci-framework-data/{{ item }}"
           loop:
             - 'artifacts/repositories/delorean.repo.md5'
+            - 'artifacts/repositories/{{ cifmw_repo_setup_component_name }}_{{ cifmw_repo_setup_component_promotion_tag }}_delorean.repo'
         - name: Assert file status
           ansible.builtin.assert:
             that:

--- a/ci_framework/roles/repo_setup/tasks/component_repo.yml
+++ b/ci_framework/roles/repo_setup/tasks/component_repo.yml
@@ -1,0 +1,18 @@
+---
+- name: Get component repo
+  ansible.builtin.get_url:
+    url: "{{ cifmw_repo_setup_dlrn_uri }}/{{ cifmw_repo_setup_os_release }}{{ cifmw_repo_setup_dist_major_version }}-{{ cifmw_repo_setup_branch }}/component/{{ cifmw_repo_setup_component_name }}/{{ cifmw_repo_setup_component_promotion_tag }}/delorean.repo"
+    dest: "{{ cifmw_repo_setup_output }}/{{ cifmw_repo_setup_component_name }}_{{ cifmw_repo_setup_component_promotion_tag }}_delorean.repo"
+
+- name: Rename component repo
+  ansible.builtin.replace:
+    path: "{{ cifmw_repo_setup_output }}/{{ cifmw_repo_setup_component_name }}_{{ cifmw_repo_setup_component_promotion_tag }}_delorean.repo"
+    regexp: 'delorean-component-{{ cifmw_repo_setup_component_name }}'
+    replace: '{{ cifmw_repo_setup_component_name }}-{{ cifmw_repo_setup_component_promotion_tag }}'
+
+- name: Lower the priority of component repo in current-podified dlrn repo
+  community.general.ini_file:
+    path: "{{ cifmw_repo_setup_output }}/delorean.repo"
+    section: 'delorean-component-{{ cifmw_repo_setup_component_name }}'
+    option: priority
+    value: 20

--- a/ci_framework/roles/repo_setup/tasks/main.yml
+++ b/ci_framework/roles/repo_setup/tasks/main.yml
@@ -18,6 +18,9 @@
   ansible.builtin.import_tasks: install.yml
 - name: Configure repo-setup
   ansible.builtin.import_tasks: configure.yml
+- name: Include component repo if required
+  ansible.builtin.import_tasks: component_repo.yml
+  when: cifmw_repo_setup_component_name|length > 0
 - name: Generate additional artifacts
   ansible.builtin.import_tasks: artifacts.yml
 - name: Generate downstream base os repos


### PR DESCRIPTION
When running in the component lines, a component
based repo, which is ahead of current-podified
needs to be included.

This PR adds a task to allow the option to
include a component repo.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
