### PR TITLE
Configure Ceph Object Store to use external Ceph rgw

### DIFF
--- a/roles/cifmw_cephadm/tasks/configure_object.yml
+++ b/roles/cifmw_cephadm/tasks/configure_object.yml
@@ -1,0 +1,61 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Check for existing object store config
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+  delegate_to: localhost
+  when: cifmw_openshift_kubeconfig is defined
+  block:
+    - name: Check if swift is enabled in deployed controlplane
+      ansible.builtin.shell: "set -o pipefail && oc get $(oc get oscp -n openstack -o name) -o json| jq .spec.swift.enabled"
+      register: swift_in_ctlplane
+
+    # checking swift_endpoints_count will avoid unnecessary errors during ceph deployment re-run
+    - name: Check if swift endpoint is already created
+      ansible.builtin.shell: "set -o pipefail && oc rsh openstackclient openstack endpoint list | grep 'swift.*object-store' | wc -l"
+      register: swift_endpoints_count
+      ignore_errors: true
+
+- name: Display a note about swift deployment
+  ansible.builtin.debug:
+    msg: "WARNING: Swift is deployed and the endpoint exists already, ceph RGW cannot be configured as object store service"
+  when:
+    - cifmw_openshift_kubeconfig is defined
+    - cifmw_ceph_daemons_layout.rgw_enabled | default(true) | bool
+    - swift_in_ctlplane.stdout | bool
+
+- name: Configure object store to use rgw
+  cifmw.general.ci_script:
+    extra_args:
+      KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    output_dir: "/home/zuul/ci-framework-data/artifacts"
+    script: |-
+      oc rsh openstackclient openstack service create --name swift --description 'OpenStack Object Storage' object-store
+      oc rsh openstackclient openstack user create --project service --password {{ cifmw_ceph_rgw_keystone_psw }}  swift
+      oc rsh openstackclient openstack role create swiftoperator
+      oc rsh openstackclient openstack role create ResellerAdmin
+      oc rsh openstackclient openstack role add --user swift --project service member
+      oc rsh openstackclient openstack role add --user swift --project service admin
+      oc rsh openstackclient openstack endpoint create --region regionOne object-store public http://{{ cifmw_cephadm_vip }}:8080/swift/v1/AUTH_%\(tenant_id\)s
+      oc rsh openstackclient openstack endpoint create --region regionOne object-store internal http://{{ cifmw_cephadm_vip }}:8080/swift/v1/AUTH_%\(tenant_id\)s
+      oc rsh openstackclient openstack role add --project admin --user admin swiftoperator
+  delegate_to: localhost
+  when:
+    - cifmw_openshift_kubeconfig is defined
+    - cifmw_ceph_daemons_layout.rgw_enabled | default(true) | bool
+    - not swift_in_ctlplane.stdout | bool
+    - swift_endpoints_count.stdout == "0"

--- a/roles/cifmw_cephadm/tasks/post.yml
+++ b/roles/cifmw_cephadm/tasks/post.yml
@@ -17,6 +17,9 @@
 - name: Get ceph_cli
   ansible.builtin.include_tasks: ceph_cli.yml
 
+- name: Configure ceph object store to use external ceph object gateway
+  ansible.builtin.include_tasks: configure_object.yml
+
 - name: Get the ceph orchestrator status
   ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} orch status --format json"
   register: ceph_orch_status


### PR DESCRIPTION
 This patch configures ceph object store to use external ceph object gateway (rgw) by running set of openstack commands in [1].

[1]
https://github.com/openstack-k8s-operators/docs/blob/main/ceph.md#configure-swift-with-a-rgw-backend


As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
