### PR TITLE
Fix docs bug with Anisble inventory

### DIFF
--- a/docs/source/reproducers/02-layout.md
+++ b/docs/source/reproducers/02-layout.md
@@ -78,7 +78,7 @@ In order to clean the deployed layout, you can just call the `reproducer-clean.y
 playbook. It will clean the virtual machines:
 
 ```Bash
-[laptop]$ ansible-playbook -i inventory_hypervisor.yml reproducer-clean.yml
+[laptop]$ ansible-playbook -i custom/inventory.yml reproducer-clean.yml
 ```
 It doesn't require any environment file since it will list all of the existing
 virtual machines, and clean the ones which name starts with `cifmw-`.


### PR DESCRIPTION
At this section of the guide we have been using `custom/inventory.yml`
so we should continue using it.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running