### PR TITLE
Add iDRAC role to control Dell baremetal osp compute nodes

### DIFF
--- a/ci_framework/roles/idrac_configuration/README.md
+++ b/ci_framework/roles/idrac_configuration/README.md
@@ -1,0 +1,76 @@
+# idrac_configuration
+Role to configure iDRAC and controlling Dell iDRAC via Redfish API.
+
+Capable to perform the following tasks:
+* Query iDRAC information.
+* Set Bios Attributes.
+* Set boot mode.
+* Set device boot order.
+* Execute a power action.
+
+## Requirements
+* iDRAC 7/8 with Firmware version 2.82.82.82 or above.
+* iDRAC 9 with Firmware version 3.00.00.00 or above.
+
+## Parameters
+* `cifmw_idrac_configuration_bios_attributes`: (String) iDRAC BIOS attributes. Defaults to `False`.
+* `cifmw_idrac_configuration_boot_mode`: (String) iDRAC BIOS boot mode. Defaults to `False`.
+* `cifmw_idrac_configuration_boot_order`: (String) iDRAC BIOS boot order. Defaults to `False`.
+* `cifmw_idrac_configuration_delete_previous_idrac_jobs`: (Boolean) Remove previously completed jobs from iDRAC job inventory. Defaults to `False`.
+* `cifmw_idrac_configuration_target_hosts`: (String) Set a list of hosts to run this role against.
+* `cifmw_idrac_configuration_power_action`: (String) Execute power action on iDRAC. Defaults to `False`.
+* `cifmw_idrac_configuration_query`: (String) Whether to query iDRAC for info. Defaults to `False`.
+* `cifmw_idrac_configuration_racreset`: (String) Performs 'GracefulRestart' on iDRAC controller. Defaults to `False`.
+* `cifmw_idrac_configuration_skip_clear_pending`: (Boolean) Skips clearing pending BIOS attributes. Defaults to `False`.
+* `cifmw_idrac_configuration_task_retries`: (Integer) Amount of retries attempted in supported tasks. Defaults to `30`.
+* `cifmw_idrac_configuration_timeout`: (String) Timeout in seconds for URL requests to OOB (out of band) controller. Defaults to `30`.
+* `cifmw_idrac_configuration_validate_ssl_certs`: (Boolean) Validate SSL certificates. Defaults to `False`.
+
+## Examples
+```YAML
+- name: Set a dynamic inventory
+  hosts: all
+  tasks:
+    - name: Split target_hosts into a list
+      ansible.builtin.set_fact:
+        host_list: "{{ cifmw_idrac_configuration_target_hosts.split(',') }}"
+
+    - name: Add hosts dynamically
+      ansible.builtin.add_host:
+        name: "{{ item }}"
+        group: idrac_target_hosts
+      with_items: "{{ host_list }}"
+
+- hosts: idrac_target_hosts
+  connection: local
+  vars_files:
+    - idrac_hosts_vars.yml
+  roles:
+    - idrac_configuration
+```
+
+idrac_hosts_vars.yml:
+```YAML
+cifmw_idrac_configuration_target_hosts: node1-bmc.example.com,node2-bmc.example.com
+cifmw_idrac_configuration_user: username
+cifmw_idrac_configuration_password: password
+
+node1-bmc.example.com:
+  cifmw_idrac_configuration_boot_mode: "Bios"
+  cifmw_idrac_configuration_bios_attributes:
+    SysProfile: "PerfOptimized" # Set performance profile
+    EnergyEfficientTurbo: "Disabled" # Disabling Intel Turbo Boost, we don't want dynamic CPU frequency
+    EnergyPerformanceBias: "MaxPower" # Max power consumption
+    MemFrequency: "MaxPerf" # Maximum performance for memory for best performance
+    PowerSaver: "Disabled" # Disable power saver
+    ProcVirtualization: "Enabled" # Enable virtualization (VT-d for Intel, AMD-V for AMD)
+    LogicalProc: "Enabled" # Enable hyperthreading
+    SriovGlobalEnable: "Enabled" # Enable SR-IOV
+    PxeDev1EnDis: "Enabled" # Enabling PXE Device 1
+    PxeDev1Interface: "NIC.Embedded.1-1-1" # Assigning physical NIC to PXE device 1
+    PxeDev1Protocol: "IPv4" # Assigning PXE device 1 to IPv4
+    PxeDev1VlanEnDis: "Disabled" # Disable VLAN for PXE device 1
+  cifmw_idrac_configuration_boot_order:
+    - "NIC.Integrated.1-1-1"
+    - "NIC.Integrated.1-2-1"
+```

--- a/ci_framework/roles/idrac_configuration/defaults/main.yml
+++ b/ci_framework/roles/idrac_configuration/defaults/main.yml
@@ -1,0 +1,31 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_idrac_configuration"
+
+cifmw_idrac_configuration_task_retries: 30
+cifmw_idrac_configuration_timeout: 30
+cifmw_idrac_configuration_query: false
+cifmw_idrac_configuration_bios_attributes: false
+cifmw_idrac_configuration_boot_mode: false
+cifmw_idrac_configuration_boot_order: false
+cifmw_idrac_configuration_power_action: false
+cifmw_idrac_configuration_delete_previous_idrac_jobs: false
+cifmw_idrac_configuration_skip_clear_pending: false
+cifmw_idrac_configuration_racreset: false
+cifmw_idrac_configuration_validate_ssl_certs: false

--- a/ci_framework/roles/idrac_configuration/meta/main.yml
+++ b/ci_framework/roles/idrac_configuration/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- idrac_configuration
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: edpm
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - edpm
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/ci_framework/roles/idrac_configuration/molecule/default/converge.yml
+++ b/ci_framework/roles/idrac_configuration/molecule/default/converge.yml
@@ -1,0 +1,25 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Do not do anything
+      ansible.builtin.debug:
+        msg: |
+          This role exclusively relies on the hardware that is connection is only in RH internal network.
+          Molecule cannot run and mimic it in an environment outside the designated network segment.

--- a/ci_framework/roles/idrac_configuration/molecule/default/molecule.yml
+++ b/ci_framework/roles/idrac_configuration/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/ci_framework/roles/idrac_configuration/tasks/check_bios.yml
+++ b/ci_framework/roles/idrac_configuration/tasks/check_bios.yml
@@ -1,0 +1,71 @@
+---
+- name: Set Facts
+  ansible.builtin.set_fact:
+    idrac_scheduled_bios_jobs: {}
+    idrac_runnig_jobs: {}
+
+- name: Retrieve Jobs From iDRAC
+  when: not ansible_check_mode
+  ansible.builtin.include_tasks:
+    file: retrieve_idrac_jobs.yml
+
+- name: Check If There Are Non Completed Jobs
+  when: idrac_job['results']
+  block:
+    - name: Check For Scheduled BIOS Configuration Jobs
+      ansible.builtin.set_fact:
+        idrac_scheduled_bios_jobs: >-
+          "{{ idrac_job['results'] |
+           selectattr('content', 'contains', 'Task successfully scheduled') |
+           selectattr('content', 'contains', 'BIOSConfiguration') | list }}"
+      when: >-
+        idrac_job['results'] |
+        selectattr('content', 'contains', 'Task successfully scheduled') |
+        selectattr('content', 'contains', 'BIOSConfiguration') | list
+
+    - name: Check For Running Jobs
+      when: idrac_job['results'] | selectattr('content', 'contains', 'Job in progress') | list
+      ansible.builtin.set_fact:
+        idrac_runnig_jobs: >-
+          "{{ idrac_job['results'] |
+           selectattr('content', 'contains', 'Job in progress') |
+           list }}"
+
+- name: Deleting Scheduled BIOS Configuration Jobs If Present
+  # Can not use map filter due to special character '@'
+  # Forced to use jinja2 loop
+  # Jobs that are being executed will not be able to be deleted,
+  # we will attempt to wait for them to finish
+  # Not all iDRAC versions support Deleting Job Queue via Redfish
+  vars:
+    idrac_jobs_uris: >-
+      {%- set jobs=[] -%}
+      {%- for job in idrac_scheduled_bios_jobs -%}
+        {{ jobs.append(cifmw_idrac_configuration_uri_protocol + '://' +
+         inventory_hostname + job['json']['@odata.id']) }}
+      {%- endfor -%}
+      {{ jobs }}
+  when:
+    - idrac_scheduled_bios_jobs is defined
+    - not check_bios_jobs
+  ansible.builtin.uri:
+    url: "{{ item }}"
+    method: 'DELETE'
+    user: "{{ cifmw_idrac_configuration_user }}"
+    password: "{{ cifmw_idrac_configuration_password }}"
+    force_basic_auth: true
+    return_content: true
+    validate_certs: "{{ cifmw_idrac_configuration_validate_ssl_certs }}"
+  register: idrac_scheduled_job_deletion
+  retries: "{{ cifmw_idrac_configuration_task_retries }}"
+  delay: 5
+  until: >-
+    (idrac_scheduled_job_deletion['status'] == 200) or
+    (idrac_scheduled_job_deletion['status'] == 400 and
+    idrac_scheduled_job_deletion['json']['error']['@Message.ExtendedInfo'] |
+    selectattr('Message', 'contains', 'Invalid Job ID') | list)
+  loop: "{{ idrac_jobs_uris }}"
+
+- name: Wait For Running Jobs To Complete
+  ansible.builtin.include_tasks:
+    file: wait_for_running_jobs.yml

--- a/ci_framework/roles/idrac_configuration/tasks/clear_job_inventory.yml
+++ b/ci_framework/roles/idrac_configuration/tasks/clear_job_inventory.yml
@@ -1,0 +1,52 @@
+---
+- name: Retrieve Jobs From iDRAC
+  when: not ansible_check_mode
+  ansible.builtin.include_role:
+    name: idrac_configuration
+    tasks_from: retrieve_idrac_jobs
+
+- name: Check If There Populated Jobs
+  when: idrac_job['results']
+  block:
+    - name: Check For Completed BIOS Configuration Jobs
+      ansible.builtin.set_fact:
+        idrac_previous_bios_jobs: >-
+          "{{ idrac_job['results'] |
+           selectattr('content', 'contains', 'Job completed successfully.') |
+           selectattr('content', 'contains', 'BIOSConfiguration') | list }}"
+      when: >-
+        idrac_job['results'] |
+         selectattr('content', 'contains', 'Job completed successfully.') |
+         selectattr('content', 'contains', 'BIOSConfiguration') | list
+
+- name: Deleting Previous BIOS Jobs From Inventory
+  # Can not use map filter due to special character '@'
+  # Forced to use jinja2 loop
+  # Jobs that are being executed will not be able to be deleted, we will attempt to wait
+  # for them to finish
+  # Also not all iDRAC versions support Deleting Job Queue via Redfish
+  when:
+    - idrac_previous_bios_jobs is defined
+    - idrac_job
+  vars:
+    idrac_jobs_uris: >-
+      {%- set jobs=[] -%}
+      {%- for job in idrac_previous_bios_jobs -%}
+        {{ jobs.append(cifmw_idrac_configuration_uri_protocol + '://' + inventory_hostname + job['json']['@odata.id']) }}
+      {%- endfor -%}
+      {{ jobs }}
+  ansible.builtin.uri:
+    url: "{{ item }}"
+    method: 'DELETE'
+    user: "{{ cifmw_idrac_configuration_user }}"
+    password: "{{ cifmw_idrac_configuration_password }}"
+    force_basic_auth: true
+    return_content: true
+    validate_certs: "{{ cifmw_idrac_configuration_validate_ssl_certs }}"
+  register: idrac_previous_bios_job_deletion
+  retries: "{{ cifmw_idrac_configuration_task_retries }}"
+  delay: 5
+  until: >-
+    (idrac_previous_bios_job_deletion['status'] == 200) or
+    (idrac_previous_bios_job_deletion['status'] == 400 and idrac_previous_bios_job_deletion['json']['error']['@Message.ExtendedInfo'] | selectattr('Message', 'contains', 'Invalid Job ID') | list)
+  loop: "{{ idrac_jobs_uris }}"

--- a/ci_framework/roles/idrac_configuration/tasks/clear_pending_configuration.yml
+++ b/ci_framework/roles/idrac_configuration/tasks/clear_pending_configuration.yml
@@ -1,0 +1,25 @@
+---
+- name: Clear Pending BIOS Configuration For iDRAC If Needed
+  until: >-
+    (idrac_clear_pending['status'] == 200) or
+    (idrac_clear_pending['status'] == 400 and
+     idrac_clear_pending['json']['error']['@Message.ExtendedInfo'] |
+     selectattr('Message', 'contains', 'There are no pending values to be cleared') |
+     list)
+  register: idrac_clear_pending
+  retries: "{{ cifmw_idrac_configuration_task_retries }}"
+  ansible.builtin.uri:
+    url: "{{ cifmw_idrac_configuration_uri}}/Systems/System.Embedded.1/Bios/Settings/Actions/Oem/DellManager.ClearPending"
+    method: 'POST'
+    headers:
+      Content-Type: application/json
+    body_format: 'json'
+    body: {}
+    status_code:
+      - 200
+      - 400
+    user: "{{ cifmw_idrac_configuration_user }}"
+    password: "{{ cifmw_idrac_configuration_password }}"
+    force_basic_auth: true
+    return_content: true
+    validate_certs: "{{ cifmw_idrac_configuration_validate_ssl_certs }}"

--- a/ci_framework/roles/idrac_configuration/tasks/configure_bios.yml
+++ b/ci_framework/roles/idrac_configuration/tasks/configure_bios.yml
@@ -1,0 +1,156 @@
+---
+# Will attempt to configure BIOS
+- name: Configure BIOS
+  block:
+    - name: Set BIOS Configuration
+      register: bios_config_change
+      retries: "{{ cifmw_idrac_configuration_task_retries }}"
+      until:
+        - "'EOF occurred in violation of protocol' not in bios_config_change['msg']"
+      community.general.redfish_config:
+        category: Systems
+        command: "{{ bios_config_command }}"
+        bios_attributes: "{{ host_bios_configuration }}"
+        boot_order: "{{ cifmw_idrac_configuration_boot_order }}"
+        baseuri: "{{ inventory_hostname }}"
+        username: "{{ cifmw_idrac_configuration_user }}"
+        password: "{{ cifmw_idrac_configuration_password }}"
+        timeout: "{{ cifmw_idrac_configuration_timeout }}"
+
+  # Error handling in edge scenarios
+  rescue:
+    - name: Proceed If New Configuration Is Committed But Not Applied - Job Is Created By iDRAC
+      when:
+        - "'HTTP Error 400 on PATCH request' in bios_config_change['msg']"
+        - "'Pending configuration values are already committed' in bios_config_change['msg']"
+      ansible.builtin.set_fact:
+        bios_config_change: "{{ bios_config_change | combine({'changed': True, 'failed':  False, 'self_created_job': True}) }}"
+
+- name: Fail If iDRAC Import/Export Operation In Progress (FATAL)
+  when:
+    - "'Unable to apply the configuration changes because an import or export operation is currently in progress' in bios_config_change['msg']"
+    - bios_config_change is failed
+  ansible.builtin.fail:
+    msg:
+      - "An operation running in iDRAC {{ inventory_hostname }} is preventing updating BIOS configuration."
+      - 'Consider restarting iDRAC, this can be done remotely:'
+      - "ssh {{ cifmw_idrac_configuration_user }}@{{ inventory_hostname }} 'racadm  racreset soft'"
+
+- name: Fail If Can't Handle BIOS Configuration Error
+  when:
+    - bios_config_change is failed
+    - bios_config_change is not changed
+    - bios_config_change is not skipped
+  ansible.builtin.fail:
+    msg:
+      - 'Encountered an error that is deemed as FATAL.'
+      - 'Error:'
+      - "{{ bios_config_change['msg'] }}"
+
+- name: Create BIOS Configuration Job (Schedule BIOS Setting Update) If Needed
+  block:
+    - name: Create Job If Required
+      register: bios_config_job
+      when:
+        - bios_config_change is changed
+        - "'self_created_job' not in bios_config_change"
+        - "'BootOrder set' not in bios_config_change['msg']"
+      retries: "{{ cifmw_idrac_configuration_task_retries }}"
+      until:
+        - "'EOF occurred in violation of protocol' not in bios_config_job['msg']"
+        - "'The specified job starts when Lifecycle Controller is available.' not in bios_config_job['msg']"
+      community.general.idrac_redfish_command:
+        category: Systems
+        command: CreateBiosConfigJob
+        baseuri: "{{ inventory_hostname }}"
+        username: "{{ cifmw_idrac_configuration_user }}"
+        password: "{{ cifmw_idrac_configuration_password }}"
+        timeout: "{{ cifmw_idrac_configuration_timeout }}"
+
+  # Error handling in edge scenarios
+  rescue:
+    - name: Proceed If Job Is Scheduled But Not Applied
+      when:
+        - "'HTTP Error 500 on POST request' in bios_config_job['msg']"
+        - "'Pending configuration values are already committed' in bios_config_job['msg']"
+      ansible.builtin.set_fact:
+        bios_config_job: "{{ bios_config_job | combine({'changed': True}) }}"
+
+    - name: Proceed If Requested Configuration Is Already Applied
+      when:
+        - "'HTTP Error 400 on POST request' in bios_config_job['msg']"
+        - "'Pending configuration values are already committed' in bios_config_job['msg']"
+      ansible.builtin.set_fact:
+        bios_config_job:
+          changed: true
+
+- name: Power Off iDRAC Before Applying New BIOS Settings If Needed
+  vars:
+    power_action: 'PowerForceOff'
+  when: >-
+    'self_created_job' in bios_config_change or
+    bios_config_change is changed or
+    bios_config_job is changed
+  ansible.builtin.include_tasks:
+    file: power_action.yml
+
+- name: Save Power Action Result Of 'PowerForceOff'
+  ansible.builtin.set_fact:
+    # From our point of view, there is no difference between successful and changed
+    # but keeping it for the sake of consistency
+    bios_idrac_poweroff: >-
+      {%- set status_dict = dict() -%}
+      {%- if power_action_result is defined and power_action_result is skipped -%}
+        {%- set _ = status_dict.update({'skipped': True}) -%}
+      {%- elif power_action_result is defined and power_action_result is successful -%}
+        {%- set _ = status_dict.update({'successful': True}) -%}
+      {%- elif power_action_result is defined and power_action_result is changed -%}
+        {%- set _ = status_dict.update({'changed': True}) -%}
+      {%- endif -%}
+      {{ status_dict }}
+
+- name: Pause To Let iDRAC Shutdown Before PowerOn
+  when:
+    - (bios_idrac_poweroff is successful) or (bios_idrac_poweroff is changed)
+    - bios_idrac_poweroff is not skipped
+  ansible.builtin.pause:
+    seconds: 20
+
+- name: Power On iDRAC To Apply New BIOS Settings If Needed
+  vars:
+    power_action: 'PowerOn'
+  retries: "{{ cifmw_idrac_configuration_task_retries }}"
+  until:
+    - power_action_result is changed
+  when:
+    - (bios_idrac_poweroff is successful) or (bios_idrac_poweroff is changed)
+    - bios_idrac_poweroff is not skipped
+  ansible.builtin.import_tasks:
+    file: power_action.yml
+  # Will attempt to wait for iDRAC to be powered on because in some cases GracefulShutdown will take a while.
+
+- name: Save Power Action Result Of PowerOn
+  ansible.builtin.set_fact:
+    bios_idrac_poweron: >-
+      {%- set status_dict=dict() -%}
+      {%- if power_action_result is skipped -%}
+        {{ status_dict.update({'skipped': True}) }}
+      {%- elif power_action_result is successful -%}
+        {{ status_dict.update({'successful': True}) }}
+      {%- elif power_action_result is changed -%}
+        {{ status_dict.update({'changed': True}) }}
+      {%- endif -%}
+      {{ status_dict }}
+
+- name: Pause To Let iDRAC Trigger Job Before Proceeding # noqa: no-handler
+  when: bios_config_job is changed
+  ansible.builtin.pause:
+    seconds: 150
+
+- name: Check BIOS Configuration Status
+  when:
+    - not ansible_check_mode
+    - check_bios_jobs
+  ansible.builtin.include_role:
+    name: idrac_configuration
+    tasks_from: check_bios

--- a/ci_framework/roles/idrac_configuration/tasks/healthcheck.yml
+++ b/ci_framework/roles/idrac_configuration/tasks/healthcheck.yml
@@ -1,0 +1,12 @@
+---
+- name: IDRAC Healtcheck
+  register: idrac_healtcheck
+  retries: "{{ cifmw_idrac_configuration_task_retries | default(30) }}"
+  until: idrac_healtcheck['status'] == 200
+  ansible.builtin.uri:
+    url: "{{ cifmw_idrac_configuration_uri }}/Sessions"
+    user: "{{ cifmw_idrac_configuration_user }}"
+    password: "{{ cifmw_idrac_configuration_password }}"
+    force_basic_auth: true
+    return_content: true
+    validate_certs: false

--- a/ci_framework/roles/idrac_configuration/tasks/main.yml
+++ b/ci_framework/roles/idrac_configuration/tasks/main.yml
@@ -1,0 +1,141 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Build A List Of Variables For iDRAC
+  ansible.builtin.set_fact:
+    host_play_variables: "{{ hostvars[inventory_hostname] }}"
+
+# This allows us to override variables for individual hosts
+- name: Append Extra Vars To host_play_variables If Supplied
+  ansible.builtin.set_fact:
+    host_play_variables: "{{ host_play_variables | combine(hostvars[inventory_hostname][inventory_hostname]) }}"
+  when: "inventory_hostname in hostvars[inventory_hostname]"
+
+- name: Check if can authenticate with iDRAC Using REST API
+  when: not ansible_check_mode
+  ansible.builtin.include_tasks:
+    file: healthcheck.yml
+
+- name: Reset iDRAC If Requested By User
+  when: cifmw_idrac_configuration_racreset
+  ansible.builtin.include_tasks:
+    file: racreset.yml
+
+- name: Query iDRAC
+  when: cifmw_idrac_configuration_query | bool
+  ansible.builtin.include_tasks:
+    file: query.yml
+
+- name: Delete Previous Completed iDRAC Jobs
+  when: cifmw_idrac_configuration_delete_previous_idrac_jobs
+  ansible.builtin.include_tasks:
+    file: clear_job_inventory.yml
+
+- name: Configure BIOS
+  vars:
+    host_bios_attributes: >-
+      {%- if 'bios_attributes' in host_play_variables -%}
+        {{ host_play_variables['bios_attributes'] }}
+      {%- else -%}
+        {{ cifmw_idrac_configuration_bios_attributes }}
+      {%- endif -%}
+    host_boot_mode: >-
+      {%- if 'cifmw_idrac_configuration_boot_mode' in host_play_variables -%}
+        {{ host_play_variables['cifmw_idrac_configuration_boot_mode'] }}
+      {%- else -%}
+        {{ cifmw_idrac_configuration_boot_mode }}
+      {%- endif -%}
+    host_boot_order: >-
+      {%- if 'boot_order' in host_play_variables -%}
+        {%- if (host_play_variables['boot_order'] | type_debug) == 'str' -%}
+          {{ host_play_variables['boot_order'].split(',') }}
+        {%- elif (host_play_variables['boot_order'] | type_debug) == 'list' -%}
+          {{ host_play_variables['boot_order'] }}
+        {%- endif -%}
+      {%- else -%}
+        {{ cifmw_idrac_configuration_boot_order }}
+      {%- endif -%}
+    host_bios_configuration: >-
+      {%- set bios_dict=dict() -%}
+      {%- if host_bios_attributes -%}
+        {{ bios_dict.update(host_bios_attributes) }}
+      {%- endif -%}
+      {%- if host_boot_mode -%}
+        {{ bios_dict.update({'BootMode': host_boot_mode}) }}
+      {%- endif -%}
+      {{ bios_dict }}
+  # We parse each BIOS attribute individually in order to build a correct config
+  when: >-
+      (host_bios_attributes) and (host_bios_attributes | type_debug == 'dict') or
+      (host_boot_mode) and (host_boot_mode in ['Bios', 'Uefi']) or
+      (host_boot_order) and (host_boot_order | type_debug == 'list')
+  block:
+    - name: Delete Pending BIOS Jobs
+      when: not ansible_check_mode
+      ansible.builtin.import_tasks:
+        file: check_bios.yml
+
+    - name: Clear Pending Configuration
+      when:
+        - not ansible_check_mode
+        - not cifmw_idrac_configuration_skip_clear_pending
+      ansible.builtin.include_tasks:
+        file: clear_pending_configuration.yml
+
+    # In this scenario we will wait for job completion
+    - name: Update BIOS Configuration - Boot Mode
+      vars:
+        bios_config_command: 'SetBiosAttributes'
+        check_bios_jobs: true
+        host_bios_configuration:
+          BootMode: "{{ cifmw_idrac_configuration_boot_mode }}"
+      when:
+        - cifmw_idrac_configuration_boot_mode is defined
+        - cifmw_idrac_configuration_boot_mode in ['Bios', 'Uefi']
+      ansible.builtin.include_tasks:
+        file: configure_bios.yml
+
+    - name: Update BIOS Configuration - Boot Attributes
+      vars:
+        bios_config_command: 'SetBiosAttributes'
+        check_bios_jobs: true
+      when:
+        - host_bios_attributes
+        - host_bios_attributes | type_debug == 'dict'
+      ansible.builtin.include_tasks:
+        file: configure_bios.yml
+
+    - name: Update BIOS Configuration - Boot Order
+      vars:
+        bios_config_command: 'SetBootOrder'
+      when:
+        - cifmw_idrac_configuration_boot_order
+        - cifmw_idrac_configuration_boot_order | type_debug == 'list'
+      ansible.builtin.include_tasks:
+        file: configure_bios.yml
+
+- name: Power Action
+  when:
+    - cifmw_idrac_configuration_power_action | bool
+    - host_play_variables['cifmw_idrac_configuration_power_action'] in
+      ['PowerOn',
+      'PowerForceOff',
+      'PowerForceRestart',
+      'PowerGracefulRestart',
+      'PowerGracefulShutdown',
+      'PowerReboot']
+  ansible.builtin.include_tasks:
+    file: power_action.yml

--- a/ci_framework/roles/idrac_configuration/tasks/power_action.yml
+++ b/ci_framework/roles/idrac_configuration/tasks/power_action.yml
@@ -1,0 +1,33 @@
+---
+- name: Ensure Jobs Are Completed Before Any Restart Action
+  when:
+    - power_action in ['PowerForceRestart', 'PowerGracefulRestart', 'PowerReboot']
+    - not ansible_check_mode
+  block:
+    - name: Set Facts
+      ansible.builtin.set_fact:
+        idrac_runnig_jobs: {}
+
+    - name: Retrieve Jobs From iDRAC
+      when: not ansible_check_mode
+      ansible.builtin.include_role:
+        name: idrac_configuration
+        tasks_from: retrieve_idrac_jobs
+
+    - name: Wait For Running Jobs To Complete
+      ansible.builtin.include_role:
+        name: idrac_configuration
+        tasks_from: wait_for_running_jobs
+
+- name: Execute Power Action '{{ power_action }}'
+  register: power_action_result
+  retries: "{{ cifmw_idrac_configuration_task_retries }}"
+  until:
+    - "'EOF occurred in violation of protocol' not in power_action_result['msg']"
+  community.general.redfish_command:
+    category: Systems
+    command: "{{ power_action }}"
+    baseuri: "{{ inventory_hostname }}"
+    username: "{{ cifmw_idrac_configuration_user }}"
+    password: "{{ cifmw_idrac_configuration_password }}"
+    timeout: "{{ cifmw_idrac_configuration_timeout }}"

--- a/ci_framework/roles/idrac_configuration/tasks/query.yml
+++ b/ci_framework/roles/idrac_configuration/tasks/query.yml
@@ -1,0 +1,24 @@
+---
+- name: Get Generic iDRAC Info (This May Take Time)
+  register: generic_redfish_info
+  community.general.redfish_info:
+    category: Systems
+    command: all
+    baseuri: "{{ inventory_hostname }}"
+    username: "{{ cifmw_idrac_configuration_user }}"
+    password: "{{ cifmw_idrac_configuration_password }}"
+    timeout: "{{ cifmw_idrac_configuration_timeout }}"
+
+- name: Get Manager iDRAC Info
+  register: manager_redfish_info
+  community.general.idrac_redfish_info:
+    category: Manager
+    command: GetManagerAttributes
+    baseuri: "{{ inventory_hostname }}"
+    username: "{{ cifmw_idrac_configuration_user }}"
+    password: "{{ cifmw_idrac_configuration_password }}"
+    timeout: "{{ cifmw_idrac_configuration_timeout }}"
+
+- name: Print Collected iDRAC Info
+  ansible.builtin.debug:
+    msg: "{{ generic_redfish_info | combine(manager_redfish_info) }}"

--- a/ci_framework/roles/idrac_configuration/tasks/racreset.yml
+++ b/ci_framework/roles/idrac_configuration/tasks/racreset.yml
@@ -1,0 +1,24 @@
+---
+- name: Reset iDRAC With 'GracefulRestart'
+  ansible.builtin.uri:
+    url: "{{ cifmw_idrac_configuration_uri}}/Managers/iDRAC.Embedded.1/Actions/Manager.Reset/"
+    method: 'POST'
+    headers:
+      Content-Type: application/json
+    body_format: 'json'
+    body:
+      ResetType: "GracefulRestart"
+    status_code:
+      - 204
+    user: "{{ cifmw_idrac_configuration_user }}"
+    password: "{{ cifmw_idrac_configuration_password }}"
+    force_basic_auth: true
+    return_content: true
+    validate_certs: "{{ cifmw_idrac_configuration_validate_ssl_certs }}"
+
+- name: Pause While iDRAC Is Being Restarted
+  ansible.builtin.pause:
+    seconds: 20
+
+- name: Wait For iDRAC To Be Online (Using SSH)
+  ansible.builtin.wait_for:

--- a/ci_framework/roles/idrac_configuration/tasks/retrieve_idrac_jobs.yml
+++ b/ci_framework/roles/idrac_configuration/tasks/retrieve_idrac_jobs.yml
@@ -1,0 +1,50 @@
+---
+- name: Retrieve All Jobs From iDRAC
+  register: idrac_jobs
+  retries: "{{ cifmw_idrac_configuration_task_retries }}"
+  until: idrac_jobs['status'] == 200
+  ansible.builtin.uri:
+    url: "{{ cifmw_idrac_configuration_uri}}/Managers/iDRAC.Embedded.1/Jobs"
+    user: "{{ cifmw_idrac_configuration_user }}"
+    password: "{{ cifmw_idrac_configuration_password }}"
+    force_basic_auth: true
+    return_content: true
+    validate_certs: "{{ cifmw_idrac_configuration_validate_ssl_certs }}"
+
+- name: Query Each Job Present In iDRAC
+  # Can not use map filter due to special character '@'
+  # Forced to use jinja2 loop
+  # Jobs that are being executed will not be able to be deleted, we will attempt to wait
+  # for them to finish
+  # Also not all iDRAC versions support Deleting Job Queue via Redfish
+  vars:
+    idrac_jobs_uris: >-
+      {%- set jobs=[] -%}
+      {%- for job in idrac_jobs['json']['Members'] -%}
+        {{ jobs.append(cifmw_idrac_configuration_uri_protocol + '://' + inventory_hostname + job['@odata.id']) }}
+      {%- endfor -%}
+      {{ jobs }}
+  register: idrac_job
+  retries: "{{ cifmw_idrac_configuration_task_retries }}"
+  delay: 5
+  until: >-
+    (idrac_job['status'] == 200) or
+    (idrac_job['status'] == 400 and
+     idrac_job['json']['error']['@Message.ExtendedInfo'] |
+     selectattr('Message', 'contains', 'Invalid Job ID') | list) or
+    (idrac_job['status'] == 404 and
+    idrac_job['json']['error']['@Message.ExtendedInfo'] |
+    selectattr('Message', 'contains', 'The resource at the URI') | list)
+  loop: "{{ idrac_jobs_uris }}"
+  when: idrac_jobs['json']['Members']
+  ansible.builtin.uri:
+    url: "{{ item }}"
+    method: 'GET'
+    status_code:
+      - 200
+      - 404
+    user: "{{ cifmw_idrac_configuration_user }}"
+    password: "{{ cifmw_idrac_configuration_password }}"
+    force_basic_auth: true
+    return_content: true
+    validate_certs: "{{ cifmw_idrac_configuration_validate_ssl_certs }}"

--- a/ci_framework/roles/idrac_configuration/tasks/wait_for_running_jobs.yml
+++ b/ci_framework/roles/idrac_configuration/tasks/wait_for_running_jobs.yml
@@ -1,0 +1,29 @@
+---
+
+# We don't want to interrupt running jobs in order to prevent corruption
+- name: Query For Running Jobs Completion
+  # Can not use map filter due to special character '@'
+  # Forced to use jinja2 loop
+  # Jobs that are being executed will not be able to be deleted, we will attempt to wait
+  # for them to finish
+  # Also not all iDRAC versions support Deleting Job Queue via Redfish
+  vars:
+    idrac_jobs_uris: >-
+      {%- set jobs=[] -%}
+      {%- for job in idrac_runnig_jobs -%}
+        {{ jobs.append(cifmw_idrac_configuration_uri_protocol + '://' + inventory_hostname + job['json']['@odata.id']) }}
+      {%- endfor -%}
+      {{ jobs }}
+  register: idrac_runnig_jobs_query
+  retries: "{{ cifmw_idrac_configuration_task_retries }}"
+  delay: 5
+  until: idrac_runnig_jobs_query['json']['JobState'] == 'Completed'
+  loop: "{{ idrac_jobs_uris }}"
+  when: idrac_runnig_jobs
+  ansible.builtin.uri:
+    url: "{{ item }}"
+    user: "{{ cifmw_idrac_configuration_user }}"
+    password: "{{ cifmw_idrac_configuration_password }}"
+    force_basic_auth: true
+    return_content: true
+    validate_certs: "{{ cifmw_idrac_configuration_validate_ssl_certs }}"

--- a/ci_framework/roles/idrac_configuration/vars/main.yml
+++ b/ci_framework/roles/idrac_configuration/vars/main.yml
@@ -1,0 +1,23 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# HTTP protocol
+cifmw_idrac_configuration_uri_protocol: https
+# Location of RedFish REST API
+cifmw_idrac_configuration_uri_redfish: /redfish/v1
+# URI of host Redfish endpoint
+cifmw_idrac_configuration_uri: >-
+  {{ cifmw_idrac_configuration_uri_protocol }}://{{ inventory_hostname }}{{ cifmw_idrac_configuration_uri_redfish }}

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -145,6 +145,7 @@ gowork
 gpg
 gpgcheck
 gpsbwcm
+gracefulrestart
 groupinstall
 gw
 gzwu
@@ -211,9 +212,9 @@ kvm
 ldp
 libguestfs
 libvirt
+libvirt's
 libvirtd
 libvirterror
-libvirt's
 ljaumtawojy
 ljaumtaxojy
 ljaumtayojy
@@ -288,6 +289,7 @@ odkvmf
 okd
 ol
 olm
+oob
 opendev
 openrc
 openshift

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -284,6 +284,16 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
+    - ^ci_framework/roles/idrac_configuration/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    name: cifmw-molecule-idrac_configuration
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: idrac_configuration
+- job:
+    files:
+    - ^ansible-requirements.txt
+    - ^molecule-requirements.txt
     - ^ci_framework/roles/install_ca/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-install_ca

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -35,6 +35,7 @@
       - cifmw-molecule-env_op_images
       - cifmw-molecule-hci_prepare
       - cifmw-molecule-hive
+      - cifmw-molecule-idrac_configuration
       - cifmw-molecule-install_ca
       - cifmw-molecule-install_yamls
       - cifmw-molecule-libvirt_manager


### PR DESCRIPTION
This role will be used for DELL systems in RH internal network, To allow cifmw to manipulate bios/bmc to configure it for OSP network

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
