### PR TITLE
Revert "Skip manila tempest test"

### DIFF
--- a/roles/tempest/files/list_skipped.yml
+++ b/roles/tempest/files/list_skipped.yml
@@ -1073,16 +1073,6 @@ known_failures:
         lp: http://no.bug
     jobs:
       - nova-operator
-# Manila Operator
-  - test: manila_tempest_tests.tests.api.test_rules_negative.ShareCephxRulesForCephFSNegativeTest.test_can_apply_new_cephx_rules_when_one_is_in_error_state
-    deployment:
-      - overcloud
-    releases:
-      - name: master
-        reason: Fix not landed yet
-        lp: http://no.bug
-    jobs:
-      - manila-operator
   - test: manila_tempest_tests.tests.api.test_share_network_subnets.ShareNetworkSubnetsTest.test_create_delete_subnet
     deployment:
       - overcloud


### PR DESCRIPTION
Reverts openstack-k8s-operators/ci-framework#962

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/968

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running