### PR TITLE
Attach storagemgmt net to computes in the Networking Definition

### DIFF
--- a/scenarios/reproducers/networking-definition.yml
+++ b/scenarios/reproducers/networking-definition.yml
@@ -113,6 +113,7 @@ cifmw_networking_definition:
         internalapi: {}
         tenant: {}
         storage: {}
+        storagemgmt: {}
   instances:
     controller-0:
       networks:


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
