### PR TITLE
[Tobiko] Create tobiko.conf and ssh keys

### DIFF
--- a/roles/tobiko/README.md
+++ b/roles/tobiko/README.md
@@ -10,17 +10,12 @@ become - Required to install required rpm packages
 * `cifmw_tobiko_image_tag`: (String) Tag for the `cifmw_tobiko_image`. Default to `current-podified`
 * `cifmw_tobiko_dry_run`: (Boolean) Whether tobiko should run or not. Default to `false`
 * `cifmw_tobiko_remove_container`: (Boolean) Cleanup tobiko container after it is done. Default to `false`
-* `cifmw_tobiko_debug`: (Boolean) Whether tobiko log level is debug or not
 * `cifmw_tobiko_testenv`: (String) Executed tobiko testenv. See tobiko `tox.ini` file for further details. Some allowed values: scenario, sanity, faults, neutron, octavia, py3, etc
 
 ## Parameters with default values from tcib or tobiko default configurations
 The default values from the following parameters are not taken from this tobiko role, but from the tobiko image defined on the tcib project or from the config.py files within the tobiko project.
 * `cifmw_tobiko_version`: (String) Tobiko version to install. It could refer to a branch (master, osp-16.2), a tag (0.6.x, 0.7.x) or an sha-1. Default value: master
-* `cifmw_tobiko_ubuntu_interface_name`: (String) Name of the primary interface created on the Ubuntu VM instances. Default value: enp3s0
-* `cifmw_tobiko_keystone_interface`: (String) Name of the keystone interface to send the requests to. Default value: public
-* `cifmw_tobiko_testcase_timeout`: (Float) Timeout (in seconds) used for interrupting test case execution. Default value: 1800.0
-* `cifmw_tobiko_testrunner_timeout`: (Float) Timeout (in seconds) used for interrupting test runner execution. Default value: 14400.0
 * `cifmw_tobiko_pytest_addopts`: (String) `PYTEST_ADDOPTS` env variable with input pytest args. Example: `-m <markers> --maxfail <max-failed-tests> --skipregex <regex>`. Default value is empty string
-* `cifmw_tobiko_report_dir`: (String) Directory where tobiko logs and results are saved
-* `cifmw_tobiko_manila_share_protocol`: (String) Share protocol needed for manila to create volumes
-* `cifmw_tobiko_prevent_create`: (Boolean) Sets the value of the env variable TOBIKO_PREVENT_CREATE that specifies whether tobiko scenario tests create new resources or expect that those resource had been created before
+* `cifmw_tobiko_prevent_create`: (Boolean) Sets the value of the env variable `TOBIKO_PREVENT_CREATE` that specifies whether tobiko scenario tests create new resources or expect that those resource had been created before
+* `cifmw_tobiko_num_processes`: (Integer) Sets the value of the env variable `TOX_NUM_PROCESSES` that is used to run pytest with `--numprocesses $TOX_NUM_PROCESSES`. Default value: auto
+* `cifmw_tobiko_tobikoconf`: (Dict) Overrides the default configuration that will be used to generate the tobiko.conf file

--- a/roles/tobiko/defaults/main.yml
+++ b/roles/tobiko/defaults/main.yml
@@ -27,14 +27,9 @@ cifmw_tobiko_dry_run: false
 cifmw_tobiko_remove_container: true
 cifmw_tobiko_dns_servers:
   - "192.168.122.10"
-cifmw_tobiko_debug: true
 cifmw_tobiko_testenv: scenario
 cifmw_tobiko_version: null
-cifmw_tobiko_ubuntu_interface_name: null
-cifmw_tobiko_keystone_interface: null
-cifmw_tobiko_testcase_timeout: null
-cifmw_tobiko_testrunner_timeout: null
 cifmw_tobiko_pytest_addopts: null
-cifmw_tobiko_report_dir: null
-cifmw_tobiko_manila_share_protocol: null
 cifmw_tobiko_prevent_create: null
+cifmw_tobiko_num_processes: null
+cifmw_tobiko_tobikoconf: {}

--- a/roles/tobiko/tasks/create-tobiko-conf.yml
+++ b/roles/tobiko/tasks/create-tobiko-conf.yml
@@ -1,0 +1,9 @@
+- name: Create tobiko.conf section by section
+  community.general.ini_file:
+    path: "{{ cifmw_tobiko_artifacts_basedir }}/tobiko.conf"
+    section: "{{ tobikoconf_section.key }}"
+    option: "{{ tobikoconf_option.key }}"
+    value: "{{ tobikoconf_option.value }}"
+  loop: "{{ tobikoconf_section.value | dict2items }}"
+  loop_control:
+    loop_var: tobikoconf_option

--- a/roles/tobiko/tasks/main.yml
+++ b/roles/tobiko/tasks/main.yml
@@ -33,6 +33,21 @@
     tasks_from: create-clouds-file
   when: not cifmw_tobiko_dry_run | bool
 
+
+- name: Generate ssh keys used for the VMs that tobiko creates
+  block:
+    - name: Check if the ssh keys already exist
+      ansible.builtin.stat:
+        path: "{{ cifmw_tobiko_artifacts_basedir }}/id_ecdsa"
+      register: check_id_ecdsa
+
+    - name: Create the ssh keys
+      community.crypto.openssh_keypair:
+        path: "{{ cifmw_tobiko_artifacts_basedir }}/id_ecdsa"
+        type: ecdsa
+        passphrase: ''
+      when: not check_id_ecdsa.stat.exists
+
 - name: Create tobiko.conf
   vars:
     tobikoconf_combined: >-

--- a/roles/tobiko/tasks/main.yml
+++ b/roles/tobiko/tasks/main.yml
@@ -33,6 +33,18 @@
     tasks_from: create-clouds-file
   when: not cifmw_tobiko_dry_run | bool
 
+- name: Create tobiko.conf
+  vars:
+    tobikoconf_combined: >-
+      {{
+          cifmw_tobiko_tobikoconf_default |
+          combine(cifmw_tobiko_tobikoconf, recursive=True)
+      }}
+  ansible.builtin.include_tasks: create-tobiko-conf.yml
+  loop: "{{ tobikoconf_combined | dict2items }}"
+  loop_control:
+    loop_var: tobikoconf_section
+
 - name: Copy CA bundle to cifmw_tobiko_artifacts_basedir
   ansible.builtin.copy:
     src: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
@@ -66,20 +78,16 @@
     volume:
       - "{{ cifmw_tobiko_artifacts_basedir }}/:/var/lib/tobiko/external_files:Z"
       - "{{ cifmw_tobiko_artifacts_basedir }}/tls-ca-bundle.pem:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:Z"
+      - "{{ cifmw_tobiko_artifacts_basedir }}/tls-ca-bundle.pem:/etc/pki/tls/certs/ca-bundle.trust.crt:Z"
+
     detach: false
     dns: "{{ cifmw_tobiko_dns_servers }}"
     env:
-      TOBIKO_DEBUG: "{{ cifmw_tobiko_debug }}"
       TOBIKO_TESTENV: "{{ cifmw_tobiko_testenv }}"
       TOBIKO_PREVENT_CREATE: "{{ cifmw_tobiko_prevent_create if cifmw_tobiko_prevent_create is not none else omit }}"
       TOBIKO_VERSION: "{{ cifmw_tobiko_version if cifmw_tobiko_version is not none else omit }}"
-      TOBIKO_UBUNTU_INTERFACE_NAME: "{{ cifmw_tobiko_ubuntu_interface_name if cifmw_tobiko_ubuntu_interface_name is not none else omit }}"
-      TOBIKO_KEYSTONE_INTERFACE: "{{ cifmw_tobiko_keystone_interface if cifmw_tobiko_keystone_interface is not none else omit }}"
-      TOBIKO_TESTCASE_TIMEOUT: "{{ cifmw_tobiko_testcase_timeout if cifmw_tobiko_testcase_timeout is not none else omit }}"
-      TOBIKO_TESTRUNNER_TIMEOUT: "{{ cifmw_tobiko_testrunner_timeout if cifmw_tobiko_testrunner_timeout is not none else omit }}"
       TOBIKO_PYTEST_ADDOPTS: "{{ cifmw_tobiko_pytest_addopts if cifmw_tobiko_pytest_addopts is not none else omit }}"
-      TOBIKO_REPORT_DIR: "{{ cifmw_tobiko_report_dir if cifmw_tobiko_report_dir is not none else omit }}"
-      TOBIKO_MANILA_SHARE_PROTOCOL: "{{ cifmw_tobiko_manila_share_protocol if cifmw_tobiko_manila_share_protocol is not none else omit }}"
+      TOBIKO_NUM_PROCESSES: "{{ cifmw_tobiko_num_processes if cifmw_tobiko_num_processes is not none else omit }}"
   when: not cifmw_tobiko_dry_run | bool
   register: tobiko_run_output
 

--- a/roles/tobiko/vars/main.yml
+++ b/roles/tobiko/vars/main.yml
@@ -1,0 +1,14 @@
+cifmw_tobiko_tobikoconf_default:
+  DEFAULT:
+    log_file: tobiko.log
+    debug: true
+  testcase:
+    timeout: 1800.0
+    test_runner_timeout: 14400.0
+  ubuntu:
+    interface_name: enp3s0
+    image_file: ~/.downloaded-images/ubuntu-minimal
+  keystone:
+    interface: public
+  manila:
+    share_protocol: cephfs


### PR DESCRIPTION
With this change, ci-framework will create tobiko.conf based on the input param cifmw_tobiko_tobikoconf, which should be defined as a dictionary, providing total flexibility to define tobiko.conf.

Besides, the framework will generate ssh key files that can be shared between different tobiko containers running tests, so that they can connect to the VMs created by a previous tobiko container (the Openstack workloads created by tobiko are persistent).

Related: https://github.com/openstack-k8s-operators/tcib/pull/120


As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
