### PR TITLE
[libvirt_manager] Rely on `community.crypto.openssh_keypair` for temporary keypair generation

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -19,6 +19,8 @@ collections:
     type: git
   - name: https://github.com/ansible-collections/community.general
     type: git
+  - name: https://github.com/ansible-collections/community.crypto
+    type: git
   - name: https://github.com/containers/ansible-podman-collections
     type: git
   - name: https://github.com/ansible-collections/community.libvirt

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -40,11 +40,10 @@
     label: "{{ item.key }}"
 
 - name: Create temporary ssh keypair
-  ansible.builtin.command:
-    cmd: >-
-      ssh-keygen -t ed25519
-      -f {{ ansible_user_dir }}/.ssh/cifmw_reproducer_key -P '' -q
-    creates: "{{ ansible_user_dir }}/.ssh/cifmw_reproducer_key"
+  community.crypto.openssh_keypair:
+    path: "{{ ansible_user_dir }}/.ssh/cifmw_reproducer_key"
+    type: "ed25519"
+    regenerate: full_idempotence
 
 - name: Slurp public key for later use
   register: pub_ssh_key


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
