### PR TITLE
Be smarter with existing network names

### DIFF
--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -30,6 +30,7 @@ Used for checking if:
 * `cifmw_libvirt_manager_net_prefix_add` (Boolean) Adds `cifmw-` prefix to the network resources managed by this role. By default, it is set to `true`.
 * `cifmw_libvirt_manager_pub_net`: (String) Network name playing the "public" interface. Defaults to `public`.
 * `cifmw_libvirt_manager_vm_net_ip_set`: (Dict) Allow to extend the existing mapping for host family to IP mapping. Defaults to `{}`.
+* `cifmw_libvirt_manager_fixed_networks`: (List) Network names you don't want to prefix with `cifmw-`. It will be concatenated with cifmw_libvirt_manager_fixed_networks_defaults. Defaults to`[]`.
 
 ### Structure for `cifmw_libvirt_manager_configuration`
 

--- a/roles/libvirt_manager/defaults/main.yml
+++ b/roles/libvirt_manager/defaults/main.yml
@@ -64,3 +64,5 @@ cifmw_libvirt_manager_crc_private_nic: "{{ cifmw_reproducer_crc_private_nic | d
 
 # Allow to inject custom node family
 cifmw_libvirt_manager_vm_net_ip_set: {}
+
+cifmw_libvirt_manager_fixed_networks: []

--- a/roles/libvirt_manager/tasks/create_networks.yml
+++ b/roles/libvirt_manager/tasks/create_networks.yml
@@ -17,15 +17,22 @@
 
 - name: Define the localized variables for performing the tasks here.
   vars:
+    _fixed_names: >-
+      {{
+        cifmw_libvirt_manager_fixed_networks_defaults +
+        cifmw_libvirt_manager_fixed_networks
+      }}
     data:
       name: >-
         {{
-          (cifmw_libvirt_manager_net_prefix_add | bool) |
+          (cifmw_libvirt_manager_net_prefix_add | bool and
+           item.key not in _fixed_names) |
           ternary('cifmw-' + item.key, item.key)
         }}
       xml: >-
         {{
-          (cifmw_libvirt_manager_net_prefix_add | bool) |
+          (cifmw_libvirt_manager_net_prefix_add | bool and
+           item.key not in _fixed_names) |
           ternary(
             item.value | replace(item.key, 'cifmw-' ~ item.key),
             item.value

--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -152,11 +152,16 @@
 
 - name: "Format port list to something more consumable for {{ vm_type }}"
   vars:
-    _fixed_net_name: >-
+    _prefixed_net_names: >-
       {{
         _fixed_ip_nets | dict2items |
         map(attribute='key') |
         map('regex_replace', '^', 'cifmw-')
+      }}
+    _fixed_net_names: >-
+      {{
+        _fixed_ip_nets | dict2items |
+        map(attribute='key')
       }}
     _vals: >-
       {{
@@ -176,7 +181,7 @@
     macs: >-
       {{
         (macs | default([]) + _macs) |
-        selectattr('network', 'in', _fixed_net_name)
+        selectattr('network', 'in', _fixed_net_names + _prefixed_net_names)
       }}
     public_net_nics: >-
       {{

--- a/roles/libvirt_manager/vars/main.yml
+++ b/roles/libvirt_manager/vars/main.yml
@@ -49,3 +49,6 @@ cifmw_libvirt_manager_vm_net_ip_set_default:
   compute: 100
 
 cifmw_libvirt_manager_storage_pool: "cifmw-pool"
+cifmw_libvirt_manager_fixed_networks_defaults:
+  - ocpbm
+  - ocppr


### PR DESCRIPTION
Until now, it was more a "all or none" politic regarding the prefix
added to the network names.

This patch allows to be slightly smarter by allowing to point to actual
network names we don't want to prefix.

This is especially interesting for multi-hypervisor layout, with an OCP
cluster deployed: since ocpbm and ocppr are managed by the 3rd party
product "dev-scripts", this new feature will allow to deploy the same
networks on remote nodes, ensuring consistency in the names all the way
around.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
