### PR TITLE
Add cert-manager installation to BM jobs

### DIFF
--- a/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
+++ b/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
@@ -32,6 +32,8 @@ cifmw_openshift_setup_skip_internal_registry: true
 cifmw_use_crc: true
 cifmw_rhol_crc_use_installyamls: true
 
+cifmw_config_certmanager: true
+
 # openshift_login role vars
 cifmw_openshift_user: "kubeadmin"
 cifmw_openshift_password: "123456789"


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date: