### PR TITLE
[edpm_deploy]Fix a bug when cifmw_edpm_deploy_env is undefined

### DIFF
--- a/ci_framework/roles/edpm_deploy/tasks/main.yml
+++ b/ci_framework/roles/edpm_deploy/tasks/main.yml
@@ -47,7 +47,7 @@
       ansible.builtin.set_fact:
         cifmw_edpm_deploy_env: >-
           {{
-            cifmw_edpm_deploy_env |
+            cifmw_edpm_deploy_env | default({}) |
             combine({'DATAPLANE_EXTRA_NOVA_CONFIG_FILE': _cifmw_edpm_deploy_nova_extra_config_file })
           }}
         cacheable: true


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
