### PR TITLE
Make /etc/yum.repos.d writeable for component repos

### DIFF
--- a/roles/repo_setup/tasks/component_repo.yml
+++ b/roles/repo_setup/tasks/component_repo.yml
@@ -1,16 +1,19 @@
 ---
 - name: Get component repo
+  become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"
   ansible.builtin.get_url:
     url: "{{ cifmw_repo_setup_dlrn_uri }}/{{ cifmw_repo_setup_os_release }}{{ cifmw_repo_setup_dist_major_version }}-{{ cifmw_repo_setup_branch }}/component/{{ cifmw_repo_setup_component_name }}/{{ cifmw_repo_setup_component_promotion_tag }}/delorean.repo"
     dest: "{{ cifmw_repo_setup_output }}/{{ cifmw_repo_setup_component_name }}_{{ cifmw_repo_setup_component_promotion_tag }}_delorean.repo"
 
 - name: Rename component repo
+  become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"
   ansible.builtin.replace:
     path: "{{ cifmw_repo_setup_output }}/{{ cifmw_repo_setup_component_name }}_{{ cifmw_repo_setup_component_promotion_tag }}_delorean.repo"
     regexp: 'delorean-component-{{ cifmw_repo_setup_component_name }}'
     replace: '{{ cifmw_repo_setup_component_name }}-{{ cifmw_repo_setup_component_promotion_tag }}'
 
 - name: Disable component repo in current-podified dlrn repo
+  become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"
   community.general.ini_file:
     path: "{{ cifmw_repo_setup_output }}/delorean.repo"
     section: 'delorean-component-{{ cifmw_repo_setup_component_name }}'


### PR DESCRIPTION
On using cifmw_repo_setup_output: '/etc/yum.repos.d'.
The component_repo tasks are failing with
```
The destination directory (/etc/yum.repos.d) is not writable by the current user
```

In order to fix it, we need to set become: true for these tasks.
We are already using the same conditional for repo-setup commands.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

