### PR TITLE
Install cert-manager from ci-framework cert-manager role

### DIFF
--- a/ci_framework/playbooks/02-infra.yml
+++ b/ci_framework/playbooks/02-infra.yml
@@ -64,6 +64,10 @@
       ansible.builtin.import_role:
         name: openshift_setup
 
+    - name: Install certmanager operator role
+      ansible.builtin.import_role:
+        name: cert_manager
+
     - name: Configure hosts networking using nmstate
       when:
         - cifmw_config_network is defined

--- a/scenarios/centos-9/ceph_backends.yml
+++ b/scenarios/centos-9/ceph_backends.yml
@@ -10,6 +10,7 @@ cifmw_install_yamls_vars:
   BMO_SETUP: false
   OPENSTACK_CR: "{{ cifmw_kustomize_cr_artifact_dir }}/kustomized_{{ cifmw_kustomize_cr_file_name }}"
   STORAGE_CLASS: crc-csi-hostpath-provisioner
+  INSTALL_CERT_MANAGER: false
 
 cifmw_edpm_prepare_skip_crc_storage_creation: true
 

--- a/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
+++ b/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
@@ -10,6 +10,7 @@ cifmw_install_yamls_vars:
   BMAAS_INSTANCE_VCPUS: 6
   BMAAS_INSTANCE_DISK_SIZE: 40
   DATAPLANE_GROWVOLS_ARGS: "/=8GB /tmp=1GB /home=1GB /var=8GB"
+  INSTALL_CERT_MANAGER: false
 
 pre_infra:
   - name: Download needed tools

--- a/scenarios/centos-9/edpm_ci.yml
+++ b/scenarios/centos-9/edpm_ci.yml
@@ -5,6 +5,7 @@ cifmw_install_yamls_vars:
   DATAPLANE_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/dataplane-operator"
   STORAGE_CLASS: crc-csi-hostpath-provisioner
   BMO_SETUP: false
+  INSTALL_CERT_MANAGER: false
 
 # edpm_prepare role vars
 cifmw_operator_build_meta_name: "openstack-operator"

--- a/zuul.d/end-to-end.yaml
+++ b/zuul.d/end-to-end.yaml
@@ -63,3 +63,6 @@
     files:
       - ^ci_framework/roles/rhol_crc/(?!meta|README).*
       - ^ci_framework/roles/libvirt_manager/(?!meta|README).*
+      - ^ci_framework/roles/cert_manager/(?!meta|README).*
+      - scenarios/centos-9/edpm_baremetal_deployment_ci.yml
+    run: ci/playbooks/edpm_baremetal_deployment/run.yml


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/ci-framework/pull/820 adds cert-manager role to install cert-manager operator and https://github.com/openstack-k8s-operators/install_yamls/pull/634/ adds `INSTALL_CERT_MANAGER` flag to disable cert-manager installation.

This pr switches the cert-manager installation from install_yamls to ci-framework cert-manager role.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/634

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

