### PR TITLE
Add Molecule job for copy-containers

### DIFF
--- a/roles/copy_container/molecule/default/converge.yml
+++ b/roles/copy_container/molecule/default/converge.yml
@@ -1,0 +1,58 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Run copy-container role
+      ansible.builtin.include_role:
+        name: copy_container
+
+    - name: Deploy Local Registry
+      ansible.builtin.include_role:
+        name: registry_deploy
+
+    - name: Create copy-quay-config.yaml
+      vars:
+        _data: |
+          ---
+          zuul_api: "https://review.rdoproject.org/zuul/api/"
+          pull_registry: "quay.rdoproject.org"
+          push_registry: "127.0.0.1:5001"
+          entries:
+            - name: "antelopecentos9"
+              release: "antelopecentos9"
+              job_name: "periodic-container-tcib-build-push-centos-9-antelope"
+              api_entry: "https://trunk.rdoproject.org/api-centos9-antelope"
+              from_namespace: "podified-antelope-centos9"
+              to_namespace: "podified-antelope-centos9"
+      ansible.builtin.copy:
+        dest: "/tmp/copy-quay-config.yaml"
+        content: "{{ _data }}"
+
+    - name: Copy containers from RDO quay to local registry
+      ansible.builtin.command:
+        cmd: >-
+          copy-quay --debug
+          --config /tmp/copy-quay-config.yaml
+          --release antelopecentos9 copy
+      args:
+        chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/roles/copy_container/files/copy-quay"
+
+    - name: Curl local registry
+      ansible.builtin.uri:
+        url: http://localhost:5001

--- a/roles/copy_container/molecule/default/molecule.yml
+++ b/roles/copy_container/molecule/default/molecule.yml
@@ -1,0 +1,9 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true

--- a/roles/copy_container/molecule/default/prepare.yml
+++ b/roles/copy_container/molecule/default/prepare.yml
@@ -1,0 +1,21 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -174,6 +174,16 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/copy_container/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    name: cifmw-molecule-copy_container
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: copy_container
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/devscripts/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-devscripts

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -24,6 +24,7 @@
       - cifmw-molecule-cifmw_cephadm
       - cifmw-molecule-cifmw_create_admin
       - cifmw-molecule-cifmw_test_role
+      - cifmw-molecule-copy_container
       - cifmw-molecule-devscripts
       - cifmw-molecule-discover_latest_image
       - cifmw-molecule-dlrn_promote


### PR DESCRIPTION
It will help to test the copy-container golang binary build process.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/999

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
