### PR TITLE
DNM Checking if hosts are re-used by the Zuul CI

### DIFF
--- a/ci/playbooks/multinode-customizations.yml
+++ b/ci/playbooks/multinode-customizations.yml
@@ -181,6 +181,27 @@
 - name: "Add cloud-admin user on Compute"
   hosts: computes
   tasks:
+
+    - name: Check other host info
+      ansible.builtin.shell: |
+        cat /etc/machine-id
+        uptime
+
+    - name: Check if file exists to verify if VM was re-used
+      ansible.builtin.stat:
+        path: ~/used-instance
+      register: _already_used_instance
+
+    - name: Fail when instance is re-used
+      when: _already_used_instance.stat.exists
+      ansible.builtin.fail:
+        msg: "Instance is re-used!"
+
+    - name: Create a file to mark host as used
+      ansible.builtin.file:
+        path: ~/used-instance
+        state: touch
+
     - name: Create cloud-admin
       become: true
       ansible.builtin.user:


### PR DESCRIPTION
That PR is veryfying if the VMs are re-used by Zuul CI.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
