### PR TITLE
Add test-operator role

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -1,0 +1,45 @@
+# Test operator
+
+Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/test-operator/).
+
+## Parameters
+
+* `cifmw_test_operator_artifacts_basedir`: (String) Directory where we will have all test_operator related files. Default value: `{{ cifmw_basedir }}/tests/test_operator` which defaults to `~/ci-framework-data/tests/test_operator`
+* `cifmw_test_operator_namespace`: (String) Namespace inside which all the resources are created. Default value: `openstack`
+* `cifmw_test_operator_index`: (String) Full name of container image with index that contains the test_operator. Default value: `quay.io/openstack-k8s-operators/test-operator-index:latest`
+* `cifmw_test_operator_timeout`: (Integer) Timeout in seconds for the execution of the tests. Default value: `3600`
+* `cifmw_test_operator_logs_image`: (String) Image that should be used to collect logs from the pods spawned by the test-operator. Default value: `quay.io/quay/busybox`
+* `cifmw_test_operator_concurrency`: (Integer) Tempest concurrency value. Default value: `8`
+* `cifmw_test_operator_cleanup`: (Bool) Delete all resources created by the role at the end of the testing. Default value: `false`
+* `cifmw_test_operator_default_groups`: (List) List of groups in the include list to search for tests to be executed. Default value: `[ 'default' ]`
+* `cifmw_test_operator_default_jobs`: (List) List of jobs in the exclude list to search for tests to be excluded. Default value: `[ 'default' ]`
+* `cifmw_test_operator_dry_run`: (Boolean) Whether test-operator should run or not. Default value: `false`
+
+* `cifmw_test_operator_tempest_registry`: (String) The registry where to pull tempest container. Default value: `quay.io`
+* `cifmw_test_operator_tempest_namespace`: (String) Registry's namespace where to pull tempest container. Default value: `podified-antelope-centos9`
+* `cifmw_test_operator_tempest_container`: (String) Name of the tempest container. Default value: `openstack-tempest`
+* `cifmw_test_operator_tempest_image`: (String) Tempest image to be used. Default value: `{{ cifmw_test_operator_tempest_registry }}/{{ cifmw_test_operator_tempest_namespace }}/{{ cifmw_test_operator_tempest_container }}`
+* `cifmw_test_operator_tempest_image_tag`: (String) Tag for the `cifmw_test_operator_tempest_image`. Default value: `current-podified`
+* `cifmw_test_operator_tempest_include_list`: (String) List of tests to be executed. Setting this will not use the `list_allowed` plugin. Default value: `''`
+* `cifmw_test_operator_tempest_exclude_list`: (List) List of tests to be skipped. Setting this will not use the `list_skipped` plugin. Default value: `''`
+* `cifmw_test_operator_tempest_tests_include_override_scenario`: (Boolean) Whether to override the scenario `cifmw_tempest_tests_allowed` definition. Default value: `false`
+* `cifmw_test_operator_tempest_tests_exclude_override_scenario`: (Boolean) Whether to override the scenario `cifmw_tempest_tests_skipped` definition. Default value: `false`
+
+# Please refer to https://openstack-k8s-operators.github.io/test-operator/guide.html#executing-tempest-tests
+* `cifmw_test_operator_tempest_config`: (Object) Definition of Tempest CRD instance that is passed to the test-operator. Default value:
+```
+  apiVersion: test.openstack.org/v1beta1
+  kind: Tempest
+  metadata:
+    name: tempest-tests
+    namespace: "{{ cifmw_test_operator_namespace }}"
+  spec:
+    containerImage: "{{ cifmw_test_operator_tempest_image }}:{{ cifmw_test_operator_tempest_image_tag }}"
+    tempestRun:
+      includeList: |
+        {{ cifmw_test_operator_include_list | default('') }}
+      excludeList: |
+        {{ cifmw_test_operator_exclude_list | default('') }}
+      concurrency: "{{ cifmw_test_operator_concurrency }}"
+    tempestconfRun: "{{ cifmw_tempest_tempestconf_config | default(omit) }}"
+```

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -1,0 +1,57 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# defaults file for test_operator
+# All variables within this role should have a prefix of "cifmw_test_operator"
+cifmw_test_operator_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}/tests/test_operator"
+cifmw_test_operator_namespace: openstack
+cifmw_test_operator_index: quay.io/openstack-k8s-operators/test-operator-index:latest
+cifmw_test_operator_timeout: 3600
+cifmw_test_operator_logs_image: quay.io/quay/busybox
+cifmw_test_operator_concurrency: 8
+cifmw_test_operator_cleanup: false
+cifmw_test_operator_dry_run: false
+
+cifmw_test_operator_tempest_registry: quay.io
+cifmw_test_operator_tempest_namespace: podified-antelope-centos9
+cifmw_test_operator_tempest_container: openstack-tempest
+cifmw_test_operator_tempest_image: "{{ cifmw_test_operator_tempest_registry }}/{{ cifmw_test_operator_tempest_namespace }}/{{ cifmw_test_operator_tempest_container }}"
+cifmw_test_operator_tempest_image_tag: current-podified
+
+# Please refer to https://openstack-k8s-operators.github.io/test-operator/guide.html#executing-tempest-tests
+cifmw_test_operator_tempest_config:
+  apiVersion: test.openstack.org/v1beta1
+  kind: Tempest
+  metadata:
+    name: tempest-tests
+    namespace: "{{ cifmw_test_operator_namespace }}"
+  spec:
+    containerImage: "{{ cifmw_test_operator_tempest_image }}:{{ cifmw_test_operator_tempest_image_tag }}"
+    tempestRun:
+      includeList: |
+        {{ cifmw_test_operator_tempest_include_list | default('') }}
+      excludeList: |
+        {{ cifmw_test_operator_tempest_exclude_list | default('') }}
+      concurrency: "{{ cifmw_test_operator_concurrency }}"
+    tempestconfRun: "{{ cifmw_tempest_tempestconf_config | default(omit) }}"
+
+cifmw_test_operator_default_groups:
+  - default
+cifmw_test_operator_default_jobs:
+  - default
+cifmw_test_operator_tests_include_override_scenario: false
+cifmw_test_operator_tests_exclude_override_scenario: false

--- a/roles/test_operator/files/list_allowed.yml
+++ b/roles/test_operator/files/list_allowed.yml
@@ -1,0 +1,41 @@
+groups:
+  - name: default
+    tests:
+      - tempest.api.identity.*.v3
+    releases:
+      - all
+  - name: openstack-operator
+    tests:
+      - tempest.api.identity.*.v3
+    releases:
+      - all
+  - name: cinder-operator
+    tests:
+      - tempest.api.volume
+    releases:
+      - all
+  - name: keystone-operator
+    tests:
+      - tempest.api.identity.*.v3
+    releases:
+      - all
+  - name: neutron-operator
+    tests:
+      - tempest.api.network.*
+    releases:
+      - all
+  - name: nova-operator
+    tests:
+      - tempest.api.compute.*
+    releases:
+      - all
+  - name: manila-operator
+    tests:
+      - manila_tempest_tests.tests.api
+    releases:
+      - all
+  - name: ironic-operator
+    tests:
+      - ironic_tempest_plugin.tests.api
+    releases:
+      - all

--- a/roles/test_operator/files/list_skipped.yml
+++ b/roles/test_operator/files/list_skipped.yml
@@ -1,0 +1,1267 @@
+known_failures:
+  # Neutron operator
+  - test: 'tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestJSON'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - neutron-operator
+  - test: 'tempest.api.network.admin.test_ports.PortsAdminExtendedAttrsIpV6TestJSON'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - neutron-operator
+  - test: 'tempest.api.network.admin.test_ports.PortsAdminExtendedAttrsTestJSON'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - neutron-operator
+  # Cinder operator
+  - test: 'tempest.api.volume.admin.test_volume_types.VolumeTypesTest.test_volume_crud_with_volume_type_and_extra_specs'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - cinder-operator
+  - test: 'tempest.api.volume.admin.test_volumes_actions.VolumesActionsTest.test_force_detach_volume'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - cinder-operator
+  - test: 'tempest.api.volume.test_volumes_actions.VolumesActionsTest.test_attach_detach_volume_to_instance'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - cinder-operator
+  - test: 'tempest.api.volume.test_volumes_actions.VolumesActionsTest.test_get_volume_attachment'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - cinder-operator
+  - test: 'tempest.api.volume.test_volumes_backup.VolumesBackupsTest.test_backup_create_attached_volume'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - cinder-operator
+  - test: 'tempest.api.volume.test_volumes_backup.VolumesBackupsTest.test_volume_backup_create_get_detailed_list_restore_delete'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - cinder-operator
+  - test: 'tempest.api.volume.test_volumes_negative.VolumesNegativeTest.test_attach_volumes_with_nonexistent_volume_id'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - cinder-operator
+  - test: 'tempest.api.volume.test_volumes_snapshots.VolumesSnapshotTestJSON.test_snapshot_create_delete_with_volume_in_use'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - cinder-operator
+  - test: 'tempest.api.volume.test_volumes_snapshots.VolumesSnapshotTestJSON.test_snapshot_create_offline_delete_online'
+    deployment:
+      - 'overcloud'
+    releases:
+      - name: 'master'
+        reason: 'No controller'
+        lp: 'http://no.bug'
+    jobs:
+      - cinder-operator
+  # Nova operator
+  - test: tempest.api.compute.admin.test_hypervisor_negative.HypervisorAdminNegativeUnderV252Test.test_search_hypervisor_with_non_admin_user
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hypervisor.HypervisorAdminTestJSON.test_get_hypervisor_list
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hypervisor.HypervisorAdminTestJSON.test_get_hypervisor_list_details
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hypervisor_negative.HypervisorAdminNegativeUnderV252Test.test_show_servers_with_non_admin_user
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_aggregates_negative.AggregatesAdminNegativeTestJSON.test_aggregate_add_existent_host
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hypervisor.HypervisorAdminTestJSON.test_get_hypervisor_show_details
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_auto_allocate_network.AutoAllocateNetworkTest.test_server_create_no_allocate
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_aggregates_negative.AggregatesAdminNegativeTestJSON.test_aggregate_add_host_as_user
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_auto_allocate_network.AutoAllocateNetworkTest.test_server_multi_create_auto_allocate
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hosts.HostsAdminTestJSON.test_show_host_detail
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_delete_server.DeleteServersAdminTestJSON.test_admin_delete_servers_of_others
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hypervisor_negative.HypervisorAdminNegativeTestJSON.test_get_hypervisor_uptime_with_non_admin_user
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hypervisor_negative.HypervisorAdminNegativeTestJSON.test_show_hypervisor_with_non_admin_user
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_delete_server.DeleteServersAdminTestJSON.test_delete_server_while_in_error_state
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_aggregates_negative.AggregatesAdminNegativeTestJSON.test_aggregate_remove_host_as_user
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hypervisor.HypervisorAdminUnderV252Test.test_get_hypervisor_show_servers
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hypervisor.HypervisorAdminUnderV252Test.test_search_hypervisor
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_services.ServicesAdminTestJSON.test_get_service_by_service_binary_name
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hypervisor.HypervisorAdminV253TestBase.test_list_show_detail_hypervisors
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_volumes_negative.VolumesAdminNegativeTest.test_update_attached_volume_with_nonexistent_volume_in_body
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_servers.ServersAdmin275Test.test_rebuild_update_server_275
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_hypervisor.HypervisorAdminV228Test.test_get_list_hypervisor_details
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_volumes_negative.VolumesAdminNegativeTest.test_update_attached_volume_with_nonexistent_volume_in_uri
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.images.test_images_negative.ImagesNegativeTestJSON.test_create_image_from_deleted_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_server_external_events.ServerExternalEventsTest.test_create_server_external_events
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_server_diagnostics.ServerDiagnosticsTest.test_get_server_diagnostics
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_create_server.ServersWithSpecificFlavorTestJSON.test_verify_created_server_ephemeral_disk
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_device_tagging.TaggedBootDevicesTest.test_tagged_boot_devices
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_server_diagnostics.ServerDiagnosticsV248Test.test_get_server_diagnostics
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.floating_ips.test_floating_ips_actions.FloatingIPsTestJSON.test_allocate_floating_ip
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers.ServersTestJSON.test_create_server_specify_multibyte_character_name
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.floating_ips.test_floating_ips_actions.FloatingIPsTestJSON.test_delete_floating_ip
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_server_diagnostics_negative.ServerDiagnosticsNegativeTest.test_get_server_diagnostics_by_non_admin
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_attach_interfaces.AttachInterfacesTestJSON.test_create_list_show_delete_interfaces_by_fixed_ip
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_attach_interfaces.AttachInterfacesTestJSON.test_create_list_show_delete_interfaces_by_network_port
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.security_groups.test_security_groups.SecurityGroupsTestJSON.test_list_security_groups_by_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_disk_config.ServerDiskConfigTestJSON.test_rebuild_server_with_auto_disk_config
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers.ServersTestJSON.test_create_server_with_ipv6_addr_only
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_attach_interfaces.AttachInterfacesTestJSON.test_reassign_port_between_servers
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_disk_config.ServerDiskConfigTestJSON.test_rebuild_server_with_manual_disk_config
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers.ServersTestJSON.test_create_specify_keypair
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_availability_zone.AZV2TestJSON.test_get_availability_zone_list_with_non_admin_user
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_attach_interfaces.AttachInterfacesUnderV243Test.test_add_remove_fixed_ip
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_device_tagging.TaggedAttachmentsTest.test_tagged_attachment
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_disk_config.ServerDiskConfigTestJSON.test_update_server_from_auto_to_manual
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_delete_server.DeleteServersTestJSON.test_delete_active_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers.ServersTestJSON.test_create_with_existing_server_name
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_create_server_multi_nic.ServersTestMultiNic.test_verify_duplicate_network_nics
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_delete_server.DeleteServersTestJSON.test_delete_server_while_in_attached_volume
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers.ServersTestJSON.test_update_access_server_address
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.security_groups.test_security_groups.SecurityGroupsTestJSON.test_server_security_groups
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_attach_interfaces.AttachInterfacesV270Test.test_create_get_list_interfaces
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.volumes.test_attach_volume.AttachVolumeTestJSON.test_attach_detach_volume
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_create_server_multi_nic.ServersTestMultiNic.test_verify_multiple_nics_order
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers_microversions.ServerShowV257Test.test_rebuild_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers.ServersTestJSON.test_update_server_name
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.volumes.test_attach_volume.AttachVolumeTestJSON.test_list_get_volume_attachments
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_delete_server.DeleteServersTestJSON.test_delete_server_while_in_pause_state
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_device_tagging.TaggedBootDevicesTest_v242.test_tagged_boot_devices
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_delete_server.DeleteServersTestJSON.test_delete_server_while_in_shelved_state
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.volumes.test_attach_volume_negative.AttachVolumeNegativeTest.test_attach_attached_volume_to_different_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_actions.ServersAaction247Test.test_create_backup
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_volume.AttachSCSIVolumeTestJSON.test_attach_scsi_disk_with_config_drive
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_delete_server.DeleteServersTestJSON.test_delete_server_while_in_shutoff_state
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.volumes.test_attach_volume_negative.AttachVolumeNegativeTest.test_attach_attached_volume_to_same_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers_microversions.ServerShowV254Test.test_rebuild_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.volumes.test_attach_volume_negative.AttachVolumeNegativeTest.test_delete_attached_volume
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_delete_server.DeleteServersTestJSON.test_delete_server_while_in_suspended_state
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers.ServerShowV247Test.test_update_rebuild_list_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_group.ServerGroupTestJSON.test_create_server_with_scheduler_hint_group
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_multiple_create.MultipleCreateTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.images.test_images.ImagesTestJSON.test_create_image_from_paused_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_instance_actions.InstanceActionsV221TestJSON.test_get_list_deleted_instance_actions
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.images.test_images.ImagesTestJSON.test_create_image_from_stopped_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.images.test_images.ImagesTestJSON.test_create_image_from_suspended_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.images.test_images.ImagesTestJSON.test_create_server_from_snapshot
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.images.test_images.ImagesTestJSON.test_delete_saving_image
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.volumes.test_attach_volume.AttachVolumeShelveTestJSON.test_attach_volume_shelved_or_offload_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.volumes.test_attach_volume.AttachVolumeShelveTestJSON.test_detach_volume_shelved_or_offload_server
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_servers_negative.ServersAdminNegativeTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.floating_ips.test_list_floating_ips.FloatingIPDetailsTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_create_server.ServersTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_tags.ServerTagsTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.images.test_images_oneserver_negative.ImagesOneServerNegativeTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.floating_ips.test_floating_ips_actions.FloatingIPsAssociationTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_addresses_negative.ServerAddressesNegativeTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_servers.ServersAdminTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_create_server.ServersTestBootFromVolume
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_simple_tenant_usage.TenantUsagesTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_addresses.ServerAddressesTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_create_server.ServersTestManualDisk
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.floating_ips.test_floating_ips_actions_negative.FloatingIPsAssociationNegativeTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_metadata_negative.ServerMetadataNegativeTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.images.test_images_oneserver.ImagesOneServerTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_instance_actions_negative.InstanceActionsNegativeTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers_negative.ServersNegativeTestMultiTenantJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_password.ServerPasswordTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_instance_actions.InstanceActionsTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_list_servers_negative.ListServersNegativeTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_rescue.ServerRescueTestJSONUnderV235
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_list_server_filters.ListServerFiltersTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_servers_negative.ServersNegativeTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_rescue.ServerRescueTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_rescue_negative.ServerRescueNegativeTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.images.test_list_image_filters.ListImageFiltersTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_availability_zone.AZAdminV2TestJSON.test_get_availability_zone_list
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: manila_tempest_tests.tests.api.test_share_network_subnets.ShareNetworkSubnetsTest.test_create_delete_subnet
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Fix not landed yet
+        lp: http://no.bug
+    jobs:
+      - manila-operator
+  - test: tempest.api.compute.admin.test_live_migration_negative.LiveMigrationNegativeTest.test_live_block_migration_suspended
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Test env does not have compute
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_live_migration_negative.LiveMigrationNegativeTest.test_invalid_host_for_migration
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Test env does not have compute
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  # TODO (rlandy) remove when https://issues.redhat.com/browse/OSPCIX-126 is fixed
+  - test: tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_mtu_sized_frames
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: IBM cloud exposes MTU setup differences exposing a real issue
+        lp: https://issues.redhat.com/browse/OSPCIX-126
+      - name: antelope
+        reason: IBM cloud exposes MTU setup differences exposing a real issue
+        lp: https://issues.redhat.com/browse/OSPCIX-126
+    jobs: []
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodeProtected.test_node_protected
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_allocations.TestBackfill.test_backfill_allocation
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodeProtected.test_node_protected_from_deletion
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_allocations.TestBackfill.test_backfill_without_resource_class
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodeProtected.test_node_protected_negative
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodesProtectedOldApi.test_node_protected_old_api
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodeProtected.test_node_protected_set_unset
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodestates.TestNodeStatesV1_4.test_set_node_provision_state
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodesVif.test_vif_already_set
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodesVif.test_vif_on_port
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodestates.TestNodeStatesV1_1.test_set_node_provision_state
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodesVif.test_vif_on_portgroup
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestHardwareInterfaces.test_reset_interfaces
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestResetInterfaces.test_reset_interfaces
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodestates.TestNodeStatesV1_6.test_set_node_provision_state
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodestates.TestNodeStatesV1_11.test_set_node_provision_state
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodestates.TestNodeStatesV1_2.test_set_node_provision_state
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator

--- a/roles/test_operator/meta/main.yml
+++ b/roles/test_operator/meta/main.yml
@@ -1,0 +1,42 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- Test Operator
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: cifmw
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - cifmw
+    - testoperator
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/test_operator/molecule/default/converge.yml
+++ b/roles/test_operator/molecule/default/converge.yml
@@ -1,0 +1,24 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_test_operator_dry_run: true
+  roles:
+    - role: "test_operator"

--- a/roles/test_operator/molecule/default/molecule.yml
+++ b/roles/test_operator/molecule/default/molecule.yml
@@ -1,0 +1,9 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true

--- a/roles/test_operator/molecule/default/prepare.yml
+++ b/roles/test_operator/molecule/default/prepare.yml
@@ -1,0 +1,24 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_test_operator_dry_run: true
+  roles:
+    - role: "test_operator"

--- a/roles/test_operator/tasks/cleanup.yml
+++ b/roles/test_operator/tasks/cleanup.yml
@@ -1,0 +1,111 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Delete Tempest
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    kind: Tempest
+    state: absent
+    api_version: test.openstack.org/v1beta1
+    name: "{{ cifmw_test_operator_tempest_name }}"
+    namespace: "{{ cifmw_test_operator_namespace }}"
+    wait: true
+
+- name: Delete Tempest CRD
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    kind: CustomResourceDefinition
+    state: absent
+    api_version: v1
+    name: tempests.test.openstack.org
+    namespace: "{{ cifmw_test_operator_namespace }}"
+    wait: true
+
+- name: Delete Subscription
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    state: absent
+    name: test-operator
+    namespace: "{{ cifmw_test_operator_namespace }}"
+    wait: true
+
+- name: Delete CatalogSource
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    kind: CatalogSource
+    state: absent
+    api_version: operators.coreos.com/v1alpha1
+    name: test-operator-catalog
+    namespace: "{{ cifmw_test_operator_namespace }}"
+    wait: true
+
+- name: Delete OperatorGroup
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    kind: OperatorGroup
+    state: absent
+    api_version: operators.coreos.com/v1
+    name: test-operator-operatorgroup
+    namespace: "{{ cifmw_test_operator_namespace }}"
+    wait: true
+
+- name: Delete ClusterServiceVersion
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    kind: ClusterServiceVersion
+    state: absent
+    api_version: operators.coreos.com/v1alpha1
+    name: "{{ test_operator_csv_name }}"
+    namespace: "{{ cifmw_test_operator_namespace }}"
+    wait: true
+
+- name: Delete Operator
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    kind: Operator
+    state: absent
+    api_version: operators.coreos.com/v1
+    name: test-operator.openstack
+    namespace: "{{ cifmw_test_operator_namespace }}"
+    wait: true
+
+- name: Delete test-operator-logs-pod
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    kind: Pod
+    state: absent
+    api_version: v1
+    name: test-operator-logs-pod
+    namespace: "{{ cifmw_test_operator_namespace }}"
+    wait: true

--- a/roles/test_operator/tasks/main.yml
+++ b/roles/test_operator/tasks/main.yml
@@ -1,0 +1,248 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure test_operator folder exists
+  ansible.builtin.file:
+    path: "{{ cifmw_test_operator_artifacts_basedir }}"
+    state: directory
+    recurse: true
+
+- name: Setup Tempest tests
+  ansible.builtin.include_tasks: tempest-tests.yml
+
+- name: Ensure OperatorGroup for the test-operator is present
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    state: present
+    wait: true
+    definition:
+      apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        name: test-operator-operatorgroup
+        namespace: "{{ cifmw_test_operator_namespace }}"
+      spec:
+        targetNamespaces:
+          - "{{ cifmw_test_operator_namespace }}"
+  when: not cifmw_test_operator_dry_run | bool
+
+- name: Ensure CatalogSource for the test-operator is present
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    state: present
+    wait: true
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: CatalogSource
+      metadata:
+        name: test-operator-catalog
+        namespace: "{{ cifmw_test_operator_namespace }}"
+      spec:
+        sourceType: grpc
+        image: "{{ cifmw_test_operator_index }}"
+  when: not cifmw_test_operator_dry_run | bool
+
+- name: Ensure Subscription for the test-operator is present
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    state: present
+    wait: true
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: test-operator
+        namespace: "{{ cifmw_test_operator_namespace }}"
+      spec:
+        name: test-operator
+        source: test-operator-catalog
+        sourceNamespace: "{{ cifmw_test_operator_namespace }}"
+  when: not cifmw_test_operator_dry_run | bool
+
+- name: Wait unitl the test-operator csv is present
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    namespace: "{{ cifmw_test_operator_namespace }}"
+    kind: ClusterServiceVersion
+    api_version: operators.coreos.com/v1alpha1
+  register: csv_list
+  delay: 10
+  retries: 20
+  until: |
+    csv_list | json_query('resources[*].metadata.name') | select('match', 'test-operator')
+  when: not cifmw_test_operator_dry_run | bool
+
+- name: Get full name of the test-operator csv
+  ansible.builtin.set_fact:
+    test_operator_csv_name: >-
+      {{ csv_list | json_query('resources[*].metadata.name') | select('match', 'test-operator') | first }}
+  when: not cifmw_test_operator_dry_run | bool
+
+- name: Wait for the test-operator csv to Succeed
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    namespace: "{{ cifmw_test_operator_namespace }}"
+    kind: ClusterServiceVersion
+    api_version: operators.coreos.com/v1alpha1
+    name: "{{ test_operator_csv_name }}"
+  register: csv
+  retries: 20
+  delay: 10
+  until: csv.resources[0].status.phase | default(omit) == "Succeeded"
+  when: not cifmw_test_operator_dry_run | bool
+
+- name: Start Tempest tests
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    state: present
+    wait: true
+    definition: "{{ cifmw_test_operator_tempest_config }}"
+  when: not cifmw_test_operator_dry_run | bool
+
+- name: Wait for the Tempest job to be Ready
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    namespace: "{{ cifmw_test_operator_namespace }}"
+    kind: Job
+    name: "{{ cifmw_test_operator_tempest_name }}"
+    wait: true
+  when: not cifmw_test_operator_dry_run | bool
+
+- name: Wait for the Tempest job to be Completed
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    namespace: "{{ cifmw_test_operator_namespace }}"
+    kind: Job
+    name: "{{ cifmw_test_operator_tempest_name }}"
+    wait: true
+    wait_timeout: "{{ cifmw_test_operator_timeout }}"
+    wait_condition:
+      type: Complete
+      status: true
+  when: not cifmw_test_operator_dry_run | bool
+
+- name: Start test-operator-logs-pod
+  when: not cifmw_test_operator_dry_run | bool
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: test-operator-logs-pod
+        namespace: "{{ cifmw_test_operator_namespace }}"
+      spec:
+        containers:
+          - name: test-operator-logs-container
+            image: "{{ cifmw_test_operator_logs_image }}"
+            command: ["sleep"]
+            args: ["infinity"]
+            volumeMounts:
+              - name: logs-volume
+                mountPath: /mnt
+        volumes:
+          - name: logs-volume
+            persistentVolumeClaim:
+              claimName: "{{ cifmw_test_operator_tempest_config.metadata.name }}"
+
+- name: Ensure that the test-operator-logs-pod is Running
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    namespace: "{{ cifmw_test_operator_namespace }}"
+    kind: Pod
+    name: test-operator-logs-pod
+    wait: true
+  register: logs_pod
+  until: logs_pod.resources[0].status.phase == "Running"
+  delay: 10
+  retries: 20
+  when: not cifmw_test_operator_dry_run | bool
+
+- name: Get logs from test-operator-logs-pod
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.shell: >
+    oc cp -n {{ cifmw_test_operator_namespace }} openstack/test-operator-logs-pod:mnt/
+    {{ cifmw_test_operator_artifacts_basedir }}
+  when: not cifmw_test_operator_dry_run | bool
+
+- name: Get list of all pods
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    namespace: "{{ cifmw_test_operator_namespace }}"
+    kind: Pod
+  register: pod_list
+  when: not cifmw_test_operator_dry_run | bool
+
+- name: Get full name of the tempest-tests pod
+  ansible.builtin.set_fact:
+    tempest_pod_name: >-
+      {{ pod_list | json_query('resources[*].metadata.name') | select('match', 'tempest-tests') | first }}
+  when: not cifmw_test_operator_dry_run | bool
+
+- name: Save stdout from tempest-pod
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.shell: |
+    oc logs -n {{ cifmw_test_operator_namespace }} pod/{{ tempest_pod_name }} > \
+      {{ cifmw_test_operator_artifacts_basedir }}/tempest_pod_stdout.txt
+  when: not cifmw_test_operator_dry_run | bool
+
+- name: Get test result (Success / Fail)
+  register: tempest_pod
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    namespace: "{{ cifmw_test_operator_namespace }}"
+    kind: Pod
+    name: "{{ tempest_pod_name }}"
+  when: not cifmw_test_operator_dry_run | bool
+
+- name: Delete all resources created by the role
+  ansible.builtin.include_tasks: cleanup.yml
+  when: cifmw_test_operator_cleanup | bool and not cifmw_test_operator_dry_run | bool
+
+- name: Fail if the tempest pod did not succeed
+  when: not cifmw_test_operator_dry_run | bool
+  ansible.builtin.assert:
+    that:
+      - tempest_pod.resources[0].status.phase == "Succeeded"

--- a/roles/test_operator/tasks/tempest-tests.yml
+++ b/roles/test_operator/tasks/tempest-tests.yml
@@ -1,0 +1,58 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+- name: Configuring tests to be executed via skiplist
+  when: >
+   cifmw_test_operator_tempest_include_list is not defined or
+   cifmw_test_operator_tempest_tests_include_override_scenario | bool
+  block:
+    - name: Copy list_allowed to artifacts dir
+      ansible.builtin.copy:
+        dest: "{{ cifmw_test_operator_artifacts_basedir }}/list_allowed.yml"
+        src: "list_allowed.yml"
+
+    - name: Get list of tests to be executed
+      tempest_list_allowed:
+        yaml_file: "{{ cifmw_test_operator_artifacts_basedir }}/list_allowed.yml"
+        groups: "{{ cifmw_test_operator_default_groups }}"
+        job: "{{ cifmw_test_operator_job_name | default(omit) }}"
+      register:
+        list_allowed
+
+    - name: Set variable
+      ansible.builtin.set_fact:
+        cifmw_test_operator_tempest_include_list: "{{ list_allowed.allowed_tests | join('\n') }}"
+
+- name: Configuring tests to be skipped via skiplist
+  when: >
+    cifmw_test_operator_tempest_exclude_list is not defined or
+    cifmw_test_operator_tempest_tests_exclude_override_scenario | bool
+  block:
+    - name: Copy list_skipped to artifacts dir
+      ansible.builtin.copy:
+        dest: "{{ cifmw_test_operator_artifacts_basedir }}/list_skipped.yml"
+        src: "list_skipped.yml"
+
+    - name: Get list of tests to be excluded
+      tempest_list_skipped:
+        yaml_file: "{{ cifmw_test_operator_artifacts_basedir }}/list_skipped.yml"
+        jobs: "{{ cifmw_test_operator_default_jobs }}"
+      register:
+        list_skipped
+
+    - name: Set variable
+      ansible.builtin.set_fact:
+        cifmw_test_operator_tempest_exclude_list: "{{ list_skipped.skipped_tests | join('\n') }}"

--- a/roles/test_operator/vars/main.yml
+++ b/roles/test_operator/vars/main.yml
@@ -1,0 +1,17 @@
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+cifmw_test_operator_tempest_name: "tempest-tests"
+cifmw_test_operator_controller_name: "test-operator-controller-manager"

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -549,6 +549,16 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/test_operator/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    name: cifmw-molecule-test_operator
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: test_operator
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/tobiko/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-tobiko

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -59,6 +59,7 @@
       - cifmw-molecule-set_openstack_containers
       - cifmw-molecule-tempest
       - cifmw-molecule-test_deps
+      - cifmw-molecule-test_operator
       - cifmw-molecule-tobiko
       - cifmw-molecule-tofu
     name: openstack-k8s-operators/ci-framework


### PR DESCRIPTION
This patch introduced [test-operator](https://openstack-k8s-operators.github.io/test-operator/) role. The role first spawns a test-operator, then creates an instance of the Tempest CRD which initiates creation of tempest pod. Finally, it waits for the end of the tests execution and copies artifacts from the tempest pod to a predefined directory.

- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
