### PR TITLE
Skip manila tempest test

### DIFF
--- a/ci_framework/roles/tempest/files/list_skipped.yml
+++ b/ci_framework/roles/tempest/files/list_skipped.yml
@@ -1073,6 +1073,16 @@ known_failures:
         lp: http://no.bug
     jobs:
       - nova-operator
+# Manila Operator
+  - test: manila_tempest_tests.tests.api.test_rules_negative.ShareCephxRulesForCephFSNegativeTest.test_can_apply_new_cephx_rules_when_one_is_in_error_state
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Fix not landed yet
+        lp: http://no.bug
+    jobs:
+      - manila-operator
   - test: manila_tempest_tests.tests.api.test_share_network_subnets.ShareNetworkSubnetsTest.test_create_delete_subnet
     deployment:
       - overcloud


### PR DESCRIPTION
manila_tempest_tests.tests.api.test_rules_negative. ShareCephxRulesForCephFSNegativeTest failing with
intermittent String Exception error

We will deal this test in different pr, currently
skiping of this test will unblock
https://github.com/openstack-k8s-operators/ci-framework/pull/463

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
