### PR TITLE
Support TLS for RGW

### DIFF
--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -253,6 +253,9 @@
         tasks_from: monitoring
       vars:
         cifmw_cephadm_monitoring_network: "{{ lookup('ansible.builtin.ini', 'public_network section=global file=' ~ cifmw_cephadm_bootstrap_conf) }}"
+        cifmw_cephadm_dashboard_crt: "{{ cifmw_cephadm_certificate }}"
+        cifmw_cephadm_dashboard_key: "{{ cifmw_cephadm_key }}"
+
 
     - name: Create cephfs volume
       ansible.builtin.import_role:

--- a/roles/cifmw_cephadm/README.md
+++ b/roles/cifmw_cephadm/README.md
@@ -57,15 +57,15 @@ need to be changed for a typical EDPM deployment.
  `cifmw_cephadm_certs`: The path on the ceph host where TLS/SSL certificates
    are located. It points to '/etc/pki/tls'
 
-* `cifmw_cephadm_dashboard_crt`: The SSL/TLS certificate signed by CA which is
-   an optional parameter. If it is provided, ceph dashboard will be configured
-   for SSL automatically. Certificate should be made available in
+* `cifmw_cephadm_certificate`: The SSL/TLS certificate signed by CA which is
+   an optional parameter. If it is provided, ceph dashboard and rgw will be
+   configured for SSL automatically. Certificate should be made available in
    `cifmw_cephadm_certs` path only. To enable SSL for dashboard, both
-   `cifmw_cephadm_dashboard_crt` and `cifmw_cephadm_dashboard_key` are needed.
+   `cifmw_cephadm_certificate` and `cifmw_cephadm_key` are needed.
 
-* `cifmw_cephadm_dashboard_key`: The SSL/TLS certificate key which is an
-   optional parameter. If it is provided, ceph dashboard will be configured
-   for SSL automatically.
+* `cifmw_cephadm_key`: The SSL/TLS certificate key which is an
+   optional parameter. If it is provided, ceph dashboard and rgw will be
+   configured for SSL automatically.
 
 * `cifmw_cephadm_monitoring_network`: the Ceph `public_network` where the
    dashboard monitoring stack instances should be bound. The network range

--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -90,8 +90,8 @@ cifmw_ceph_rgw_config:
 cifmw_cephadm_cephfs_name: "cephfs"
 cifmw_cephadm_ceph_spec_fqdn: "{{ ceph_spec_fqdn | default(false) | bool }}"
 cifmw_ceph_dashboard_spec_path: /tmp/ceph_dashboard.yml
-cifmw_cephadm_dashboard_crt: ""
-cifmw_cephadm_dashboard_key: ""
+cifmw_cephadm_certificate: ""
+cifmw_cephadm_key: ""
 cifmw_cephadm_dashboard_port: 8444
 cifmw_cephadm_grafana_admin_user: 'admin'
 cifmw_cephadm_grafana_admin_password: '/home/grafana_password.yml'

--- a/roles/cifmw_cephadm/tasks/rgw.yml
+++ b/roles/cifmw_cephadm/tasks/rgw.yml
@@ -29,6 +29,19 @@
     _hosts: "{{ _hosts|default([]) + [ hostvars[item][ceph_hostname_var] ] }}"
   loop: "{{ groups['edpm'] }}"
 
+- name: Get and save TLS certificate for rgw spec if provided
+  when: cifmw_cephadm_certificate | length > 0 and
+        cifmw_cephadm_key | length > 0
+  block:
+    - name: Get the certificate content
+      register: slurp_cert
+      ansible.builtin.slurp:
+        src: "{{ cifmw_cephadm_certificate }}"
+
+    - name: Set rgw_frontend_cert for rgw spec
+      ansible.builtin.set_fact:
+        rgw_frontend_cert: "{{ slurp_cert['content'] | b64decode }}"
+
 - name: Create a Ceph RGW spec
   ansible.builtin.template:
     src: templates/ceph_rgw.yml.j2

--- a/roles/cifmw_cephadm/templates/ceph_rgw.yml.j2
+++ b/roles/cifmw_cephadm/templates/ceph_rgw.yml.j2
@@ -13,6 +13,11 @@ spec:
   rgw_frontend_port: 8082
   rgw_realm: default
   rgw_zone: default
+{% if rgw_frontend_cert is defined %}
+  ssl: true
+  rgw_frontend_ssl_certificate: |
+    {{ rgw_frontend_cert | indent( width=4 ) }}
+{% endif %}
 ---
 service_type: ingress
 service_id: rgw.default
@@ -26,3 +31,7 @@ spec:
   virtual_ip: {{ cifmw_cephadm_rgw_vip }}
   virtual_interface_networks:
   - {{ cifmw_cephadm_rgw_network }}
+{% if rgw_frontend_cert is defined %}
+  ssl_cert: |
+    {{ rgw_frontend_cert | indent( width=4 ) }}
+{% endif %}


### PR DESCRIPTION
With this patch, during cifmw ceph deployment, rgw deployment includes the TLS certificate if it is passed.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
