### PR TITLE
Revert "Remove install_yamls installation method for CRC"

### DIFF
--- a/ci_framework/roles/rhol_crc/README.md
+++ b/ci_framework/roles/rhol_crc/README.md
@@ -9,6 +9,8 @@ Become - required for the tasks in `sudoers_grant.yml` and `sudoers_revoke.yml` 
 ## Parameters
 
 * `cifmw_rhol_crc_basedir`: (String) Directory where we will have the RHOL/CRC binary and the configuration (e.g. `artifacts/.rhol_crc_pull_secret.txt`). Default to `cifmw_basedir` which defaults to `~/ci-framework-data`.
+* `cifmw_edpm_deploy_installyamls`: (String) install_yamls root location. Defaults to `cifmw_installyamls_repos` which defaults to `../..`.
+* `cifmw_rhol_crc_use_installyamls`: (Boolean) Tell the role to leverage install_yamls `crc` related targets. Defaults to `False`.
 * `cifmw_rhol_crc_dryrun`: (Boolean) Toggle the `ci_make` `dry_run` parameter. Defaults to `False`.
 * `cifmw_rhol_crc_config`: (Dict) This structure is merged with the `cifmw_rhol_crc_config_defaults` dictionary. We can add extra properties or override the existing one using this parameter. We can know the parameters that can be used with the output of the `crc config --help` command. Defaults to `{}`.
 * `cifmw_rhol_crc_version`: (String) RHOL/CRC binary version we want to use. Default: `latest`.

--- a/ci_framework/roles/rhol_crc/defaults/main.yml
+++ b/ci_framework/roles/rhol_crc/defaults/main.yml
@@ -18,6 +18,10 @@
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_rhol_crc"
 
+# install_yamls root location
+cifmw_rhol_crc_installyamls: "{{ cifmw_installyamls_repos | default('../..') }}"
+# Deploy CRC using install_yamls
+cifmw_rhol_crc_use_installyamls: false
 cifmw_rhol_crc_kubeadmin_pwd: 12345678
 
 # Toggle ci_make dry_run parameter

--- a/ci_framework/roles/rhol_crc/molecule/install_yamls/cleanup.yml
+++ b/ci_framework/roles/rhol_crc/molecule/install_yamls/cleanup.yml
@@ -1,0 +1,26 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+  tasks:
+    - name: Cleanup RHOL/CRC after tests
+      ansible.builtin.command:
+        cmd: crc cleanup

--- a/ci_framework/roles/rhol_crc/molecule/install_yamls/converge.yml
+++ b/ci_framework/roles/rhol_crc/molecule/install_yamls/converge.yml
@@ -1,0 +1,26 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: all
+  gather_facts: true
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_rhol_crc_use_installyamls: true
+    cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+  roles:
+    - role: "rhol_crc"

--- a/ci_framework/roles/rhol_crc/molecule/install_yamls/molecule.yml
+++ b/ci_framework/roles/rhol_crc/molecule/install_yamls/molecule.yml
@@ -1,0 +1,6 @@
+---
+log: true
+
+provisioner:
+  name: ansible
+  log: true

--- a/ci_framework/roles/rhol_crc/molecule/install_yamls/prepare.yml
+++ b/ci_framework/roles/rhol_crc/molecule/install_yamls/prepare.yml
@@ -1,0 +1,39 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_basedir: "{{ ansible_user_dir }}/ci-framework-data"
+    cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
+    cifmw_install_yamls_defaults:
+      NAMESPACE: openstack
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+  roles:
+    - role: test_deps
+    - role: ci_setup
+    - role: install_yamls
+  tasks:
+    - name: Create crc_pull_secrets.txt
+      ansible.builtin.copy:
+        dest: "{{ cifmw_basedir }}/artifacts/.rhol_crc_pull_secret.txt"
+        content: |
+          {}
+    - name: Get rid of CRC
+      ansible.builtin.command:
+        cmd: crc cleanup

--- a/ci_framework/roles/rhol_crc/tasks/install_yamls.yml
+++ b/ci_framework/roles/rhol_crc/tasks/install_yamls.yml
@@ -1,0 +1,33 @@
+---
+# Configure CRC from install_yamls directly
+- name: Set some facts for later use
+  ansible.builtin.set_fact:
+    crc_configuration: "{{ cifmw_rhol_crc_config_defaults | ansible.builtin.combine(cifmw_rhol_crc_config) }}"
+
+- name: Cleanup if needed/wanted
+  when:
+    - "'crc' in vm_domains"
+    - cifmw_rhol_crc_force_cleanup|bool
+  vars:
+    make_crc_cleanup_dryrun: "{{ cifmw_rhol_crc_dryrun }}"
+    make_crc_cleanup_env:
+      PATH: "{{ cifmw_path }}"
+  ansible.builtin.include_role:
+    name: "install_yamls_makes"
+    tasks_from: "make_crc_cleanup.yml"
+
+- name: Configure crc
+  vars:
+    make_crc_dryrun: "{{ cifmw_rhol_crc_dryrun }}"
+    make_crc_env:
+      PATH: "{{ cifmw_path }}"
+      CPUS: "{{ crc_configuration['cpus'] }}"
+      MEMORY: "{{ crc_configuration['memory'] }}"
+      DISK: "{{ crc_configuration['disk-size'] }}"
+    make_crc_params:
+      CRC_URL: "{{ cifmw_rhol_crc_base_url }}/{{ cifmw_rhol_crc_tarball_name }}"
+      KUBEADMIN_PWD: "{{ cifmw_rhol_crc_kubeadmin_pwd }}"
+      PULL_SECRET: "{{ crc_configuration['pull-secret-file'] }}"
+  ansible.builtin.include_role:
+    name: "install_yamls_makes"
+    tasks_from: "make_crc.yml"

--- a/ci_framework/roles/rhol_crc/tasks/main.yml
+++ b/ci_framework/roles/rhol_crc/tasks/main.yml
@@ -63,16 +63,33 @@
     - name: Configure and start RHOL/CRC
       when: (cifmw_rhol_crc_force_cleanup|bool) or not crc_running|bool
       block:
-        - name: Set RHOL/CRC configuration options
-          ansible.builtin.import_tasks: configuration.yml
+        - name: Configure RHOL/CRC using install_yamls
+          when: cifmw_rhol_crc_use_installyamls|bool
+          ansible.builtin.import_tasks: install_yamls.yml
 
-        - name: Setup RHOL/CRC
-          ansible.builtin.command: "{{ cifmw_rhol_crc_binary }} setup"
-          register: cifmw_rhol_crc_cmd_setup
+        - name: Manually configure RHOL/CRC
+          when: not cifmw_rhol_crc_use_installyamls|bool
+          block:
+            - name: Set RHOL/CRC configuration options
+              ansible.builtin.import_tasks: configuration.yml
 
-        - name: Start RHOL/CRC
-          ansible.builtin.command: "{{ cifmw_rhol_crc_binary }} start"
-          register: cifmw_rhol_crc_cmd_start
+            - name: Setup RHOL/CRC
+              ansible.builtin.command: "{{ cifmw_rhol_crc_binary }} setup"
+              register: cifmw_rhol_crc_cmd_setup
+
+            - name: Start RHOL/CRC
+              ansible.builtin.command: "{{ cifmw_rhol_crc_binary }} start"
+              register: cifmw_rhol_crc_cmd_start
+
+    - name: Attach default network to CRC
+      when: cifmw_rhol_crc_use_installyamls|bool
+      vars:
+        make_crc_attach_default_interface_dryrun: "{{ cifmw_rhol_crc_dryrun }}"
+        make_crc_attach_default_interface_env:
+          PATH: "{{ cifmw_path }}"
+      ansible.builtin.include_role:
+        name: "install_yamls_makes"
+        tasks_from: "make_crc_attach_default_interface.yml"
 
   always:
     - name: Delete sudoers file


### PR DESCRIPTION
Reverts openstack-k8s-operators/ci-framework#823

As a pull request owner and reviewers, I checked that:
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] Content of the docs/source is reflecting the changes
  
Reason: Broken baremetal job