### PR TITLE
Tweak adoption nodeset with larger crc node

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -9,11 +9,10 @@
     attempts: 1
     nodeset:
       nodes:
-        # TODO(marios) update controller try smaller nodeset
         - name: controller
-          label: cloud-centos-9-stream-tripleo-vexxhost-xl
+          label: cloud-centos-9-stream-tripleo-vexxhost
         - name: crc
-          label: coreos-crc-extracted-xxl
+          label: coreos-crc-extracted-3xl
         - name: standalone
           label: cloud-rhel-9-2
       groups:


### PR DESCRIPTION
Tweak adoption nodeset to use a 3xl instance label for crc, since we're
seeing often crc failures in the adoption job. Also use a smaller label
for the controller, since we no longer create any vms there.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
