### PR TITLE
Run crc cleanup only when crc binary exists

### DIFF
--- a/roles/rhol_crc/tasks/cleanup.yml
+++ b/roles/rhol_crc/tasks/cleanup.yml
@@ -16,5 +16,12 @@
 
 # It actually deletes everything related with the instance:
 # domain and XML definition, network and XML definition, crc instance, ...
+
+- name: Check RHOL/CRC binary exists
+  ansible.builtin.stat:
+    path: "{{ cifmw_rhol_crc_binary }}"
+  register: cifmw_rhol_crc_binary_stat
+
 - name: Delete RHOL/CRC instance and associated configuration
+  when: cifmw_rhol_crc_binary_stat.stat.exists
   ansible.builtin.command: "{{ cifmw_rhol_crc_binary }} cleanup"


### PR DESCRIPTION
The devscript reproducer baremetal job is failing with following error from long time during cleanup.
```
TASK [rhol_crc : Delete RHOL/CRC instance and associated configuration _raw_params={{ cifmw_rhol_crc_binary }} cleanup] ***
2023-12-21 15:38:36.623889 | primary | Thursday 21 December 2023  15:38:36 -0500 (0:00:00.051)       0:00:04.214 *****
2023-12-21 15:38:36.904213 | primary | fatal: [hypervisor]: FAILED! => {"changed": false, "cmd": "/root/ci-framework-data/bin/crc cleanup", "msg": "[Errno 2] No such file or directory: b'/root/ci-framework-data/bin/crc'", "rc": 2, "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
```

This pr fixes the issue.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

