### PR TITLE
Initialise NodeSet /spec/env

### DIFF
--- a/ci_framework/hooks/playbooks/fetch_compute_facts.yml
+++ b/ci_framework/hooks/playbooks/fetch_compute_facts.yml
@@ -159,6 +159,10 @@
 
                   - op: add
                     path: /spec/env
+                    value: {}
+
+                  - op: add
+                    path: /spec/env
                     value:
                       - name: "ANSIBLE_VERBOSITY"
                         value: "2"


### PR DESCRIPTION
This change ensures the /spec/env dictionary exists before trying to append values to it with kustomize.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
