### PR TITLE
[network-values] Use shared bridge for ctlplane network

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/network-values.j2
+++ b/roles/ci_gen_kustomize_values/templates/network-values.j2
@@ -81,6 +81,8 @@ data:
         "type": "macvlan",
 {%  if network.vlan_id is defined%}
         "master": "{{ network.network_name }}",
+{%  elif network.network_name == "ctlplane" %}
+        "master": "ospbr",
 {%  else %}
         "master": "{{ ns.interfaces[network.network_name] }}",
 {%  endif %}


### PR DESCRIPTION
Required for [1] to have bridge configured for ctlplane network attachment definition.

[1] https://github.com/openstack-k8s-operators/architecture/pull/101

Depends-On: https://github.com/openstack-k8s-operators/architecture/pull/101
Related-Issue: [OSPRH-3947](https://issues.redhat.com//browse/OSPRH-3947)

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
