### PR TITLE
Allow to skip the libvirt bootstrap

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -118,6 +118,7 @@ or `--skip-tags`:
 * `bootstrap`: Run all of the package installation tasks as well as the potential system configuration depending on the options you set.
 * `packages`: Run all package installation tasks associated to the options you set.
 * `bootstrap_layout`: Run the [reproducer](../reproducers/01-considerations.md) bootstrap steps only.
+* `bootstrap_libvirt`: Run the [reproducer](../reproducers/01-considerations.md) libvirt bootstrap only.
 * `bootstrap_repositories`: Run the [reproducer](../reproducers/01-considerations.md) repositories bootstrap steps only.
 * `infra`: Denotes tasks to prepare host virtualization and Openshift Container Platform when deploy-edpm.yml playbook is run.
 * `build-packages`: Denotes tasks to call the role [pkg_build](../roles/pkg_build.md) when deploy-edpm.yml playbook is run.

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -49,6 +49,8 @@
   ansible.builtin.import_tasks: ci_data.yml
 
 - name: Bootstrap libvirt if needed
+  tags:
+    - bootstrap_libvirt
   when:
     - cifmw_use_libvirt | default(false) | bool
   ansible.builtin.import_role:


### PR DESCRIPTION
This new tag will ensure we're not running over and over the libvirt
bootstrap tasks - those are usually needed only once, on a fresh
hypervisor.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] Content of the docs/source is reflecting the changes
