### PR TITLE
Add playbooks and job definition for ci-bootstrap jobs

### DIFF
--- a/ci/playbooks/crc/reconfigure-kubelet.yml
+++ b/ci/playbooks/crc/reconfigure-kubelet.yml
@@ -1,0 +1,50 @@
+---
+# Currently, the CRC is using:
+# --system-reserved=cpu=200m,memory=350Mi,ephemeral-storage=350Mi
+# Which means:
+# - SYSTEM_RESERVED_CPU = 200m
+# - SYSTEM_RESERVED_MEMORY = 350Mi
+# - SYSTEM_RESERVED_ES = 350Mi
+# Which might be not enough for basic services on high utilized worker node.
+# Those values are set in /etc/node-sizing.env (base on kubelet service file)
+# with values: https://github.com/crc-org/snc/blob/release-4.12/node-sizing-enabled.env
+# Helpful doc: https://docs.openshift.com/container-platform/4.12/nodes/nodes/nodes-nodes-resources-configuring.html
+
+- hosts: crc
+  tasks:
+    - name: Reconfigure kubelet service
+      become: true
+      block:
+        - name: Change the kubelet service EnvironmentFile
+          ansible.builtin.lineinfile:
+            path: /etc/node-sizing.env
+            regexp: "{{ item.regexp }}"
+            line: "{{ item.line }}"
+          loop:
+            - regexp: "^SYSTEM_RESERVED_CPU=200m"
+              line: "SYSTEM_RESERVED_CPU={{ bootstrap_ci_crc_systemd_cpu | default('800m') }}"
+            - regexp: "^SYSTEM_RESERVED_MEMORY=350Mi"
+              line: "SYSTEM_RESERVED_MEMORY={{ bootstrap_ci_crc_systemd_mem | default('700Mi') }}"
+            - regexp: "^SYSTEM_RESERVED_ES=350Mi"
+              line: "SYSTEM_RESERVED_ES={{ bootstrap_ci_crc_systemd_disk | default('700Mi') }}"
+
+        - name: Change the kubelet sizing enabled
+          ansible.builtin.lineinfile:
+            path: /etc/node-sizing-enabled.env
+            regexp: "{{ item.regexp }}"
+            line: "{{ item.line }}"
+          loop:
+            - regexp: "^SYSTEM_RESERVED_CPU=200m"
+              line: "SYSTEM_RESERVED_CPU={{ bootstrap_ci_crc_systemd_cpu | default('800m') }}"
+            - regexp: "^SYSTEM_RESERVED_MEMORY=350Mi"
+              line: "SYSTEM_RESERVED_MEMORY={{ bootstrap_ci_crc_systemd_mem | default('700Mi') }}"
+            - regexp: "^SYSTEM_RESERVED_ES=350Mi"
+              line: "SYSTEM_RESERVED_ES={{ bootstrap_ci_crc_systemd_disk | default('700Mi') }}"
+            - regexp: "^NODE_SIZING_ENABLED=false"
+              line: "NODE_SIZING_ENABLED={{ bootstrap_ci_crc_systemd_autosizing | default('false') }}"
+
+        - name: Reboot host after kubelet is reconfigured
+          ansible.builtin.reboot:
+
+    - include_role:
+        name: start-zuul-console

--- a/ci/playbooks/multinode-customizations.yml
+++ b/ci/playbooks/multinode-customizations.yml
@@ -64,10 +64,22 @@
         state: restarted
         name: crc-pre
 
-    - name: Restart dnsmasq
+    # Avoid 'state: restarted' due to issues with IP not available when crc-dnsmasq starts
+    - name: Stop dnsmasq
       become: true
       ansible.builtin.systemd:
-        state: restarted
+        state: stopped
+        name: crc-dnsmasq
+
+    - name: Make sure that crc-dnsmasq is not running
+      containers.podman.podman_container:
+        name: crc-dnsmasq
+        state: absent
+
+    - name: Start dnsmasq
+      become: true
+      ansible.builtin.systemd:
+        state: started
         name: crc-dnsmasq
 
     - name: Wait for CRC to be ready

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -107,7 +107,7 @@
     parent: base-extracted-crc
     timeout: 10800
     attempts: 1
-    nodeset:
+    nodeset: &multinode_edpm_nodeset
       nodes:
         - name: controller
           label: cloud-centos-9-stream-tripleo-vexxhost-medium
@@ -120,7 +120,7 @@
           nodes:
             - compute-0
     irrelevant-files: *ir_files
-    required-projects:
+    required-projects: &multinode_edpm_rp
       - openstack-k8s-operators/ci-framework
       - openstack-k8s-operators/dataplane-operator
       - openstack-k8s-operators/install_yamls
@@ -130,17 +130,17 @@
       - openstack-k8s-operators/openstack-operator
       - openstack-k8s-operators/repo-setup
       - openstack-k8s-operators/edpm-ansible
-    roles:
+    roles: &multinode_edpm_roles
       - zuul: github.com/openstack-k8s-operators/ci-framework
-    pre-run:
+    pre-run: &multinode_edpm_pre_run
       - ci/playbooks/multinode-customizations.yml
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
-    post-run:
+    post-run: &multinode_edpm_post_run
       - ci/playbooks/e2e-collect-logs.yml
       - ci/playbooks/collect-logs.yml
       - ci/playbooks/multinode-autohold.yml
-    vars:
+    vars: &multinode_edpm_vars
       zuul_log_collection: true
       registry_login_enabled: true
       push_registry: quay.rdoproject.org
@@ -197,6 +197,29 @@
               tenant:
                 ip: 172.19.0.100
                 config_nm: false
+#
+# Base jobs using ci-bootstrap layout
+#
+- job:
+    name: cifmw-podified-multinode-edpm-ci-bootstrap-staging
+    parent: base-extracted-crc-ci-bootstrap-staging
+    timeout: 10800
+    attempts: 1
+    nodeset: *multinode_edpm_nodeset
+    irrelevant-files: *ir_files
+    required-projects: *multinode_edpm_rp
+    roles: *multinode_edpm_roles
+    pre-run:
+      - ci/playbooks/crc/reconfigure-kubelet.yml
+      - ci/playbooks/multinode-customizations.yml
+      - ci/playbooks/e2e-prepare.yml
+      - ci/playbooks/dump_zuul_data.yml
+    post-run: *multinode_edpm_post_run
+    vars:
+      <<: *multinode_edpm_vars
+      ci_bootstrap_role_enabled: true
+      cifmw_bootstrap_cloud_name: cifmw_vexxhost
+      cifmw_bootstrap_public_key_file: "{{ ansible_user_dir }}/.ssh/id_ed25519.pub"
 
 #
 # EDPM BASE Jobs

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -288,3 +288,15 @@
       - ^.*/*.md
       - ^OWNERS
       - ^.github
+
+#
+# Jobs using ci-bootstrap layout
+#
+- job:
+    name: podified-multinode-edpm-deployment-crc-staging
+    parent: cifmw-podified-multinode-edpm-ci-bootstrap-staging
+    vars:
+      cifmw_extras:
+        - '@scenarios/centos-9/multinode-ci.yml'
+    run:
+      - ci/playbooks/edpm/run.yml


### PR DESCRIPTION
Adds a playbook to reconfigure kubelet, which lives in config repo[1], and defines a staging job that uses ci-bootstrap to configure networks between zuul nodes.
This PR converts crc-dnsmasq restart task to 2 tasks, stop and start. In this new job layout we are seeing many errors while restarting crc-dnsmasq, due to IP no yet available:

```
crc-74q6p-master-0 podman[3004]: Error: unable to start container
"7293b76c8f99e18623d437dfa941b6a82d984130612353c9a7b65a5100156ca1":
plugin type="bridge" failed (add): cni plugin bridge failed: failed
to allocate for range 0: requested IP address 10.88.0.8 is not
available in range set 10.88.0.1-10>
```

[1] https://github.com/rdo-infra/review.rdoproject.org-config/blob/master/playbooks/crc/reconfigure_kubelet.yaml

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
