### PR TITLE
Kustomize hostName to align it with hostnames set

### DIFF
--- a/ci_framework/hooks/playbooks/fetch_compute_facts.yml
+++ b/ci_framework/hooks/playbooks/fetch_compute_facts.yml
@@ -117,6 +117,11 @@
               - target:
                   kind: OpenStackDataPlaneNodeSet
                 patch: |-
+              {% for compute_node in groups['computes'] %}
+                  - op: replace
+                    path: /spec/nodes/edpm-{{ compute_node }}/hostName
+                    value: "{{compute_node}}.ci-rdo.local"
+              {% endfor %}
                   - op: replace
                     path: /spec/nodeTemplate/ansible/ansibleVars/neutron_public_interface_name
                     value: "{{ crc_ci_bootstrap_networks_out['compute-0'].default.iface | default('') }}"


### PR DESCRIPTION
NodeSet spec hostName should be aligned with the actual hostnames set on nodes.

As a pull request owner and reviewers, I checked that:
- [ x] Appropriate testing is done and actually running