### PR TITLE
Allow to create blank VMs

### DIFF
--- a/ci_framework/roles/libvirt_manager/README.md
+++ b/ci_framework/roles/libvirt_manager/README.md
@@ -29,8 +29,91 @@ Used for checking if:
 * `cifmw_libvirt_manager_apply_virtproxy_patch` (Boolean) Apply patch virtproxy patch for improved libvirt stability. This is set to `true` by default.
 * `cifmw_libvirt_manager_net_prefix_add` (Boolean) Adds `cifmw-` prefix to the network resources managed by this role. By default, it is set to `true`.
 * `cifmw_libvirt_manager_pub_net`: (String) Network name playing the "public" interface. Defaults to `public`.
+* `cifmw_libvirt_manager_vm_net_ip_set`: (Dict) Allow to extend the existing mapping for host family to IP mapping. Defaults to `{}`.
 
-### Parameters imported from the reproducer role
+### Structure for `cifmw_libvirt_manager_configuration`
+
+The following structure has to be passed via the configuration parameter:
+```YAML
+cifmw_libvirt_manager_configuration:
+  vms:
+    type_name:  # (string, such as "compute", "controller")
+      amount: (integer, optional. Optional, defaults to 1)
+      image_url: (string, URI to the base image. Optional if disk_file_name is set to "blank")
+      sha256_image_name: (string, image checksum. Optional if disk_file_name is set to "blank")
+      image_local_dir: (string, image destination for download. Optional if disk_file_name is set to "blank")
+      disk_file_name: (string, target image name. If set to "blank", will create a blank image)
+      disksize: (integer, disk size for the VM type. Optional, defaults to 40G)
+      memory: (integer, RAM amount in GB. Optional, defaults to 2)
+      cpus: (integer, amount of CPU. Optional, defaults to 2)
+      nets: (ordered list of networks to connect to)
+  networks:
+    net_name: <XML definition of the network to create>
+```
+
+Specific `type_name`: `^crc.*` and `^ocp.*` are enabling specific paths in the module.
+
+#### Example
+```YAML
+cifmw_libvirt_manager_networks:
+  public:
+    range: "192.168.100.0/24"
+  osp_trunk:
+    default: true
+    range: "192.168.122.0/24"
+    mtu: 9000
+    static_ip: true
+
+cifmw_libvirt_manager_configuration:
+  vms:
+    compute:
+      amount: 3
+      disk_file_name: blank
+      nets:
+        - public
+        - osp_trunk
+    controller:
+      image_url: "{{ cifmw_discovered_image_url }}"
+      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "centos-stream-9.qcow2"
+      disksize: 50
+      memory: 4
+      cpus: 2
+      nets:
+        - public
+        - osp_trunk
+  networks:
+    public: |-
+      <network>
+        <name>public</name>
+        <forward mode='nat'/>
+        <bridge name='public' stp='on' delay='0'/>
+        <ip family='ipv4'
+         address='{{ cifmw_libvirt_manager_networks.public.range | ansible.utils.nthhost(1) }}'
+         prefix='24'>
+          <dhcp>
+            <range
+             start='{{ cifmw_libvirt_manager_networks.public.range | ansible.utils.nthhost(10) }}'
+             end='{{ cifmw_libvirt_manager_networks.public.range | ansible.utils.nthhost(100) }}'/>
+          </dhcp>
+        </ip>
+      </network>
+    osp_trunk: |-
+      <network>
+        <name>osp_trunk</name>
+        <forward mode='nat'/>
+        <bridge name='osp_trunk' stp='on' delay='0'/>
+        <mtu size='{{ cifmw_libvirt_manager_networks.osp_trunk.mtu }}'/>
+        <ip
+         family='ipv4'
+         address='{{ cifmw_libvirt_manager_networks.osp_trunk.range | ansible.utils.nthhost(1) }}'
+         prefix='24'>
+        </ip>
+      </network>
+```
+
+### Parameters imported from the reproducer role
 
 The following parameters are usually set in the [reproducer](./reproducer.md) context.
 The parameters listed here are therefore merely proxies to the ones set in the reproducer,

--- a/ci_framework/roles/libvirt_manager/defaults/main.yml
+++ b/ci_framework/roles/libvirt_manager/defaults/main.yml
@@ -63,3 +63,6 @@ cifmw_libvirt_manager_crc_ip4: "{{ cifmw_reproducer_crc_ip4 | default('192.168.1
 cifmw_libvirt_manager_crc_gw4: "{{ cifmw_reproducer_crc_gw4 | default('192.168.122.1') }}"
 cifmw_libvirt_manager_dns_servers: "{{ cifmw_reproducer_dns_servers | default(['1.1.1.1', '8.8.8.8']) }}"
 cifmw_libvirt_manager_crc_private_nic: "{{ cifmw_reproducer_crc_private_nic | default('enp2s0') }}"
+
+# Allow to inject custom node family
+cifmw_libvirt_manager_vm_net_ip_set: {}

--- a/ci_framework/roles/libvirt_manager/molecule/deploy_layout/converge.yml
+++ b/ci_framework/roles/libvirt_manager/molecule/deploy_layout/converge.yml
@@ -20,6 +20,9 @@
   vars:
     ansible_user_dir: "{{ lookup('env', 'HOME') }}"
     cifmw_basedir: "/opt/basedir"
+    cifmw_libvirt_manager_vm_net_ip_set:
+      compute: 100
+      baremetal: 110
     cifmw_libvirt_manager_networks:
       osp_trunk:
         default: true
@@ -45,13 +48,22 @@
           nets:
             - public
             - osp_trunk
+        baremetal:
+          amount: 1
+          disk_file_name: 'blank'
+          nets:
+            - public
+            - osp_trunk
       networks:
         public: |-
           <network>
             <name>public</name>
             <forward mode='nat'/>
             <bridge name='public' stp='on' delay='0'/>
-            <ip family='ipv4' address='{{ cifmw_libvirt_manager_networks.public.range | ansible.utils.nthhost(1) }}' prefix='24'>
+            <ip
+             family='ipv4'
+             address='{{ cifmw_libvirt_manager_networks.public.range | ansible.utils.nthhost(1) }}'
+             prefix='24'>
               <dhcp>
                 <range start='{{ cifmw_libvirt_manager_networks.public.range | ansible.utils.nthhost(10) }}'
                 end='{{ cifmw_libvirt_manager_networks.public.range | ansible.utils.nthhost(100) }}'/>
@@ -63,7 +75,10 @@
             <name>osp_trunk</name>
             <forward mode='nat'/>
             <bridge name='osp_trunk' stp='on' delay='0'/>
-            <ip family='ipv4' address='{{ cifmw_libvirt_manager_networks.osp_trunk.range | ansible.utils.nthhost(1) }}' prefix='24'>
+            <ip
+             family='ipv4'
+             address='{{ cifmw_libvirt_manager_networks.osp_trunk.range | ansible.utils.nthhost(1) }}'
+             prefix='24'>
             </ip>
           </network>
   roles:
@@ -123,7 +138,9 @@
             sorted_vms: "{{ vms.list_vms | sort }}"
             compare_vms: >-
               {{
-                ['cifmw-compute-0', 'cifmw-compute-1'] | sort
+                ['cifmw-compute-0',
+                 'cifmw-compute-1',
+                 'cifmw-baremetal-0'] | sort
               }}
           ansible.builtin.assert:
             that:

--- a/ci_framework/roles/libvirt_manager/tasks/create_vms.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/create_vms.yml
@@ -1,10 +1,10 @@
 ---
-- name: "Create VM overlays for {{ vm_type }}"
+- name: "Create VM overlays or images for {{ vm_type }}"
   become: true
   vars:
     _base_img_name: >-
       {{
-        (vm_data.value.image_local_dir,
+        (vm_data.value.image_local_dir | default(ansible_user_dir),
          vm_data.value.disk_file_name) |
          path_join
       }}
@@ -17,7 +17,9 @@
   ansible.builtin.command:
     cmd: >-
       qemu-img create
+      {% if vm_data.value.disk_file_name != 'blank' %}
       -o backing_file={{ _img }},backing_fmt=qcow2
+      {% endif %}
       -f qcow2
       "{{ vm_type }}-{{ vm_id }}.qcow2"
       "{{ vm_data.value.disksize|default ('40') }}G"
@@ -31,7 +33,12 @@
 - name: Ensure file ownership and rights
   become: true
   ansible.builtin.file:
-    path: "{{ cifmw_libvirt_manager_basedir }}/workload/{{ vm_type }}-{{ vm_id }}.qcow2"
+    path: >-
+      {{
+        (cifmw_libvirt_manager_basedir, 'workload',
+        vm_type ~ '-' ~ vm_id ~ '.qcow2') |
+        path_join
+      }}
     group: "qemu"
     mode: "0664"
     owner: "{{ ansible_user_id }}"
@@ -179,193 +186,7 @@
     loop_var: mac_node
     label: "{{ mac_node.host }}"
 
-- name: "Start VMs for type {{ vm_type }}"
-  community.libvirt.virt:
-    state: running
-    name: "cifmw-{{ vm_type }}-{{ vm_id }}"
-    uri: "qemu:///system"
-  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
-  loop_control:
-    index_var: vm_id
-    label: "{{ vm_type }}-{{ vm_id }}"
-
-- name: "Grab IPs for nodes type {{ vm_type }}"  # noqa: risky-shell-pipe
-  register: vm_ips
-  ansible.builtin.shell:
-    cmd: >-
-      virsh -c qemu:///system -q
-      domifaddr --source arp
-      cifmw-{{ nic.host }} | grep "{{ nic.mac }}"
-  loop: "{{ public_net_nics }}"
-  loop_control:
-    loop_var: nic
-    label: "{{ nic.host }}"
-  retries: 20
-  delay: 5
-  until:
-    - vm_ips.rc == 0
-    - vm_ips.stdout != ''
-
-- name: "(localhost) Inject ssh jumpers for {{ vm_type }}"
+- name: Start and grab IP if image is not blank
   when:
-    - inventory_hostname != 'localhost'
-  delegate_to: localhost
-  vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
-    proxy_hostname: "{{ ansible_host | default(inventory_hostname) }}"
-  ansible.builtin.blockinfile:
-    create: true
-    path: "{{ lookup('env', 'HOME') }}/.ssh/config"
-    marker: "## {mark} {{ vm_ip.nic.host }}"
-    mode: "0600"
-    block: |-
-      Host {{ vm_ip.nic.host }} cifmw-{{ vm_ip.nic.host }} {{ extracted_ip }}
-        ProxyJump {{ ansible_user | default(lookup('env', 'USER')) }}@{{ proxy_hostname }}
-        Hostname {{ extracted_ip }}
-        User zuul
-        StrictHostKeyChecking no
-        UserKnownHostsFile /dev/null
-  loop: "{{ vm_ips.results }}"
-  loop_control:
-    loop_var: vm_ip
-    label: "{{ vm_ip.nic.host }}"
-
-- name: "({{ inventory_hostname }}) Inject ssh jumpers for {{ vm_type }}"  # noqa: name[template]
-  vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
-    identity_file: >-
-      {{
-        cifmw_reproducer_basedir ~ '/artifacts/cifmw_ocp_access_key' if vm_type == 'ocp' else
-        ansible_user_dir ~ '/.ssh/cifmw_reproducer_key'
-      }}
-  ansible.builtin.blockinfile:
-    create: true
-    path: "{{ ansible_user_dir }}/.ssh/config"
-    marker: "## {mark} {{ vm_ip.nic.host }}"
-    mode: "0600"
-    block: |-
-      Host {{ vm_ip.nic.host }} cifmw-{{ vm_ip.nic.host }} {{ extracted_ip }}
-        Hostname {{ extracted_ip }}
-        User zuul
-        IdentityFile {{ identity_file }}
-        StrictHostKeyChecking no
-        UserKnownHostsFile /dev/null
-  loop: "{{ vm_ips.results }}"
-  loop_control:
-    loop_var: vm_ip
-    label: "{{ vm_ip.nic.host }}"
-
-- name: Inject nodes in the ansible inventory
-  delegate_to: localhost
-  vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
-  ansible.builtin.add_host:
-    name: "{{ vm_ip.nic.host }}"
-    groups: "{{ vm_type }}"
-    ansible_host: "{{ extracted_ip }}"
-  loop: "{{ vm_ips.results }}"
-  loop_control:
-    loop_var: vm_ip
-    label: "{{ vm_ip.nic.host }}"
-
-- name: "Create group inventory for {{ vm_type }}"
-  vars:
-    hosts: "{{ vm_ips.results }}"
-    admin_user: "{{ vm_data.value.admin_user | default('zuul') }}"
-  ansible.builtin.template:
-    dest: "{{ cifmw_libvirt_manager_basedir }}/reproducer-inventory/{{ vm_type }}-group.yml"
-    src: inventory.yml.j2
-
-- name: "Wait for SSH on VMs type {{ vm_type }}"
-  vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
-  ansible.builtin.wait_for:
-    host: "{{ extracted_ip }}"
-    port: 22
-    delay: 5
-  loop: "{{ vm_ips.results }}"
-  loop_control:
-    loop_var: vm_ip
-    label: "{{ extracted_ip }}"
-
-- name: "Configure ssh access on type {{ vm_type }}"
-  when:
-    - vm_type is not match('^(crc|ocp).*$')
-  delegate_to: "{{ vm_ip.nic.host }}"
-  remote_user: "{{ _init_admin_user }}"
-  ansible.posix.authorized_key:
-    user: "{{ _init_admin_user }}"
-    state: present
-    key: "{{ pub_key }}"
-  loop: "{{ vm_ips.results }}"
-  loop_control:
-    loop_var: "vm_ip"
-    label: "{{ vm_ip.nic.host }}"
-
-- name: "Configure VMs type {{ vm_type }}"
-  when:
-    - vm_type is not match('^(crc|ocp).*$')
-  delegate_to: "{{ vm_ip.nic.host }}"
-  remote_user: "{{ _init_admin_user }}"
-  ansible.builtin.shell:
-    executable: /bin/bash
-    cmd: |-
-      test -d /home/zuul && exit 0;
-      set -xe -o pipefail;
-      echo "{{ vm_ip.nic.host }}" | sudo tee /etc/hostname;
-      sudo hostname -F /etc/hostname;
-      sudo useradd -m -d /home/zuul zuul;
-      echo "zuul ALL=(ALL)  NOPASSWD: ALL" | sudo tee /etc/sudoers.d/zuul;
-      sudo -u zuul mkdir -p /home/zuul/.ssh /home/zuul/src/github.com/openstack-k8s-operators;
-      sudo cp ${HOME}/.ssh/authorized_keys /home/zuul/.ssh/;
-      chown -R zuul: /home/zuul/.ssh;
-  loop: "{{ vm_ips.results }}"
-  loop_control:
-    loop_var: "vm_ip"
-    label: "{{ vm_ip.nic.host }}"
-
-- name: "Inject private key on hosts {{ vm_type }}"
-  when:
-    - vm_type is match('^controller.*$')
-  delegate_to: "{{ vm_ip.nic.host }}"
-  remote_user: "{{ _init_admin_user }}"
-  ansible.builtin.copy:
-    dest: "/home/zuul/.ssh/id_ed25519"
-    content: "{{ priv_key }}"
-    owner: zuul
-    group: zuul
-    mode: "0400"
-  loop: "{{ vm_ips.results }}"
-  loop_control:
-    loop_var: "vm_ip"
-    label: "{{ vm_ip.nic.host }}"
-
-- name: "Inject public key on hosts {{ vm_type }}"
-  when:
-    - vm_type is match('^controller.*$')
-  delegate_to: "{{ vm_ip.nic.host }}"
-  remote_user: "{{ _init_admin_user }}"
-  ansible.builtin.copy:
-    dest: "/home/zuul/.ssh/id_ed25519.pub"
-    content: "{{ pub_key }}"
-    owner: zuul
-    group: zuul
-    mode: "0444"
-  loop: "{{ vm_ips.results }}"
-  loop_control:
-    loop_var: "vm_ip"
-    label: "{{ vm_ip.nic.host }}"
-
-- name: "Inject network configuration file on {{ vm_type }}"
-  ansible.builtin.template:
-    dest: "{{ cifmw_libvirt_manager_basedir }}/reproducer-network-env/{{ vm_type }}-{{ vm_id }}.yml"
-    src: >-
-      {{
-        (ci_job_networking is defined)
-        | ternary('ci-network-data.yml.j2', 'network-data.yml.j2')
-      }}
-    mode: "0644"
-  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
-  loop_control:
-    index_var: vm_id
-    label: "{{ vm_type }}-{{ vm_id }}"
+    - vm_data.value.disk_file_name != 'blank'
+  ansible.builtin.include_tasks: start_manage_vms.yml

--- a/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -66,6 +66,7 @@
 
 - name: Prepare disk image with SSH and growing volume  # noqa: risky-shell-pipe
   when:
+    - item.value.disk_file_name != 'blank'
     - item.key is not match('^(crc|ocp).*$')
   vars:
     _admin_user: "{{ item.value.admin_user | default('root') }}"
@@ -89,6 +90,7 @@
   ansible.builtin.set_fact:
     cacheable: true
     cifmw_reproducer_network_data: {}
+    cifmw_libvirt_manager_mac_map: {}
     _fixed_ip_nets: >-
       {{
         cifmw_libvirt_manager_networks | default({}) |
@@ -115,6 +117,11 @@
   ansible.builtin.template:
     dest: "{{ cifmw_libvirt_manager_basedir }}/reproducer-inventory/all-group.yml"
     src: "all-inventory.yml.j2"
+
+- name: Dump MAC mapping
+  ansible.builtin.copy:
+    dest: "{{ cifmw_libvirt_manager_basedir }}/artifacts/mac-mapping.yml"
+    content: "{{ cifmw_libvirt_manager_mac_map | to_nice_yaml }}"
 
 - name: Ensure we get proper access to CRC
   when:

--- a/ci_framework/roles/libvirt_manager/tasks/get_image.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/get_image.yml
@@ -1,55 +1,60 @@
-- name: Ensure directory exists
-  become: true
-  ansible.builtin.file:
-    path: "{{ image_data.image_local_dir }}"
-    state: directory
-    mode: "0775"
-    owner: "{{ ansible_user_id }}"
-
-- name: Check if base image exists
-  ansible.builtin.stat:
-    path: "{{ image_data.image_local_dir }}/{{ image_data.disk_file_name }}"
-    get_checksum: false
-  register: disk_file_name_status
-
-- name: Download base image
+---
+- name: Run only if we want actual image
   when:
-    - not disk_file_name_status.stat.exists
-    - image_data.image_url is defined
-  register: download_base_img
-  ansible.builtin.get_url:
-    url: "{{ image_data.image_url }}"
-    dest: "{{ image_data.image_local_dir }}/{{ image_data.disk_file_name }}"
-    checksum: >-
-      {% if image_data.sha256_image_name -%}
-      sha256:{{ image_data.sha256_image_name }}
-      {% endif -%}
-  until:
-    - download_base_img.status_code is defined
-    - download_base_img.status_code == 200
-  retries: 30
-  delay: 5
-
-- name: Validate image availability
+    - image_data.disk_file_name != 'blank'
   block:
-    - name: Check image
-      register: image_status
+    - name: Ensure directory exists
+      become: true
+      ansible.builtin.file:
+        path: "{{ image_data.image_local_dir }}"
+        state: directory
+        mode: "0775"
+        owner: "{{ ansible_user_id }}"
+
+    - name: Check if base image exists
       ansible.builtin.stat:
         path: "{{ image_data.image_local_dir }}/{{ image_data.disk_file_name }}"
         get_checksum: false
+      register: disk_file_name_status
 
-    - name: Assert image status
-      ansible.builtin.assert:
-        that:
-          - image_status.stat.exists is defined
-          - image_status.stat.exists|bool
-        msg: "Unable to find {{ image_data.image_local_dir }}/{{ image_data.disk_file_name }}!"
+    - name: Download base image
+      when:
+        - not disk_file_name_status.stat.exists
+        - image_data.image_url is defined
+      register: download_base_img
+      ansible.builtin.get_url:
+        url: "{{ image_data.image_url }}"
+        dest: "{{ image_data.image_local_dir }}/{{ image_data.disk_file_name }}"
+        checksum: >-
+          {% if image_data.sha256_image_name -%}
+          sha256:{{ image_data.sha256_image_name }}
+          {% endif -%}
+      until:
+        - download_base_img.status_code is defined
+        - download_base_img.status_code == 200
+      retries: 30
+      delay: 5
 
-- name: Ensure image access rights
-  become: true
-  ansible.builtin.file:
-    path: "{{ image_data.image_local_dir }}/{{ image_data.disk_file_name }}"
-    group: "qemu"
-    mode: "0664"
-    owner: "{{ ansible_user_id }}"
-    state: file
+    - name: Validate image availability
+      block:
+        - name: Check image
+          register: image_status
+          ansible.builtin.stat:
+            path: "{{ image_data.image_local_dir }}/{{ image_data.disk_file_name }}"
+            get_checksum: false
+
+        - name: Assert image status
+          ansible.builtin.assert:
+            that:
+              - image_status.stat.exists is defined
+              - image_status.stat.exists|bool
+            msg: "Unable to find {{ image_data.image_local_dir }}/{{ image_data.disk_file_name }}!"
+
+    - name: Ensure image access rights
+      become: true
+      ansible.builtin.file:
+        path: "{{ image_data.image_local_dir }}/{{ image_data.disk_file_name }}"
+        group: "qemu"
+        mode: "0664"
+        owner: "{{ ansible_user_id }}"
+        state: file

--- a/ci_framework/roles/libvirt_manager/tasks/reserve_ip.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/reserve_ip.yml
@@ -70,27 +70,52 @@
   ansible.builtin.set_fact:
     mac_address: "{{ reserved }}"
 
+- name: "Generate IP address for {{ vm_name }}"
+  vars:
+    _net_ip_set: >-
+      {{
+        cifmw_libvirt_manager_vm_net_ip_set_default |
+        combine(cifmw_libvirt_manager_vm_net_ip_set)
+      }}
+    _vm_name: >-
+      {{
+        vm_name |
+        replace('cifmw-', '') |
+        replace('-', '_') |
+        split('_')
+      }}
+    _ip_index: >-
+      {{
+        _net_ip_set[_vm_name[0]] +
+        (_vm_name[1] | default(0)) | int
+      }}
+  ansible.builtin.set_fact:
+    _lm_ip_address: "{{ network.cidr | ansible.utils.nthhost(_ip_index) }}"
+
+- name: Inject data in cifmw_libvirt_manager_mac_map
+  vars:
+    _net_name: >-
+      {{
+        (network.name is match('^(ocp|default)')) |
+        ternary(network.name, 'cifmw-' ~ network.name)
+      }}
+    _dataset: >-
+      {{
+        {vm_name: [{'MAC': mac_address,
+                    'IP': _lm_ip_address,
+                    'network': _net_name}]}
+      }}
+  ansible.builtin.set_fact:
+    cifmw_libvirt_manager_mac_map: >-
+      {{
+        cifmw_libvirt_manager_mac_map | default({}) |
+        combine(_dataset, recursive=true)
+      }}
+
 - name: Reserve IP address
   when:
     - reserved == ''
   block:
-    - name: "Generate IP address for {{ vm_name }}"
-      vars:
-        _vm_name: >-
-          {{
-            vm_name |
-            replace('cifmw-', '') |
-            replace('-', '_') |
-            split('_')
-          }}
-        _ip_index: >-
-          {{
-            cifmw_libvirt_manager_vm_net_ip_set[_vm_name[0]] +
-            (_vm_name[1] | default(0)) | int
-          }}
-      ansible.builtin.set_fact:
-        _lm_ip_address: "{{ network.cidr | ansible.utils.nthhost(_ip_index) }}"
-
     - name: "Reserve IP for {{ vm_name }} on {{ network.name }}"  # noqa: name[template]
       vars:
         _vm_name: "{{ vm_name | replace('^cifmw-', '') }}"

--- a/ci_framework/roles/libvirt_manager/tasks/start_manage_vms.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/start_manage_vms.yml
@@ -1,0 +1,195 @@
+---
+# Start and manage VMs, such as injecting SSH configurations,
+# inject the VMs in the live inventory for later reference, and so on.
+# In case we create a "blank" VM, without any OS, it shouldn't be known by
+# ansible, so no access should be done.
+- name: "Start VMs for type {{ vm_type }}"
+  community.libvirt.virt:
+    state: running
+    name: "cifmw-{{ vm_type }}-{{ vm_id }}"
+    uri: "qemu:///system"
+  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
+  loop_control:
+    index_var: vm_id
+    label: "{{ vm_type }}-{{ vm_id }}"
+
+- name: "Grab IPs for nodes type {{ vm_type }}"  # noqa: risky-shell-pipe
+  register: vm_ips
+  ansible.builtin.shell:
+    cmd: >-
+      virsh -c qemu:///system -q
+      domifaddr --source arp
+      cifmw-{{ nic.host }} | grep "{{ nic.mac }}"
+  loop: "{{ public_net_nics }}"
+  loop_control:
+    loop_var: nic
+    label: "{{ nic.host }}"
+  retries: 20
+  delay: 5
+  until:
+    - vm_ips.rc == 0
+    - vm_ips.stdout != ''
+
+- name: "(localhost) Inject ssh jumpers for {{ vm_type }}"
+  when:
+    - inventory_hostname != 'localhost'
+  delegate_to: localhost
+  vars:
+    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
+    proxy_hostname: "{{ ansible_host | default(inventory_hostname) }}"
+  ansible.builtin.blockinfile:
+    create: true
+    path: "{{ lookup('env', 'HOME') }}/.ssh/config"
+    marker: "## {mark} {{ vm_ip.nic.host }}"
+    mode: "0600"
+    block: |-
+      Host {{ vm_ip.nic.host }} cifmw-{{ vm_ip.nic.host }} {{ extracted_ip }}
+        ProxyJump {{ ansible_user | default(lookup('env', 'USER')) }}@{{ proxy_hostname }}
+        Hostname {{ extracted_ip }}
+        User zuul
+        StrictHostKeyChecking no
+        UserKnownHostsFile /dev/null
+  loop: "{{ vm_ips.results }}"
+  loop_control:
+    loop_var: vm_ip
+    label: "{{ vm_ip.nic.host }}"
+
+- name: "({{ inventory_hostname }}) Inject ssh jumpers for {{ vm_type }}"  # noqa: name[template]
+  vars:
+    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
+    identity_file: >-
+      {{
+        cifmw_reproducer_basedir ~ '/artifacts/cifmw_ocp_access_key' if vm_type == 'ocp' else
+        ansible_user_dir ~ '/.ssh/cifmw_reproducer_key'
+      }}
+  ansible.builtin.blockinfile:
+    create: true
+    path: "{{ ansible_user_dir }}/.ssh/config"
+    marker: "## {mark} {{ vm_ip.nic.host }}"
+    mode: "0600"
+    block: |-
+      Host {{ vm_ip.nic.host }} cifmw-{{ vm_ip.nic.host }} {{ extracted_ip }}
+        Hostname {{ extracted_ip }}
+        User zuul
+        IdentityFile {{ identity_file }}
+        StrictHostKeyChecking no
+        UserKnownHostsFile /dev/null
+  loop: "{{ vm_ips.results }}"
+  loop_control:
+    loop_var: vm_ip
+    label: "{{ vm_ip.nic.host }}"
+
+- name: Inject nodes in the ansible inventory
+  delegate_to: localhost
+  vars:
+    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
+  ansible.builtin.add_host:
+    name: "{{ vm_ip.nic.host }}"
+    groups: "{{ vm_type }}"
+    ansible_host: "{{ extracted_ip }}"
+  loop: "{{ vm_ips.results }}"
+  loop_control:
+    loop_var: vm_ip
+    label: "{{ vm_ip.nic.host }}"
+
+- name: "Create group inventory for {{ vm_type }}"
+  vars:
+    hosts: "{{ vm_ips.results }}"
+    admin_user: "{{ vm_data.value.admin_user | default('zuul') }}"
+  ansible.builtin.template:
+    dest: "{{ cifmw_libvirt_manager_basedir }}/reproducer-inventory/{{ vm_type }}-group.yml"
+    src: inventory.yml.j2
+
+- name: "Wait for SSH on VMs type {{ vm_type }}"
+  vars:
+    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
+  ansible.builtin.wait_for:
+    host: "{{ extracted_ip }}"
+    port: 22
+    delay: 5
+  loop: "{{ vm_ips.results }}"
+  loop_control:
+    loop_var: vm_ip
+    label: "{{ extracted_ip }}"
+
+- name: "Configure ssh access on type {{ vm_type }}"
+  when:
+    - vm_type is not match('^(crc|ocp).*$')
+  delegate_to: "{{ vm_ip.nic.host }}"
+  remote_user: "{{ _init_admin_user }}"
+  ansible.posix.authorized_key:
+    user: "{{ _init_admin_user }}"
+    state: present
+    key: "{{ pub_key }}"
+  loop: "{{ vm_ips.results }}"
+  loop_control:
+    loop_var: "vm_ip"
+    label: "{{ vm_ip.nic.host }}"
+
+- name: "Configure VMs type {{ vm_type }}"
+  when:
+    - vm_type is not match('^(crc|ocp).*$')
+  delegate_to: "{{ vm_ip.nic.host }}"
+  remote_user: "{{ _init_admin_user }}"
+  ansible.builtin.shell:
+    executable: /bin/bash
+    cmd: |-
+      test -d /home/zuul && exit 0;
+      set -xe -o pipefail;
+      echo "{{ vm_ip.nic.host }}" | sudo tee /etc/hostname;
+      sudo hostname -F /etc/hostname;
+      sudo useradd -m -d /home/zuul zuul;
+      echo "zuul ALL=(ALL)  NOPASSWD: ALL" | sudo tee /etc/sudoers.d/zuul;
+      sudo -u zuul mkdir -p /home/zuul/.ssh /home/zuul/src/github.com/openstack-k8s-operators;
+      sudo cp ${HOME}/.ssh/authorized_keys /home/zuul/.ssh/;
+      chown -R zuul: /home/zuul/.ssh;
+  loop: "{{ vm_ips.results }}"
+  loop_control:
+    loop_var: "vm_ip"
+    label: "{{ vm_ip.nic.host }}"
+
+- name: "Inject private key on hosts {{ vm_type }}"
+  when:
+    - vm_type is match('^controller.*$')
+  delegate_to: "{{ vm_ip.nic.host }}"
+  remote_user: "{{ _init_admin_user }}"
+  ansible.builtin.copy:
+    dest: "/home/zuul/.ssh/id_ed25519"
+    content: "{{ priv_key }}"
+    owner: zuul
+    group: zuul
+    mode: "0400"
+  loop: "{{ vm_ips.results }}"
+  loop_control:
+    loop_var: "vm_ip"
+    label: "{{ vm_ip.nic.host }}"
+
+- name: "Inject public key on hosts {{ vm_type }}"
+  when:
+    - vm_type is match('^controller.*$')
+  delegate_to: "{{ vm_ip.nic.host }}"
+  remote_user: "{{ _init_admin_user }}"
+  ansible.builtin.copy:
+    dest: "/home/zuul/.ssh/id_ed25519.pub"
+    content: "{{ pub_key }}"
+    owner: zuul
+    group: zuul
+    mode: "0444"
+  loop: "{{ vm_ips.results }}"
+  loop_control:
+    loop_var: "vm_ip"
+    label: "{{ vm_ip.nic.host }}"
+
+- name: "Inject network configuration file on {{ vm_type }}"
+  ansible.builtin.template:
+    dest: "{{ cifmw_libvirt_manager_basedir }}/reproducer-network-env/{{ vm_type }}-{{ vm_id }}.yml"
+    src: >-
+      {{
+        (ci_job_networking is defined)
+        | ternary('ci-network-data.yml.j2', 'network-data.yml.j2')
+      }}
+    mode: "0644"
+  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
+  loop_control:
+    index_var: vm_id
+    label: "{{ vm_type }}-{{ vm_id }}"

--- a/ci_framework/roles/libvirt_manager/vars/main.yml
+++ b/ci_framework/roles/libvirt_manager/vars/main.yml
@@ -35,7 +35,7 @@ cifmw_libvirt_manager_polkit_rules_dir: /etc/polkit-1/rules.d
 cifmw_libvirt_manager_polkit_rules_file: "{{ cifmw_libvirt_manager_polkit_rules_dir }}/80-libvirt-manage.rules"
 
 # It is either compute or extraworker and not both hence the numbers are reused
-cifmw_libvirt_manager_vm_net_ip_set:
+cifmw_libvirt_manager_vm_net_ip_set_default:
   controller: 5
   crc: 10
   master: 10

--- a/ci_framework/roles/reproducer/molecule/crc_layout/converge.yml
+++ b/ci_framework/roles/reproducer/molecule/crc_layout/converge.yml
@@ -127,6 +127,11 @@
           ansible.builtin.stat:
             path: "{{ ansible_user_dir }}/.ssh/crc_key"
 
+        - name: Ensure we have the MAC mapping file
+          register: _mac_mapping
+          ansible.builtin.stat:
+            path: "{{ ansible_user_dir }}/ci-framework-data/artifacts/mac-mapping.yml"
+
         - name: Ensure we can ping compute-0 on osp_trunk net
           register: _cmp0_ping
           failed_when: false
@@ -167,6 +172,7 @@
         that:
           - _kubeconfig.stat.exists | bool
           - _crc_key.stat.exists | bool
+          - _mac_mapping.stat.exists | bool
           - _inventory_files.matched == 4
           - _inventory_content == _expected_files
           - _crc_ping.rc == 0

--- a/ci_framework/roles/reproducer/tasks/configure_controller.yml
+++ b/ci_framework/roles/reproducer/tasks/configure_controller.yml
@@ -46,7 +46,16 @@
         cmd: >-
           cat /home/zuul/reproducer-inventory/* >
           {{  _ctl_reproducer_basedir }}/zuul_inventory.yml
-        creates: ci-framework-data/artifacts/zuul_inventory.yml
+        creates: "{{ _ctl_reproducer_basedir }}/zuul_inventory.yml"
+
+    - name: Push the MAC mapping data
+      tags:
+        - bootstrap
+      become: true
+      become_user: zuul
+      ansible.builtin.copy:
+        dest: "{{ _ctl_reproducer_basedir }}/mac-mapping.yml"
+        content: "{{ cifmw_libvirt_manager_mac_map | to_nice_yaml }}"
 
     - name: Ensure /etc/ci/env is created
       become: true


### PR DESCRIPTION
This step is mandatory for baremetal support in the reproducer.

With this patch, setting the "disk_file_name" to "blank" will create a
blank, empty VM. It will also avoid trying to start and configure it (of
course).

In addition, we now generate a MAC address mapping file allowinw to
associate fixed IPs to a MAC and a VM in such a way we can, later,
provision the baremetal nodes properly.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
