### PR TITLE
Revert "Add back BM nodeset update packages in bootstrap"

### DIFF
--- a/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -196,20 +196,6 @@
             "path": "/spec/nodeTemplate/ansible/ansibleVars/edpm_container_registry_insecure_registries",
             "value": [{{ content_provider_registry_ip }}:5001]}]'
 
-- name: Patch OpenStackDataPlaneNodeSet resource to update bootstrap packages
-  when: not cifmw_edpm_deploy_baremetal_dry_run
-  environment:
-    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-    PATH: "{{ cifmw_path }}"
-  ansible.builtin.command:
-    cmd: >-
-      oc patch openstackdataplanenodeset openstack-edpm-ipam
-      -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
-      --type json
-      -p '[{"op": "add",
-            "path": "/spec/nodeTemplate/ansible/ansibleVars/edpm_bootstrap_command",
-            "value": "sudo dnf -y update"}]'
-
 - name: Wait for OpenStackDataPlaneNodeSet to be Ready
   when: not cifmw_edpm_deploy_baremetal_dry_run
   environment:


### PR DESCRIPTION
Reverts openstack-k8s-operators/ci-framework#994

Test results here: https://review.rdoproject.org/r/c/testproject/+/51226/2#message-19838ba0d7e193471ac55cfa369f81d7bfc7a477

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/532