### PR TITLE
Don't override pull-secret-file

### DIFF
--- a/scenarios/reproducers/3-nodes.yml
+++ b/scenarios/reproducers/3-nodes.yml
@@ -8,7 +8,6 @@ cifmw_basedir: "{{ ansible_user_dir }}/ci-framework-data"
 cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
 
 cifmw_rhol_crc_config:
-  pull-secret-file: "{{ ansible_user_dir }}/pull-secret"
   disk-size: 100
   memory: 24000
 


### PR DESCRIPTION
Since it's now managed with manage_secrets we don't need/want to
override it.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
