### PR TITLE
Add a new role that integrates ovirt

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -47,9 +47,9 @@ cephx
 cfg
 cguujglklirwawqujgnjdglklmfzb
 chandan
+changeme
 changerefspec
 changerepository
-changeme
 chdir
 chrony
 chronyc
@@ -89,6 +89,7 @@ crypto
 csv
 ctl
 ctlplane
+ctrl
 ctx
 dashboard
 dataplane
@@ -152,6 +153,7 @@ gapped
 genericcloud
 genindex
 gerrit
+gib
 githooks
 golang
 gowork
@@ -229,9 +231,9 @@ lacp
 ldp
 libguestfs
 libvirt
+libvirt's
 libvirtd
 libvirterror
-libvirt's
 ljaumtawojy
 ljaumtaxojy
 ljaumtayojy
@@ -329,6 +331,8 @@ osd
 osp
 osprh
 otz
+ovirt
+ovirtmgmt
 ovn
 ovnkubernetes
 pablintino

--- a/requirements.yml
+++ b/requirements.yml
@@ -43,3 +43,5 @@ collections:
     type: git
   - name: https://github.com/openshift/community.okd
     type: git
+  - name: https://github.com/ovirt/ovirt-ansible-collection
+    type: git

--- a/roles/ovirt/README.md
+++ b/roles/ovirt/README.md
@@ -1,0 +1,79 @@
+# ovirt
+
+This role facilitates the integration of the ci-framework with oVirt, it is designed to deploy VMs on top of an oVirt infrastructure.
+
+## Requirements
+
+* The running Ansible host must have the `python3-ovirt-engine-sdk4` package installed.
+* A working oVirt instance is required.
+* A template for the created VMs must be available in the oVirt instance.
+
+Please ensure these requirements are met before using this role.
+
+## Parameters
+
+* `cifmw_ovirt_artifacts_basedir`: (String) Base artifacts directory. Defaults to `~/ci-framework-data/artifacts/ovirt`.
+* `cifmw_ovirt_ssh_public_key`: (String) SSH public key to pass to used as `authorized_ssh_keys`.
+* `cifmw_ovirt_vm_timeout`: (Integer) A number in seconds for vm creation process to time out. Defaults to `300`.
+* `cifmw_ovirt_sdk_package`: (String) Package name or URL to rpm, default to ovirt upstream rpm.
+* `cifmw_ovirt_layout`: (Dictionary) Dictionary specifying the layout of oVirt virtual machines for different roles:
+  * `name`: (String) Name of the VM.
+  * `amount`: (Integer) Number of VM instances.
+  * `memory`: (Integer) Memory allocation for the VM.
+  * `cpu`: (Integer) Number of CPUs for the VM.
+  * `template`: (String) Template for the VM. Defaults to "{{ cifmw_ovirt_template_rhel_guest_image }}".
+  * `nets` (List): List of network profiles for the oVirt virtual machines.
+    * `ovirtmgmt`: (String) Name of the network profile. ovirtmgmt is the default network.
+* `cifmw_ovirt_cloud_init`: (Dictionary) Configuration for cloud-init settings on the VMs:
+  * `user_name`: (String) Username for the VM. Defaults to 'root'.
+  * `root_password`: (String) Root password for the VM. Defaults to '12345678'.
+  * `authorized_ssh_keys`: (String) Authorized SSH keys for the VM.
+* `cifmw_ovirt_engine`: (Dictionary) Details for connecting to the oVirt engine.
+  It is recommended to store this sensitive information in a separate YAML file and encrypt it using Ansible Vault for security.
+  * `url`: (String) URL for the oVirt engine API.
+  * `fqdn`: (String) Fully Qualified Domain Name (FQDN) of the oVirt engine.
+  * `username`: (String) Username for authenticating with the oVirt engine.
+  * `password`: (String) Password for authenticating with the oVirt engine.
+  * `insecure`: (Boolean) Whether to ignore SSL certificate validation.
+* `cifmw_ovirt_cluster_name`: (String) Name of the oVirt cluster.
+* `cifmw_ovirt_template_rhel_guest_image`: (String) Name of the oVirt template for RHEL guest images.
+
+## Examples
+
+Create a new YAML file to store the oVirt engine details, for example, `ovirt_engine_vars.yml`
+(It is recommended to encrypt this file):
+
+```YAML
+---
+# ovirt_engine_vars.yml
+cifmw_ovirt_engine:
+  url: "https://ovirt.example.com/ovirt-engine/api"
+  username: "admin"
+  password: "password"
+  insecure: true
+```
+
+```YAML
+---
+- name: ovirt integration
+  hosts: localhost
+  var_files: ovirt_engine_vars.yml
+  vars:
+    cifmw_ovirt_layout:
+      - name: test-vm
+        amount: 1
+        # GiB
+        memory: 4
+        cpu: 8
+        template: "{{ cifmw_ovirt_template_rhel_guest_image }}"
+        nets:
+          - ovirtmgmt
+  roles:
+    - ovirt
+```
+
+## Molecule
+
+This role depends on a pre-existing oVirt instance.
+As the setup of an oVirt instance is not included in the automation, Molecule testing is not applicable for this role in the context of oVirt.
+The role assumes the presence of a functioning oVirt environment for its execution.

--- a/roles/ovirt/defaults/main.yml
+++ b/roles/ovirt/defaults/main.yml
@@ -1,0 +1,46 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_ovirt"
+
+cifmw_ovirt_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts"
+cifmw_ovirt_ssh_key_type: "{{ cifmw_ssh_keytype | default('ecdsa') }}"
+cifmw_ovirt_ssh_key_size: "{{ cifmw_ssh_keysize | default(521) }}"
+cifmw_ovirt_ssh_public_key: ""
+cifmw_ovirt_vm_timeout: 300
+cifmw_ovirt_sdk_package: "https://github.com/oVirt/python-ovirt-engine-sdk4/releases/download/4.6.2/python3-ovirt-engine-sdk4-4.6.2-1.el9.x86_64.rpm"
+
+cifmw_ovirt_cloud_init:
+  user_name: "{{ cifmw_ovirt_vm_user | default('root') }}"
+  root_password: "{{ cifmw_ovirt_vm_pass | default('12345678') }}"
+  authorized_ssh_keys: "{{ cifmw_ovirt_ssh_public_key | default(_ssh_public_key.public_key) }}"
+  custom_script: |
+    runcmd:
+      - sed -i 's/^PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+      - sed -i -e 's/#*\s*PermitRootLogin/PermitRootLogin/g' /etc/ssh/sshd_config
+
+cifmw_ovirt_layout:
+  - name: test-vm
+    amount: 1
+    # GiB
+    memory: 4
+    cpu: 8
+    template: "{{ cifmw_ovirt_template_rhel_guest_image }}"
+    cloud_init: "{{ cifmw_ovirt_cloud_init }}"
+    nets:
+      - rhevm-ifacemacspoof

--- a/roles/ovirt/meta/main.yml
+++ b/roles/ovirt/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- ovirt
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: cifmw
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - cifmw
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/ovirt/tasks/cleanup.yml
+++ b/roles/ovirt/tasks/cleanup.yml
@@ -1,0 +1,63 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Check if variables are defined and have specific values
+  ansible.builtin.assert:
+    fail_msg: >-
+      One or more variables are not defined or do not have expected values!
+    that:
+      - (cifmw_ovirt_engine.url is defined) or (lookup('env','OVIRT_URL'))
+      - (cifmw_ovirt_engine.username is defined) or (lookup('env','OVIRT_USERNAME'))
+      - (cifmw_ovirt_engine.password is defined) or (lookup('env','OVIRT_PASSWORD'))
+      - (cifmw_ovirt_engine.insecure is defined) or (lookup('env','OVIRT_INSECURE'))
+
+- name: Ensure artifact file exists
+  register: _artifact_file
+  ansible.builtin.stat:
+    path: "{{ cifmw_ovirt_artifacts_basedir }}/ovirt-vms-info.yml"
+
+- name: Tasks to perform on ovirt
+  when: _artifact_file.stat.exists
+  block:
+    - name: Login to oVirt
+      when: cifmw_ovirt_engine is defined or not cifmw_ovirt_engine
+      ovirt.ovirt.ovirt_auth:
+        url: "{{ cifmw_ovirt_engine.url | default(lookup('env','OVIRT_URL')) | default(omit) }}"
+        username: "{{ cifmw_ovirt_engine.username | default(lookup('env','OVIRT_USERNAME')) | default(omit) }}"
+        password: "{{ cifmw_ovirt_engine.password | default(lookup('env','OVIRT_PASSWORD')) | default(omit) }}"
+        insecure: "{{ cifmw_ovirt_engine.insecure | default(lookup('env','OVIRT_INSECURE')) | default(false) }}"
+
+    - name: Include variable file
+      ansible.builtin.include_vars:
+        file: "{{ cifmw_ovirt_artifacts_basedir }}/ovirt-vms-info.yml"
+
+    - name: Delete VMs from artifact file
+      ovirt.ovirt.ovirt_vm:
+        auth: "{{ ovirt_auth }}"
+        name: "{{ item.name }}"
+        state: "absent"
+      loop: "{{ cifmw_ovirt_vms }}"
+
+  always:
+    - name: Logout from oVirt
+      ovirt.ovirt.ovirt_auth:
+        state: absent
+        ovirt_auth: "{{ ovirt_auth }}"
+
+- name: Remove ovirt artifacts file
+  ansible.builtin.file:
+    path: "{{ cifmw_ovirt_artifacts_basedir }}/ovirt-vms-info.yml"
+    state: absent

--- a/roles/ovirt/tasks/create_vms.yml
+++ b/roles/ovirt/tasks/create_vms.yml
@@ -1,0 +1,64 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Generate list of networks
+  when: vm_layout.nets | length > 0
+  ansible.builtin.set_fact:
+    _nics_list: "{{ _nics_list | default([]) + [{'name': 'nic' ~ (index + 1) , 'profile_name': item}] }}"
+  loop: "{{ vm_layout.nets }}"
+  loop_control:
+    index_var: index
+
+- name: Gather vnic profiles info
+  loop: "{{ _nics_list }}"
+  register: _network_info
+  ovirt.ovirt.ovirt_vnic_profile_info:
+    auth: "{{ ovirt_auth }}"
+    name: "{{ item.profile_name }}"
+
+- name: Fail if any of the vnic profiles does not exist
+  when: item.ovirt_vnic_profiles | length == 0
+  loop: "{{ _network_info.results }}"
+  ansible.builtin.fail:
+    msg: "Network profile {{ item.item.profile_name }} does not exist"
+
+- name: Create VMs from the imported template
+  ovirt.ovirt.ovirt_vm:
+    auth: "{{ ovirt_auth }}"
+    name: "cifmw-{{ cifmw_ovirt_env_prefix }}-{{ vm_layout.name }}{{ '%02d' | format(index + 1) }}"
+    type: server
+    cluster: "{{ cifmw_ovirt_cluster_name }}"
+    template: "{{ vm_layout.template }}"
+    cpu_cores: "{{ vm_layout.cpu | default ('1') }}"
+    memory: "{{ vm_layout.memory | default ('4') }}GiB"
+    state: "{{ cifmw_ovirt_vm_state }}"
+    comment: "{{ cifmw_ovirt_vm_comment }}"
+    clone: true
+    nics: "{{ _nics_list }}"
+    wait: true
+    timeout: "{{ cifmw_ovirt_vm_timeout }}"
+    cloud_init: "{{ cifmw_ovirt_cloud_init | default(omit) }}"
+  loop: "{{ range(0, vm_layout.amount | default(1) | int ) }}"
+  loop_control:
+    index_var: index
+
+- name: Fetch IP addresses
+  vars:
+    indexed_vm_name: "cifmw-{{ cifmw_ovirt_env_prefix }}-{{ vm_layout.name }}{{ '%02d' | format(index + 1) }}"
+  ansible.builtin.include_tasks: retrieve_vm_ip.yml
+  loop: "{{ range(0, vm_layout.amount | default(1) | int ) }}"
+  loop_control:
+    index_var: index

--- a/roles/ovirt/tasks/main.yml
+++ b/roles/ovirt/tasks/main.yml
@@ -1,0 +1,102 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.1
+
+- name: Check if variables are defined and have specific values
+  ansible.builtin.assert:
+    fail_msg: >-
+      One or more variables are not defined or do not have expected values!
+    that:
+      - (cifmw_ovirt_engine.url is defined) or (lookup('env','OVIRT_URL'))
+      - (cifmw_ovirt_engine.username is defined) or (lookup('env','OVIRT_USERNAME'))
+      - (cifmw_ovirt_engine.password is defined) or (lookup('env','OVIRT_PASSWORD'))
+      - (cifmw_ovirt_engine.insecure is defined) or (lookup('env','OVIRT_INSECURE'))
+      - (cifmw_ovirt_cluster_name is defined) or (lookup('env','OVIRT_CLUSTER_NAME'))
+      - cifmw_ovirt_template_rhel_guest_image is defined
+
+- name: Install oVirt SDK package
+  become: true
+  ansible.builtin.package:
+    name: "{{ cifmw_ovirt_sdk_package }}"
+    state: present
+    disable_gpg_check: true
+
+- name: Ensure artifacts directory present
+  ansible.builtin.file:
+    path: "{{ cifmw_ovirt_artifacts_basedir }}"
+    state: directory
+
+- name: Ensure ssh key exists
+  when: cifmw_ovirt_ssh_public_key | length > 0
+  register: _ssh_public_key
+  community.crypto.openssh_keypair:
+    path: "{{ ansible_user_dir  }}/.ssh/id_{{ cifmw_ovirt_ssh_key_type }}"
+    type: "{{ cifmw_ovirt_ssh_key_type }}"
+    size: "{{ cifmw_ovirt_ssh_key_size }}"
+
+- name: Login to oVirt
+  when: cifmw_ovirt_engine is defined or not cifmw_ovirt_engine
+  ovirt.ovirt.ovirt_auth:
+    url: "{{ cifmw_ovirt_engine.url | default(lookup('env','OVIRT_URL')) | default(omit) }}"
+    username: "{{ cifmw_ovirt_engine.username | default(lookup('env','OVIRT_USERNAME')) | default(omit) }}"
+    password: "{{ cifmw_ovirt_engine.password | default(lookup('env','OVIRT_PASSWORD')) | default(omit) }}"
+    insecure: "{{ cifmw_ovirt_engine.insecure | default(lookup('env','OVIRT_INSECURE')) | default(false) }}"
+
+- name: Tasks to perform on ovirt
+  block:
+    - name: Set an environment prefix
+      when: cifmw_ovirt_env_prefix is undefined
+      ansible.builtin.set_fact:
+        cifmw_ovirt_env_prefix: >-
+          {{
+            lookup('community.general.random_string',
+                    length=5,
+                    lower=true,
+                    upper=false,
+                    special=false)
+          }}
+
+    - name: Gather template info
+      register: _template_info
+      ovirt.ovirt.ovirt_template_info:
+        auth: "{{ ovirt_auth }}"
+        pattern: "name={{ cifmw_ovirt_template_rhel_guest_image }}"
+
+    - name: Fail if template does not exist
+      when: _template_info.ovirt_templates | length == 0
+      ansible.builtin.fail:
+        msg: "Template {{ cifmw_ovirt_template_rhel_guest_image }} does not exist"
+
+    - name: Loop over cifmw_ovirt_layout and include tasks
+      ansible.builtin.include_tasks: create_vms.yml
+      loop: "{{ cifmw_ovirt_layout }}"
+      loop_control:
+        loop_var: vm_layout
+
+    - name: Export some variables as an artifacts
+      vars:
+        ovirt_info:
+          cifmw_ovirt_env_prefix: "{{ cifmw_ovirt_env_prefix }}"
+          cifmw_ovirt_vms: "{{ _vm_ip_addresses }}"
+      ansible.builtin.copy:
+        dest: "{{ cifmw_ovirt_artifacts_basedir }}/ovirt-vms-info.yml"
+        content: |
+          {{ ovirt_info | to_nice_yaml(indent=2) }}
+
+  always:
+    - name: Logout from oVirt
+      ovirt.ovirt.ovirt_auth:
+        state: absent
+        ovirt_auth: "{{ ovirt_auth }}"

--- a/roles/ovirt/tasks/retrieve_vm_ip.yml
+++ b/roles/ovirt/tasks/retrieve_vm_ip.yml
@@ -1,0 +1,32 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Wait for VM IP
+  ovirt.ovirt.ovirt_vm_info:
+    auth: "{{ ovirt_auth }}"
+    pattern: "name={{ indexed_vm_name }}"
+    fetch_nested: true
+    nested_attributes: ips
+  register: _vm_info
+  retries: 10
+  delay: 5
+  until: _vm_info.ovirt_vms | ovirt.ovirt.ovirtvmipv4 | length > 0
+
+- name: Gather VM IPv4 addresses
+  when: _vm_info.ovirt_vms | ovirt.ovirt.ovirtvmipv4 is defined
+  ansible.builtin.set_fact:
+    _vm_ip_addresses: "{{ _vm_ip_addresses | default([]) + [{'name': indexed_vm_name, 'ip_address': item}] }}"
+  loop: "{{ [_vm_info.ovirt_vms | ovirt.ovirt.ovirtvmipv4] }}"

--- a/roles/ovirt/vars/main.yml
+++ b/roles/ovirt/vars/main.yml
@@ -1,0 +1,25 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# While options found within the vars/ path can be overridden using extra
+# vars, items within this path are considered part of the role and not
+# intended to be modified.
+
+# All variables within this role should have a prefix of "cifmw_ovirt"
+
+cifmw_ovirt_vm_comment: "ci-framework"
+cifmw_ovirt_vm_state: "running"


### PR DESCRIPTION
This role facilitates the integration of the ci-framework with oVirt,
enabling adoption testing.
The role is designed to deploy OSP-17.x VMs on top of the oVirt
infrastructure specifically for adoption testing purposes.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
