### PR TITLE
Add job from new layout with ci-bootstrap on main branch

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -201,6 +201,26 @@
 # Base jobs using ci-bootstrap layout
 #
 - job:
+    name: cifmw-podified-multinode-edpm-ci-bootstrap
+    parent: base-extracted-crc-ci-bootstrap
+    timeout: 10800
+    attempts: 1
+    nodeset: *multinode_edpm_nodeset
+    irrelevant-files: *ir_files
+    required-projects: *multinode_edpm_rp
+    roles: *multinode_edpm_roles
+    pre-run:
+      - ci/playbooks/crc/reconfigure-kubelet.yml
+      - ci/playbooks/multinode-customizations.yml
+    post-run: *multinode_edpm_post_run
+    vars:
+      <<: *multinode_edpm_vars
+      ci_bootstrap_role_enabled: true
+      cifmw_bootstrap_cloud_name: cifmw_vexxhost
+      cifmw_bootstrap_public_key_file: "{{ ansible_user_dir }}/.ssh/id_ed25519.pub"
+
+# Job with ci-bootstrap staging branch job - to be used to test ci-bootstrap
+- job:
     name: cifmw-podified-multinode-edpm-ci-bootstrap-staging
     parent: base-extracted-crc-ci-bootstrap-staging
     timeout: 10800

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -293,10 +293,66 @@
 # Jobs using ci-bootstrap layout
 #
 - job:
-    name: podified-multinode-edpm-deployment-crc-staging
-    parent: cifmw-podified-multinode-edpm-ci-bootstrap-staging
-    vars:
+    name: podified-multinode-edpm-deployment-crc-bootstrap
+    parent: cifmw-podified-multinode-edpm-ci-bootstrap
+    extra-vars: &edpm_bootstrap_extra_vars
+      # TODO: to be removed after removing its dependency in ci-bootstrap
+      crc_ci_bootstrap_networking: {}
+    vars: &edpm_bootstrap_vars
+      cifmw_networking_definition:
+        networks:
+          default:
+            network: "192.168.122.0/24"
+            gateway: "192.168.122.1"
+            mtu: 1500
+          internal-api:
+            network: "172.17.0.0/24"
+            gateway: "172.17.0.1"
+            vlan: 20
+          storage:
+            network: "172.18.0.0/24"
+            gateway: "172.18.0.1"
+            vlan: 21
+          tenant:
+            network: "172.19.0.0/24"
+            gateway: "172.19.0.1"
+            vlan: 22
+        instances:
+          controller:
+            networks:
+              default:
+                ip: "192.168.122.11"
+          crc:
+            networks:
+              default:
+                ip: "192.168.122.10"
+              internal-api:
+                ip: "172.17.0.5"
+              storage:
+                ip: "172.18.0.5"
+              tenant:
+                ip: "172.19.0.5"
+          compute-0:
+            skip-nm-configuration: true
+            networks:
+              default:
+                ip: "192.168.122.100"
+              internal-api:
+                ip: "172.17.0.100"
+              storage:
+                ip: "172.18.0.100"
+              tenant:
+                ip: "172.19.0.100"
       cifmw_extras:
         - '@scenarios/centos-9/multinode-ci.yml'
+    run:
+      - ci/playbooks/edpm/run.yml
+
+# Job with ci-bootstrap staging branch job - to be used to test ci-bootstrap
+- job:
+    name: podified-multinode-edpm-deployment-crc-bootstrap-staging
+    parent: cifmw-podified-multinode-edpm-ci-bootstrap-staging
+    extra-vars: *edpm_bootstrap_extra_vars
+    vars: *edpm_bootstrap_vars
     run:
       - ci/playbooks/edpm/run.yml


### PR DESCRIPTION
This job is the same as the staging branch one, but has a different parent defined in config repo[1],
which sets the ci-bootstrap main branch to be used.

The job based on ci-bootstrap repo should replace the code that we use from config repos, and allow us to test it as a role in its own repo. This job also takes a new network definition as input to configure the infrastructure needed to run our tests on zuul.
This patch doesn't wire up, or replace the current multinode-edpm job, but may do this in a next PR.

[1] https://review.rdoproject.org/r/c/config/+/51257/2/zuul.d/_jobs-crc.yaml

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
