### PR TITLE
Add missing uri parameter

### DIFF
--- a/ci_framework/roles/libvirt_manager/tasks/attach_interface.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/attach_interface.yml
@@ -23,10 +23,8 @@
 #     static_ip     boolean if static address is required.
 
 - name: Get existing networks and bridges
-  when:
-    - _net_bridge_map is undefined
   block:
-    - name: Loop over existing nets to extract info
+    - name: Get virtual network information
       register: _net_info
       community.libvirt.virt_net:
         command: "info"
@@ -36,7 +34,6 @@
       vars:
         _local_map: "{{ {net.key: net.value.bridge} }}"
       ansible.builtin.set_fact:
-        cached: true
         _net_bridge_map: >-
           {{
             _net_bridge_map | default({}) |
@@ -47,6 +44,10 @@
         loop_var: net
         label: "{{ net.key }}"
 
+- name: Debug bridge mapping
+  ansible.builtin.debug:
+    var: _net_bridge_map
+
 - name: "Check ports attached to the domain {{ vm_name }}"
   block:
     - name: Dump domain xml
@@ -54,6 +55,7 @@
       community.libvirt.virt:
         command: "get_xml"
         name: "{{ vm_name }}"
+        uri: "qemu:///system"
 
     - name: Extract networks from XML
       register: _extracted_xml
@@ -62,6 +64,10 @@
         xmlstring: "{{ _domain_xml.get_xml }}"
         xpath: "/domain/devices/interface/source"
         content: "attribute"
+
+- name: Debug extracted XML
+  ansible.builtin.debug:
+    var: _extracted_xml
 
 - name: Attach new port if needed
   vars:
@@ -85,6 +91,13 @@
   when:
     - _attached_bridges | length == 0
   block:
+    - name: Debug generated vars
+      ansible.builtin.debug:
+        msg:
+          - "{{ _net_name }}"
+          - "{{ _local_bridge_name }}"
+          - "{{ _attached_bridges }}"
+
     - name: "Generate a random MAC address for {{ vm_name }}"
       ansible.builtin.set_fact:
         _lm_mac_address: "{{ '0A:02' | community.general.random_mac }}"


### PR DESCRIPTION
While doc states default value is `qemu:///system`, it is not.

Also remove potentially problematic `cached: true`, and add some
debugging tasks, as well as removing the "filter" that may prevent
re-generating the fact if it's already set with some previous run. This
should ensure we're consuming up-to-date list.

References:
- https://docs.ansible.com/ansible/latest/collections/community/libvirt/virt_module.html#parameter-uri
- https://docs.ansible.com/ansible/latest/collections/community/libvirt/virt_net_module.html#parameter-uri

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
