### PR TITLE
Return DLRN MD5 hash to the child job

### DIFF
--- a/ci/playbooks/tcib/run.yml
+++ b/ci/playbooks/tcib/run.yml
@@ -33,11 +33,38 @@
           {%- endif %}
           -e "@{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml"
 
+    - name: Slurp dlrn md5 hash
+      become: true
+      vars:
+        _repo_path: >-
+          {%- if cifmw_repo_setup_output is defined %}
+          {{ cifmw_repo_setup_output }}
+          {%- else %}
+          {{ ansible_user_dir }}/ci-framework-data/artifacts/repositories
+          {%- endif %}
+      block:
+        - name: Check DLRN md5 exists or not
+          ansible.builtin.stat:
+            path: "{{ _repo_path }}/delorean.repo.md5"
+          register: _check_dlrn_md5
+
+        - name: Slurp dlrn md5 hash
+          ansible.builtin.slurp:
+            path: "{{ _repo_path }}/delorean.repo.md5"
+          register: _md5_data
+          when: _check_dlrn_md5.stat.exists
+
+        - name: Store md5 content
+          ansible.builtin.set_fact:
+            _dlrn_md5: "{{ _md5_data['content'] | b64decode }}"
+          when: _check_dlrn_md5.stat.exists
+
     - name: Return Zuul Data
       ansible.builtin.debug:
         msg: >-
           Running Content provider registry on
-          {{ node_ip | default('nowhere') }}
+          {{ node_ip | default('nowhere') }} with dlrn md5 hash
+          {{ _dlrn_md5 | default('nowhere') }}
 
     - name: Set up content registry IP address
       zuul_return:
@@ -45,3 +72,4 @@
           zuul:
             pause: true
           content_provider_registry_ip: "{{ node_ip | default('nowhere') }}"
+          content_provider_dlrn_md5_hash: "{{ _dlrn_md5 | default('nowhere') }}"

--- a/roles/repo_setup/tasks/configure.yml
+++ b/roles/repo_setup/tasks/configure.yml
@@ -1,4 +1,9 @@
 ---
+- name: Set cifmw_repo_setup_dlrn_hash_tag from content provider
+  ansible.builtin.set_fact:
+    cifmw_repo_setup_dlrn_hash_tag: "{{ content_provider_dlrn_md5_hash }}"
+  when: content_provider_dlrn_md5_hash is defined
+
 - name: Run repo-setup
   become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"
   ansible.builtin.command:


### PR DESCRIPTION
Due to multiple promotions, the tcib job and child job gets different current-podified hashes leading failure of pulling containers in the EDPM deployment jobs.

Returning the dlrn md5 hash to the child job makes sure we populate the same repo on the node.

Note: It also set the returned dlrn md5 hash to the repo-setup to generate proper repos with passed dlrn hash.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
