### PR TITLE
Avoid too much verbosity in network creation

### DIFF
--- a/ci_framework/roles/libvirt_manager/tasks/create_networks.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/create_networks.yml
@@ -44,6 +44,8 @@
     xml: "{{ item.xml }}"
     uri: "qemu:///system"
   loop: "{{ networks }}"
+  loop_control:
+    label: "{{ item.name }}"
 
 - name: Ensure networks are created/started
   community.libvirt.virt_net:
@@ -51,6 +53,8 @@
     name: "{{ item.name }}"
     uri: "qemu:///system"
   loop: "{{ networks }}"
+  loop_control:
+    label: "{{ item.name }}"
 
 - name: Ensure networks are active
   community.libvirt.virt_net:
@@ -58,6 +62,8 @@
     name: "{{ item.name }}"
     uri: "qemu:///system"
   loop: "{{ networks }}"
+  loop_control:
+    label: "{{ item.name }}"
 
 - name: Ensure networks enabled to autostart
   community.libvirt.virt_net:
@@ -65,3 +71,5 @@
     name: "{{ item.name }}"
     uri: "qemu:///system"
   loop: "{{ networks }}"
+  loop_control:
+    label: "{{ item.name }}"


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
