### PR TITLE
Install gcc for dlrn reporting

### DIFF
--- a/roles/dlrn_report/tasks/install.yml
+++ b/roles/dlrn_report/tasks/install.yml
@@ -17,6 +17,7 @@
           - krb5-devel
           - krb5-workstation
           - krb5-libs
+          - gcc
         state: present
 
     - name: Install dlrn kerberos related packages


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
