### PR TITLE
[networking_mapper] Fix default handling of skip NM flag.

### DIFF
--- a/plugins/module_utils/net_map/networking_definition.py
+++ b/plugins/module_utils/net_map/networking_definition.py
@@ -1463,7 +1463,7 @@ class GroupTemplateNetworkDefinition:
     group_name: str
     ipv6_range: HostNetworkRange = None
     ipv4_range: HostNetworkRange = None
-    skip_nm_configuration: bool = False
+    skip_nm_configuration: bool = None
 
     def __hash__(self) -> int:
         return hash(
@@ -1550,7 +1550,7 @@ class GroupTemplateDefinition:
             raise ValueError("group_name is a mandatory argument")
         self.__group_name = group_name
 
-        self.__skip_nm_configuration: bool = False
+        self.__skip_nm_configuration: typing.Optional[bool] = None
         self.__groups_networks_definitions = {}
         self.__parse_raw(raw_definition, network_definitions)
 
@@ -1560,7 +1560,7 @@ class GroupTemplateDefinition:
         return self.__groups_networks_definitions
 
     @property
-    def skip_nm_configuration(self) -> bool:
+    def skip_nm_configuration(self) -> typing.Optional[bool]:
         """Indicates that Network Manager configuration should be
         skipped for all the networks of the group."""
         return self.__skip_nm_configuration
@@ -1575,8 +1575,10 @@ class GroupTemplateDefinition:
         raw_definition: typing.Dict[str, typing.Any],
         network_definitions: typing.Dict[str, NetworkDefinition],
     ):
-        self.__skip_nm_configuration = bool(
-            raw_definition.get(self.__FIELD_SKIP_NM, False)
+        self.__skip_nm_configuration = (
+            bool(raw_definition[self.__FIELD_SKIP_NM])
+            if self.__FIELD_SKIP_NM in raw_definition
+            else None
         )
 
         networks = _validate_parse_field_type(
@@ -1628,8 +1630,10 @@ class GroupTemplateDefinition:
             templated_net_data, network_definition
         )
 
-        skip_nm_configuration = bool(
-            templated_net_data.get(self.__FIELD_NETWORK_SKIP_NM, False)
+        skip_nm_configuration = (
+            bool(templated_net_data[self.__FIELD_NETWORK_SKIP_NM])
+            if self.__FIELD_NETWORK_SKIP_NM in templated_net_data
+            else None
         )
 
         self.__groups_networks_definitions[
@@ -1712,9 +1716,9 @@ class GroupTemplateDefinition:
 @dataclasses.dataclass(frozen=True)
 class InstanceNetworkDefinition:
     network: NetworkDefinition
-    ipv4: typing.Union[ipaddress.IPv4Address] = None
-    ipv6: typing.Union[ipaddress.IPv6Address] = None
-    skip_nm_configuration: bool = False
+    ipv4: ipaddress.IPv4Address = None
+    ipv6: ipaddress.IPv6Address = None
+    skip_nm_configuration: bool = None
 
     def __hash__(self) -> int:
         return hash((self.network, self.ipv4, self.ipv6, self.skip_nm_configuration))
@@ -1779,7 +1783,7 @@ class InstanceDefinition:
             raise ValueError("name is a mandatory argument")
 
         self.__name = name
-        self.__skip_nm_configuration: bool = False
+        self.__skip_nm_configuration: typing.Optional[bool] = None
         self.__instances_network_definitions = {}
         self.__parse_raw(raw_definition, network_definitions)
 
@@ -1789,7 +1793,7 @@ class InstanceDefinition:
         return self.__instances_network_definitions
 
     @property
-    def skip_nm_configuration(self) -> bool:
+    def skip_nm_configuration(self) -> typing.Optional[bool]:
         """Indicates that Network Manager configuration should be skipped
         for all the networks of the instance."""
         return self.__skip_nm_configuration
@@ -1804,8 +1808,10 @@ class InstanceDefinition:
         raw_definition: typing.Dict[str, typing.Any],
         network_definitions: typing.Dict[str, NetworkDefinition],
     ):
-        self.__skip_nm_configuration = bool(
-            raw_definition.get(self.__FIELD_SKIP_NM, False)
+        self.__skip_nm_configuration = (
+            bool(raw_definition[self.__FIELD_SKIP_NM])
+            if self.__FIELD_SKIP_NM in raw_definition
+            else None
         )
         networks = raw_definition.get(self.__FIELD_NETWORKS, {})
         if not isinstance(networks, dict):
@@ -1840,8 +1846,10 @@ class InstanceDefinition:
             parent_name=self.__name,
         )
 
-        skip_nm_configuration = bool(
-            network_data.get(self.__FIELD_NETWORK_SKIP_NM, False)
+        skip_nm_configuration = (
+            bool(network_data[self.__FIELD_NETWORK_SKIP_NM])
+            if self.__FIELD_NETWORK_SKIP_NM in network_data
+            else None
         )
 
         self.__instances_network_definitions[network_name] = InstanceNetworkDefinition(

--- a/tests/unit/module_utils/net_map/test_networking_definitions_all.py
+++ b/tests/unit/module_utils/net_map/test_networking_definitions_all.py
@@ -192,7 +192,7 @@ def test_networking_definition_load_networking_definition_all_tools_dual_stack_o
     # Simple basic checks of the group template
     group1_def = test_net_1.group_templates["group-1"]
     assert group1_def.group_name == "group-1"
-    assert not group1_def.skip_nm_configuration
+    assert group1_def.skip_nm_configuration is None
     assert len(group1_def.networks) == 3
     assert "network-2" in group1_def.networks
     assert "network-3" in group1_def.networks
@@ -212,7 +212,7 @@ def test_networking_definition_load_networking_definition_all_tools_dual_stack_o
     # Simple basic checks of the explicit instance
     instance1_def = test_net_1.instances["instance-1"]
     assert instance1_def.name == "instance-1"
-    assert not instance1_def.skip_nm_configuration
+    assert instance1_def.skip_nm_configuration is None
     assert len(instance1_def.networks) == 2
     assert "network-1" in instance1_def.networks
     assert "network-3" in instance1_def.networks
@@ -296,7 +296,7 @@ def test_networking_definition_load_networking_definition_all_tools_ipv6_only_ok
     # Simple basic checks of the group template
     group1_def = test_net_1.group_templates["group-1"]
     assert group1_def.group_name == "group-1"
-    assert not group1_def.skip_nm_configuration
+    assert group1_def.skip_nm_configuration is None
     assert len(group1_def.networks) == 3
     assert "network-1" in group1_def.networks
     assert "network-2" in group1_def.networks
@@ -316,7 +316,7 @@ def test_networking_definition_load_networking_definition_all_tools_ipv6_only_ok
     # Simple basic checks of the explicit instance
     instance1_def = test_net_1.instances["instance-1"]
     assert instance1_def.name == "instance-1"
-    assert not instance1_def.skip_nm_configuration
+    assert instance1_def.skip_nm_configuration is None
     assert len(instance1_def.networks) == 2
     assert "network-1" in instance1_def.networks
     assert "network-3" in instance1_def.networks

--- a/tests/unit/module_utils/net_map/test_networking_definitions_group_template.py
+++ b/tests/unit/module_utils/net_map/test_networking_definitions_group_template.py
@@ -21,7 +21,7 @@ def test_group_template_definition_parse_simple_ok():
     group_template_definition = networking_definition.GroupTemplateDefinition(
         inventory_group, group_template_definition_raw, networks_definitions
     )
-    assert not group_template_definition.skip_nm_configuration
+    assert group_template_definition.skip_nm_configuration is None
     assert group_template_definition.group_name == inventory_group
     assert isinstance(group_template_definition.networks, dict)
 
@@ -81,7 +81,7 @@ def test_group_template_definition_parse_networks_v4_ok():
         stub_networks_definitions[net_map_stub_data.NETWORK_1_NAME]
         == group_template_net_1.network
     )
-    assert not group_template_net_1.skip_nm_configuration
+    assert group_template_net_1.skip_nm_configuration is None
     assert group_template_net_1.ipv4_range == networking_definition.HostNetworkRange(
         group_template_net_1.network.ipv4_network, start=100, length=30
     )
@@ -109,7 +109,7 @@ def test_group_template_definition_parse_networks_v4_ok():
         stub_networks_definitions[net_map_stub_data.NETWORK_3_NAME]
         == group_template_net_3.network
     )
-    assert not group_template_net_3.skip_nm_configuration
+    assert group_template_net_3.skip_nm_configuration is None
     assert group_template_net_3.ipv4_range is None
     assert group_template_net_3.ipv6_range is None
     assert group_template_net_3.group_name == group_template_definition.group_name
@@ -132,7 +132,7 @@ def test_group_template_definition_parse_networks_v6_ok():
         stub_networks_definitions[net_map_stub_data.NETWORK_1_NAME]
         == group_template_net_1.network
     )
-    assert not group_template_net_1.skip_nm_configuration
+    assert group_template_net_1.skip_nm_configuration is None
     assert group_template_net_1.ipv6_range == networking_definition.HostNetworkRange(
         group_template_net_1.network.ipv6_network, start=100, length=30
     )
@@ -158,7 +158,7 @@ def test_group_template_definition_parse_networks_v6_ok():
         stub_networks_definitions[net_map_stub_data.NETWORK_3_NAME]
         == group_template_net_3.network
     )
-    assert not group_template_net_3.skip_nm_configuration
+    assert group_template_net_3.skip_nm_configuration is None
     assert group_template_net_3.ipv4_range is None
     assert group_template_net_3.ipv6_range is None
 
@@ -171,7 +171,10 @@ def test_group_template_definition_parse_networks_mixed_ok():
     group_template_definition_raw = {
         "skip-nm-configuration": True,
         "networks": {
-            net_map_stub_data.NETWORK_1_NAME: {"range": {"start": 100, "length": 30}},
+            net_map_stub_data.NETWORK_1_NAME: {
+                "range": {"start": 100, "length": 30},
+                "skip-nm-configuration": False,
+            },
             net_map_stub_data.NETWORK_2_NAME: {
                 "range-v4": {"start": 150, "length": 60},
                 "range-v6": {"start": 150, "length": 2048},
@@ -195,7 +198,7 @@ def test_group_template_definition_parse_networks_mixed_ok():
         stub_networks_definitions[net_map_stub_data.NETWORK_1_NAME]
         == group_template_net_1.network
     )
-    assert not group_template_net_1.skip_nm_configuration
+    assert group_template_net_1.skip_nm_configuration is False
     assert group_template_net_1.ipv4_range == networking_definition.HostNetworkRange(
         group_template_net_1.network.ipv4_network, start=100, length=30
     )
@@ -223,7 +226,7 @@ def test_group_template_definition_parse_networks_mixed_ok():
         stub_networks_definitions[net_map_stub_data.NETWORK_3_NAME]
         == group_template_net_3.network
     )
-    assert not group_template_net_3.skip_nm_configuration
+    assert group_template_net_3.skip_nm_configuration is None
     assert group_template_net_3.ipv6_range == networking_definition.HostNetworkRange(
         group_template_net_3.network.ipv6_network, start=150, length=60
     )

--- a/tests/unit/module_utils/net_map/test_networking_definitions_instance.py
+++ b/tests/unit/module_utils/net_map/test_networking_definitions_instance.py
@@ -21,7 +21,6 @@ def test_instance_definition_parse_networks_no_tools_v4_ok():
     second_net = list(networks_definitions.values())[1]
     third_net = list(networks_definitions.values())[2]
     instance_definition_raw = {
-        "skip-nm-configuration": True,
         "networks": {
             first_net.name: {
                 "ip": net_map_stub_data.NETWORK_1_IPV4_NET[18],
@@ -36,7 +35,7 @@ def test_instance_definition_parse_networks_no_tools_v4_ok():
     )
 
     assert hash(instance_definition)
-    assert instance_definition.skip_nm_configuration
+    assert instance_definition.skip_nm_configuration is None
     assert instance_definition.name == instance_name
     assert isinstance(instance_definition.networks, dict)
     assert len(instance_definition.networks) == len(instance_definition_raw["networks"])
@@ -61,7 +60,7 @@ def test_instance_definition_parse_networks_no_tools_v4_ok():
 
     group_template_net_3 = instance_definition.networks[third_net.name]
     assert third_net == group_template_net_3.network
-    assert not group_template_net_3.skip_nm_configuration
+    assert group_template_net_3.skip_nm_configuration is None
     assert group_template_net_3.ipv4 is None
     assert group_template_net_3.ipv6 is None
 
@@ -75,7 +74,7 @@ def test_instance_definition_parse_networks_no_tools_v6_ok():
     second_net = list(networks_definitions.values())[1]
     third_net = list(networks_definitions.values())[2]
     instance_definition_raw = {
-        "skip-nm-configuration": True,
+        "skip-nm-configuration": False,
         "networks": {
             first_net.name: {
                 "ip": net_map_stub_data.NETWORK_1_IPV6_NET[77],
@@ -92,7 +91,7 @@ def test_instance_definition_parse_networks_no_tools_v6_ok():
     )
 
     assert hash(instance_definition)
-    assert instance_definition.skip_nm_configuration
+    assert instance_definition.skip_nm_configuration is False
     assert instance_definition.name == instance_name
     assert isinstance(instance_definition.networks, dict)
     assert len(instance_definition.networks) == len(instance_definition_raw["networks"])
@@ -117,7 +116,7 @@ def test_instance_definition_parse_networks_no_tools_v6_ok():
 
     group_template_net_3 = instance_definition.networks[third_net.name]
     assert third_net == group_template_net_3.network
-    assert not group_template_net_3.skip_nm_configuration
+    assert group_template_net_3.skip_nm_configuration is None
     assert group_template_net_3.ipv6 == net_map_stub_data.NETWORK_3_IPV6_NET[100]
     assert group_template_net_3.ipv4 is None
 
@@ -138,7 +137,7 @@ def test_instance_definition_parse_networks_no_tools_mixed_ok():
                 "skip-nm-configuration": True,
             },
             net_map_stub_data.NETWORK_2_NAME: {
-                "skip-nm-configuration": True,
+                "skip-nm-configuration": False,
                 "ip-v4": net_map_stub_data.NETWORK_2_IPV4_NET[77],
                 "ip-v6": net_map_stub_data.NETWORK_2_IPV6_NET[77],
             },
@@ -175,7 +174,7 @@ def test_instance_definition_parse_networks_no_tools_mixed_ok():
         net_map_stub_data.NETWORK_2_NAME
     ]
     assert second_net == instance_definition_net_2.network
-    assert instance_definition_net_2.skip_nm_configuration
+    assert instance_definition_net_2.skip_nm_configuration is False
     assert instance_definition_net_2.ipv4 == net_map_stub_data.NETWORK_2_IPV4_NET[77]
     assert instance_definition_net_2.ipv6 == net_map_stub_data.NETWORK_2_IPV6_NET[77]
 
@@ -183,7 +182,7 @@ def test_instance_definition_parse_networks_no_tools_mixed_ok():
         net_map_stub_data.NETWORK_3_NAME
     ]
     assert third_net == group_template_net_3.network
-    assert not group_template_net_3.skip_nm_configuration
+    assert group_template_net_3.skip_nm_configuration is None
     assert group_template_net_3.ipv4 is None
     assert group_template_net_3.ipv6 == net_map_stub_data.NETWORK_3_IPV6_NET[77]
 


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
