### PR TITLE
Clone all projects in the zuul reproducer

### DIFF
--- a/roles/reproducer/tasks/push_code.yml
+++ b/roles/reproducer/tasks/push_code.yml
@@ -41,11 +41,10 @@
 
     - name: Fetch zuul.projects repositories for dependencies
       when:
-        - repo.key is match('^github.com')
         - "repo.key not in (zuul['items'] | map(attribute='project.canonical_name'))"
       ansible.builtin.git:
         dest: "{{ repo.value.src_dir }}"
-        repo: "https://{{ repo.key }}"
+        repo: "https://{{ repo.value.canonical_hostname }}/{{ repo.value.canonical_hostname | reproducer_gerrit_infix }}{{ repo.value.name }}"
         version: "{{ repo.value.commit }}"
         force: true
       loop: "{{ zuul['projects'] | dict2items }}"


### PR DESCRIPTION
Clone all projects listed in the zuul inventory when reproducing a zuul
job, not just those coming from github. This is needed when reproducing
jobs defined in downstream gitlab that consume playbooks from internal
gerrit repos. If the internal gerrit repos are not in a depends-on, they
are not pulled and the playbooks are not found.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
