### PR TITLE
[networking_mapping] Fix method rename usage in exception handling

### DIFF
--- a/plugins/action/ci_net_map.py
+++ b/plugins/action/ci_net_map.py
@@ -320,6 +320,6 @@ class ActionModule(ActionBase):
             result["networking_env_definition"] = mapping_result
             result["complete_map"] = is_complete_map
         except exceptions.NetworkMappingError as run_exception:
-            result = {**result, **(run_exception.to_dict()), "failed": True}
+            result = {**result, **(run_exception.to_raw()), "failed": True}
 
         return result


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
