### PR TITLE
Temp remove test_mtu_sized_frames - IBM4 debug

### DIFF
--- a/ci_framework/roles/tempest/files/list_skipped.yml
+++ b/ci_framework/roles/tempest/files/list_skipped.yml
@@ -1100,3 +1100,15 @@ known_failures:
         lp: http://no.bug
     jobs:
       - nova-operator
+  # TODO (rlandy) remove when https://issues.redhat.com/browse/OSPCIX-126 is fixed
+  - test: tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_mtu_sized_frames
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: IBM cloud exposes MTU setup differences exposing a real issue
+        lp: https://issues.redhat.com/browse/OSPCIX-126
+      - name: antelope
+        reason: IBM cloud exposes MTU setup differences exposing a real issue
+        lp: https://issues.redhat.com/browse/OSPCIX-126
+    jobs: []


### PR DESCRIPTION
IBM4 setup has reveal an issue with MTU setting
and usage. Removing this test from running while
the debug is in progress to allow this other
provider to be added.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
