### PR TITLE
Use an empty dict as fallback instead of omit

### DIFF
--- a/hooks/playbooks/fetch_compute_facts.yml
+++ b/hooks/playbooks/fetch_compute_facts.yml
@@ -251,7 +251,7 @@
     - name: Save compute info
       vars:
         file_content:
-          cifmw_edpm_deploy_extra_vars: "{{ cifmw_edpm_deploy_extra_vars | default(omit) }}"
+          cifmw_edpm_deploy_extra_vars: "{{ cifmw_edpm_deploy_extra_vars | default({}) }}"
           cifmw_edpm_prepare_extra_vars: "{{ cifmw_edpm_prepare_extra_vars }}"
       ansible.builtin.copy:
         dest: "{{ cifmw_basedir }}/artifacts/{{ step }}_{{ hook_name }}.yml"


### PR DESCRIPTION
Usage of `omit` seems to lead to this error:

```
2024-01-24 08:15:08.710945 | controller | fatal: [localhost]: FAILED! => {"msg": "failed to combine variables, expected dicts but got a 'dict' and a 'AnsibleUnicode': \n{\"DATAPLANE_REPO\": \"/home/zuul/src/github.com/openstack-k8s-operators/dataplane-operator\", \"BMO_SETUP\": false, \"INSTALL_CERT_MANAGER\": false, \"OUT\": \"/home/zuul/ci-framework-data/artifacts/manifests\", \"OUTPUT_DIR\": \"/home/zuul/ci-framework-data/artifacts/edpm\", \"KUBECONFIG\": \"/home/zuul/.crc/machines/crc/kubeconfig\", \"PATH\": \"/home/zuul/.crc/bin:/home/zuul/.crc/bin/oc:/home/zuul/bin:/home/zuul/.local/bin:/home/zuul/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin\", \"DATAPLANE_REGISTRY_URL\": \"quay.io/podified-antelope-centos9\", \"DATAPLANE_CONTAINER_TAG\": \"0e2de945ea12cc5033f0b6569dd33639\"}\n\"__omit_place_holder__d904e7f4fd8faecd1e39f0b5599fa662bd8cabaa\""}
```

So we will adopt a fallback using an empty dictionary.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
