### PR TITLE
Reconfig molecule tests include files

### DIFF
--- a/ci/templates/molecule.yaml.j2
+++ b/ci/templates/molecule.yaml.j2
@@ -7,6 +7,6 @@
     files:
       - ^ansible-requirements.txt
       - ^molecule-requirements.txt
-      - ^ci_framework/roles/{{ role_name }}/(?!meta|README).*
+      - ^roles/{{ role_name }}/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 {% endfor %}

--- a/scripts/create_role_molecule.py
+++ b/scripts/create_role_molecule.py
@@ -37,7 +37,7 @@ def get_project_paths(project_dir=None):
     script_dir = project_dir / "scripts"
     ci_templates_dir = project_dir / "ci" / "templates"
     ci_config_dir = project_dir / "ci" / "config"
-    roles_dir = project_dir / "ci_framework" / "roles"
+    roles_dir = project_dir / "roles"
     zuul_job_dir = project_dir / "zuul.d"
     source_roles_docs_dir = project_dir / "docs" / "source" / "roles"
 

--- a/scripts/tests/test_create_role_molecule.py
+++ b/scripts/tests/test_create_role_molecule.py
@@ -153,7 +153,7 @@ class CreateRoleMoleculeTest(unittest.TestCase):
                     "files": [
                         "^ansible-requirements.txt",
                         "^molecule-requirements.txt",
-                        "^ci_framework/roles/role_2/(?!meta|README).*",
+                        "^roles/role_2/(?!meta|README).*",
                         "^ci/playbooks/molecule.*",
                     ],
                     "name": "cifmw-molecule-role_2",
@@ -166,7 +166,7 @@ class CreateRoleMoleculeTest(unittest.TestCase):
                     "files": [
                         "^ansible-requirements.txt",
                         "^molecule-requirements.txt",
-                        "^ci_framework/roles/role_1/(?!meta|README).*",
+                        "^roles/role_1/(?!meta|README).*",
                         "^ci/playbooks/molecule.*",
                     ],
                     "name": "cifmw-molecule-role_1",
@@ -179,7 +179,7 @@ class CreateRoleMoleculeTest(unittest.TestCase):
                     "files": [
                         "^ansible-requirements.txt",
                         "^molecule-requirements.txt",
-                        "^ci_framework/roles/role_3/(?!meta|README).*",
+                        "^roles/role_3/(?!meta|README).*",
                         "^ci/playbooks/molecule.*",
                     ],
                     "name": "cifmw-molecule-role_3",

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -2,7 +2,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/artifacts/(?!meta|README).*
+    - ^roles/artifacts/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-artifacts
     parent: cifmw-molecule-base
@@ -12,7 +12,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/build_containers/(?!meta|README).*
+    - ^roles/build_containers/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-build_containers
     parent: cifmw-molecule-base
@@ -22,7 +22,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/build_openstack_packages/(?!meta|README).*
+    - ^roles/build_openstack_packages/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-build_openstack_packages
     parent: cifmw-molecule-base
@@ -32,7 +32,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/cert_manager/(?!meta|README).*
+    - ^roles/cert_manager/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-cert_manager
     nodeset: centos-9-crc-xxl
@@ -43,7 +43,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/ci_metallb/(?!meta|README).*
+    - ^roles/ci_metallb/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-ci_metallb
     parent: cifmw-molecule-base-crc
@@ -53,7 +53,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/ci_multus/(?!meta|README).*
+    - ^roles/ci_multus/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-ci_multus
     parent: cifmw-molecule-base-crc
@@ -63,7 +63,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/ci_netconfig/(?!meta|README).*
+    - ^roles/ci_netconfig/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-ci_netconfig
     parent: cifmw-molecule-base-crc
@@ -73,7 +73,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/ci_network/(?!meta|README).*
+    - ^roles/ci_network/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-ci_network
     parent: cifmw-molecule-base
@@ -83,7 +83,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/ci_nmstate/(?!meta|README).*
+    - ^roles/ci_nmstate/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-ci_nmstate
     parent: cifmw-molecule-base-crc
@@ -93,7 +93,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/ci_setup/(?!meta|README).*
+    - ^roles/ci_setup/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-ci_setup
     parent: cifmw-molecule-base
@@ -103,7 +103,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/cifmw_block_device/(?!meta|README).*
+    - ^roles/cifmw_block_device/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-cifmw_block_device
     parent: cifmw-molecule-base
@@ -113,7 +113,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/cifmw_ceph_client/(?!meta|README).*
+    - ^roles/cifmw_ceph_client/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-cifmw_ceph_client
     parent: cifmw-molecule-base
@@ -123,7 +123,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/cifmw_ceph_spec/(?!meta|README).*
+    - ^roles/cifmw_ceph_spec/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-cifmw_ceph_spec
     parent: cifmw-molecule-base
@@ -133,7 +133,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/cifmw_cephadm/(?!meta|README).*
+    - ^roles/cifmw_cephadm/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-cifmw_cephadm
     parent: cifmw-molecule-base
@@ -143,7 +143,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/cifmw_create_admin/(?!meta|README).*
+    - ^roles/cifmw_create_admin/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-cifmw_create_admin
     parent: cifmw-molecule-base
@@ -153,7 +153,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/cifmw_test_role/(?!meta|README).*
+    - ^roles/cifmw_test_role/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-cifmw_test_role
     parent: cifmw-molecule-base
@@ -163,7 +163,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/devscripts/(?!meta|README).*
+    - ^roles/devscripts/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-devscripts
     parent: cifmw-molecule-base
@@ -173,7 +173,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/discover_latest_image/(?!meta|README).*
+    - ^roles/discover_latest_image/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-discover_latest_image
     parent: cifmw-molecule-base
@@ -183,7 +183,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/dlrn_promote/(?!meta|README).*
+    - ^roles/dlrn_promote/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-dlrn_promote
     parent: cifmw-molecule-base
@@ -193,7 +193,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/dlrn_report/(?!meta|README).*
+    - ^roles/dlrn_report/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-dlrn_report
     parent: cifmw-molecule-base
@@ -203,7 +203,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/edpm_build_images/(?!meta|README).*
+    - ^roles/edpm_build_images/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-edpm_build_images
     parent: cifmw-molecule-base
@@ -213,7 +213,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/edpm_deploy/(?!meta|README).*
+    - ^roles/edpm_deploy/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-edpm_deploy
     parent: cifmw-molecule-base
@@ -223,7 +223,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/edpm_deploy_baremetal/(?!meta|README).*
+    - ^roles/edpm_deploy_baremetal/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-edpm_deploy_baremetal
     parent: cifmw-molecule-base
@@ -233,7 +233,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/edpm_kustomize/(?!meta|README).*
+    - ^roles/edpm_kustomize/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-edpm_kustomize
     parent: cifmw-molecule-base
@@ -243,7 +243,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/edpm_prepare/(?!meta|README).*
+    - ^roles/edpm_prepare/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-edpm_prepare
     parent: cifmw-molecule-base
@@ -253,7 +253,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/env_op_images/(?!meta|README).*
+    - ^roles/env_op_images/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-env_op_images
     nodeset: centos-9-crc-xl
@@ -264,7 +264,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/hci_prepare/(?!meta|README).*
+    - ^roles/hci_prepare/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-hci_prepare
     parent: cifmw-molecule-base
@@ -274,7 +274,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/hive/(?!meta|README).*
+    - ^roles/hive/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-hive
     parent: cifmw-molecule-base
@@ -284,7 +284,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/idrac_configuration/(?!meta|README).*
+    - ^roles/idrac_configuration/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-idrac_configuration
     parent: cifmw-molecule-base
@@ -294,7 +294,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/install_ca/(?!meta|README).*
+    - ^roles/install_ca/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-install_ca
     parent: cifmw-molecule-base
@@ -304,7 +304,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/install_yamls/(?!meta|README).*
+    - ^roles/install_yamls/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-install_yamls
     parent: cifmw-molecule-base
@@ -314,7 +314,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/libvirt_manager/(?!meta|README).*
+    - ^roles/libvirt_manager/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-libvirt_manager
     parent: cifmw-molecule-base
@@ -324,7 +324,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/manage_secrets/(?!meta|README).*
+    - ^roles/manage_secrets/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-manage_secrets
     nodeset: centos-9-crc-xl
@@ -335,7 +335,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/openshift_login/(?!meta|README).*
+    - ^roles/openshift_login/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-openshift_login
     nodeset: centos-9-crc-xl
@@ -346,7 +346,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/openshift_provisioner_node/(?!meta|README).*
+    - ^roles/openshift_provisioner_node/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-openshift_provisioner_node
     nodeset: centos-9-crc-xl
@@ -357,7 +357,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/openshift_setup/(?!meta|README).*
+    - ^roles/openshift_setup/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-openshift_setup
     nodeset: centos-9-crc-xl
@@ -368,7 +368,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/operator_build/(?!meta|README).*
+    - ^roles/operator_build/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-operator_build
     parent: cifmw-molecule-base
@@ -378,7 +378,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/operator_deploy/(?!meta|README).*
+    - ^roles/operator_deploy/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-operator_deploy
     nodeset: centos-9-crc-xl
@@ -389,7 +389,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/os_must_gather/(?!meta|README).*
+    - ^roles/os_must_gather/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-os_must_gather
     parent: cifmw-molecule-base-crc
@@ -399,7 +399,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/pkg_build/(?!meta|README).*
+    - ^roles/pkg_build/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-pkg_build
     parent: cifmw-molecule-base
@@ -409,7 +409,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/registry_deploy/(?!meta|README).*
+    - ^roles/registry_deploy/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-registry_deploy
     parent: cifmw-molecule-base
@@ -419,7 +419,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/repo_setup/(?!meta|README).*
+    - ^roles/repo_setup/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-repo_setup
     parent: cifmw-molecule-base
@@ -429,7 +429,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/reproducer/(?!meta|README).*
+    - ^roles/reproducer/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-reproducer
     nodeset: centos-9-crc-xxl
@@ -441,7 +441,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/rhol_crc/(?!meta|README).*
+    - ^roles/rhol_crc/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-rhol_crc
     nodeset: centos-9-crc-xxl
@@ -453,7 +453,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/run_hook/(?!meta|README).*
+    - ^roles/run_hook/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-run_hook
     parent: cifmw-molecule-base
@@ -463,7 +463,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/set_openstack_containers/(?!meta|README).*
+    - ^roles/set_openstack_containers/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-set_openstack_containers
     parent: cifmw-molecule-base-crc
@@ -473,7 +473,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/switch_config/(?!meta|README).*
+    - ^roles/switch_config/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-switch_config
     parent: cifmw-molecule-base
@@ -483,7 +483,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/tempest/(?!meta|README).*
+    - ^roles/tempest/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-tempest
     parent: cifmw-molecule-base
@@ -493,7 +493,7 @@
     files:
     - ^ansible-requirements.txt
     - ^molecule-requirements.txt
-    - ^ci_framework/roles/test_deps/(?!meta|README).*
+    - ^roles/test_deps/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-test_deps
     parent: cifmw-molecule-base


### PR DESCRIPTION
Post [#943](https://github.com/openstack-k8s-operators/ci-framework/pull/943) no molecule tests are triggered as the include file directory is a soft link.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
