### PR TITLE
Only collect crc logs on failed runs

### DIFF
--- a/roles/artifacts/tasks/main.yml
+++ b/roles/artifacts/tasks/main.yml
@@ -67,7 +67,7 @@
 
 - name: Collect crc logs when tests failed
   ignore_errors: true  # noqa: ignore-errors
-#  when: not cifmw_success_flag.stat.exists
+  when: not cifmw_success_flag.stat.exists
   ansible.builtin.import_tasks: crc.yml
 
 - name: Get EDPM logs


### PR DESCRIPTION
As mentioned here [1] I think this was a nit introduced just for testing.

Now we are collecting crc logs on every run, not just failed which
doesn't line up with the commit message on #1058

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/1058/files#r1473713965

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
