### PR TITLE
Add wait for openstack operator

### DIFF
--- a/roles/edpm_prepare/tasks/main.yml
+++ b/roles/edpm_prepare/tasks/main.yml
@@ -193,6 +193,22 @@
       ansible.builtin.debug:
         var: cifmw_edpm_prepare_crs_kustomize_result
 
+    - name: Wait for openstack-operator-controller-manager pod to be ready
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit)}}"
+        context: "{{ cifmw_openshift_context | default(omit) }}"
+        namespace: openstack-operators
+        kind: Pod
+        wait: true
+        wait_sleep: 10
+        wait_timeout: 600
+        wait_condition:
+          type: Ready
+          status: "True"
+        label_selectors:
+          - "openstack.org/operator-name = openstack"
+
     - name: Apply the OpenStackControlPlane CR
       environment:
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"


### PR DESCRIPTION
\- Add wait on openstack operator status being ready

Problem:
We're seeing issues applying the OpenStackControlPlane CR because the
openstack operator webhook is not up yet. Waiting for the ready condition
will ensure the operator is ready for requests.

[1]
```
2024-02-12 18:46:38.263494 TASK [edpm_prepare : Apply the OpenStackControlPlane CR
`Internal error occurred: failed calling webhook \"mopenstackcontrolplane.kb.io\": failed to call webhook`
```

[2]
```
2024-02-12T23:46:45.169Z	INFO	controller-runtime.webhook	Serving webhook server	{"host": "", "port": 9443}
```

[1] https://logserver.rdoproject.org/22/722/e2dd0f26cbf33fba8cf4aeff668ade3575a53de0/github-check/install-yamls-crc-podified-edpm-baremetal/1b424aa/job-output.txt
[2] https://logserver.rdoproject.org/22/722/e2dd0f26cbf33fba8cf4aeff668ade3575a53de0/github-check/install-yamls-crc-podified-edpm-baremetal/1b424aa/ci-framework-data/logs/openstack-k8s-operators-openstack-must-gather/namespaces/openstack-operators/pods/openstack-operator-controller-manager-699f5c6f99-c9cgh/logs/manager.log

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running