### PR TITLE
[rhol_crc] add_crc_creds: Fix check for kubeconfig

### DIFF
--- a/ci_framework/roles/rhol_crc/tasks/add_crc_creds.yml
+++ b/ci_framework/roles/rhol_crc/tasks/add_crc_creds.yml
@@ -4,6 +4,11 @@
     path: "{{ cifmw_rhol_crc_kubeconfig }}"
   register: crc_kubeconfig
 
+- name: Warn the user that the kubeconfig files doesn't exist
+  ansible.builtin.fail:
+    msg: "The kubeconfig file was not found at {{ cifmw_rhol_crc_kubeconfig }}."
+  when: not (crc_kubeconfig.stat.exists | bool)
+
 - name: Add crc kubeconfig to user's bashrc
   when: crc_kubeconfig.stat.exists
   block:
@@ -13,7 +18,7 @@
         create: true
         block: |-
           eval $(crc oc-env)
-          export KUBECONFIG="{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+          export KUBECONFIG="{{ cifmw_rhol_crc_kubeconfig }}"
 
     - name: Source bashrc and confirm crc login
       ansible.builtin.shell: |


### PR DESCRIPTION
The check currently doesn't provide any feedback when the kubeconfig doesn't exist in the expected location.
If the kubeconfig doesn't exist in the expected location, there should be an error. This enhances the user experience by telling them the issue right away.

The error come up here: https://review.rdoproject.org/zuul/build/f77349f5e5cb4fff829e5272f04f5b0b/console#9/0/6/controller


As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
