### PR TITLE
Added krb dlrn reporting support

### DIFF
--- a/ci_framework/roles/dlrn_report/README.md
+++ b/ci_framework/roles/dlrn_report/README.md
@@ -17,6 +17,8 @@ This role does not need privilege escalation.
 * `cifmw_dlrn_report_kerberos_auth`: (boolean) Whether to use Kerberos authentication when reporting results to DLRN. Default: `false`
 * `cifmw_dlrn_report_dlrnapi_host_principal`: (string) DLRN principal to use with Kerberos authentication. Default `""`
 * `cifmw_dlrn_report_result`: (boolean) Whether to report DLRN results. Can be disabled if a test run should not be registered to DLRN. Default `true`
+* `cifmw_dlrn_report_krb_user_realm`: (string) Name of valid Kerberos REALM.
+* `cifmw_dlrn_report_keytab`: (string) file path to valid keytab file for performing kinit.
 
 ## Dependencies
 

--- a/ci_framework/roles/dlrn_report/defaults/main.yml
+++ b/ci_framework/roles/dlrn_report/defaults/main.yml
@@ -23,3 +23,5 @@ cifmw_dlrn_report_dlrnapi_user: "{{ dlrnapi_user | default('review_rdoproject_or
 cifmw_dlrn_report_kerberos_auth: false
 cifmw_dlrn_report_result: true
 cifmw_dlrn_report_dlrnapi_host_principal: ""
+cifmw_dlrn_report_keytab: ""
+cifmw_dlrn_report_krb_user_realm: ""

--- a/ci_framework/roles/dlrn_report/tasks/dlrn_report_results.yml
+++ b/ci_framework/roles/dlrn_report/tasks/dlrn_report_results.yml
@@ -8,6 +8,14 @@
   ansible.builtin.include_role:
     name: repo_setup
 
+- name: Perform kinit for DLRN kerberos authentication
+  ansible.builtin.command:
+    cmd: >-
+      kinit
+      -k {{ cifmw_dlrn_report_krb_user_realm }}
+      -t {{ cifmw_dlrn_report_keytab }}
+  when: cifmw_dlrn_report_kerberos_auth|bool
+
 - name: Report results to dlrn for the tested hash
   ansible.builtin.shell:
     cmd: >-

--- a/ci_framework/roles/dlrn_report/tasks/install.yml
+++ b/ci_framework/roles/dlrn_report/tasks/install.yml
@@ -10,10 +10,13 @@
 - name: Install dlrnapi-client[kerberos] shyaml package
   when: cifmw_dlrn_report_kerberos_auth | bool
   block:
-    - name: Install krb5-devel package
+    - name: Install kinit related package
       become: true
       ansible.builtin.package:
-        name: krb5-devel
+        name:
+          - krb5-devel
+          - krb5-workstation
+          - krb5-libs
         state: present
 
     - name: Install dlrn kerberos related packages

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -192,6 +192,8 @@ keepalived
 kerberos
 keypair
 keyring
+keytab
+kinit
 kni
 kube
 kubeadmin


### PR DESCRIPTION
In order to reporting zuul job status using DLRN kerberous auth, We need to do kinit with proper keytab and realm before calling dlrnapi-client.

This pr adds the same.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

