### PR TITLE
Correct ci_script issues

### DIFF
--- a/plugins/action/ci_script.py
+++ b/plugins/action/ci_script.py
@@ -161,12 +161,7 @@ class ActionModule(ActionBase):
             raise AnsibleActionFail("script parameter is missing")
 
         output_dir = pathlib.Path(task_args.pop("output_dir"))
-        if not output_dir.is_dir():
-            raise AnsibleActionFail("output_dir points to a non-existing directory")
-
         logs_dir = output_dir.parent.joinpath("logs")
-        if not logs_dir.is_dir():
-            raise AnsibleActionFail(f"logs dir, {logs_dir} doesn't exist")
 
         # Remove cmd if not passed, we are going to use _raw_params
         # to pass the cmd we create here
@@ -209,6 +204,10 @@ class ActionModule(ActionBase):
         file_task.args.update(
             {"_raw_params": script_path_str, "chdir": output_dir.as_posix()}
         )
+        file_task.args.pop('output_dir')
+        file_task.args.pop('script')
+        if 'dry_run' in file_task.args:
+            file_task.args.pop('dry_run')
 
         if not dry_run:
             return self._shared_loader_obj.action_loader.get(


### PR DESCRIPTION
Since we're consuming ci_script more widely in the project, we're seeing
some issues:
- it was checking for local directories to exist, while we may not need
  them in case of remote run.
- it wasn't properly cleaning parameters when passed down to the
  ansible.builtin.script, leading to issues

This patch corrects both issues, by not checking for directory
availability anymore, and properly cleaning parameters when needed.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
