### PR TITLE
Fix skipped deployment task after ci_make/ci_scripts switch

### DIFF
--- a/roles/devscripts/tasks/03_install.yml
+++ b/roles/devscripts/tasks/03_install.yml
@@ -26,11 +26,10 @@
   ansible.builtin.import_tasks: sub_tasks/32_params.yml
 
 - name: Deploying the OpenShift platform
-  when: cifmw_devscripts_make_target is defined
   tags:
     - bootstrap
   ci_script:
     chdir: "{{ cifmw_devscripts_repo_dir }}"
     output_dir: "{{ cifmw_devscripts_output_dir }}"
     dry_run: "{{ cifmw_devscripts_dry_run | bool }}"
-    script: " make {{ cifmw_devscripts_make_target }}"
+    script: "make {{ cifmw_devscripts_make_target | default('') }}"


### PR DESCRIPTION
This nit was introduced with the merge of [1]. Instead of skipping the task when the make target is not defined, we should just run make with no target (i.e. default target) to keep previous behaviour.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/653/files#diff-0af62e35d536a23bbb025c5e1ba37906f6a187ad7e44ef4d6af6b4674e61b5e3

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
