### PR TITLE
Ensure some configurations are always set

### DIFF
--- a/ci_framework/roles/reproducer/tasks/ci_job.yml
+++ b/ci_framework/roles/reproducer/tasks/ci_job.yml
@@ -32,34 +32,6 @@
   delegate_to: controller-0
   remote_user: zuul
   block:
-    - name: Set facts related to the reproducer
-      ansible.builtin.set_fact:
-        _ctl_reproducer_basedir: >-
-          {{
-            (
-             '/home/zuul',
-             'ci-framework-data',
-             'artifacts'
-             ) | path_join
-          }}
-
-    - name: Ensure directory exists
-      ansible.builtin.file:
-        path: "{{ _ctl_reproducer_basedir }}"
-        state: directory
-
-    - name: Create data directory on controller-0
-      ansible.builtin.file:
-        path: "{{ _ctl_reproducer_basedir }}/parameters"
-        state: directory
-
-    - name: Ensure /etc/ci/env is created
-      become: true
-      ansible.builtin.file:
-        path: /etc/ci/env
-        state: directory
-        mode: "0755"
-
     - name: Create crc_ci_bootstrap_networks_out fact
       vars:
         net_config_list: |-
@@ -124,22 +96,6 @@
           ansible.builtin.copy:
             dest: zuul-network-data.yml
             content: "{{ {'job_network': ci_job_networking} | to_nice_yaml}}"
-
-    - name: Install collections
-      tags:
-        - bootstrap
-      ansible.builtin.command:
-        chdir: "src/github.com/openstack-k8s-operators/ci-framework"
-        cmd: ansible-galaxy collection install -r requirements.yml
-
-    - name: Build job inventory for hook usage
-      tags:
-        - bootstrap
-      ansible.builtin.shell:
-        cmd: >-
-          cat reproducer-inventory/* >
-          ci-framework-data/artifacts/zuul_inventory.yml
-        creates: ci-framework-data/artifacts/zuul_inventory.yml
 
     - name: Push pre-CI job playbook
       tags:

--- a/ci_framework/roles/reproducer/tasks/configure_controller.yml
+++ b/ci_framework/roles/reproducer/tasks/configure_controller.yml
@@ -1,4 +1,15 @@
 ---
+- name: Set facts related to the reproducer
+  ansible.builtin.set_fact:
+    _ctl_reproducer_basedir: >-
+      {{
+        (
+         '/home/zuul',
+         'ci-framework-data',
+         'artifacts'
+         ) | path_join
+      }}
+
 - name: Configure controller-0
   delegate_to: controller-0
   delegate_facts: true
@@ -9,6 +20,40 @@
         gather_subset:
           - '!all'
           - 'min'
+
+    - name: Ensure directory exists
+      ansible.builtin.file:
+        path: "{{ _ctl_reproducer_basedir }}"
+        state: directory
+        owner: zuul
+        group: zuul
+        mode: "0755"
+
+    - name: Create data directory on controller-0
+      ansible.builtin.file:
+        path: "{{ _ctl_reproducer_basedir }}/parameters"
+        state: directory
+        owner: zuul
+        group: zuul
+        mode: "0755"
+
+    - name: Build job inventory for hook usage
+      tags:
+        - bootstrap
+      become: true
+      become_user: zuul
+      ansible.builtin.shell:
+        cmd: >-
+          cat /home/zuul/reproducer-inventory/* >
+          {{  _ctl_reproducer_basedir }}/zuul_inventory.yml
+        creates: ci-framework-data/artifacts/zuul_inventory.yml
+
+    - name: Ensure /etc/ci/env is created
+      become: true
+      ansible.builtin.file:
+        path: /etc/ci/env
+        state: directory
+        mode: "0755"
 
     - name: Tweak dnf configuration
       community.general.ini_file:
@@ -122,7 +167,6 @@
     - name: Install some tools
       ansible.builtin.package:
         name:
-          - ansible-core
           - bash-completion
           - git-core
           - make

--- a/ci_framework/roles/reproducer/tasks/push_code.yml
+++ b/ci_framework/roles/reproducer/tasks/push_code.yml
@@ -69,3 +69,9 @@
       loop_control:
         loop_var: repository
         label: "{{ repository.src | basename }}"
+
+- name: Install collections on controller-0
+  delegate_to: controller-0
+  ansible.builtin.command:
+    chdir: "src/github.com/openstack-k8s-operators/ci-framework"
+    cmd: ansible-galaxy collection install -r requirements.yml


### PR DESCRIPTION
We need the inventory and the collections in any cases, not just the
ci_job.

Also don't install ansible-core from packages, since we install it via
pip. It will then be in .local/bin, and we ensure libraries consistency.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
