### PR TITLE
Revert "Try to be smarter with zuul jobs"

### DIFF
--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -1,17 +1,7 @@
 ---
-# Common configurations for multinode - DO NOT USE AS IS
-# this is for ci-framework usage only!
-- job:
-    name: cifmw-multinode-base
-    parent: podified-multinode-edpm-deployment-crc
-    irrelevant-files:
-      - ci_framework/roles/libvirt_manager
-      - ci_framework/roles/reproducer
-      - ci_framework/roles/devscripts
-
 - job:
     name: podified-multinode-edpm-deployment-crc-3comp
-    parent: cifmw-multinode-base
+    parent: podified-multinode-edpm-deployment-crc
     nodeset:
       nodes:
         - name: controller
@@ -102,7 +92,7 @@
 
 - job:
     name: podified-multinode-hci-deployment-crc-3comp
-    parent: cifmw-multinode-base
+    parent: podified-multinode-edpm-deployment-crc
     nodeset:
       nodes:
         - name: controller
@@ -213,7 +203,7 @@
 
 - job:
     name: podified-multinode-edpm-deployment-crc
-    parent: cifmw-multinode-base
+    parent: cifmw-podified-multinode-edpm-base-crc
     vars:
       cifmw_extras:
         - '@scenarios/centos-9/multinode-ci.yml'


### PR DESCRIPTION
This partially reverts commit 4acd3782b5c5b69d3a1340a4fb5178bb9f6160d1.

This change broke hci jobs parenting. So we are reverting changes on edpm_multinode.yaml file

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
