### PR TITLE
set owner and permissions for libvirt config files

### DIFF
--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -106,6 +106,7 @@
             chdir: "{{ ansible_user_dir }}/zuul-output/logs/system-config"
             cmd: |
               cp -r /etc/libvirt/*.conf libvirt/;
+              chown -R "{{ ansible_user }}" libvirt
               chown "{{ ansible_user }}" *
               cp /etc/containers/registries.conf {{ ansible_user_dir }}/zuul-output/logs/
 


### PR DESCRIPTION
Going forward libvirt will be installed on the host.
https://github.com/openstack-k8s-operators/edpm-ansible/pull/467
As part of that change we now creating the libvirtconfig files
mode "0640". As a result that now causes rsync to fail to copy the
files into the logs. To adress that this change chmods the
libvirt configs to 0644 and recursivly set the ownership.
Closes: #909

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
