### PR TITLE
Manage pull-secret only if needed

### DIFF
--- a/ci_framework/roles/rhol_crc/tasks/main.yml
+++ b/ci_framework/roles/rhol_crc/tasks/main.yml
@@ -41,7 +41,11 @@
     - not cifmw_rhol_crc_force_cleanup|bool
     - not cifmw_rhol_crc_reuse | bool
 
-- name: Ensure pull-secret is in place
+- name: Ensure pull-secret is in place if we need to configure CRC
+  when:
+    - (cifmw_rhol_crc_force_cleanup|bool) or
+      (not crc_present|bool) or
+      (not crc_running|bool)
   vars:
     cifmw_manage_secrets_pullsecret_dest: "{{ cifmw_rhol_crc_pullsecret_dest }}"
   ansible.builtin.include_role:


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
