### PR TITLE
Add repo sync repos and set_openstack_containers roles to update playbook

### DIFF
--- a/playbooks/update.yml
+++ b/playbooks/update.yml
@@ -3,13 +3,21 @@
     step: pre_update
   ansible.builtin.import_playbook: ./hooks.yml
 
-- name: Update repos playbook
+- name: Update repos and openstack services containers
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
     - name: Run repo_setup
       ansible.builtin.include_role:
         name: repo_setup
+
+    - name: Update all openstack services containers env vars in meta operator with tag from delorean
+      vars:
+        cifmw_set_openstack_containers_dlrn_md5_path: "{{ cifmw_basedir }}/artifacts/repositories/delorean.repo.md5"
+        cifmw_set_openstack_containers_tag_from_md5: true
+        cifmw_set_openstack_containers_extra_vars: "{{ cifmw_edpm_prepare_extra_vars }}"
+      ansible.builtin.include_role:
+        name: set_openstack_containers
 
 - name: Sync repos for controller to compute
   hosts: computes

--- a/playbooks/update.yml
+++ b/playbooks/update.yml
@@ -3,7 +3,7 @@
     step: pre_update
   ansible.builtin.import_playbook: ./hooks.yml
 
-- name: Update playbook
+- name: Update repos playbook
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
@@ -11,6 +11,20 @@
       ansible.builtin.include_role:
         name: repo_setup
 
+- name: Sync repos for controller to compute
+  hosts: computes
+  gather_facts: true
+  tasks:
+    - name: Copy repositories from controller to computes
+      become: true
+      ansible.builtin.copy:
+        dest: "/etc/yum.repos.d/"
+        src: "{{ cifmw_basedir }}/artifacts/repositories/"
+
+- name: Run update role
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
     - name: Run update
       tags:
         - update

--- a/scenarios/centos-9/multinode-ci.yml
+++ b/scenarios/centos-9/multinode-ci.yml
@@ -4,11 +4,13 @@ cifmw_use_libvirt: false
 
 cifmw_openshift_setup_skip_internal_registry_tls_verify: true
 
-post_infra:
+post_infra: &fetch_nodes_facts
   - name: Fetch nodes facts and save them as parameters
     type: playbook
     inventory: "{{ ansible_user_dir }}/ci-framework-data/artifacts/zuul_inventory.yml"
     source: fetch_compute_facts.yml
+
+pre_update: *fetch_nodes_facts
 
 post_ctlplane_deploy:
   - name: Tune rabbitmq resources


### PR DESCRIPTION
To update repos on compute we need to copy updated repos from controller
nodes to computes. This change adds sync repos task to update playbook.

Signed-off-by: Mikołaj Ciecierski <mikolaj.ciecierski@redhat.com>

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
