### PR TITLE
Correct interface name used in base_iface

### DIFF
--- a/roles/networking_mapper/molecule/default/vars/internalapi_output.yml
+++ b/roles/networking_mapper/molecule/default/vars/internalapi_output.yml
@@ -18,7 +18,7 @@ internalapi:
   mtu: 1496
   vlan: 20
   iface: internalapi
-  base_iface: eth0.20
+  base_iface: eth0
   net-attach-def: |
     {
       "cniVersion": "0.3.1",

--- a/roles/networking_mapper/templates/network-config-values.j2
+++ b/roles/networking_mapper/templates/network-config-values.j2
@@ -5,7 +5,12 @@
 data:
 {% for host in _network_mapper.instances.keys() -%}
 {%   for network in _network_mapper.instances[host]['networks'].values() -%}
-{%     set ns.interfaces = ns.interfaces | combine({network.network_name: network.interface_name}, recursive=true) -%}
+{%     set ns.interfaces = ns.interfaces |
+                           combine({network.network_name: (network.parent_interface |
+                                                           default(network.interface_name)
+                                                          )
+                                   },
+                                   recursive=true) -%}
 {%   endfor -%}
 {%   if host is match('^(ocp|crc).*') %}
   node_{{ ns.ocp_index }}:


### PR DESCRIPTION
We have to use the parent interface name, not the computed, non-existing
interface_name.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
