### PR TITLE
Integrate manage_secrets in devscripts role

### DIFF
--- a/ci_framework/roles/devscripts/README.md
+++ b/ci_framework/roles/devscripts/README.md
@@ -20,11 +20,6 @@ managed services.
 ## Parameters
 
 * `cifmw_devscripts_artifacts_dir` (str) path to the directory to store the role artifacts.
-* `cifmw_devscripts_ci_token` (str) oAuth token required for accessing
-  [openshift-console](https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/).
-* `cifmw_devscripts_ci_token_file` (str) oAuth token required for accessing
-  [openshift-console](https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/).
-  We can use `cifmw_devscripts_ci_token` or `cifmw_devscripts_ci_token_file` for passing OAuth token.
 * `cifmw_devscripts_config_overrides` (dict) key/value pairs to be used for overriding the default
   configuration. Refer [section](#supported-keys-in-cifmw_devscripts_config_overrides) for more information.
 * `cifmw_devscripts_dry_run` (bool) If enabled, the workflow is evaluated.
@@ -33,13 +28,29 @@ managed services.
 * `cifmw_devscripts_osp_compute_nodes` (list) A list of nodes which has key/value pairs
   containing details about OpenStack compute nodes. Refer
   [section](#supported-keys-in-cifmw_devscripts_osp_compute_nodes) for more information.
-* `cifmw_devscripts_pull_secret` (str) Access secret for pulling OCP component images.
-* `cifmw_devscripts_pull_secret_file` (str) Path to pull-secret for pulling OCP component images.
-  We can use `cifmw_devscripts_pull_secret` or `cifmw_devscripts_pull_secret_file` for passing pull_secrets
 * `cifmw_devscripts_src_dir` (str) The parent folder of dev-scripts repository.
 * `cifmw_devscripts_use_layers` (bool) Toggle overlay support. Specifically, this boolean will instruct the role to
   shutdown the whole OCP cluster, dump the XML, undefine the nodes, and prevents running the "post" tasks. Defaults to `false`.
 * `cifmw_devscripts_remove_default_net` (bool) Remove the default virtual network. Defaults to `false`.
+
+### Secrets management
+
+This role calls the [manage_secrets](./manage_secrets.md) role. It allows to copy or create
+the needed secrets.
+
+#### pull-secret
+
+You **must** provide either `cifmw_manage_secrets_pullsecret_file` OR
+`cifmw_manage_secrets_pullsecret_content`.
+
+If you provide neither, or both, it will fail.
+
+#### CI Token
+
+You **must** provide either `cifmw_manage_secrets_citoken_file` OR
+`cifmw_manage_secrets_citoken_content`.
+
+If you provide neither, or both, it will fail.
 
 ### Supported keys in cifmw_devscripts_config_overrides
 

--- a/ci_framework/roles/devscripts/molecule/default/converge.yml
+++ b/ci_framework/roles/devscripts/molecule/default/converge.yml
@@ -26,8 +26,6 @@
       domains:
         - "ocp.openstack.lab"
     cifmw_devscripts_dry_run: true
-    cifmw_devscripts_ci_token: "random value"
-    cifmw_devscripts_pull_secret: "should be a json"
     cifmw_devscripts_ocp_version: "4.13.12"
     cifmw_devscripts_user: "{{ ansible_user_id }}"
     cifmw_devscripts_repo_dir: "{{ (ansible_user_dir, 'src', 'dev-scripts') | path_join }}"
@@ -45,6 +43,9 @@
 
   tasks:
     - name: Apply devscripts role
+      vars:
+        cifmw_manage_secrets_citoken_content: "random value"
+        cifmw_manage_secrets_pullsecret_content: "should be a json"
       ansible.builtin.include_role:
         name: devscripts
 
@@ -110,12 +111,10 @@
         content: "hello world"
         dest: '/tmp/ci_token'
 
-    - name: Set fact for cifmw_devscripts_pull_secret_file
-      ansible.builtin.set_fact:
-        cifmw_devscripts_pull_secret_file: '/tmp/pull-secret'
-        cifmw_devscripts_ci_token_file: '/tmp/pull-secret'
-
     - name: Re-run devscripts role
+      vars:
+        cifmw_manage_secrets_pullsecret_file: '/tmp/pull-secret'
+        cifmw_manage_secrets_citoken_file: '/tmp/pull-secret'
       ansible.builtin.include_role:
         name: devscripts
 

--- a/ci_framework/roles/devscripts/tasks/main.yml
+++ b/ci_framework/roles/devscripts/tasks/main.yml
@@ -26,6 +26,46 @@
       }}
     cacheable: true
 
+- name: Fail in case of deprecated parameter
+  block:
+    - name: Fail if cifmw_devscripts_ci_token is defined
+      when:
+        - cifmw_devscripts_ci_token is defined
+      ansible.builtin.fail:
+        msg: |
+          cifmw_devscripts_ci_token is deprecated, please use
+          cifmw_manage_secrets_citoken_content instead!
+
+    - name: Fail if cifmw_devscripts_ci_token_file is defined
+      when:
+        - cifmw_devscripts_ci_token_file is defined
+      ansible.builtin.fail:
+        msg: |
+          cifmw_devscripts_ci_token_file is deprecated, please use
+          cifmw_manage_secrets_citoken_file instead!
+
+    - name: Fail if cifmw_devscripts_pull_secret is defined
+      when:
+        - cifmw_devscripts_pull_secret is defined
+      ansible.builtin.fail:
+        msg: |
+          cifmw_devscripts_pull_secret is deprecated, please use
+          cifmw_manage_secrets_citoken_content instead!
+
+    - name: Fail if cifmw_devscripts_pull_secret_file is defined
+      when:
+        - cifmw_devscripts_pull_secret_file is defined
+      ansible.builtin.fail:
+        msg: |
+          cifmw_devscripts_pull_secret_file is deprecated, please use
+          cifmw_manage_secrets_pullsecret_file instead !
+
+- name: Initialize manage_secrets role
+  tags:
+    - always
+  ansible.builtin.import_role:
+    name: manage_secrets
+
 - name: Ensure the required folders are present.
   tags:
     - always

--- a/ci_framework/roles/devscripts/tasks/sub_tasks/32_params.yml
+++ b/ci_framework/roles/devscripts/tasks/sub_tasks/32_params.yml
@@ -16,13 +16,15 @@
 
 
 - name: Copy the CI token file in devscripts source directory
-  when: cifmw_devscripts_ci_token_file is defined
-  ansible.builtin.copy:
-    src: "{{ cifmw_devscripts_ci_token_file }}"
-    dest: "{{ cifmw_devscripts_repo_dir }}/ci_token"
-    owner: "{{ cifmw_devscripts_user }}"
-    group: "{{ cifmw_devscripts_user }}"
-    mode: "0600"
+  vars:
+    cifmw_manage_secrets_citoken_dest: >-
+     {{
+       (cifmw_devscripts_repo_dir, 'ci_token') |
+       path_join
+     }}
+  ansible.builtin.include_role:
+    name: manage_secrets
+    tasks_from: ci_token.yml
 
 - name: Copy the OCP config file.
   ansible.builtin.template:
@@ -30,20 +32,13 @@
     dest: >-
       {{ cifmw_devscripts_repo_dir }}/config_{{ cifmw_devscripts_user }}.sh
 
-- name: Copy the user pull secret from cifmw_devscripts_pull_secret var
-  when: cifmw_devscripts_pull_secret is defined
-  ansible.builtin.copy:
-    dest: "{{ cifmw_devscripts_repo_dir }}/pull_secret.json"
-    content: "{{ cifmw_devscripts_pull_secret }}"
-    owner: "{{ cifmw_devscripts_user }}"
-    group: "{{ cifmw_devscripts_user }}"
-    mode: "0600"
-
-- name: Copy the user pull secret from cifmw_devscripts_pull_secret_file var
-  when: cifmw_devscripts_pull_secret_file is defined
-  ansible.builtin.copy:
-    dest: "{{ cifmw_devscripts_repo_dir }}/pull_secret.json"
-    src: "{{ cifmw_devscripts_pull_secret_file }}"
-    owner: "{{ cifmw_devscripts_user }}"
-    group: "{{ cifmw_devscripts_user }}"
-    mode: "0600"
+- name: Copy pull-secret file
+  vars:
+    cifmw_manage_secrets_pullsecret_dest: >-
+      {{
+        (cifmw_devscripts_repo_dir, 'pull_secret.json') |
+        path_join
+      }}
+  ansible.builtin.include_role:
+    name: manage_secrets
+    tasks_from: pull_secret.yml

--- a/ci_framework/roles/devscripts/templates/conf_ciuser.sh.j2
+++ b/ci_framework/roles/devscripts/templates/conf_ciuser.sh.j2
@@ -4,11 +4,7 @@
 # Refer https://github.com/openshift-metal3/dev-scripts/blob/master/config_example.sh
 #
 set +x
-{% if cifmw_devscripts_ci_token_file is defined %}
 export CI_TOKEN=$(cat {{ cifmw_devscripts_repo_dir }}/ci_token)
-{% else %}
-export CI_TOKEN="{{ cifmw_devscripts_ci_token }}"
-{% endif %}
 set -x
 
 {% for item in cifmw_devscripts_config %}


### PR DESCRIPTION
This will allow to converge secret management through the framework.

We also have a hard failure in case a user is passing the old parameter.
This may sound hard, but that's the best way to not have to maintain old
variables.
The error message is clear enough to help users moving to the new
schema.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
