### PR TITLE
Allow loading ceph playbook network ranges from Net Env Def

### DIFF
--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -123,6 +123,31 @@
       when:
         - hostvars[item][ceph_hostname_var] is defined
       loop: "{{ groups[cifmw_ceph_target | default('computes')] | default([]) }}"
+
+    - name: Load network ranges from Networking Environment Definition if not provided
+      when: >-
+        storage_network_range is not defined or
+        storage_mgmt_network_range is not defined
+      block:
+        - name: Load Networking Environment Definition
+          vars:
+            cifmw_networking_mapper_assert_env_load: false
+          ansible.builtin.import_role:
+            name: networking_mapper
+            tasks_from: load_env_definition.yml
+
+        - name: Set network ranges vars
+          when: "cifmw_networking_env_definition is defined"
+          ansible.builtin.set_fact:
+            storage_network_range: >-
+              {{
+                cifmw_networking_env_definition.networks.storage.network_v4
+              }}
+            storage_mgmt_network_range: >-
+              {{
+                cifmw_networking_env_definition.networks.storagemgmt.network_v4
+              }}
+
   roles:
     - role: cifmw_ceph_spec
       cifmw_ceph_spec_host_to_ip: "{{ host_to_ip }}"

--- a/roles/networking_mapper/README.md
+++ b/roles/networking_mapper/README.md
@@ -8,6 +8,7 @@ networking details of a given environment.
 * `cifmw_networking_definition`: The Networking Definition as a dictionary.
 * `cifmw_networking_mapper_ifaces_info`: The interface information dictionary that holds low-level info for full maps.
 * `cifmw_networking_mapper_network_name`: The network name to filter `cifmw_networking_mapper_ifaces_info` interfaces.
+* `cifmw_networking_mapper_assert_env_load`: Ensures that calling the Networking Environment Definition ends with a valid one loaded. Defaults to `true`.
 
 ## Important definitions
 - Networking Definition: The input to the CI-framework that defines all the networking-needed data.

--- a/roles/networking_mapper/defaults/main.yml
+++ b/roles/networking_mapper/defaults/main.yml
@@ -29,3 +29,4 @@ cifmw_networking_mapper_networking_env_def_path: >-
       'networking-environment-definition.yml') | path_join
   }}
 cifmw_networking_mapper_ifaces_info_path: "{{ cifmw_networking_mapper_basedir }}/parameters/interfaces-info.yml"
+cifmw_networking_mapper_assert_env_load: true

--- a/roles/networking_mapper/tasks/load_env_definition.yml
+++ b/roles/networking_mapper/tasks/load_env_definition.yml
@@ -8,6 +8,7 @@
       register: _net_env_def_stat
 
     - name: Check for Networking Definition file existance
+      when: cifmw_networking_mapper_assert_env_load
       ansible.builtin.assert:
         that:
           - "_net_env_def_stat.stat.exists"
@@ -17,16 +18,18 @@
         quiet: true
 
     - name: Load the Networking Definition from file
+      when: "_net_env_def_stat.stat.exists"
       ansible.builtin.slurp:
         path: "{{ cifmw_networking_mapper_networking_env_def_path }}"
       register: _net_env_def_slurp
 
     - name: Set cifmw_networking_env_definition is present
+      when: "_net_env_def_slurp.content is defined"
       ansible.builtin.set_fact:
         cifmw_networking_env_definition: >-
           {{
-             _net_env_def_slurp['content'] |
-             b64decode |
-             from_yaml
+            _net_env_def_slurp['content'] |
+            b64decode |
+            from_yaml
           }}
         cacheable: true


### PR DESCRIPTION
To align the ceph.yml playbook with the new way of configuring networking in the framework, but keeping its standalone functionality, we now try to load `storage_network_range` and `storage_mgmt_network_range` from the Networking Environment Definition file. If the file is not present, like using it without the rest of framework, we still rely on the existing defaults.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
