### PR TITLE
Properly detect partition id for 3-nodes layout as well

### DIFF
--- a/scenarios/reproducers/3-nodes.yml
+++ b/scenarios/reproducers/3-nodes.yml
@@ -16,6 +16,11 @@ cifmw_libvirt_manager_configuration:
   vms:
     compute:
       amount: 1
+      root_part_id: >-
+        {{
+          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
+          ternary(4, 1)
+        }}
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"
@@ -28,6 +33,11 @@ cifmw_libvirt_manager_configuration:
         - osp_trunk
     controller:
       image_url: "{{ cifmw_discovered_image_url }}"
+      root_part_id: >-
+        {{
+          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
+          ternary(4, 1)
+        }}
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"
       disk_file_name: "centos-stream-9.qcow2"


### PR DESCRIPTION
The validated-architecture-1.yml file has a way to detect what partition
has to be grown depending on the OS. This was missing from the
3-nodes.yml.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
