### PR TITLE
Set default network vals on the base job

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -41,10 +41,12 @@
       cifmw_use_libvirt: true
       cifmw_use_crc: false
       cifmw_zuul_target_host: controller
+      crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"
       crc_ci_bootstrap_networking:
         networks:
           default:
-            mtu: 1500
+            mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
+            router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
             range: 192.168.122.0/24
           internal-api:
             vlan: 20

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -153,10 +153,12 @@
       cifmw_openshift_skip_tls_verify: true
       cifmw_use_libvirt: false
       cifmw_zuul_target_host: controller
+      crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"
       crc_ci_bootstrap_networking:
         networks:
           default:
-            mtu: 1500
+            mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
+            router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
             range: 192.168.122.0/24
           internal-api:
             vlan: 20

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -21,10 +21,12 @@
             - compute-1
             - compute-2
     vars:
+      crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"
       crc_ci_bootstrap_networking:
         networks:
           default:
-            mtu: 1500
+            mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
+            router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
             range: 192.168.122.0/24
           internal-api:
             vlan: 20
@@ -118,10 +120,12 @@
             - compute-2
     vars:
       cifmw_edpm_deploy_hci: true
+      crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"
       crc_ci_bootstrap_networking:
         networks:
           default:
-            mtu: 1500
+            mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
+            router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
             range: 192.168.122.0/24
           internal-api:
             vlan: 20

--- a/zuul.d/kuttl_multinode.yaml
+++ b/zuul.d/kuttl_multinode.yaml
@@ -13,11 +13,13 @@
     vars:
       zuul_log_collection: true
     extra-vars:
+      crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"
       crc_ci_bootstrap_networking:
         networks:
           default:
             range: 192.168.122.0/24
-            mtu: 1500
+            mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
+            router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
           internal-api:
             vlan: 20
             range: 172.17.0.0/24

--- a/zuul.d/tempest_multinode.yaml
+++ b/zuul.d/tempest_multinode.yaml
@@ -14,11 +14,13 @@
       cifmw_operator_build_operators: []
       cifmw_tempest_tests_allowed_override_scenario: true
     extra-vars:
+      crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"
       crc_ci_bootstrap_networking:
         networks:
           default:
             range: 192.168.122.0/24
-            mtu: 1500
+            mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
+            router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
           internal-api:
             vlan: 20
             range: 172.17.0.0/24


### PR DESCRIPTION
In order to be able to run the same job
on any cloud provider, the values required to
use that provider must be able to be vary.

This PR allows for setting the cloud name,
mtus and router_net as specified in cloud
secrets.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
