### PR TITLE
Change nodesets to use unified labels

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -59,13 +59,13 @@
     nodeset:
       nodes:
         - name: controller
-          label: cloud-centos-9-stream-tripleo-vexxhost-medium
+          label: cloud-centos-9-stream-tripleo-medium
         - name: compute-0
-          label: cloud-centos-9-stream-tripleo-vexxhost-medium
+          label: cloud-centos-9-stream-tripleo-medium
         - name: compute-1
-          label: cloud-centos-9-stream-tripleo-vexxhost-medium
+          label: cloud-centos-9-stream-tripleo-medium
         - name: crc
-          label: cloud-centos-9-stream-tripleo-vexxhost-medium
+          label: cloud-centos-9-stream-tripleo-medium
       groups:
         - name: computes
           nodes:

--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -10,7 +10,7 @@
     nodeset:
       nodes:
         - name: controller
-          label: cloud-centos-9-stream-tripleo-vexxhost
+          label: cloud-centos-9-stream-tripleo
         - name: crc
           label: coreos-crc-extracted-3xl
         - name: standalone

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -110,9 +110,9 @@
     nodeset: &multinode_edpm_nodeset
       nodes:
         - name: controller
-          label: cloud-centos-9-stream-tripleo-vexxhost-medium
+          label: cloud-centos-9-stream-tripleo-medium
         - name: compute-0
-          label: cloud-centos-9-stream-tripleo-vexxhost
+          label: cloud-centos-9-stream-tripleo
         - name: crc
           label: coreos-crc-extracted-3xl
       groups:

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -5,13 +5,13 @@
     nodeset:
       nodes:
         - name: controller
-          label: cloud-centos-9-stream-tripleo-vexxhost-medium
+          label: cloud-centos-9-stream-tripleo-medium
         - name: compute-0
-          label: cloud-centos-9-stream-tripleo-vexxhost
+          label: cloud-centos-9-stream-tripleo
         - name: compute-1
-          label: cloud-centos-9-stream-tripleo-vexxhost
+          label: cloud-centos-9-stream-tripleo
         - name: compute-2
-          label: cloud-centos-9-stream-tripleo-vexxhost
+          label: cloud-centos-9-stream-tripleo
         - name: crc
           label: coreos-crc-extracted-2-19-0-xxl
       groups:
@@ -98,13 +98,13 @@
     nodeset:
       nodes:
         - name: controller
-          label: cloud-centos-9-stream-tripleo-vexxhost-medium
+          label: cloud-centos-9-stream-tripleo-medium
         - name: compute-0
-          label: cloud-centos-9-stream-tripleo-vexxhost
+          label: cloud-centos-9-stream-tripleo
         - name: compute-1
-          label: cloud-centos-9-stream-tripleo-vexxhost
+          label: cloud-centos-9-stream-tripleo
         - name: compute-2
-          label: cloud-centos-9-stream-tripleo-vexxhost
+          label: cloud-centos-9-stream-tripleo
         - name: crc
           label: coreos-crc-extracted-2-19-0-xxl
       groups:
@@ -215,9 +215,9 @@
     nodeset:
       nodes:
         - name: controller
-          label: cloud-centos-9-stream-tripleo-vexxhost
+          label: cloud-centos-9-stream-tripleo
         - name: compute-0
-          label: cloud-centos-9-stream-tripleo-vexxhost
+          label: cloud-centos-9-stream-tripleo
         - name: crc
           label: coreos-crc-extracted-2-19-0-3xl
       groups:
@@ -259,9 +259,9 @@
     nodeset:
       nodes:
         - name: controller
-          label: cloud-centos-9-stream-tripleo-vexxhost
+          label: cloud-centos-9-stream-tripleo
         - name: compute-0
-          label: cloud-centos-9-stream-tripleo-vexxhost
+          label: cloud-centos-9-stream-tripleo
         - name: crc
           label: coreos-crc-extracted-2-19-0-3xl
       groups:

--- a/zuul.d/kuttl_multinode.yaml
+++ b/zuul.d/kuttl_multinode.yaml
@@ -7,7 +7,7 @@
     nodeset:
       nodes:
         - name: controller
-          label: cloud-centos-9-stream-tripleo-vexxhost-medium
+          label: cloud-centos-9-stream-tripleo-medium
         - name: crc
           label: coreos-crc-extracted-2-19-0-3xl
     vars:

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -389,13 +389,13 @@
         - compute-0
         - compute-1
       nodes:
-      - label: cloud-centos-9-stream-tripleo-vexxhost-medium
+      - label: cloud-centos-9-stream-tripleo-medium
         name: controller
-      - label: cloud-centos-9-stream-tripleo-vexxhost-medium
+      - label: cloud-centos-9-stream-tripleo-medium
         name: compute-0
-      - label: cloud-centos-9-stream-tripleo-vexxhost-medium
+      - label: cloud-centos-9-stream-tripleo-medium
         name: compute-1
-      - label: cloud-centos-9-stream-tripleo-vexxhost-medium
+      - label: cloud-centos-9-stream-tripleo-medium
         name: crc
     parent: cifmw-molecule-base
     vars:

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -33,7 +33,7 @@
     name: centos-stream-9
     nodes:
       - name: controller
-        label: cloud-centos-9-stream-tripleo-vexxhost
+        label: cloud-centos-9-stream-tripleo
     groups:
       - name: switch
         nodes:
@@ -45,7 +45,7 @@
     name: multinode-centos-9-stream-crc
     nodes:
       - name: controller
-        label: cloud-centos-9-stream-tripleo-vexxhost-medium
+        label: cloud-centos-9-stream-tripleo-medium
       - name: crc
         label: coreos-crc-extracted-2-19-0-3xl
     groups:


### PR DESCRIPTION
This PRs removes Vexxhost-specific node labels
to use unified node labels that can take advantage of other cloud providers.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
