### PR TITLE
Fix skeleton_role tasks to use fqcn debug module

### DIFF
--- a/_skeleton_role_/tasks/cleanup.yml.j2
+++ b/_skeleton_role_/tasks/cleanup.yml.j2
@@ -15,5 +15,5 @@
 # under the License.
 
 - name: Cleaning the World
-  debug:
+  ansible.builtin.debug:
     msg: "So here {{ role_name }} should clean things up!"

--- a/_skeleton_role_/tasks/main.yml.j2
+++ b/_skeleton_role_/tasks/main.yml.j2
@@ -15,5 +15,5 @@
 # under the License.
 
 - name: Hello World
-  debug:
+  ansible.builtin.debug:
     msg: "Hello world from {{ role_name }}"


### PR DESCRIPTION
Tasks in skeleton_role contains debug module action. To fix ansible-lint fqcn violation change debug action to fqcn module.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
