### PR TITLE
Fix reproducer zuul repo checkout with no change

### DIFF
--- a/roles/reproducer/tasks/push_code.yml
+++ b/roles/reproducer/tasks/push_code.yml
@@ -32,7 +32,7 @@
         dest: "{{ repo.project.src_dir }}"
         repo: "https://{{ repo.project.canonical_hostname }}/{{ repo.project.canonical_hostname | reproducer_gerrit_infix }}{{ repo.project.name }}"
         refspec: "{{ omit if _skip_refspec else repo | reproducer_refspec ~ ':' ~ job_id }}"
-        version: "{{ job_id | default(omit) }}"
+        version: "{{ omit if _skip_refspec else job_id }}"
         force: true
       loop: "{{ zuul['items'] }}"
       loop_control:


### PR DESCRIPTION
When the projects listed in a zuul job to reproducer do not point to
a change (e.g periodic, component pipeline jobs) omit the version
parameter in the ansible git module to pull from master/main.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
