### PR TITLE
Correct detection of the content-provider

### DIFF
--- a/roles/reproducer/tasks/ci_data.yml
+++ b/roles/reproducer/tasks/ci_data.yml
@@ -52,13 +52,17 @@
             zuul_inventory.all.hosts.keys() |
             select('match', '^compute.*') | length
            }}
+        zuul_params: >-
+          {{
+            lookup('file', _reproducer_basedir ~ '/parameters/zuul-params.yml') |
+            from_yaml
+          }}
       ansible.builtin.set_fact:
         cacheable: true
         ci_job_networking: "{{ zuul_inventory.all.hosts.crc.crc_ci_bootstrap_networking }}"
         use_content_provider: >-
           {{
-            zuul_inventory.all.hosts.crc.content_provider_registry_ip is defined and
-            zuul_inventory.all.hosts.crc.cifmw_operator_build_output is defined
+            zuul_params.content_provider_registry_ip is defined
           }}
         updated_layout:
           vms:


### PR DESCRIPTION
It seems DS isn't working like US, leading to some issues. We can't rely
on two parameters to check, only on registry_ip one - and its detection
doesn't need to rely on the zuul inventory.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
