### PR TITLE
Adds new cifmw-adoption-base-source-multinode base job for DPA CI jobs

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -114,3 +114,130 @@
       - LICENSE
       - OWNERS
       - .*/*.md
+
+- job:
+    name: cifmw-adoption-base-source-multinode
+    parent: base-extracted-crc
+    abstract: true
+    timeout: 10800
+    attempts: 1
+    nodeset: centos-9-multinode-rhel-9-2-crc-extracted-2.30-3xl
+    roles:
+      - zuul: github.com/openstack-k8s-operators/ci-framework
+    pre-run:
+      - ci/playbooks/multinode-customizations.yml
+      - ci/playbooks/e2e-prepare.yml
+      - ci/playbooks/dump_zuul_data.yml
+    post-run:
+      - ci/playbooks/e2e-collect-logs.yml
+      - ci/playbooks/collect-logs.yml
+      - ci/playbooks/multinode-autohold.yml
+    vars:
+      <<: *adoption_vars
+      crc_ci_bootstrap_networking:
+        networks:
+          default:
+            mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
+            router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            range: 192.168.122.0/24
+          internal-api:
+            vlan: 20
+            range: 172.17.0.0/24
+          storage:
+            vlan: 21
+            range: 172.18.0.0/24
+          tenant:
+            vlan: 22
+            range: 172.19.0.0/24
+        instances:
+          controller:
+            networks:
+              default:
+                ip: 192.168.122.11
+              internal-api:
+                ip: 172.17.0.4
+              storage:
+                ip: 172.18.0.4
+              tenant:
+                ip: 172.19.0.4
+          crc:
+            networks:
+              default:
+                ip: 192.168.122.10
+              internal-api:
+                ip: 172.17.0.5
+              storage:
+                ip: 172.18.0.5
+              tenant:
+                ip: 172.19.0.5
+          undercloud:
+            networks:
+              default:
+                ip: 192.168.122.100
+                config_nm: false
+              internal-api:
+                ip: 172.17.0.100
+                config_nm: false
+              storage:
+                ip: 172.18.0.100
+                config_nm: false
+              tenant:
+                ip: 172.19.0.100
+                config_nm: false
+# TODO(marios): uncomment node config as needed
+#          tripleo-controller-1:
+#            networks:
+#              default:
+#                ip: 192.168.122.110
+#                config_nm: false
+#              internal-api:
+#                ip: 172.17.0.110
+#                config_nm: false
+#              storage:
+#                ip: 172.18.0.110
+#                config_nm: false
+#              tenant:
+#                ip: 172.19.0.110
+#                config_nm: false
+#          tripleo-compute-1:
+#            networks:
+#              default:
+#                ip: 192.168.122.111
+#                config_nm: false
+#              internal-api:
+#                ip: 172.17.0.111
+#                config_nm: false
+#              storage:
+#                ip: 172.18.0.111
+#                config_nm: false
+#              tenant:
+#                ip: 172.19.0.111
+#                config_nm: false
+#          tripleo-controller-2:
+#            networks:
+#              default:
+#                ip: 192.168.122.102
+#                config_nm: false
+#              internal-api:
+#                ip: 172.17.0.102
+#                config_nm: false
+#              storage:
+#                ip: 172.18.0.102
+#                config_nm: false
+#              tenant:
+#                ip: 172.19.0.102
+#                config_nm: false
+#          tripleo-controller-3:
+#            networks:
+#              default:
+#                ip: 192.168.122.103
+#                config_nm: false
+#              internal-api:
+#                ip: 172.17.0.103
+#                config_nm: false
+#              storage:
+#                ip: 172.18.0.103
+#                config_nm: false
+#              tenant:
+#                ip: 172.19.0.103
+#                config_nm: false

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -99,6 +99,37 @@
       - name: ocps
         nodes:
           - crc
+      - name: rh-subscription
+        nodes:
+          - standalone
+
+- nodeset:
+    name: centos-9-multinode-rhel-9-2-crc-extracted-2.30-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: coreos-crc-extracted-2-30-0-3xl
+      - name: undercloud
+        label: cloud-rhel-9-2
+      # TODO(marios): uncomment nodes as needed
+      # - name: tripleo-controller-1
+      #  label: cloud-rhel-9-2
+      # - name: tripleo-compute-1
+      #  label: cloud-rhel-9-2
+      # - name: tripleo-controller-2
+      #   label: cloud-rhel-9-2
+      # - name: tripleo-controller-3
+      #   label: cloud-rhel-9-2
+    groups:
+      - name: computes
+        nodes: []
+      - name: ocps
+        nodes:
+          - crc
+      - name: rh-subscription
+        nodes:
+          - undercloud # TODO(marios) add overcloud nodes
 
 - nodeset:
     name: centos-9-medium-centos-9-crc-extracted-2.30-3xl


### PR DESCRIPTION
Adds new cifmw-adoption-base-source-multinode base job for DPA CI jobs

As part of [1] adds the new base job for deploying multinode source
tripleo environment. For now we only activate the undercloud node and a
new patch will follow to add the overcloud nodes. This adds rh-subscription
group to the zuul nodeset groups for use with the subscription plays.

https://issues.redhat.com/browse/OSPRH-4411

[1] https://issues.redhat.com/browse/OSPRH-3038

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
