### PR TITLE
Update rhol_crc and global documentation

### DIFF
--- a/ci_framework/roles/rhol_crc/README.md
+++ b/ci_framework/roles/rhol_crc/README.md
@@ -25,13 +25,13 @@ Become - required for the tasks in `sudoers_grant.yml` and `sudoers_revoke.yml` 
 * `cifmw_rhol_crc_pullsecret_dest`: (String) Absolute path of the pull-secrets destination. Defaults to `~/pull-secret.json`.
 
 ### Pull-secret management
+
 This role calls the [manage_secrets](./manage_secrets.md) role. It allows to copy or create
 the pull-secret on the target host, in a known location. In order to run the `rhol_crc`
 role, you **must** provide either `cifmw_manage_secrets_pullsecret_file` OR
 `cifmw_manage_secrets_pullsecret_content`.
 
-If you provide neither, it will fail. If you provide both, it will also fail.
-
+If you provide neither, or both, it will fail.
 
 ## Cleanup
 

--- a/docs/source/quickstart/03_deploy_infra.md
+++ b/docs/source/quickstart/03_deploy_infra.md
@@ -14,9 +14,8 @@ In such a case, additional notes will be provided.
 In order to deploy that infrastructure, you have to:
 
 - Retrieve your [pull-secret](https://console.redhat.com/openshift/create/local) (chose "Download pull secret")
-- Push it onto the hypervisor (`scp pull-secret user@hypervisor:pull-secret` for instance)
 - Prepare an inventory file
-- Maybe prepare a custom variables file
+- Prepare a custom variables file
 - run `ansible-playbook`
 
 ### Inventory file
@@ -48,6 +47,13 @@ You may want to override some of the default settings provided in the
 [3-node.yml](https://github.com/openstack-k8s-operators/ci-framework/blob/main/scenarios/reproducers/3-nodes.yml)
 scenario file.
 
+Among the needed overrides, the pull-secret has to be passed down, for instance:
+
+~~~{code-block} YAML
+:caption: custom/private-params.yml
+cifmw_manage_secrets_pullsecret_file: "{{ lookup('env', 'HOME') }}/pull-secret.txt"
+~~~
+
 ### Run the deployment
 
 Once you're ready, run:
@@ -57,7 +63,7 @@ $ cd ci-framework
 $ ansible-playbook -i custom-inventory.yml \
     -e @scenarios/reproducers/3-nodes.yml \
     -e cifmw_target_host=hypervisor-1 \
-    [-e @custom-env-file.yml] \
+    -e @custom/private-params.yml
     reproducer.yml
 ```
 

--- a/docs/source/reproducers/01-considerations.md
+++ b/docs/source/reproducers/01-considerations.md
@@ -3,16 +3,25 @@
 This reproducer has been successfully tested on a CentOS Stream 9 hypervisor
 running latest CRC qcow2, and latest CentOS Stream 9 qcow2 images.
 
-It *may* work on RHEL based hypervisor and VMs, provided you give the correct
+It also works on RHEL based hypervisor and VMs, provided you give the correct
 information for the [discover_latest_image](../roles/discover_latest_image.md)
 role/plugin, or download beforehand the images and consume them from within the
-configuration, but it **wasn't tested** (yet).
+configuration, but this will **not** be covered in this documentation.
+
+## Custom extra variables files
+You can push your custom variables files in the `custom` directory available
+at the root of the `ci-framework` git repository. Its content is ignored via the
+provided `.gitignore` file.
 
 ## Prerequisites
 ### CRC
-For now, you have to ensure your `pull-secret` is present on the target host (in the case
-of a remote deployment). A proper way to copy and manage it is in the pipe, but for now,
-this is your responsibility to get it on the remote node.
+You have to get a working [pull-secret](https://console.redhat.com/openshift/create/local) and
+pass it to the deployment using a custom parameter file, for instance:
+
+~~~{code-block} YAML
+:caption: custom/private-params.yml
+cifmw_manage_secrets_pullsecret_file: "{{ lookup('env', 'HOME') }}/pull-secret.txt"
+~~~
 
 ### Ssh authorized_keys
 On the target hypervisor, you have to ensure the ~/.ssh/authorized_keys has all


### PR DESCRIPTION
Since we integrated the manage_secret role in rhol_crc, we have to
update the documentation to reflect that change.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
