### PR TITLE
Ensure inventory supports multi-hypervisor

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -12,5 +12,6 @@ fact_caching_connection = ~/ansible_facts_cache
 fact_caching_timeout = 0
 inventory = inventory.yml
 pipelining = True
+any_errors_fatal = True
 [ssh_connection]
 ssh_args = -o ControlMaster=auto -o ControlPersist=60s

--- a/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/roles/libvirt_manager/tasks/clean_layout.yml
@@ -108,6 +108,14 @@
         key: "{{ _pub_key['content'] | b64decode }}"
         state: absent
 
+    - name: Remove keypair
+      ansible.builtin.file:
+        state: absent
+        path: "{{ ansible_user_dir }}/.ssh/{{ item }}"
+      loop:
+        - cifmw_reproducer_key.pub
+        - cifmw_reproducer_key
+
 - name: Remove data directories
   ansible.builtin.file:
     path: "{{ cifmw_libvirt_manager_basedir }}/{{ item }}"

--- a/roles/libvirt_manager/templates/all-inventory.yml.j2
+++ b/roles/libvirt_manager/templates/all-inventory.yml.j2
@@ -2,6 +2,21 @@ all:
   children:
 {% for vm in _layout.vms.keys() %}
     {{ vm }}s:
+      vars:
+{% if _layout.vms[vm].target is defined %}
+{% set _target = _layout.vms[vm].target %}
+{% set _hostname = hostvars[_target]['ansible_host'] | default(hostvars[_target]['inventory_hostname']) %}
+{#
+Here we set ssh options to consume the right private key (one per hypervisor), as well as
+the right hypervisor depending on the virtual machine.
+Note that none of the options such as StrictHostKeyChecking nor the
+identity file will be applied to the ProxyHost (-J option value), meaning
+we have to push some ssh configuration on the controller-0 to properly connect to the various
+virtual machines.
+#}
+        ansible_ssh_private_key_file: "~/.ssh/ssh_{{ _hostname }}"
+        ansible_ssh_common_args: "-o StrictHostKeyChecking=no -J {{ ansible_user | default(ansible_user_id) }}@{{ _hostname }}"
+{% endif %}
 {% endfor %}
 localhosts:
   hosts:

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -52,7 +52,6 @@
         cmd: >-
           cat /home/zuul/reproducer-inventory/* >
           {{  _ctl_reproducer_basedir }}/zuul_inventory.yml
-        creates: "{{ _ctl_reproducer_basedir }}/zuul_inventory.yml"
 
     - name: Push the MAC mapping data
       tags:
@@ -87,6 +86,55 @@
       loop_control:
         label: "{{ config.option }}"
         loop_var: 'config'
+
+    - name: Inject other Hypervisor SSH keys
+      when:
+        - hostvars[host]['priv_ssh_key'] is defined
+      vars:
+        _ssh_key: "{{ hostvars[host]['priv_ssh_key']['content'] | b64decode }}"
+        _ssh_host: >-
+          {{
+            hostvars[host]['ansible_host'] |
+            default(hostvars[host]['inventory_hostname'])
+          }}
+      ansible.builtin.copy:
+        dest: "/home/zuul/.ssh/ssh_{{ _ssh_host }}"
+        content: "{{ _ssh_key }}"
+        mode: "0600"
+        owner: "zuul"
+        group: "zuul"
+      loop: "{{ hostvars.keys() }}"
+      loop_control:
+        label: "{{ host }}"
+        loop_var: "host"
+
+    # We need to configure SSH on controller-0 so that
+    # it will consume the right ssh key and not obsess on
+    # remote host key checking. We have to put this in the
+    # local .ssh/config, because ProxyJump doesn't take the
+    # command line options, meaning ssh won't consume the various
+    # options set in the ansible inventory.
+    - name: Inject ProxyJump configuration
+      when:
+        - hostvars[host]['priv_ssh_key'] is defined
+      vars:
+        _ssh_host: >-
+          {{
+            hostvars[host]['ansible_host'] |
+            default(hostvars[host]['inventory_hostname'])
+          }}
+      ansible.builtin.blockinfile:
+        create: true
+        path: "/home/zuul/.ssh/config"
+        block: |-
+          Host {{ _ssh_host }}
+            IdentityFile ~/.ssh/ssh_{{ _ssh_host }}
+            StrictHostKeyChecking no
+            UserKnownHostsFile /dev/null
+      loop: "{{ hostvars.keys() }}"
+      loop_control:
+        label: "{{ host }}"
+        loop_var: "host"
 
     - name: Create kube directory
       ansible.builtin.file:


### PR DESCRIPTION
With #952, we add the capability to get multiple hypervisor.

We therefore need to ensure the inventory is properly generated to allow
accesses from the controller-0.

Note that specific documentation about this feature will come shortly,
in a dedicated patch, with proper example for the hypervisor setup.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
