### PR TITLE
fix: correctly print the excluded tests, if any

### DIFF
--- a/ci_framework/roles/tempest/tasks/tempest-tests.yml
+++ b/ci_framework/roles/tempest/tasks/tempest-tests.yml
@@ -92,6 +92,6 @@
         dest: "{{ cifmw_tempest_artifacts_basedir }}/exclude.txt"
         content: "{% for test in cifmw_tempest_tests_skipped %}{{ test }}\n{% endfor %}"
 
-    - name: Show tests to be executed
+    - name: Show tests to be excluded
       ansible.builtin.debug:
-        msg: "{{ cifmw_tempest_tests_allowed }}"
+        msg: "{{ cifmw_tempest_tests_skipped }}"


### PR DESCRIPTION
When setting the list of excluded tests, The debug instruction was printing the list of allowed tests, not the excluded ones.

- [x] No testing executed, just code inspection, but the change looks trivial enough.
