### PR TITLE
Drop nested virt edpm job definitions

### DIFF
--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -1,13 +1,4 @@
 ---
-# EDPM job with single node
-- job:
-    name: cifmw-crc-podified-edpm-deployment
-    parent: cifmw-base-crc-openstack
-    run: ci/playbooks/edpm/run.yml
-    vars:
-      cifmw_extras:
-        - '@scenarios/centos-9/nested_virt.yml'
-
 # Virtual Baremetal job with CRC and single compute node.
 - job:
     name: cifmw-crc-podified-edpm-baremetal
@@ -17,37 +8,6 @@
     vars:
       crc_parameters: "--memory 32000 --disk-size 240 --cpus 12"
       cifmw_manage_secrets_pullsecret_content: '{}'
-
-# Podified galera job
-- job:
-    name: cifmw-crc-podified-galera-deployment
-    parent: cifmw-crc-podified-edpm-deployment
-    vars:
-      cifmw_deploy_edpm: false
-      cifmw_use_libvirt: false
-      podified_validation: true
-      cifmw_run_tests: false
-
-# Install Yamls specific job
-- job:
-    name: ci-framework-crc-podified-edpm-deployment
-    parent: cifmw-crc-podified-edpm-deployment
-    files:
-      - ^playbooks/*
-      - ^roles/edpm_prepare/(?!meta|README).*
-      - ^roles/edpm_deploy/(?!meta|README).*
-      - ^roles/artifacts/tasks/edpm.yml
-      - ^deploy-edpm.yml
-      - ^scenarios/centos-9/edpm_ci.yml
-
-- job:
-    name: ci-framework-crc-podified-galera-deployment
-    parent: cifmw-crc-podified-galera-deployment
-    files:
-      - ^playbooks/*
-      - ^roles/edpm_prepare/(?!meta|README).*
-      - ^deploy-edpm.yml
-      - ^scenarios/centos-9/edpm_ci.yml
 
 - job:
     name: ci-framework-crc-podified-edpm-baremetal

--- a/zuul.d/edpm_periodic.yaml
+++ b/zuul.d/edpm_periodic.yaml
@@ -1,7 +1,7 @@
 ---
 - job:
-    name: periodic-podified-edpm-deployment-master-ocp-crc-1cs9
-    parent: cifmw-crc-podified-edpm-deployment
+    name: periodic-podified-edpm-baremetal-master-ocp-crc
+    parent: cifmw-crc-podified-edpm-baremetal
     vars: &edpm_vars
       cifmw_repo_setup_branch: master
       cifmw_repo_setup_promotion: podified-ci-testing
@@ -10,10 +10,6 @@
         - '@scenarios/centos-9/nested_virt.yml'
         - '@scenarios/centos-9/edpm_periodic.yml'
 
-- job:
-    name: periodic-podified-edpm-baremetal-master-ocp-crc
-    parent: cifmw-crc-podified-edpm-baremetal
-    vars: *edpm_vars
 
 - job:
     name: periodic-podified-multinode-edpm-deployment-master-ocp-crc-cs9
@@ -38,13 +34,6 @@
       cifmw_dlrn_report_result: true
 
 # Antelope jobs
-- job:
-    name: periodic-podified-edpm-deployment-antelope-ocp-crc-1cs9
-    parent: periodic-podified-edpm-deployment-master-ocp-crc-1cs9
-    vars:
-      cifmw_repo_setup_branch: antelope
-      cifmw_set_openstack_containers_namespace: podified-{{ cifmw_repo_setup_branch }}-centos9
-
 - job:
     name: periodic-podified-edpm-baremetal-antelope-ocp-crc
     parent: periodic-podified-edpm-baremetal-master-ocp-crc


### PR DESCRIPTION
These jobs are no longer used and it needs to be cleaned up.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running

