### PR TITLE
Ensure we consume valid CA bundle

### DIFF
--- a/ci_framework/roles/os_net_setup/tasks/main.yml
+++ b/ci_framework/roles/os_net_setup/tasks/main.yml
@@ -39,6 +39,7 @@
   openstack.cloud.networks_info:
     auth: "{{ openstack_auth }}"
     validate_certs: "{{ cifmw_os_net_setup_verify_tls }}"
+    ca_cert: /etc/pki/tls/certs/ca-bundle.crt
   register: cifmw_os_net_setup_network_list_out
   until: cifmw_os_net_setup_network_list_out is not failed
   retries: "{{ cifmw_os_net_setup_osp_calls_retries }}"

--- a/ci_framework/roles/os_net_setup/tasks/subtask_net.yml
+++ b/ci_framework/roles/os_net_setup/tasks/subtask_net.yml
@@ -4,6 +4,7 @@
     net_args: "{{ net_item | combine ({'subnets': omit}, recursive=true) }}"
   openstack.cloud.network:
     admin_state_up: '{{ net_args.admin_state_up | default(omit) }}'
+    ca_cert: /etc/pki/tls/certs/ca-bundle.crt
     dns_domain: '{{ net_args.dns_domain | default(omit) }}'
     external: '{{ net_args.external | default(omit) }}'
     mtu: '{{ net_args.mtu | default(omit) }}'
@@ -26,6 +27,7 @@
   openstack.cloud.subnet:
     allocation_pool_end: '{{ subnet_item.allocation_pool_end | default(omit) }}'
     allocation_pool_start: '{{ subnet_item.allocation_pool_start | default(omit) }}'
+    ca_cert: /etc/pki/tls/certs/ca-bundle.crt
     cidr: '{{ subnet_item.cidr | default(omit) }}'
     description: '{{ subnet_item.description | default(omit) }}'
     disable_gateway_ip: '{{ subnet_item.disable_gateway_ip | default(omit) }}'


### PR DESCRIPTION
Since we may inject custom CA in the system, we have to ensure we're
consuming the right bundle.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
