### PR TITLE
Update refspec for gitlab

### DIFF
--- a/plugins/filter/reproducer_refspec.py
+++ b/plugins/filter/reproducer_refspec.py
@@ -65,6 +65,8 @@ class FilterModule:
             patchset = repo["patchset"]
             # changes coming from gerrit
             return f"refs/changes/{change[-2:]}/{change}/{patchset}"
+        elif "gitlab" in hostname:
+            return f"merge-requests/{change}/head"
         else:
             # changes coming from github
             return f"pull/{change}/head"

--- a/tests/integration/targets/filter_reproducer_refspec/tasks/main.yml
+++ b/tests/integration/targets/filter_reproducer_refspec/tasks/main.yml
@@ -108,7 +108,7 @@
       change: "1035"
   ansible.builtin.assert:
     that:
-      - "input | cifmw.general.reproducer_refspec == 'pull/1035/head'"
+      - "input | cifmw.general.reproducer_refspec == 'merge-requests/1035/head'"
 
 - name: Test reproducer_refspec gerrit refspec
   vars:


### PR DESCRIPTION
With the migration to gitlab update refspec to create filter for merge requests when appropriate.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running