### PR TITLE
Adds config_nm false for data plane adoption standalone node

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -139,12 +139,16 @@
             networks:
               default:
                 ip: 192.168.122.100
+                config_nm: false
               internal-api:
                 ip: 172.17.0.100
+                config_nm: false
               storage:
                 ip: 172.18.0.100
+                config_nm: false
               tenant:
                 ip: 172.19.0.100
+                config_nm: false
 
 - job:
     name: cifmw-data-plane-adoption-github-rdo-centos-9-extracted-crc


### PR DESCRIPTION
Then we can also remove the explicit deletion we have in [1]

[1] https://review.rdoproject.org/r/c/rdo-jobs/+/50590/48/playbooks/data_plane_adoption/setup_standalone_os_net_config.yaml

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running