### PR TITLE
Add ci_local_storage role

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -45,3 +45,6 @@
 - job:
     name: cifmw-molecule-manage_secrets
     nodeset: centos-9-crc-xl
+- job:
+    name: cifmw-molecule-ci_local_storage
+    nodeset: centos-9-crc-xl

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -117,6 +117,7 @@ dryrun
 ecdsa
 edploy
 edpm
+ee
 eno
 enp
 env
@@ -345,6 +346,7 @@ provisionserver
 pubkey
 publicdomain
 pullsecret
+pvs
 pwd
 py
 pyspelling

--- a/roles/ci_local_storage/README.md
+++ b/roles/ci_local_storage/README.md
@@ -1,0 +1,34 @@
+# ci_local_storage
+
+Ansible role to create persistent volumes on Openshift cluster needed
+by openstack services.
+
+## Privilege escalation
+If apply, please explain the privilege escalation done in this role.
+
+## Parameters
+* `cifmw_cls_basedir`:  (String) Base directory. Defaults to `"{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"`
+* `cifmw_cls_manifests_dir`: (String) Directory in where OCP manifests will be placed. Defaults to `"{{ cifmw_manifests | default(cifmw_cls_basedir ~ '/artifacts/manifests') }}/storage"`
+* `cifmw_cls_storage_class`: (String) The name of the storage class. Defaults to `local-storage`.
+* `cifmw_cls_storage_capacity`: (String) Storage capacity in GB. Defaults to `10Gi`.
+* `cifmw_cls_local_storage_name`: (String) Name of the local storage name. Defaults to `/mnt/openstack`.
+* `cifmw_cls_pv_count`: (Int) Numbers of pvs to create. Defaults to `12`.
+* `cifmw_cls_storage_provisioner`: (String) Name of the storage provisioner. Defaults to `cifmw`.
+* `cifmw_cls_create_ee_storage`: (Bool) Param to create ee_storage. Defaults to `false`.
+* `cifmw_cls_namespace`: (String) The namespace where OCP resources will be installed. Defaults to `openstack`.
+* `cifmw_cls_action`: (String) Command to creating/deleting directories on worker node. Defaults to `mkdir`.
+* `cifmw_cls_storage_manifest`:  (Dict) The storage manifest resource to be used to initiate storage class.
+
+## Examples
+```YAML
+    - hosts: localhost
+      vars:
+        cifmw_openshift_user: "kubeadmin"
+        cifmw_openshift_password: "12345678"
+        cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+        ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+        cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+      tasks:
+        - ansible.builtin.include_role:
+            name: ci_local_storage
+```

--- a/roles/ci_local_storage/defaults/main.yml
+++ b/roles/ci_local_storage/defaults/main.yml
@@ -1,0 +1,39 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_cls"
+
+cifmw_cls_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+cifmw_cls_manifests_dir: "{{ cifmw_manifests | default(cifmw_cls_basedir ~ '/artifacts/manifests') }}/storage"
+cifmw_cls_storage_class: local-storage
+cifmw_cls_storage_capacity: 10Gi
+cifmw_cls_local_storage_name: /mnt/openstack
+cifmw_cls_pv_count: 12
+cifmw_cls_storage_provisioner: cifmw
+cifmw_cls_create_ee_storage: false
+cifmw_cls_namespace: openstack
+cifmw_cls_action: "mkdir -p"
+
+cifmw_cls_storage_manifest:
+  kind: StorageClass
+  apiVersion: storage.k8s.io/v1
+  metadata:
+    name: "{{ cifmw_cls_storage_class }}"
+  provisioner: kubernetes.io/no-provisioner
+  volumeBindingMode: WaitForFirstConsumer
+  allowVolumeExpansion: true

--- a/roles/ci_local_storage/meta/main.yml
+++ b/roles/ci_local_storage/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- ci_local_storage
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: cifmw
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - cifmw
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/ci_local_storage/molecule/default/converge.yml
+++ b/roles/ci_local_storage/molecule/default/converge.yml
@@ -1,0 +1,73 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: all
+  vars:
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+    cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+    cifmw_cls_storage_provisioner: crc-devsetup
+    cifmw_cls_storage_class: molecule-storage
+    cifmw_cls_namespace: openstack
+  tasks:
+    - name: Run ci_local_storage role
+      ansible.builtin.include_role:
+        name: ci_local_storage
+
+    - name: Get all pvs
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit)}}"
+        context: "{{ cifmw_openshift_context | default(omit)}}"
+        kind: PersistentVolume
+        label_selectors:
+          - provisioned-by={{ cifmw_cls_storage_provisioner }}
+      register: _pv_info
+
+    - name: Get all pvs
+      ansible.builtin.set_fact:
+        _cls_pvs: >-
+          {{ _pv_info.resources |
+              selectattr("metadata.name", "defined") |
+              map(attribute="metadata.name")
+          }}
+
+    - name: Assert the created pvs
+      ansible.builtin.assert:
+        that:
+          - "cifmw_cls_storage_class in _cls_pvs[0]"
+
+    - name: Delete the created pvs
+      ansible.builtin.include_role:
+        name: ci_local_storage
+        tasks_from: cleanup.yml
+
+    - name: Get all namespaces
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        kind: Namespace
+      register: _ns
+
+    - name: Assert that the cifmw_cls_namespace ns is deleted
+      vars:
+        ns_names: >-
+          {{
+            _ns.resources |
+            default([]) |
+            map(attribute='metadata.name')
+          }}
+      ansible.builtin.assert:
+        that: "cifmw_cls_namespace not in ns_names"

--- a/roles/ci_local_storage/molecule/default/molecule.yml
+++ b/roles/ci_local_storage/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/roles/ci_local_storage/molecule/default/prepare.yml
+++ b/roles/ci_local_storage/molecule/default/prepare.yml
@@ -1,0 +1,25 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps
+  tasks:
+    - name: Ensure CRC is started
+      ansible.builtin.command:
+        cmd: crc start

--- a/roles/ci_local_storage/tasks/cleanup.yml
+++ b/roles/ci_local_storage/tasks/cleanup.yml
@@ -1,0 +1,79 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Get all pvs
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    kind: PersistentVolume
+    label_selectors:
+      - provisioned-by={{ cifmw_cls_storage_provisioner }}
+  register: _pv_info
+
+- name: Get all pvs
+  ansible.builtin.set_fact:
+    cifmw_cls_pvs: >-
+      {{ _pv_info.resources |
+          selectattr("metadata.name", "defined") |
+          map(attribute="metadata.name")
+      }}
+
+- name: Delete all pvs
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    kind: PersistentVolume
+    state: absent
+    api_version: v1
+    namespace: "{{ cifmw_cls_namespace }}"
+    name: "{{ item }}"
+  loop: "{{ cifmw_cls_pvs }}"
+
+- name: Get the worker nodes
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    kind: Node
+    label_selectors:
+      - node-role.kubernetes.io/worker
+  register: _node_info
+
+- name: Get all the worker nodes
+  ansible.builtin.set_fact:
+    cifmw_cls_nodes: >-
+      {{ _node_info.resources |
+          selectattr("metadata.name", "defined") |
+          map(attribute="metadata.name")
+      }}
+
+- name: Delete directories on worker nodes
+  vars:
+    cifmw_cls_action: "rm -rf"
+    _msg: "Deleting"
+  ansible.builtin.import_tasks: worker_node_dirs.yml
+
+- name: Remove the cifmw_cls_namespace namespace
+  kubernetes.core.k8s:
+    state: absent
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    kind: Namespace
+    name: "{{ cifmw_cls_namespace }}"
+    wait: true

--- a/roles/ci_local_storage/tasks/main.yml
+++ b/roles/ci_local_storage/tasks/main.yml
@@ -1,0 +1,79 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Create role needed directories
+  ansible.builtin.file:
+    path: "{{ cifmw_cls_manifests_dir }}"
+    state: directory
+
+- name: Create the cifmw_cls_namespace namespace"
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    name: "{{ cifmw_cls_namespace }}"
+    kind: Namespace
+    state: present
+
+- name: Save storage manifests as artifacts
+  ansible.builtin.copy:
+    dest: "{{ cifmw_cls_manifests_dir }}/storage-class.yaml"
+    content: "{{ cifmw_cls_storage_manifest | to_nice_yaml }}"
+
+- name: Apply the storage class manifests
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig  }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit)  }}"
+    state: present
+    src: "{{ cifmw_cls_manifests_dir }}/storage-class.yaml"
+
+- name: Get the worker nodes
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    kind: Node
+    label_selectors:
+      - node-role.kubernetes.io/worker
+  register: _node_info
+
+- name: Get all the worker nodes
+  ansible.builtin.set_fact:
+    _cls_nodes: >-
+      {{ _node_info.resources |
+          selectattr("metadata.name", "defined") |
+          map(attribute="metadata.name")
+      }}
+
+- name: Create directories on worker node
+  vars:
+    _msg: "Creating"
+  ansible.builtin.import_tasks: worker_node_dirs.yml
+
+- name: Generate pv related storage manifest file
+  ansible.builtin.template:
+    src: storage.yaml.j2
+    dest: "{{ cifmw_cls_manifests_dir }}/storage.yaml"
+    mode: "0644"
+
+- name: Apply pv related storage manifest file
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig  }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit)  }}"
+    state: present
+    src: "{{ cifmw_cls_manifests_dir }}/storage.yaml"

--- a/roles/ci_local_storage/tasks/worker_node_dirs.yml
+++ b/roles/ci_local_storage/tasks/worker_node_dirs.yml
@@ -1,0 +1,12 @@
+---
+- name: Perform operation on worker node
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.shell:
+    cmd: >-
+      oc debug node/{{ item }} -T -- chroot /host
+      /usr/bin/bash -c "for i in `seq -w -s ' ' {{ cifmw_cls_pv_count }}`;
+      do echo \"{{ _msg }} dir {{ cifmw_cls_local_storage_name }}/pv\$i on {{ item }}\";
+      {{ cifmw_cls_action }} {{ cifmw_cls_local_storage_name }}/pv\$i; done"
+  loop: "{{ _cls_nodes }}"

--- a/roles/ci_local_storage/templates/storage.yaml.j2
+++ b/roles/ci_local_storage/templates/storage.yaml.j2
@@ -1,0 +1,52 @@
+{% for node in _cls_nodes %}
+{% for pv_number in range(cifmw_cls_pv_count + 1) %}
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: {{ cifmw_cls_storage_class }}{{ pv_number }}-{{ node }}
+  annotations:
+    pv.kubernetes.io/provisioned-by: {{ cifmw_cls_storage_provisioner }}
+  labels:
+    provisioned-by: {{ cifmw_cls_storage_provisioner }}
+spec:
+  storageClassName: {{ cifmw_cls_storage_class }}
+  capacity:
+    storage: {{ cifmw_cls_storage_capacity }}
+  accessModes:
+    - ReadWriteOnce
+    - ReadWriteMany
+    - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Delete
+  local:
+    path: {{ cifmw_cls_local_storage_name }}/pv{{ pv_number }}
+    type: DirectoryOrCreate
+  volumeMode: Filesystem
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: [{{ node }}]
+{% endfor %}
+{% endfor %}
+{% if cifmw_cls_create_ee_storage | bool %}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ansible-ee-logs
+  namespace: {{ cifmw_cls_namespace }}
+  annotations:
+    pv.kubernetes.io/provisioned-by: {{ cifmw_cls_storage_provisioner }}
+spec:
+  resources:
+    requests:
+      storage: {{ cifmw_cls_storage_capacity }}
+  accessModes:
+    - ReadWriteOnce
+    - ReadWriteMany
+    - ReadOnlyMany
+  storageClassName: {{ cifmw_cls_storage_class }}
+{% endif %}

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -43,6 +43,17 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
+    - ^roles/ci_local_storage/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    name: cifmw-molecule-ci_local_storage
+    nodeset: centos-9-crc-xl
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: ci_local_storage
+- job:
+    files:
+    - ^ansible-requirements.txt
+    - ^molecule-requirements.txt
     - ^roles/ci_metallb/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-ci_metallb

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -11,6 +11,7 @@
       - cifmw-molecule-build_containers
       - cifmw-molecule-build_openstack_packages
       - cifmw-molecule-cert_manager
+      - cifmw-molecule-ci_local_storage
       - cifmw-molecule-ci_metallb
       - cifmw-molecule-ci_multus
       - cifmw-molecule-ci_netconfig


### PR DESCRIPTION
This role is similar to `make crc_storage` and `make crc_storage_cleanup` install_yamls target.
    
It will create Persistant volumes needed during openstack services deployment.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
