### PR TITLE
Remove extra-verbose debugging

### DIFF
--- a/ci_framework/roles/libvirt_manager/tasks/attach_interface.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/attach_interface.yml
@@ -44,10 +44,6 @@
         loop_var: net
         label: "{{ net.key }}"
 
-- name: Debug bridge mapping
-  ansible.builtin.debug:
-    var: _net_bridge_map
-
 - name: "Check ports attached to the domain {{ vm_name }}"
   block:
     - name: Dump domain xml
@@ -64,10 +60,6 @@
         xmlstring: "{{ _domain_xml.get_xml }}"
         xpath: "/domain/devices/interface/source"
         content: "attribute"
-
-- name: Debug extracted XML
-  ansible.builtin.debug:
-    var: _extracted_xml
 
 - name: Attach new port if needed
   vars:
@@ -91,13 +83,6 @@
   when:
     - _attached_bridges | length == 0
   block:
-    - name: Debug generated vars
-      ansible.builtin.debug:
-        msg:
-          - "{{ _net_name }}"
-          - "{{ _local_bridge_name }}"
-          - "{{ _attached_bridges }}"
-
     - name: "Generate a random MAC address for {{ vm_name }}"
       ansible.builtin.set_fact:
         _lm_mac_address: "{{ '0A:02' | community.general.random_mac }}"


### PR DESCRIPTION
Those were leftover and aren't providing any value to the deploy.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running