### PR TITLE
[ci_kustomize]Allow loading non local files

### DIFF
--- a/ci_framework/plugins/action/ci_kustomize.py
+++ b/ci_framework/plugins/action/ci_kustomize.py
@@ -311,7 +311,15 @@ def sha1_file(file_path: typing.Union[str, os.PathLike]) -> str:
 
 
 class CifmwKustomizeWrapper:
-    __CI_KUSTOMIZE_CMD_OPTS = [".", "-o"]
+    # NOTE(gibi): the "-o" opt needs to be the last one in the list as
+    # the output dir appended to the command line after it by
+    # __create_kustomize_build_command()
+    __CI_KUSTOMIZE_CMD_OPTS = [
+        ".",
+        "--load-restrictor",
+        "LoadRestrictionsNone",
+        "-o",
+    ]
     __CI_KUSTOMIZE_TOOLS_OPTS = {"kustomize": ["build"], "oc": ["kustomize"]}
     __CI_KUSTOMIZE_WORKSPACE_DIR_NAME = "cifmw-kustomize-workspace"
     __CI_KUSTOMIZE_FILES_GLOB_EXPRESSIONS = ["*.yaml", "*.yml"]


### PR DESCRIPTION
By default kustomize restrict file loading to directory tree under the kustomization workspace. However the ci_kustomize action relocates the kustomization workspace generated by instal_yamls' edpm_deploy_prep target. That relocation is selective and only moves the manifests but not other files. So when edpm_deploy_prep generate a congfigMapGenerator kustomization that references local files in it kustomization workspace such file is not relocated to the new workspace used by ci_kustomize. The install_yamls uses absolute file paths in the configMapGenerator so the relocation does not break the accessibility of the extra files. But the default behavior of kustomize does not allow loading the file with the error:
```
  "error": "loading KV pairs: file sources:
  [25-nova-extra.conf=/home/zuul/ci-framework-data/artifacts/manifests/openstack/dataplane/cr/25-nova-extra.conf]:
  security; file '/home/zuul/ci-framework-data/artifacts/manifests/openstack/dataplane/cr/25-nova-extra.conf'
  is not in or below '/home/zuul/ci-framework-data/artifacts/manifests/openstack/dataplane/cr/cifmw-kustomize-workspace'"
```

This PR adds `-load-restrictor LoadRestrictionsNone` to the kustomize call done by ci_kustomize to allow loading the file.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
