### PR TITLE
[devscripts] Enable ip forwarding at global level

### DIFF
--- a/roles/devscripts/files/forwarding.yaml
+++ b/roles/devscripts/files/forwarding.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  defaultNetwork:
+    ovnKubernetesConfig:
+      gatewayConfig:
+        ipForwarding: Global

--- a/roles/devscripts/molecule/default/converge.yml
+++ b/roles/devscripts/molecule/default/converge.yml
@@ -26,7 +26,7 @@
       domains:
         - "ocp.openstack.lab"
     cifmw_devscripts_dry_run: true
-    cifmw_devscripts_ocp_version: "4.13.12"
+    cifmw_devscripts_ocp_version: "4.14.9"
     cifmw_devscripts_user: "{{ ansible_user_id }}"
     cifmw_devscripts_repo_dir: "{{ (ansible_user_dir, 'src', 'dev-scripts') | path_join }}"
     cifmw_devscripts_data_dir: "{{ (ansible_user_dir, 'ci-framework-data') | path_join }}"
@@ -61,6 +61,7 @@
           - cifmw_devscripts_config.provisioning_network_profile == 'Managed'
           - cifmw_devscripts_config.num_masters == 3
           - cifmw_devscripts_config.num_workers == 0
+          - cifmw_devscripts_config.assets_extra_folder == '/home/dev-scripts/assets'
 
     - name: Collect stat information
       ansible.builtin.stat:
@@ -71,6 +72,7 @@
         - "{{ cifmw_devscripts_repo_dir }}"
         - "{{ cifmw_devscripts_logs_dir }}"
         - "{{ cifmw_devscripts_output_dir }}"
+        - "{{ cifmw_devscripts_config.assets_extra_folder }}"
       register: stat_results
 
     - name: Test directory exists
@@ -86,6 +88,7 @@
       loop:
         - "{{ cifmw_devscripts_repo_dir }}/pull_secret.json"
         - "{{ cifmw_devscripts_repo_dir }}/config_{{ cifmw_devscripts_user }}.sh"
+        - "{{ cifmw_devscripts_config.assets_extra_folder }}/forwarding.yaml"
       register: file_stat_results
 
     - name: Test pull secret file stat information

--- a/roles/devscripts/tasks/sub_tasks/14_user.yml
+++ b/roles/devscripts/tasks/sub_tasks/14_user.yml
@@ -26,6 +26,7 @@
   loop:
     - "{{ cifmw_devscripts_repo_dir }}"
     - "{{ cifmw_devscripts_config['working_dir'] }}"
+    - "{{ cifmw_devscripts_config['assets_extra_folder'] }}"
 
 - name: Generate SSH keys for accessing OCP cluster
   community.crypto.openssh_keypair:
@@ -44,3 +45,14 @@
     mode: "0640"
     content: |
       {{ cifmw_devscripts_user }}    ALL=(ALL)    NOPASSWD: ALL
+
+- name: Enable IP forwarding in the Network Operator.
+  when:
+    - cifmw_devscripts_config['network_type'] == 'OVNKubernetes'
+    - "cifmw_devscripts_config.openshift_version is ansible.builtin.version('4.14.0', '>=')"
+  ansible.builtin.copy:
+    src: "files/forwarding.yaml"
+    dest: "{{ cifmw_devscripts_config['assets_extra_folder'] }}/forwarding.yaml"
+    owner: "{{ cifmw_devscripts_user }}"
+    group: "{{ cifmw_devscripts_user }}"
+    mode: "0644"

--- a/roles/devscripts/vars/main.yml
+++ b/roles/devscripts/vars/main.yml
@@ -33,6 +33,7 @@ cifmw_devscripts_rhsm_enabled_repos: false
 
 cifmw_devscripts_config_defaults:
   working_dir: "/home/dev-scripts"
+  assets_extra_folder: "/home/dev-scripts/assets"
   openshift_release_type: "ga"
   openshift_version: "{{ cifmw_devscripts_ocp_version | default('4.14.0') }}"
   cluster_name: "ocp"


### PR DESCRIPTION
This patch enables IP forwarding when the network type is OVNKubernetes by default. This is required as the default number of NICs in the deployed cluster is 2.

It fixes the DNS query issue observed when configuring the OpenStack compute nodes.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

*Network Operator details*
````
Name:         cluster
Namespace:    
Labels:       <none>
Annotations:  networkoperator.openshift.io/ovn-cluster-initiator: 192.168.111.22
API Version:  operator.openshift.io/v1
Kind:         Network
Metadata:
  Creation Timestamp:  2024-01-29T09:12:43Z
  Generation:          74
  Resource Version:    35543
  UID:                 e3805527-d2ed-486b-9b89-06de28e363d1
Spec:
  Cluster Network:
    Cidr:         192.168.16.0/20
    Host Prefix:  22
  Default Network:
    Ovn Kubernetes Config:
      Egress IP Config:
      Gateway Config:
        Ip Forwarding:     Global
        Routing Via Host:  false
      Geneve Port:         6081
```