### PR TITLE
Ensure we clear some directories

### DIFF
--- a/reproducer-clean.yml
+++ b/reproducer-clean.yml
@@ -25,6 +25,24 @@
         name: rhol_crc
         tasks_from: cleanup.yml
 
+    - name: Remove remote selected data directories
+      tags:
+        - deepscrub
+      ansible.builtin.file:
+        path: "{{ cifmw_reproducer_basedir }}/{{ item }}"
+        state: absent
+      loop:
+        - reproducer-inventory
+        - reproducer-network-env
+
+    - name: Remove local ci-reproducer data directory
+      tags:
+        - deepscrub
+      delegate_to: localhost
+      ansible.builtin.file:
+        path: "{{ lookup('env', 'HOME') }}/ci-framework-data/ci-reproducer"
+        state: absent
+
     - name: Remove basedir
       tags:
         - never


### PR DESCRIPTION
There's a need to clear some directories, even without deepscrub tag.

Without this clean on the hypervisor, we may end with broken ansible
inventory, listing 2 "ocps" groups, one with CRC, the other for OCP
cluster.

Regarding the "local" directory (from the laptop/desktop/whatever),
it wasn't cleaned, meaning we may end with an ever growing directory, if
we're running many zuul job reproducers.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
