### PR TITLE
Install python3-pip package in e2e-prepare.yml

### DIFF
--- a/ci/playbooks/e2e-prepare.yml
+++ b/ci/playbooks/e2e-prepare.yml
@@ -7,10 +7,6 @@
       ansible.builtin.include_role:
         name: prepare-workspace
 
-    - name: Output pip related things
-      ansible.builtin.command:
-        cmd: pip --version
-
     - name: Create zuul-output directory
       ansible.builtin.file:
         path: "{{ ansible_user_dir }}/zuul-output/logs"
@@ -24,6 +20,11 @@
           - make
           - python3
           - podman
+          - python3-pip
+
+    - name: Output pip related things
+      ansible.builtin.command:
+        cmd: pip --version
 
     - name: Install requirements
       community.general.make:


### PR DESCRIPTION
This package is no longer installed by default
on all RHEL platforms.
Also switched the order of checking the pip
version until after the installation.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
