### PR TITLE
[networking_mapping] Fix missing interface name

### DIFF
--- a/plugins/module_utils/net_map/networking_mapper.py
+++ b/plugins/module_utils/net_map/networking_mapper.py
@@ -178,10 +178,11 @@ class NetworkingInstanceMapper:
             net_def.name, group_net_def, instance_net_definition
         )
         iface_data = self.__map_instance_network_interface_data()
-        parent_interface = (
-            f"{iface_data['device']}.{net_def.vlan}"
-            if "device" in iface_data and net_def.vlan
-            else None
+        device_name = iface_data.get("device", None)
+        interface_name = (
+            f"{device_name}.{net_def.vlan}"
+            if device_name and net_def.vlan
+            else device_name
         )
         mtu = iface_data.get("mtu", net_def.mtu)
         return networking_env_definitions.MappedInstanceNetwork(
@@ -193,7 +194,8 @@ class NetworkingInstanceMapper:
             ip_v6=ipv6,
             mtu=int(mtu) if mtu else None,
             vlan_id=net_def.vlan,
-            parent_interface=parent_interface,
+            parent_interface=device_name if net_def.vlan else None,
+            interface_name=interface_name,
             mac_addr=self.__map_instance_network_interface_mac(
                 iface_data.get("macaddress", None), net_def.vlan
             ),

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-dual-stack-full-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-dual-stack-full-map-out.json
@@ -269,6 +269,7 @@
           "network_name": "network-1",
           "skip_nm": false,
           "mac_addr": "27:b9:47:74:b3:02",
+          "interface_name": "eth1",
           "ip_v4": "192.168.122.10",
           "ip_v6": "fdc0:8b54:108a:c949:0000:0000:0000:000a",
           "mtu": 1500
@@ -277,26 +278,29 @@
           "network_name": "network-2",
           "skip_nm": false,
           "mac_addr": "52:54:00:3b:4c:47",
+          "interface_name": "eth1.21",
           "ip_v4": "172.18.0.10",
           "mtu": 1496,
-          "parent_interface": "eth1.21",
+          "parent_interface": "eth1",
           "vlan_id": 21
         },
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
           "mac_addr": "52:54:00:57:a5:bd",
+          "interface_name": "eth1.20",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:0037",
           "mtu": 1496,
-          "parent_interface": "eth1.20",
+          "parent_interface": "eth1",
           "vlan_id": 20
         },
         "network-4": {
           "network_name": "network-4",
           "skip_nm": false,
           "mac_addr": "52:54:00:5b:40:e3",
+          "interface_name": "eth1.22",
           "ip_v4": "172.19.0.37",
-          "parent_interface": "eth1.22",
+          "parent_interface": "eth1",
           "vlan_id": 22
         }
       },
@@ -309,6 +313,7 @@
           "network_name": "network-1",
           "skip_nm": false,
           "mac_addr": "a1:69:da:21:aa:03",
+          "interface_name": "eth2",
           "ip_v4": "192.168.122.11",
           "ip_v6": "fdc0:8b54:108a:c949:0000:0000:0000:000b",
           "mtu": 1500
@@ -317,9 +322,10 @@
           "network_name": "network-3",
           "skip_nm": false,
           "mac_addr": "52:54:00:67:13:df",
+          "interface_name": "eth2.20",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:0038",
           "mtu": 1496,
-          "parent_interface": "eth2.20",
+          "parent_interface": "eth2",
           "vlan_id": 20
         }
       },
@@ -332,6 +338,7 @@
           "network_name": "network-1",
           "skip_nm": false,
           "mac_addr": "bf:99:4b:3f:5e:01",
+          "interface_name": "eth0",
           "ip_v4": "192.168.122.12",
           "ip_v6": "fdc0:8b54:108a:c949:0000:0000:0000:000c",
           "mtu": 1500

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-full-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-full-map-out.json
@@ -224,6 +224,7 @@
           "network_name": "ctlplane",
           "skip_nm": false,
           "mac_addr": "27:b9:47:74:b3:02",
+          "interface_name": "eth1",
           "ip_v4": "192.168.122.10",
           "mtu": 1500
         },
@@ -231,27 +232,30 @@
           "network_name": "internal-api",
           "skip_nm": false,
           "mac_addr": "52:54:00:57:a5:bd",
+          "interface_name": "eth1.20",
           "ip_v4": "172.17.0.10",
           "mtu": 1496,
-          "parent_interface": "eth1.20",
+          "parent_interface": "eth1",
           "vlan_id": 20
         },
         "storage": {
           "network_name": "storage",
           "skip_nm": false,
           "mac_addr": "52:54:00:3b:4c:47",
+          "interface_name": "eth1.21",
           "ip_v4": "172.18.0.10",
           "mtu": 1496,
-          "parent_interface": "eth1.21",
+          "parent_interface": "eth1",
           "vlan_id": 21
         },
         "tenant": {
           "network_name": "tenant",
           "skip_nm": false,
           "mac_addr": "52:54:00:5b:40:e3",
+          "interface_name": "eth1.22",
           "ip_v4": "172.19.0.10",
           "mtu": 1496,
-          "parent_interface": "eth1.22",
+          "parent_interface": "eth1",
           "vlan_id": 22
         }
       },
@@ -264,6 +268,7 @@
           "network_name": "ctlplane",
           "skip_nm": false,
           "mac_addr": "a1:69:da:21:aa:03",
+          "interface_name": "eth2",
           "ip_v4": "192.168.122.11",
           "mtu": 1500
         },
@@ -271,27 +276,30 @@
           "network_name": "internal-api",
           "skip_nm": false,
           "mac_addr": "52:54:00:67:13:df",
+          "interface_name": "eth2.20",
           "ip_v4": "172.17.0.11",
           "mtu": 1496,
-          "parent_interface": "eth2.20",
+          "parent_interface": "eth2",
           "vlan_id": 20
         },
         "storage": {
           "network_name": "storage",
           "skip_nm": false,
           "mac_addr": "52:54:00:69:83:6c",
+          "interface_name": "eth2.21",
           "ip_v4": "172.18.0.11",
           "mtu": 1496,
-          "parent_interface": "eth2.21",
+          "parent_interface": "eth2",
           "vlan_id": 21
         },
         "tenant": {
           "network_name": "tenant",
           "skip_nm": false,
           "mac_addr": "52:54:00:51:4f:fb",
+          "interface_name": "eth2.22",
           "ip_v4": "172.19.0.11",
           "mtu": 1496,
-          "parent_interface": "eth2.22",
+          "parent_interface": "eth2",
           "vlan_id": 22
         }
       },
@@ -304,18 +312,20 @@
           "network_name": "storage",
           "skip_nm": true,
           "mac_addr": "52:54:00:4f:a2:4b",
+          "interface_name": "eth0.21",
           "ip_v4": "172.18.0.12",
           "mtu": 1496,
-          "parent_interface": "eth0.21",
+          "parent_interface": "eth0",
           "vlan_id": 21
         },
         "tenant": {
           "network_name": "tenant",
           "skip_nm": true,
           "mac_addr": "52:54:00:4e:f5:61",
+          "interface_name": "eth0.22",
           "ip_v4": "172.19.0.12",
           "mtu": 1496,
-          "parent_interface": "eth0.22",
+          "parent_interface": "eth0",
           "vlan_id": 22
         }
       },

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-full-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-full-map-out.json
@@ -149,6 +149,7 @@
           "network_name": "network-1",
           "skip_nm": false,
           "mac_addr": "27:b9:47:74:b3:02",
+          "interface_name": "eth1",
           "ip_v6": "fdc0:8b54:108a:c949:0000:0000:0000:0f1a",
           "mtu": 1500
         },
@@ -156,17 +157,19 @@
           "network_name": "network-2",
           "skip_nm": false,
           "mac_addr": "52:54:00:3b:4c:47",
+          "interface_name": "eth1.21",
           "ip_v6": "fd5e:bdb2:6091:9306:0000:0000:0000:0190",
-          "parent_interface": "eth1.21",
+          "parent_interface": "eth1",
           "vlan_id": 21
         },
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
           "mac_addr": "52:54:00:57:a5:bd",
+          "interface_name": "eth1.20",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:0f1a",
           "mtu": 1496,
-          "parent_interface": "eth1.20",
+          "parent_interface": "eth1",
           "vlan_id": 20
         }
       },
@@ -179,17 +182,19 @@
           "network_name": "network-2",
           "skip_nm": false,
           "mac_addr": "52:54:00:69:83:6c",
+          "interface_name": "eth2.21",
           "ip_v6": "fd5e:bdb2:6091:9306:0000:0000:0000:0191",
-          "parent_interface": "eth2.21",
+          "parent_interface": "eth2",
           "vlan_id": 21
         },
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
           "mac_addr": "52:54:00:67:13:df",
+          "interface_name": "eth2.20",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:01f4",
           "mtu": 1496,
-          "parent_interface": "eth2.20",
+          "parent_interface": "eth2",
           "vlan_id": 20
         }
       },
@@ -202,9 +207,10 @@
           "network_name": "network-3",
           "skip_nm": false,
           "mac_addr": "52:54:00:04:3f:e5",
+          "interface_name": "eth0.20",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:01f5",
           "mtu": 1496,
-          "parent_interface": "eth0.20",
+          "parent_interface": "eth0",
           "vlan_id": 20
         }
       },

--- a/tests/unit/module_utils/test_files/networking-definition-valid-full-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-full-map-out.json
@@ -57,6 +57,7 @@
           "network_name": "ctlplane",
           "skip_nm": false,
           "mac_addr": "27:b9:47:74:b3:02",
+          "interface_name": "eth1",
           "ip_v4": "192.168.122.100",
           "mtu": 1500
         },
@@ -64,27 +65,30 @@
           "network_name": "internal-api",
           "skip_nm": false,
           "mac_addr": "52:54:00:57:a5:bd",
+          "interface_name": "eth1.20",
           "ip_v4": "172.17.0.10",
           "mtu": 1496,
-          "parent_interface": "eth1.20",
+          "parent_interface": "eth1",
           "vlan_id": 20
         },
         "storage": {
           "network_name": "storage",
           "skip_nm": true,
           "mac_addr": "52:54:00:3b:4c:47",
+          "interface_name": "eth1.21",
           "ip_v4": "172.18.0.100",
           "mtu": 1496,
-          "parent_interface": "eth1.21",
+          "parent_interface": "eth1",
           "vlan_id": 21
         },
         "tenant": {
           "network_name": "tenant",
           "skip_nm": true,
           "mac_addr": "52:54:00:5b:40:e3",
+          "interface_name": "eth1.22",
           "ip_v4": "172.19.0.10",
           "mtu": 1496,
-          "parent_interface": "eth1.22",
+          "parent_interface": "eth1",
           "vlan_id": 22
         }
       },


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date