### PR TITLE
Install cert-manager operator from community operators

### DIFF
--- a/ci_framework/roles/cert_manager/defaults/main.yml
+++ b/ci_framework/roles/cert_manager/defaults/main.yml
@@ -21,7 +21,7 @@
 cifmw_cert_manager_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_cert_manager_manifests_dir: "{{ cifmw_manifests | default(cifmw_cert_manager_basedir ~ '/artifacts/manifests') }}/cert-manager"
 cifmw_cert_manager_operator_namespace: cert-manager-operator
-cifmw_cert_manager_openshift_version: stable-v1
+cifmw_cert_manager_openshift_version: stable
 
 cifmw_cert_manager_olm_operator_group:
   apiVersion: operators.coreos.com/v1
@@ -37,7 +37,7 @@ cifmw_cert_manager_olm_operator_group:
       - "{{ cifmw_cert_manager_operator_namespace }}"
     upgradeStrategy: Default
 
-cifmw_cert_manager_subscription_source: redhat-operators
+cifmw_cert_manager_subscription_source: community-operators
 cifmw_cert_manager_subscription_sourcenamespace: openshift-marketplace
 
 cifmw_cert_manager_olm_subscription:


### PR DESCRIPTION
Currently we are installing cert-manager from redhat-operators. Let's try using community-operators.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running

