### PR TITLE
External projects want to trigger jobs on Makefile

### DIFF
--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -8,7 +8,6 @@
       - ci_framework/roles/libvirt_manager
       - ci_framework/roles/reproducer
       - ci_framework/roles/devscripts
-      - Makefile
 
 - job:
     name: podified-multinode-edpm-deployment-crc-3comp


### PR DESCRIPTION
While it makes no sense in the ci-framework project to trigger any
deploy based on Makefile changes, external projects inheriting from our
jobs may want to get this feature, such as install_yamls and
nove_operator.

We may stay as-is, since we don't modify the Makefile that often - and
finding a way out would probably be too much of an issue due to the way
parenting is working.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
