### PR TITLE
Ensure we have correct rights on gathered content

### DIFF
--- a/ci_framework/roles/artifacts/tasks/environment.yml
+++ b/ci_framework/roles/artifacts/tasks/environment.yml
@@ -19,8 +19,6 @@
     cmd: |-
       cp /etc/resolv.conf /etc/hosts {{ cifmw_artifacts_basedir }}/artifacts/
       cp -r /etc/NetworkManager/system-connections {{ cifmw_artifacts_basedir }}/artifacts/NetworkManager
-      find {{ cifmw_artifacts_basedir }}/artifacts/NetworkManager -type f -exec chmod 0644 '{}' \;
-      find {{ cifmw_artifacts_basedir }}/artifacts/NetworkManager -type d -exec chmod 0755 '{}' \;
       test -d /etc/ci/env && cp -r /etc/ci/env {{ cifmw_artifacts_basedir }}/artifacts/ci-env
       test -d /var/log/bmaas_console_logs && cp -r /var/log/bmaas_console_logs {{ cifmw_artifacts_basedir }}/logs
       ip ro ls > {{ cifmw_artifacts_basedir }}/artifacts/ip-network.txt

--- a/ci_framework/roles/artifacts/tasks/main.yml
+++ b/ci_framework/roles/artifacts/tasks/main.yml
@@ -73,3 +73,13 @@
 - name: Get EDPM logs
   ignore_errors: true  # noqa: ignore-errors
   ansible.builtin.import_tasks: edpm.yml
+
+- name: Ensure we have proper rights on the gathered content
+  ignore_errors: true  # noqa: ignore-errors
+  become: true
+  ansible.builtin.shell:
+    cmd: |-
+      find {{ cifmw_artifacts_basedir }}/logs -type f -exec chmod 0644 '{}' \;
+      find {{ cifmw_artifacts_basedir }}/logs -type d -exec chmod 0755 '{}' \;
+      find {{ cifmw_artifacts_basedir }}/artifacts -type f -exec chmod 0644 '{}' \;
+      find {{ cifmw_artifacts_basedir }}/artifacts -type d -exec chmod 0755 '{}' \;


### PR DESCRIPTION
It may happen artifacts or logs have strict access rights, prventing
proper access in later steps.

This patch ensures we set proper rights to files and directories.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
