### PR TITLE
Set srbac by default

### DIFF
--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -45,6 +45,32 @@ cifmw_test_operator_tempest_network_attachments: []
 cifmw_test_operator_tempest_tests_include_override_scenario: false
 cifmw_test_operator_tempest_tests_exclude_override_scenario: false
 cifmw_test_operator_tempest_workflow: []
+
+# Enabling SRBAC by default, in jobs where this does not make sense should be turned off explicitly
+cifmw_tempest_tempestconf_config_defaults:
+  deployerInput: |
+    [enforce_scope]
+    nova = true
+    neutron = true
+    glance = true
+    cinder = true
+    keystone = true
+    placement = true
+    manila = true
+
+    [barbican_rbac_scope_verification]
+    enforce_scope = true
+
+    [identity-feature-enabled]
+    enforce_scope = true
+
+    [load_balancer]
+    member_role = load-balancer_member
+    admin_role = load-balancer_admin
+    RBAC_test_type = keystone_default_roles
+    enforce_new_defaults = true
+    enforce_scope = false
+
 # Please refer to https://openstack-k8s-operators.github.io/test-operator/guide.html#executing-tempest-tests
 cifmw_test_operator_tempest_config:
   apiVersion: test.openstack.org/v1beta1
@@ -68,7 +94,7 @@ cifmw_test_operator_tempest_config:
       concurrency: "{{ cifmw_test_operator_concurrency }}"
       externalPlugin: "{{ cifmw_test_operator_tempest_external_plugin | default([]) }}"
       extraImages: "{{ cifmw_test_operator_tempest_extra_images | default([]) }}"
-    tempestconfRun: "{{ cifmw_tempest_tempestconf_config | default(omit) }}"
+    tempestconfRun: "{{ cifmw_tempest_tempestconf_config_defaults | combine(cifmw_tempest_tempestconf_config | default({})) }}"
     workflow: "{{ cifmw_test_operator_tempest_workflow }}"
 
 # Section 3: tobiko parameters - used when run_test_fw is 'tobiko'


### PR DESCRIPTION
Let's set srbac (enforce_scope) by default. In jobs where it does
not make sense it should be disabled explicitly.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
