### PR TITLE
Fix the path for cifmw_openshift_kubeconfig

### DIFF
--- a/scenarios/centos-9/edpm_ci.yml
+++ b/scenarios/centos-9/edpm_ci.yml
@@ -20,7 +20,7 @@ cifmw_openshift_setup_skip_internal_registry: true
 cifmw_openshift_user: "kubeadmin"
 cifmw_openshift_password: "123456789"
 cifmw_openshift_api: api.crc.testing:6443
-cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.kube/config"
 cifmw_openshift_skip_tls_verify: true
 
 pre_deploy:


### PR DESCRIPTION
In extracted crc jobs, the location of kubeconfig file is `~/.kube/config` on the controller. Let's use this one.

The crc provided kubeconfig does not exists on controller. So let's use the ~/.kube/config to avoid any issue.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

