### PR TITLE
Follow-up and corrections to the networking_mapper

### DIFF
--- a/roles/networking_mapper/molecule/default/converge.yml
+++ b/roles/networking_mapper/molecule/default/converge.yml
@@ -208,6 +208,6 @@
         that:
           - _content.data.node_0 is defined
           - _content.data.ctlplane is defined
-          - _content.data['internal-api'] is defined
+          - _content.data['internalapi'] is defined
           - _content.data.ctlplane == _ctlplane_output.ctlplane
-          - _content.data['internal-api'] == _internalapi_output['internal-api']
+          - _content.data['internalapi'] == _internalapi_output['internalapi']

--- a/roles/networking_mapper/molecule/default/vars/input.yml
+++ b/roles/networking_mapper/molecule/default/vars/input.yml
@@ -21,7 +21,7 @@ networks:
         ranges:
           - start: "192.168.122.80"
             end: "192.168.122.90"
-  internal-api:
+  internalapi:
     network: "172.17.0.0/24"
     gateway: "172.17.0.1"
     vlan: 20
@@ -67,7 +67,7 @@ group-templates:
     networks:
       ctlplane:
         range: "192.168.122.10-192.168.122.14"
-      internal-api:
+      internalapi:
         range: "10-14"
       tenant:
         range:

--- a/roles/networking_mapper/molecule/default/vars/internalapi_output.yml
+++ b/roles/networking_mapper/molecule/default/vars/internalapi_output.yml
@@ -1,6 +1,6 @@
 ---
-internal-api:
-  dnsDomain: internal-api.example.com
+internalapi:
+  dnsDomain: internalapi.example.com
   subnets:
     - allocationRanges:
         - end: 172.17.0.49
@@ -11,20 +11,20 @@ internal-api:
   lb_addresses:
     - 172.17.0.90-172.17.0.100
   endpoint_annotations:
-    metallb.universe.tf/address-pool: internal-api
-    metallb.universe.tf/allow-shared-ip: internal-api
+    metallb.universe.tf/address-pool: internalapi
+    metallb.universe.tf/allow-shared-ip: internalapi
     metallb.universe.tf/loadBalancerIPs: 172.17.0.90
   prefix-length: 24
   mtu: 1496
   vlan: 20
-  iface: internal-api
+  iface: internalapi
   base_iface: eth0.20
   net-attach-def: |
     {
       "cniVersion": "0.3.1",
-      "name": "internal-api",
+      "name": "internalapi",
       "type": "macvlan",
-      "master": "internal-api",
+      "master": "internalapi",
       "ipam": {
         "type": "whereabouts",
         "range": "172.17.0.0/24",

--- a/roles/networking_mapper/tasks/network_config_values.yml
+++ b/roles/networking_mapper/tasks/network_config_values.yml
@@ -6,11 +6,13 @@
     mode: "0755"
 
 - name: Load mapper definition file into _network_mapper
-  ansible.builtin.include_vars:
-    file: "{{ cifmw_networking_mapper_networking_env_def_path }}"
-    name: _network_mapper
+  register: _net_env
+  ansible.builtin.slurp:
+    src: "{{ cifmw_networking_mapper_networking_env_def_path }}"
 
 - name: Generate value file for deployment
+  vars:
+    _network_mapper: "{{ _net_env.content | b64decode | from_yaml }}"
   ansible.builtin.template:
     src: 'network-config-values.j2'
     dest: >-

--- a/roles/networking_mapper/templates/network-config-values.j2
+++ b/roles/networking_mapper/templates/network-config-values.j2
@@ -56,10 +56,14 @@ data:
     mtu: {{ network.mtu | default(1500) }}
 {%  if network.vlan_id is defined  %}
     vlan: {{ network.vlan_id }}
+{%    if ns.interfaces[network.network_name] is defined %}
     iface: {{ network.network_name }}
     base_iface: {{ ns.interfaces[network.network_name] }}
+{%    endif %}
 {%  else %}
+{%    if ns.interfaces[network.network_name] is defined %}
     iface: {{ ns.interfaces[network.network_name] }}
+{%    endif %}
 {%  endif %}
 {%  if network.tools.multus is defined %}
     net-attach-def: |
@@ -107,11 +111,11 @@ data:
   rabbitmq:
     endpoint_annotations:
       metallb.universe.tf/address-pool: internalapi
-      metallb.universe.tf/loadBalancerIPs: {{ _network_mapper.networks['internal-api'].network_v4 | ansible.utils.ipmath(85) }}
+      metallb.universe.tf/loadBalancerIPs: {{ _network_mapper.networks['internalapi'].network_v4 | ansible.utils.ipmath(85) }}
   rabbitmq-cell1:
     endpoint_annotations:
       metallb.universe.tf/address-pool: internalapi
-      metallb.universe.tf/loadBalancerIPs: {{ _network_mapper.networks['internal-api'].network_v4 | ansible.utils.ipmath(86) }}
+      metallb.universe.tf/loadBalancerIPs: {{ _network_mapper.networks['internalapi'].network_v4 | ansible.utils.ipmath(86) }}
 
   lbServiceType: LoadBalancer
   storageClass: local-storage


### PR DESCRIPTION
There were some issues with the way network_config_values was working:
- include_vars doesn't work with remote content, switched to slurp
- template faced issues for some networks that were defined, but not
  associated to instances, leading to empty "interface"
- renamed "internal-api" to match actual architecture

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
