### PR TITLE
Fix MTU computing for EDPM in multinode

### DIFF
--- a/ci_framework/hooks/playbooks/fetch_compute_facts.yml
+++ b/ci_framework/hooks/playbooks/fetch_compute_facts.yml
@@ -123,24 +123,54 @@
 
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleVars/ctlplane_mtu
-                    value: {{ crc_ci_bootstrap_networks_out['compute-0'].default.mtu | default(1500) }}
+                    value: {{ (crc_ci_bootstrap_networks_out['compute-0'].default.mtu | default(1500)) | int }}
 
               {% if 'tenant' in crc_ci_bootstrap_networks_out['compute-0'] %}
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleVars/tenant_mtu
-                    value: {{ crc_ci_bootstrap_networks_out['compute-0']['tenant'].mtu | default(1500) }}
+                    value: {{ (crc_ci_bootstrap_networks_out['compute-0']['tenant'].mtu | default(1500)) | int }}
+              {% else %}
+                  - op: remove
+                    path: /spec/nodeTemplate/ansible/ansibleVars/tenant_mtu
+
+                  - op: remove
+                    path: /spec/nodeTemplate/ansible/ansibleVars/networks_lower/Tenant
               {% endif %}
 
               {% if 'storage' in crc_ci_bootstrap_networks_out['compute-0'] %}
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleVars/storage_mtu
-                    value: {{ crc_ci_bootstrap_networks_out['compute-0']['storage'].mtu | default(1500) }}
+                    value: {{ (crc_ci_bootstrap_networks_out['compute-0']['storage'].mtu | default(1500)) | int }}
+              {% else %}
+                  - op: remove
+                    path: /spec/nodeTemplate/ansible/ansibleVars/storage_mtu
+
+                  - op: remove
+                    path: /spec/nodeTemplate/ansible/ansibleVars/networks_lower/Storage
               {% endif %}
 
               {% if 'internal-api' in crc_ci_bootstrap_networks_out['compute-0'] %}
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleVars/internal_api_mtu
-                    value: {{ crc_ci_bootstrap_networks_out['compute-0']['internal-api'].mtu | default(1500) }}
+                    value: {{ (crc_ci_bootstrap_networks_out['compute-0']['internal-api'].mtu | default(1500)) | int }}
+              {% else %}
+                  - op: remove
+                    path: /spec/nodeTemplate/ansible/ansibleVars/internal_api_mtu
+
+                  - op: remove
+                    path: /spec/nodeTemplate/ansible/ansibleVars/networks_lower/InternalApi
+              {% endif %}
+
+              {% if 'external' in crc_ci_bootstrap_networks_out['compute-0'] %}
+                  - op: replace
+                    path: /spec/nodeTemplate/ansible/ansibleVars/external_mtu
+                    value: {{ (crc_ci_bootstrap_networks_out['compute-0']['external'].mtu | default(1500)) | int }}
+              {% else %}
+                  - op: remove
+                    path: /spec/nodeTemplate/ansible/ansibleVars/external_mtu
+
+                  - op: remove
+                    path: /spec/nodeTemplate/ansible/ansibleVars/networks_lower/External
               {% endif %}
 
               {% for compute_node in groups['computes'] if compute_node != 'compute-0' %}
@@ -170,6 +200,16 @@
                         edpm-compute:
                           nic2: "{{ crc_ci_bootstrap_networks_out['compute-0'].default.iface | default('ens7') }}"
 
+                  - op: add
+                    path: /spec/nodeTemplate/ansible/ansibleVars/edpm_network_config_debug
+                    value: true
+
+                  - op: add
+                    path: /spec/env
+                    value:
+                      - name: "ANSIBLE_VERBOSITY"
+                        value: "2"
+
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleVars/edpm_network_config_template
                     value: |-
@@ -197,7 +237,7 @@
                             primary: true
                         {% for network in role_networks %}
                           - type: vlan
-                            mtu: 1496
+                            mtu: {{ min_viable_mtu - 4 }}
                             vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
                             addresses:
                             - ip_netmask:


### PR DESCRIPTION
The os-net-config template we were using has a hardcoded value for the MTU, a leftover of the multinode PoC.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date: