### PR TITLE
[edpm_deploy]Install dataplane services

### DIFF
--- a/ci_framework/roles/edpm_deploy/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy/tasks/main.yml
@@ -39,6 +39,24 @@
     name: 'install_yamls_makes'
     tasks_from: 'make_edpm_deploy_prep'
 
+- name: Install Dataplane services
+  vars:
+    _cifmw_edpm_deploy_service_path: >-
+      {{
+        [
+          cifmw_edpm_deploy_manifests_dir,
+          'operator/dataplane-operator',
+          'config/services'
+        ] | ansible.builtin.path_join
+      }}
+  when: not cifmw_edpm_deploy_dryrun
+  environment:
+    PATH: "{{ cifmw_path }}"
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+  ci_script:
+    output_dir: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
+    script: "oc apply -f {{ _cifmw_edpm_deploy_service_path }}"
+
 - name: Kustomize and deploy OpenStackDataPlaneNodeSet
   when:
     - not cifmw_edpm_deploy_dryrun | bool


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/install_yamls/pull/650 improves the edpm_deploy_prep target to generate crs with kustomization.

All the oc apply commands are moved to edpm_deploy target. In CI-framework job, we donot use edpm_deploy target to deploy dataplane.

We use oc apply over dataplane kustomization.
Since dataplane service config[1] are moved to edpm_deploy. So we are no longer installing these services and it will not start the edpm compute deployment due to missing services.

In order to fix this, we need to install the services in ci-framework and it will start the deployment.

Links:
[1]. https://github.com/openstack-k8s-operators/install_yamls/blame/1874191404df509e982ef48699bd5c9f12a5b8f7/Makefile#L680

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/911
