### PR TITLE
Refactor: Simplify Ansible tasks for directory creation and variable inclusion

### DIFF
--- a/hooks/playbooks/control_plane_ceph_backends.yml
+++ b/hooks/playbooks/control_plane_ceph_backends.yml
@@ -6,15 +6,12 @@
     - name: Load vars from previous hooks
       when: cifmw_control_plane_ceph_backend_include_vars is defined
       ansible.builtin.include_vars:
-        file: "{{ item }}"
-      loop: "{{ cifmw_control_plane_ceph_backend_include_vars }}"
+        file: "{{ cifmw_control_plane_ceph_backend_include_vars }}"
 
     - name: Ensure the kustomizations dir exists
       ansible.builtin.file:
-        path: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/{{ item }}"
+        path: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/controlplane"
         state: directory
-      loop:
-        - controlplane
 
     - name: Create kustomization to add Ceph as backend
       ansible.builtin.copy:

--- a/hooks/playbooks/control_plane_ironic.yml
+++ b/hooks/playbooks/control_plane_ironic.yml
@@ -5,10 +5,8 @@
   tasks:
     - name: Ensure the kustomizations dir exists
       ansible.builtin.file:
-        path: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/{{ item }}"
+        path: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/controlplane"
         state: directory
-      loop:
-        - controlplane
 
     - name: Create kustomization to enable ironic
       ansible.builtin.copy:


### PR DESCRIPTION
Refactor: Simplify ansible tasks for directory creation and variable inclusion
- remove loop in directory creation task for 'kustomizations/controlplane'
- directly use 'cifmw_control_plane_ceph_backend_include_vars' in include_vars task without loop
- enhance playbook efficiency and readability by eliminating unnecessary loops

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
