### PR TITLE
Move must-gather folder to a predictable name

### DIFF
--- a/roles/os_must_gather/tasks/main.yml
+++ b/roles/os_must_gather/tasks/main.yml
@@ -64,6 +64,19 @@
           --dest-dir {{ cifmw_os_must_gather_output_dir }}/logs
           -- ADDITIONAL_NAMESPACES={{ cifmw_os_must_gather_additional_namespaces }} gather &> {{ cifmw_os_must_gather_output_dir }}/logs/os_must_gather.log
 
+    - name: Get exact must-gather output folder name
+      ansible.builtin.find:
+        paths: "{{ cifmw_os_must_gather_output_dir }}/logs"
+        patterns: "quay-io-openstack-k8s-operators-openstack-must-gather*"
+        file_type: directory
+      register: _must_gather_output_folder
+
+    - name: Move must-gather folder name to a fixed name
+      ansible.builtin.command:
+        cmd: >
+          mv "{{ _must_gather_output_folder.files[0].path  }}/"
+          "{{ cifmw_os_must_gather_output_dir }}/logs/openstack-k8s-operators-openstack-must-gather"
+
   rescue:
     - name: Create oc_inspect log directory
       ansible.builtin.file:


### PR DESCRIPTION
The must-gather output has a random sha suffix which makes it difficult
to link directly to folders inside of it in zuul artifacts. This commit
renames the must-gather output folder with a predictable
name, which then can be linked.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
