### PR TITLE
[network-values] Include missing vlan in subnet1

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/network-values.j2
+++ b/roles/ci_gen_kustomize_values/templates/network-values.j2
@@ -43,6 +43,9 @@ data:
         gateway: {{ network.gw_v4 }}
 {%      endif %}
         name: subnet1
+{%  if network.vlan_id is defined  %}
+        vlan: {{ network.vlan_id }}
+{%  endif %}
 {%    if ns.lb_tools | length > 0 %}
     lb_addresses:
 {%      for tool in ns.lb_tools.keys() %}


### PR DESCRIPTION
Without it vlan get set to null in Netconfig.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
