### PR TITLE
Render AsciiDoc docs

### DIFF
--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -119,6 +119,14 @@
             src: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/docs/_build/html"
             dest: "{{ ansible_user_dir }}/zuul-output/logs/doc_build"
 
+        - name: Copy generated AsciiDoc documentation if available
+          when:
+            - asciidoc_available | default(false) | bool
+          ansible.builtin.copy:
+            remote_src: true
+            src: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/docs_build"
+            dest: "{{ ansible_user_dir }}/zuul-output/logs/docs_build"
+
       always:
         - name: Copy files from workspace on node
           vars:

--- a/ci/playbooks/pre-doc.yml
+++ b/ci/playbooks/pre-doc.yml
@@ -23,3 +23,5 @@
         name:
           - make
           - python3
+          - golang
+          - ruby


### PR DESCRIPTION
Ref: https://github.com/openstack-k8s-operators/openstack-ansibleee-operator/pull/304/files#r1474357562

Logs: https://review.rdoproject.org/zuul/build/14c8a797c4a84c2ca3fb9bcc8dc1f903/logs

Preview: https://logserver.rdoproject.org/04/304/65cfd5f720e8c6f34dbcf2a82bbfe1672d7bcb4c/github-check/ansibleee-operator-docs-preview/14c8a79/docs_build/docs_build/ansibleee/index-upstream.html


As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes

