### PR TITLE
Remove unused adoption job

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -152,11 +152,10 @@
                 ip: 172.19.0.100
                 config_nm: false
 
-# TODO(marios) remove this definition after new OSP17 job is running and stable
 - job:
-    name: cifmw-data-plane-adoption-github-rdo-centos-9-extracted-crc
-    parent: content-provider-data-plane-adoption-github-rdo-centos-9-extracted-crc
-    files: &dpa_job_files
+    name: cifmw-data-plane-adoption-OSP-17-to-extracted-crc
+    parent: content-provider-data-plane-adoption-OSP-17-to-extracted-crc
+    files:
       - ^playbooks/01-bootstrap.yml
       - ^playbooks/02-infra.yml
       - ^playbooks/06-deploy-edpm.yml
@@ -172,8 +171,3 @@
       - ^zuul.d/adoption.yaml
       - go.mod
       - apis/go.mod
-
-- job:
-    name: cifmw-data-plane-adoption-OSP-17-to-extracted-crc
-    parent: content-provider-data-plane-adoption-OSP-17-to-extracted-crc
-    files: *dpa_job_files


### PR DESCRIPTION
Remove data-plane adoption job that deploys standalone in a nested vm,
since we have a new job that supercedes it.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
