### PR TITLE
Try to be smarter with zuul jobs

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -44,7 +44,6 @@
       - ci_framework/roles/dlrn_report
       - ci_framework/roles/dlrn_promote
       - ci_framework/roles/devscripts
-      - ci_framework/roles/libvirt_manager
       # Other openstack operators
       - containers/ci
       - .ci-operator.yaml

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -1,7 +1,18 @@
 ---
+# Common configurations for multinode - DO NOT USE AS IS
+# this is for ci-framework usage only!
+- job:
+    name: cifmw-multinode-base
+    parent: podified-multinode-edpm-deployment-crc
+    irrelevant-files:
+      - ci_framework/roles/libvirt_manager
+      - ci_framework/roles/reproducer
+      - ci_framework/roles/devscripts
+      - Makefile
+
 - job:
     name: podified-multinode-edpm-deployment-crc-3comp
-    parent: podified-multinode-edpm-deployment-crc
+    parent: cifmw-multinode-base
     nodeset:
       nodes:
         - name: controller
@@ -92,7 +103,7 @@
 
 - job:
     name: podified-multinode-hci-deployment-crc-3comp
-    parent: podified-multinode-edpm-deployment-crc
+    parent: cifmw-multinode-base
     nodeset:
       nodes:
         - name: controller
@@ -203,7 +214,7 @@
 
 - job:
     name: podified-multinode-edpm-deployment-crc
-    parent: cifmw-podified-multinode-edpm-base-crc
+    parent: cifmw-multinode-base
     vars:
       cifmw_extras:
         - '@scenarios/centos-9/multinode-ci.yml'


### PR DESCRIPTION
We don't need any deploy job when we affect some of the roles. But we
can't ignore them from the common, base jobs, because some other jobs
are actually consuming them in some way.

This also correct a dependency issue with content-provider not beeing
kicked, while it should for the adoption job.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
