### PR TITLE
Correct how we detect nested virtualization layout

### DIFF
--- a/ci_framework/roles/artifacts/tasks/edpm.yml
+++ b/ci_framework/roles/artifacts/tasks/edpm.yml
@@ -1,12 +1,7 @@
 ---
-- name: Gather services
-  when:
-    - not ansible_facts.services is defined
-  ansible.builtin.service_facts:
-
 - name: Check for virtualized compute in Baremetal jobs
   when:
-    - "'libvirtd.service' in ansible_facts.services"
+    - cifmw_is_nested_virt | default(false) | bool
   block:
     - name: List all of the existing virtual machines
       register: vms_list
@@ -26,7 +21,7 @@
 
 - name: Hit compute nodeset
   when:
-    - "'libvirtd' not in ansible_facts.services"
+    - not cifmw_is_nested_virt | default(false) | bool
   block:
     - name: Check for CI env directory
       register: network_env_dir

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -193,6 +193,7 @@
     parent: base-simple-crc
     vars:
       crc_parameters: "--memory 22000 --disk-size 120 --cpus 10"
+      cifmw_is_nested_virt: true
       pre_pull_images:
         - registry.redhat.io/rhosp-rhel9/openstack-rabbitmq:17.0
 


### PR DESCRIPTION
Since we have to handle two kinds of layout, multinode and nested
virtualization, we better have to get a strong way to differenciate
them.

Until now, we were trying to be smart, by looking up libvirtd.service
availability, and listing VMs therein. But it wasn't strong enough and
lead to some issues with multinode having libvirtd available.

This patch introduces a new, CI dedicated parameter, allowing to toggle
the right "path" in the log gathering.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
