### PR TITLE
Ensure second interface doesn't configure second default route.

### DIFF
--- a/roles/reproducer/tasks/configure_computes.yml
+++ b/roles/reproducer/tasks/configure_computes.yml
@@ -11,7 +11,7 @@
         ifname: "{{ _iface }}"
         type: ethernet
         ip4: "{{ _ip4 }}/{{ _prefix }}"
-        gw4: "{{ _gw4 }}"
+        never_default4: true
         state: present
 
     - name: Ensure we can ping controller-0 from ctlplane

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -309,7 +309,7 @@
         ifname: "{{ _controller_data.interface_name }}"
         type: ethernet
         ip4: "{{ _controller_data.ip_v4 }}/{{ _prefix }}"
-        gw4: "{{ _ctlplane_net.gw_v4 }}"
+        never_default4: true
         state: present
 
     - name: Inject CRC related content if needed

--- a/roles/reproducer/tasks/configure_crc.yml
+++ b/roles/reproducer/tasks/configure_crc.yml
@@ -21,7 +21,7 @@
         ifname: "{{ _crc.interface_name }}"
         type: ethernet
         ip4: "{{ _crc.ip_v4 }}/24"
-        gw4: "{{ _ctlplane.gw_v4 }}"
+        never_default4: true
         state: present
 
     - name: Ensure crc-0 does not get "public" DNS


### PR DESCRIPTION
Generally nodes should only have a single default route, when adding
the second interface to the nodes a second route is being added that
can cause routing issues.

This patch adds the `never_default4: true` parameter to ensure only
one default route is configured.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running