### PR TITLE
[devscripts] Enhance cleanup for CI token errors

### DIFF
--- a/roles/devscripts/tasks/cleanup.yml
+++ b/roles/devscripts/tasks/cleanup.yml
@@ -29,10 +29,16 @@
     path: "{{ cifmw_devscripts_repo_dir }}"
   register: devscript_repodir
 
+- name: Gather the metal3-dev-env repo directory information.
+  ansible.builtin.stat:
+    path: "{{ cifmw_devscripts_config_defaults.working_dir }}/metal3-dev-env"
+  register: metal3_dev_env_repodir
+
 - name: Remove the deployed OpenShift platform.
   when:
     - not cifmw_devscripts_dry_run | bool
     - devscript_repodir.stat.exists
+    - metal3_dev_env_repodir.stat.exists
   community.general.make:
     chdir: "{{ cifmw_devscripts_repo_dir }}"
     target: clean


### PR DESCRIPTION
Improved cleanup to handle CI token issues by checking logs for errors.
In case CI token is invalid, deployment would fail and a cleanup
afterwards will try to clean non-existed directory.
This is ensuring `make clean` will be done only if the required
directory exists.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
