### PR TITLE
Addressing comments in #1025

### DIFF
--- a/docs/source/files/multinode-params.yml
+++ b/docs/source/files/multinode-params.yml
@@ -1,12 +1,4 @@
 ---
-# Since we don't have zuul data, we have to provide some
-# networking information to the libvirt_manager so that it will be able to
-# generate the needed content for later usage
-_networks:
-  public:
-    range: "192.168.111.0/24"
-    mtu: 1500
-
 # HERE, we have to manually segment the network.
 # computesb1 will run on hypervisor-1,
 # while computesb2 will run on hypervisor-2.
@@ -22,14 +14,11 @@ cifmw_libvirt_manager_configuration:
         <forward mode='nat'/>
         <bridge name='public' stp='on' delay='0'/>
         <mac address='52:54:00:6a:f2:dc'/>
-        <mtu size='{{ _networks.public.mtu }}'/>
-        <ip family='ipv4'
-        address='{{ _networks.public.range | ansible.utils.nthhost(1) }}'
-        prefix='24'>
+        <mtu size='1500'/>
+        <ip family='ipv4' address='192.168.111.1' prefix='24'>
           <dhcp>
             <range
-            start='{{ _networks.public.range | ansible.utils.nthhost(10) }}'
-            end='{{ _networks.public.range | ansible.utils.nthhost(100) }}'/>
+            start='192.168.111.10' end='192.168.111.99'/>
           </dhcp>
         </ip>
       </network>

--- a/roles/devscripts/tasks/sub_tasks/_521_gather.yml
+++ b/roles/devscripts/tasks/sub_tasks/_521_gather.yml
@@ -35,14 +35,6 @@
       vars:
         _nets_data:
           name: "{{ item }}"
-          mtu: "{{ ansible_facts[item]['mtu'] }}"
-          cidr: >-
-            {{
-              ansible_facts[item]['ipv4']['network'] +
-              '/' +
-              ansible_facts[item]['ipv4']['prefix']
-            }}
-          static_ip: false
       when:
         - _bridges is defined
         - "not item.endswith('bm')"

--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -130,13 +130,7 @@ The parameters listed here are therefore merely proxies to the ones set in the r
 and have the same name, less the role prefix. Default values are the same as the
 reproducer role.
 
-* `cifmw_libvirt_manager_private_nic`: `{{ cifmw_reproducer_private_nic | default('eth1') }}`
-* `cifmw_libvirt_manager_ctl_ip4`: `{{ cifmw_reproducer_ctl_ip4 | default('192.168.122.11') }}`
-* `cifmw_libvirt_manager_ctl_gw4`: `{{ cifmw_reproducer_ctl_gw4 | default('192.168.122.1') }}`
-* `cifmw_libvirt_manager_crc_ip4`: `{{ cifmw_reproducer_crc_ip4 | default('192.168.122.10') }}`
-* `cifmw_libvirt_manager_crc_gw4`: `{{ cifmw_reproducer_crc_gw4 | default('192.168.122.1') }}`
 * `cifmw_libvirt_manager_dns_servers`: `{{ cifmw_reproducer_dns_servers | default(['1.1.1.1', '8.8.8.8']) }}`
-* `cifmw_libvirt_manager_crc_private_nic`: `{{ cifmw_reproducer_crc_private_nic | default('enp2s0') }}`
 
 ## Calling attach_network.yml from another role
 

--- a/roles/libvirt_manager/defaults/main.yml
+++ b/roles/libvirt_manager/defaults/main.yml
@@ -54,11 +54,6 @@ cifmw_libvirt_manager_pub_net: public
 
 # Those parameters are usually set via the reproducer role.
 # We will therefore use them, and default to the same value set in the role.
-cifmw_libvirt_manager_private_nic: "{{ cifmw_reproducer_private_nic | default('eth1') }}"
-cifmw_libvirt_manager_ctl_ip4: "{{ cifmw_reproducer_ctl_ip4 | default('192.168.122.11') }}"
-cifmw_libvirt_manager_ctl_gw4: "{{ cifmw_reproducer_ctl_gw4 | default('192.168.122.1') }}"
-cifmw_libvirt_manager_crc_ip4: "{{ cifmw_reproducer_crc_ip4 | default('192.168.122.10') }}"
-cifmw_libvirt_manager_crc_gw4: "{{ cifmw_reproducer_crc_gw4 | default('192.168.122.1') }}"
 cifmw_libvirt_manager_dns_servers: "{{ cifmw_reproducer_dns_servers | default(['1.1.1.1', '8.8.8.8']) }}"
 cifmw_libvirt_manager_crc_private_nic: "{{ cifmw_reproducer_crc_private_nic | default('enp2s0') }}"
 

--- a/roles/reproducer/README.md
+++ b/roles/reproducer/README.md
@@ -7,16 +7,10 @@ None
 ## Parameters
 * `cifmw_reproducer_basedir`: (String) Base directory. Defaults to `cifmw_basedir`, which defaults to `~/ci-framework-data`.
 * `cifmw_reproducer_compute_repos`: (List[mapping]) List of yum repository that must be deployed on the compute nodes during their creation. Defaults to `[]`.
-* `cifmw_reproducer_ctl_ip4`: (String) IPv4 address for ansible controller on the *private* interface. Defaults to 192.168.122.10.
-* `cifmw_reproducer_ctl_gw4`: (String) IPv4 gateway for ansible controller on the *private* interface. Defaults to 192.168.122.1.
-* `cifmw_reproducer_crc_ip4`: (String) IPv4 address for CRC node on the *private* interface. Defaults to 192.168.122.11.
-* `cifmw_reproducer_crc_gw4`: (String) IPv4 gateway for CRC node on the *private* interface. Defaults to 192.168.122.1.
 * `cifmw_reproducer_kubecfg`: (String) Path to the CRC kubeconfig file. Defaults to the image_local_dir defined in the cifmw_libvirt_manager_configuration dict.
 * `cifmw_reproducer_repositories`: (List[mapping]) List of repositories you want to synchronize from your local machine to the ansible controller.
 * `cifmw_reproducer_run_job`: (Bool) Run actual CI job. Defaults to `true`.
 * `cifmw_reproducer_params`: (Dict) Specific parameters you want to pass to the reproducer. Defaults to `{}`.
-* `cifmw_reproducer_private_nic`: (String) Private NIC for compute and controller. Defaults to `eth1`.
-* `cifmw_reproducer_crc_private_nic`: (String) Private NIC for CRC node. Defaults to `enp6s0`.
 * `cifmw_reproducer_dns_servers`: List of dns servers which should be used by the CRC VM as upstream dns servers. Defaults to 1.1.1.1, 8.8.8.8.
 * `cifmw_reproducer_hp_rhos_release`: (Bool) Allows to consume rhos-release on the hypervisor. Defaults to `false`.
 * `cifmw_reproducer_dnf_tweaks`: (List) Options you want to inject in dnf.conf, both on controller-0 and hypervisor. Defaults to `[]`.

--- a/roles/reproducer/defaults/main.yml
+++ b/roles/reproducer/defaults/main.yml
@@ -18,12 +18,6 @@
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_reproducer"
 cifmw_reproducer_basedir: "{{ cifmw_basedir | default( ansible_user_dir ~ '/ci-framework-data') }}"
-cifmw_reproducer_ctl_ip4: 192.168.122.11
-cifmw_reproducer_ctl_gw4: 192.168.122.1
-cifmw_reproducer_crc_ip4: 192.168.122.10
-cifmw_reproducer_crc_gw4: 192.168.122.1
-cifmw_reproducer_private_nic: eth1
-cifmw_reproducer_crc_private_nic: enp6s0
 cifmw_reproducer_kubecfg: "{{ cifmw_libvirt_manager_configuration.vms.crc.image_local_dir }}/kubeconfig"
 cifmw_reproducer_params: {}
 cifmw_reproducer_run_job: true

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -208,30 +208,6 @@
         label: "{{ config.option }}"
         loop_var: 'config'
 
-    - name: Inject CRC related content if needed
-      when:
-        - _layout.vms.crc is defined
-      block:
-        - name: Inject CRC ssh key
-          ansible.builtin.copy:
-            dest: "/home/zuul/.ssh/crc_key"
-            content: "{{ crc_priv_key['content'] | b64decode }}"
-            mode: "0400"
-            owner: zuul
-            group: zuul
-
-        - name: Inject crc related host entry
-          become: true
-          ansible.builtin.lineinfile:
-            path: /etc/hosts
-            line: >-
-              {{ cifmw_reproducer_crc_ip4 }} api.crc.testing
-              canary-openshift-ingress-canary.apps-crc.testing
-              console-openshift-console.apps-crc.testing
-              default-route-openshift-image-registry.apps-crc.testing
-              downloads-openshift-console.apps-crc.testing
-              oauth-openshift.apps-crc.testing
-
     - name: RHEL repository setup for ansible-controller
       become: true
       when:
@@ -335,3 +311,29 @@
         ip4: "{{ _controller_data.ip_v4 }}/{{ _prefix }}"
         gw4: "{{ _ctlplane_net.gw_v4 }}"
         state: present
+
+    - name: Inject CRC related content if needed
+      when:
+        - _layout.vms.crc is defined
+      block:
+        - name: Inject CRC ssh key
+          ansible.builtin.copy:
+            dest: "/home/zuul/.ssh/crc_key"
+            content: "{{ crc_priv_key['content'] | b64decode }}"
+            mode: "0400"
+            owner: zuul
+            group: zuul
+
+        - name: Inject crc related host entry
+          become: true
+          vars:
+            _crc_data: "{{ cifmw_networking_env_definition.instances['crc-0'].networks.ctlplane}}"
+          ansible.builtin.lineinfile:
+            path: /etc/hosts
+            line: >-
+              {{ _crc_data.ip_v4 }} api.crc.testing
+              canary-openshift-ingress-canary.apps-crc.testing
+              console-openshift-console.apps-crc.testing
+              default-route-openshift-image-registry.apps-crc.testing
+              downloads-openshift-console.apps-crc.testing
+              oauth-openshift.apps-crc.testing

--- a/roles/rhol_crc/tasks/main.yml
+++ b/roles/rhol_crc/tasks/main.yml
@@ -103,9 +103,6 @@
         vm_name: crc
         network:
           name: default
-          static_ip: true
-          cidr: "192.168.122.0/24"
-          mtu: 1500
       block:
         - name: List VMs
           register: _vm_list

--- a/scenarios/reproducers/3-nodes.yml
+++ b/scenarios/reproducers/3-nodes.yml
@@ -11,28 +11,6 @@ cifmw_rhol_crc_config:
   disk-size: 100
   memory: 24000
 
-# Since we don't have zuul data, we have to provide some
-# networking information to the libvirt_manager so that it will be able to
-# generate the needed content for later usage
-_networks:
-  public:
-    range: "192.168.100.0/24"
-  osp_trunk:
-    range: "192.168.122.0/24"
-    mtu: 1500
-  internal-api:
-    range: "172.17.0.0/24"
-    vlan: 20
-  storage:
-    range: "172.18.0.0/24"
-    vlan: 21
-  tenant:
-    range: "172.19.0.0/24"
-    vlan: 22
-  storage-mgmt:
-    range: "172.20.0.0/24"
-    vlan: 23
-
 cifmw_use_libvirt: true
 cifmw_libvirt_manager_configuration:
   vms:
@@ -88,6 +66,9 @@ cifmw_libvirt_manager_configuration:
         <forward mode='nat'/>
         <bridge name='osp_trunk' stp='on' delay='0'/>
         <mac address='52:54:00:fd:be:d0'/>
-        <ip family='ipv4' address='192.168.122.1' prefix='24'>
+        <ip family='ipv4'
+        address='{{ cifmw_networking_definition.networks.ctlplane.gateway }}'
+        prefix='{{ cifmw_networking_definition.networks.ctlplane.network |
+                   ansible.utils.ipaddr('prefix') }}'>
         </ip>
       </network>

--- a/scenarios/reproducers/validated-architecture-1.yml
+++ b/scenarios/reproducers/validated-architecture-1.yml
@@ -11,30 +11,9 @@ cifmw_reproducer_epel_pkgs:
   - python3-bcrypt
   - python3-passlib
 
-# Since we don't have zuul data, we have to provide some
-# networking information to the libvirt_manager so that it will be able to
-# generate the needed content for later usage
-_networks:
-  ocpbm:
-    range: "192.168.111.0/24"
-  osp_trunk:
-    default: true
-    range: "192.168.122.0/24"
-    mtu: 9000
-    static_ip: true
-  internal-api:
-    range: "172.17.0.0/24"
-    vlan: 20
-  storage:
-    range: "172.18.0.0/24"
-    vlan: 21
-  tenant:
-    range: "172.19.0.0/24"
-    vlan: 22
-  storage-mgmt:
-    range: "172.20.0.0/24"
-    vlan: 23
-
+# ocpbm network is managed by the dev-scripts 3rd party installer.
+# It replaces the usual "public" network we create - the one providing
+# Internet access for packages, containers and other content.
 cifmw_libvirt_manager_pub_net: ocpbm
 
 # This will instruct libvirt_manager to create 3 compute and
@@ -54,8 +33,11 @@ cifmw_libvirt_manager_configuration:
         <name>osp_trunk</name>
         <forward mode='nat'/>
         <bridge name='osp_trunk' stp='on' delay='0'/>
-        <mtu size='{{ _networks.osp_trunk.mtu }}'/>
-        <ip family='ipv4' address='{{ _networks.osp_trunk.range | ansible.utils.nthhost(1) }}' prefix='24'>
+        <ip family='ipv4'
+        address='{{ cifmw_networking_definition.networks.ctlplane.network |
+                    ansible.utils.nthhost(1) }}'
+        prefix='{{ cifmw_networking_definition.networks.ctlplane.network |
+                   ansible.utils.ipaddr('prefix') }}'>
         </ip>
       </network>
   vms:


### PR DESCRIPTION
There were some comments in the [mentioned PR](https://github.com/openstack-k8s-operators/ci-framework/pull/1025), and we're currently
addressing them here.

- the `_network` parameter is now removed from the proposed reproducer
  environment files, since we don't need it anymore
- there were some mentions of the old, deprecated `static_ip` and some
  other parameters in the network that were passed down for the fixed
  IP. We don't need those data anymore
- a debug task is also removed, since it's useless
- the generated "values.yaml" is now properly renamed and placed, so
  that we know it's mostly controle-plane related.
- also take the opportunity to remove a fair amount of deprecated
  parameters.


As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
