### PR TITLE
Remove ci_framework references to use collection

### DIFF
--- a/.config/molecule/config_local.yml
+++ b/.config/molecule/config_local.yml
@@ -24,7 +24,7 @@ provisioner:
   log: true
   env:
     ANSIBLE_STDOUT_CALLBACK: yaml
-    ANSIBLE_ROLES_PATH: "${ANSIBLE_ROLES_PATH}:${HOME}/zuul-jobs/roles:${HOME}/ci-framework-data/artifacts/roles:${HOME}/src/github.com/openstack-k8s-operators/ci-framework/ci_framework/roles"
+    ANSIBLE_ROLES_PATH: "${ANSIBLE_ROLES_PATH}:${HOME}/zuul-jobs/roles:${HOME}/ci-framework-data/artifacts/roles:${HOME}/src/github.com/openstack-k8s-operators/ci-framework/roles"
     ANSIBLE_LIBRARY: "${ANSIBLE_LIBRARY:-/usr/share/ansible/plugins/modules}:${HOME}/.ansible/plugins/modules:${HOME}/src/github.com/openstack-k8s-operators/ci-framework/plugins/modules"
     ANSIBLE_ACTION_PLUGINS: "${ANSIBLE_ACTION_PLUGINS:-/usr/share/ansible/plugins/action}:${HOME}/.ansible/plugins/action:${HOME}/src/github.com/openstack-k8s-operators/ci-framework/plugins/action"
 

--- a/ci/playbooks/content_provider/content_provider.yml
+++ b/ci/playbooks/content_provider/content_provider.yml
@@ -5,7 +5,6 @@
         [
           ansible_user_dir,
           zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
-          'ci_framework',
           'playbooks',
           '01-bootstrap.yml'
         ] | ansible.builtin.path_join
@@ -62,7 +61,6 @@
         [
           ansible_user_dir,
           zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
-          'ci_framework',
           'playbooks',
           '99-logs.yml'
         ] | ansible.builtin.path_join

--- a/ci/playbooks/e2e-collect-logs.yml
+++ b/ci/playbooks/e2e-collect-logs.yml
@@ -24,5 +24,5 @@
       ansible.builtin.command:
         chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
         cmd: >-
-          ansible-playbook ci_framework/playbooks/99-logs.yml
+          ansible-playbook playbooks/99-logs.yml
           -e @scenarios/centos-9/base.yml

--- a/ci/playbooks/edpm_build_images/edpm_build_images_content_provider.yaml
+++ b/ci/playbooks/edpm_build_images/edpm_build_images_content_provider.yaml
@@ -70,7 +70,6 @@
         [
           ansible_user_dir,
           zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
-          'ci_framework',
           'playbooks',
           '99-logs.yml'
         ] | ansible.builtin.path_join

--- a/ci/playbooks/edpm_build_images/edpm_image_builder.yml
+++ b/ci/playbooks/edpm_build_images/edpm_image_builder.yml
@@ -5,7 +5,6 @@
         [
           ansible_user_dir,
           zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
-          'ci_framework',
           'playbooks',
           '01-bootstrap.yml'
         ] | ansible.builtin.path_join

--- a/ci/playbooks/kuttl/e2e-kuttl.yml
+++ b/ci/playbooks/kuttl/e2e-kuttl.yml
@@ -5,7 +5,6 @@
         [
           ansible_user_dir,
           zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
-          'ci_framework',
           'playbooks',
           '01-bootstrap.yml'
         ] | ansible.builtin.path_join
@@ -39,7 +38,6 @@
         [
           ansible_user_dir,
           zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
-          'ci_framework',
           'playbooks',
           'hooks.yml'
         ] | ansible.builtin.path_join
@@ -63,7 +61,6 @@
         [
           ansible_user_dir,
           zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
-          'ci_framework',
           'playbooks',
           'hooks.yml'
         ] | ansible.builtin.path_join
@@ -75,7 +72,6 @@
         [
           ansible_user_dir,
           zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
-          'ci_framework',
           'playbooks',
           '99-logs.yml'
         ] | ansible.builtin.path_join

--- a/ci/playbooks/tcib/tcib.yml
+++ b/ci/playbooks/tcib/tcib.yml
@@ -5,7 +5,6 @@
         [
           ansible_user_dir,
           zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
-          'ci_framework',
           'playbooks',
           '01-bootstrap.yml'
         ] | ansible.builtin.path_join

--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -15,40 +15,40 @@
         state: absent
 
 - name: Bootstrap step
-  ansible.builtin.import_playbook: ci_framework/playbooks/01-bootstrap.yml
+  ansible.builtin.import_playbook: playbooks/01-bootstrap.yml
 
 - name: Import infra entrypoint playbook
-  ansible.builtin.import_playbook: ci_framework/playbooks/02-infra.yml
+  ansible.builtin.import_playbook: playbooks/02-infra.yml
   tags:
     - infra
 
 - name: Import package build playbook
-  ansible.builtin.import_playbook: ci_framework/playbooks/03-build-packages.yml
+  ansible.builtin.import_playbook: playbooks/03-build-packages.yml
   tags:
     - build-packages
 
 - name: Import containers build playbook
-  ansible.builtin.import_playbook: ci_framework/playbooks/04-build-containers.yml
+  ansible.builtin.import_playbook: playbooks/04-build-containers.yml
   tags:
     - build-containers
 
 - name: Import operators build playbook
-  ansible.builtin.import_playbook: ci_framework/playbooks/05-build-operators.yml
+  ansible.builtin.import_playbook: playbooks/05-build-operators.yml
   tags:
     - build-operators
 
 - name: Import deploy edpm playbook
-  ansible.builtin.import_playbook: ci_framework/playbooks/06-deploy-edpm.yml
+  ansible.builtin.import_playbook: playbooks/06-deploy-edpm.yml
   tags:
     - edpm
 
 - name: Import admin setup related playbook
-  ansible.builtin.import_playbook: ci_framework/playbooks/07-admin-setup.yml
+  ansible.builtin.import_playbook: playbooks/07-admin-setup.yml
   tags:
     - admin-setup
 
 - name: Import run test playbook
-  ansible.builtin.import_playbook: ci_framework/playbooks/08-run-tests.yml
+  ansible.builtin.import_playbook: playbooks/08-run-tests.yml
   when: cifmw_run_tests | default('false') | bool
   tags:
     - run-tests
@@ -62,7 +62,7 @@
         state: touch
 
 - name: Run log related tasks
-  ansible.builtin.import_playbook: ci_framework/playbooks/99-logs.yml
+  ansible.builtin.import_playbook: playbooks/99-logs.yml
   when: not zuul_log_collection | default('false') | bool
   tags:
     - logs

--- a/docs/source/development/01_guidelines.md
+++ b/docs/source/development/01_guidelines.md
@@ -39,4 +39,4 @@ and cover as many corner cases as possible.
 ### Ansible custom plugins
 Please take the time to consider how to test your custom plugins. You may
 either rely on [molecule](./02_molecule.md) or, maybe,
-[ansible-test](https://github.com/openstack-k8s-operators/ci-framework/tree/main/ci_framework/tests/integration).
+[ansible-test](https://github.com/openstack-k8s-operators/ci-framework/tree/main/tests/integration).

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -99,7 +99,7 @@ pre_infra:
 ~~~
 
 In the above example, the `foo.yml` is located in
-[ci_framework/hooks/playbooks](https://github.com/openstack-k8s-operators/ci-framework/tree/main/ci_framework/hooks/playbooks) while
+[hooks/playbooks](https://github.com/openstack-k8s-operators/ci-framework/tree/main/hooks/playbooks) while
 `glorious.crd` is located in some external path.
 
 Also, the list order is important: the hook will first load the playbook,

--- a/docs/source/usage/02_own_ci.md
+++ b/docs/source/usage/02_own_ci.md
@@ -46,10 +46,10 @@ definition, you can pass any kind of parameters as a list:
     name: cifmw-end-to-end
     parent: cifmw-end-to-end-base
     files:
-      - ^ci_framework/roles/.*_build/(?!meta|README).*
-      - ^ci_framework/roles/build.*/(?!meta|README).*
-      - ^ci_framework/roles/openshift_*/(?!meta|README).*
-      - ^ci_framework/playbooks/.*build.*.yml
+      - ^roles/.*_build/(?!meta|README).*
+      - ^roles/build.*/(?!meta|README).*
+      - ^roles/openshift_*/(?!meta|README).*
+      - ^playbooks/.*build.*.yml
     irrelevant-files:
       - ^.*/*.md
       - ^ci/templates

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -80,6 +80,9 @@ dependencies:
   'git+https://github.com/openstack/ansible-collections-openstack': 'master'
   'git+https://github.com/ansible-collections/ansible.netcommon': 'main'
   'git+https://github.com/openstack/ansible-config_template': 'master'
+  'git+https://github.com/ansible-collections/junipernetworks.junos': '2.10.0'
+  'git+https://github.com/ansible-collections/cisco.ios': '3.3.2'
+  'git+https://github.com/ansible-collections/mellanox.onyx': 'master'
 
 # The URL of the originating SCM repository
 repository: https://github.com/openstack-k8s-operators/ci-framework

--- a/roles/cifmw_cephadm/README.md
+++ b/roles/cifmw_cephadm/README.md
@@ -191,5 +191,5 @@ export ANSIBLE_HOST_KEY_CHECKING=False
 
 ```
 cd ~/ci-framework/
-ansible-playbook ci_framework/playbooks/ceph.yml
+ansible-playbook playbooks/ceph.yml
 ```

--- a/roles/dlrn_promote/README.md
+++ b/roles/dlrn_promote/README.md
@@ -26,7 +26,7 @@ The sample `cifmw_dlrn_promote_criteria_file` criteria file can be found in `fil
 
 ## Dependencies
 
-This role depends on ci-framework [repo-setup](https://github.com/openstack-k8s-operators/ci-framework/tree/main/ci_framework/roles/repo_setup)
+This role depends on ci-framework [repo-setup](https://github.com/openstack-k8s-operators/ci-framework/tree/main/roles/repo_setup)
 and [set-zuul-log-path-fact](https://opendev.org/zuul/zuul-jobs/src/branch/master/roles/set-zuul-log-path-fact) roles.
 
 ## Example

--- a/roles/dlrn_report/README.md
+++ b/roles/dlrn_report/README.md
@@ -22,7 +22,7 @@ This role does not need privilege escalation.
 
 ## Dependencies
 
-This role depends on ci-framework [repo-setup](https://github.com/openstack-k8s-operators/ci-framework/tree/main/ci_framework/roles/repo_setup)
+This role depends on ci-framework [repo-setup](https://github.com/openstack-k8s-operators/ci-framework/tree/main/roles/repo_setup)
 and [set-zuul-log-path-fact](https://opendev.org/zuul/zuul-jobs/src/branch/master/roles/set-zuul-log-path-fact) roles.
 
 ## Example

--- a/roles/edpm_deploy/README.md
+++ b/roles/edpm_deploy/README.md
@@ -21,4 +21,4 @@ None
 - Integrate EDPM kustomize
 
 ## Resources
-* [ci_framework](https://github.com/openstack-k8s-operators/install_yamls)
+* [install_yamls](https://github.com/openstack-k8s-operators/install_yamls)

--- a/roles/install_yamls/README.md
+++ b/roles/install_yamls/README.md
@@ -12,7 +12,7 @@ It contains a set of playbooks to deploy podified control plane.
 * `cifmw_install_yamls_edpm_dir`: (String) Output directory for EDPM related artifacts (OUTPUT_BASEDIR). Defaults to `{{ cifmw_install_yamls_out_dir_basedir ~ '/artifacts/edpm' }}`
 
 ## Use case
-This module uses [a custom plugin](https://github.com/openstack-k8s-operators/ci-framework/blob/main/ci_framework/plugins/modules/generate_make_tasks.py) created to generate the role with tasks from Makefile.
+This module uses [a custom plugin](https://github.com/openstack-k8s-operators/ci-framework/blob/main/plugins/modules/generate_make_tasks.py) created to generate the role with tasks from Makefile.
 The created role directory contains multiple task files, similar to
 ```YAML
 ---

--- a/roles/os_net_setup/README.md
+++ b/roles/os_net_setup/README.md
@@ -8,7 +8,7 @@ being an openstack admin on the API.
 That is provided by `openshift_login` role.
 
 ## Parameters
-* `cifmw_os_net_setup_config`: See an example in ci_framework/roles/os_net_setup/defaults/main.yml
+* `cifmw_os_net_setup_config`: See an example in roles/os_net_setup/defaults/main.yml
 * `cifmw_os_net_setup_osp_calls_retries`: (Integer) Number of attempts to retry an OSP action if it fails. Defaults to `10`.
 * `cifmw_os_net_setup_osp_calls_delay`: (Integer) Delay, in seconds, between failed OSP call retries. Defaults to `5`.
 * `cifmw_os_net_setup_verify_tls`: (Boolean) In case of TLS enabled for OpenStack endpoint, validates against the CA. Defaults to `true`.

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -119,7 +119,7 @@
         cmd: >-
           ansible-playbook
           -e @~/reproducer-variables.yml
-          ci_framework/playbooks/01-bootstrap.yml
+          playbooks/01-bootstrap.yml
 
     - name: Emulate CI job
       when:

--- a/roles/reproducer/tasks/push_code.yml
+++ b/roles/reproducer/tasks/push_code.yml
@@ -71,7 +71,8 @@
         label: "{{ repository.src | basename }}"
 
 - name: Install collections on controller-0
+  # installing the cifmw collection will pull it's dependencies alongside it
   delegate_to: controller-0
   ansible.builtin.command:
     chdir: "src/github.com/openstack-k8s-operators/ci-framework"
-    cmd: ansible-galaxy collection install -r requirements.yml
+    cmd: ansible-galaxy collection install -U .

--- a/roles/run_hook/README.md
+++ b/roles/run_hook/README.md
@@ -18,7 +18,7 @@ In such a case, the following data can be provided to the hook:
 * `creates`: (String) Refer to the `ansible.builtin.command` "creates" parameter. Defaults to `omit`.
 * `inventory`: (String) Refer to the `--inventory` option for `ansible-playbook`. Defaults to `inventory_file`.
 * `name`: (String) Describe the hook.
-* `source`: (String) Source of the playbook. If it's a filename, the playbook is expected in `ci_framework/hooks/playbooks`. It can be an absolute path.
+* `source`: (String) Source of the playbook. If it's a filename, the playbook is expected in `hooks/playbooks`. It can be an absolute path.
 * `type`: (String) Type of the hook. In this case, set it to `playbook`.
 * `extra_vars`: (Dict) Structure listing the extra variables you want to pass down
 
@@ -58,7 +58,7 @@ pre_deploy:
 ### CRD
 In such a case, the following data can be provided to the hook:
 * `type`: (String) Type of the hook. In this case, set it to `crd`.
-* `source`: (String) Source of the CRD. If it's a filename, the CRD is expected in `ci_framework/hooks/crds`. It can be an absolute path.
+* `source`: (String) Source of the CRD. If it's a filename, the CRD is expected in `hooks/crds`. It can be an absolute path.
 * `host`: (String) Cluster API endpoint. Defaults to `https://api.crc.testing:6443`.
 * `username`: (String) Username for authentication against the cluster. Defaults to `kubeadmin`.
 * `password`: (String) Password for authentication against the cluster. Defaults to `12345678`.

--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -155,18 +155,18 @@
     name: cifmw-data-plane-adoption-github-rdo-centos-9-extracted-crc
     parent: content-provider-data-plane-adoption-github-rdo-centos-9-extracted-crc
     files: &dpa_job_files
-      - ^ci_framework/playbooks/01-bootstrap.yml
-      - ^ci_framework/playbooks/02-infra.yml
-      - ^ci_framework/playbooks/06-deploy-edpm.yml
-      - ^ci_framework/roles/discover_latest_image/(?!meta|README|molecule).*
-      - ^ci_framework/roles/edpm_prepare/(?!meta|README|molecule).*
-      - ^ci_framework/roles/install_ca/(?!meta|README|molecule).*
-      - ^ci_framework/roles/install_yamls/(?!meta|README|molecule).*
-      - ^ci_framework/roles/libvirt_manager/(?!meta|README|molecule).*
-      - ^ci_framework/roles/openshift_login/(?!meta|README|molecule).*
-      - ^ci_framework/roles/openshift_setup/(?!meta|README|molecule).*
-      - ^ci_framework/roles/repo_setup/(?!meta|README|molecule).*
-      - ^ci_framework/hooks/playbooks/fetch_compute_facts.yml
+      - ^playbooks/01-bootstrap.yml
+      - ^playbooks/02-infra.yml
+      - ^playbooks/06-deploy-edpm.yml
+      - ^roles/discover_latest_image/(?!meta|README|molecule).*
+      - ^roles/edpm_prepare/(?!meta|README|molecule).*
+      - ^roles/install_ca/(?!meta|README|molecule).*
+      - ^roles/install_yamls/(?!meta|README|molecule).*
+      - ^roles/libvirt_manager/(?!meta|README|molecule).*
+      - ^roles/openshift_login/(?!meta|README|molecule).*
+      - ^roles/openshift_setup/(?!meta|README|molecule).*
+      - ^roles/repo_setup/(?!meta|README|molecule).*
+      - ^hooks/playbooks/fetch_compute_facts.yml
       - ^zuul.d/adoption.yaml
       - go.mod
       - apis/go.mod

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -41,9 +41,9 @@
       - roles/.*/molecule/.*
       # ci-framework
       - .readthedocs.yaml
-      - ci_framework/roles/dlrn_report
-      - ci_framework/roles/dlrn_promote
-      - ci_framework/roles/devscripts
+      - roles/dlrn_report
+      - roles/dlrn_promote
+      - roles/devscripts
       # Other openstack operators
       - containers/ci
       - .ci-operator.yaml

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -33,10 +33,10 @@
     name: ci-framework-crc-podified-edpm-deployment
     parent: cifmw-crc-podified-edpm-deployment
     files:
-      - ^ci_framework/playbooks/*
-      - ^ci_framework/roles/edpm_prepare/(?!meta|README).*
-      - ^ci_framework/roles/edpm_deploy/(?!meta|README).*
-      - ^ci_framework/roles/artifacts/tasks/edpm.yml
+      - ^playbooks/*
+      - ^roles/edpm_prepare/(?!meta|README).*
+      - ^roles/edpm_deploy/(?!meta|README).*
+      - ^roles/artifacts/tasks/edpm.yml
       - ^deploy-edpm.yml
       - ^scenarios/centos-9/edpm_ci.yml
 
@@ -44,8 +44,8 @@
     name: ci-framework-crc-podified-galera-deployment
     parent: cifmw-crc-podified-galera-deployment
     files:
-      - ^ci_framework/playbooks/*
-      - ^ci_framework/roles/edpm_prepare/(?!meta|README).*
+      - ^playbooks/*
+      - ^roles/edpm_prepare/(?!meta|README).*
       - ^deploy-edpm.yml
       - ^scenarios/centos-9/edpm_ci.yml
 
@@ -53,8 +53,8 @@
     name: ci-framework-crc-podified-edpm-baremetal
     parent: cifmw-crc-podified-edpm-baremetal
     files:
-      - ^ci_framework/playbooks/*
-      - ^ci_framework/roles/edpm_deploy_baremetal/(?!meta|README).*
+      - ^playbooks/*
+      - ^roles/edpm_deploy_baremetal/(?!meta|README).*
       - ^ci/playbooks/edpm_baremetal_deployment/run.yml
       - ^deploy-edpm.yml
       - ^scenarios/centos-9/edpm_baremetal_deployment_ci.yml

--- a/zuul.d/edpm_build_images.yaml
+++ b/zuul.d/edpm_build_images.yaml
@@ -27,4 +27,4 @@
       - ^ci/playbooks/edpm_build_images/.*
       - ^scenarios/centos-9/edpm_build_images_ci.yml
       - ^zuul.d/edpm_build_images.yaml
-      - ^ci_framework/roles/edpm_build_images/*
+      - ^roles/edpm_build_images/*

--- a/zuul.d/edpm_build_images_content_provider.yaml
+++ b/zuul.d/edpm_build_images_content_provider.yaml
@@ -26,5 +26,5 @@
     files:
       - ^ci/playbooks/edpm_build_images/edpm_build_images_content_provider.yaml
       - ^ci/playbooks/edpm_build_images/edpm_build_images_content_provider_run.yaml
-      - ^ci_framework/roles/edpm_build_images/*
+      - ^roles/edpm_build_images/*
       - ^zuul.d/edpm_build_images_content_provider.yaml

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -214,13 +214,13 @@
     name: podified-multinode-hci-deployment-crc
     parent: podified-multinode-hci-deployment-crc-3comp
     files:
-      - ^ci_framework/playbooks/06-deploy-edpm.yml
-      - ^ci_framework/playbooks/ceph.yml
-      - ^ci_framework/roles/edpm_deploy/(?!meta|README).*
-      - ^ci_framework/roles/hci_prepare/(?!meta|README).*
-      - ^ci_framework/roles/cifmw_ceph.*/(?!meta|README).*
-      - ^ci_framework/roles/cifmw_block_device/(?!meta|README).*
-      - ^ci_framework/roles/cifmw_create_admin/(?!meta|README).*
+      - ^playbooks/06-deploy-edpm.yml
+      - ^playbooks/ceph.yml
+      - ^roles/edpm_deploy/(?!meta|README).*
+      - ^roles/hci_prepare/(?!meta|README).*
+      - ^roles/cifmw_ceph.*/(?!meta|README).*
+      - ^roles/cifmw_block_device/(?!meta|README).*
+      - ^roles/cifmw_create_admin/(?!meta|README).*
 
 - job:
     name: podified-multinode-edpm-e2e-nobuild-tagged-crc
@@ -245,9 +245,9 @@
     run:
       - ci/playbooks/e2e-run.yml
     irrelevant-files:
-      - ^ci_framework/roles/.*_build
-      - ^ci_framework/roles/build.*
-      - ^ci_framework/roles/local_env_vm
+      - ^roles/.*_build
+      - ^roles/build.*
+      - ^roles/local_env_vm
       - ^ci/templates
       - ^docs
       - ^.*/*.md

--- a/zuul.d/end-to-end.yaml
+++ b/zuul.d/end-to-end.yaml
@@ -23,10 +23,10 @@
     name: cifmw-end-to-end
     parent: cifmw-end-to-end-base
     files:
-      - ^ci_framework/roles/.*_build/(?!meta|README).*
-      - ^ci_framework/roles/build.*/(?!meta|README).*
-      - ^ci_framework/roles/openshift_.*/(?!meta|README).*
-      - ^ci_framework/playbooks/.*build.*.yml
+      - ^roles/.*_build/(?!meta|README).*
+      - ^roles/build.*/(?!meta|README).*
+      - ^roles/openshift_.*/(?!meta|README).*
+      - ^playbooks/.*build.*.yml
     irrelevant-files:
       - ^.*/*.md
       - ^ci/templates
@@ -44,8 +44,8 @@
     name: cifmw-end-to-end-nobuild-tagged
     parent: cifmw-end-to-end-base
     irrelevant-files:
-      - ^ci_framework/roles/.*_build
-      - ^ci_framework/roles/build.*
+      - ^roles/.*_build
+      - ^roles/build.*
       - ^ci/templates
       - ^docs
       - ^.*/*.md
@@ -61,8 +61,8 @@
     name: cifmw-baremetal-nested-crc
     parent: cifmw-crc-podified-edpm-baremetal
     files:
-      - ^ci_framework/roles/rhol_crc/(?!meta|README).*
-      - ^ci_framework/roles/libvirt_manager/(?!meta|README).*
-      - ^ci_framework/roles/cert_manager/(?!meta|README).*
+      - ^roles/rhol_crc/(?!meta|README).*
+      - ^roles/libvirt_manager/(?!meta|README).*
+      - ^roles/cert_manager/(?!meta|README).*
       - scenarios/centos-9/edpm_baremetal_deployment_ci.yml
     run: ci/playbooks/edpm_baremetal_deployment/run.yml

--- a/zuul.d/molecule-base.yaml
+++ b/zuul.d/molecule-base.yaml
@@ -10,7 +10,7 @@
     required-projects:
       - github.com/openstack-k8s-operators/install_yamls
     vars:
-      roles_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/ci_framework/roles/{{ TEST_RUN }}"
+      roles_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/roles/{{ TEST_RUN }}"
       mol_config_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/.config/molecule/config_local.yml"
 
 - job:
@@ -23,5 +23,5 @@
     required-projects:
       - github.com/openstack-k8s-operators/install_yamls
     vars:
-      roles_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/ci_framework/roles/{{ TEST_RUN }}"
+      roles_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/roles/{{ TEST_RUN }}"
       mol_config_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/.config/molecule/config_local.yml"

--- a/zuul.d/tcib.yaml
+++ b/zuul.d/tcib.yaml
@@ -22,6 +22,6 @@
     name: cifmw-tcib
     parent: cifmw-tcib-base
     files:
-      - ^ci_framework/roles/build_containers/(?!meta|README).*
+      - ^roles/build_containers/(?!meta|README).*
       - ^scenarios/centos-9/tcib.yml
       - ^ci/playbooks/tcib

--- a/zuul.d/tempest_multinode.yaml
+++ b/zuul.d/tempest_multinode.yaml
@@ -65,7 +65,7 @@
     name: cifmw-multinode-tempest
     parent: cifmw-base-multinode-tempest
     files:
-      - ^ci_framework/roles/tempest
+      - ^roles/tempest
       - ^scenarios/centos-9/multinode-ci.yml
       - ^scenarios/centos-9/ci.yml
       - ^scenarios/centos-9/ceph_backends.yml


### PR DESCRIPTION
Since we moved to a collection structure, when referring to playbooks,
roles, etc. we should not point to ci_framework folder but to the
repo root.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] Content of the docs/source is reflecting the changes
