### PR TITLE
Allow to install custom CA on reproducer env

### DIFF
--- a/reproducer.yml
+++ b/reproducer.yml
@@ -35,6 +35,10 @@
         label: "{{ config.option }}"
         loop_var: 'config'
 
+    - name: Install custom CA if needed
+      ansible.builtin.import_role:
+        name: install_ca
+
     - name: Setup repositories via rhos-release if needed
       tags:
         - packages

--- a/roles/reproducer/tasks/configure_computes.yml
+++ b/roles/reproducer/tasks/configure_computes.yml
@@ -19,6 +19,24 @@
         cmd: |
           ping -c2 {{ _controller_ip4 }}
 
+    - name: Tweak dnf configuration
+      become: true
+      community.general.ini_file:
+        no_extra_spaces: true
+        option: "{{ config.option }}"
+        path: "/etc/dnf/dnf.conf"
+        section: "{{ config.section | default('main') }}"
+        state: "{{ config.state | default(omit) }}"
+        value: "{{ config.value | default(omit) }}"
+      loop: "{{ cifmw_reproducer_dnf_tweaks }}"
+      loop_control:
+        label: "{{ config.option }}"
+        loop_var: 'config'
+
+    - name: Install custom CA if needed
+      ansible.builtin.import_role:
+        name: install_ca
+
     - name: RHEL related tasks on computes
       become: true
       when:

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -208,6 +208,10 @@
         label: "{{ config.option }}"
         loop_var: 'config'
 
+    - name: Install custom CA if needed
+      ansible.builtin.import_role:
+        name: install_ca
+
     - name: RHEL repository setup for ansible-controller
       become: true
       when:


### PR DESCRIPTION
This may be handy when you're using some squid proxy configured to bump
TLS connection - or if you want to access some self-signed content
(repositories or anything).

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
