### PR TITLE
Fix the conditions when to use the default network as OCP external subnet

### DIFF
--- a/ci_framework/roles/devscripts/README.md
+++ b/ci_framework/roles/devscripts/README.md
@@ -27,7 +27,6 @@ managed services.
   We can use `cifmw_devscripts_ci_token` or `cifmw_devscripts_ci_token_file` for passing OAuth token.
 * `cifmw_devscripts_config_overrides` (dict) key/value pairs to be used for overriding the default
   configuration. Refer [section](#supported-keys-in-cifmw_devscripts_config_overrides) for more information.
-* `cifmw_devscripts_crb_repo` (str) Repo URL of code ready builder.
 * `cifmw_devscripts_dry_run` (bool) If enabled, the workflow is evaluated.
 * `cifmw_devscripts_make_target` (str) Optional, the target to be used with dev-scripts.
 * `cifmw_devscripts_ocp_version` (str) The version of OpenShift to be deployed.

--- a/ci_framework/roles/devscripts/tasks/02_gather_env_details.yml
+++ b/ci_framework/roles/devscripts/tasks/02_gather_env_details.yml
@@ -14,49 +14,49 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Gather default IPv4 network notation.
-  tags:
-    - bootstrap
-  when:
-    - "'manage_br_bridge' in cifmw_devscripts_config"
-    - cifmw_devscripts_config['manage_br_bridge'] == 'n'
-    - cifmw_devscripts_config['ip_stack'] != 'v6'
-    - cifmw_devscripts_ext_net_cidr is not defined
-  vars:
-    subnet: >-
-      {{ ansible_default_ipv4.network}}/{{ ansible_default_ipv4.netmask }}
-    ext_net_v4:
-      external_subnet_v4: >-
-        {{
-          subnet | ansible.utils.ipaddr('network/prefix')
-        }}
-  ansible.builtin.set_fact:
-    cifmw_devscripts_config: >-
-      {{
-        cifmw_devscripts_config | combine(ext_net_v4, recursive=true)
-      }}
 
-- name: Gather default IPv6 network notation.
+- name: Gather external network subnet information.
   tags:
     - bootstrap
   when:
-    - "'manage_br_bridge' in cifmw_devscripts_config"
+    - cifmw_devscripts_config['manage_br_bridge'] is defined
     - cifmw_devscripts_config['manage_br_bridge'] == 'n'
-    - cifmw_devscripts_config['ip_stack'] != 'v4'
-    - cifmw_devscripts_ext_net_cidr_6 is not defined
-  vars:
-    subnet: >-
-      {{ ansible_default_ipv6.network}}/{{ ansible_default_ipv6.netmask }}
-    ext_net_v6:
-      external_subnet_v6: >-
-        {{
-          subnet | ansible.utils.ipaddr('network/prefix')
-        }}
-  ansible.builtin.set_fact:
-    cifmw_devscripts_config: >-
-      {{
-        cifmw_devscripts_config | combine(ext_net_v6, recursive=true)
-      }}
+  block:
+    - name: Collect subnet when v4 family is enabled.
+      when:
+        - cifmw_devscripts_config['external_subnet_v4'] is not defined
+        - cifmw_devscripts_config['ip_stack'] != 'v6'
+      vars:
+        subnet: >-
+          {{ ansible_default_ipv4.network}}/{{ ansible_default_ipv4.netmask }}
+        ext_net_v4:
+          external_subnet_v4: >-
+            {{
+              subnet | ansible.utils.ipaddr('network/prefix')
+            }}
+      ansible.builtin.set_fact:
+        cifmw_devscripts_config: >-
+          {{
+            cifmw_devscripts_config | combine(ext_net_v4, recursive=true)
+          }}
+
+    - name: Gather subnet when v6 family is enabled.
+      when:
+        - cifmw_devscripts_config['external_subnet_v6'] is not defined
+        - cifmw_devscripts_config['ip_stack'] != 'v4'
+      vars:
+        subnet: >-
+          {{ ansible_default_ipv6.network}}/{{ ansible_default_ipv6.netmask }}
+        ext_net_v6:
+          external_subnet_v6: >-
+            {{
+              subnet | ansible.utils.ipaddr('network/prefix')
+            }}
+      ansible.builtin.set_fact:
+        cifmw_devscripts_config: >-
+          {{
+            cifmw_devscripts_config | combine(ext_net_v6, recursive=true)
+          }}
 
 - name: Add external network IPv4 address
   tags:


### PR DESCRIPTION
In this PR, the conditions when to use the default subnet as external subnet is correct. It is fixed by checking if the user has provided external_subnet_ipv[46] or not.

If provided the values are not replaced.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running