### PR TITLE
Quickstart

### DIFF
--- a/ci/playbooks/multinode-customizations.yml
+++ b/ci/playbooks/multinode-customizations.yml
@@ -129,12 +129,12 @@
 
     - name: Generate an ssh keypair
       ansible.builtin.command:
-        cmd: ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -P ''
+        cmd: ssh-keygen -t ecdsa -f ~/.ssh/id_cifw -P ''
 
     - name: Get public key
       register: pub_key_slurp
       ansible.builtin.slurp:
-        path: "{{ ansible_user_dir }}/.ssh/id_ed25519.pub"
+        path: "{{ ansible_user_dir }}/.ssh/id_cifw.pub"
 
     - name: Register pub key as a fact
       ansible.builtin.set_fact:

--- a/docs/source/reproducers/03-zuul.md
+++ b/docs/source/reproducers/03-zuul.md
@@ -155,7 +155,7 @@ instance.
 
 #### Access to the virtual machines
 Your local ssh configuration file will be modified by the reproducer in order to offer
-an easy access to the nodes: `ssh controller-0`, `ssh core@crc-0`, `ssh compute-0` and
+an easy access to the nodes: `ssh controller-0`, `ssh crc-0`, `ssh compute-0` and
 so on will work right out of the box.
 
 ### Specific parameters

--- a/hooks/playbooks/fetch_compute_facts.yml
+++ b/hooks/playbooks/fetch_compute_facts.yml
@@ -102,7 +102,7 @@
           vars:
             dns_servers: "{{ ((['192.168.122.10'] + ansible_facts['dns']['nameservers']) | unique)[0:2] }}"
             edpm_install_yamls_vars:
-              SSH_KEY_FILE: "{{ ansible_user_dir }}/.ssh/id_ed25519"
+              SSH_KEY_FILE: "{{ ansible_user_dir }}/.ssh/id_cifw"
               DATAPLANE_COMPUTE_IP: >-
                 {{
                   crc_ci_bootstrap_networks_out['compute-0'].default.ip4 |

--- a/roles/devscripts/tasks/sub_tasks/14_user.yml
+++ b/roles/devscripts/tasks/sub_tasks/14_user.yml
@@ -32,7 +32,7 @@
     comment: "cifmw generated key for ocp access"
     path: >-
       {{ cifmw_devscripts_artifacts_dir }}/cifmw_ocp_access_key
-    type: "ed25519"
+    type: "ecdsa"
   register: cifmw_devscripts_ssh_key
 
 - name: Verify sudoers privileges

--- a/roles/hive/README.md
+++ b/roles/hive/README.md
@@ -100,7 +100,7 @@ cifmw_hive_namespace: openstack
 cifmw_hive_baremetal:
   cluster_name: unittest-01
   install_config: "{{ ansible_user_dir }}/install_config.yml"
-  ssh_key: 'ssh-ed25519 ...REDACTED'
+  ssh_key: 'ssh-cifw ...REDACTED'
   ocp_image: "quay.io/openshift-release-dev/ocp-release:4.13.0-x86_64"
 
 cifmw_operator_build_push_registry: "default-route-openshift-image-registry.unittest-01.openstack.ccitredhat.com"
@@ -161,7 +161,7 @@ platform:
                 enabled: true
                 dhcp: true
 pullSecret: ''
-sshKey: 'ssh-ed25519 ...'
+sshKey: 'ssh-cifw ...'
 ```
 
 ## Reference

--- a/roles/hive/molecule/default/converge.yml
+++ b/roles/hive/molecule/default/converge.yml
@@ -56,11 +56,11 @@
             state: touch
             mode: "0644"
 
-        - name: Testing requirements - root ed25519 ssh key
-          register: root_ed25519_key
+        - name: Testing requirements - root ecdsa ssh key
+          register: root_cifw_key
           community.crypto.openssh_keypair:
-            path: "{{ cifmw_hive_artifacts_dir }}/id_ed25519_root"
-            type: ed25519
+            path: "{{ cifmw_hive_artifacts_dir }}/id_cifw_root"
+            type: ecdsa
 
         - name: Including the role with right values
           vars:
@@ -68,7 +68,7 @@
             cifmw_hive_action: deploy_cluster
             cifmw_opn_host: 127.0.10.10
             cifmw_opn_user: kni
-            cifmw_opn_user_ssh_key: "{{ root_ed25519_key }}"
+            cifmw_opn_user_ssh_key: "{{ root_cifw_key }}"
             cifmw_opn_host_ssh_key: "ssh - some-known-hosts-key"
             cifmw_opn_bootstrap_boot_mac: "aa:ff:ee"
             cifmw_opn_external_bridge_name: "baremetal"
@@ -79,7 +79,7 @@
               cluster_name: "unittest-01"
               install_config: "files/foo_bm_install_config.yml"
               ocp_image: "registry.foo/openshift-release/ocp-fake:latest"
-              ssh_key: "{{ root_ed25519_key.public_key }}"
+              ssh_key: "{{ root_cifw_key.public_key }}"
           ansible.builtin.include_role:
             role: hive
 

--- a/roles/hive/molecule/default/files/foo_bm_install_config.yml
+++ b/roles/hive/molecule/default/files/foo_bm_install_config.yml
@@ -28,4 +28,4 @@ platform:
           password: bar
         bootMACAddress: aa-60-db-b2-3c-ff
 pullSecret: ''
-sshKey: 'ssh-ed25519 '
+sshKey: 'ssh-cifw '

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -61,7 +61,7 @@
 - name: Create temporary ssh keypair
   community.crypto.openssh_keypair:
     path: "{{ ansible_user_dir }}/.ssh/cifmw_reproducer_key"
-    type: "ed25519"
+    type: "ecdsa"
     regenerate: full_idempotence
 
 - name: Slurp public key for later use

--- a/roles/libvirt_manager/tasks/start_manage_vms.yml
+++ b/roles/libvirt_manager/tasks/start_manage_vms.yml
@@ -162,7 +162,7 @@
   delegate_to: "{{ vm_ip.nic.host }}"
   remote_user: "{{ _init_admin_user }}"
   ansible.builtin.copy:
-    dest: "/home/zuul/.ssh/id_ed25519"
+    dest: "/home/zuul/.ssh/id_cifw"
     content: "{{ priv_key }}"
     owner: zuul
     group: zuul
@@ -178,7 +178,7 @@
   delegate_to: "{{ vm_ip.nic.host }}"
   remote_user: "{{ _init_admin_user }}"
   ansible.builtin.copy:
-    dest: "/home/zuul/.ssh/id_ed25519.pub"
+    dest: "/home/zuul/.ssh/id_cifw.pub"
     content: "{{ pub_key }}"
     owner: zuul
     group: zuul

--- a/roles/libvirt_manager/tasks/start_manage_vms.yml
+++ b/roles/libvirt_manager/tasks/start_manage_vms.yml
@@ -54,7 +54,7 @@
       Host {{ vm_ip.nic.host }} cifmw-{{ vm_ip.nic.host }} {{ extracted_ip }}
         ProxyJump {{ ansible_user | default(lookup('env', 'USER')) }}@{{ proxy_hostname }}
         Hostname {{ extracted_ip }}
-        User zuul
+        User {{ 'core' if vm_ip.nic.host.startswith('crc') else 'zuul' }}
         StrictHostKeyChecking no
         UserKnownHostsFile /dev/null
   loop: "{{ vm_ips.results }}"
@@ -78,7 +78,7 @@
     block: |-
       Host {{ vm_ip.nic.host }} cifmw-{{ vm_ip.nic.host }} {{ extracted_ip }}
         Hostname {{ extracted_ip }}
-        User zuul
+        User {{ 'core' if vm_ip.nic.host.startswith('crc') else 'zuul' }}
         IdentityFile {{ identity_file }}
         StrictHostKeyChecking no
         UserKnownHostsFile /dev/null

--- a/roles/libvirt_manager/vars/main.yml
+++ b/roles/libvirt_manager/vars/main.yml
@@ -22,14 +22,15 @@
 # All variables within this role should have a prefix of "cifmw_libvirt_manager"
 
 cifmw_libvirt_manager_dependency_packages:
+  - guestfs-tools
+  - libguestfs
   - libvirt
   - libvirt-client
   - libvirt-daemon
   - libvirt-daemon-kvm
-  - virt-install
+  - python3-lxml
   - qemu-kvm
-  - libguestfs
-  - guestfs-tools
+  - virt-install
 
 cifmw_libvirt_manager_polkit_rules_dir: /etc/polkit-1/rules.d
 cifmw_libvirt_manager_polkit_rules_file: "{{ cifmw_libvirt_manager_polkit_rules_dir }}/80-libvirt-manage.rules"

--- a/roles/libvirt_manager/vars/main.yml
+++ b/roles/libvirt_manager/vars/main.yml
@@ -30,6 +30,9 @@ cifmw_libvirt_manager_dependency_packages:
   - libvirt-daemon-kvm
   - python3-lxml
   - qemu-kvm
+  - rsync
+  - tar
+  - unzip
   - virt-install
 
 cifmw_libvirt_manager_polkit_rules_dir: /etc/polkit-1/rules.d

--- a/roles/openshift_provisioner_node/tasks/add_user.yml
+++ b/roles/openshift_provisioner_node/tasks/add_user.yml
@@ -29,8 +29,8 @@
   tags:
     - bootstrap
   community.crypto.openssh_keypair:
-    path: "{{ cifmw_opn_artifacts_dir }}/{{ cifmw_opn_user }}_id_ed25519"
-    type: "ed25519"
+    path: "{{ cifmw_opn_artifacts_dir }}/{{ cifmw_opn_user }}_id_cifw"
+    type: "ecdsa"
   register: cifmw_opn_user_ssh_key
   delegate_to: localhost
 

--- a/roles/reproducer/tasks/push_code.yml
+++ b/roles/reproducer/tasks/push_code.yml
@@ -7,6 +7,24 @@
   delegate_to: controller-0
   delegate_facts: true
   block:
+    - name: Check if repository directories already exist
+      when: job_id is defined
+      ansible.builtin.stat:
+        path: "{{ item.project.src_dir }}"
+      register: repos_dir_stats
+      with_items: "{{ zuul['items'] }}"
+
+    - name: Ensure we are not in the job_id branch
+      when:
+        - repos_dir_stats is defined
+        - item.1.stat.exists
+      ansible.builtin.git:
+        dest: "{{ item.0.project.src_dir }}"
+        repo: "https://{{ item.0.project.canonical_name }}"
+        version: "origin/main"
+        force: true
+      loop: "{{ zuul['items'] | zip(repos_dir_stats.results) | list }}"
+
     - name: Fetch zuul.items repositories
       ansible.builtin.git:
         dest: "{{ repo.project.src_dir }}"

--- a/roles/rhol_crc/vars/main.yml
+++ b/roles/rhol_crc/vars/main.yml
@@ -23,6 +23,7 @@
 
 # https://access.redhat.com/documentation/en-us/red_hat_openshift_local/2.14/html/getting_started_guide/installation_gsg#required-software-packages_gsg
 cifmw_rhol_crc_dependency_packages:
+  - python3-lxml
   - NetworkManager
 
 cifmw_rhol_crc_sudoers_file_name: rhol_crc

--- a/scripts/setup_env
+++ b/scripts/setup_env
@@ -37,21 +37,22 @@ SYSTEM_PIP=$(dirname "$PYTHON_EXEC")/pip3
 # Install the requirements we need to run local tests
 command -v gcc || sudo dnf -y install gcc
 
-PIP='pip3'
 PIP_INSTALL_ARGUMENTS="-U -r ${PROJECT_DIR}/common-requirements.txt"
 case ${USE_VENV} in
     y|yes|true)
         PIP="${HOME}/test-python/bin/pip3"
         USE_VENV='yes'
-        PIP_INSTALL_ARGUMENTS="${PIP_INSTALL_ARGUMENTS}"
         echo
         echo ### USING VIRTUALENV
         echo
         ;;
-    'n|no|false')
+    *)
         PIP="pip3"
         USE_VENV='no'
-        PIP_INSTALL_ARGUMENTS="--user ${PIP_INSTALL_ARGUMENTS}"
+        # Gate jobs don't have /root/.local/bin in PATH, so install globally
+        if [ "$(whoami)" != "root" ]; then
+            PIP_INSTALL_ARGUMENTS="--user ${PIP_INSTALL_ARGUMENTS}"
+        fi
         echo
         echo ### NO VENV - may break your system!
         echo

--- a/scripts/setup_molecule
+++ b/scripts/setup_molecule
@@ -25,13 +25,19 @@ export PROJECT_DIR="$(dirname $(dirname $(readlink -f ${BASH_SOURCE[0]})))"
 #                  system ansible may be installed.
 export ANSIBLE_SKIP_CONFLICT_CHECK=1
 
-PIP='pip3'
-GALAXY='ansible-galaxy'
 PIP_INSTALL_ARGUMENTS="-U -r ${PROJECT_DIR}/test-requirements.txt"
 case ${USE_VENV-'yes'} in
     y|yes|true)
         GALAXY="${HOME}/test-python/bin/ansible-galaxy"
         PIP="${HOME}/test-python/bin/pip3"
+        ;;
+    *)
+        PIP='pip3'
+        GALAXY='ansible-galaxy'
+        # Gate jobs don't have /root/.local/bin in PATH, so install globally
+        if [ "$(whoami)" != "root" ]; then
+            PIP_INSTALL_ARGUMENTS="--user ${PIP_INSTALL_ARGUMENTS}"
+        fi
         ;;
 esac
 

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -145,7 +145,7 @@
       registry_login_enabled: true
       push_registry: quay.rdoproject.org
       quay_login_secret_name: quay_nextgen_zuulgithubci
-      cifmw_artifacts_crc_sshkey: "~/.ssh/id_ed25519"
+      cifmw_artifacts_crc_sshkey: "~/.ssh/id_cifw"
       cifmw_openshift_user: kubeadmin
       cifmw_openshift_password: "123456789"
       cifmw_openshift_api: api.crc.testing:6443


### PR DESCRIPTION
This PR fixes issues when running the lightweight deployment as described on the quickstart guide on host that have very few packages installed.

Issues found and fixed are:

- Hypervisor host needed `tar` and `rsync` to be present which was not mentioned in the docs.
- `setup_env` was failing when working on virtualenv because it was trying to use `pip` from the host
- A couple of roles were missing the `python-lxml` dependency because the ansible role documentation for the `community.libvirt` collection is incorrect.
- Change SSH key algorithm from `ed25519` to `ecdsa` to avoid failing with FIPS enabled.

This PR also changes the default user for the CRC VM so it uses `core`, which is the right user.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running: I deployed with the changed code
- [x] Appropriate documentation exists and/or is up-to-date: I added the dependencies for the hypervisor host