### PR TITLE
Temporarly pin ansible-core

### DIFF
--- a/ansible-requirements.txt
+++ b/ansible-requirements.txt
@@ -1,4 +1,5 @@
 ansible>=7.0.0
+ansible-core<2.15.6
 importlib-metadata
 jsonschema  # MIT
 oauthlib>=3.2.0 # k8s lib that requires manual upgrade


### PR DESCRIPTION
ansible-core 2.15.7 is out, and apparently there was a change in the way
it passes down some parameters to the custom plugins.

This is mostly a workaround in order to get the time to fix ci_script
and, probably, ci_make plugins.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
