### PR TITLE
[test_operator] Update var name for tempest override_scenario bools

### DIFF
--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -53,5 +53,5 @@ cifmw_test_operator_default_groups:
   - default
 cifmw_test_operator_default_jobs:
   - default
-cifmw_test_operator_tests_include_override_scenario: false
-cifmw_test_operator_tests_exclude_override_scenario: false
+cifmw_test_operator_tempest_tests_include_override_scenario: false
+cifmw_test_operator_tempest_tests_exclude_override_scenario: false


### PR DESCRIPTION
After passing the cifmw_test_operator_tempest_include_list var to the role, the following error occurred in roles/test_operator/tasks/tempest-tests.yml': line 22

'cifmw_test_operator_tempest_tests_include_override_scenario' is undefined

Previously, the first condition was false and caused the check to fail. Now that that var is defined, the second condition is being evaluated.

The cifmw_test_operator_tempest_tests_include_override_scenario var does not have a default set in default/main.yml

However, defaults/main.yml defines:
cifmw_test_operator_tests_include_override_scenario: false cifmw_test_operator_tests_exclude_override_scenario: false

The names of the vars were updated so that this bool is defined.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
