### PR TITLE
Make post-ceph ConfigMap values with cifmw_ceph_client

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -49,6 +49,7 @@ cguujglklirwawqujgnjdglklmfzb
 chandan
 changerefspec
 changerepository
+changeme
 chdir
 chrony
 chronyc
@@ -68,6 +69,7 @@ codeql
 conf
 config
 configmap
+configmaps
 configs
 containerfile
 controlplane

--- a/roles/cifmw_ceph_client/defaults/main.yml
+++ b/roles/cifmw_ceph_client/defaults/main.yml
@@ -33,3 +33,5 @@ cifmw_ceph_client_rbd_log_file: "{{ cifmw_ceph_client_rbd_log_path }}/qemu-guest
 cifmw_ceph_client_external_cluster_mon_ips: ''
 cifmw_ceph_client_k8s_secret_name: ceph-conf-files
 cifmw_ceph_client_k8s_namespace: openstack
+cifmw_ceph_client_values_post_ceph_path_dst: "{{ cifmw_ceph_client_fetch_dir }}/edpm_values_post_ceph.yaml"
+cifmw_ceph_client_service_values_post_ceph_path_dst: "{{ cifmw_ceph_client_fetch_dir }}/edpm_service_values_post_ceph.yaml"

--- a/roles/cifmw_ceph_client/tasks/edpm_service_values_post_ceph.yml
+++ b/roles/cifmw_ceph_client/tasks/edpm_service_values_post_ceph.yml
@@ -1,0 +1,42 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Read HCI post Ceph service values source file
+  ansible.builtin.slurp:
+    path: "{{ cifmw_ceph_client_service_values_post_ceph_path_src }}"
+  register: yaml_content
+
+- name: Write source service values to destination with modified keys
+  ansible.builtin.copy:
+    content: "{{ yaml_content.content | b64decode | from_yaml
+      | combine(modified_keys, recursive=True) | to_nice_yaml }}"
+    dest: "{{ cifmw_ceph_client_service_values_post_ceph_path_dst }}"
+  vars:
+    modified_keys:
+      data:
+        cinderVolumes:
+          ceph:
+            customServiceConfig: |-
+              [DEFAULT]
+              enabled_backends=ceph
+              [ceph]
+              volume_backend_name=ceph
+              volume_driver=cinder.volume.drivers.rbd.RBDDriver
+              rbd_flatten_volume_from_snapshot=False
+              rbd_pool=volumes
+              rbd_ceph_conf=/etc/ceph/{{ cifmw_ceph_client_cluster }}.conf
+              rbd_user={{ keys[0].name | replace('client.', '') }}
+              rbd_secret_uuid={{ cifmw_ceph_client_fsid }}

--- a/roles/cifmw_ceph_client/tasks/edpm_values_post_ceph.yml
+++ b/roles/cifmw_ceph_client/tasks/edpm_values_post_ceph.yml
@@ -1,0 +1,44 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Read HCI post Ceph values source file
+  ansible.builtin.slurp:
+    path: "{{ cifmw_ceph_client_values_post_ceph_path_src }}"
+  register: yaml_content
+
+- name: Write source values to destination with modified keys
+  ansible.builtin.copy:
+    content: "{{ yaml_content.content | b64decode | from_yaml
+      | combine(modified_keys, recursive=True) | to_nice_yaml }}"
+    dest: "{{ cifmw_ceph_client_values_post_ceph_path_dst }}"
+  vars:
+    modified_keys:
+      data:
+        ceph:
+          conf: "{{ cifmw_ceph_client_conf_file_b64.content }}"
+          keyring: "{{ cifmw_ceph_client_key_file_b64.content }}"
+        nova:
+          ceph:
+            conf: |-
+              [libvirt]
+              images_type=rbd
+              images_rbd_pool=vms
+              images_rbd_ceph_conf=/etc/ceph/{{ cifmw_ceph_client_cluster }}.conf
+              images_rbd_glance_store_name=default_backend
+              images_rbd_glance_copy_poll_interval=15
+              images_rbd_glance_copy_timeout=600
+              rbd_user={{ keys[0].name | replace('client.', '') }}
+              rbd_secret_uuid={{ cifmw_ceph_client_fsid }}

--- a/roles/cifmw_ceph_client/tasks/main.yml
+++ b/roles/cifmw_ceph_client/tasks/main.yml
@@ -77,3 +77,15 @@
     dest: "{{ cifmw_ceph_client_fetch_dir }}/k8s_ceph_secret.yml"
     mode: "0600"
     force: true
+
+- name: Create edpm-values-post-ceph ConfigMap if sample path provided
+  ansible.builtin.include_tasks: edpm_values_post_ceph.yml
+  when:
+    - cifmw_ceph_client_values_post_ceph_path_src is defined
+    - cifmw_ceph_client_values_post_ceph_path_src | length > 0
+
+- name: Create edpm-service-values-post-ceph ConfigMap if sample path provided
+  ansible.builtin.include_tasks: edpm_service_values_post_ceph.yml
+  when:
+    - cifmw_ceph_client_service_values_post_ceph_path_src is defined
+    - cifmw_ceph_client_service_values_post_ceph_path_src | length > 0


### PR DESCRIPTION
If the cifmw_ceph_client role is called with the variable `cifmw_ceph_client_values_post_ceph_path_src` set to the path of an HCI post Ceph values file [1], and with variable `cifmw_ceph_client_service_values_post_ceph_path_src` set to the path of a HCI post Ceph service values file [2], then copy those files to produce a version of them with the actual Ceph values substituted for the CHANGEME values.

The cifmw_ceph_client role already produces `k8s_ceph_secret.yaml` with the same values. However, that file should not be "oc applied" when the ci-framework deploys HCI VA, since those values should instead be passed as input to a kustomization in the architecture repo.

If the new variables are undefined, then the behavior of the cifmw_ceph_client role is unchanged.

[1] https://github.com/openstack-k8s-operators/architecture/blob/4af9a06c0a23f97bf73006e38931cf1e40597bc5/examples/va/hci/values.yaml
[2] https://github.com/openstack-k8s-operators/architecture/blob/4af9a06c0a23f97bf73006e38931cf1e40597bc5/examples/va/hci/service-values.yaml


As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
