### PR TITLE
Correctly collect logs in collect-logs.yml

### DIFF
--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -69,12 +69,19 @@
               pip3 freeze >> ./python.log;
               dmesg -T > ./dmesg.log;
 
+        - name: Generate list of logs to collect in home directory
+          ansible.builtin.find:
+            paths: "{{ ansible_user_dir }}"
+            patterns: "*.log"
+          register: files_to_copy
+
         - name: Copy logs from home directory
           ignore_errors: true  # noqa: ignore-errors
-          ansible.builtin.command:
-            chdir: "{{ ansible_user_dir }}/zuul-output/logs/"
-            cmd: |
-              cp {{ ansible_user_dir }}/*.log .;
+          ansible.builtin.copy:
+            src: "{{ item.path }}"
+            dest: "{{ ansible_user_dir }}/zuul-output/logs/"
+            remote_src: true
+          loop: "{{ files_to_copy.files }}"
 
         - name: Copy crio stats log file
           when: cifmw_openshift_crio_stats | default(true)


### PR DESCRIPTION
This patch corrects an error in the collect-logs.yml playbook [1]
With this patch logs are now correctly collected.
    
[1]
```
TASK [Copy logs from home directory]
{"msg": "Source /home/zuul/*.log not found"}
```

Tested here: https://github.com/openstack-k8s-operators/tcib/pull/128
Captured log: https://logserver.rdoproject.org/28/128/1b4f01dfb0c152eb12924bbff765495c63262126/github-check/tcib-build-containers/9c737d6/dlrn.log

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
