### PR TITLE
Cleanup and update edpm_multinode.yaml jobs to CRC 2.30 (OCP 4.14)

### DIFF
--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -2,24 +2,7 @@
 - job:
     name: podified-multinode-edpm-deployment-crc-3comp
     parent: podified-multinode-edpm-deployment-crc
-    nodeset:
-      nodes:
-        - name: controller
-          label: cloud-centos-9-stream-tripleo-vexxhost-medium
-        - name: compute-0
-          label: cloud-centos-9-stream-tripleo-vexxhost
-        - name: compute-1
-          label: cloud-centos-9-stream-tripleo-vexxhost
-        - name: compute-2
-          label: cloud-centos-9-stream-tripleo-vexxhost
-        - name: crc
-          label: coreos-crc-extracted-2-19-0-xxl
-      groups:
-        - name: computes
-          nodes:
-            - compute-0
-            - compute-1
-            - compute-2
+    nodeset: centos-9-medium-3x-centos-9-crc-extracted-2-30-0-xxl
     vars:
       crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"
       crc_ci_bootstrap_networking:
@@ -95,24 +78,7 @@
 - job:
     name: podified-multinode-hci-deployment-crc-3comp
     parent: podified-multinode-edpm-deployment-crc
-    nodeset:
-      nodes:
-        - name: controller
-          label: cloud-centos-9-stream-tripleo-vexxhost-medium
-        - name: compute-0
-          label: cloud-centos-9-stream-tripleo-vexxhost
-        - name: compute-1
-          label: cloud-centos-9-stream-tripleo-vexxhost
-        - name: compute-2
-          label: cloud-centos-9-stream-tripleo-vexxhost
-        - name: crc
-          label: coreos-crc-extracted-2-19-0-xxl
-      groups:
-        - name: computes
-          nodes:
-            - compute-0
-            - compute-1
-            - compute-2
+    nodeset: centos-9-medium-3x-centos-9-crc-extracted-2-30-0-xxl
     vars:
       cifmw_edpm_deploy_hci: true
       crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"
@@ -212,18 +178,7 @@
 - job:
     name: podified-multinode-edpm-ironic-nobuild-tagged-crc
     parent: cifmw-podified-multinode-edpm-base-crc
-    nodeset:
-      nodes:
-        - name: controller
-          label: cloud-centos-9-stream-tripleo-vexxhost
-        - name: compute-0
-          label: cloud-centos-9-stream-tripleo-vexxhost
-        - name: crc
-          label: coreos-crc-extracted-2-19-0-3xl
-      groups:
-        - name: computes
-          nodes:
-            - compute-0
+    nodeset: centos-9-medium-centos-9-crc-extracted-2.30-3xl
     vars:
       cifmw_extras:
         - '@scenarios/centos-9/ci.yml'
@@ -256,18 +211,7 @@
 - job:
     name: podified-multinode-edpm-e2e-nobuild-tagged-crc
     parent: cifmw-podified-multinode-edpm-base-crc
-    nodeset:
-      nodes:
-        - name: controller
-          label: cloud-centos-9-stream-tripleo-vexxhost
-        - name: compute-0
-          label: cloud-centos-9-stream-tripleo-vexxhost
-        - name: crc
-          label: coreos-crc-extracted-2-19-0-3xl
-      groups:
-        - name: computes
-          nodes:
-            - compute-0
+    nodeset: centos-9-medium-centos-9-crc-extracted-2.30-3xl
     vars:
       cifmw_extras:
         - '@scenarios/centos-9/ci.yml'

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -90,3 +90,26 @@
     nodes:
       - name: controller
         label: centos-9-stream-crc-2-30-0-3xl
+
+- nodeset:
+    name: centos-9-medium-3x-centos-9-crc-extracted-2-30-0-xxl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-2
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: coreos-crc-extracted-2-30-0-xxl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+          - compute-2
+      - name: ocps
+        nodes:
+          - crc


### PR DESCRIPTION
- Update from crc 2.19 to 2.30
- Extract nodeset from inline to nodeset.yaml
- Add ocps group (this may be used in the future)
- Move to unified zuul node label

JIRA: [OSPRH-4340](https://issues.redhat.com//browse/OSPRH-4340)
JIRA: [OSPRH-2712](https://issues.redhat.com//browse/OSPRH-2712)

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
