### PR TITLE
Add support for extra disks

### DIFF
--- a/ci_framework/roles/libvirt_manager/README.md
+++ b/ci_framework/roles/libvirt_manager/README.md
@@ -34,6 +34,7 @@ Used for checking if:
 ### Structure for `cifmw_libvirt_manager_configuration`
 
 The following structure has to be passed via the configuration parameter:
+
 ```YAML
 cifmw_libvirt_manager_configuration:
   vms:
@@ -55,6 +56,7 @@ cifmw_libvirt_manager_configuration:
 Specific `type_name`: `^crc.*` and `^ocp.*` are enabling specific paths in the module.
 
 #### Example
+
 ```YAML
 cifmw_libvirt_manager_networks:
   public:
@@ -130,6 +132,7 @@ reproducer role.
 * `cifmw_libvirt_manager_crc_private_nic`: `{{ cifmw_reproducer_crc_private_nic | default('enp2s0') }}`
 
 ## Calling attach_network.yml from another role
+
 You may want to include that specific tasks file from another role in order to inject some networks into
 a virtual machine.
 
@@ -144,6 +147,7 @@ In order to do so, you have to provide specific variables:
 * `cifmw_libvirt_manager_net_prefix_add`: (Bool) Toggle this to `true` if the network name needs to get the `cifmw-` prefix (advanced usage). Optional. Defaults to `true`.
 
 ### Example
+
 ```YAML
 - name: Attach my network to my virtual machine
   vars:

--- a/ci_framework/roles/libvirt_manager/molecule/deploy_layout/converge.yml
+++ b/ci_framework/roles/libvirt_manager/molecule/deploy_layout/converge.yml
@@ -57,6 +57,8 @@
           nets:
             - public
             - osp_trunk
+          extra_disks_num: 1
+          extra_disks_size: 1G
       networks:
         public: |-
           <network>

--- a/ci_framework/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/clean_layout.yml
@@ -108,6 +108,11 @@
         key: "{{ _pub_key['content'] | b64decode }}"
         state: absent
 
+- name: Remove storage pool
+  vars:
+    action: "delete"
+  ansible.builtin.include_tasks: storage_pool.yml
+
 - name: Remove data directories
   ansible.builtin.file:
     path: "{{ cifmw_libvirt_manager_basedir }}/{{ item }}"
@@ -115,3 +120,4 @@
   loop:
     - workload
     - images
+    - volumes

--- a/ci_framework/roles/libvirt_manager/tasks/create_vms.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/create_vms.yml
@@ -79,6 +79,7 @@
         loop_var: "_xml"
         index_var: "_xml_id"
         label: "{{ vm_type }}-{{ _xml_id }}"
+
     - name: "Load VM XMLs for type {{ vm_type }}"
       register: _vm_xmls
       ansible.builtin.slurp:
@@ -99,6 +100,20 @@
         label: "{{ vm_type }}-{{ vm_id }}"
         loop_var: '_xml'
 
+- name: Ensure the required volumes are present.
+  when:
+    - vm_data.value.extra_disks_num is defined
+    - vm_data.value.extra_disks_num | int != 0
+    - vm_data.value.xml_paths is undefined
+  vars:
+    vol_prefix: "cifmw-{{ vm_type }}-{{ vm_id }}"
+    vol_num: "{{ vm_data.value.extra_disks_num }}"
+    vol_size: "{{ vm_data.value.extra_disks_size }}"
+  ansible.builtin.include_tasks: volumes.yml
+  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
+  loop_control:
+    index_var: vm_id
+    label: "{{ vm_type }}-{{ vm_id }}"
 
 - name: "Define VMs with default template for type {{ vm_type }}"
   when:

--- a/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create needed worload directory
+- name: Create needed workload directory
   ansible.builtin.file:
     path: "{{ cifmw_libvirt_manager_basedir }}/{{ item }}"
     state: directory
@@ -8,15 +8,19 @@
     - workload
     - reproducer-inventory
     - reproducer-network-env
+    - volumes
 
 - name: Allow QEMU on workload directory
   become: true
   ansible.posix.acl:
-    path: "{{ cifmw_libvirt_manager_basedir }}/workload"
+    path: "{{ cifmw_libvirt_manager_basedir }}/{{ item }}"
     entity: "qemu"
     etype: "user"
     permissions: rwx
     state: present
+  loop:
+    - workload
+    - volumes
 
 - name: Chose right parameter for layout definition
   ansible.builtin.set_fact:
@@ -27,6 +31,11 @@
   when:
     - _layout.networks is defined
   ansible.builtin.import_tasks: create_networks.yml
+
+- name: Ensure storage pool is present
+  vars:
+    action: "create"
+  ansible.builtin.include_tasks: storage_pool.yml
 
 - name: Ensure images are present
   when:

--- a/ci_framework/roles/libvirt_manager/tasks/storage_pool.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/storage_pool.yml
@@ -1,0 +1,84 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Gather the status of cifmw-pool storage pool.
+  register: pool_exists
+  ansible.builtin.shell:
+    cmd: >-
+      virsh -c qemu:///system pool-list --name |
+      grep -c 'cifmw-pool'
+  failed_when: pool_exists.rc != 0 and pool_exists.rc != 1
+
+- name: Create and start the storage pool.
+  when:
+    - action == "create"
+    - pool_exists.stdout | int == 0
+  block:
+    - name: Create the storage pool
+      ansible.builtin.command:
+        cmd: >-
+          virsh -c qemu:///system
+          pool-define-as
+          --name {{ cifmw_libvirt_manager_storage_pool }}
+          --type dir
+          --target {{ cifmw_libvirt_manager_basedir }}/volumes
+
+    - name: Ensure the storage pool is started
+      ansible.builtin.command:
+        cmd: >-
+          virsh -c qemu:///system
+          {{ item }}
+          {{ cifmw_libvirt_manager_storage_pool }}
+      loop:
+        - 'pool-start'
+        - 'pool-autostart'
+
+- name: Remove the storage pool.
+  when:
+    - action == "delete"
+    - pool_exists.stdout | int == 1
+  block:
+    - name: Gather all the volumes in the pool.
+      register: _volumes
+      ansible.builtin.shell:
+        cmd: >-
+          virsh -c qemu:///system vol-list
+          --pool {{ cifmw_libvirt_manager_storage_pool }} |
+          awk 'NR>2 { print $1 }' |
+          awk 'NF'
+      failed_when: _volumes.rc != 0 and _volumes.rc != 1
+
+    - name: Remove the volumes
+      when:
+        - _volumes.stdout_lines is defined
+        - _volumes.stdout_lines | length > 0
+      ansible.builtin.command:
+        cmd: >-
+          virsh -c qemu:///system vol-delete
+          --vol {{ item }}
+          --pool {{ cifmw_libvirt_manager_storage_pool }}
+      loop: "{{ _volumes.stdout_lines }}"
+
+    - name: Remove the storage pool
+      ansible.builtin.command:
+        cmd: >-
+          virsh -c qemu:///system
+          {{ item }}
+          --pool {{ cifmw_libvirt_manager_storage_pool }}
+      loop:
+        - "pool-destroy"
+        - "pool-undefine"

--- a/ci_framework/roles/libvirt_manager/tasks/volumes.yml
+++ b/ci_framework/roles/libvirt_manager/tasks/volumes.yml
@@ -1,0 +1,35 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Requires
+#   - volume prefix
+#   - number of volumes
+#   - volume size
+
+
+- name: Create volume in the storage pool.
+  ansible.builtin.command:
+    cmd: >-
+      virsh -c qemu:///system
+      vol-create-as
+      --pool {{ cifmw_libvirt_manager_storage_pool }}
+      --name {{ vol_prefix }}-vol-{{ vol-id }}
+      --capacity {{ vol_size }}
+      --format {{ vol_format | default('qcow2') }}
+  loop: "{{ range(0, vol_num | int) }}"
+  loop_control:
+    index_var: vol_id
+    label: "{{ vol_prefix }}-vol-{{ vol-id }}"

--- a/ci_framework/roles/libvirt_manager/templates/domain.xml.j2
+++ b/ci_framework/roles/libvirt_manager/templates/domain.xml.j2
@@ -22,8 +22,21 @@
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2'/>
       <source file='{{ cifmw_libvirt_manager_basedir }}/workload/{{ vm_type }}-{{ vm_id }}.qcow2'/>
-      <target dev='sda' bus='sata'/>
+      <target dev='sda' bus='scsi'/>
     </disk>
+{% if vm_data.value.extra_disks_num is defined %}
+{% for n in range(vm_data.value.extra_disks_num) %}
+    <disk type='volume' device='disk'>
+      <driver name='qemu' type='qcow2' />
+      <source pool='{{ cifmw_libvirt_manager_storage_pool }}' volume='cifmw-{{ vm_type }}-{{ vm_id }}-vol-{{ n }}' />
+      <target dev='{{ cifmw_libvirt_manager_disk_mapping[n] }}' bus='scsi' />
+    </disk>
+{% endfor %}
+{% endif%}
+    <controller type='scsi' index='0' model='virtio-scsi'>
+      <alias name='scsi0' />
+      <address type='pci' domain='0x0000' bus='0x00' function='0x0' />
+    </controller>
     <controller type='usb' index='0' model='ich9-ehci1'>
       <alias name='usb'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x7'/>

--- a/ci_framework/roles/libvirt_manager/vars/main.yml
+++ b/ci_framework/roles/libvirt_manager/vars/main.yml
@@ -43,3 +43,6 @@ cifmw_libvirt_manager_vm_net_ip_set_default:
   worker: 13
   extraworker: 100
   compute: 100
+
+cifmw_libvirt_manager_storage_pool: "cifmw-pool"
+cifmw_libvirt_manager_disk_mapping: ['vdb', 'vdc', 'vdd', 'vde', 'vdf']


### PR DESCRIPTION
This change set includes support for pool and volume creation. It introduces two new configuration keys 

```
`extra_disks_num`  The number of disks to be attached to the vm 
`extra_disks_size`  The storage capacity to be allocated 
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes

_Testing results_

*Storage pool*
```
# virsh pool-list
 Name         State    Autostart
----------------------------------
 cifmw-pool   active   yes
 crc          active   no
 default      active   yes
```
*Extra disks aka volumes*
```
# virsh vol-list --pool cifmw-pool
 Name                    Path
-------------------------------------------------------------------------------------
 cifmw-compute-0-vol-0   /home/zuul/ci-framework-data/volumes/cifmw-compute-0-vol-0
 cifmw-compute-0-vol-1   /home/zuul/ci-framework-data/volumes/cifmw-compute-0-vol-1
 cifmw-compute-0-vol-2   /home/zuul/ci-framework-data/volumes/cifmw-compute-0-vol-2
 cifmw-compute-0-vol-3   /home/zuul/ci-framework-data/volumes/cifmw-compute-0-vol-3
 cifmw-compute-0-vol-4   /home/zuul/ci-framework-data/volumes/cifmw-compute-0-vol-4
```

*Disks identified by host*
```
ssh -l [redacted] -i [redacted] [compute-0] lsblk
NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
sda      8:0    0   50G  0 disk 
├─sda1   8:1    0    1M  0 part 
├─sda2   8:2    0  200M  0 part /boot/efi
├─sda3   8:3    0  500M  0 part /boot
└─sda4   8:4    0  9.3G  0 part /
sdb      8:16   0   10G  0 disk 
sdc      8:32   0   10G  0 disk 
sdd      8:48   0   10G  0 disk 
sde      8:64   0   10G  0 disk 
sdf      8:80   0   10G  0 disk 
```