### PR TITLE
[reproducer] disable static ip for ocpbm

### DIFF
--- a/roles/libvirt_manager/vars/main.yml
+++ b/roles/libvirt_manager/vars/main.yml
@@ -40,7 +40,7 @@ cifmw_libvirt_manager_polkit_rules_file: "{{ cifmw_libvirt_manager_polkit_rules_
 
 # It is either compute or extraworker and not both hence the numbers are reused
 cifmw_libvirt_manager_vm_net_ip_set_default:
-  controller: 5
+  controller: 9
   crc: 10
   master: 10
   ocp: 10

--- a/scenarios/reproducers/validated-architecture-1.yml
+++ b/scenarios/reproducers/validated-architecture-1.yml
@@ -17,7 +17,6 @@ cifmw_reproducer_epel_pkgs:
 cifmw_libvirt_manager_networks:
   ocpbm:
     range: "192.168.111.0/24"
-    static_ip: true
   osp_trunk:
     default: true
     range: "192.168.122.0/24"


### PR DESCRIPTION
Avoid IP address reservation for `ocpbm` network. Ensure IP `controller-0` does not conflict with api address

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

*Logs*

Snippet
```
PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
localhost                  : ok=465  changed=116  unreachable=0    failed=0    skipped=242  rescued=3    ignored=0   

Monday 15 January 2024  12:44:50 +0200 (0:00:00.159)       0:54:26.777 ******** 
=============================================================================== 
devscripts : Deploying the OpenShift platform -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2616.58s
reproducer : Install internal CA ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 239.70s
reproducer : Install some tools ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 52.38s
reproducer : Bootstrap environment on controller-0 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 34.13s
libvirt_manager : Grab IPs for nodes type ocp ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 31.67s
reproducer : Install collections on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 28.99s
libvirt_manager : Grab IPs for nodes type compute ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 21.30s
libvirt_manager : Prepare disk image with SSH and growing volume --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 17.05s
libvirt_manager : Grab IPs for nodes type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.76s
libvirt_manager : Wait for SSH on VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.57s
libvirt_manager : Wait for SSH on VMs type ocp --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.47s
reproducer : Install ansible dependencies -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 12.85s
libvirt_manager : Download base image ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 10.55s
ci_setup : Install packages from EPEL ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 8.29s
ci_setup : Install needed packages ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 5.60s
libvirt_manager : Wait for SSH on VMs type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 5.19s
reproducer : Enable RHEL repos -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 3.52s
reproducer : Clone repository if needed: ci-framework --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2.92s
devscripts : Clone the dev-scripts repository. ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2.68s
reproducer : Clone repository if needed: install_yamls -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2.60s
[ciuser@titanamd126 ci-framework]$ export KUBECONFIG=/home/ciuser/src/github.com/openshift-metal3/dev-scripts/ocp/ocp/auth/kubeconfig 
[ciuser@titanamd126 ci-framework]$ oc get nodes
NAME       STATUS   ROLES                         AGE   VERSION
master-0   Ready    control-plane,master,worker   36m   v1.27.9+5c56cc3
master-1   Ready    control-plane,master,worker   36m   v1.27.9+5c56cc3
master-2   Ready    control-plane,master,worker   36m   v1.27.9+5c56cc3
[ciuser@titanamd126 ci-framework]$ ssh controller-0
Warning: Permanently added '192.168.111.38' (ED25519) to the list of known hosts.
Register this system with Red Hat Insights: insights-client --register
Create an account or view all your systems at https://red.ht/insights-dashboard
[zuul@controller-0 ~]$ oc get nodes
NAME       STATUS   ROLES                         AGE   VERSION
master-0   Ready    control-plane,master,worker   37m   v1.27.9+5c56cc3
master-1   Ready    control-plane,master,worker   37m   v1.27.9+5c56cc3
master-2   Ready    control-plane,master,worker   37m   v1.27.9+5c56cc3
[zuul@controller-0 ~]$ 
```