### PR TITLE
Match black linting for ci_script

### DIFF
--- a/plugins/action/ci_script.py
+++ b/plugins/action/ci_script.py
@@ -133,7 +133,7 @@ class ActionModule(ActionBase):
         __SCRIPT_ARG,
         __DRY_RUN_ARG,
         __EXTRA_ARGS_ARG,
-        __CHDIR_ARG
+        __CHDIR_ARG,
     ]
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
The one time Prow was down and we had to merge a patch without it, of
course it introduced an issue...

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
