### PR TITLE
libvirt manager/multi hypervisor

### DIFF
--- a/ci_framework/roles/libvirt_manager/README.md
+++ b/ci_framework/roles/libvirt_manager/README.md
@@ -47,6 +47,7 @@ cifmw_libvirt_manager_configuration:
       memory: (integer, RAM amount in GB. Optional, defaults to 2)
       cpus: (integer, amount of CPU. Optional, defaults to 2)
       nets: (ordered list of networks to connect to)
+      target: (Hypervisor hostname you want to deploy the family on. Optional)
   networks:
     net_name: <XML definition of the network to create>
 ```

--- a/ci_framework/roles/libvirt_manager/molecule/deploy_layout/cleanup.yml
+++ b/ci_framework/roles/libvirt_manager/molecule/deploy_layout/cleanup.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright Red Hat, Inc.
+# Copyright 2023 Red Hat, Inc.
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -14,21 +14,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
-- name: Prepare
+- name: Cleanup
   hosts: instance
-  vars:
-    cifmw_basedir: "/opt/basedir"
-  pre_tasks:
-    - name: Create custom basedir
-      become: true
-      ansible.builtin.file:
-        path: "{{ cifmw_basedir }}"
-        state: directory
-        owner: zuul
-        group: zuul
-        mode: "0755"
-  roles:
-    - role: "test_deps"
-    - role: "ci_setup"
-    - role: "libvirt_manager"
+  gather_facts: true
+  tasks:
+    - name: Clean layout
+      ansible.builtin.import_role:
+        name: libvirt_manager
+        tasks_from: clean_layout.yml

--- a/ci_framework/roles/libvirt_manager/molecule/deploy_layout/converge.yml
+++ b/ci_framework/roles/libvirt_manager/molecule/deploy_layout/converge.yml
@@ -15,7 +15,7 @@
 # under the License.
 
 - name: Converge
-  hosts: all
+  hosts: instance
   gather_facts: true
   vars:
     ansible_user_dir: "{{ lookup('env', 'HOME') }}"
@@ -43,13 +43,16 @@
           image_local_dir: "{{ cifmw_basedir }}/images/"
           disk_file_name: "centos-stream-9.qcow2"
           disksize: 20
-          memory: 4
-          cpus: 2
+          memory: 1
+          cpus: 1
           nets:
             - public
             - osp_trunk
         baremetal:
           amount: 1
+          disksize: 10
+          memory: 1
+          cpus: 1
           disk_file_name: 'blank'
           nets:
             - public
@@ -214,3 +217,119 @@
               ansible.builtin.assert:
                 that:
                   - cmp_1.host.ip == '192.168.140.101'
+
+- name: Cleanup
+  hosts: instance
+  tasks:
+    - name: Clean layout
+      ansible.builtin.import_role:
+        name: libvirt_manager
+        tasks_from: clean_layout.yml
+
+- name: Inject fake hosts in inventory
+  hosts: instance
+  tasks:
+    - name: Inject compute-0 in inventory
+      ansible.builtin.add_host:
+        name: compute-0
+        ansible_host: localhost
+        ansible_connection: local
+
+    - name: Inject compute-1 in inventory
+      ansible.builtin.add_host:
+        name: compute-1
+        ansible_host: localhost
+        ansible_connection: local
+
+- name: Converge
+  hosts: all
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_basedir: "/opt/basedir"
+    cifmw_libvirt_manager_vm_net_ip_set:
+      computecp0: 100
+      computecp1: 110
+    cifmw_libvirt_manager_networks:
+      osp_trunk:
+        default: true
+        range: "192.168.140.0/24"
+        mtu: 1500
+        static_ip: true
+      public:
+        range: "192.168.100.0/24"
+      internal-api:
+        range: "172.17.0.0/24"
+        vlan: 20
+    cifmw_libvirt_manager_configuration:
+      vms:
+        computecp0:
+          target: compute-0
+          amount: 1
+          disk_file_name: "blank"
+          disksize: 20
+          memory: 1
+          cpus: 1
+          nets:
+            - public
+            - osp_trunk
+        computecp1:
+          target: compute-1
+          amount: 1
+          disk_file_name: "blank"
+          disksize: 20
+          memory: 1
+          cpus: 1
+          nets:
+            - public
+            - osp_trunk
+      networks:
+        public: |-
+          <network>
+            <name>public</name>
+            <forward mode='nat'/>
+            <bridge name='public' stp='on' delay='0'/>
+            <ip
+             family='ipv4'
+             address='{{ cifmw_libvirt_manager_networks.public.range | ansible.utils.nthhost(1) }}'
+             prefix='24'>
+              <dhcp>
+                <range start='{{ cifmw_libvirt_manager_networks.public.range | ansible.utils.nthhost(10) }}'
+                end='{{ cifmw_libvirt_manager_networks.public.range | ansible.utils.nthhost(100) }}'/>
+              </dhcp>
+            </ip>
+          </network>
+        osp_trunk: |-
+          <network>
+            <name>osp_trunk</name>
+            <forward mode='nat'/>
+            <bridge name='osp_trunk' stp='on' delay='0'/>
+            <ip
+             family='ipv4'
+             address='{{ cifmw_libvirt_manager_networks.osp_trunk.range | ansible.utils.nthhost(1) }}'
+             prefix='24'>
+            </ip>
+          </network>
+  roles:
+    - role: "discover_latest_image"
+  tasks:
+    - name: Deploy layout
+      ansible.builtin.import_role:
+        name: libvirt_manager
+        tasks_from: deploy_layout
+
+    - name: Gather instances
+      run_once: true
+      register: _vms
+      community.libvirt.virt:
+        command: "list_vms"
+
+    - name: Debug created VMs
+      run_once: true
+      ansible.builtin.debug:
+        var: _vms
+
+    - name: Ensure we get only 2 VMs
+      run_once: true
+      ansible.builtin.assert:
+        that:
+          - (_vms.list_vms | length) == 2

--- a/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -40,7 +40,6 @@
     label: "{{ item.key }}"
 
 - name: Create temporary ssh keypair
-  delegate_facts: true
   ansible.builtin.command:
     cmd: >-
       ssh-keygen -t ed25519
@@ -48,13 +47,11 @@
     creates: "{{ ansible_user_dir }}/.ssh/cifmw_reproducer_key"
 
 - name: Slurp public key for later use
-  delegate_facts: true
   register: pub_ssh_key
   ansible.builtin.slurp:
     path: "{{ ansible_user_dir }}/.ssh/cifmw_reproducer_key.pub"
 
 - name: Slurp private key for later use
-  delegate_facts: true
   register: priv_ssh_key
   ansible.builtin.slurp:
     path: "{{ ansible_user_dir }}/.ssh/cifmw_reproducer_key"
@@ -101,6 +98,12 @@
       }}
 
 - name: Create and run VMs
+  when:
+    - (
+        vm_data.value.target is defined and
+        vm_data.value.target == inventory_hostname
+      ) or
+      vm_data.value.target is undefined
   vars:
     vm_type: "{{ vm_data.key }}"
     pub_key: "{{ pub_ssh_key.content | b64decode }}"
@@ -131,6 +134,11 @@
 - name: Ensure we get proper access to CRC
   when:
     - _layout.vms.crc is defined
+    - (
+        _layout.vms.crc.target is defined and
+        _layout.vms.crc.target == inventory_hostname
+      ) or
+      _layout.vms.crc.target is undefined
   vars:
     crc_private_key: >-
       {{

--- a/ci_framework/roles/reproducer/tasks/configure_controller.yml
+++ b/ci_framework/roles/reproducer/tasks/configure_controller.yml
@@ -11,6 +11,12 @@
       }}
 
 - name: Configure controller-0
+  when:
+    - (
+        cifmw_libvirt_manager_configuration.vms.controller.target is defined and
+        cifmw_libvirt_manager_configuration.vms.controller.target == inventory_hostname
+      ) or
+      cifmw_libvirt_manager_configuration.vms.controller.target is undefined
   delegate_to: controller-0
   delegate_facts: true
   remote_user: root

--- a/ci_framework/roles/reproducer/tasks/devscripts_post.yml
+++ b/ci_framework/roles/reproducer/tasks/devscripts_post.yml
@@ -1,3 +1,4 @@
+---
 - name: Run post tasks from devscripts role
   tags:
     - devscripts_layout

--- a/ci_framework/roles/reproducer/tasks/gather_inventories.yml
+++ b/ci_framework/roles/reproducer/tasks/gather_inventories.yml
@@ -1,0 +1,16 @@
+---
+- name: "Gather inventories from {{ host }}"
+  when:
+    - hostvars[host]['_inventories']['results'] is defined
+    - _data.skipped is undefined or not _data.skipped
+  ansible.builtin.copy:
+    dest: >-
+      {{
+        (cifmw_reproducer_basedir, 'reproducer-inventory',
+         (_data.source | basename)) |
+        path_join
+      }}
+    content: "{{ _data.content | b64decode }}"
+  loop: "{{ hostvars[host]['_inventories']['results']}}"
+  loop_control:
+    loop_var: '_data'

--- a/ci_framework/roles/reproducer/tasks/libvirt_layout.yml
+++ b/ci_framework/roles/reproducer/tasks/libvirt_layout.yml
@@ -6,6 +6,28 @@
     name: libvirt_manager
     tasks_from: deploy_layout
 
+- name: Get all generated inventory on remote hypervisors
+  when:
+    - cifmw_libvirt_manager_configuration.vms.controller.target is defined
+    - cifmw_libvirt_manager_configuration.vms.controller.target != inventory_hostname
+  block:
+    - name: Get deployed VM group inventories
+      register: _inventories
+      ansible.builtin.slurp:
+        path: >-
+          {{
+            (cifmw_reproducer_basedir, 'reproducer-inventory',
+             item ~ '-group.yml') |
+            path_join
+          }}
+      loop: >-
+          {{
+            cifmw_libvirt_manager_configuration.vms |
+            dict2items |
+            selectattr('value.target', 'equalto', inventory_hostname) |
+            map(attribute="key")
+          }}
+
 - name: Run tasks on controller-0 hypervisor
   when:
     - (
@@ -14,6 +36,12 @@
       ) or
       cifmw_libvirt_manager_configuration.vms.controller.target is undefined
   block:
+    - name: Inject remote inventories onto main hypervisor
+      ansible.builtin.include_tasks: gather_inventories.yml
+      loop: "{{ hostvars.keys() }}"
+      loop_control:
+        loop_var: "host"
+
     - name: Push generated inventory from hypervisor
       ansible.builtin.command:  # noqa: command-instead-of-module
         cmd: >-

--- a/ci_framework/roles/reproducer/tasks/libvirt_layout.yml
+++ b/ci_framework/roles/reproducer/tasks/libvirt_layout.yml
@@ -6,15 +6,28 @@
     name: libvirt_manager
     tasks_from: deploy_layout
 
-- name: Push generated inventory from hypervisor
-  ansible.builtin.command:  # noqa: command-instead-of-module
-    cmd: >-
-      rsync -r {{ cifmw_reproducer_basedir }}/reproducer-inventory/
-      zuul@controller-0:reproducer-inventory
+- name: Run tasks on controller-0 hypervisor
+  when:
+    - (
+        cifmw_libvirt_manager_configuration.vms.controller.target is defined and
+        cifmw_libvirt_manager_configuration.vms.controller.target == inventory_hostname
+      ) or
+      cifmw_libvirt_manager_configuration.vms.controller.target is undefined
+  block:
+    - name: Push generated inventory from hypervisor
+      ansible.builtin.command:  # noqa: command-instead-of-module
+        cmd: >-
+          rsync -r {{ cifmw_reproducer_basedir }}/reproducer-inventory/
+          zuul@controller-0:reproducer-inventory
 
 - name: Run post tasks in devscripts case
   when:
-    - cifmw_use_devscripts | default(false) | bool
+    - cifmw_libvirt_manager_configuration.vms.ocp is defined
+    - (
+        cifmw_libvirt_manager_configuration.vms.ocp.target is defined and
+        cifmw_libvirt_manager_configuration.vms.ocp.target == inventory_hostname
+      ) or
+      cifmw_libvirt_manager_configuration.vms.ocp.target is undefined
   tags:
     - boostrap
     - bootstrap_layout
@@ -22,7 +35,12 @@
 
 - name: Configure CRC node if available
   when:
-    - _layout.vms.crc is defined
+    - cifmw_libvirt_manager_configuration.vms.crc is defined
+    - (
+        cifmw_libvirt_manager_configuration.vms.crc.target is defined and
+        cifmw_libvirt_manager_configuration.vms.crc.target == inventory_hostname
+      ) or
+      cifmw_libvirt_manager_configuration.vms.crc.target is undefined
   tags:
     - bootstrap
     - bootstrap_layout

--- a/ci_framework/roles/reproducer/tasks/main.yml
+++ b/ci_framework/roles/reproducer/tasks/main.yml
@@ -57,6 +57,11 @@
 - name: Deploy CRC if needed
   when:
     - cifmw_libvirt_manager_configuration.vms.crc is defined
+    - (
+        cifmw_libvirt_manager_configuration.vms.crc.target is defined and
+        cifmw_libvirt_manager_configuration.vms.crc.target == inventory_hostname
+      ) or
+      cifmw_libvirt_manager_configuration.vms.crc.target is undefined
   tags:
     - bootstrap
     - bootstrap_layout
@@ -65,7 +70,12 @@
 
 - name: Consume dev-scripts for OCP cluster
   when:
-    - cifmw_use_devscripts | default(false) | bool
+    - cifmw_libvirt_manager_configuration.vms.ocp is defined
+    - (
+        cifmw_libvirt_manager_configuration.vms.ocp.target is defined and
+        cifmw_libvirt_manager_configuration.vms.ocp.target == inventory_hostname
+      ) or
+      cifmw_libvirt_manager_configuration.vms.ocp.target is undefined
   tags:
     - bootstrap
     - boostrap_layout
@@ -79,31 +89,39 @@
     - bootstrap_layout
   ansible.builtin.import_tasks: libvirt_layout.yml
 
-- name: Push local code
-  tags:
-    - bootstrap_repositories
-    - bootstrap
-  ansible.builtin.import_tasks: push_code.yml
-
-- name: Rotate some logs
-  tags:
-    - always
-  ansible.builtin.include_tasks: rotate_log.yml
-  loop:
-    - ansible-bootstrap.log
-
-- name: Bootstrap environment on controller-0
-  delegate_to: controller-0
-  environment:
-    ANSIBLE_LOG_PATH: "~/ansible-bootstrap.log"
-  ansible.builtin.command:
-    chdir: "src/github.com/openstack-k8s-operators/ci-framework"
-    cmd: >-
-      ansible-playbook
-      -e @~/reproducer-variables.yml
-      ci_framework/playbooks/01-bootstrap.yml
-
-- name: Emulate CI job
+- name: Run only on hypervisor with controller-0
   when:
-    - cifmw_job_uri is defined
-  ansible.builtin.import_tasks: ci_job.yml
+    - (
+        cifmw_libvirt_manager_configuration.vms.controller.target is defined and
+        cifmw_libvirt_manager_configuration.vms.controller.target == inventory_hostname
+      ) or
+      cifmw_libvirt_manager_configuration.vms.controller.target is undefined
+  block:
+    - name: Push local code
+      tags:
+        - bootstrap_repositories
+        - bootstrap
+      ansible.builtin.import_tasks: push_code.yml
+
+    - name: Rotate some logs
+      tags:
+        - always
+      ansible.builtin.include_tasks: rotate_log.yml
+      loop:
+        - ansible-bootstrap.log
+
+    - name: Bootstrap environment on controller-0
+      delegate_to: controller-0
+      environment:
+        ANSIBLE_LOG_PATH: "~/ansible-bootstrap.log"
+      ansible.builtin.command:
+        chdir: "src/github.com/openstack-k8s-operators/ci-framework"
+        cmd: >-
+          ansible-playbook
+          -e @~/reproducer-variables.yml
+          ci_framework/playbooks/01-bootstrap.yml
+
+    - name: Emulate CI job
+      when:
+        - cifmw_job_uri is defined
+      ansible.builtin.import_tasks: ci_job.yml


### PR DESCRIPTION
#### Add support for multiple hypervisor in libvirt_manager

    This patch alone won't work on its own. But we need to get that feature
    in before we can work on the reproducer side in order to ensure we
    filter things properly.

#### Add support for multiple hypervisors to reproducer

    Here, we have to ensure we're running delegated tasks from the correct
    hypervisor. We also have to ensure we're deploying the OCP or CRC or
    controller-0 on the correct hypervisor.

#### Ensure we gather the various inventories

    Since the controller-0 is running on one specific hypervisor, we have to
    ensure we can collect and group all of the generated inventories.
    
    This patch ensures we're fetching other hypervisors inventories and copy
    them onto the hypervisor running controller-0 before we push everything
    onto the controller-0.
    
    That way, we should get all of the needed data for the future steps,
    meaning mostly "deploy".
    
    Note that networking may be an issue - but ensuring hypervisors are able
    to communicate with each others is not really in the scope of the
    ci-framework.

#### Add proper testing for multi-hypervisor

    We create a series of "fake" hosts in the molecule inventory in order to
    show we're able to deploy VM only on the targeted hypervisors.
    
    Doing so, we ensure we don't use too many resources, allowing to keep
    our CI footprint low.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
