### PR TITLE
Use proper periodic repos in periodic jobs

### DIFF
--- a/ci_framework/hooks/playbooks/fetch_compute_facts.yml
+++ b/ci_framework/hooks/playbooks/fetch_compute_facts.yml
@@ -1,4 +1,17 @@
 ---
+- name: Sync repos for controller to compute for periodic jobs
+  hosts: computes
+  gather_facts: true
+  tasks:
+    - name: Copy repositories from controller to computes
+      when:
+        - zuul is defined
+        - "'periodic' in zuul.job"
+      become: true
+      ansible.builtin.copy:
+        dest: "/etc/yum.repos.d/"
+        src: "{{ cifmw_basedir }}/artifacts/repositories/"
+
 - name: Build dataset hook
   hosts: localhost
   gather_facts: false
@@ -214,6 +227,12 @@
                   - op: add
                     path: /spec/nodeTemplate/ansible/ansibleVars/edpm_container_registry_insecure_registries
                     value: ["{{ content_provider_registry_ip }}:5001"]
+              {% endif %}
+
+              {% if zuul is defined and 'periodic' in zuul.job %}
+                  - op: remove
+                    path: /spec/services/0
+                    value: repo-setup
               {% endif %}
 
 


### PR DESCRIPTION
Currently we use install_yamls dataplane_v1beta1_openstackdataplaneservice_reposetup.yaml service to lay down repos on edpm nodes. It will populate dlrn repos with current-podified antelope branch. We donot need these repos in periodic jobs. Otherwise we will issue mentioned in https://issues.redhat.com/browse/OSPCIX-132.

This pr fixes multiple things to address the above issue:
- We generate proper repos on controller, it needs to be copied on compute node in periodic EDPM jobs. Then we also need to disable repo-setup services coming from edpm_deploy_prep make target. It will make sure proper periodic repos are enabled on extracted crc edpm job.

- In BM job, we need to update the dataplane_v1beta1_openstackdataplaneservice_reposetup.yaml service file to pull proper repos based on branch and tag.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

