### PR TITLE
Expose external kustomizations field for ctrlplane

### DIFF
--- a/roles/edpm_prepare/README.md
+++ b/roles/edpm_prepare/README.md
@@ -16,3 +16,4 @@ This role doesn't need privilege escalation.
 * `cifmw_edpm_prepare_timeout`: (Integer) Time, in minutes to wait for the deployment to be ready. Defaults to `30`.
 * `cifmw_edpm_prepare_verify_tls`: (Boolean) In case of TLS enabled for OpenStack endpoint, validates against the CA. Defaults to `true`.
 * `cifmw_edpm_prepare_skip_patch_ansible_runner`: (Boolean) Intentionally skips setting ansible runner image to `latest` from quay.io. Defaults to `False`.
+* `cifmw_edpm_prepare_kustomizations`: (List) Kustomizations to apply on top of the controlplane CRs. Defaults to `[]`.

--- a/roles/edpm_prepare/defaults/main.yml
+++ b/roles/edpm_prepare/defaults/main.yml
@@ -27,3 +27,4 @@ cifmw_edpm_prepare_update_os_containers: false
 cifmw_edpm_prepare_timeout: 30
 cifmw_edpm_prepare_verify_tls: true
 cifmw_edpm_prepare_skip_patch_ansible_runner: false
+cifmw_edpm_prepare_kustomizations: []

--- a/roles/edpm_prepare/tasks/main.yml
+++ b/roles/edpm_prepare/tasks/main.yml
@@ -173,6 +173,7 @@
       ci_kustomize:
         target_path: "{{ cifmw_edpm_prepare_openstack_crs_path }}"
         sort_ascending: false
+        kustomizations: "{{ cifmw_edpm_prepare_kustomizations }}"
         kustomizations_paths: >-
           {{
             [


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
