### PR TITLE
Remove individual network settings

### DIFF
--- a/ci_framework/hooks/playbooks/fetch_compute_facts.yml
+++ b/ci_framework/hooks/playbooks/fetch_compute_facts.yml
@@ -121,58 +121,6 @@
                     path: /spec/nodeTemplate/ansible/ansibleVars/neutron_public_interface_name
                     value: "{{ crc_ci_bootstrap_networks_out['compute-0'].default.iface | default('') }}"
 
-                  - op: replace
-                    path: /spec/nodeTemplate/ansible/ansibleVars/ctlplane_mtu
-                    value: {{ (crc_ci_bootstrap_networks_out['compute-0'].default.mtu | default(1500)) | int }}
-
-              {% if 'tenant' in crc_ci_bootstrap_networks_out['compute-0'] %}
-                  - op: replace
-                    path: /spec/nodeTemplate/ansible/ansibleVars/tenant_mtu
-                    value: {{ (crc_ci_bootstrap_networks_out['compute-0']['tenant'].mtu | default(1500)) | int }}
-              {% else %}
-                  - op: remove
-                    path: /spec/nodeTemplate/ansible/ansibleVars/tenant_mtu
-
-                  - op: remove
-                    path: /spec/nodeTemplate/ansible/ansibleVars/networks_lower/Tenant
-              {% endif %}
-
-              {% if 'storage' in crc_ci_bootstrap_networks_out['compute-0'] %}
-                  - op: replace
-                    path: /spec/nodeTemplate/ansible/ansibleVars/storage_mtu
-                    value: {{ (crc_ci_bootstrap_networks_out['compute-0']['storage'].mtu | default(1500)) | int }}
-              {% else %}
-                  - op: remove
-                    path: /spec/nodeTemplate/ansible/ansibleVars/storage_mtu
-
-                  - op: remove
-                    path: /spec/nodeTemplate/ansible/ansibleVars/networks_lower/Storage
-              {% endif %}
-
-              {% if 'internal-api' in crc_ci_bootstrap_networks_out['compute-0'] %}
-                  - op: replace
-                    path: /spec/nodeTemplate/ansible/ansibleVars/internal_api_mtu
-                    value: {{ (crc_ci_bootstrap_networks_out['compute-0']['internal-api'].mtu | default(1500)) | int }}
-              {% else %}
-                  - op: remove
-                    path: /spec/nodeTemplate/ansible/ansibleVars/internal_api_mtu
-
-                  - op: remove
-                    path: /spec/nodeTemplate/ansible/ansibleVars/networks_lower/InternalApi
-              {% endif %}
-
-              {% if 'external' in crc_ci_bootstrap_networks_out['compute-0'] %}
-                  - op: replace
-                    path: /spec/nodeTemplate/ansible/ansibleVars/external_mtu
-                    value: {{ (crc_ci_bootstrap_networks_out['compute-0']['external'].mtu | default(1500)) | int }}
-              {% else %}
-                  - op: remove
-                    path: /spec/nodeTemplate/ansible/ansibleVars/external_mtu
-
-                  - op: remove
-                    path: /spec/nodeTemplate/ansible/ansibleVars/networks_lower/External
-              {% endif %}
-
               {% for compute_node in groups['computes'] if compute_node != 'compute-0' %}
                   - op: replace
                     path: /spec/nodes/edpm-{{ compute_node }}/ansible/ansibleHost

--- a/ci_framework/roles/hci_prepare/tasks/phase1.yml
+++ b/ci_framework/roles/hci_prepare/tasks/phase1.yml
@@ -37,22 +37,6 @@
       - target:
           kind: OpenStackDataPlaneNodeSet
         patch: |-
-          - op: replace
-            path: /spec/nodeTemplate/ansible/ansibleVars/storage_mgmt_mtu
-            value: {{ cifmw_hci_prepare_storage_mgmt_mtu }}
-
-          - op: replace
-            path: /spec/nodeTemplate/ansible/ansibleVars/storage_mgmt_vlan_id
-            value: {{ cifmw_hci_prepare_storage_mgmt_vlan }}
-
-          - op: add
-            path: /spec/nodeTemplate/ansible/ansibleVars/role_networks/-
-            value: StorageMgmt
-
-          - op: add
-            path: /spec/nodeTemplate/ansible/ansibleVars/networks_lower/StorageMgmt
-            value: storage_mgmt
-
       {% for compute_node in groups['computes'] %}
           - op: add
             path: /spec/nodes/edpm-{{ compute_node }}/networks/-


### PR DESCRIPTION
Our sample files are being refactored to leverage IPAM rather than requiring users to individually provide network specific settings. The IPAM implementation within the dataplane-operator will ensure these variables are set correctly as per the information provided in the NetConfig CR. Thus, it is not necessary to individually set these options during the deployment.

This change removes all ansibleVars specific to the network configuration that are able to be automatically generated by the dataplane-operator.

Related: https://github.com/openstack-k8s-operators/dataplane-operator/pull/501

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes