### PR TITLE
Fix zuul HCI job that is missing the bootstrap service

### DIFF
--- a/roles/hci_prepare/tasks/phase1.yml
+++ b/roles/hci_prepare/tasks/phase1.yml
@@ -61,6 +61,7 @@
             path: /spec/services
             value:
               - repo-setup
+              - bootstrap
               - download-cache
               - configure-network
               - validate-network


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date: