### PR TITLE
Gather additional namespaces when must-gather is executed

### DIFF
--- a/roles/os_must_gather/README.md
+++ b/roles/os_must_gather/README.md
@@ -13,6 +13,8 @@ testing the new changes.
 * `cifmw_os_must_gather_repo_path`: (string) Path to local clone of openstack-must-gather git repo
 * `cifmw_os_must_gather_timeout`: (String) Timeout for must-gather command
 * `cifmw_os_must_gather_host_network`: (Bool) Flag to gather host network data
+* `cifmw_os_must_gather_namespaces`: (List) List of namespaces required by the gather task in case of failure
+* `cifmw_os_must_gather_additional_namespaces`: (String) List of comma separated additional namespaces
 
 ## Examples
 ```

--- a/roles/os_must_gather/defaults/main.yml
+++ b/roles/os_must_gather/defaults/main.yml
@@ -23,4 +23,13 @@ cifmw_os_must_gather_image_registry: "quay.rdoproject.org/openstack-k8s-operator
 cifmw_os_must_gather_output_dir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_os_must_gather_repo_path: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/openstack-must-gather"
 cifmw_os_must_gather_timeout: "10m"
+cifmw_os_must_gather_additional_namespaces: "kuttl,sushy-emulator"
+cifmw_os_must_gather_namespaces:
+  - openstack-operators
+  - openstack
+  - baremetal-operator-system
+  - openshift-machine-api
+  - cert-manager
+  - openshift-nmstate
+  - metallb-system
 cifmw_os_must_gather_host_network: false

--- a/roles/os_must_gather/tasks/main.yml
+++ b/roles/os_must_gather/tasks/main.yml
@@ -61,8 +61,16 @@
           oc adm must-gather --image {{ cifmw_os_must_gather_image }}
           --timeout {{ cifmw_os_must_gather_timeout }}
           --host-network={{ cifmw_os_must_gather_host_network }}
-          --dest-dir {{ cifmw_os_must_gather_output_dir }}/logs > {{ cifmw_os_must_gather_output_dir }}/logs/os_must_gather.log
+          --dest-dir {{ cifmw_os_must_gather_output_dir }}/logs
+          -- ADDITIONAL_NAMESPACES={{ cifmw_os_must_gather_additional_namespaces }} gather &> {{ cifmw_os_must_gather_output_dir }}/logs/os_must_gather.log
+
   rescue:
+    - name: Create oc_inspect log directory
+      ansible.builtin.file:
+        path: "{{ cifmw_os_must_gather_output_dir }}/logs/oc_inspect"
+        state: directory
+        mode: "0755"
+
     - name: Inspect the cluster after must-gather failure
       ignore_errors: true # noqa: ignore-errors
       environment:
@@ -71,7 +79,13 @@
       cifmw.general.ci_script:
         output_dir: "{{ cifmw_os_must_gather_output_dir }}/artifacts"
         script: |
-          mkdir -p {{ cifmw_os_must_gather_output_dir }}/logs/oc_inspect
-          for ns in openstack-operators openstack baremetal-operator-system openshift-machine-api cert-manager openshift-nmstate metallb-system; do
-            oc adm inspect namespace/"${ns}" --dest-dir={{ cifmw_os_must_gather_output_dir }}/logs/oc_inspect || echo "Error getting logs from ${ns}"
-          done
+            oc adm inspect namespace/{{ item }} --dest-dir={{ cifmw_os_must_gather_output_dir }}/logs/oc_inspect
+      loop: >-
+        {{
+          (
+            cifmw_os_must_gather_namespaces | default([]) +
+            (
+              cifmw_os_must_gather_additional_namespaces | split(',') | list
+            )
+          ) | unique
+        }}


### PR DESCRIPTION
This change aligns the `os_must_gather` role to pass additional `namespaces` that are relevant for CI.
By default all the ns matching `*kuttl*` and `sushy-emulator` are added, but the env variable can be used as an override to the default behavior.


As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
- [x] README in the role
- [x] Content of the docs/source is reflecting the changes


Depends-On: https://github.com/openstack-k8s-operators/openstack-must-gather/pull/31