### PR TITLE
Dump zuul vars and inventory in molecule jobs

### DIFF
--- a/zuul.d/molecule-base.yaml
+++ b/zuul.d/molecule-base.yaml
@@ -4,7 +4,9 @@
     name: cifmw-molecule-base
     nodeset: centos-stream-9
     parent: base-ci-framework
-    pre-run: ci/playbooks/molecule-prepare.yml
+    pre-run:
+      - ci/playbooks/dump_zuul_data.yml
+      - ci/playbooks/molecule-prepare.yml
     run: ci/playbooks/molecule-test.yml
     post-run: ci/playbooks/collect-logs.yml
     required-projects:
@@ -17,7 +19,9 @@
     name: cifmw-molecule-base-crc
     nodeset: centos-9-crc-xxl
     parent: base-simple-crc
-    pre-run: ci/playbooks/molecule-prepare.yml
+    pre-run:
+      - ci/playbooks/dump_zuul_data.yml
+      - ci/playbooks/molecule-prepare.yml
     run: ci/playbooks/molecule-test.yml
     post-run: ci/playbooks/collect-logs.yml
     required-projects:


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date
