### PR TITLE
Ensure hosts are ready before collecting facts

### DIFF
--- a/roles/networking_mapper/tasks/main.yml
+++ b/roles/networking_mapper/tasks/main.yml
@@ -73,6 +73,13 @@
         _net_def_groups_instances + _net_def_instances_filtered
       }}
 
+- name: Ensure hosts are ready
+  ansible.builtin.wait_for:
+    host: "{{ hostvars[item]['ansible_host'] }}"
+    port: 22
+    delay: 5
+  loop: "{{ _networking_mapper_instance_names }}"
+
 - name: Ensure that networking and hostname facts are in place
   ansible.builtin.setup:
     gather_subset:


### PR DESCRIPTION
With automation, it may happen hosts are being booted, ansible goes on
other tasks, and when we hit this fact collection, hosts are in a middle
stage where they seem to have some networking issues.

This is especially visible with the OCP cluster - the libvirt_manager
role starts them, wait for them, gets access on them and everything's
good, moves on, but later the OCP cluster is unreachable for a limited
amount of time.

This new task ensure everything's as ready as possible before looping on
the fact collection, avoiding a crash.

(Mostly tested while debugging #1025 against OCP cluster)

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
