### PR TITLE
Ensure we have install_yamls in prow container

### DIFF
--- a/containerfiles/Containerfile.ci
+++ b/containerfiles/Containerfile.ci
@@ -5,3 +5,5 @@ USER root
 # workaround for RHBZ#2184640
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 RUN dnf update -y && dnf install -y git python3-pip python3-netaddr make gcc sudo rsync && yum clean all
+RUN mkdir -p /home/zuul/src/github.com/openstack-k8s-operators
+RUN git clone https://github.com/openstack-k8s-operators/install_yamls /home/zuul/src/github.com/openstack-k8s-operators/install_yamls


### PR DESCRIPTION
This is needed when we want to run ansible-lint and other things on
ci-framwork code that may depend on install_yamls (mostly when we
`import_playbook`).

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
