### PR TITLE
[libvirt_manager] Fix undefined variable cifmw_reproducer_basedir

### DIFF
--- a/roles/libvirt_manager/tasks/start_manage_vms.yml
+++ b/roles/libvirt_manager/tasks/start_manage_vms.yml
@@ -67,7 +67,7 @@
     extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
     identity_file: >-
       {{
-        cifmw_reproducer_basedir ~ '/artifacts/cifmw_ocp_access_key' if vm_type == 'ocp' else
+        cifmw_libvirt_manager_basedir ~ '/artifacts/cifmw_ocp_access_key' if vm_type == 'ocp' else
         ansible_user_dir ~ '/.crc/machines/crc/id_ecdsa' if vm_type == 'crc' else
         ansible_user_dir ~ '/.ssh/cifmw_reproducer_key'
       }}


### PR DESCRIPTION
This change removes the reference of `cifmw_reproducer_basedir` in `libvirt_manager` role. Referencing the tasks from `start_manage_vms` throws `undefined variable name`.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
