### PR TITLE
[devscripts] Fix no more available PCI slots.

### DIFF
--- a/roles/devscripts/tasks/sub_tasks/52_networking.yml
+++ b/roles/devscripts/tasks/sub_tasks/52_networking.yml
@@ -36,3 +36,7 @@
 
     - name: Ensure firewall and routing rules are configured
       ansible.builtin.import_tasks: _524_firewall.yml
+
+    - name: Ensure the OCP cluster is in running state
+      when: cifmw_devscripts_extra_networks | length > 1
+      ansible.builtin.import_tasks: _525_wait_ocp.yml

--- a/roles/devscripts/tasks/sub_tasks/_523_attach.yml
+++ b/roles/devscripts/tasks/sub_tasks/_523_attach.yml
@@ -37,6 +37,17 @@
     vms: "{{ vms + [item] }}"
   loop: "{{ vms_list.stdout_lines }}"
 
+- name: "Power OFF virtual machine {{ item }}"
+  when:
+    - vms is defined
+    - vms | length > 0
+    - cifmw_devscripts_extra_networks | length > 1
+  community.libvirt.virt:
+    command: "destroy"
+    name: "{{ item }}"
+    uri: "qemu:///system"
+  loop: "{{ vms }}"
+
 - name: Attach an interface for each extra_network
   when:
     - vms is defined
@@ -44,10 +55,22 @@
   vars:
     vm_name: "{{ item[0] }}"
     network: "{{ item[1] }}"
+    offline: "{{ cifmw_devscripts_extra_networks | length > 1 }}"
   ansible.builtin.include_role:
     name: libvirt_manager
     tasks_from: attach_interface.yml
   loop: "{{ vms | product(cifmw_devscripts_extra_networks) }}"
+
+- name: "Power ON virtual machine {{ item }}"
+  when:
+    - vms is defined
+    - vms | length > 0
+    - cifmw_devscripts_extra_networks | length > 1
+  community.libvirt.virt:
+    command: "start"
+    name: "{{ item }}"
+    uri: "qemu:///system"
+  loop: "{{ vms }}"
 
 - name: Add vlan tags to the attached interfaces.
   become: true

--- a/roles/devscripts/tasks/sub_tasks/_525_wait_ocp.yml
+++ b/roles/devscripts/tasks/sub_tasks/_525_wait_ocp.yml
@@ -1,0 +1,38 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Wait until the OCP API endpoint is reachable
+  ansible.builtin.uri:
+    url: "{{ cifmw_openshift_api }}"
+    return_content: true
+    validate_certs: false
+    status_code: 200
+  register: ocp_api_result
+  until: ocp_api_result.status == 200
+  retries: 30
+  delay: 5
+
+- name: Wait until OCP login succeeds
+  kubernetes.core.k8s_auth:
+    host: "{{ cifmw_openshift_api }}"
+    password: "{{ cifmw_openshift_password }}"
+    state: present
+    username: "{{ cifmw_openshift_user }}"
+    validate_certs: false
+  register: _oc_login_result
+  until: _oc_login_result.k8s_auth is defined
+  retries: 30
+  delay: 5

--- a/roles/libvirt_manager/tasks/attach_interface.yml
+++ b/roles/libvirt_manager/tasks/attach_interface.yml
@@ -77,15 +77,17 @@
         _extracted_xml.matches | default([]) |
         selectattr('source.bridge', 'equalto', _local_bridge_name) | default([])
       }}
+    _lm_mac_address: "{{ '0A:02' | community.general.random_mac }}"
   when:
     - _attached_bridges | length == 0
   block:
-    - name: "Generate a random MAC address for {{ vm_name }}"
-      ansible.builtin.set_fact:
-        _lm_mac_address: "{{ '0A:02' | community.general.random_mac }}"
-
     - name: "Attach interface {{ network.name }} on {{ vm_name }}"  # noqa: name[template]
-      when: _lm_mac_address is defined
+      vars:
+        _cmd_suffix: >-
+          {{
+            (offline | default(false)) |
+            ternary('--config', '--config --persistent')
+          }}
       ansible.builtin.command:
         cmd: >-
           virsh -c qemu:///system
@@ -94,11 +96,9 @@
           --type bridge
           --mac "{{ _lm_mac_address }}"
           --model virtio
-          --config
-          --persistent
+          {{ _cmd_suffix }}
 
     - name: Inject data in cifmw_libvirt_manager_mac_map
-      when: _lm_mac_address is defined
       vars:
         _vm_name: "{{ vm_name | replace('cifmw-', '') }}"
         _dataset: >-
@@ -110,5 +110,6 @@
         cifmw_libvirt_manager_mac_map: >-
           {{
             cifmw_libvirt_manager_mac_map | default({}) |
-            combine(_dataset, recursive=true)
+            combine(_dataset, list_merge='append', recursive=true)
           }}
+        cacheable: true


### PR DESCRIPTION
This change allows `devscripts` role to support attaching of more than 1 non-default network interfaces to the deployed OpenShift cluster.

The node having OCP master or worker role is powered OFF before a network attachment. This step is performed when there is more than 1 non-default network attachments. The node is brought online after the attachments are done.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

*Testing Results*
```
[zuul@titanamd125 ci-framework]$ sudo virsh list --all
 Id   Name                 State
------------------------------------
 8    cifmw-compute-0      running
 9    cifmw-compute-1      running
 10   cifmw-compute-2      running
 11   cifmw-controller-0   running
 12   cifmw-ocp-0          running
 13   cifmw-ocp-1          running
 14   cifmw-ocp-2          running

[zuul@titanamd125 ci-framework]$ sudo virsh domiflist cifmw-ocp-0
 Interface   Type     Source            Model    MAC
--------------------------------------------------------------------
 vnet25      bridge   ocppr             virtio   00:1a:fe:ba:bd:da
 vnet26      bridge   ocpbm             virtio   00:1a:fe:ba:bd:dc
 vnet27      bridge   cifmw-osp_trunk   virtio   0a:02:f6:98:7e:54
 vnet28      bridge   cifmw-external    virtio   0a:02:35:74:f5:b7
```

reproducer play failed but not related changes
```
PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
localhost                  : ok=379  changed=144  unreachable=0    failed=1    skipped=169  rescued=2    ignored=0   

Wednesday 31 January 2024  07:15:49 +0200 (0:00:00.119)       0:45:36.010 ***** 
=============================================================================== 
devscripts : Deploying the OpenShift platform -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2318.91s
reproducer : Wait for OCP nodes to be ready ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 48.83s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 44.73s
reproducer : Install some tools ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 33.37s
libvirt_manager : Grab IPs for nodes type ocp ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 31.68s
libvirt_manager : Grab IPs for nodes type compute ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 21.31s
libvirt_manager : Prepare disk image with SSH and growing volume --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.82s
libvirt_manager : Grab IPs for nodes type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.74s
libvirt_manager : Wait for SSH on VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.58s
libvirt_manager : Wait for SSH on VMs type ocp --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.49s
libvirt_manager : Download base image ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 10.91s
ci_setup : Install packages from EPEL ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 10.91s
reproducer : Install ansible dependencies -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 10.88s
ci_setup : Install needed packages ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 5.62s
libvirt_manager : Wait for SSH on VMs type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 5.20s
ci_setup : Install openshift client --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 5.19s
networking_mapper : Ensure that networking and hostname facts are in place ------------------------------------------------------------------------------------------------------------------------------------------------------------ 4.30s
reproducer : Enable RHEL repos -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 3.37s
devscripts : Clone the dev-scripts repository. ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2.57s
libvirt_manager : Start VMs for type ocp ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2.13s
```
