### PR TITLE
Gather controller-0 logs in nested virt molecule

### DIFF
--- a/roles/reproducer/molecule/crc_layout/converge.yml
+++ b/roles/reproducer/molecule/crc_layout/converge.yml
@@ -162,6 +162,22 @@
           ansible.builtin.command:
             cmd: "ping -c1 -w1 {{ _ip }}"
 
+    - name: Gather logs from nested controller-0
+      vars:
+        _log_dest: "{{ ansible_user_dir }}/ci-framework-data/logs/controller-0"
+      block:
+        - name: Create log directory
+          ansible.builtin.file:
+            path: "{{ _log_dest }}"
+            state: directory
+            mode: "0755"
+
+        - name: Sync logs from controller-0
+          ansible.builtin.shell:  # noqa: command-instead-of-module
+            cmd: |-
+              rsync -r zuul@controller-0:"*.log" {{ _log_dest }};
+              rsync -r zuul@controller-0:ci-framework-data/logs {{ _log_dest }};
+
     - name: Assert all of the tests
       vars:
         _inventory_content: >-


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
