### PR TITLE
Updating hosts so that the task runs on both controller and primary nodes

### DIFF
--- a/ci/playbooks/dump_zuul_data.yml
+++ b/ci/playbooks/dump_zuul_data.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Run ci/playbooks/dump_zuul_data.yml"
-  hosts: controller
+  hosts: controller, primary
   gather_facts: true
   tasks:
     - name: Create zuul-output directory

--- a/ci/playbooks/e2e-prepare.yml
+++ b/ci/playbooks/e2e-prepare.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Run ci/playbooks/e2e-prepare.yml"
-  hosts: controller
+  hosts: controller, primary
   gather_facts: true
   tasks:
     - name: Clone repos in the job workspace


### PR DESCRIPTION
Updating hosts so that the task runs on both controller and primary nodes. Using inclusion instead of exclusion as later when we change the nodesets to use "controller " instead of "primary" , we can simply remove primary from the hosts here.
As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
