### PR TITLE
Get zuul reproducer back on track

### DIFF
--- a/docs/source/reproducers/03-zuul.md
+++ b/docs/source/reproducers/03-zuul.md
@@ -1,11 +1,5 @@
 # Zuul job
 
-~~~{warning}
-This feature is currently broken. The ci-framework is slightly ahead of
-actual job definitions and we need to change them to provide the needed
-bits again.
-~~~
-
 ~~~{tip}
 It is strongly advised to run this reproducer against a dedicated hypervisor
 with enough resources. The current configuration will require close to 40G
@@ -117,6 +111,7 @@ the job:
     reproducer.yml \
     -e cifmw_target_host=hypervisor-1 \
     -e @scenarios/reproducers/3-nodes.yml \
+    -e @scenarios/reproducers/networking-definition.yml \
     -e @custom/my-job.yml [-e @custom/repo-overrides.yml]
 ```
 #### What does it do?!
@@ -138,6 +133,10 @@ that file in the `custom` directory described earlier with your own resources.
 
 Note that the reproducer will update the amount of computes. You therefore don't need
 to change it.
+
+#### @scenarios/reproducers/networking-definition.yml
+That file describe the networking so that [networking_mapper](../roles/networking_mapper.md)
+can expose the needed configuration.
 
 #### Generated files
 There will be a fair amount of generated files, as you may expect. As usual, most of them
@@ -214,12 +213,14 @@ Note: you **must** have an already deployed layout before running only this tag.
 [laptop]$ ansible-playbook -i custom/inventory.yml reproducer.yml \
     -e cifmw_target_host=hypervisor-1 \
     -e @scenarios/reproducers/3-nodes.yml \
+    -e @scenarios/reproducers/networking-definition.yml \
     -e @custom/my-job.yml
 
 # Iterate with the second iteration of your PR that failed on Zuul
 [laptop]$ ansible-playbook -i custom/inventory.yml reproducer.yml \
     -e cifmw_target_host=hypervisor-1 \
     -e @scenarios/reproducers/3-nodes.yml \
+    -e @scenarios/reproducers/networking-definition.yml \
     -e @custom/my-job.yml \
     --tags bootstrap_repositories
 ```
@@ -237,12 +238,14 @@ Note: you **must** have an already deployed layout before skipping this tag.
 [laptop]$ ansible-playbook -i custom/inventory.yml reproducer.yml \
     -e cifmw_target_host=hypervisor-1 \
     -e @scenarios/reproducers/3-nodes.yml \
+    -e @scenarios/reproducers/networking-definition.yml \
     -e @custom/my-job.yml
 
 # Iterate with the second iteration of your PR that failed on Zuul
 [laptop]$ ansible-playbook -i custom/inventory.yml reproducer.yml \
     -e cifmw_target_host=hypervisor-1 \
     -e @scenarios/reproducers/3-nodes.yml \
+    -e @scenarios/reproducers/networking-definition.yml \
     -e @custom/my-job.yml \
     --skip-tags bootstrap_layout
 ```
@@ -267,12 +270,14 @@ recommend *against* skipping it due to the lack of data regeneration.
 [laptop]$ ansible-playbook -i custom/inventory.yml reproducer.yml \
     -e cifmw_target_host=hypervisor-1 \
     -e @scenarios/reproducers/3-nodes.yml \
+    -e @scenarios/reproducers/networking-definition.yml \
     -e @custom/my-job.yml
 
 # Iterate with the second iteration of your PR that failed on Zuul
 [laptop]$ ansible-playbook -i custom/inventory.yml reproducer.yml \
     -e cifmw_target_host=hypervisor-1 \
     -e @scenarios/reproducers/3-nodes.yml \
+    -e @scenarios/reproducers/networking-definition.yml \
     -e @custom/my-job.yml \
     --skip-tags bootstrap_layout,bootstrap
 ```

--- a/roles/reproducer/README.md
+++ b/roles/reproducer/README.md
@@ -6,6 +6,7 @@ None
 
 ## Parameters
 * `cifmw_reproducer_basedir`: (String) Base directory. Defaults to `cifmw_basedir`, which defaults to `~/ci-framework-data`.
+* `cifmw_reproducer_compute_repos`: (List[mapping]) List of yum repository that must be deployed on the compute nodes during their creation. Defaults to `[]`.
 * `cifmw_reproducer_ctl_ip4`: (String) IPv4 address for ansible controller on the *private* interface. Defaults to 192.168.122.10.
 * `cifmw_reproducer_ctl_gw4`: (String) IPv4 gateway for ansible controller on the *private* interface. Defaults to 192.168.122.1.
 * `cifmw_reproducer_crc_ip4`: (String) IPv4 address for CRC node on the *private* interface. Defaults to 192.168.122.11.

--- a/roles/reproducer/defaults/main.yml
+++ b/roles/reproducer/defaults/main.yml
@@ -33,3 +33,4 @@ cifmw_reproducer_dns_servers:
 cifmw_reproducer_repositories: []
 cifmw_reproducer_hp_rhos_release: false
 cifmw_reproducer_dnf_tweaks: []
+cifmw_reproducer_compute_repos: []

--- a/roles/reproducer/files/pre-ci-play.yml
+++ b/roles/reproducer/files/pre-ci-play.yml
@@ -1,39 +1,83 @@
 ---
-- name: Configure networking on all nodes
-  hosts: all,!localhost
+- name: Generate and inject old networking-info based on networking_mapper
+  hosts: localhost
   gather_facts: false
-  become: true
-  vars:
-    cifmw_network_generated_layout: "/etc/ci/env/networking-info.yml"
   tasks:
-    - name: Create ci-env directory tree
-      when:
-        - inventory_hostname != 'controller-0'
-      ansible.builtin.file:
-        path: "/etc/ci/env"
-        state: directory
-    - name: Copy networking-info to hosts
-      when:
-        - inventory_hostname != 'controller-0'
-      ansible.builtin.copy:
-        src: "{{ cifmw_network_generated_layout }}"
-        dest: "{{ cifmw_network_generated_layout }}"
-    - name: Configure networking on nodes
-      ansible.builtin.import_role:
-        role: ci_network
+    - name: Load networking-environment-definition
+      ansible.builtin.include_vars:
+        file: "/etc/ci/env/networking-environment-definition.yml"
+        name: _net_env
 
-- name: Reboot CRC and wait for its services
-  hosts: crc-0
-  gather_facts: false
-  tasks:
-    - name: Reboot CRC node
+    - name: Map networking_mapper environment to networking-info
       become: true
-      ansible.builtin.reboot:
+      ansible.builtin.copy:
+        dest: "/etc/ci/env/networking-info.yml"
+        content: |-
+          crc_ci_bootstrap_networks_out:
+          {% for instance in _net_env.instances.keys() %}
+            {{ instance | replace('controller-0', 'controller') }}:
+          {%   for net in _net_env.instances[instance].networks.keys() %}
+          {%     if net == 'ctlplane' %}
+              default:
+                connection: ci-private-network
+                gw: {{ _net_env.networks[net].gw_v4 }}
+          {%     else %}
+              {{ net | replace('internalapi', 'internal-api') }}:
+                vlan: {{ _net_env.networks[net].vlan_id | default('foo') }}
+          {%     endif %}
+                iface: {{ _net_env.instances[instance]['networks'][net]['interface_name']}}
+                ip: {{ _net_env.instances[instance]['networks'][net]['ip_v4'] }}/24
+                mac: {{ _net_env.instances[instance]['networks'][net]['mac_addr'] }}
+                mtu: {{ _net_env.instances[instance]['networks'][net]['mtu'] }}
+                skip_nm: false
+          {%   endfor %}
+          {% endfor %}
 
-- name: Disable cloud-init on computes
+    - name: Configure NetworkManager to not override /etc/resolv.conf
+      become: true
+      community.general.ini_file:
+        path: "/etc/NetworkManager/NetworkManager.conf"
+        option: dns
+        section: main
+        value: none
+
+    - name: Restart NetworkManager to ensure we apply new configuration
+      become: true
+      ansible.builtin.service:
+        name: NetworkManager
+        state: restarted
+
+    - name: Inject custom nameservers in /etc/resolv.conf
+      become: true
+      vars:
+        _pub_resolver: >-
+          {{ _net_env.networks.ctlplane.dns_v4.0 }}
+        _crc_resolver: >-
+          {{ _net_env.networks.ctlplane.tools.metallb.ipv4_ranges.0.start }}
+      ansible.builtin.copy:
+        dest: "/etc/resolv.conf"
+        content: |
+          nameserver {{ _crc_resolver }}
+          nameserver {{ _pub_resolver }}
+
+- name: Prepare computes for next steps
   hosts: computes
   gather_facts: false
   tasks:
+    - name: Ensure /etc/ci/env directory exists
+      become: true
+      ansible.builtin.file:
+        path: /etc/ci/env
+        state: directory
+        mode: "0755"
+
+    - name: Push networking-info.yml
+      become: true
+      ansible.builtin.copy:
+        src: /etc/ci/env/networking-info.yml
+        dest: /etc/ci/env/networking-info.yml
+        mode: "0644"
+
     - name: Disable cloud-init
       become: true
       ansible.builtin.service:

--- a/roles/reproducer/tasks/configure_computes.yml
+++ b/roles/reproducer/tasks/configure_computes.yml
@@ -18,3 +18,28 @@
       ansible.builtin.command:
         cmd: |
           ping -c2 {{ _controller_ip4 }}
+
+    - name: RHEL related tasks on computes
+      become: true
+      when:
+        - cifmw_repo_setup_rhos_release_rpm is defined
+      block:
+        - name: Get rhos-release and CA
+          ansible.builtin.import_tasks: rhos_release.yml
+
+        - name: Configure rhos-release
+          ansible.builtin.command:
+            cmd: "rhos-release {{ cifmw_repo_setup_rhos_release_args }}"
+
+    - name: Create repositories on computes
+      become: true
+      ansible.builtin.yum_repository:
+        name: "{{ item.name }}"
+        description: "{{ item.description | default(omit) }}"
+        baseurl: "{{ item.baseurl }}"
+        gpgcheck: "{{ item.gpgcheck | default(omit) }}"
+        enabled: "{{ item.enabled | default(omit) }}"
+        priority: "{{ item.priority | default(omit) }}"
+      loop: "{{ cifmw_reproducer_compute_repos }}"
+      loop_control:
+        label: "{{ item.name }}"

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -237,20 +237,16 @@
       when:
         - cifmw_repo_setup_rhos_release_rpm is defined
       block:
-        - name: Get rhos-release
-          ansible.builtin.package:
-            name: "{{ cifmw_repo_setup_rhos_release_rpm }}"
-            state: present
-            disable_gpg_check: true
+        - name: Get rhos-release and CA
+          ansible.builtin.import_tasks: rhos_release.yml
 
-        - name: Enable RHEL repos
-          ansible.builtin.command:
-            cmd: "rhos-release rhel"
-
-        - name: Install internal CA
-          ansible.builtin.package:
-            name: "{{ cifmw_reproducer_internal_ca }}"
-            disable_gpg_check: true
+        - name: Create bundle for CRC
+          ansible.builtin.shell:
+            cmd: >-
+              set -o pipefail;
+              cat /etc/pki/ca-trust/source/anchors/* >
+              /etc/pki/ca-trust/source/anchors/rh.crt
+            creates: "/etc/pki/ca-trust/source/anchors/rh.crt"
 
     - name: Install some tools
       become: true

--- a/roles/reproducer/tasks/rhos_release.yml
+++ b/roles/reproducer/tasks/rhos_release.yml
@@ -1,0 +1,15 @@
+---
+- name: Get rhos-release
+  ansible.builtin.dnf:
+    name: "{{ cifmw_repo_setup_rhos_release_rpm }}"
+    state: present
+    disable_gpg_check: true
+
+- name: Enable RHEL repos
+  ansible.builtin.command:
+    cmd: "rhos-release rhel"
+
+- name: Install internal CA
+  ansible.builtin.dnf:
+    name: "{{ cifmw_reproducer_internal_ca }}"
+    disable_gpg_check: true

--- a/roles/reproducer/templates/play.yml.j2
+++ b/roles/reproducer/templates/play.yml.j2
@@ -7,20 +7,14 @@
   tasks:
     - name: Load interfaces-info.yml
       ansible.builtin.include_vars:
-        file: "{{ ansible_user_dir }}/ci-framework-data/artifacts/interfaces-info.yml"
-        name: cifmw_mac_mapping
+        file: "/etc/ci/env/networking-environment-definition.yml"
+        name: _net_env
 
     - name: Set cifmw_rp_registry_ip
       ansible.builtin.set_fact:
         cacheable: true
         cifmw_rp_registry_ip: >-
-          {{
-            ((cifmw_mac_mapping | dict2items |
-            selectattr('key', 'match', '.*controller-0') |
-            first)['value'] |
-            selectattr('network', 'match', '.*osp_trunk') |
-            first)['IP']
-          }}
+          {{ _net_env.instances['controller-0'].networks.ctlplane.ip_v4 }}
 
 
 - name: Configure OCPs for insecure registry
@@ -58,7 +52,6 @@
       ansible.builtin.include_vars:
         file: "{{ item }}"
       loop:
-        - "{{ ansible_user_dir }}/ci-framework-data/artifacts/interfaces-info.yml"
         - "{{ ansible_user_dir }}/{{ job_id }}-params/zuul-params.yml"
         - "./scenarios/centos-9/base.yml"
         - "./scenarios/centos-9/content_provider.yml"
@@ -114,45 +107,6 @@
           }}
 {% endraw %}
 {% endif %}
-
-{% raw %}
-- name: Configure NetworkManager on controller-0
-  hosts: localhost
-  gather_facts: false
-  become: true
-  tasks:
-    - name: Instruct NetworkManager to not manage DNS
-      community.general.ini_file:
-        path: "/etc/NetworkManager/NetworkManager.conf"
-        option: dns
-        section: main
-        value: none
-
-    - name: Restart NetworkManager
-      ansible.builtin.service:
-        name: NetworkManager
-        state: restarted
-
-    - name: Inject proper DNS resolver
-      vars:
-        _net: "{{ cifmw_rp_registry_ip }}/24"
-        _crc_resolver: >-
-          {{
-            _net | ansible.utils.ipaddr('host/prefix') |
-            ansible.utils.nthhost(80)
-          }}
-        _pub_resolver: >-
-          {{
-            _net | ansible.utils.ipaddr('host/prefix') |
-            ansible.utils.nthhost(1)
-          }}
-      ansible.builtin.copy:
-        dest: "/etc/resolv.conf"
-        content: |
-          # Managed by ansible/cifmw reproducer role
-          nameserver {{ _crc_resolver }}
-          nameserver {{ _pub_resolver }}
-{% endraw %}
 
 {% for play in zuul_plays %}
 - name: "Reproducer for {{ job_id }}: {{ play }}"


### PR DESCRIPTION
Since the introduction of networking_mapper in the reproducer role, the
zuul reproducer feature was broken.

This patch provides the needed update to re-enable the feature, by
remapping the networking_mapper environment output to the old
networking-info.yml format/file, allowing to re-run the job until we
switch the CI itself to the new networking_mapper usage.

This patch also provides the needed bits to properly support downstream
zuul and the RHEL ecosystem specificities. Most of the involved changes
are transparent to the user, since the tasks were already done on the
controller-0 - we had to extend them to the compute nodes.


As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] Content of the docs/source is reflecting the changes
