### PR TITLE
Enable compute accesses from the controller-0

### DIFF
--- a/roles/reproducer/README.md
+++ b/roles/reproducer/README.md
@@ -15,7 +15,7 @@ None
 * `cifmw_reproducer_run_job`: (Bool) Run actual CI job. Defaults to `true`.
 * `cifmw_reproducer_params`: (Dict) Specific parameters you want to pass to the reproducer. Defaults to `{}`.
 * `cifmw_reproducer_private_nic`: (String) Private NIC for compute and controller. Defaults to `eth1`.
-* `cifmw_reproducer_crc_private_nic`: (String) Private NIC for CRC node. Defaults to `enp2s0`.
+* `cifmw_reproducer_crc_private_nic`: (String) Private NIC for CRC node. Defaults to `enp6s0`.
 * `cifmw_reproducer_dns_servers`: List of dns servers which should be used by the CRC VM as upstream dns servers. Defaults to 1.1.1.1, 8.8.8.8.
 * `cifmw_reproducer_hp_rhos_release`: (Bool) Allows to consume rhos-release on the hypervisor. Defaults to `false`.
 * `cifmw_reproducer_dnf_tweaks`: (List) Options you want to inject in dnf.conf, both on controller-0 and hypervisor. Defaults to `[]`.

--- a/roles/reproducer/defaults/main.yml
+++ b/roles/reproducer/defaults/main.yml
@@ -23,7 +23,7 @@ cifmw_reproducer_ctl_gw4: 192.168.122.1
 cifmw_reproducer_crc_ip4: 192.168.122.10
 cifmw_reproducer_crc_gw4: 192.168.122.1
 cifmw_reproducer_private_nic: eth1
-cifmw_reproducer_crc_private_nic: enp5s0
+cifmw_reproducer_crc_private_nic: enp6s0
 cifmw_reproducer_kubecfg: "{{ cifmw_libvirt_manager_configuration.vms.crc.image_local_dir }}/kubeconfig"
 cifmw_reproducer_params: {}
 cifmw_reproducer_run_job: true

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -114,7 +114,7 @@
     # local .ssh/config, because ProxyJump doesn't take the
     # command line options, meaning ssh won't consume the various
     # options set in the ansible inventory.
-    - name: Inject ProxyJump configuration
+    - name: Inject remote hypervisor SSH configuration
       when:
         - hostvars[host]['priv_ssh_key'] is defined
       vars:
@@ -126,15 +126,52 @@
       ansible.builtin.blockinfile:
         create: true
         path: "/home/zuul/.ssh/config"
+        marker: "## {mark} {{ _ssh_host }}"
         block: |-
-          Host {{ _ssh_host }}
+          Host {{ _ssh_host }} {{ hostvars[host]['inventory_hostname'] }}
             IdentityFile ~/.ssh/ssh_{{ _ssh_host }}
             StrictHostKeyChecking no
             UserKnownHostsFile /dev/null
+            User {{ hostvars[host]['ansible_user'] | default(ansible_user_id) }}
       loop: "{{ hostvars.keys() }}"
       loop_control:
         label: "{{ host }}"
         loop_var: "host"
+
+    - name: Inject ProxyJump configuration for remote hypervisor VMs
+      when:
+        - _vm_data.target is defined
+      vars:
+        _vm_type: "{{ host | regex_replace('\\-[0-9]*', '') }}"
+        _vm_data: "{{ cifmw_libvirt_manager_configuration['vms'][_vm_type] }}"
+        _proxy_user: >-
+          {{
+            hostvars[_vm_data.target]['ansible_user'] |
+            default(ansible_user_id)
+          }}
+        _proxy_host: "{{ _vm_data.target }}"
+        _ssh_host: >-
+          {{
+            hostvars[_proxy_host]['ansible_host'] |
+            default(hostvars[_proxy_host]['inventory_hostname'])
+          }}
+        _vm_ip: "{{ hostvars[host]['ansible_host'] }}"
+      ansible.builtin.blockinfile:
+        path: "/home/zuul/.ssh/config"
+        marker: "## {mark} {{ host }}"
+        block: |-
+          Host {{ host }} {{ _vm_ip }}
+            Hostname {{ _vm_ip }}
+            IdentityFile ~/.ssh/ssh_{{ _ssh_host }}
+            StrictHostKeyChecking no
+            UserKnownHostsFile /dev/null
+          {% if _vm_data.target != cifmw_libvirt_manager_configuration.vms.controller.target %}
+            ProxyJump {{ _proxy_user }}@{{ _proxy_host }}
+          {% endif %}
+      loop: "{{ hostvars.keys() }}"
+      loop_control:
+        loop_var: host
+        label: "{{ host }}"
 
     - name: Create kube directory
       ansible.builtin.file:


### PR DESCRIPTION
Until now, we had to check the IP in the ansible inventory. While it
works "well" when it comes to mono-hypervisor, the ssh command is a bit
more complicated to tweak when it comes to multi-hypervisor.

Note: it also has another patch, fixing the default NIC for CRC node.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
