### PR TITLE
Update multinode-centos-9-stream-crc

### DIFF
--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -47,7 +47,7 @@
       - name: controller
         label: cloud-centos-9-stream-tripleo-vexxhost-medium
       - name: crc
-        label: coreos-crc-extracted-xxl
+        label: coreos-crc-extracted-3xl
     groups:
       - name: computes
         nodes: []


### PR DESCRIPTION
multinode-centos-9-stream-crc uses coreos-crc-extracted-xxl which is not sufficient and results in timed_out[1]

[1] https://logserver.rdoproject.org/96/196/8e043db26841a70ed57a54fe0c5b02dfd4bc493a/github-check/manila-operator-tempest/f9f8d5b/controller/ci-framework-data/logs/os_must_gather.log

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
