### PR TITLE
Update cifmw-adoption-base to CRC 2.30 (OCP 4.14)

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -7,17 +7,7 @@
     abstract: true
     timeout: 10800
     attempts: 1
-    nodeset:
-      nodes:
-        - name: controller
-          label: cloud-centos-9-stream-tripleo-vexxhost
-        - name: crc
-          label: coreos-crc-extracted-3xl
-        - name: standalone
-          label: cloud-rhel-9-2
-      groups:
-        - name: computes
-          nodes: []
+    nodeset: centos-9-rhel-9-2-crc-extracted-2.30-3xl
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run:

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -51,3 +51,19 @@
     groups:
       - name: computes
         nodes: []
+
+- nodeset:
+    name: centos-9-rhel-9-2-crc-extracted-2.30-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: coreos-crc-extracted-2-30-0-3xl
+      - name: standalone
+        label: cloud-rhel-9-2
+    groups:
+      - name: computes
+        nodes: []
+      - name: ocps
+        nodes:
+          - crc


### PR DESCRIPTION
- Update from crc 2.19 to 2.30
- Extract nodeset from inline to nodeset.yaml
- Add ocps group (this may be used in the future)
- Move to unified zuul node label

JIRA: [OSPRH-4340](https://issues.redhat.com//browse/OSPRH-4340)
JIRA: [OSPRH-2712](https://issues.redhat.com//browse/OSPRH-2712)

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running