### PR TITLE
Ensure target repository directories exists

### DIFF
--- a/roles/reproducer/tasks/push_code.yml
+++ b/roles/reproducer/tasks/push_code.yml
@@ -56,6 +56,21 @@
   vars:
     repo_base_dir: '/home/zuul/src'
   block:
+    - name: Create target directories beforehand
+      vars:
+        _destinations: >-
+          {{
+            cifmw_reproducer_repositories |
+            map(attribute="dest") |
+            map('dirname') |
+            unique |
+            list
+          }}
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+      loop: "{{ _destinations }}"
+
     - name: Sync local repositories to ansible controller
       delegate_to: localhost
       when:


### PR DESCRIPTION
The current implementation of the repository copy from the reproducer Ansible controller to the controller of the fresh generated environment assumes that the directory where repos are copied already exists, which is sadly false for non GitHub based repositories.
This commit creates the parent directories before rsync or git creates the target destination.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date: