### PR TITLE
Add dmesg log in post-run

### DIFF
--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -67,6 +67,7 @@
               pip3 --version >> ./python.log;
               command -v ansible && ansible --version >> ./python.log;
               pip3 freeze >> ./python.log;
+              dmesg -T > ./dmesg.log;
 
         - name: Copy logs from home directory
           ignore_errors: true  # noqa: ignore-errors


### PR DESCRIPTION
Sometimes, the job might fail not because of the change but because of the hypervisor issue. This commit starts collecting dmesg logs into a separate file for later analysis.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running

