### PR TITLE
Cleanup and update base.yaml jobs to CRC 2.30 (OCP 4.14)

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -107,18 +107,7 @@
     parent: base-extracted-crc
     timeout: 10800
     attempts: 1
-    nodeset: &multinode_edpm_nodeset
-      nodes:
-        - name: controller
-          label: cloud-centos-9-stream-tripleo-vexxhost-medium
-        - name: compute-0
-          label: cloud-centos-9-stream-tripleo-vexxhost
-        - name: crc
-          label: coreos-crc-extracted-3xl
-      groups:
-        - name: computes
-          nodes:
-            - compute-0
+    nodeset: centos-9-medium-centos-9-crc-extracted-2.30-3xl
     irrelevant-files: *ir_files
     required-projects: &multinode_edpm_rp
       - openstack-k8s-operators/ci-framework
@@ -205,7 +194,7 @@
     parent: base-extracted-crc-ci-bootstrap
     timeout: 10800
     attempts: 1
-    nodeset: *multinode_edpm_nodeset
+    nodeset: centos-9-medium-centos-9-crc-extracted-2.30-3xl
     irrelevant-files: *ir_files
     required-projects: *multinode_edpm_rp
     roles: *multinode_edpm_roles
@@ -225,7 +214,7 @@
     parent: base-extracted-crc-ci-bootstrap-staging
     timeout: 10800
     attempts: 1
-    nodeset: *multinode_edpm_nodeset
+    nodeset: centos-9-medium-centos-9-crc-extracted-2.30-3xl
     irrelevant-files: *ir_files
     required-projects: *multinode_edpm_rp
     roles: *multinode_edpm_roles
@@ -244,7 +233,7 @@
 #
 - job:
     name: cifmw-base-crc
-    nodeset: centos-9-crc-3xl
+    nodeset: centos-9-crc-2-30-0-3xl
     timeout: 10800
     abstract: true
     parent: base-simple-crc

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -33,7 +33,7 @@
     name: centos-stream-9
     nodes:
       - name: controller
-        label: cloud-centos-9-stream-tripleo-vexxhost
+        label: cloud-centos-9-stream-tripleo
     groups:
       - name: switch
         nodes:
@@ -67,3 +67,26 @@
       - name: ocps
         nodes:
           - crc
+
+- nodeset:
+    name: centos-9-medium-centos-9-crc-extracted-2.30-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: coreos-crc-extracted-2-30-0-3xl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-crc-2-30-0-3xl
+    nodes:
+      - name: controller
+        label: centos-9-stream-crc-2-30-0-3xl


### PR DESCRIPTION
- Update from crc 2.19 to 2.30
- Extract nodeset from inline to nodeset.yaml
- Add ocps group (this may be used in the future)
- Move to unified zuul node label

JIRA: [OSPRH-4340](https://issues.redhat.com//browse/OSPRH-4340)
JIRA: [OSPRH-2712](https://issues.redhat.com//browse/OSPRH-2712)

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running