### PR TITLE
Improve cert manager cleanup playbook

### DIFF
--- a/roles/cert_manager/README.md
+++ b/roles/cert_manager/README.md
@@ -15,6 +15,7 @@ If apply, please explain the privilege escalation done in this role.
 * `cifmw_cert_manager_subscription_sourcenamespace`: (String) The Source namespace of `Subscription` resource to pull cert-manager operator content.
 * `cifmw_cert_manager_validate`: (Bool) Validate the cert-manager api. Default to `True`.
 * `cifmw_cert_manager_version`: (String) Version of cert_manager tool. Default to `latest`.
+* `cifmw_cert_manager_crds`: (List) List of cert-manager crds to cleanup.
 
 ## Examples
 ```YAML

--- a/roles/cert_manager/defaults/main.yml
+++ b/roles/cert_manager/defaults/main.yml
@@ -58,3 +58,9 @@ cifmw_cert_manager_olm_subscription:
 cifmw_cert_manager_version: latest
 cifmw_cert_manager_validate: true
 cifmw_cert_manager_cleanup: false
+cifmw_cert_manager_crds:
+  - Certificate
+  - CertificateRequest
+  - Challenge
+  - ClusterIssuer
+  - Issuer

--- a/roles/cert_manager/tasks/cleanup.yml
+++ b/roles/cert_manager/tasks/cleanup.yml
@@ -14,6 +14,28 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Delete deployment of cert-manager
+  kubernetes.core.k8s:
+    state: absent
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    kind: Deployment
+    namespace: cert-manager
+    label_selectors:
+      - "app.kubernetes.io/instance=cert-manager"
+
+- name: Delete CRDs related to cert-manager
+  kubernetes.core.k8s:
+    state: absent
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    kind: CustomResourceDefinition
+    namespace: "{{ cifmw_cert_manager_operator_namespace }}"
+    name: "{{ item }}"
+  loop: "{{ cifmw_cert_manager_crds }}"
+
 - name: Remove the cert-manager-operator namespace
   when: cifmw_cert_manager_cleanup | bool
   kubernetes.core.k8s:


### PR DESCRIPTION
It now includes:
- Deleting the deployment
- Deleting the crds.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
