### PR TITLE
interfaces_info does not contain information for compute-0

### DIFF
--- a/roles/libvirt_manager/tasks/attach_interface.yml
+++ b/roles/libvirt_manager/tasks/attach_interface.yml
@@ -58,8 +58,9 @@
         xpath: "/domain/devices/interface/source"
         content: "attribute"
 
-- name: Attach new port if needed
+- name: "Attach interface {{ network.name }} on {{ vm_name }}"  # noqa: name[template]
   vars:
+    _lm_mac_address: "{{ '52:54:00' | community.general.random_mac }}"
     # add prefix if needed/wanted
     _net_name: >-
       {{
@@ -79,36 +80,13 @@
       }}
   when:
     - _attached_bridges | length == 0
-  block:
-    - name: "Generate a random MAC address for {{ vm_name }}"
-      ansible.builtin.set_fact:
-        _lm_mac_address: "{{ '0A:02' | community.general.random_mac }}"
-
-    - name: "Attach interface {{ network.name }} on {{ vm_name }}"  # noqa: name[template]
-      when: _lm_mac_address is defined
-      ansible.builtin.command:
-        cmd: >-
-          virsh -c qemu:///system
-          attach-interface "{{ vm_name }}"
-          --source "{{ _local_bridge_name }}"
-          --type bridge
-          --mac "{{ _lm_mac_address }}"
-          --model virtio
-          --config
-          --persistent
-
-    - name: Inject data in cifmw_libvirt_manager_mac_map
-      when: _lm_mac_address is defined
-      vars:
-        _vm_name: "{{ vm_name | replace('cifmw-', '') }}"
-        _dataset: >-
-          {{
-            {_vm_name: [{'mac': _lm_mac_address,
-                        'network': network.name}]}
-          }}
-      ansible.builtin.set_fact:
-        cifmw_libvirt_manager_mac_map: >-
-          {{
-            cifmw_libvirt_manager_mac_map | default({}) |
-            combine(_dataset, recursive=true)
-          }}
+  ansible.builtin.command:
+    cmd: >-
+      virsh -c qemu:///system
+      attach-interface "{{ vm_name }}"
+      --source "{{ _local_bridge_name }}"
+      --type bridge
+      --mac "{{ _lm_mac_address }}"
+      --model virtio
+      --config
+      --persistent

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -105,7 +105,6 @@
   ansible.builtin.set_fact:
     cacheable: true
     cifmw_reproducer_network_data: {}
-    cifmw_libvirt_manager_mac_map: {}
 
 - name: List existing networks
   register: _virt_nets
@@ -136,7 +135,24 @@
     dest: "{{ cifmw_libvirt_manager_basedir }}/reproducer-inventory/all-group.yml"
     src: "all-inventory.yml.j2"
 
+- name: List running virtual machines.
+  community.libvirt.virt:
+    command: list_vms
+    state: running
+    uri: "qemu:///system"
+  register: _vms
+
+- name: Gather the networking information of running virtual machines.
+  when: "domain_name.startswith('cifmw')"
+  ansible.builtin.include_tasks: gather_vm_networks.yml
+  loop: "{{ _vms.list_vms }}"
+  loop_control:
+    label: "{{ domain_name }}"
+    loop_var: domain_name
+
+# The destination is intentional and does not match with other references.
 - name: Dump MAC mapping
+  when: cifmw_libvirt_manager_mac_map is defined
   ansible.builtin.copy:
     dest: "{{ cifmw_libvirt_manager_basedir }}/artifacts/interfaces-info.yml"
     content: "{{ cifmw_libvirt_manager_mac_map | to_nice_yaml }}"

--- a/roles/libvirt_manager/tasks/gather_vm_networks.yml
+++ b/roles/libvirt_manager/tasks/gather_vm_networks.yml
@@ -1,0 +1,40 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: List the attached interfaces.
+  ansible.builtin.command:
+    cmd: >-
+      virsh -q -c qemu:///system
+      domiflist
+      {{ domain_name }}
+  register: _dom_list
+
+- name: Gather the network and mac address.
+  vars:
+    _values: "{{ item.split() }}"
+    _data:
+      - key: "{{ domain_name | replace('cifmw-', '') }}"
+        value:
+          - network: "{{ _values[2] | replace('cifmw-', '') }}"
+            mac: "{{ _values[4] }}"
+  ansible.builtin.set_fact:
+    cifmw_libvirt_manager_mac_map: >-
+      {{
+        cifmw_libvirt_manager_mac_map |
+        default({}) |
+        combine(_data | items2dict, list_merge='append', recursive=true)
+      }}
+  loop: "{{ _dom_list.stdout_lines }}"


### PR DESCRIPTION
The default behavior of `combine` when it encounters a list is to `replace`. This was leading to erroneous information. This PR ensures that when `combine` encounters an existing role it appends to the list. 

As a pull request owner and reviewers, I checked that:

- [x] Appropriate testing is done and actually running

*Log Snippet*
The  greenfield deployment using `reproducer.yml` play was successful

```
PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
localhost                  : ok=369  changed=136  unreachable=0    failed=0    skipped=190  rescued=3    ignored=0   

Thursday 08 February 2024  15:35:40 +0200 (0:00:00.112)       0:53:39.646 ***** 
=============================================================================== 
devscripts : Deploying the OpenShift platform -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2358.14s
reproducer : Install internal CA ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 129.65s
reproducer : Install internal CA ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 112.57s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 78.59s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 48.35s
repo_setup : Install RHOS Release tool ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 39.14s
reproducer : Bootstrap environment on controller-0 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 38.85s
reproducer : Wait for OCP nodes to be ready ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 36.30s
reproducer : Install some tools ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 34.69s
reproducer : Install collections on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 33.16s
libvirt_manager : Grab IPs for nodes type ocp ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 31.63s
libvirt_manager : Grab IPs for nodes type compute ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 21.30s
libvirt_manager : Prepare disk image with SSH and growing volume --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 16.24s
libvirt_manager : Grab IPs for nodes type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.76s
libvirt_manager : Wait for SSH on VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.58s
libvirt_manager : Wait for SSH on VMs type ocp --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.50s
reproducer : Install ansible dependencies -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 11.12s
libvirt_manager : Download base image ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 11.12s
ci_setup : Install packages from EPEL ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 8.56s
libvirt_manager : Wait for SSH on VMs type controller ------------------------------------------------------------------------------------------------------------------------------------
```

There is a slight change (more) in the information captured in the `interfaces_info.yml`

```
compute-0:
-   mac: 52:54:00:xx:xx:xx
    network: ocpbm
-   mac: 52:54:00:xx:xx:xx
    network: osp_trunk
```

_Subsequent runs_
After cleanup and reruns scenario testing is complete and the tests have passed.

```
PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
localhost                  : ok=314  changed=116  unreachable=0    failed=0    skipped=125  rescued=0    ignored=0   

Thursday 08 February 2024  15:59:21 +0200 (0:00:00.104)       0:13:06.377 ***** 
=============================================================================== 
reproducer : Install internal CA ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 145.36s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 92.18s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 76.46s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 74.30s
reproducer : Bootstrap environment on controller-0 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 44.51s
reproducer : Install some tools ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 41.55s
reproducer : Install collections on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 30.88s
libvirt_manager : Grab IPs for nodes type ocp ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 26.49s
libvirt_manager : Grab IPs for nodes type compute ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 21.33s
libvirt_manager : Grab IPs for nodes type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.76s
libvirt_manager : Wait for SSH on VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.60s
libvirt_manager : Wait for SSH on VMs type ocp --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.50s
libvirt_manager : Prepare disk image with SSH and growing volume --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.08s
reproducer : Wait for OCP nodes to be ready ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 13.81s
libvirt_manager : Download base image ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 11.41s
reproducer : Install ansible dependencies -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 10.93s
libvirt_manager : Wait for SSH on VMs type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 5.21s
reproducer : Enable RHEL repos -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 4.02s
reproducer : Enable RHEL repos -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 3.98s
reproducer : Clone repository if needed: ci-framework --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 3.70s
[zuul@titanamd125 ci-framework]$
```