### PR TITLE
Make ctlplane backward compatible

### DIFF
--- a/hooks/playbooks/fetch_compute_facts.yml
+++ b/hooks/playbooks/fetch_compute_facts.yml
@@ -198,7 +198,7 @@
                           dns_servers: {{ ctlplane_dns_nameservers }}
                           domain: {{ dns_search_domains }}
                           addresses:
-                          - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+                          - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr | default(ctlplane_subnet_cidr) }}
                           members:
                           - type: interface
                             name: nic2


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
