### PR TITLE
[test_operator] Pass externalPlugin to the tempest operator config

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -47,6 +47,8 @@ cephx
 cfg
 cguujglklirwawqujgnjdglklmfzb
 chandan
+changerefspec
+changerepository
 chdir
 chrony
 chronyc

--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -23,6 +23,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_tempest_image_tag`: (String) Tag for the `cifmw_test_operator_tempest_image`. Default value: `current-podified`
 * `cifmw_test_operator_tempest_include_list`: (String) List of tests to be executed. Setting this will not use the `list_allowed` plugin. Default value: `''`
 * `cifmw_test_operator_tempest_exclude_list`: (List) List of tests to be skipped. Setting this will not use the `list_skipped` plugin. Default value: `''`
+* `cifmw_test_operator_tempest_external_plugin`: (List) List of dicts describing any external plugin to be installed. The dictionary contains a repository, changeRepository (optional) and changeRefspec (optional). Default value: `[]`
 * `cifmw_test_operator_tempest_tests_include_override_scenario`: (Boolean) Whether to override the scenario `cifmw_tempest_tests_allowed` definition. Default value: `false`
 * `cifmw_test_operator_tempest_tests_exclude_override_scenario`: (Boolean) Whether to override the scenario `cifmw_tempest_tests_skipped` definition. Default value: `false`
 * `cifmw_test_operator_tempest_ssh_key_secret_name`: (String) Name of a secret that contains ssh-privatekey field with a private key. The private key is mounted to `/var/lib/tempest/.ssh/id_ecdsa`
@@ -42,5 +43,6 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
       excludeList: |
         {{ cifmw_test_operator_exclude_list | default('') }}
       concurrency: "{{ cifmw_test_operator_concurrency }}"
+      externalPlugin: "{{ cifmw_test_operator_tempest_external_plugin | default([]) }}"
     tempestconfRun: "{{ cifmw_tempest_tempestconf_config | default(omit) }}"
 ```

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -48,6 +48,7 @@ cifmw_test_operator_tempest_config:
       excludeList: |
         {{ cifmw_test_operator_tempest_exclude_list | default('') }}
       concurrency: "{{ cifmw_test_operator_concurrency }}"
+      externalPlugin: "{{ cifmw_test_operator_tempest_external_plugin | default([]) }}"
     tempestconfRun: "{{ cifmw_tempest_tempestconf_config | default(omit) }}"
 
 cifmw_test_operator_default_groups:


### PR DESCRIPTION
This allows using an arbitrary version of a plugin without overriding the whole cifmw_test_operator_tempest_config.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
