### PR TITLE
Add new cifwm base job for ci-bootstrap layout

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -241,3 +241,16 @@
       registry_login_enabled: true
       push_registry: quay.rdoproject.org
       quay_login_secret_name: quay_nextgen_zuulgithubci
+
+#
+# CI-BOOTSTRAP EDPM MULTINODE JOBS
+#
+
+- job:
+    name: cifmw-extracted-crc-pre-bootstrap
+    parent: base-extracted-crc-wo-networks
+    abstract: true
+    description: |
+      CI-Framework base extracted CRC job which runs after starting
+      CRC environment and before running ci-boostrap roles to
+      configure networking between nodes.


### PR DESCRIPTION
This new job will run after extracted crc starts and before calling ci-bootstrap to configure the networking between nodes.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
