### PR TITLE
[kustomize_deploy] Introduce `kustomize_deploy` role

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -33,6 +33,12 @@
     name: cifmw-molecule-ci_metallb
     parent: cifmw-molecule-base-crc
 - job:
+    name: cifmw-molecule-kustomize_deploy
+    parent: cifmw-molecule-base-crc
+    nodeset: centos-9-crc-3xl
+    extra-vars:
+      crc_parameters: "--memory 24576 --disk-size 100 --cpus 8"
+- job:
     name: cifmw-molecule-reproducer
     nodeset: centos-9-crc-xxl
     timeout: 5400
@@ -51,17 +57,17 @@
 - job:
     name: cifmw-molecule-networking_mapper
     nodeset:
-        nodes:
-            - name: controller
-              label: cloud-centos-9-stream-tripleo-vexxhost-medium
-            - name: compute-0
-              label: cloud-centos-9-stream-tripleo-vexxhost-medium
-            - name: compute-1
-              label: cloud-centos-9-stream-tripleo-vexxhost-medium
-            - name: crc
-              label: cloud-centos-9-stream-tripleo-vexxhost-medium
-        groups:
-            - name: computes
-              nodes:
-                  - compute-0
-                  - compute-1
+      nodes:
+        - name: controller
+          label: cloud-centos-9-stream-tripleo-vexxhost-medium
+        - name: compute-0
+          label: cloud-centos-9-stream-tripleo-vexxhost-medium
+        - name: compute-1
+          label: cloud-centos-9-stream-tripleo-vexxhost-medium
+        - name: crc
+          label: cloud-centos-9-stream-tripleo-vexxhost-medium
+      groups:
+        - name: computes
+          nodes:
+            - compute-0
+            - compute-1

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -5,37 +5,40 @@
 The following parameters allow to set a common value for parameters that
 are shared among multiple roles:
 
-* `cifmw_basedir`: The base directory for all of the artifacts. Defaults to
-`~/ci-framework-data`.
-* `cifmw_crc_hostname`: Allow to set the actual CRC inventory hostname. Mostly used in the fetch_compute_facts hook.
-in the multinode layout, especially for the reproducer case.
-* `cifmw_edpm_deploy_baremetal`: (Bool) Toggle whether to deploy edpm on compute nodes.
-provisioned with virtual baremetal vs pre-provisioned VM.
-* `cifmw_installyamls_repos`: install_yamls repository location. Defaults to `../..`.
-* `cifmw_manifests`: Directory where k8s related manifests will be places. Defaults to
-`{{ cifmw_basedir }}/manifests`.
-* `cifmw_path`: customized PATH. Defaults to `~/.crc/bin:~/.crc/bin/oc:~/bin:${PATH}`.
-* `cifmw_use_libvirt`: (Bool) toggle libvirt support.
-* `cifmw_use_crc`: (Bool) toggle rhol/crc usage.
-* `cifmw_use_devscripts`: (Bool) toggle devscripts usage.
-* `cifmw_openshift_kubeconfig`: (String) Path to the kubeconfig file if externally provided. If provided will be the kubeconfig to use and update after login.
-* `cifmw_openshift_api`: (String) Path to the kubeconfig file. If provided will be the API to authenticate against.
-* `cifmw_openshift_user`: (String) Login user. If provided, the user that logins.
-* `cifmw_openshift_provided_token`: (String) Initial login token. If provided, that token will be used to authenticate into OpenShift.
-* `cifmw_openshift_password`: (String) Login password. If provided is the password used for login in.
-* `cifmw_openshift_password_file`: (String) Path to a file that contains the plain login password. If provided is the password used for login in.
-* `cifmw_openshift_skip_tls_verify`: (Boolean) Skip TLS verification to login. Defaults to `false`.
-* `cifmw_use_opn`: (Bool) toggle openshift provisioner node support.
-* `cifmw_use_hive`: (Bool) toggle OpenShift deployment using hive operator.
-* `cifmw_use_devscripts`: (Bool) toggle OpenShift deploying using devscripts role.
-* `cifmw_openshift_crio_stats`: (Bool) toggle collecting cri-o stats in CRC deployment.
-* `cifmw_deploy_edpm`: (Bool) toggle deploying EDPM. Default to false.
-* `cifmw_config_nmstate`: (Bool) toggle NMstate networking deployment. Default to false.
-* `cifmw_config_certmanager`: (Bool) toggle cert-manager deployment. Default to false.
-* `cifmw_ssh_keytype`: (String) Type of ssh keys that will be injected into the controller in order to connect to the rest of the nodes. Defaults to `ecdsa`.
-* `cifmw_ssh_keysize`: (Integer) Size of ssh keys that will be injected into the controller in order to connect to the rest of the nodes. Defaults to 521.
+- `cifmw_basedir`: The base directory for all of the artifacts. Defaults to
+  `~/ci-framework-data`.
+- `cifmw_crc_hostname`: Allow to set the actual CRC inventory hostname. Mostly used in the fetch_compute_facts hook.
+  in the multinode layout, especially for the reproducer case.
+- `cifmw_edpm_deploy_baremetal`: (Bool) Toggle whether to deploy edpm on compute nodes.
+  provisioned with virtual baremetal vs pre-provisioned VM.
+- `cifmw_installyamls_repos`: install_yamls repository location. Defaults to `../..`.
+- `cifmw_manifests`: Directory where k8s related manifests will be places. Defaults to
+  `{{ cifmw_basedir }}/manifests`.
+- `cifmw_path`: customized PATH. Defaults to `~/.crc/bin:~/.crc/bin/oc:~/bin:${PATH}`.
+- `cifmw_use_libvirt`: (Bool) toggle libvirt support.
+- `cifmw_use_crc`: (Bool) toggle rhol/crc usage.
+- `cifmw_use_devscripts`: (Bool) toggle devscripts usage.
+- `cifmw_openshift_kubeconfig`: (String) Path to the kubeconfig file if externally provided. If provided will be the kubeconfig to use and update after login.
+- `cifmw_openshift_api`: (String) Path to the kubeconfig file. If provided will be the API to authenticate against.
+- `cifmw_openshift_user`: (String) Login user. If provided, the user that logins.
+- `cifmw_openshift_provided_token`: (String) Initial login token. If provided, that token will be used to authenticate into OpenShift.
+- `cifmw_openshift_password`: (String) Login password. If provided is the password used for login in.
+- `cifmw_openshift_password_file`: (String) Path to a file that contains the plain login password. If provided is the password used for login in.
+- `cifmw_openshift_skip_tls_verify`: (Boolean) Skip TLS verification to login. Defaults to `false`.
+- `cifmw_use_opn`: (Bool) toggle openshift provisioner node support.
+- `cifmw_use_hive`: (Bool) toggle OpenShift deployment using hive operator.
+- `cifmw_use_devscripts`: (Bool) toggle OpenShift deploying using devscripts role.
+- `cifmw_openshift_crio_stats`: (Bool) toggle collecting cri-o stats in CRC deployment.
+- `cifmw_deploy_edpm`: (Bool) toggle deploying EDPM. Default to false.
+- `cifmw_config_nmstate`: (Bool) toggle NMstate networking deployment. Default to false.
+- `cifmw_config_certmanager`: (Bool) toggle cert-manager deployment. Default to false.
+- `cifmw_ssh_keytype`: (String) Type of ssh keys that will be injected into the controller in order to connect to the rest of the nodes. Defaults to `ecdsa`.
+- `cifmw_ssh_keysize`: (Integer) Size of ssh keys that will be injected into the controller in order to connect to the rest of the nodes. Defaults to 521.
+- `cifmw_architecture_repo`: (String) Path of the architecture repository on the controller node.
+  Defaults to `~/src/github.com/openstack-k8s-operators/architecture`
+- `cifmw_architecture_va_scenario`: (String) The selected VA scenario to deploy.
 
-~~~{admonition} Words of caution
+```{admonition} Words of caution
 :class: danger
 If you want to output the content in another location than `~/ci-framework-data`
 (namely set the `cifmw_basedir` to some other location), you will have to update
@@ -43,7 +46,7 @@ the `ansible.cfg`, updating the value of `roles_path` so that it includes
 this new location.
 
 We cannot do this change runtime unfortunately.
-~~~
+```
 
 ## Role level parameters
 
@@ -63,28 +66,28 @@ specific points in the standard run.
 
 Allowed parameter names are:
 
-* `pre_infra`: before bootstrapping the infrastructure
-* `post_infra`: after bootstrapping the infrastructure
-* `pre_package_build`: before building packages against sources
-* `post_package_build`: after building packages against sources
-* `pre_container_build`: before building container images
-* `post_container_build`: after building container images
-* `pre_deploy`: before deploying EDPM
-* `post_deploy`: after deploying EDPM
-* `post_ctlplane_deploy`: after Control Plane deployment
-* `pre_tests`: before running tests
-* `post_tests`: after running tests
-* `pre_admin_setup`: before admin setup
-* `post_admin_setup`: before admin setup
-* `pre_reporting`: before running reporting
-* `post_reporting`: after running reporting
+- `pre_infra`: before bootstrapping the infrastructure
+- `post_infra`: after bootstrapping the infrastructure
+- `pre_package_build`: before building packages against sources
+- `post_package_build`: after building packages against sources
+- `pre_container_build`: before building container images
+- `post_container_build`: after building container images
+- `pre_deploy`: before deploying EDPM
+- `post_deploy`: after deploying EDPM
+- `post_ctlplane_deploy`: after Control Plane deployment
+- `pre_tests`: before running tests
+- `post_tests`: after running tests
+- `pre_admin_setup`: before admin setup
+- `post_admin_setup`: before admin setup
+- `pre_reporting`: before running reporting
+- `post_reporting`: after running reporting
 
 Since steps may be skipped, we must ensure proper post/pre exists for specific
 steps.
 
 In order to provide a hook, please pass the following as an environment file:
 
-~~~{code-block} YAML
+```{code-block} YAML
 :caption: custom/my-hook.yml
 :linenos:
 pre_infra:
@@ -99,7 +102,7 @@ pre_infra:
       wait_condition:
         type: pod
       source: /path/to/my/glorious.crd
-~~~
+```
 
 In the above example, the `foo.yml` is located in
 [hooks/playbooks](https://github.com/openstack-k8s-operators/ci-framework/tree/main/hooks/playbooks) while
@@ -117,20 +120,20 @@ In order to allow user to run only a subset of tasks while still consuming the
 entry playbook, the Framework exposes tags one may leverage with either `--tags`
 or `--skip-tags`:
 
-* `bootstrap`: Run all of the package installation tasks as well as the potential system configuration depending on the options you set.
-* `packages`: Run all package installation tasks associated to the options you set.
-* `bootstrap_layout`: Run the [reproducer](../reproducers/01-considerations.md) bootstrap steps only.
-* `bootstrap_libvirt`: Run the [reproducer](../reproducers/01-considerations.md) libvirt bootstrap only.
-* `bootstrap_repositories`: Run the [reproducer](../reproducers/01-considerations.md) repositories bootstrap steps only.
-* `infra`: Denotes tasks to prepare host virtualization and Openshift Container Platform when deploy-edpm.yml playbook is run.
-* `build-packages`: Denotes tasks to call the role [pkg_build](../roles/pkg_build.md) when deploy-edpm.yml playbook is run.
-* `build-containers`: Denotes tasks to call the role [build_containers](../roles/build_containers.md) when deploy-edpm.yml playbook is run.
-* `build-operators`: Denotes tasks to call the role [operator_build](../roles/operator_build.md) when deploy-edpm.yml playbook is run.
-* `control-plane`: Deploys the control-plane on OpenShift by creating `OpenStackControlPlane` CRs when deploy-edpm.yml playbook is run.
-* `edpm`: Deploys the data-plane (External Data Plane Management) on RHEL nodes by creating `OpenStackDataPlane` CRs when deploy-edpm.yml playbook is run.
-* `admin-setup`: Denotes tasks to call the role [os_net_setup](../roles/os_net_setup.md) when deploy-edpm.yml playbook is run.
-* `run-tests`: Denotes tasks to call the roles [tempest](../roles/tempest.md) and/or [tobiko](../roles/tobiko.md) when deploy-edpm.yml playbook is run.
-* `logs`: Denotes tasks which generate artifacts via the role [artifacts](../roles/artifacts.md) and when collect logs when deploy-edpm.yml playbook is run.
+- `bootstrap`: Run all of the package installation tasks as well as the potential system configuration depending on the options you set.
+- `packages`: Run all package installation tasks associated to the options you set.
+- `bootstrap_layout`: Run the [reproducer](../reproducers/01-considerations.md) bootstrap steps only.
+- `bootstrap_libvirt`: Run the [reproducer](../reproducers/01-considerations.md) libvirt bootstrap only.
+- `bootstrap_repositories`: Run the [reproducer](../reproducers/01-considerations.md) repositories bootstrap steps only.
+- `infra`: Denotes tasks to prepare host virtualization and Openshift Container Platform when deploy-edpm.yml playbook is run.
+- `build-packages`: Denotes tasks to call the role [pkg_build](../roles/pkg_build.md) when deploy-edpm.yml playbook is run.
+- `build-containers`: Denotes tasks to call the role [build_containers](../roles/build_containers.md) when deploy-edpm.yml playbook is run.
+- `build-operators`: Denotes tasks to call the role [operator_build](../roles/operator_build.md) when deploy-edpm.yml playbook is run.
+- `control-plane`: Deploys the control-plane on OpenShift by creating `OpenStackControlPlane` CRs when deploy-edpm.yml playbook is run.
+- `edpm`: Deploys the data-plane (External Data Plane Management) on RHEL nodes by creating `OpenStackDataPlane` CRs when deploy-edpm.yml playbook is run.
+- `admin-setup`: Denotes tasks to call the role [os_net_setup](../roles/os_net_setup.md) when deploy-edpm.yml playbook is run.
+- `run-tests`: Denotes tasks to call the roles [tempest](../roles/tempest.md) and/or [tobiko](../roles/tobiko.md) when deploy-edpm.yml playbook is run.
+- `logs`: Denotes tasks which generate artifacts via the role [artifacts](../roles/artifacts.md) and when collect logs when deploy-edpm.yml playbook is run.
 
 For instance, if you want to bootstrap a hypervisor, and reuse it over and
 over, you'll run the following commands:
@@ -144,6 +147,7 @@ $
     -K --skip-tags bootstrap,packages \
     [-e @scenarios/centos-9/some-environment -e <...>]
 ```
+
 Running the command twice, with `--tags` and `--skip-tags` as only difference,
 will ensure your environment has the needed directories, packages and
 configurations with the first run, while skip all of those tasks in the
@@ -153,6 +157,7 @@ If you've already deployed OpenStack but it failed
 during [os_net_setup](../roles/os_net_setup.md) and you've taken steps
 to correct the problem and want to test if they resolved the issue,
 then use:
+
 ```Bash
 [controller-0]$ ansible-playbook deploy-edpm.yml -K --tags admin-setup
 ```

--- a/roles/kustomize_deploy/README.md
+++ b/roles/kustomize_deploy/README.md
@@ -1,0 +1,60 @@
+# kustomize_deploy
+
+Ansible role designed to deploy VA scenarios using the kustomize tool.
+
+## Parameters
+
+```{warning}
+The top level parameter `cifmw_architecture_va_scenario` is required in order
+to select the proper VA scenario to deploy. If not provided, the role will fail
+with a message.
+```
+
+- `cifmw_kustomize_deploy_destfiles_basedir`: Base directory for the ci-framework artifacts.
+  Defaults to `~/ci-framework-data/`
+- `cifmw_kustomize_deploy_architecture_repo_url`: URL of the "architecture" repository, where the VA scenarios are defined.
+  Defaults to `https://github.com/openstack-k8s-operators/architecture`
+- `cifmw_kustomize_deploy_architecture_repo_dest_dir`: Directory where the architecture repo is cloned on the controller node.
+  Defaults to `~/src/github.com/openstack-k8s-operators/architecture`
+- `cifmw_kustomize_deploy_architecture_repo_version`: Default branch of the architecture repo to clone.Defaults to `HEAD`
+- `cifmw_kustomize_deploy_kustomizations_dest_dir`: Path for the generated CR files.
+  Defaults to `cifmw_kustomize_deploy_destfiles_basedir + /artifacts/kustomize_deploy`
+- `cifmw_kustomize_deploy_olm_dest_file`: Path of the generated CR file for OLM resources.
+  Defaults to `cifmw_kustomize_deploy_kustomizations_dest_dir + olm.yml`
+- `cifmw_kustomize_deploy_olm_source_files`: Path of the source kustomization files for OLM resources.
+  Defaults to `cifmw_kustomize_deploy_architecture_repo_dest_dir + /examples/common/olm`
+- `cifmw_kustomize_deploy_metallb_dest_file`: Path of the generated CR file for MetalLB resources.
+  Defaults to `cifmw_kustomize_deploy_kustomizations_dest_dir + metallb.yml`
+- `cifmw_kustomize_deploy_metallb_source_files`: Path of the source kustomization files for MetalLB resources.
+  Defaults to `cifmw_kustomize_deploy_architecture_repo_dest_dir + /examples/common/metallb/`
+- `cifmw_kustomize_deploy_nmstate_dest_file`: Path of the generated CR file for NMstate resources.
+  Defaults to `cifmw_kustomize_deploy_kustomizations_dest_dir + nmstate.yml`
+- `cifmw_kustomize_deploy_nmstate_source_files`: Path of the source kustomization files for NMstate resources.
+  Defaults to `cifmw_kustomize_deploy_architecture_repo_dest_dir + /examples/common/nmstate`
+- `cifmw_kustomize_deploy_cp_values_src_file`: Path of the `values.yaml` file for the control-plane customization.
+  Defaults to `~/ci-framework-data/artifacts/ci_gen_kustomize_values/values.yaml`
+- `cifmw_kustomize_deploy_cp_source_files`: Path of the control-plane kustomize source files.
+  Defaults to `cifmw_kustomize_deploy_architecture_repo_dest_dir + /examples/va/hci/`
+- `cifmw_kustomize_deploy_cp_values_dest_file`: Path of the generated CR file for the control-plane deploy.
+  Defaults to `cifmw_kustomize_deploy_cp_source_files + values.yml`
+- `cifmw_kustomize_deploy_cp_dest_file`: Path of the generated CR file for OSP control-plane resources.
+  Defaults to `cifmw_kustomize_deploy_kustomizations_dest_dir + control-plane.yml`
+- `cifmw_kustomize_deploy_architecture_examples_common_path`: Relative path of the common CRs in the architecture repo.
+  Defaults to `/examples/common`
+- `cifmw_kustomize_deploy_architecture_examples_va_path`: Relative path of the VA scenario list in the operator repo.
+  Defaults to `/examples/va`
+
+## Examples
+
+```yaml
+- name: Call kustomize_deploy role
+  vars:
+    cifmw_kustomize_deploy_cp_values_src_file: /tmp/values.yml
+    cifmw_architecture_va_scenario: hci
+  ansible.builtin.include_role:
+    name: "kustomize_deploy"
+```
+
+## TODO
+
+- Implement all the steps

--- a/roles/kustomize_deploy/defaults/main.yml
+++ b/roles/kustomize_deploy/defaults/main.yml
@@ -1,0 +1,138 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_kustomize_deploy"
+
+cifmw_kustomize_deploy_destfiles_basedir: >-
+  {{
+    cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data')
+  }}
+
+cifmw_kustomize_deploy_architecture_repo_url: "https://github.com/openstack-k8s-operators/architecture"
+
+cifmw_kustomize_deploy_architecture_repo_dest_dir: >-
+  {{
+    cifmw_architecture_repo |
+    default( [
+        ansible_user_dir,
+        'src',
+        'github.com',
+        'openstack-k8s-operators',
+        'architecture'
+      ] | path_join )
+  }}
+
+cifmw_kustomize_deploy_architecture_repo_version: "HEAD"
+
+cifmw_kustomize_deploy_architecture_examples_common_path: "examples/common/"
+cifmw_kustomize_deploy_architecture_examples_va_path: "examples/va/"
+
+cifmw_kustomize_deploy_cp_values_src_file: >-
+  {{
+    [
+      cifmw_kustomize_deploy_destfiles_basedir,
+      'artifacts',
+      'ci_gen_kustomize_values',
+      'network-values',
+      'values.yaml'
+    ] | path_join
+  }}
+
+cifmw_kustomize_deploy_cp_source_files: >-
+  {{
+    [
+      cifmw_kustomize_deploy_architecture_repo_dest_dir,
+      cifmw_kustomize_deploy_architecture_examples_va_path,
+      cifmw_architecture_va_scenario
+    ] | path_join
+  }}
+
+cifmw_kustomize_deploy_cp_values_dest_file: >-
+  {{
+    [
+      cifmw_kustomize_deploy_cp_source_files,
+      'values.yml'
+    ] | path_join
+  }}
+
+cifmw_kustomize_deploy_kustomizations_dest_dir: >-
+  {{
+    [
+      cifmw_kustomize_deploy_destfiles_basedir,
+      'artifacts',
+      'kustomize_deploy'
+    ] | path_join
+  }}
+
+cifmw_kustomize_deploy_olm_dest_file: >-
+  {{
+    [
+      cifmw_kustomize_deploy_kustomizations_dest_dir,
+      'olm.yml'
+    ] | path_join
+  }}
+
+cifmw_kustomize_deploy_olm_source_files: >-
+  {{
+    [
+      cifmw_kustomize_deploy_architecture_repo_dest_dir,
+      cifmw_kustomize_deploy_architecture_examples_common_path,
+      'olm'
+    ] | path_join
+  }}
+
+cifmw_kustomize_deploy_metallb_dest_file: >-
+  {{
+    [
+      cifmw_kustomize_deploy_kustomizations_dest_dir,
+      'metallb.yml'
+    ] | path_join
+  }}
+
+cifmw_kustomize_deploy_metallb_source_files: >-
+  {{
+    [
+      cifmw_kustomize_deploy_architecture_repo_dest_dir,
+      cifmw_kustomize_deploy_architecture_examples_common_path,
+      'metallb'
+    ] | path_join
+  }}
+
+cifmw_kustomize_deploy_nmstate_dest_file: >-
+  {{
+    [
+      cifmw_kustomize_deploy_kustomizations_dest_dir,
+      'nmstate.yml'
+    ] | path_join
+  }}
+
+cifmw_kustomize_deploy_nmstate_source_files: >-
+  {{
+    [
+      cifmw_kustomize_deploy_architecture_repo_dest_dir,
+      cifmw_kustomize_deploy_architecture_examples_common_path,
+      'nmstate'
+    ] | path_join
+  }}
+
+cifmw_kustomize_deploy_cp_dest_file: >-
+  {{
+    [
+      cifmw_kustomize_deploy_kustomizations_dest_dir,
+      'control-plane.yml'
+    ] | path_join
+  }}

--- a/roles/kustomize_deploy/meta/main.yml
+++ b/roles/kustomize_deploy/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- kustomize_deploy
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: cifmw
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - cifmw
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/kustomize_deploy/molecule/default/cleanup.yml
+++ b/roles/kustomize_deploy/molecule/default/cleanup.yml
@@ -1,0 +1,26 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Cleanup
+  hosts: all
+  vars:
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+    cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+  tasks:
+    - name: Cleanup deployed resources
+      ansible.builtin.include_role:
+        name: kustomize_deploy
+        tasks_from: cleanup.yml

--- a/roles/kustomize_deploy/molecule/default/converge.yml
+++ b/roles/kustomize_deploy/molecule/default/converge.yml
@@ -1,0 +1,26 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: all
+  vars:
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+    cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+    cifmw_architecture_va_scenario: "hci"
+  tasks:
+    - name: Call kustomize_deploy role
+      ansible.builtin.include_role:
+        name: "kustomize_deploy"

--- a/roles/kustomize_deploy/molecule/default/molecule.yml
+++ b/roles/kustomize_deploy/molecule/default/molecule.yml
@@ -1,0 +1,22 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml
+scenario:
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy
+verifier:
+  name: ansible

--- a/roles/kustomize_deploy/molecule/default/prepare.yml
+++ b/roles/kustomize_deploy/molecule/default/prepare.yml
@@ -1,0 +1,68 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Prepare
+  hosts: all
+  vars_files:
+    - ../../defaults/main.yml
+  vars:
+    _install_yamls_path: >-
+      {{
+        cifmw_installyamls_repos |
+        default(
+          '~/src/github.com/openstack-k8s-operators/install_yamls',
+          true
+        )
+      }}
+  pre_tasks:
+    - name: Ensure CRC is started
+      async: 1800
+      poll: 0
+      register: _crc_start
+      ansible.builtin.command:
+        cmd: crc start
+  tasks:
+    - name: Check for CRC status
+      ansible.builtin.async_status:
+        jid: "{{ _crc_start.ansible_job_id }}"
+      register: _crc_status
+      until: _crc_status.finished
+      retries: 100
+      delay: 10
+    - name: Create local storage
+      ansible.builtin.include_role:
+        name: ci_local_storage
+      vars:
+        cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+        cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+        cifmw_cls_storage_capacity: "1Gi"
+    - name: Attach the default network to crc vm
+      ansible.builtin.command:
+        cmd: "make crc_attach_default_interface"
+        chdir: "{{ _install_yamls_path ~ '/devsetup' }}"
+    - name: Deploy a compute vm
+      ansible.builtin.command:
+        cmd: "make edpm_compute"
+        chdir: "{{ _install_yamls_path ~ '/devsetup' }}"
+    - name: Create values.yml destination folder if it doesn't exists
+      ansible.builtin.file:
+        path: "{{ cifmw_kustomize_deploy_cp_values_src_file | dirname }}"
+        state: directory
+        mode: "0775"
+    - name: Copy sample values.yml to its destination
+      ansible.builtin.copy:
+        src: resources/values.yml
+        dest: "{{ cifmw_kustomize_deploy_cp_values_src_file }}"

--- a/roles/kustomize_deploy/molecule/default/resources/values.yml
+++ b/roles/kustomize_deploy/molecule/default/resources/values.yml
@@ -1,0 +1,189 @@
+# local-config: referenced, but not emitted by kustomize
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: network-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  # nodes
+  node_0:
+    name: edpm-compute-0
+    internalapi_ip: 172.17.0.5
+    tenant_ip: 172.19.0.5
+    ctlplane_ip: 192.168.122.10
+    storage_ip: 172.18.0.5
+
+  # networks
+  ctlplane:
+    dnsDomain: ctlplane.example.com
+    subnets:
+      - allocationRanges:
+          - end: 192.168.122.120
+            start: 192.168.122.100
+          - end: 192.168.122.200
+            start: 192.168.122.150
+        cidr: 192.168.122.0/24
+        gateway: 192.168.122.1
+        name: subnet1
+    prefix-length: 24
+    iface: enp6s0
+    mtu: 9000
+    lb_addresses:
+      - 192.168.122.80-192.168.122.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: ctlplane
+      metallb.universe.tf/allow-shared-ip: ctlplane
+      metallb.universe.tf/loadBalancerIPs: 192.168.122.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "ctlplane",
+        "type": "macvlan",
+        "master": "enp7s0",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "192.168.122.0/24",
+          "range_start": "192.168.122.30",
+          "range_end": "192.168.122.70"
+        }
+      }
+  internalapi:
+    dnsDomain: internalapi.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.17.0.250
+            start: 172.17.0.100
+        cidr: 172.17.0.0/24
+        name: subnet1
+        vlan: 20
+    mtu: 1500
+    prefix-length: 24
+    iface: internalapi
+    vlan: 20
+    base_iface: enp7s0
+    lb_addresses:
+      - 172.17.0.80-172.17.0.90
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/allow-shared-ip: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "internalapi",
+        "type": "macvlan",
+        "master": "internalapi",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.17.0.0/24",
+          "range_start": "172.17.0.30",
+          "range_end": "172.17.0.70"
+        }
+      }
+  storage:
+    dnsDomain: storage.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.18.0.250
+            start: 172.18.0.100
+        cidr: 172.18.0.0/24
+        name: subnet1
+        vlan: 21
+    mtu: 9000
+    prefix-length: 24
+    iface: storage
+    vlan: 21
+    base_iface: enp7s0
+    lb_addresses:
+      - 172.18.0.80-172.18.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "storage",
+        "type": "macvlan",
+        "master": "storage",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.18.0.0/24",
+          "range_start": "172.18.0.30",
+          "range_end": "172.18.0.70"
+        }
+      }
+  storagemgmt: # used on RHEL, not used on OpenShift
+    dnsDomain: storagemgmt.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.20.0.250
+            start: 172.20.0.100
+        cidr: 172.20.0.0/24
+        name: subnet1
+        vlan: 23
+    mtu: 9000
+  tenant:
+    dnsDomain: tenant.example.com
+    subnets:
+      - allocationRanges:
+          - end: 172.19.0.250
+            start: 172.19.0.100
+        cidr: 172.19.0.0/24
+        name: subnet1
+        vlan: 22
+    mtu: 1500
+    prefix-length: 24
+    iface: tenant
+    vlan: 22
+    base_iface: enp7s0
+    lb_addresses:
+      - 172.19.0.80-172.19.0.90
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "tenant",
+        "type": "macvlan",
+        "master": "tenant",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "172.19.0.0/24",
+          "range_start": "172.19.0.30",
+          "range_end": "172.19.0.70"
+        }
+      }
+  external:
+    dnsDomain: external.example.com
+    subnets:
+      - allocationRanges:
+          - end: 10.0.0.250
+            start: 10.0.0.100
+        cidr: 10.0.0.0/24
+        gateway: 10.0.0.1
+        name: subnet1
+    mtu: 1500
+
+  dns-resolver:
+    config:
+      server:
+        - 192.168.122.1
+      search: []
+    options:
+      - key: server
+        values:
+          - 192.168.122.1
+
+  routes:
+    config:
+      - destination: 0.0.0.0/0
+        next-hop-address: 192.168.122.1
+        next-hop-interface: enp6s0
+
+  rabbitmq:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.85
+  rabbitmq-cell1:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: 172.17.0.86
+
+  lbServiceType: LoadBalancer
+  storageClass: local-storage

--- a/roles/kustomize_deploy/molecule/default/verify.yml
+++ b/roles/kustomize_deploy/molecule/default/verify.yml
@@ -1,0 +1,83 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Verify
+  hosts: all
+  vars:
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+    cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+  tasks:
+    - name: Check cert-manager related pods
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        kind: Pod
+        namespace: "{{ item.namespace }}"
+        label_selectors:
+          - "{{ item.label_selectors_key }} = {{ item.label_selectors_value }}"
+        field_selectors:
+          - status.phase=Running
+      loop:
+        - namespace: "cert-manager-operator"
+          label_selectors_key: "name"
+          label_selectors_value: "cert-manager-operator"
+        - namespace: "cert-manager"
+          label_selectors_key: "app"
+          label_selectors_value: "cainjector"
+        - namespace: "cert-manager"
+          label_selectors_key: "app"
+          label_selectors_value: "webhook"
+        - namespace: "cert-manager"
+          label_selectors_key: "app"
+          label_selectors_value: "cert-manager"
+
+    - name: Check MetalLB related pods
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        kind: Pod
+        namespace: "metallb-system"
+        label_selectors:
+          - "{{ item.label_selectors_key }} = {{ item.label_selectors_value }}"
+        field_selectors:
+          - status.phase=Running
+      loop:
+        - label_selectors_key: "control-plane"
+          label_selectors_value: "controller-manager"
+        - label_selectors_key: "component"
+          label_selectors_value: "webhook-server"
+        - label_selectors_key: "component"
+          label_selectors_value: "speaker"
+
+    - name: Check NMstate related pods
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        kind: Pod
+        namespace: openshift-nmstate
+        label_selectors:
+          - component = kubernetes-nmstate-handler
+        field_selectors:
+          - status.phase=Running
+
+    - name: Check NMstate related deployments
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        kind: Deployment
+        namespace: "openshift-nmstate"
+        name: "{{ item }}"
+        field_selectors:
+          - status.phase=Succeeded
+      loop:
+        - "nmstate-operator"
+        - "nmstate-webhook"

--- a/roles/kustomize_deploy/tasks/00_check_requirements.yml
+++ b/roles/kustomize_deploy/tasks/00_check_requirements.yml
@@ -1,0 +1,55 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure that architecture repo exists
+  ansible.builtin.git: # noqa: latest
+    repo: "{{ cifmw_kustomize_deploy_architecture_repo_url }}"
+    dest: "{{ cifmw_kustomize_deploy_architecture_repo_dest_dir }}"
+    update: false
+    version: "{{ cifmw_kustomize_deploy_architecture_repo_version }}"
+
+- name: Ensure that the selected scenario exists
+  vars:
+    _va_scenario_dir: >-
+      {{
+        [
+          cifmw_kustomize_deploy_architecture_repo_dest_dir,
+          cifmw_kustomize_deploy_architecture_examples_va_path
+        ] | path_join
+      }}
+  block:
+    - name: Gather the list of scenario folders
+      ansible.builtin.find:
+        paths: "{{ _va_scenario_dir }}"
+        patterns: "kustomization.y*ml"
+        recurse: true
+      register: _va_scenario_dir_list
+    - name: Check if scenario is in the list
+      ansible.builtin.fail:
+        msg: >
+          You need to properly set the `cifmw_architecture_va_scenario` variable
+          in order to select the VA scenario to deploy. You can take a list of
+          scenario in the `examples/va` folder in the architecture repo.
+      when:
+        - cifmw_architecture_va_scenario is not defined
+        - cifmw_kustomize_deploy_architecture_repo_version not in \
+          _va_scenario_dir.results.path | dirname | relpath(_va_scenario_dir)
+
+- name: Ensure that destination directory exists
+  ansible.builtin.file:
+    path: "{{ cifmw_kustomize_deploy_kustomizations_dest_dir }}"
+    mode: "0755"
+    state: "directory"

--- a/roles/kustomize_deploy/tasks/01_install_operators.yml
+++ b/roles/kustomize_deploy/tasks/01_install_operators.yml
@@ -1,0 +1,212 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: OLM resources
+  block:
+    - name: Generate the OLM kustomization file
+      ansible.builtin.copy:
+        content: >-
+          {{
+            lookup(
+              'kubernetes.core.kustomize',
+              dir=cifmw_kustomize_deploy_olm_source_files
+            )
+          }}
+        dest: "{{ cifmw_kustomize_deploy_olm_dest_file }}"
+        mode: "0644"
+
+    - name: Apply the kustomized CRs
+      kubernetes.core.k8s:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit) }}"
+        context: "{{ cifmw_openshift_context | default(omit) }}"
+        state: present
+        wait: true
+        src: "{{ cifmw_kustomize_deploy_olm_dest_file }}"
+
+    - name: Wait until cert-manager resources are deployed
+      block:
+        - name: Wait for cert-manager-operator pods
+          kubernetes.core.k8s_info:
+            kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+            kind: Pod
+            namespace: cert-manager-operator
+            label_selectors:
+              - name = cert-manager-operator
+            wait: true
+            wait_condition:
+              type: Ready
+              status: "True"
+            wait_timeout: 300
+        - name: Wait for cainjector pods
+          kubernetes.core.k8s_info:
+            kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+            kind: Pod
+            namespace: cert-manager
+            label_selectors:
+              - app = cainjector
+            wait: true
+            wait_condition:
+              type: Ready
+              status: "True"
+            wait_timeout: 300
+        - name: Wait for webhook pods
+          kubernetes.core.k8s_info:
+            kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+            kind: Pod
+            namespace: cert-manager
+            label_selectors:
+              - app = webhook
+            wait: true
+            wait_condition:
+              type: Ready
+              status: "True"
+            wait_timeout: 300
+        - name: Wait for certmanager pods
+          kubernetes.core.k8s_info:
+            kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+            kind: Pod
+            namespace: cert-manager
+            label_selectors:
+              - app = cert-manager
+            wait: true
+            wait_condition:
+              type: Ready
+              status: "True"
+            wait_timeout: 300
+
+    - name: Wait until MetalLB operator resources are deployed
+      block:
+        - name: Wait for controller-manager pods
+          kubernetes.core.k8s_info:
+            kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+            kind: Pod
+            namespace: metallb-system
+            label_selectors:
+              - control-plane = controller-manager
+            wait: true
+            wait_condition:
+              type: Ready
+              status: "True"
+            wait_timeout: 300
+        - name: Wait for webhook-server pods
+          kubernetes.core.k8s_info:
+            kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+            kind: Pod
+            namespace: metallb-system
+            label_selectors:
+              - component = webhook-server
+            wait: true
+            wait_condition:
+              type: Ready
+              status: "True"
+            wait_timeout: 300
+
+    - name: Wait until NMstate operator resources are deployed
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        kind: Deployment
+        namespace: openshift-nmstate
+        name: nmstate-operator
+        wait: true
+        wait_condition:
+          type: Available
+          status: "True"
+        wait_timeout: 300
+
+- name: MetalLB resources
+  block:
+    - name: Generate MetalLB kustomization file
+      ansible.builtin.copy:
+        content: >-
+          {{
+            lookup(
+              'kubernetes.core.kustomize',
+              dir=cifmw_kustomize_deploy_metallb_source_files
+            )
+          }}
+        dest: "{{ cifmw_kustomize_deploy_metallb_dest_file }}"
+        mode: "0644"
+
+    - name: Apply the kustomized MetalLB CRs
+      kubernetes.core.k8s:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit) }}"
+        context: "{{ cifmw_openshift_context | default(omit) }}"
+        state: present
+        wait: true
+        src: "{{ cifmw_kustomize_deploy_metallb_dest_file }}"
+
+    - name: Wait for MetalLB speaker pods
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        kind: Pod
+        namespace: metallb-system
+        label_selectors:
+          - component = speaker
+        wait: true
+        wait_condition:
+          type: Ready
+          status: "True"
+        wait_timeout: 300
+
+- name: NMstate resources
+  block:
+    - name: Generate NMstate kustomization file
+      ansible.builtin.copy:
+        content: >-
+          {{
+            lookup(
+              'kubernetes.core.kustomize',
+              dir=cifmw_kustomize_deploy_nmstate_source_files
+            )
+          }}
+        dest: "{{ cifmw_kustomize_deploy_nmstate_dest_file }}"
+        mode: "0644"
+
+    - name: Apply the kustomized NMstate CRs
+      kubernetes.core.k8s:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit) }}"
+        context: "{{ cifmw_openshift_context | default(omit) }}"
+        state: present
+        wait: true
+        src: "{{ cifmw_kustomize_deploy_nmstate_dest_file }}"
+
+    - name: Wait for NMstate handler pods
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        kind: Pod
+        namespace: openshift-nmstate
+        label_selectors:
+          - component = kubernetes-nmstate-handler
+        wait: true
+        wait_condition:
+          type: Ready
+          status: "True"
+        wait_timeout: 300
+
+    - name: Wait for NMstate webhook deployment
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        kind: Deployment
+        namespace: openshift-nmstate
+        name: nmstate-webhook
+        wait: true
+        wait_condition:
+          type: Available
+          status: "True"
+        wait_timeout: 300

--- a/roles/kustomize_deploy/tasks/02_install_controlplane.yml
+++ b/roles/kustomize_deploy/tasks/02_install_controlplane.yml
@@ -1,0 +1,77 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure that values.yml file for control plane deployment exists
+  ansible.builtin.stat:
+    path: "{{ cifmw_kustomize_deploy_cp_values_src_file }}"
+  register: _cifmw_kustomize_deploy_cp_values_exists
+  failed_when: not _cifmw_kustomize_deploy_cp_values_exists.stat.exists
+
+- name: Copy values.yml file to example/va/hci directory
+  ansible.builtin.copy:
+    remote_src: true
+    src: "{{ cifmw_kustomize_deploy_cp_values_src_file }}"
+    dest: "{{ cifmw_kustomize_deploy_cp_values_dest_file }}"
+    mode: "0644"
+
+- name: Generate the control plane kustomization file
+  ansible.builtin.copy:
+    content: >-
+      {{
+        lookup
+        (
+          'kubernetes.core.kustomize',
+          dir=cifmw_kustomize_deploy_cp_source_files
+        )
+      }}
+
+    dest: "{{ cifmw_kustomize_deploy_cp_dest_file }}"
+    mode: "0644"
+
+- name: Apply the control plane CR
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    namespace: openstack
+    state: present
+    src: "{{ cifmw_kustomize_deploy_cp_dest_file }}"
+
+- name: Wait until controlplane resources are deployed
+  block:
+    - name: Wait for NNCP resources
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        kind: nncp
+        namespace: openstack
+        label_selectors:
+          - osp/nncm-config-type = standard
+        wait: true
+        wait_condition:
+          type: SuccessfullyConfigured
+          status: "True"
+        wait_timeout: 300
+    - name: Wait for control plane resources
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        kind: osctlplane
+        name: controlplane
+        namespace: openstack
+        wait: true
+        wait_condition:
+          type: Ready
+          status: "True"
+        wait_timeout: 600

--- a/roles/kustomize_deploy/tasks/cleanup.yml
+++ b/roles/kustomize_deploy/tasks/cleanup.yml
@@ -1,0 +1,37 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure that kustomization files are present
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  loop:
+    - "{{ cifmw_kustomize_deploy_cp_dest_file }}"
+    - "{{ cifmw_kustomize_deploy_nmstate_dest_file }}"
+    - "{{ cifmw_kustomize_deploy_metallb_dest_file }}"
+    - "{{ cifmw_kustomize_deploy_olm_dest_file }}"
+  register: _cifmw_kustomize_files
+
+- name: Cleaning operators resources
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    state: absent
+    src: "{{ item.stat.path }}"
+    wait: true
+    wait_timeout: 600
+  loop: "{{ _cifmw_kustomize_files.results }}"
+  when: item.stat.exists

--- a/roles/kustomize_deploy/tasks/main.yml
+++ b/roles/kustomize_deploy/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Check requirements
+  ansible.builtin.import_tasks: 00_check_requirements.yml
+
+- name: Install OSP operators
+  ansible.builtin.import_tasks: 01_install_operators.yml
+
+- name: Install OSP control plane
+  ansible.builtin.import_tasks: 02_install_controlplane.yml

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -342,6 +342,19 @@
     vars:
       TEST_RUN: install_yamls
 - job:
+    extra-vars:
+      crc_parameters: --memory 24576 --disk-size 100 --cpus 8
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
+    - ^roles/kustomize_deploy/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    name: cifmw-molecule-kustomize_deploy
+    nodeset: centos-9-crc-3xl
+    parent: cifmw-molecule-base-crc
+    vars:
+      TEST_RUN: kustomize_deploy
+- job:
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -41,6 +41,7 @@
       - cifmw-molecule-idrac_configuration
       - cifmw-molecule-install_ca
       - cifmw-molecule-install_yamls
+      - cifmw-molecule-kustomize_deploy
       - cifmw-molecule-libvirt_manager
       - cifmw-molecule-manage_secrets
       - cifmw-molecule-networking_mapper


### PR DESCRIPTION
This PR introduce the `kustomize_deploy` role which is used to deploy VA scenarios using as input:

1. VAs taken from [architecture](https://github.com/openstack-k8s-operators/architecture) repo
2. configurations taken `values.yml` file(s)

Combining those two input sources, and following the manual steps defined [here](https://github.com/openstack-k8s-operators/architecture/tree/main/examples/va/hci), `kustomize` tool is used to generate CR files so they can be applied on an Openshift cluster.

A proper molecule scenario for the hci architecture is provided.

This PR will cover the deployment of the OLM dependencies and the deployment of the OSP control-plane.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
