### PR TITLE
OCP cluster as configured by dev-scripts uses volumes

### DIFF
--- a/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/roles/libvirt_manager/tasks/clean_layout.yml
@@ -5,6 +5,11 @@
     command: list_vms
     uri: "qemu:///system"
 
+- name: Get pool configuration
+  community.libvirt.virt_pool:
+    command: facts
+    uri: "qemu:///system"
+
 - name: Filter out target environment
   ansible.builtin.set_fact:
     cleanup_vms: "{{ vms_list.list_vms | select('match', '^cifmw-.*$') }}"
@@ -93,6 +98,16 @@
   vars:
     action: "delete"
   ansible.builtin.include_tasks: storage_pool.yml
+
+- name: Remove custom images from oooq_pool if exists
+  when:
+    - item is match('^ocp-[0-9]\.qcow2+$')
+  ansible.builtin.command:
+    cmd: >-
+      virsh -c qemu:///system vol-delete
+      --vol {{ item }}
+      --pool oooq_pool
+  loop: "{{ ansible_libvirt_pools['oooq_pool'].volumes | default([]) }}"
 
 - name: Get temporary key status
   register: _tmp_key

--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -14,91 +14,56 @@
         ternary(_base_img_name ~ "_" ~ vm_id ~ ".qcow2",
                 _base_img_name)
       }}
-  ansible.builtin.command:
-    cmd: >-
-      qemu-img create
-      {% if vm_data.value.disk_file_name != 'blank' %}
-      -o backing_file={{ _img }},backing_fmt=qcow2
-      {% endif %}
-      -f qcow2
-      "{{ vm_type }}-{{ vm_id }}.qcow2"
-      "{{ vm_data.value.disksize|default ('40') }}G"
-    creates: "{{ vm_type }}-{{ vm_id }}.qcow2"
-    chdir: "{{ cifmw_libvirt_manager_basedir }}/workload"
-  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
-  loop_control:
-    index_var: vm_id
-    label: "{{ vm_type }}-{{ vm_id }}"
-
-- name: "Ensure file ownership and rights for {{ vm_type }}"
-  become: true
-  ansible.builtin.file:
-    path: >-
-      {{
-        (cifmw_libvirt_manager_basedir, 'workload',
-        vm_type ~ '-' ~ vm_id ~ '.qcow2') |
-        path_join
-      }}
-    group: "qemu"
-    mode: "0664"
-    owner: "{{ ansible_user_id }}"
-    state: file
-  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
-  loop_control:
-    index_var: vm_id
-    label: "{{ vm_type }}-{{ vm_id }}"
-
-- name: "Manipulate XMLs and load them if provided for {{ vm_type }}"
-  when:
-    vm_data.value.xml_paths is defined
+    _workload: "{{ cifmw_libvirt_manager_basedir }}/workload"
+    _ocp_pool: "{{ ansible_libvirt_pools['oooq_pool']['path'] | default('') }}"
+    _chdir: >-
+      {{ (vm_type is match('.*ocp.*')) | ternary(_ocp_pool, _workload) }}
   block:
-    - name: "Set disk path for {{ vm_type }}"
-      community.general.xml:
-        path: "{{ _xml }}"
-        xpath: "/domain/devices/disk/source"
-        attribute: "file"
-        value: >-
-          {{ (cifmw_libvirt_manager_basedir,
-              'workload',
-              vm_type ~ '-' ~ _xml_id ~ '.qcow2') |
-              path_join
-          }}
-      loop: "{{ vm_data.value.xml_paths }}"
-      loop_control:
-        loop_var: "_xml"
-        index_var: "_xml_id"
-        label: "{{ vm_type }}-{{ _xml_id }}"
-
-    - name: "Remove document description header for {{ vm_type }}"
-      ansible.builtin.replace:
-        path: "{{ _xml }}"
-        regexp: "<\\?xml version='1.0' encoding='UTF-8'\\?>\n"
-        replace: ""
-      loop: "{{ vm_data.value.xml_paths }}"
-      loop_control:
-        loop_var: "_xml"
-        index_var: "_xml_id"
-        label: "{{ vm_type }}-{{ _xml_id }}"
-
-    - name: "Load VM XMLs for {{ vm_type }}"
-      register: _vm_xmls
-      ansible.builtin.slurp:
-        path: "{{ item }}"
-      loop: "{{ vm_data.value.xml_paths }}"
-      loop_control:
-        index_var: "_xml_id"
-        label: "{{ vm_type }}-{{ _xml_id }}"
-
-    - name: "Define VMs with custom XML for {{ vm_type }}"
-      community.libvirt.virt:
-        command: define
-        xml: "{{ _xml['content'] | b64decode }}"
-        uri: "qemu:///system"
-      loop: "{{ _vm_xmls.results }}"
+    - name: "Create VM overlay for {{ vm_type }}"
+      vars:
+        _vm_img: "{{ vm_type }}-{{ vm_id }}.qcow2"
+      ansible.builtin.command:
+        cmd: >-
+          qemu-img create
+          {% if vm_data.value.disk_file_name != 'blank' %}
+          -o backing_file={{ _img }},backing_fmt=qcow2
+          {% endif %}
+          -f qcow2
+          "{{ _vm_img }}"
+          "{{ vm_data.value.disksize|default ('40') }}G"
+        creates: "{{ vm_type }}-{{ vm_id }}.qcow2"
+        chdir: "{{ _chdir }}"
+      loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
       loop_control:
         index_var: vm_id
         label: "{{ vm_type }}-{{ vm_id }}"
-        loop_var: '_xml'
+
+    - name: "Ensure file ownership and rights for {{ vm_type }}"
+      become: true
+      vars:
+        _vm_img: "{{ vm_type }}-{{ vm_id }}.qcow2"
+      ansible.builtin.file:
+        path: "{{ (_chdir, _vm_img) | path_join }}"
+        group: "qemu"
+        mode: "0664"
+        owner: "{{ ansible_user_id }}"
+        state: file
+      loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
+      loop_control:
+        index_var: vm_id
+        label: "{{ vm_type }}-{{ vm_id }}"
+
+- name: "Manipulate XMLs and load them if provided for {{ vm_type }}"
+  when:
+    - vm_data.value.xml_paths is defined
+  block:
+    - name: Load OCP VMs
+      ansible.builtin.include_tasks: ocp_xml.yml
+      loop: "{{ vm_data.value.xml_paths }}"
+      loop_control:
+        loop_var: "_xml"
+        index_var: "_xml_id"
+        label: "{{ vm_type }}-{{ _xml_id }}"
 
 - name: "Define the requested virtual machines {{ vm_type }}"
   when:

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -111,6 +111,12 @@
   community.libvirt.virt_net:
     command: "list_nets"
 
+- name: Gather pool fact
+  when:
+    - ansible_libvirt_pools is undefined
+  community.libvirt.virt_pool:
+    command: facts
+
 - name: Create and run VMs
   when:
     - (

--- a/roles/libvirt_manager/tasks/ocp_xml.yml
+++ b/roles/libvirt_manager/tasks/ocp_xml.yml
@@ -1,0 +1,37 @@
+---
+- name: Load XML source
+  register: _xmlfile
+  ansible.builtin.slurp:
+    path: "{{ _xml }}"
+
+- name: "Set disk path for {{ vm_type }}"
+  vars:
+    _xmlstring: "{{ _xmlfile.content | b64decode }}"
+  block:
+    - name: Set proper VM name
+      register: _editor
+      community.general.xml:
+        xmlstring: "{{ _xmlstring }}"
+        xpath: "/domain/name"
+        value: "cifmw-{{ vm_type }}-{{ _xml_id }}"
+
+    - name: Rebuild disk entry
+      register: _editor
+      community.general.xml:
+        xmlstring: "{{ _editor.xmlstring }}"
+        xpath: "/domain/devices/disk/source[@pool='oooq_pool']"
+        attribute: "volume"
+        state: present
+        value: "{{ vm_type }}-{{ _xml_id }}.qcow2"
+
+    - name: "Define VMs with custom XML for {{ vm_type }}"
+      vars:
+        _cleaned: >-
+          {{
+            _editor.xmlstring |
+            replace("<?xml version='1.0' encoding='UTF-8'?>", "")
+          }}
+      community.libvirt.virt:
+        command: define
+        xml: "{{ _cleaned }}"
+        uri: "qemu:///system"

--- a/roles/libvirt_manager/tasks/start_manage_vms.yml
+++ b/roles/libvirt_manager/tasks/start_manage_vms.yml
@@ -1,4 +1,10 @@
 ---
+- name: Refresh pools before starting VMs
+  community.libvirt.virt_pool:
+    command: refresh
+    name: "{{ item }}"
+  loop: "{{ ansible_libvirt_pools.keys() }}"
+
 # Start and manage VMs, such as injecting SSH configurations,
 # inject the VMs in the live inventory for later reference, and so on.
 # In case we create a "blank" VM, without any OS, it shouldn't be known by


### PR DESCRIPTION
We cannot just replace the "source" like it was done: libvirt is strict,
but also "dumb" in the way it handles a source with multiple conflicting
attributes.

This patch changes how OCP overlays are created - more precisely, the
location to be seen in the oooq_pool.

It also extracts the OCP XML manipulations in a way to make it easier to
loop.

We also ensure we clean the volumes on due time.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
