### PR TITLE
Disable cloud-init override of NM DNS

### DIFF
--- a/ci/playbooks/multinode-customizations.yml
+++ b/ci/playbooks/multinode-customizations.yml
@@ -128,6 +128,28 @@
       ansible.builtin.set_fact:
         persistent_ssh_key: "{{ pub_key_slurp['content'] | b64decode }}"
 
+    - name: Check if cloud-init is overriding NM settings
+      become: true
+      ansible.builtin.stat:
+        path: "/etc/NetworkManager/conf.d/99-cloud-init.conf"
+      register: _cloud_init_nm_override_stat
+
+    - name: Remove cloud-init DNS override if present and reload
+      become: true
+      when: _cloud_init_nm_override_stat.stat.exists
+      block:
+        - name: Remove cloud-init DNS override if present
+          community.general.ini_file:
+            path: "/etc/NetworkManager/conf.d/99-cloud-init.conf"
+            section: main
+            option: dns
+            state: absent
+
+        - name: Reload the NetworkManager to pick the changes
+          ansible.builtin.service:
+            name: NetworkManager
+            state: "reloaded"
+
     - name: Get the default iface connection
       register: controller_default_connection_out
       ansible.builtin.command:


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date
