### PR TITLE
Avoid running edpm jobs for a couple of roles

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -28,6 +28,8 @@
       - .readthedocs.yaml
       - ci_framework/roles/dlrn_report
       - ci_framework/roles/dlrn_promote
+      - ci_framework/roles/devscripts
+      - ci_framework/roles/libvirt_manager
       # Other openstack operators
       - containers/ci
       - .ci-operator.yaml


### PR DESCRIPTION
devscripts and libvirt_manager role shouldn't trigger any edpm related
job: they are providing features that aren't used in CI.

As a pull request owner and reviewers, I checked that:
- [x] no test nor doc
