### PR TITLE
Change the var SSH_KEY to SSH_KEY_FILE

### DIFF
--- a/roles/install_yamls/defaults/main.yml
+++ b/roles/install_yamls/defaults/main.yml
@@ -34,4 +34,4 @@ cifmw_install_yamls_whitelisted_vars:
   - KUBECONFIG
   - OUTPUT_BASEDIR
   - OUTPUT_DIR
-  - SSH_KEY
+  - SSH_KEY_FILE


### PR DESCRIPTION
Since SSH_KEY doesn't exist anymore, but this same var is now set by the ci-framework playbooks[1]

Added the SSH_KEY_FILE var in `cifmw_install_yamls_whitelisted_vars`.

[1]: https://github.com/openstack-k8s-operators/ci-framework/blob/0307bd6cf552e8e2234f30f527f29c51cc1da329/hooks/playbooks/fetch_compute_facts.yml#L105

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
