### PR TITLE
[test-operator] Fix handling of failed job

### DIFF
--- a/roles/test_operator/tasks/main.yml
+++ b/roles/test_operator/tasks/main.yml
@@ -143,15 +143,25 @@
     namespace: "{{ cifmw_test_operator_namespace }}"
     kind: Job
     name: "{{ cifmw_test_operator_tempest_name }}"
-    wait: true
-    wait_timeout: "{{ cifmw_test_operator_timeout }}"
-    wait_condition:
-      type: Complete
-      status: true
+  retries: "{{ (cifmw_test_operator_timeout / 10) | round | int }}"
+  delay: 10
+  until: >
+    tempest.resources[0].status.succeeded | default(0) | int >= 1 or
+    tempest.resources[0].status.failed | default(0) | int >= 1
+  ignore_errors: true
+  register: tempest
+  when: not cifmw_test_operator_dry_run | bool
+
+- name: Check whether tempest timed out
+  ansible.builtin.set_fact:
+    tempest_timed_out: >-
+      {{ tempest.attempts == (cifmw_test_operator_timeout / 10) | round | int }}
   when: not cifmw_test_operator_dry_run | bool
 
 - name: Start test-operator-logs-pod
-  when: not cifmw_test_operator_dry_run | bool
+  when:
+    - not cifmw_test_operator_dry_run | bool
+    - not tempest_timed_out
   kubernetes.core.k8s:
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
     api_key: "{{ cifmw_openshift_token | default(omit)}}"
@@ -190,7 +200,9 @@
   until: logs_pod.resources[0].status.phase == "Running"
   delay: 10
   retries: 20
-  when: not cifmw_test_operator_dry_run | bool
+  when:
+    - not cifmw_test_operator_dry_run | bool
+    - not tempest_timed_out
 
 - name: Get logs from test-operator-logs-pod
   environment:
@@ -199,7 +211,9 @@
   ansible.builtin.shell: >
     oc cp -n {{ cifmw_test_operator_namespace }} openstack/test-operator-logs-pod:mnt/
     {{ cifmw_test_operator_artifacts_basedir }}
-  when: not cifmw_test_operator_dry_run | bool
+  when:
+    - not cifmw_test_operator_dry_run | bool
+    - not tempest_timed_out
 
 - name: Get list of all pods
   kubernetes.core.k8s_info:


### PR DESCRIPTION
 [test-operator] Fix handling of failed job

There are two issues in the way of how the role does handle failed job

- Currently, the role waits for the Job that starts the execution of
  the test pod to reach Completed state but this state is only reached
  when the execution of the tests was successful. If there is an error
  the job finishes with Failed state.

- Logs are not collected when the the test pod times out

This patch updates the role so that it correctly waits for the job
completion (either with success or failure) and ensures that we collect
the logs (output of oc logs) even when the test pod times out.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
