### PR TITLE
Prepare for removal of duplicated adoption base jobs

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -9,20 +9,23 @@
     attempts: 1
     nodeset:
       nodes:
+        # TODO(marios) update controller try smaller nodeset
         - name: controller
           label: cloud-centos-9-stream-tripleo-vexxhost-xl
         - name: crc
           label: coreos-crc-extracted-xxl
+        - name: standalone
+          label: cloud-rhel-9-2
       groups:
         - name: computes
           nodes: []
-    roles: &adoption_roles
+    roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
-    pre-run: &pre_run
+    pre-run:
       - ci/playbooks/multinode-customizations.yml
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
-    post-run: &post_run
+    post-run:
       - ci/playbooks/e2e-collect-logs.yml
       - ci/playbooks/collect-logs.yml
       - ci/playbooks/multinode-autohold.yml
@@ -78,65 +81,6 @@
                 ip: 172.18.0.5
               tenant:
                 ip: 172.19.0.5
-
-- job:
-    name: cifmw-adoption-standalone-base
-    parent: base-extracted-crc
-    abstract: true
-    timeout: 10800
-    attempts: 1
-    nodeset:
-      nodes:
-        # TODO(marios) update controller try smaller nodeset
-        - name: controller
-          label: cloud-centos-9-stream-tripleo-vexxhost-xl
-        - name: crc
-          label: coreos-crc-extracted-xxl
-        - name: standalone
-          label: cloud-rhel-9-2
-      groups:
-        - name: computes
-          nodes: []
-    roles: *adoption_roles
-    pre-run: *pre_run
-    post-run: *post_run
-    vars:
-      <<: *adoption_vars
-      crc_ci_bootstrap_networking:
-        networks:
-          default:
-            mtu: 1500
-            range: 192.168.122.0/24
-          internal-api:
-            vlan: 20
-            range: 172.17.0.0/24
-          storage:
-            vlan: 21
-            range: 172.18.0.0/24
-          tenant:
-            vlan: 22
-            range: 172.19.0.0/24
-        instances:
-          controller:
-            networks:
-              default:
-                ip: 192.168.122.11
-              internal-api:
-                ip: 172.17.0.4
-              storage:
-                ip: 172.18.0.4
-              tenant:
-                ip: 172.19.0.4
-          crc:
-            networks:
-              default:
-                ip: 192.168.122.10
-              internal-api:
-                ip: 172.17.0.5
-              storage:
-                ip: 172.18.0.5
-              tenant:
-                ip: 172.19.0.5
           standalone:
             networks:
               default:
@@ -151,6 +95,10 @@
               tenant:
                 ip: 172.19.0.100
                 config_nm: false
+
+- job:
+    name: cifmw-adoption-standalone-base
+    parent: cifmw-adoption-base
 
 - job:
     name: cifmw-data-plane-adoption-OSP-17-to-extracted-crc


### PR DESCRIPTION
Due to different nodes in newest adoption job, we had to create a new
base job, this change prepares to remove the duplication and just keep
one. We still need to change the rdo-jobs definition, so we can't remove
the duplicated base yet.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

Depends-On: https://review.rdoproject.org/r/c/rdo-jobs/+/51170
