### PR TITLE
Add edpm_sshd_allowed_ranges variable

### DIFF
--- a/ci_framework/hooks/playbooks/fetch_compute_facts.yml
+++ b/ci_framework/hooks/playbooks/fetch_compute_facts.yml
@@ -235,6 +235,9 @@
                     value: repo-setup
               {% endif %}
 
+                  - op: add
+                    path: /spec/nodeTemplate/ansible/ansibleVars/edpm_sshd_allowed_ranges
+                    value: ["0.0.0.0/0"]
 
         - name: Ensure we know about the private host keys
           ansible.builtin.shell:


### PR DESCRIPTION
This change adds the variable edpm_sshd_allowed_ranges to the kustomize file. This will allow us to remove unnecessary defaults used only for CI and development from our samples.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
