### PR TITLE
Update content provider job to use Vexxhost label

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -23,6 +23,7 @@
 - job:
     name: openstack-k8s-operators-content-provider
     parent: cifmw-base-minimal
+    nodeset: centos-stream-9-vexxhost
     irrelevant-files: &ir_files
       - .*/*.md
       - ^.github/.*$

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -42,6 +42,18 @@
         nodes: []
 
 - nodeset:
+    name: centos-stream-9-vexxhost
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-vexxhost
+    groups:
+      - name: switch
+        nodes:
+          - controller
+      - name: peers
+        nodes: []
+
+- nodeset:
     name: multinode-centos-9-stream-crc
     nodes:
       - name: controller


### PR DESCRIPTION
Currently the content provider node can get scheduled onto IBM cloud
and get a private IP, only jobs also scheduled on IBM cloud can access
and pull containers. You can see it here how only one job passed:
https://review.rdoproject.org/zuul/buildset/682107b0c1b7406383063a285e4a2cb1

The job that passed and the content-provider are on IBM cloud, the rest
are running in Vexxhost and failing to pull containers from the
content-provider.

- Add new nodeset `centos-stream-9-vexxhost` that only targets Vexxhost
cloud
- Update `openstack-k8s-operators-content-provider` to use new nodeset

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running