### PR TITLE
Add missing doc about the VM password

### DIFF
--- a/docs/source/quickstart/99_FAQ.md
+++ b/docs/source/quickstart/99_FAQ.md
@@ -7,6 +7,11 @@
 On the machine from where you launched the `ansible-playbook` command, you
 can access `~/ansible.log`.
 
+### What's the root password on the virtual machines?
+
+By default, the very secure `fooBar` password is set for all of the created machines. You can
+override it from within the [layout description](../roles/libvirt_manager.md#structure-for-cifmw-libvirt-manager-configuration)
+
 ### How can I see the deployed libvirt resources?
 
 On the hypervisor, you can check the deployed resources using `virsh` command, for instance:

--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -51,6 +51,7 @@ cifmw_libvirt_manager_configuration:
       nets: (ordered list of networks to connect to)
       extra_disks_num: (integer, optional. Number of extra disks to be configured.)
       extra_disks_size: (string, optional. Storage capacity to be allocated. Example 1G, 512M)
+      password: (string, optional, defaults to fooBar. Root password for console access)
       target: (Hypervisor hostname you want to deploy the family on. Optional)
   networks:
     net_name: <XML definition of the network to create>


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
