### PR TITLE
Fix some ansible_vars to make them generic

### DIFF
--- a/hooks/playbooks/fetch_compute_facts.yml
+++ b/hooks/playbooks/fetch_compute_facts.yml
@@ -198,7 +198,7 @@
                           dns_servers: {{ ctlplane_dns_nameservers }}
                           domain: {{ dns_search_domains }}
                           addresses:
-                          - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_subnet_cidr }}
+                          - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
                           members:
                           - type: interface
                             name: nic2

--- a/roles/libvirt_manager/templates/kustomize_compute.yml.j2
+++ b/roles/libvirt_manager/templates/kustomize_compute.yml.j2
@@ -10,8 +10,8 @@ spec:
   node:
     ansibleVars: |
       tenant_ip: 192.168.24.{{ ip_suffix }}
-          internal_api_ip: 172.17.0.{{ ip_suffix }}
+          internalapi_ip: 172.17.0.{{ ip_suffix }}
           storage_ip: 172.18.0.{{ ip_suffix }}
           tenant_ip: 172.10.0.{{ ip_suffix }}
-          fqdn_internal_api: edpm-compute-{{ item }}.example.com
+          fqdn_internalapi: edpm-compute-{{ item }}.example.com
     ansibleSSHPrivateKeySecret: cifmw_install_yamls_defaults['DATAPLANE_ANSIBLE_SECRET']


### PR DESCRIPTION
ctlplane uses a var `ctlplane_subnet_cidr` where as other networks just use `<network_name>_cidr` ex. `storage_cidr`.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
