### PR TITLE
Simplify adoption jobs layout in ci-framework

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -96,12 +96,8 @@
                 config_nm: false
 
 - job:
-    name: cifmw-adoption-standalone-base
-    parent: cifmw-adoption-base
-
-- job:
-    name: cifmw-data-plane-adoption-OSP-17-to-extracted-crc
-    parent: content-provider-data-plane-adoption-OSP-17-to-extracted-crc
+    name: cifmw-data-plane-adoption-osp-17-to-extracted-crc
+    parent: data-plane-adoption-osp-17-to-extracted-crc
     files:
       - ^playbooks/01-bootstrap.yml
       - ^playbooks/02-infra.yml
@@ -118,3 +114,14 @@
       - ^zuul.d/adoption.yaml
       - go.mod
       - apis/go.mod
+    required-projects:
+      - openstack-k8s-operators/openstack-operator
+    irrelevant-files:
+      - .ci-operator.yaml
+      - .ansible-lint
+      - .gitignore
+      - .yamllint
+      - .pre-commit-config.yaml
+      - LICENSE
+      - OWNERS
+      - .*/*.md

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -32,6 +32,6 @@
     github-check:
       jobs:
         - openstack-k8s-operators-content-provider
-        - cifmw-data-plane-adoption-OSP-17-to-extracted-crc:
+        - cifmw-data-plane-adoption-osp-17-to-extracted-crc:
             dependencies:
               - openstack-k8s-operators-content-provider


### PR DESCRIPTION
This commit contains two changes:

- Simplify adoption jobs using content provider

There were two adoption jobs using content provider, one for
install_yamls and one for ci-framework, this change prepares to remove
the install_yamls one and use the ci-framework job everywhere.

- Cleanup and rename adoption jobs

This change removes duplicated base jobs and renames the adoption jobs
to use only lowercase.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
