### PR TITLE
Allow installing CA from a url in install_ca

### DIFF
--- a/roles/install_ca/README.md
+++ b/roles/install_ca/README.md
@@ -13,6 +13,10 @@ our capabilities to access remote package repositories, among possible targets.
 * `cifmw_install_ca_bundle_src`: (String) Path to the CA bundle we want to inject.
 * `cifmw_install_ca_trust_dir`: (String) Directory where we put custom CA. Must be known by the update-ca-trust command. Defaults to `/etc/pki/ca-trust/source/anchors/`.
 * `cifmw_install_ca_update_cmd`: (String) Command to run in order to update the CA trust ring. Defaults to `update-ca-trust`.
+* `cifmw_install_ca_url`: (String) URL pointing to a CA bundle that will be stored in `cifmw_install_ca_trust_dir`.
+* `cifmw_install_ca_url_validate_certs`: (Bool) Whether to validate SSL
+certificates when pulling a CA bundle from a url, will have no effect if
+`cifmw_install_ca_url` is not set.
 
 ## Examples
 ```YAML
@@ -28,6 +32,12 @@ our capabilities to access remote package repositories, among possible targets.
         -----BEGIN CERTIFICATE-----
         ....
         -----END CERTIFICATE-----
+  ansible.builtin.include_role:
+    role: install_ca
+
+- name: Inject custom CA from url
+  vars:
+    cifmw_install_ca_url: https://dummyurl.com/ca_file.pem
   ansible.builtin.include_role:
     role: install_ca
 ```

--- a/roles/install_ca/tasks/main.yml
+++ b/roles/install_ca/tasks/main.yml
@@ -22,6 +22,13 @@
         path: "{{ cifmw_install_ca_trust_dir }}"
         state: directory
 
+    - name: Install internal CA from url
+      when: cifmw_install_ca_url is defined
+      ansible.builtin.get_url:
+        url: "{{ cifmw_install_ca_url }}"
+        dest: "{{ cifmw_install_ca_trust_dir }}"
+        validate_certs: "{{ cifmw_install_ca_url_validate_certs | default(omit) }}"
+
     - name: Install custom CA bundle from inline
       register: ca_inline
       when:

--- a/roles/openshift_setup/README.md
+++ b/roles/openshift_setup/README.md
@@ -10,3 +10,8 @@ No privilege escalation needed.
 * `cifmw_openshift_setup_create_namespaces`: (Strings) Namespaces to create beforehand. Defaults to `[]`.
 * `cifmw_openshift_setup_skip_internal_registry`: (Boolean) Skips login and setup of the Internal Openshift registry. Defaults to `false`.
 * `cifmw_openshift_setup_skip_internal_registry_tls_verify`: (Boolean) Skip TLS verification for Podman login. Defaults to `false`.
+* `cifmw_openshift_setup_ca_registry_to_add`: (String) Registry to which the CA
+should be configured for in an OCP/CRC cluster.
+* `cifmw_openshift_setup_ca_bundle_path`: (String) Path to the CA bundle.
+Defaults to `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`. Only has an
+effect if `cifmw_openshift_setup_ca_registry_to_add` is set.

--- a/roles/openshift_setup/defaults/main.yml
+++ b/roles/openshift_setup/defaults/main.yml
@@ -22,3 +22,4 @@ cifmw_openshift_setup_dry_run: false
 cifmw_openshift_setup_create_namespaces: []
 cifmw_openshift_setup_skip_internal_registry: false
 cifmw_openshift_setup_skip_internal_registry_tls_verify: false
+cifmw_openshift_setup_ca_bundle_path: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"

--- a/roles/openshift_setup/molecule/default/converge.yml
+++ b/roles/openshift_setup/molecule/default/converge.yml
@@ -22,5 +22,36 @@
       NAMESPACE: openstack
       OPERATOR_NAMESPACE: openstack-operators
     cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+    cifmw_openshift_setup_ca_registry_to_add: test.registry.com
   roles:
     - role: "openshift_setup"
+  tasks:
+    - name: Check that config map is created
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit)}}"
+        context: "{{ cifmw_openshift_context | default(omit)}}"
+        kind: ConfigMap
+        namespace: openshift-config
+        name: registry-cas
+      register: _configmap
+
+    - name: Assert that configmap was created
+      ansible.builtin.assert:
+        that:
+          - _configmap.api_found
+
+    - name: Check that Image cluster is patched
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit)}}"
+        context: "{{ cifmw_openshift_context | default(omit)}}"
+        api_version: config.openshift.io/v1
+        kind: Image
+        name: cluster
+      register: _image_patch
+
+    - name: Assert that cluster was patched
+      ansible.builtin.assert:
+        that:
+          - _image_patch.resources[0].spec.additionalTrustedCA.name == "registry-cas"

--- a/roles/openshift_setup/tasks/main.yml
+++ b/roles/openshift_setup/tasks/main.yml
@@ -116,3 +116,53 @@
       delay: 30
       register: cifmw_openshift_setup_podman_login_stdout
       until: cifmw_openshift_setup_podman_login_stdout.rc == 0
+
+- name: Add custom CA bundle to OCP registry
+  when: cifmw_openshift_setup_ca_registry_to_add is defined
+  block:
+    - name: Ensure we have custom CA installed on host
+      ansible.builtin.include_role:
+        role: install_ca
+
+    - name: Update ca bundle
+      become: true
+      ansible.builtin.command:
+        cmd: update-ca-trust extract
+
+    - name: Slurp CAs file
+      ansible.builtin.slurp:
+        src: "{{ cifmw_openshift_setup_ca_bundle_path }}"
+      register: _ca_content
+
+    - name: Create config map with registry CAs
+      vars:
+        _config_map_data:
+          - key: "{{ cifmw_openshift_setup_ca_registry_to_add  }}"
+            value: "{{ _ca_content.content | b64decode  }}"
+      kubernetes.core.k8s:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit)}}"
+        context: "{{ cifmw_openshift_context | default(omit)}}"
+        definition:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            namespace: openshift-config
+            name: registry-cas
+          data:
+            "{{ _config_map_data | items2dict  }}"
+
+    - name: Install Red Hat CA for pulling images from internal registry
+      kubernetes.core.k8s:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit)}}"
+        context: "{{ cifmw_openshift_context | default(omit)}}"
+        merge_type: "merge"
+        definition:
+          apiVersion: config.openshift.io/v1
+          kind: Image
+          metadata:
+            name: cluster
+          spec:
+            additionalTrustedCA:
+              name: "registry-cas"


### PR DESCRIPTION
Allow downloading a certificate file directly into
/etc/pki/ca-trust/source/anchors/ in install_ca role, whitout it
being part of an rpm. This change also introduces new tasks to add CAs
to an openshift image registry in the openshift_setup role.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
