### PR TITLE
Avoid useless computations

### DIFF
--- a/roles/reproducer/tasks/crc_layout.yml
+++ b/roles/reproducer/tasks/crc_layout.yml
@@ -10,6 +10,9 @@
       }}
   ansible.builtin.stat:
     path: "{{ _img }}"
+    get_checksum: false
+    get_mime: false
+    get_attributes: false
 
 - name: Deploy CRC if needed
   when:


### PR DESCRIPTION
Until now, we were computing the checksum for CRC image and gathering
useless data, losing time for nothing.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
