### PR TITLE
Add defaults for dashboard container image params

### DIFF
--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -97,3 +97,8 @@ cifmw_cephadm_grafana_admin_user: 'admin'
 cifmw_cephadm_grafana_admin_password: '/home/grafana_password.yml'
 cifmw_cephadm_prometheus_port: 9092
 cifmw_cephadm_grafana_port: 3100
+cifmw_cephadm_prometheus_container_ns: "quay.io/prometheus"
+cifmw_cephadm_alertmanager_container_image: "{{ cifmw_cephadm_prometheus_container_ns }}/alertmanager:v0.25.0"
+cifmw_cephadm_grafana_container_image: "{{ cifmw_cephadm_container_ns }}/ceph-grafana:9.4.7"
+cifmw_cephadm_node_exporter_container_image: "{{ cifmw_cephadm_prometheus_container_ns }}/node-exporter:v1.5.0"
+cifmw_cephadm_prometheus_container_image: "{{ cifmw_cephadm_prometheus_container_ns }}/prometheus:v2.43.0"


### PR DESCRIPTION
This patch adds default values for container images of dashabord services.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
