### PR TITLE
Set IP and netmask for storage, tenant and internal API networks

### DIFF
--- a/ci_framework/hooks/playbooks/fetch_compute_facts.yml
+++ b/ci_framework/hooks/playbooks/fetch_compute_facts.yml
@@ -129,21 +129,55 @@
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleVars/tenant_mtu
                     value: {{ crc_ci_bootstrap_networks_out['compute-0']['tenant'].mtu | default(1500) }}
+
+              {% if 'ip' in crc_ci_bootstrap_networks_out['compute-0']['tenant'] %}
+                  - op: replace
+                    path: /spec/nodeTemplate/ansible/ansibleVars/tenant_ip
+                    value: {{ crc_ci_bootstrap_networks_out['compute-0']['tenant'].ip | ansible.utils.ipaddr('address') }}
+
+                  - op: replace
+                    path: /spec/nodeTemplate/ansible/ansibleVars/tenant_cidr
+                    value: {{ crc_ci_bootstrap_networks_out['compute-0']['tenant'].ip | ansible.utils.ipaddr('prefix') }}
+              {% endif %}
               {% endif %}
 
               {% if 'storage' in crc_ci_bootstrap_networks_out['compute-0'] %}
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleVars/storage_mtu
                     value: {{ crc_ci_bootstrap_networks_out['compute-0']['storage'].mtu | default(1500) }}
+
+              {% if 'ip' in crc_ci_bootstrap_networks_out['compute-0']['storage'] %}
+                  - op: replace
+                    path: /spec/nodeTemplate/ansible/ansibleVars/storage_ip
+                    value: {{ crc_ci_bootstrap_networks_out['compute-0']['storage'].ip | ansible.utils.ipaddr('address') }}
+
+                  - op: replace
+                    path: /spec/nodeTemplate/ansible/ansibleVars/storage_cidr
+                    value: {{ crc_ci_bootstrap_networks_out['compute-0']['storage'].ip | ansible.utils.ipaddr('prefix') }}
+              {% endif %}
               {% endif %}
 
               {% if 'internal-api' in crc_ci_bootstrap_networks_out['compute-0'] %}
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleVars/internal_api_mtu
                     value: {{ crc_ci_bootstrap_networks_out['compute-0']['internal-api'].mtu | default(1500) }}
+
+              {% if 'ip' in crc_ci_bootstrap_networks_out['compute-0']['internal-api'] %}
+                  - op: replace
+                    path: /spec/nodeTemplate/ansible/ansibleVars/internal_api_ip
+                    value: {{ crc_ci_bootstrap_networks_out['compute-0']['internal-api'].ip | ansible.utils.ipaddr('address') }}
+
+                  - op: replace
+                    path: /spec/nodeTemplate/ansible/ansibleVars/internal_api_cidr
+                    value: {{ crc_ci_bootstrap_networks_out['compute-0']['internal-api'].ip | ansible.utils.ipaddr('prefix') }}
+              {% endif %}
               {% endif %}
 
               {% for compute_node in groups['computes'] if compute_node != 'compute-0' %}
+                  - op: add
+                    path: /spec/nodes/edpm-{{ compute_node }}/ansible/ansibleVars
+                    value: {}
+
                   - op: replace
                     path: /spec/nodes/edpm-{{ compute_node }}/ansible/ansibleHost
                     value: >-
@@ -161,6 +195,36 @@
                         default(crc_ci_bootstrap_networks_out[compute_node].default.ip) |
                         ansible.utils.ipaddr('address')
                       }}
+
+              {% if 'tenant' in crc_ci_bootstrap_networks_out[compute_node] and 'ip' in crc_ci_bootstrap_networks_out[compute_node]['tenant'] %}
+                  - op: replace
+                    path: /spec/nodes/edpm-{{ compute_node }}/ansible/ansibleVars/tenant_ip
+                    value: {{ crc_ci_bootstrap_networks_out[compute_node]['tenant'].ip | ansible.utils.ipaddr('address') }}
+
+                  - op: replace
+                    path: /spec/nodes/edpm-{{ compute_node }}/ansible/ansibleVars/tenant_cidr
+                    value: {{ crc_ci_bootstrap_networks_out[compute_node]['tenant'].ip | ansible.utils.ipaddr('prefix') }}
+              {% endif %}
+
+              {% if 'storage' in crc_ci_bootstrap_networks_out[compute_node] and 'ip' in crc_ci_bootstrap_networks_out[compute_node]['storage'] %}
+                  - op: replace
+                    path: /spec/nodes/edpm-{{ compute_node }}/ansible/ansibleVars/storage_ip
+                    value: {{ crc_ci_bootstrap_networks_out[compute_node]['storage'].ip | ansible.utils.ipaddr('address') }}
+
+                  - op: replace
+                    path: /spec/nodes/edpm-{{ compute_node }}/ansible/ansibleVars/storage_cidr
+                    value: {{ crc_ci_bootstrap_networks_out[compute_node]['storage'].ip | ansible.utils.ipaddr('prefix') }}
+              {% endif %}
+
+              {% if 'internal-api' in crc_ci_bootstrap_networks_out[compute_node] and 'ip' in crc_ci_bootstrap_networks_out[compute_node]['internal-api'] %}
+                  - op: replace
+                    path: /spec/nodes/edpm-{{ compute_node }}/ansible/ansibleVars/internal_api_ip
+                    value: {{ crc_ci_bootstrap_networks_out[compute_node]['internal-api'].ip | ansible.utils.ipaddr('address') }}
+
+                  - op: replace
+                    path: /spec/nodes/edpm-{{ compute_node }}/ansible/ansibleVars/internal_api_cidr
+                    value: {{ crc_ci_bootstrap_networks_out[compute_node]['internal-api'].ip | ansible.utils.ipaddr('prefix') }}
+              {% endif %}
               {% endfor %}
 
                   - op: add

--- a/ci_framework/roles/hci_prepare/tasks/phase1.yml
+++ b/ci_framework/roles/hci_prepare/tasks/phase1.yml
@@ -55,10 +55,54 @@
 
       {% for compute_node in groups['computes'] %}
           - op: add
+            path: /spec/nodes/edpm-{{ compute_node }}/ansible/ansibleVars
+            value: {}
+
+          - op: add
             path: /spec/nodes/edpm-{{ compute_node }}/networks/-
             value:
               name: StorageMgmt
               subnetName: subnet1
+
+      {% if 'ip' in crc_ci_bootstrap_networks_out[compute_node]['storage-mgmt'] %}
+          - op: replace
+            path: /spec/nodes/edpm-{{ compute_node }}/ansible/ansibleVars/storage_mgmt_ip
+            value: {{ crc_ci_bootstrap_networks_out[compute_node]['storage-mgmt'].ip | ansible.utils.ipaddr('address') }}
+
+          - op: replace
+            path: /spec/nodes/edpm-{{ compute_node }}/ansible/ansibleVars/storage_mgmt_cidr
+            value: "{{ crc_ci_bootstrap_networks_out[compute_node]['storage-mgmt'].ip | ansible.utils.ipaddr('prefix') }}"
+      {% endif %}
+
+      {% if 'tenant' in crc_ci_bootstrap_networks_out[compute_node] and 'ip' in crc_ci_bootstrap_networks_out[compute_node]['tenant'] %}
+          - op: replace
+            path: /spec/nodes/edpm-{{ compute_node }}/ansible/ansibleVars/tenant_ip
+            value: {{ crc_ci_bootstrap_networks_out[compute_node]['tenant'].ip | ansible.utils.ipaddr('address') }}
+
+          - op: replace
+            path: /spec/nodes/edpm-{{ compute_node }}/ansible/ansibleVars/tenant_cidr
+            value: {{ crc_ci_bootstrap_networks_out[compute_node]['tenant'].ip | ansible.utils.ipaddr('prefix') }}
+      {% endif %}
+
+      {% if 'storage' in crc_ci_bootstrap_networks_out[compute_node] and 'ip' in crc_ci_bootstrap_networks_out[compute_node]['storage'] %}
+          - op: replace
+            path: /spec/nodes/edpm-{{ compute_node }}/ansible/ansibleVars/storage_ip
+            value: {{ crc_ci_bootstrap_networks_out[compute_node]['storage'].ip | ansible.utils.ipaddr('address') }}
+
+          - op: replace
+            path: /spec/nodes/edpm-{{ compute_node }}/ansible/ansibleVars/storage_cidr
+            value: {{ crc_ci_bootstrap_networks_out[compute_node]['storage'].ip | ansible.utils.ipaddr('prefix') }}
+      {% endif %}
+
+      {% if 'internal-api' in crc_ci_bootstrap_networks_out[compute_node] and 'ip' in crc_ci_bootstrap_networks_out[compute_node]['internal-api'] %}
+          - op: replace
+            path: /spec/nodes/edpm-{{ compute_node }}/ansible/ansibleVars/internal_api_ip
+            value: {{ crc_ci_bootstrap_networks_out[compute_node]['internal-api'].ip | ansible.utils.ipaddr('address') }}
+
+          - op: replace
+            path: /spec/nodes/edpm-{{ compute_node }}/ansible/ansibleVars/internal_api_cidr
+            value: {{ crc_ci_bootstrap_networks_out[compute_node]['internal-api'].ip | ansible.utils.ipaddr('prefix') }}
+      {% endif %}
       {% endfor %}
 
 - name: Enable services needed to deploy Ceph


### PR DESCRIPTION
This will set explicitly IP addresses and netmasks for all networks for all compute nodes in the compute facts fetched for the CI jobs.

As a pull request owner and reviewers, I checked that:

- [x] Appropriate testing is done and actually running

Closes: #[OSPCIX-124](https://issues.redhat.com//browse/OSPCIX-124)
