### PR TITLE
Set use_libvirt false in adoption job

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -40,7 +40,7 @@
       cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
       cifmw_openshift_skip_tls_verify: true
       cifmw_openshift_setup_skip_internal_registry_tls_verify: true
-      cifmw_use_libvirt: true
+      cifmw_use_libvirt: false
       cifmw_use_crc: false
       cifmw_zuul_target_host: controller
       crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"
@@ -106,7 +106,6 @@
       - ^roles/edpm_prepare/(?!meta|README|molecule).*
       - ^roles/install_ca/(?!meta|README|molecule).*
       - ^roles/install_yamls/(?!meta|README|molecule).*
-      - ^roles/libvirt_manager/(?!meta|README|molecule).*
       - ^roles/openshift_login/(?!meta|README|molecule).*
       - ^roles/openshift_setup/(?!meta|README|molecule).*
       - ^roles/repo_setup/(?!meta|README|molecule).*


### PR DESCRIPTION
Since in adoption job we no longer need any nested vm, we can set
use_libvirt to false and not run the adoption job for libvirt_manager
role, since it should not use it anymore.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
