### PR TITLE
Fix: Hybrid environment tagged network connectivity

### DIFF
--- a/ci_framework/roles/devscripts/files/tag_vnet.sh
+++ b/ci_framework/roles/devscripts/files/tag_vnet.sh
@@ -1,0 +1,39 @@
+#! /usr/bin/bash
+#
+# Usage:
+#     bash tag_vnet.sh ens1f1
+#
+# Options
+#
+#    <iface>    Name of the trunk interface
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Invalid number of arguments"
+    exit 1
+fi
+
+iface=${1}
+
+vlans=$(nmcli -f bridge-port.vlans con show ${iface} | awk '{ print $2 }' )
+master_id=$(nmcli -f connection.master con show ${iface} | awk '{ print $2 }' )
+bridge_name=$(nmcli -f connection.id con show ${master_id} | awk '{ print $2 }')
+vlans=${vlans/,/' '}
+
+# Gather list of VMs
+vm_names=$(virsh -c qemu:///system list --name | grep '_worker') || true
+if [ -z "${vm_names}" ]; then
+    vm_names=$(virsh -c qemu:///system list --name | grep '_master')
+fi
+
+for vlan_id in ${vlans}; do
+    for vm in ${vm_names}; do
+        vnet_iface=$(virsh -c qemu:///system domiflist ${vm} | \
+                    grep ${bridge_name} | awk '{ print $1 }')
+        if [ -n "${vnet_iface}" ]; then
+            bridge vlan add dev ${vnet_iface} vid ${vlan_id}
+        fi
+    done
+done
+
+echo "Successfully attached all vlans"

--- a/ci_framework/roles/devscripts/tasks/sub_tasks/_521_gather.yml
+++ b/ci_framework/roles/devscripts/tasks/sub_tasks/_521_gather.yml
@@ -57,3 +57,16 @@
           }}
         cacheable: true
       loop: "{{ _bridges }}"
+
+    - name: Gather the trunk bridges  # noqa: jinja[invalid]
+      vars:
+        _bridge_query: "[?type=='linux-bridge'].bridge.port"
+        _trunk_query: "[?vlan.mode=='trunk'].name"
+      ansible.builtin.set_fact:
+        _cifmw_devscripts_trunk_ifaces: >-
+          {{
+            cifmw_ci_nmstate_instance_config[inventory_hostname]['interfaces'] |
+            community.general.json_query(_bridge_query) |
+            ansible.builtin.flatten |
+            community.general.json_query(_trunk_query)
+          }}

--- a/ci_framework/roles/devscripts/tasks/sub_tasks/_523_attach.yml
+++ b/ci_framework/roles/devscripts/tasks/sub_tasks/_523_attach.yml
@@ -48,3 +48,12 @@
     name: libvirt_manager
     tasks_from: attach_interface.yml
   loop: "{{ vms | product(cifmw_devscripts_extra_networks) }}"
+
+- name: Add vlan tags to the attached interfaces.
+  become: true
+  when:
+    - _cifmw_devscripts_trunk_ifaces is defined
+    - _cifmw_devscripts_trunk_ifaces | length > 0
+  ansible.builtin.script:
+    cmd: files/tag_vnet.sh "{{ item }}"
+  loop: "{{ _cifmw_devscripts_trunk_ifaces }}"


### PR DESCRIPTION
This fixes an issue in hybrid scenario wherein the vlan tags are dropped by interfaces attached to the trunk network. There is no network reach-ability between the controllers, controllers and compute. 

Due to this issue, we are unable to see any physical computes listed as part of `openstack hypervisor list`

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

__Post script execution__
```
vnet14            1 PVID Egress Untagged
                  180
                  181
                  182
                  183
                  184
vnet15            1 PVID Egress Untagged
                  180
                  181
                  182
                  183
                  184
vnet16            1 PVID Egress Untagged
                  180
                  181
                  182
                  183
                  184
```

__Connectivity testing__
```
[core@dhcp-5-130 ~]$ ping 172.18.0.6 -c 2
PING 172.18.0.6 (172.18.0.6) 56(84) bytes of data.
64 bytes from 172.18.0.6: icmp_seq=1 ttl=64 time=1.13 ms
64 bytes from 172.18.0.6: icmp_seq=2 ttl=64 time=0.351 ms

--- 172.18.0.6 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1000ms
rtt min/avg/max/mdev = 0.351/0.738/1.126/0.387 ms
[core@dhcp-5-130 ~]$ ping 172.17.0.6 -c 2
PING 172.17.0.6 (172.17.0.6) 56(84) bytes of data.
64 bytes from 172.17.0.6: icmp_seq=1 ttl=64 time=0.739 ms
64 bytes from 172.17.0.6: icmp_seq=2 ttl=64 time=0.297 ms

--- 172.17.0.6 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1018ms
rtt min/avg/max/mdev = 0.297/0.518/0.739/0.221 ms
[core@dhcp-5-130 ~]$ ip route show
default via 10.46.5.254 dev enp2s0 proto dhcp src 10.46.5.130 metric 100 
10.46.4.0/23 dev enp2s0 proto kernel scope link src 10.46.5.130 metric 100 
172.17.0.0/24 dev enp6s0.180 proto kernel scope link src 172.17.0.5 metric 400 
172.18.0.0/24 dev enp6s0.181 proto kernel scope link src 172.18.0.5 metric 401 
172.19.0.0/24 dev enp6s0.182 proto kernel scope link src 172.19.0.5 metric 402 
172.22.0.0/24 dev enp1s0 proto kernel scope link src 172.22.0.137 metric 102 
172.30.0.0/16 dev tun0 
192.168.16.0/20 dev tun0 scope link 
192.168.122.0/24 dev enp6s0 proto kernel scope link src 192.168.122.10 metric 101 
```

_Task execution_
```
TASK [devscripts : Add vlan tags to the attached interfaces. _raw_params=files/tag_vnet.sh "{{ item }}"] *************************************************************************************************************************************
Wednesday 29 November 2023  06:29:46 +0200 (0:00:00.199)       0:02:30.873 **** 
changed: [localhost] => (item=ens1f1)
```

__End to end execution snippet__
```

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
localhost                  : ok=302  changed=88   unreachable=0    failed=0    skipped=270  rescued=2    ignored=1   

Wednesday 29 November 2023  10:39:29 +0200 (0:00:00.988)       2:15:36.410 **** 
=============================================================================== 
devscripts : Deploying the OpenShift platform -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 3896.83s
edpm_deploy_baremetal : Wait for OpenStackDataPlaneNodeSet to be Ready ------------------------------------------------------------------------------------------------------------------------------------------------------------- 2670.56s
install_yamls_makes : Run openstack ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 465.22s
edpm_prepare : Wait for OpenStack controlplane to be deployed ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- 356.57s
edpm_prepare : Wait for OpenStack operator to get installed ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 227.89s
install_yamls_makes : Run crc_storage ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 74.49s
edpm_prepare : Wait for OpenStack subscription creation ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 62.37s
run_hook : Run play /home/ciuser/src/install_yamls/devsetup/download_tools.yaml ------------------------------------------------------------------------------------------------------------------------------------------------------ 41.48s
install_yamls_makes : Run edpm_deploy_baremetal -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 28.52s
install_yamls_makes : Run openstack_deploy_prep -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.09s
install_yamls_makes : Run netconfig_deploy ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.61s
os_net_setup : Process subnet list elements ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 10.01s
install_yamls_makes : Run input ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 8.69s
os_net_setup : Process network list elements ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 8.01s
repo_setup : Initialize python venv and install requirements -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 7.92s
edpm_prepare : Apply the OpenStackControlPlane CR ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 6.88s
os_net_setup : Get network information ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 6.32s
edpm_deploy_baremetal : Run nova-manage discover_hosts to ensure compute nodes are mapped --------------------------------------------------------------------------------------------------------------------------------------------- 6.08s
devscripts : Apply the baremetal host definitions ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 4.39s
run_hook : Run play /home/ciuser/src/ci-framework/ci_framework/roles/run_hook/../../hooks/playbooks/validate_podified_deployment.yml -------------------------------------------------------------------------------------------------- 3.67s
[ciuser@titan08 ci-framework]$ 
```

__Hypervisor__
```
sh-5.1$ openstack hypervisor list
+--------------------------------------+------------------------------+-----------------+-----------------+-------+
| ID                                   | Hypervisor Hostname          | Hypervisor Type | Host IP         | State |
+--------------------------------------+------------------------------+-----------------+-----------------+-------+
| cb44d609-644f-4831-a44d-8679fe5ee4b2 | titan19.ctlplane.example.com | QEMU            | 192.168.122.100 | up    |
+--------------------------------------+------------------------------+-----------------+-----------------+-------+
```