### PR TITLE
Make dnsmasq listen to localhost in the reproducer

### DIFF
--- a/roles/reproducer/tasks/configure_crc.yml
+++ b/roles/reproducer/tasks/configure_crc.yml
@@ -69,11 +69,19 @@
           }}
         _parsed: "{{ _net_conf.content | b64decode | from_yaml}}"
         _crc: "{{ _parsed.instances['crc-0'].networks.ctlplane }}"
-      register: last_modification
-      ansible.builtin.replace:
-        path: "{{ _config_file }}"
-        regexp: "192.168.130.11"
-        replace: "{{ _crc.ip_v4 }}"
+      block:
+        - name: Configure local DNS for CRC pod
+          register: last_modification
+          ansible.builtin.replace:
+            path: "{{ _config_file }}"
+            regexp: "192.168.130.11"
+            replace: "{{ _crc.ip_v4 }}"
+
+        - name: Ensure localhost address if configured as listen-address for dnsmasq
+          ansible.builtin.replace:
+            path: "{{ _config_file }}"
+            regexp: "listen-address={{ _crc.ip_v4 }}"
+            replace: "listen-address={{ _crc.ip_v4 }},127.0.0.1"
 
     - name: Reboot CRC node  # noqa: no-handler
       become: true


### PR DESCRIPTION
Change the listen-address parameter in the dnsmasq config in the crc
node so that it listens in localhost. This was causing reproducer
deployments with crc 2.32 to fail as the crc node had no working dns
server.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
