### PR TITLE
[devscripts] Support install customization.

### DIFF
--- a/roles/devscripts/README.md
+++ b/roles/devscripts/README.md
@@ -33,6 +33,7 @@ managed services.
   shutdown the whole OCP cluster, dump the XML, undefine the nodes, and prevents running the "post" tasks. Defaults to `false`.
 * `cifmw_devscripts_remove_default_net` (bool) Remove the default virtual network. Defaults to `false`.
 * `cifmw_devscripts_host_routing` (bool) Enable routing via host for OCP nodes in case of OVNKubernetes. Defaults to `false`.
+* `cifmw_devscripts_enable_iscsi` (bool) Enable iSCSI services on the OCP nodes having role as `worker`. Defaults to `false`.
 
 ### Secrets management
 

--- a/roles/devscripts/defaults/main.yml
+++ b/roles/devscripts/defaults/main.yml
@@ -32,6 +32,7 @@ cifmw_devscripts_restart_virtproxyd: true
 cifmw_devscripts_use_layers: false
 cifmw_devscripts_remove_default_net: false
 cifmw_devscripts_host_routing: false
+cifmw_devscripts_enable_iscsi: false
 
 cifmw_devscripts_osp_compute_nodes: []
 

--- a/roles/devscripts/files/ocp_iscsi.yml
+++ b/roles/devscripts/files/ocp_iscsi.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 90-enable-iscsi
+  labels:
+    machineconfiguration.openshift.io/role: worker
+    service: cinder
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+        - enabled: true
+          name: iscsid.service

--- a/roles/devscripts/tasks/01_prepare_host.yml
+++ b/roles/devscripts/tasks/01_prepare_host.yml
@@ -36,3 +36,8 @@
   tags:
     - bootstrap
   ansible.builtin.import_tasks: sub_tasks/14_user.yml
+
+- name: Custom OCP installation.
+  tags:
+    - bootstrap
+  ansible.builtin.import_tasks: sub_tasks/15_customization.yml

--- a/roles/devscripts/tasks/sub_tasks/14_user.yml
+++ b/roles/devscripts/tasks/sub_tasks/14_user.yml
@@ -45,24 +45,3 @@
     mode: "0640"
     content: |
       {{ cifmw_devscripts_user }}    ALL=(ALL)    NOPASSWD: ALL
-
-- name: Enable IP forwarding in the Network Operator.
-  when:
-    - cifmw_devscripts_config['network_type'] == 'OVNKubernetes'
-    - ("cifmw_devscripts_config.openshift_version is ansible.builtin.version('4.14.0', '>=')") or
-      (cifmw_devscripts_host_routing | bool)
-  vars:
-    ip_forward: "{{ cifmw_devscripts_config.openshift_version is ansible.builtin.version('4.14.0', '>=') }}"
-    host_routing: "{{ cifmw_devscripts_host_routing | bool }}"
-  ansible.builtin.template:
-    src: "templates/ovn_config.j2"
-    dest: >-
-      {{
-        [
-          cifmw_devscripts_config['assets_extra_folder'],
-          'ovn_k8s_config.yaml'
-        ] | ansible.builtin.path_join
-      }}
-    owner: "{{ cifmw_devscripts_user }}"
-    group: "{{ cifmw_devscripts_user }}"
-    mode: "0644"

--- a/roles/devscripts/tasks/sub_tasks/15_customization.yml
+++ b/roles/devscripts/tasks/sub_tasks/15_customization.yml
@@ -1,0 +1,53 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# Support OCP installation customization.
+
+- name: Enable IP forwarding in the Network Operator.
+  when:
+    - cifmw_devscripts_config['network_type'] == 'OVNKubernetes'
+    - ("cifmw_devscripts_config.openshift_version is ansible.builtin.version('4.14.0', '>=')") or
+      (cifmw_devscripts_host_routing | bool)
+  vars:
+    ip_forward: "{{ cifmw_devscripts_config.openshift_version is ansible.builtin.version('4.14.0', '>=') }}"
+    host_routing: "{{ cifmw_devscripts_host_routing | bool }}"
+  ansible.builtin.template:
+    src: "templates/ovn_config.j2"
+    dest: >-
+      {{
+        [
+          cifmw_devscripts_config['assets_extra_folder'],
+          'ovn_k8s_config.yaml'
+        ] | ansible.builtin.path_join
+      }}
+    owner: "{{ cifmw_devscripts_user }}"
+    group: "{{ cifmw_devscripts_user }}"
+    mode: "0644"
+
+- name: Enable iSCSI services on the OpenShift Nodes.
+  when: cifmw_devscripts_enable_iscsi | bool
+  ansible.builtin.copy:
+    src: files/ocp_iscsi.yml
+    dest: >-
+      {{
+        [
+          cifmw_devscripts_config.assets_extra_folder,
+          enable_iscsi.yaml
+        ] | ansible.builtin.path_join
+      }}
+    owner: "{{ cifmw_devscripts_user }}"
+    group: "{{ cifmw_devscripts_user }}"
+    mode: "0644"


### PR DESCRIPTION
In this change, a separete sub task is created to support customization of OpenShift Install via manifests. It includes enabling iSCSI service on the nodes participating in the cluster.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
