### PR TITLE
Remove references to requirements files deleted

### DIFF
--- a/ci/templates/molecule.yaml.j2
+++ b/ci/templates/molecule.yaml.j2
@@ -5,8 +5,8 @@
     vars:
       TEST_RUN: {{ role_name }}
     files:
-      - ^ansible-requirements.txt
-      - ^molecule-requirements.txt
+      - ^common-requirements.txt
+      - ^test-requirements.txt
       - ^roles/{{ role_name }}/(?!meta|README).*
       - ^ci/playbooks/molecule.*
 {% endfor %}

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -237,7 +237,7 @@
 
     - name: Install ansible dependencies
       ansible.builtin.pip:
-        requirements: https://raw.githubusercontent.com/openstack-k8s-operators/ci-framework/main/ansible-requirements.txt
+        requirements: https://raw.githubusercontent.com/openstack-k8s-operators/ci-framework/main/common-requirements.txt
 
     - name: Inject most of the cifmw_ parameters passed to the reproducer run
       vars:

--- a/scripts/tests/test_create_role_molecule.py
+++ b/scripts/tests/test_create_role_molecule.py
@@ -151,8 +151,8 @@ class CreateRoleMoleculeTest(unittest.TestCase):
             {
                 "job": {
                     "files": [
-                        "^ansible-requirements.txt",
-                        "^molecule-requirements.txt",
+                        "^common-requirements.txt",
+                        "^test-requirements.txt",
                         "^roles/role_2/(?!meta|README).*",
                         "^ci/playbooks/molecule.*",
                     ],
@@ -164,8 +164,8 @@ class CreateRoleMoleculeTest(unittest.TestCase):
             {
                 "job": {
                     "files": [
-                        "^ansible-requirements.txt",
-                        "^molecule-requirements.txt",
+                        "^common-requirements.txt",
+                        "^test-requirements.txt",
                         "^roles/role_1/(?!meta|README).*",
                         "^ci/playbooks/molecule.*",
                     ],
@@ -177,8 +177,8 @@ class CreateRoleMoleculeTest(unittest.TestCase):
             {
                 "job": {
                     "files": [
-                        "^ansible-requirements.txt",
-                        "^molecule-requirements.txt",
+                        "^common-requirements.txt",
+                        "^test-requirements.txt",
                         "^roles/role_3/(?!meta|README).*",
                         "^ci/playbooks/molecule.*",
                     ],

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -1,7 +1,7 @@
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/artifacts/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-artifacts
@@ -10,8 +10,8 @@
       TEST_RUN: artifacts
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/build_containers/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-build_containers
@@ -20,8 +20,8 @@
       TEST_RUN: build_containers
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/build_openstack_packages/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-build_openstack_packages
@@ -30,8 +30,8 @@
       TEST_RUN: build_openstack_packages
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/cert_manager/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-cert_manager
@@ -41,8 +41,8 @@
       TEST_RUN: cert_manager
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/ci_local_storage/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-ci_local_storage
@@ -52,8 +52,8 @@
       TEST_RUN: ci_local_storage
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/ci_metallb/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-ci_metallb
@@ -62,8 +62,8 @@
       TEST_RUN: ci_metallb
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/ci_multus/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-ci_multus
@@ -72,8 +72,8 @@
       TEST_RUN: ci_multus
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/ci_netconfig/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-ci_netconfig
@@ -82,8 +82,8 @@
       TEST_RUN: ci_netconfig
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/ci_network/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-ci_network
@@ -92,8 +92,8 @@
       TEST_RUN: ci_network
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/ci_nmstate/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-ci_nmstate
@@ -102,8 +102,8 @@
       TEST_RUN: ci_nmstate
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/ci_setup/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-ci_setup
@@ -112,8 +112,8 @@
       TEST_RUN: ci_setup
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/cifmw_block_device/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-cifmw_block_device
@@ -122,8 +122,8 @@
       TEST_RUN: cifmw_block_device
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/cifmw_ceph_client/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-cifmw_ceph_client
@@ -132,8 +132,8 @@
       TEST_RUN: cifmw_ceph_client
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/cifmw_ceph_spec/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-cifmw_ceph_spec
@@ -142,8 +142,8 @@
       TEST_RUN: cifmw_ceph_spec
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/cifmw_cephadm/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-cifmw_cephadm
@@ -152,8 +152,8 @@
       TEST_RUN: cifmw_cephadm
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/cifmw_create_admin/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-cifmw_create_admin
@@ -162,8 +162,8 @@
       TEST_RUN: cifmw_create_admin
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/cifmw_test_role/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-cifmw_test_role
@@ -172,8 +172,8 @@
       TEST_RUN: cifmw_test_role
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/devscripts/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-devscripts
@@ -182,8 +182,8 @@
       TEST_RUN: devscripts
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/discover_latest_image/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-discover_latest_image
@@ -192,8 +192,8 @@
       TEST_RUN: discover_latest_image
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/dlrn_promote/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-dlrn_promote
@@ -202,8 +202,8 @@
       TEST_RUN: dlrn_promote
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/dlrn_report/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-dlrn_report
@@ -212,8 +212,8 @@
       TEST_RUN: dlrn_report
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/edpm_build_images/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-edpm_build_images
@@ -222,8 +222,8 @@
       TEST_RUN: edpm_build_images
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/edpm_deploy/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-edpm_deploy
@@ -232,8 +232,8 @@
       TEST_RUN: edpm_deploy
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/edpm_deploy_baremetal/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-edpm_deploy_baremetal
@@ -242,8 +242,8 @@
       TEST_RUN: edpm_deploy_baremetal
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/edpm_kustomize/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-edpm_kustomize
@@ -252,8 +252,8 @@
       TEST_RUN: edpm_kustomize
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/edpm_prepare/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-edpm_prepare
@@ -262,8 +262,8 @@
       TEST_RUN: edpm_prepare
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/env_op_images/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-env_op_images
@@ -273,8 +273,8 @@
       TEST_RUN: env_op_images
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/hci_prepare/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-hci_prepare
@@ -283,8 +283,8 @@
       TEST_RUN: hci_prepare
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/hive/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-hive
@@ -293,8 +293,8 @@
       TEST_RUN: hive
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/idrac_configuration/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-idrac_configuration
@@ -303,8 +303,8 @@
       TEST_RUN: idrac_configuration
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/install_ca/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-install_ca
@@ -313,8 +313,8 @@
       TEST_RUN: install_ca
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/install_yamls/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-install_yamls
@@ -323,8 +323,8 @@
       TEST_RUN: install_yamls
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/libvirt_manager/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-libvirt_manager
@@ -333,8 +333,8 @@
       TEST_RUN: libvirt_manager
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/manage_secrets/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-manage_secrets
@@ -344,8 +344,8 @@
       TEST_RUN: manage_secrets
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/openshift_login/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-openshift_login
@@ -355,8 +355,8 @@
       TEST_RUN: openshift_login
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/openshift_provisioner_node/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-openshift_provisioner_node
@@ -366,8 +366,8 @@
       TEST_RUN: openshift_provisioner_node
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/openshift_setup/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-openshift_setup
@@ -377,8 +377,8 @@
       TEST_RUN: openshift_setup
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/operator_build/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-operator_build
@@ -387,8 +387,8 @@
       TEST_RUN: operator_build
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/operator_deploy/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-operator_deploy
@@ -398,8 +398,8 @@
       TEST_RUN: operator_deploy
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/os_must_gather/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-os_must_gather
@@ -408,8 +408,8 @@
       TEST_RUN: os_must_gather
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/pkg_build/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-pkg_build
@@ -418,8 +418,8 @@
       TEST_RUN: pkg_build
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/registry_deploy/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-registry_deploy
@@ -428,8 +428,8 @@
       TEST_RUN: registry_deploy
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/repo_setup/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-repo_setup
@@ -438,8 +438,8 @@
       TEST_RUN: repo_setup
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/reproducer/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-reproducer
@@ -450,8 +450,8 @@
       TEST_RUN: reproducer
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/rhol_crc/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-rhol_crc
@@ -462,8 +462,8 @@
       TEST_RUN: rhol_crc
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/run_hook/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-run_hook
@@ -472,8 +472,8 @@
       TEST_RUN: run_hook
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/set_openstack_containers/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-set_openstack_containers
@@ -482,8 +482,8 @@
       TEST_RUN: set_openstack_containers
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/tempest/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-tempest
@@ -492,8 +492,8 @@
       TEST_RUN: tempest
 - job:
     files:
-    - ^ansible-requirements.txt
-    - ^molecule-requirements.txt
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/test_deps/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-test_deps


### PR DESCRIPTION
In several parts of the ci-framework we had dangling references to the
requirements files deleted by
https://github.com/openstack-k8s-operators/ci-framework/pull/971, and
this file deletes them. Most of them were not that problematic in zuul.d
files, but the reproducer role contained would try to pull
ansible-requirements from main branch, which would fail.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
