### PR TITLE
Add missing delegate_to when creating repo parent tree

### DIFF
--- a/roles/reproducer/tasks/push_code.yml
+++ b/roles/reproducer/tasks/push_code.yml
@@ -57,6 +57,7 @@
     repo_base_dir: '/home/zuul/src'
   block:
     - name: Create target directories beforehand
+      delegate_to: controller-0
       vars:
         _destinations: >-
           {{


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
