### PR TITLE
Correct/update file location for generated content

### DIFF
--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -148,14 +148,9 @@
     src: "all-inventory.yml.j2"
 
 - name: Dump MAC mapping
-  vars:
-    content: >-
-      {{
-        {'cifmw_mac_mapping': cifmw_libvirt_manager_mac_map}
-      }}
   ansible.builtin.copy:
-    dest: "{{ cifmw_libvirt_manager_basedir }}/artifacts/mac-mapping.yml"
-    content: "{{ content | to_nice_yaml }}"
+    dest: "{{ cifmw_libvirt_manager_basedir }}/artifacts/interfaces-info.yml"
+    content: "{{ cifmw_libvirt_manager_mac_map | to_nice_yaml }}"
 
 - name: Ensure we get proper access to CRC
   when:

--- a/roles/libvirt_manager/tasks/reserve_ip.yml
+++ b/roles/libvirt_manager/tasks/reserve_ip.yml
@@ -101,8 +101,8 @@
       }}
     _dataset: >-
       {{
-        {vm_name: [{'MAC': mac_address,
-                    'IP': _lm_ip_address,
+        {vm_name: [{'mac': mac_address,
+                    'ip': _lm_ip_address,
                     'network': _net_name}]}
       }}
   ansible.builtin.set_fact:

--- a/roles/reproducer/molecule/crc_layout/converge.yml
+++ b/roles/reproducer/molecule/crc_layout/converge.yml
@@ -130,7 +130,7 @@
         - name: Ensure we have the MAC mapping file
           register: _mac_mapping
           ansible.builtin.stat:
-            path: "{{ ansible_user_dir }}/ci-framework-data/artifacts/mac-mapping.yml"
+            path: "{{ ansible_user_dir }}/ci-framework-data/parameters/interfaces-info.yml"
 
         - name: Ensure we can ping compute-0 on osp_trunk net
           register: _cmp0_ping

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -6,7 +6,6 @@
         (
          '/home/zuul',
          'ci-framework-data',
-         'artifacts'
          ) | path_join
       }}
 
@@ -27,21 +26,16 @@
           - '!all'
           - 'min'
 
-    - name: Ensure directory exists
+    - name: Ensure directories exist
       ansible.builtin.file:
-        path: "{{ _ctl_reproducer_basedir }}"
+        path: "{{ _ctl_reproducer_basedir }}/{{ item }}"
         state: directory
         owner: zuul
         group: zuul
         mode: "0755"
-
-    - name: Create data directory on controller-0
-      ansible.builtin.file:
-        path: "{{ _ctl_reproducer_basedir }}/parameters"
-        state: directory
-        owner: zuul
-        group: zuul
-        mode: "0755"
+      loop:
+        - parameters
+        - artifacts
 
     - name: Build job inventory for hook usage
       tags:
@@ -51,21 +45,23 @@
       ansible.builtin.shell:
         cmd: >-
           cat /home/zuul/reproducer-inventory/* >
-          {{  _ctl_reproducer_basedir }}/zuul_inventory.yml
+          {{  _ctl_reproducer_basedir }}/artifacts/zuul_inventory.yml
 
+    # You want to use the "name" parameter of the ansible.builtin.include_vars
+    # call, such as:
+    # - name: Load mac mapping
+    #   ansible.builtin.include_vars:
+    #     file: "{{ _ctl_reproducer_basedir }}/parameters/interfaces-info.yml"
+    #     name: my_fancy_name
+    # Then you'll be able to access the mapping content via `my_fancy_name`.
     - name: Push the MAC mapping data
       tags:
         - bootstrap
       become: true
       become_user: zuul
-      vars:
-        content: >-
-          {{
-            {'cifmw_mac_mapping': cifmw_libvirt_manager_mac_map}
-          }}
       ansible.builtin.copy:
-        dest: "{{ _ctl_reproducer_basedir }}/mac-mapping.yml"
-        content: "{{ content | to_nice_yaml }}"
+        dest: "{{ _ctl_reproducer_basedir }}/parameters/interfaces-info.yml"
+        content: "{{ cifmw_libvirt_manager_mac_map | to_nice_yaml }}"
 
     - name: Ensure /etc/ci/env is created
       become: true

--- a/roles/reproducer/templates/play.yml.j2
+++ b/roles/reproducer/templates/play.yml.j2
@@ -5,9 +5,10 @@
   hosts: localhost
   gather_facts: true
   tasks:
-    - name: Load mac-mapping
+    - name: Load interfaces-info.yml
       ansible.builtin.include_vars:
-        file: "{{ ansible_user_dir }}/ci-framework-data/artifacts/mac-mapping.yml"
+        file: "{{ ansible_user_dir }}/ci-framework-data/artifacts/interfaces-info.yml"
+        name: cifmw_mac_mapping
 
     - name: Set cifmw_rp_registry_ip
       ansible.builtin.set_fact:
@@ -57,7 +58,7 @@
       ansible.builtin.include_vars:
         file: "{{ item }}"
       loop:
-        - "{{ ansible_user_dir }}/ci-framework-data/artifacts/mac-mapping.yml"
+        - "{{ ansible_user_dir }}/ci-framework-data/artifacts/interfaces-info.yml"
         - "{{ ansible_user_dir }}/{{ job_id }}-params/zuul-params.yml"
         - "./scenarios/centos-9/base.yml"
         - "./scenarios/centos-9/content_provider.yml"


### PR DESCRIPTION
We have to be consistent with the content we create and their location.

We also take the opportunity to rename the "mac-mapping.yml" into a more
generic name, "interfaces-info.yml".
For the sake of consistency, we now use lowercase indexes (IP -> ip, MAC
-> mac)

Lastly, the `interfaces-info.yml` file drops its top-level parameter
name. This allows anyone to load the parameters into their own, custom
parameter name.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
