### PR TITLE
Patch dev-scripts repository for reliable deployment

### DIFF
--- a/ci_framework/roles/devscripts/files/virtproxyd.patch
+++ b/ci_framework/roles/devscripts/files/virtproxyd.patch
@@ -1,12 +1,17 @@
---- a/ocp_install_env.sh
-+++ b/ocp_install_env.sh
-@@ -288,7 +288,8 @@ function generate_ocp_install_config() {
-         exit 1
-       fi
-     fi
--
-+    # Try to fix libvirt stability before running bootstrap VM
-+    sudo systemctl restart virtproxyd.socket
-     cat > "${outdir}/install-config.yaml" << EOF
- apiVersion: v1
- baseDomain: ${BASE_DOMAIN}
+--- a/02_configure_host.sh
++++ b/02_configure_host.sh
+@@ -21,11 +21,13 @@ early_deploy_validation
+ manage_libvirtd() {
+   case ${DISTRO} in
+       centos9|rhel9)
+-          for i in qemu network nodedev nwfilter secret storage interface; do
++          for i in qemu interface network nodedev nwfilter secret storage; do
+               sudo systemctl enable --now virt${i}d.socket
+               sudo systemctl enable --now virt${i}d-ro.socket
+               sudo systemctl enable --now virt${i}d-admin.socket
+           done
++          sudo systemctl enable virtproxyd.service
++          sudo systemctl enable --now virtproxyd{,-ro,-admin}.socket
+           ;;
+       *)
+           sudo systemctl restart libvirtd.service

--- a/ci_framework/roles/devscripts/tasks/sub_tasks/31_repo.yml
+++ b/ci_framework/roles/devscripts/tasks/sub_tasks/31_repo.yml
@@ -30,6 +30,15 @@
   delay: 15
   until: "clone_out is not failed"
 
+# An upstream patch is also proposed
+# https://github.com/openshift-metal3/dev-scripts/pull/1607
+- name: Patch dev-scripts for libvirt stability
+  tags:
+    - bootstrap
+  ansible.posix.patch:
+    src: virtproxyd.patch
+    dest: "{{ cifmw_devscripts_repo_dir }}/02_configure_host.sh"
+
 - name: Read the vm_setup_vars contents.
   ansible.builtin.slurp:
     src: "{{ cifmw_devscripts_repo_dir }}/vm_setup_vars.yml"

--- a/ci_framework/roles/libvirt_manager/tasks/drivers.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/drivers.yml
@@ -1,0 +1,38 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Enable and start the provider libvirt modular driver daemon
+
+- name: "Ensure read-write socket is enabled for {{ driver_name }}."
+  become: true
+  ansible.builtin.service:
+    name: "virt{{ driver_name }}d.socket"
+    state: started
+    enabled: true
+
+- name: "Ensure read-only socket is enabled for {{ driver_name }}."
+  become: true
+  ansible.builtin.service:
+    name: "virt{{ driver_name }}d-ro.socket"
+    state: started
+    enabled: true
+
+- name: "Ensure admin socket is enabled for {{ driver_name }}."
+  become: true
+  ansible.builtin.service:
+    name: "virt{{ driver_name }}d-admin.socket"
+    state: started
+    enabled: true

--- a/ci_framework/roles/libvirt_manager/tasks/virsh_checks.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/virsh_checks.yml
@@ -27,41 +27,23 @@
       ansible.builtin.systemd_service:
         daemon_reload: true
 
-- name: Ensure proper services are enabled on newer OS
-  become: true
+- name: Ensure libvirt modular driver daemons are started.
   when:
     - ansible_facts['distribution'] in ['CentOS', 'RedHat']
     - ansible_facts['distribution_major_version'] >= '9'
-  vars:
-    _services:
-      - qemu
-      - network
-      - nodedev
-      - nwfilter
-      - secret
-      - storage
-      - interface
-  block:
-    - name: Ensure main sockets are enabled
-      ansible.builtin.service:
-        name: "virt{{ item }}d.socket"
-        state: started
-        enabled: true
-      loop: "{{ _services }}"
-
-    - name: Ensure read-only sockets are enabled
-      ansible.builtin.service:
-        name: "virt{{ item }}d-ro.socket"
-        state: started
-        enabled: true
-      loop: "{{ _services }}"
-
-    - name: Ensure admin sockets are enabled
-      ansible.builtin.service:
-        name: "virt{{ item }}d-admin.socket"
-        state: started
-        enabled: true
-      loop: "{{ _services }}"
+  ansible.builtin.include_tasks:
+    file: drivers.yml
+  loop:
+    - qemu
+    - interface
+    - network
+    - nodedev
+    - nwfilter
+    - secret
+    - storage
+    - proxy
+  loop_control:
+    loop_var: driver_name
 
 - name: Manage service for older releases
   become: true


### PR DESCRIPTION
This PR includes a proposed a patch [1607](https://github.com/openshift-metal3/dev-scripts/pull/1607) that may improve the reliability of OCP deployment. The proposed patch would fix runs failing with the below error

```
2023-11-23 15:20:02 level=error msg=Error: failed to dial libvirt: dial unix /var/run/libvirt/libvirt-sock: connect: no such file or directory
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

__ Logs __
```

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
localhost                  : ok=366  changed=87   unreachable=0    failed=0    skipped=140  rescued=2    ignored=0   

Friday 24 November 2023  12:33:48 +0200 (0:00:00.076)       0:10:07.954 ******* 
=============================================================================== 
reproducer : Install some tools ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 162.97s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 88.11s
reproducer : Bootstrap environment on controller-0 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 39.03s
reproducer : Install ansible dependencies -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 36.32s
libvirt_manager : Grab IPs for nodes type ocp ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 26.89s
libvirt_manager : Grab IPs for nodes type compute ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 21.65s
libvirt_manager : Prepare disk image with SSH and growing volume --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 19.92s
libvirt_manager : Grab IPs for nodes type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.97s
libvirt_manager : Wait for SSH on VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.70s
libvirt_manager : Wait for SSH on VMs type ocp --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.63s
reproducer : Install collections on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 13.19s
libvirt_manager : Download base image ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 11.90s
ci_setup : Install needed packages ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 5.93s
libvirt_manager : Wait for SSH on VMs type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 5.26s
reproducer : Enable RHEL repos -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 3.95s
reproducer : Sync remote repositories ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 3.94s
libvirt_manager : Configure ssh access on type compute -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 3.04s
reproducer : Clone repository if needed: ci-framework --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 3.02s
reproducer : Clone repository if needed: install_yamls -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2.94s
reproducer : Get rhos-release --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2.37s
```
