### PR TITLE
Add extra skip tests to nova-operator

### DIFF
--- a/roles/tempest/files/list_skipped.yml
+++ b/roles/tempest/files/list_skipped.yml
@@ -1100,6 +1100,33 @@ known_failures:
         lp: http://no.bug
     jobs:
       - nova-operator
+  - test: tempest.api.compute.volumes.test_volume_snapshots.VolumesSnapshotsTestJSON.test_volume_snapshot_create_get_list_delete
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.volumes.test_volumes_get.VolumesGetTestJSON.test_volume_create_get_delete
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.volumes.test_volumes_list.VolumesTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
   # TODO (rlandy) remove when https://issues.redhat.com/browse/OSPCIX-126 is fixed
   - test: tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_mtu_sized_frames
     deployment:


### PR DESCRIPTION
Add additional tempest tests to exclude from the nova-operator that are currently not supported with default deployment.

As a pull request owner and reviewers, I checked that:

- [x] Appropriate testing is done and actually running
