### PR TITLE
Add go.mod for files: match in data plane adoption job for meta operator

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -168,6 +168,8 @@
       - ^ci_framework/roles/repo_setup/(?!meta|README|molecule).*
       - ^ci_framework/hooks/playbooks/fetch_compute_facts.yml
       - ^zuul.d/adoption.yaml
+      - go.mod
+      - apis/go.mod
 
 - job:
     name: cifmw-data-plane-adoption-OSP-17-to-extracted-crc


### PR DESCRIPTION
```
    Add go.mod for files: match in data plane adoption job for meta operator
    
    We have data-plane-adoption-pipeline wired up in the openstack operator
    but it never runs because of the current files: match for the job which
    is specific to ci-framework. This add go.mod to files: so it will run
    when we bump any of the operators. See [1] related recent patch.
    
    [1] https://github.com/openstack-k8s-operators/ci-framework/pull/906
```

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/906

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running