### PR TITLE
Integrate ci_local_storage role in edpm deployment

### DIFF
--- a/playbooks/06-deploy-edpm.yml
+++ b/playbooks/06-deploy-edpm.yml
@@ -12,6 +12,10 @@
       ansible.builtin.include_vars:
         dir: "{{ cifmw_basedir }}/artifacts/parameters"
 
+    - name: Configure Storage Class
+      ansible.builtin.include_role:
+        name: ci_local_storage
+
     - name: Run edpm_prepare
       ansible.builtin.import_role:
         name: edpm_prepare

--- a/roles/ci_local_storage/molecule/default/converge.yml
+++ b/roles/ci_local_storage/molecule/default/converge.yml
@@ -21,7 +21,10 @@
     cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
     cifmw_cls_storage_provisioner: crc-devsetup
     cifmw_cls_storage_class: molecule-storage
+    cifmw_cls_pv_count: 10
     cifmw_cls_namespace: openstack
+    cifmw_cls_storage_capacity: 100Mi
+    cifmw_cls_local_storage_name: /mnt/openstack
   tasks:
     - name: Run ci_local_storage role
       ansible.builtin.include_role:
@@ -37,18 +40,47 @@
           - provisioned-by={{ cifmw_cls_storage_provisioner }}
       register: _pv_info
 
-    - name: Get all pvs
-      ansible.builtin.set_fact:
-        _cls_pvs: >-
-          {{ _pv_info.resources |
-              selectattr("metadata.name", "defined") |
-              map(attribute="metadata.name")
-          }}
-
-    - name: Assert the created pvs
+    - name: Assert that we created the wanted number of pvs
       ansible.builtin.assert:
-        that:
-          - "cifmw_cls_storage_class in _cls_pvs[0]"
+        that: "_pv_info.resources | length | int == cifmw_cls_pv_count | int"
+
+    - name: Gather names from pvs
+      ansible.builtin.set_fact:
+        _pv_names: "{{ _pv_info.resources | selectattr('metadata.name', 'defined') | map(attribute='metadata.name') }}"
+
+    - name: Gather computed PV names
+      ansible.builtin.set_fact:
+        _generated_names: "{{ _generated_names | default([]) + [ cifmw_cls_storage_class ~ '%02d' | format(item) ~ '-' ~ _cls_nodes[0] ] }}"
+      loop: "{{ range(1, cifmw_cls_pv_count + 1) | list }}"
+
+    - name: Assert that the pvs names are correct
+      ansible.builtin.assert:
+        that: "item.0 == item.1"
+      loop: "{{ _pv_names | zip(_generated_names) | list }}"
+
+    - name: Gather mountpoints from pvs
+      ansible.builtin.set_fact:
+        _pv_mountpoint: "{{ _pv_info.resources | selectattr('spec.local.path', 'defined') | map(attribute='spec.local.path') }}"
+
+    - name: Gather computed mountpoints
+      ansible.builtin.set_fact:
+        _generated_mountpoint: "{{ _generated_mountpoint | default([]) + [ cifmw_cls_local_storage_name ~ '/pv' ~ '%02d' | format(item) ] }}"
+      loop: "{{ range(1, cifmw_cls_pv_count + 1) | list }}"
+
+    - name: Assert that the mountpoints in the pv are correct
+      ansible.builtin.assert:
+        that: "item.0 == item.1"
+      loop: "{{ _pv_mountpoint | zip(_generated_mountpoint) | list }}"
+
+    - name: Assert that the storage class is correct
+      ansible.builtin.assert:
+        that: "item == cifmw_cls_storage_class"
+      loop: "{{ _pv_info.resources | selectattr('spec.storageClassName', 'defined') | map(attribute='spec.storageClassName') }}"
+
+    - name: Assert that the storage capacity is correct
+      ansible.builtin.assert:
+        that: "item == cifmw_cls_storage_capacity"
+      loop: "{{ _pv_info.resources | selectattr('spec.capacity.storage', 'defined') | map(attribute='spec.capacity.storage') }}"
 
     - name: Delete the created pvs
       ansible.builtin.include_role:

--- a/roles/ci_local_storage/tasks/worker_node_dirs.yml
+++ b/roles/ci_local_storage/tasks/worker_node_dirs.yml
@@ -6,11 +6,17 @@
   ansible.builtin.shell:
     cmd: >-
       oc debug node/{{ item }} -T -- chroot /host
-      /usr/bin/bash -c "for i in `seq -w -s ' ' {{ cifmw_cls_pv_count }}`;
-      do echo \"{{ _msg }} dir {{ cifmw_cls_local_storage_name }}/pv\$i on {{ item }}\";
-      {{ cifmw_cls_action }} {{ cifmw_cls_local_storage_name }}/pv\$i; done"
+      /usr/bin/bash -c "for pvnum in $(seq -w -s ' ' 01 {{ cifmw_cls_pv_count }});
+      do echo \"{{ _msg }} dir {{ cifmw_cls_local_storage_name }}/pv\${pvnum} on {{ item }}\";
+      {{ cifmw_cls_action }} {{ cifmw_cls_local_storage_name }}/pv\${pvnum}; done"
   loop: "{{ _cls_nodes }}"
-  until: _worker_operation_out.rc == 0 and _worker_operation_out.stdout != ""
+  until:
+    - _worker_operation_out.rc == 0
+    - _worker_operation_out.stdout != ""
   register: _worker_operation_out
   retries: 10
   delay: 20
+
+- name: Print the output of Worker node operation
+  ansible.builtin.debug:
+    msg: "{{  _worker_operation_out }}"

--- a/roles/ci_local_storage/templates/storage.yaml.j2
+++ b/roles/ci_local_storage/templates/storage.yaml.j2
@@ -1,10 +1,10 @@
 {% for node in _cls_nodes %}
-{% for pv_number in range(cifmw_cls_pv_count + 1) %}
+{% for pv_number in range(1, cifmw_cls_pv_count + 1) %}
 ---
 kind: PersistentVolume
 apiVersion: v1
 metadata:
-  name: {{ cifmw_cls_storage_class }}{{ pv_number }}-{{ node }}
+  name: {{ cifmw_cls_storage_class }}{{ "%02d" | format(pv_number) }}-{{ node }}
   annotations:
     pv.kubernetes.io/provisioned-by: {{ cifmw_cls_storage_provisioner }}
   labels:
@@ -19,7 +19,7 @@ spec:
     - ReadOnlyMany
   persistentVolumeReclaimPolicy: Delete
   local:
-    path: {{ cifmw_cls_local_storage_name }}/pv{{ pv_number }}
+    path: {{ cifmw_cls_local_storage_name }}/pv{{ "%02d" | format(pv_number) }}
     type: DirectoryOrCreate
   volumeMode: Filesystem
   nodeAffinity:

--- a/scenarios/centos-9/ceph_backends.yml
+++ b/scenarios/centos-9/ceph_backends.yml
@@ -3,7 +3,6 @@ cifmw_control_plane_ceph_backend_include_vars: "{{ cifmw_basedir }}/artifacts/pr
 
 cifmw_install_yamls_vars:
   BMO_SETUP: false
-  STORAGE_CLASS: crc-csi-hostpath-provisioner
   INSTALL_CERT_MANAGER: false
 
 cifmw_edpm_prepare_skip_crc_storage_creation: true

--- a/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
+++ b/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
@@ -3,7 +3,6 @@ ansible_user_dir: "{{ lookup('env', 'HOME') }}"
 cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
 cifmw_install_yamls_vars:
   DEPLOY_DIR: "{{ cifmw_basedir }}/artifacts/edpm_compute" # used during Baremetal deployment
-  STORAGE_CLASS: crc-csi-hostpath-provisioner
   DATAPLANE_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/dataplane-operator"
   INFRA_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/infra-operator"
   BMAAS_INSTANCE_MEMORY: 8192

--- a/scenarios/centos-9/edpm_ci.yml
+++ b/scenarios/centos-9/edpm_ci.yml
@@ -3,7 +3,6 @@ ansible_user_dir: "{{ lookup('env', 'HOME') }}"
 cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
 cifmw_install_yamls_vars:
   DATAPLANE_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/dataplane-operator"
-  STORAGE_CLASS: crc-csi-hostpath-provisioner
   BMO_SETUP: false
   INSTALL_CERT_MANAGER: false
 


### PR DESCRIPTION
ci_local_storage role is responsible for creating storageclass and persistant volumes, needed for OpenStack services during deployment. It is similar to make crc_storage.

Currently we are using `crc-csi-hostpath-provisioner` storage class in CI as it is already provided by crc setup.

Since we have ci_local_storage role available, let's use this one as already used by devs in their setup.

Note: 
- It also updates the pv sequence to create similar directories on the worder nodes mentioned in the storage manifest. 
- Add debug msg to print the failure of worker node operation. 

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
