### PR TITLE
Temp switch adoption nodeset back to CRC 2.19

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -7,7 +7,7 @@
     abstract: true
     timeout: 10800
     attempts: 1
-    nodeset: centos-9-rhel-9-2-crc-extracted-2.30-3xl
+    nodeset: centos-9-rhel-9-2-crc-extracted-2.19-3xl
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run:

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -53,6 +53,22 @@
         nodes: []
 
 - nodeset:
+    name: centos-9-rhel-9-2-crc-extracted-2.19-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: coreos-crc-extracted-2-19-0-3xl
+      - name: standalone
+        label: cloud-rhel-9-2
+    groups:
+      - name: computes
+        nodes: []
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
     name: centos-9-rhel-9-2-crc-extracted-2.30-3xl
     nodes:
       - name: controller


### PR DESCRIPTION
Related CIX: [OSPCIX-182](https://issues.redhat.com//browse/OSPCIX-182)

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
