### PR TITLE
Remove Makefile from content provider irrelevant files list

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -30,7 +30,6 @@
       - ci_framework/roles/dlrn_promote
       - ci_framework/roles/devscripts
       - ci_framework/roles/libvirt_manager
-      - Makefile
       # Other openstack operators
       - containers/ci
       - .ci-operator.yaml


### PR DESCRIPTION
In Install_yamls, we run most of the Zuul jobs based on Makefile changes and in other operators, Makefile is used to build operator images.

If we put Makefile under content provider ir list, it will skip content provider job leading to job freeze issue.

Removing it fixes the issue.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

