### PR TITLE
 Cleanup and update tufu, molecule and tempest jobs to CRC 2.30 (OCP4.14)

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -1,19 +1,19 @@
 - job:
     name: cifmw-molecule-openshift_login
-    nodeset: centos-9-crc-xl
+    nodeset: centos-9-crc-2-30-0-xl
 - job:
     name: cifmw-molecule-openshift_provisioner_node
-    nodeset: centos-9-crc-xl
+    nodeset: centos-9-crc-2-30-0-xl
 - job:
     name: cifmw-molecule-openshift_setup
-    nodeset: centos-9-crc-xl
+    nodeset: centos-9-crc-2-30-0-xl
 - job:
     name: cifmw-molecule-rhol_crc
-    nodeset: centos-9-crc-xxl
+    nodeset: centos-9-crc-2-30-0-xxl
     timeout: 5400
 - job:
     name: cifmw-molecule-operator_deploy
-    nodeset: centos-9-crc-xl
+    nodeset: centos-9-crc-2-30-0-xl
 - job:
     name: cifmw-molecule-set_openstack_containers
     parent: cifmw-molecule-base-crc
@@ -37,34 +37,20 @@
     parent: cifmw-molecule-base-crc
 - job:
     name: cifmw-molecule-reproducer
-    nodeset: centos-9-crc-xxl
+    nodeset: centos-9-crc-2-30-0-xxl
     timeout: 5400
 - job:
     name: cifmw-molecule-cert_manager
-    nodeset: centos-9-crc-xxl
+    nodeset: centos-9-crc-2-30-0-xxl
 - job:
     name: cifmw-molecule-env_op_images
-    nodeset: centos-9-crc-xl
+    nodeset: centos-9-crc-2-30-0-xl
 - job:
     name: cifmw-molecule-manage_secrets
-    nodeset: centos-9-crc-xl
+    nodeset: centos-9-crc-2-30-0-xl
 - job:
     name: cifmw-molecule-ci_local_storage
-    nodeset: centos-9-crc-xl
+    nodeset: centos-9-crc-2-30-0-xl
 - job:
     name: cifmw-molecule-networking_mapper
-    nodeset:
-      nodes:
-        - name: controller
-          label: cloud-centos-9-stream-tripleo-vexxhost-medium
-        - name: compute-0
-          label: cloud-centos-9-stream-tripleo-vexxhost-medium
-        - name: compute-1
-          label: cloud-centos-9-stream-tripleo-vexxhost-medium
-        - name: crc
-          label: cloud-centos-9-stream-tripleo-vexxhost-medium
-      groups:
-        - name: computes
-          nodes:
-            - compute-0
-            - compute-1
+    nodeset: 4x-centos-9-medium

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -35,7 +35,7 @@
     - ^roles/cert_manager/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-cert_manager
-    nodeset: centos-9-crc-xxl
+    nodeset: centos-9-crc-2-30-0-xxl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: cert_manager
@@ -56,7 +56,7 @@
     - ^roles/ci_local_storage/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-ci_local_storage
-    nodeset: centos-9-crc-xl
+    nodeset: centos-9-crc-2-30-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: ci_local_storage
@@ -287,7 +287,7 @@
     - ^roles/env_op_images/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-env_op_images
-    nodeset: centos-9-crc-xl
+    nodeset: centos-9-crc-2-30-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: env_op_images
@@ -368,7 +368,7 @@
     - ^roles/manage_secrets/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-manage_secrets
-    nodeset: centos-9-crc-xl
+    nodeset: centos-9-crc-2-30-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: manage_secrets
@@ -379,21 +379,7 @@
     - ^roles/networking_mapper/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-networking_mapper
-    nodeset:
-      groups:
-      - name: computes
-        nodes:
-        - compute-0
-        - compute-1
-      nodes:
-      - label: cloud-centos-9-stream-tripleo-vexxhost-medium
-        name: controller
-      - label: cloud-centos-9-stream-tripleo-vexxhost-medium
-        name: compute-0
-      - label: cloud-centos-9-stream-tripleo-vexxhost-medium
-        name: compute-1
-      - label: cloud-centos-9-stream-tripleo-vexxhost-medium
-        name: crc
+    nodeset: 4x-centos-9-medium
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: networking_mapper
@@ -404,7 +390,7 @@
     - ^roles/openshift_login/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-openshift_login
-    nodeset: centos-9-crc-xl
+    nodeset: centos-9-crc-2-30-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: openshift_login
@@ -415,7 +401,7 @@
     - ^roles/openshift_provisioner_node/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-openshift_provisioner_node
-    nodeset: centos-9-crc-xl
+    nodeset: centos-9-crc-2-30-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: openshift_provisioner_node
@@ -426,7 +412,7 @@
     - ^roles/openshift_setup/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-openshift_setup
-    nodeset: centos-9-crc-xl
+    nodeset: centos-9-crc-2-30-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: openshift_setup
@@ -447,7 +433,7 @@
     - ^roles/operator_deploy/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-operator_deploy
-    nodeset: centos-9-crc-xl
+    nodeset: centos-9-crc-2-30-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: operator_deploy
@@ -498,7 +484,7 @@
     - ^roles/reproducer/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-reproducer
-    nodeset: centos-9-crc-xxl
+    nodeset: centos-9-crc-2-30-0-xxl
     parent: cifmw-molecule-base
     timeout: 5400
     vars:
@@ -510,7 +496,7 @@
     - ^roles/rhol_crc/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     name: cifmw-molecule-rhol_crc
-    nodeset: centos-9-crc-xxl
+    nodeset: centos-9-crc-2-30-0-xxl
     parent: cifmw-molecule-base
     timeout: 5400
     vars:

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -139,3 +139,29 @@
     nodes:
       - name: controller
         label: centos-9-stream-crc-2-30-0-6xlarge
+
+- nodeset:
+    name: centos-9-crc-2-30-0-xl
+    nodes:
+      - name: controller
+        label: centos-9-stream-crc-2-30-0-xl
+
+- nodeset:
+    name: 4x-centos-9-medium
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: crc
+        label: cloud-centos-9-stream-tripleo-medium
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+      - name: ocps
+        nodes:
+          - crc

--- a/zuul.d/tofu.yaml
+++ b/zuul.d/tofu.yaml
@@ -6,7 +6,7 @@
       - ^ci/playbooks/molecule.*
       - ^ci_framework/playbooks/run_tofu.yml
     name: cifmw-molecule-tofu
-    nodeset: centos-9-crc-xl
+    nodeset: centos-9-crc-2-30-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: openshift_login


### PR DESCRIPTION
- Update from crc 2.19 to 2.30
- Extract nodeset from inline to nodeset.yaml
- Add ocps group (this may be used in the future)
- Move to unified zuul node label

JIRA: [OSPRH-4340](https://issues.redhat.com//browse/OSPRH-4340)
JIRA: [OSPRH-2712](https://issues.redhat.com//browse/OSPRH-2712)

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1124
