### PR TITLE
Removed patch to dev-scripts source

### DIFF
--- a/ci_framework/roles/devscripts/README.md
+++ b/ci_framework/roles/devscripts/README.md
@@ -29,8 +29,6 @@ managed services.
   configuration. Refer [section](#supported-keys-in-cifmw_devscripts_config_overrides) for more information.
 * `cifmw_devscripts_crb_repo` (str) Repo URL of code ready builder.
 * `cifmw_devscripts_dry_run` (bool) If enabled, the workflow is evaluated.
-* `cifmw_devscripts_restart_virtproxyd` (bool) Optional, if libvirt's virtproxy service should be restarted via
-  a dev-scripts patch. By default this is enabled for stability.
 * `cifmw_devscripts_make_target` (str) Optional, the target to be used with dev-scripts.
 * `cifmw_devscripts_ocp_version` (str) The version of OpenShift to be deployed.
 * `cifmw_devscripts_osp_compute_nodes` (list) A list of nodes which has key/value pairs

--- a/ci_framework/roles/devscripts/tasks/sub_tasks/31_repo.yml
+++ b/ci_framework/roles/devscripts/tasks/sub_tasks/31_repo.yml
@@ -30,17 +30,6 @@
   delay: 15
   until: "clone_out is not failed"
 
-# This is the same patch as proposed upstream with
-# https://github.com/openshift-metal3/dev-scripts/pull/1595
-# Even if it gets merged, the patch here won't fail.
-- name: Patch dev-scripts for libvirt stability
-  when: cifmw_devscripts_restart_virtproxyd | bool
-  tags:
-    - bootstrap
-  ansible.posix.patch:
-    src: virtproxyd.patch
-    dest: "{{ cifmw_devscripts_repo_dir }}/ocp_install_env.sh"
-
 - name: Read the vm_setup_vars contents.
   ansible.builtin.slurp:
     src: "{{ cifmw_devscripts_repo_dir }}/vm_setup_vars.yml"


### PR DESCRIPTION
With [1603](https://github.com/openshift-metal3/dev-scripts/pull/1603) merged, we no longer need to patch dev-scripts here. This change set removes the tasks related to source code patching.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes

_Testing log snippet_
```
PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
localhost                  : ok=265  changed=109  unreachable=0    failed=0    skipped=242  rescued=0    ignored=3 

Tuesday 21 November 2023  11:17:36 +0200 (0:00:00.952)       2:11:16.152 ****** 
=============================================================================== 
devscripts : Deploying the OpenShift platform -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 3327.08s
edpm_deploy_baremetal : Wait for OpenStackDataPlaneNodeSet to be Ready ------------------------------------------------------------------------------------------------------------------------------------------------------------- 2624.06s
edpm_prepare : Wait for OpenStack controlplane to be deployed ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- 402.07s
install_yamls_makes : Run openstack ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 399.90s
edpm_prepare : Wait for OpenStack operator to get installed ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 271.76s
libvirt_manager : Install packages required for using KVM --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 152.61s
run_hook : Run play /home/ciuser/src/install_yamls/devsetup/download_tools.yaml ------------------------------------------------------------------------------------------------------------------------------------------------------ 81.78s
ci_setup : Enabling the required repositories. --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 80.22s
install_yamls_makes : Run crc_storage ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 75.83s
edpm_prepare : Wait for OpenStack subscription creation ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 62.40s
install_yamls_makes : Run edpm_deploy_baremetal -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 23.51s
install_yamls_makes : Run netconfig_deploy ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 20.69s
install_yamls_makes : Run openstack_deploy_prep -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.97s
install_yamls_makes : Run input ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 10.81s
ci_nmstate : Install required packages ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 10.73s
repo_setup : Initialize python venv and install requirements -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 9.65s
repo_setup : Generate repos using rhos-release ceph-6.0 -r 9.2 --enable-repo rhosp-rhel-9.2-crb --------------------------------------------------------------------------------------------------------------------------------------- 8.82s
devscripts : Ensure the required packages for executing dev-scripts exists. ----------------------------------------------------------------------------------------------------------------------------------------------------------- 8.73s
repo_setup : Install RHOS Release tool ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 8.63s
os_net_setup : Process network list elements ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 8.37s
```