### PR TITLE
scenarios/centos9/multinode-ci: set install_yamls/BMO_SETUP=false by default

### DIFF
--- a/scenarios/centos-9/multinode-ci.yml
+++ b/scenarios/centos-9/multinode-ci.yml
@@ -18,6 +18,9 @@ post_ctlplane_deploy:
 # Enable tempest
 cifmw_run_tests: true
 
+cifmw_install_yamls_vars:
+  BMO_SETUP: false
+
 # Deploy EDPM in multinode scenario
 cifmw_deploy_edpm: true
 cifmw_tempest_tests_allowed:


### PR DESCRIPTION

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
