### PR TITLE
Revert "Patch BM nodeset to update all packages during bootstrap phase"

### DIFF
--- a/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -196,20 +196,6 @@
             "path": "/spec/nodeTemplate/ansible/ansibleVars/edpm_container_registry_insecure_registries",
             "value": [{{ content_provider_registry_ip }}:5001]}]'
 
-- name: Patch OpenStackDataPlaneNodeSet resource to update bootstrap packages
-  when: not cifmw_edpm_deploy_baremetal_dry_run
-  environment:
-    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-    PATH: "{{ cifmw_path }}"
-  ansible.builtin.command:
-    cmd: >-
-      oc patch openstackdataplanenodeset openstack-edpm-ipam
-      -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
-      --type json
-      -p '[{"op": "add",
-            "path": "/spec/nodeTemplate/ansible/ansibleVars/edpm_bootstrap_command",
-            "value": "sudo dnf -y update"}]'
-
 - name: Wait for OpenStackDataPlaneNodeSet to be Ready
   when: not cifmw_edpm_deploy_baremetal_dry_run
   environment:


### PR DESCRIPTION
Reverts openstack-k8s-operators/ci-framework#936

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/518

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running