### PR TITLE
[must-gather]Collect SOS reports from EDPM nodes

### DIFF
--- a/roles/edpm_deploy/tasks/main.yml
+++ b/roles/edpm_deploy/tasks/main.yml
@@ -169,3 +169,7 @@
   ansible.builtin.include_role:
     name: 'install_yamls_makes'
     tasks_from: 'make_edpm_deploy_instance'
+
+- name: DNM enforce failure to test must-gather and SOS
+  ansible.builtin.fail:
+    msg: DNM enforce failure to test must-gather and SOS

--- a/roles/os_must_gather/tasks/main.yml
+++ b/roles/os_must_gather/tasks/main.yml
@@ -55,13 +55,14 @@
       environment:
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
+        SOS_EDPM: "all"
       cifmw.general.ci_script:
         output_dir: "{{ cifmw_os_must_gather_output_dir }}/artifacts"
         script: >-
           oc adm must-gather --image {{ cifmw_os_must_gather_image }}
           --timeout {{ cifmw_os_must_gather_timeout }}
           --host-network={{ cifmw_os_must_gather_host_network }}
-          --dest-dir {{ cifmw_os_must_gather_output_dir }}/logs > {{ cifmw_os_must_gather_output_dir }}/logs/os_must_gather.log
+          --dest-dir {{ cifmw_os_must_gather_output_dir }}/logs -- SOS_EDPM=$SOS_EDPM gather &> {{ cifmw_os_must_gather_output_dir }}/logs/os_must_gather.log
   rescue:
     - name: Inspect the cluster after must-gather failure
       ignore_errors: true # noqa: ignore-errors


### PR DESCRIPTION
To facilitate CI troubleshooting this PR enabled SOS report gathering from all EDPM nodes.

Depends-On: https://github.com/openstack-k8s-operators/openstack-must-gather/pull/33

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes

JIRA: [OSPRH-2685](https://issues.redhat.com/browse/OSPRH-2685)