### PR TITLE
[devscripts] Enable routing via host

### DIFF
--- a/roles/devscripts/README.md
+++ b/roles/devscripts/README.md
@@ -32,6 +32,7 @@ managed services.
 * `cifmw_devscripts_use_layers` (bool) Toggle overlay support. Specifically, this boolean will instruct the role to
   shutdown the whole OCP cluster, dump the XML, undefine the nodes, and prevents running the "post" tasks. Defaults to `false`.
 * `cifmw_devscripts_remove_default_net` (bool) Remove the default virtual network. Defaults to `false`.
+* `cifmw_devscripts_host_routing` (bool) Enable routing via host for OCP nodes in case of OVNKubernetes. Defaults to `false`.
 
 ### Secrets management
 

--- a/roles/devscripts/defaults/main.yml
+++ b/roles/devscripts/defaults/main.yml
@@ -31,6 +31,7 @@ cifmw_devscripts_user: "{{ ansible_user_id }}"
 cifmw_devscripts_restart_virtproxyd: true
 cifmw_devscripts_use_layers: false
 cifmw_devscripts_remove_default_net: false
+cifmw_devscripts_host_routing: false
 
 cifmw_devscripts_osp_compute_nodes: []
 

--- a/roles/devscripts/molecule/default/converge.yml
+++ b/roles/devscripts/molecule/default/converge.yml
@@ -88,7 +88,7 @@
       loop:
         - "{{ cifmw_devscripts_repo_dir }}/pull_secret.json"
         - "{{ cifmw_devscripts_repo_dir }}/config_{{ cifmw_devscripts_user }}.sh"
-        - "{{ cifmw_devscripts_config.assets_extra_folder }}/forwarding.yaml"
+        - "{{ cifmw_devscripts_config.assets_extra_folder }}/ovn_k8s_config.yaml"
       register: file_stat_results
 
     - name: Test pull secret file stat information

--- a/roles/devscripts/tasks/sub_tasks/14_user.yml
+++ b/roles/devscripts/tasks/sub_tasks/14_user.yml
@@ -49,10 +49,20 @@
 - name: Enable IP forwarding in the Network Operator.
   when:
     - cifmw_devscripts_config['network_type'] == 'OVNKubernetes'
-    - "cifmw_devscripts_config.openshift_version is ansible.builtin.version('4.14.0', '>=')"
-  ansible.builtin.copy:
-    src: "files/forwarding.yaml"
-    dest: "{{ cifmw_devscripts_config['assets_extra_folder'] }}/forwarding.yaml"
+    - ("cifmw_devscripts_config.openshift_version is ansible.builtin.version('4.14.0', '>=')") or
+      (cifmw_devscripts_host_routing | bool)
+  vars:
+    ip_forward: "{{ cifmw_devscripts_config.openshift_version is ansible.builtin.version('4.14.0', '>=') }}"
+    host_routing: "{{ cifmw_devscripts_host_routing | bool }}"
+  ansible.builtin.template:
+    src: "templates/ovn_config.j2"
+    dest: >-
+      {{
+        [
+          cifmw_devscripts_config['assets_extra_folder'],
+          'ovn_k8s_config.yaml'
+        ] | ansible.builtin.path_join
+      }}
     owner: "{{ cifmw_devscripts_user }}"
     group: "{{ cifmw_devscripts_user }}"
     mode: "0644"

--- a/roles/devscripts/templates/ovn_config.j2
+++ b/roles/devscripts/templates/ovn_config.j2
@@ -7,4 +7,9 @@ spec:
   defaultNetwork:
     ovnKubernetesConfig:
       gatewayConfig:
+{% if ip_forward %}
         ipForwarding: Global
+{% endif %}
+{% if host_routing %}
+        routingViaHost: true
+{% endif %}

--- a/scenarios/reproducers/validated-architecture-1.yml
+++ b/scenarios/reproducers/validated-architecture-1.yml
@@ -110,12 +110,12 @@ cifmw_libvirt_manager_configuration:
 cifmw_use_devscripts: true
 cifmw_devscripts_ocp_version: '4.13.13'
 cifmw_devscripts_config_overrides:
-  # ovn_local_gateway_mode is required for egress traffic from pods to the osp_trunk network
-  ovn_local_gateway_mode: "true"
   worker_memory: 16384
   worker_disk: 100
   worker_vcpu: 10
   num_extra_workers: 0
+# Required for egress traffic from pods to the osp_trunk network
+cifmw_devscripts_host_routing: true
 
 # Note: with that extra_network_names "osp_trunk", we instruct
 # devscripts role to create a new network, and associate it to


### PR DESCRIPTION
When we use NetworkManagers dns services, it is required to enable routing via the OCP nodes.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

*Log snippet*
```
zuul@controller-0 ~]$ oc describe network.operator
Name:         cluster
Namespace:    
Labels:       <none>
Annotations:  networkoperator.openshift.io/ovn-cluster-initiator: 192.168.111.22
API Version:  operator.openshift.io/v1
Kind:         Network
Metadata:
  Creation Timestamp:  2024-01-31T02:25:52Z
  Generation:          76
  Resource Version:    32708
  UID:                 f9989752-d237-4c03-89c5-36716883f0be
Spec:
  Cluster Network:
    Cidr:         192.168.16.0/20
    Host Prefix:  22
  Default Network:
    Ovn Kubernetes Config:
      Egress IP Config:
      Gateway Config:
        Ip Forwarding:     Global
        Routing Via Host:  true
      Geneve Port:         6081
      Mtu:                 1400
      Policy Audit Config:
        Destination:            null
        Max File Size:          50
        Max Log Files:          5
        Rate Limit:             20
        Syslog Facility:        local0
    Type:                       OVNKubernetes
  Deploy Kube Proxy:            false
  Disable Multi Network:        false
  Disable Network Diagnostics:  false
  Log Level:                    Normal
  Management State:             Managed
  Observed Config:              <nil>
  Operator Log Level:           Normal
  Service Network:
    172.30.0.0/16
  Unsupported Config Overrides:  <nil>
  Use Multi Network Policy:      false
Status:
```
*Job progress*
```
[zuul@controller-0 custom]$ oc get jobs
NAME                                           COMPLETIONS   DURATION   AGE
bootstrap-dep-pre-ceph                         1/1           2m31s      7m51s
configure-network-dep-pre-ceph                 0/1           2m1s       2m1s
dataplane-deployment-repo-setup-dep-pre-ceph   1/1           29s        8m20s
download-cache-dep-pre-ceph                    1/1           3m19s      5m20s
keystone-cron-28444621                         1/1           5s         23m
```