### PR TITLE
Fix used of cifmw_control_plane_ceph_backend_include_vars

### DIFF
--- a/scenarios/centos-9/ceph_backends.yml
+++ b/scenarios/centos-9/ceph_backends.yml
@@ -1,6 +1,5 @@
 ---
-cifmw_control_plane_ceph_backend_include_vars:
-  - "{{ cifmw_basedir }}/artifacts/pre_deploy_ceph_deploy.yml"
+cifmw_control_plane_ceph_backend_include_vars: "{{ cifmw_basedir }}/artifacts/pre_deploy_ceph_deploy.yml"
 
 cifmw_install_yamls_vars:
   BMO_SETUP: false


### PR DESCRIPTION
This PR is a follow up from #995, which converts some single element loops into a single var call, but ceph_backends still provides a list of a single element to it.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
