### PR TITLE
Enable better logging for rhol_crc

### DIFF
--- a/roles/rhol_crc/tasks/configuration.yml
+++ b/roles/rhol_crc/tasks/configuration.yml
@@ -18,8 +18,17 @@
 - name: Set RHOL/CRC configuration options and if fail print
   block:
     - name: Set RHOL/CRC configuration options
-      ansible.builtin.command: "{{ cifmw_rhol_crc_binary }} config set {{ item.key }} {{ item.value }}"
-      loop: "{{ cifmw_rhol_crc_config_defaults | ansible.builtin.combine(cifmw_rhol_crc_config) | dict2items }}"
+      ansible.builtin.shell:  # noqa risky-shell-pipe
+        cmd: >-
+          {{ cifmw_rhol_crc_binary }} config set
+          {{ item.key }} {{ item.value }} 2>&1 |
+          tee -a {{ cifmw_rhol_crc_basedir }}/logs/crc-config.log
+      loop: >-
+        {{
+          cifmw_rhol_crc_config_defaults |
+          ansible.builtin.combine(cifmw_rhol_crc_config) |
+          dict2items
+        }}
       register: configuration_result
   rescue:
     - name: If fails print RHOL/CRC configuration execution error

--- a/roles/rhol_crc/tasks/main.yml
+++ b/roles/rhol_crc/tasks/main.yml
@@ -23,6 +23,7 @@
   loop:
     - artifacts
     - bin
+    - logs
 
 - name: Initialize manage_secrets
   ansible.builtin.import_role:
@@ -82,11 +83,17 @@
           ansible.builtin.import_tasks: configuration.yml
 
         - name: Setup RHOL/CRC
-          ansible.builtin.command: "{{ cifmw_rhol_crc_binary }} setup"
+          ansible.builtin.shell:  # noqa risky-shell-pipe
+            cmd: >-
+              {{ cifmw_rhol_crc_binary }} setup 2>&1 |
+              tee {{ cifmw_rhol_crc_basedir }}/logs/crc-setup.log
           register: cifmw_rhol_crc_cmd_setup
 
         - name: Start RHOL/CRC
-          ansible.builtin.command: "{{ cifmw_rhol_crc_binary }} start"
+          ansible.builtin.shell:  # noqa risky-shell-pipe
+            cmd: >-
+              {{ cifmw_rhol_crc_binary }} start 2>&1 |
+              tee {{ cifmw_rhol_crc_basedir }}/logs/crc-start.log
           register: cifmw_rhol_crc_cmd_start
 
     - name: Attach default network to CRC


### PR DESCRIPTION
Until now, we were missing all of the setup and startup logs for the
CRC.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
