### PR TITLE
[test-operator] Introduce params for ssh-key and custom config files

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -339,6 +339,7 @@ polarion
 polkit
 pre
 prikey
+privatekey
 projectquay
 prometheus
 provisioner

--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -4,9 +4,9 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 
 ## Parameters
 
-* `cifmw_test_operator_artifacts_basedir`: (String) Directory where we will have all test_operator related files. Default value: `{{ cifmw_basedir }}/tests/test_operator` which defaults to `~/ci-framework-data/tests/test_operator`
+* `cifmw_test_operator_artifacts_basedir`: (String) Directory where we will have all test-operator related files. Default value: `{{ cifmw_basedir }}/tests/test_operator` which defaults to `~/ci-framework-data/tests/test_operator`
 * `cifmw_test_operator_namespace`: (String) Namespace inside which all the resources are created. Default value: `openstack`
-* `cifmw_test_operator_index`: (String) Full name of container image with index that contains the test_operator. Default value: `quay.io/openstack-k8s-operators/test-operator-index:latest`
+* `cifmw_test_operator_index`: (String) Full name of container image with index that contains the test-operator. Default value: `quay.io/openstack-k8s-operators/test-operator-index:latest`
 * `cifmw_test_operator_timeout`: (Integer) Timeout in seconds for the execution of the tests. Default value: `3600`
 * `cifmw_test_operator_logs_image`: (String) Image that should be used to collect logs from the pods spawned by the test-operator. Default value: `quay.io/quay/busybox`
 * `cifmw_test_operator_concurrency`: (Integer) Tempest concurrency value. Default value: `8`
@@ -15,6 +15,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_default_jobs`: (List) List of jobs in the exclude list to search for tests to be excluded. Default value: `[ 'default' ]`
 * `cifmw_test_operator_dry_run`: (Boolean) Whether test-operator should run or not. Default value: `false`
 
+## Tempest specific parameters
 * `cifmw_test_operator_tempest_registry`: (String) The registry where to pull tempest container. Default value: `quay.io`
 * `cifmw_test_operator_tempest_namespace`: (String) Registry's namespace where to pull tempest container. Default value: `podified-antelope-centos9`
 * `cifmw_test_operator_tempest_container`: (String) Name of the tempest container. Default value: `openstack-tempest`
@@ -24,9 +25,9 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_tempest_exclude_list`: (List) List of tests to be skipped. Setting this will not use the `list_skipped` plugin. Default value: `''`
 * `cifmw_test_operator_tempest_tests_include_override_scenario`: (Boolean) Whether to override the scenario `cifmw_tempest_tests_allowed` definition. Default value: `false`
 * `cifmw_test_operator_tempest_tests_exclude_override_scenario`: (Boolean) Whether to override the scenario `cifmw_tempest_tests_skipped` definition. Default value: `false`
-
-# Please refer to https://openstack-k8s-operators.github.io/test-operator/guide.html#executing-tempest-tests
-* `cifmw_test_operator_tempest_config`: (Object) Definition of Tempest CRD instance that is passed to the test-operator. Default value:
+* `cifmw_test_operator_tempest_ssh_key_secret_name`: (String) Name of a secret that contains ssh-privatekey field with a private key. The private key is mounted to `/var/lib/tempest/.ssh/id_ecdsa`
+* `cifmw_test_operator_tempest_config_overwrite`: (Dict) Dictionary where key is name of a file and value is content of the file. All files mentioned in this field are mounted to `/etc/test_operator/<filename>`
+* `cifmw_test_operator_tempest_config`: (Object) Definition of Tempest CRD instance that is passed to the test-operator (see [the test-operator documentation](https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource)). Default value:
 ```
   apiVersion: test.openstack.org/v1beta1
   kind: Tempest

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -25,7 +25,6 @@ cifmw_test_operator_logs_image: quay.io/quay/busybox
 cifmw_test_operator_concurrency: 8
 cifmw_test_operator_cleanup: false
 cifmw_test_operator_dry_run: false
-
 cifmw_test_operator_tempest_registry: quay.io
 cifmw_test_operator_tempest_namespace: podified-antelope-centos9
 cifmw_test_operator_tempest_container: openstack-tempest
@@ -41,6 +40,8 @@ cifmw_test_operator_tempest_config:
     namespace: "{{ cifmw_test_operator_namespace }}"
   spec:
     containerImage: "{{ cifmw_test_operator_tempest_image }}:{{ cifmw_test_operator_tempest_image_tag }}"
+    SSHKeySecretName: "{{ cifmw_test_operator_tempest_ssh_key_secret_name | default(omit) }}"
+    configOverwrite: "{{ cifmw_test_operator_tempest_config_overwrite | default(omit) }}"
     tempestRun:
       includeList: |
         {{ cifmw_test_operator_tempest_include_list | default('') }}


### PR DESCRIPTION
In this patch [1] a new set of parameters were introduced to the test-operatr. The 'SSHKeySecretName' enables the user to mount custom private key via openshift secret and 'customOverwrite' gives the user the ability to mount an arbitrary file with a content into the tempest test pod.

This change exposes the newly introduced parameters via the test-operator role.

[1] https://github.com/openstack-k8s-operators/test-operator/pull/39

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
