### PR TITLE
Display vars used in EDPM deployment playbook in zuul console

### DIFF
--- a/ci/playbooks/edpm/run.yml
+++ b/ci/playbooks/edpm/run.yml
@@ -15,6 +15,25 @@
         path: "{{ ansible_user_dir }}/ci-framework-data/artifacts/edpm-ansible.yml"
       register: edpm_file
 
+    - name: Display vars used in EDPM deployment playbook
+      ansible.builtin.command:
+        chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
+        cmd: >-
+          ansible-inventory
+          -i "{{ ansible_user_dir }}/ci-framework-data/artifacts/zuul_inventory.yml"
+          -e @scenarios/centos-9/base.yml
+          -e @scenarios/centos-9/edpm_ci.yml
+          {%- if edpm_file.stat.exists %}
+          -e @{{ ansible_user_dir }}/ci-framework-data/artifacts/edpm-ansible.yml
+          {%- endif %}
+          {%- if cifmw_extras is defined %}
+          {%-   for extra_var in cifmw_extras %}
+          -e "{{   extra_var }}"
+          {%-   endfor %}
+          {%- endif %}
+          -e "@{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml"
+          --list
+
     - name: Run Podified EDPM deployment
       ansible.builtin.command:
         chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"


### PR DESCRIPTION
Display final vars values used in EDPM deployment playbook in zuul console to be able to check if expected values where set in job definition. There are many places where values of vars can be overriden and final view of vars can help to debug job.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
