### PR TITLE
Patch BM nodeset to update all packages during bootstrap phase

### DIFF
--- a/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -196,6 +196,20 @@
             "path": "/spec/nodeTemplate/ansible/ansibleVars/edpm_container_registry_insecure_registries",
             "value": [{{ content_provider_registry_ip }}:5001]}]'
 
+- name: Patch OpenStackDataPlaneNodeSet resource to update bootstrap packages
+  when: not cifmw_edpm_deploy_baremetal_dry_run
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: >-
+      oc patch openstackdataplanenodeset openstack-edpm-ipam
+      -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+      --type json
+      -p '[{"op": "add",
+            "path": "/spec/nodeTemplate/ansible/ansibleVars/edpm_bootstrap_command",
+            "value": "sudo dnf -y update"}]'
+
 - name: Wait for OpenStackDataPlaneNodeSet to be Ready
   when: not cifmw_edpm_deploy_baremetal_dry_run
   environment:


### PR DESCRIPTION
In baremetal EDPM job, we use EDPM image to create EDPM node. it has all the required packages pre-installed during image build process.

If an older version of package got included during the image build process. Then during edpm_deploy, bootstrap role is not going to update the package to latest.

It is not advisable to use latest package installation from edpm-ansible bootstrap ansible role.

For CI case, we use edpm_bootstrap_command to update all the packages.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

