### PR TITLE
Add back BM nodeset update packages in bootstrap

### DIFF
--- a/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -196,6 +196,20 @@
             "path": "/spec/nodeTemplate/ansible/ansibleVars/edpm_container_registry_insecure_registries",
             "value": [{{ content_provider_registry_ip }}:5001]}]'
 
+- name: Patch OpenStackDataPlaneNodeSet resource to update bootstrap packages
+  when: not cifmw_edpm_deploy_baremetal_dry_run
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: >-
+      oc patch openstackdataplanenodeset openstack-edpm-ipam
+      -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+      --type json
+      -p '[{"op": "add",
+            "path": "/spec/nodeTemplate/ansible/ansibleVars/edpm_bootstrap_command",
+            "value": "sudo dnf -y update"}]'
+
 - name: Wait for OpenStackDataPlaneNodeSet to be Ready
   when: not cifmw_edpm_deploy_baremetal_dry_run
   environment:


### PR DESCRIPTION
bootstrap-openstack-edpm-ipam pod calls the [bootstrap.yaml playbook](https://github.com/openstack-k8s-operators/edpm-ansible/blob/5ead70322381b4787bb735e27e0a11799f0c0549/roles/edpm_bootstrap/tasks/bootstrap.yml) .

Recently we have added [update_packages.yaml playbook](https://github.com/openstack-k8s-operators/edpm-ansible/blob/5ead70322381b4787bb735e27e0a11799f0c0549/roles/edpm_bootstrap/tasks/update_package.yml) to update all the packages on edpm node via bootstrap. 

But it is not included in above bootstrap.yaml playbook but called via [edpm_bootstrap role](https://github.com/openstack-k8s-operators/edpm-ansible/blob/5ead70322381b4787bb735e27e0a11799f0c0549/roles/edpm_bootstrap/tasks/main.yml#L23) role. That's why compute node does not have update packages, leading to tempest tests.

Since the BM job is failing from long time. We can merge this as a temprory solution till we fix the edpm-ansible repo.
It will help to get the promotion.

We can done similar thing for edpm jobs here.
https://github.com/openstack-k8s-operators/ci-framework/pull/936

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
