### PR TITLE
Ensure we clean ssh config entries

### DIFF
--- a/ci_framework/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/clean_layout.yml
@@ -33,6 +33,29 @@
     uri: "qemu:///system"
   loop: "{{ cleanup_vms }}"
 
+- name: "(localhost) Clean ssh jumpers"
+  when:
+    - inventory_hostname != 'localhost'
+  delegate_to: localhost
+  vars:
+    vm: "{{ item | replace('cifmw-', '') }}"
+  ansible.builtin.blockinfile:
+    path: "{{ lookup('env', 'HOME') }}/.ssh/config"
+    marker: "## {mark} {{ vm }}"
+    state: absent
+    create: true
+  loop: "{{ cleanup_vms }}"
+
+- name: "({{ inventory_hostname }}) Clean ssh jumpers"  # noqa: name[template]
+  vars:
+    vm: "{{ item | replace('cifmw-', '') }}"
+  ansible.builtin.blockinfile:
+    path: "{{ ansible_user_dir }}/.ssh/config"
+    marker: "## {mark} {{ vm }}"
+    state: absent
+    create: true
+  loop: "{{ cleanup_vms }}"
+
 - name: Get network list
   register: nets_list
   community.libvirt.virt_net:


### PR DESCRIPTION
Until now, we were keeping the ~/.ssh/config entries, leading to
potential confusion and errors.

With this patch, we ensure we remove all of the entries, ensuring we are
back in a clean state.

In order to do so, we don't need to actual block content, using the
"mark" is sufficient.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
