### PR TITLE
Add retry & delay while creating dirs on worker node

### DIFF
--- a/roles/ci_local_storage/tasks/worker_node_dirs.yml
+++ b/roles/ci_local_storage/tasks/worker_node_dirs.yml
@@ -10,3 +10,7 @@
       do echo \"{{ _msg }} dir {{ cifmw_cls_local_storage_name }}/pv\$i on {{ item }}\";
       {{ cifmw_cls_action }} {{ cifmw_cls_local_storage_name }}/pv\$i; done"
   loop: "{{ _cls_nodes }}"
+  until: _worker_operation_out.rc == 0 and _worker_operation_out.stdout != ""
+  register: _worker_operation_out
+  retries: 10
+  delay: 20


### PR DESCRIPTION
While creating dirs on worker node, ci_local_storage role fails randomly. Re-running the same task fixes the issue.

As a temprory measure, we are adding retries to the task to fix the issue.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

