### PR TITLE
Fix the kinit command syntax in dlrn promote role

### DIFF
--- a/ci_framework/roles/dlrn_report/tasks/dlrn_report_results.yml
+++ b/ci_framework/roles/dlrn_report/tasks/dlrn_report_results.yml
@@ -12,8 +12,8 @@
   ansible.builtin.command:
     cmd: >-
       kinit
-      -k {{ cifmw_dlrn_report_krb_user_realm }}
-      -t {{ cifmw_dlrn_report_keytab }}
+      {{ cifmw_dlrn_report_krb_user_realm }}
+      -k -t {{ cifmw_dlrn_report_keytab }}
   when: cifmw_dlrn_report_kerberos_auth|bool
 
 - name: Report results to dlrn for the tested hash


### PR DESCRIPTION
In order to use keytab with kinit, the correct command is kinit <kinit realm> -k -t <path to key tab file>.

-k is used use keytab and -t to use provide the keytab path.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
