### PR TITLE
Allow jobs to set tempest container name

### DIFF
--- a/roles/tempest/README.md
+++ b/roles/tempest/README.md
@@ -9,7 +9,10 @@ become - Required to install required rpm packages
 * `cifmw_tempest_artifacts_basedir`: (String) Directory where we will have all tempest files. Default to `cifmw_basedir/artifacts/tempest` which defaults to `~/ci-framework-data/artifacts/tempest`.
 * `cifmw_tempest_default_groups`: (List) List of groups in the include list to search for tests to be executed
 * `cifmw_tempest_default_jobs`: (List) List of jobs in the exclude list to search for tests to be excluded
-* `cifmw_tempest_image`: (String) Name of the tempest image to be used. Default to `quay.io/podified-antelope-centos9/openstack-tempest`
+* `cifmw_tempest_registry`: (String) The registry where to pull tempest container. Default to `quay.io`
+* `cifmw_tempest_namespace`: (String) Registry's namespace where to pull tempest container. Default to `podified-antelope-centos9`
+* `cifmw_tempest_container`: (String) Name of the tempest container. Default to `openstack-tempest`
+* `cifmw_tempest_image`: (String) Tempest image to be used. Default to `{{ cifmw_tempest_registry }}/{{ cifmw_tempest_namespace }}/{{ cifmw_tempest_container }}`
 * `cifmw_tempest_image_tag`: (String) Tag for the `cifmw_tempest_image`. Default to `current-podified`
 * `cifmw_tempest_dry_run`: (Boolean) Whether tempest should run or not. Default to `false`
 * `cifmw_tempest_remove_container`: (Boolean) Cleanup tempest container after it is done. Default to `false`

--- a/roles/tempest/defaults/main.yml
+++ b/roles/tempest/defaults/main.yml
@@ -22,7 +22,10 @@ cifmw_tempest_default_groups:
   - default
 cifmw_tempest_default_jobs:
   - default
-cifmw_tempest_image: quay.io/podified-antelope-centos9/openstack-tempest
+cifmw_tempest_registry: quay.io
+cifmw_tempest_namespace: podified-antelope-centos9
+cifmw_tempest_container: openstack-tempest
+cifmw_tempest_image: "{{ cifmw_tempest_registry }}/{{ cifmw_tempest_namespace }}/{{ cifmw_tempest_container }}"
 cifmw_tempest_image_tag: current-podified
 cifmw_tempest_dry_run: false
 cifmw_tempest_remove_container: false

--- a/scenarios/centos-9/ceph_backends.yml
+++ b/scenarios/centos-9/ceph_backends.yml
@@ -29,6 +29,7 @@ pre_tempest:
     source: manila_create_default_resources.yml
 
 cifmw_run_tests: true
+cifmw_tempest_container: openstack-tempest-all
 cifmw_tempest_default_groups: &test_operator_list
   - openstack-operator
   - cinder-operator

--- a/scenarios/centos-9/edpm_periodic.yml
+++ b/scenarios/centos-9/edpm_periodic.yml
@@ -9,5 +9,6 @@ cifmw_set_openstack_containers_namespace: "podified-master-centos9"
 cifmw_edpm_deploy_baremetal_update_os_containers: true
 cifmw_run_tests: true
 cifmw_edpm_deploy_registry_url: "{{ cifmw_set_openstack_containers_registry }}/{{ cifmw_set_openstack_containers_namespace }}"
-cifmw_tempest_image: "{{ cifmw_set_openstack_containers_registry }}/{{ cifmw_set_openstack_containers_namespace }}/openstack-tempest"
+cifmw_tempest_registry: "{{ cifmw_set_openstack_containers_registry }}"
+cifmw_tempest_namespace: "{{ cifmw_set_openstack_containers_namespace }}"
 cifmw_tempest_image_tag: "{{ cifmw_repo_setup_full_hash }}"

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -114,7 +114,7 @@
         - name: compute-0
           label: cloud-centos-9-stream-tripleo-vexxhost
         - name: crc
-          label: coreos-crc-extracted-3xl
+          label: coreos-crc-extracted-xxl
       groups:
         - name: computes
           nodes:

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -225,6 +225,18 @@
 - job:
     name: podified-multinode-edpm-e2e-nobuild-tagged-crc
     parent: cifmw-podified-multinode-edpm-base-crc
+    nodeset:
+      nodes:
+        - name: controller
+          label: cloud-centos-9-stream-tripleo-vexxhost
+        - name: compute-0
+          label: cloud-centos-9-stream-tripleo-vexxhost
+        - name: crc
+          label: coreos-crc-extracted-3xl
+      groups:
+        - name: computes
+          nodes:
+            - compute-0
     vars:
       cifmw_extras:
         - '@scenarios/centos-9/ci.yml'


### PR DESCRIPTION
Jobs that need tempest plugins need to use a different tempest container which already includes installed plugins ("openstack-tempest-all"). This patch updates tempest role to allow us to only change the container name, including in periodic jobs. Defaults continue to be the same. This patch also updates a job to use openstack-tempest-all container needed by manila service. It also updates nodesets to have a better use of cloud resources:
* podified-multinode-edpm-e2e-nobuild-tagged-crc needs bigger crc node due to additional resources deployed and controller node also need more resources to run more tempest tests.
* cifmw-podified-multinode-edpm-base-crc move back to use previous crc label (see PR #463)

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
