### PR TITLE
Pull tempest from content provider

### DIFF
--- a/ci/playbooks/tcib/run.yml
+++ b/ci/playbooks/tcib/run.yml
@@ -33,6 +33,15 @@
           {%- endif %}
           -e "@{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml"
 
+    - name: Include inner ansible vars file
+      ansible.builtin.slurp:
+        src: "{{ cifmw_artifacts_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts/ansible-vars.yml"
+      register: inner_ansible
+
+    - name: Get inner ansible vars
+      ansible.builtin.set_fact:
+        inner_ansible_vars: "{{ inner_ansible.content | b64decode | from_yaml }}"
+
     - name: Return Zuul Data
       ansible.builtin.debug:
         msg: >-
@@ -45,3 +54,5 @@
           zuul:
             pause: true
           content_provider_registry_ip: "{{ node_ip | default('nowhere') }}"
+          content_provider_namespace: "{{ inner_ansible_vars.cifmw_build_containers_registry_namespace }}"
+          content_provider_registry_tag: "{{ inner_ansible_vars.cifmw_repo_setup_full_hash }}"

--- a/ci/playbooks/tcib/tcib.yml
+++ b/ci/playbooks/tcib/tcib.yml
@@ -73,3 +73,15 @@
         content: "{{ cp_imgs.content }}"
         dest: "{{ ansible_user_dir }}/local_registry.log"
         mode: "0644"
+
+- name: Run log related tasks
+  ansible.builtin.import_playbook: >-
+    {{
+        [
+          ansible_user_dir,
+          zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
+          'ci_framework',
+          'playbooks',
+          '99-logs.yml'
+        ] | ansible.builtin.path_join
+    }}

--- a/ci_framework/roles/tempest/tasks/main.yml
+++ b/ci_framework/roles/tempest/tasks/main.yml
@@ -46,6 +46,12 @@
     cmd: "podman unshare chown 42480:42480 -R {{ cifmw_tempest_artifacts_basedir }}"
   when: not cifmw_tempest_dry_run | bool
 
+- name: Set tempest container url for content provider
+  when: content_provider_registry_tag is defined
+  ansible.builtin.set_fact:
+    cifmw_tempest_image: "{{ content_provider_registry_ip }}:5001/{{ content_provider_namespace }}/openstack-tempest"
+    cifmw_tempest_image_tag: "{{ content_provider_registry_tag }}"
+
 - name: Ensure we have tempest container image
   register: _tempest_fetch_img
   containers.podman.podman_image:


### PR DESCRIPTION
This pr adds more zuul return vars to openstack content provider job so that we can fetch tag and registry url for pulling tempest container.

It will help to test proper tempest container in content provider job.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

