### PR TITLE
Use `hostname` instead of `name`

### DIFF
--- a/roles/networking_mapper/templates/network-config-values.j2
+++ b/roles/networking_mapper/templates/network-config-values.j2
@@ -10,7 +10,7 @@ data:
 {%   if host is match('^(ocp|crc).*') %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
-    name: {{ _network_mapper.instances[host]['name'] }}
+    name: {{ _network_mapper.instances[host]['hostname'] }}
 {%     for network in _network_mapper.instances[host]['networks'].values() %}
     {{ network.network_name }}_ip: {{ network.ip_v4 }}
 {%     endfor %}


### PR DESCRIPTION
The `name` is the name as known in the ansible inventory - it may differ
from the actual host `hostname`.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
