### PR TITLE
Don't remove bootstrap service from sevice list

### DIFF
--- a/hooks/playbooks/fetch_compute_facts.yml
+++ b/hooks/playbooks/fetch_compute_facts.yml
@@ -233,12 +233,6 @@
                     value: ["{{ content_provider_registry_ip }}:5001"]
               {% endif %}
 
-              {% if zuul is defined and 'periodic' in zuul.job %}
-                  - op: remove
-                    path: /spec/services/0
-                    value: repo-setup
-              {% endif %}
-
                   - op: add
                     path: /spec/nodeTemplate/ansible/ansibleVars/edpm_sshd_allowed_ranges
                     value: ["0.0.0.0/0"]


### PR DESCRIPTION
This removes the first service from the service list which happens to be `bootstrap` service and hence the required users and groups are not created as expected.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
