### PR TITLE
[automation] Introduce flexible loop in deploy-edpm.yml

### DIFF
--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -38,7 +38,16 @@
     - build-operators
 
 - name: Import deploy edpm playbook
+  when:
+    - cifmw_architecture_va_scenario is undefined
   ansible.builtin.import_playbook: playbooks/06-deploy-edpm.yml
+  tags:
+    - edpm
+
+- name: Import VA deployment playbook
+  when:
+    - cifmw_architecture_va_scenario is defined
+  ansible.builtin.import_playbook: playbooks/06-deploy-architecture.yml
   tags:
     - edpm
 

--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -1,0 +1,124 @@
+---
+- name: Run pre_deploy hooks
+  vars:
+    hooks: "{{ pre_deploy | default([]) }}"
+    step: pre_deploy
+  ansible.builtin.import_playbook: ./hooks.yml
+
+- name: Deploy VA
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  tasks:
+    - name: Load Networking Environment Definition
+      ansible.builtin.include_role:
+        name: networking_mapper
+        tasks_from: load_env_definition.yml
+
+    - name: Fetch controller-0 network facts
+      when: "'ansible_interfaces' not in hostvars['controller-0']"
+      ansible.builtin.setup:
+        gather_subset: network
+      delegate_to: controller-0
+      delegate_facts: true
+
+    - name: Create nova migration keypair
+      register: _nova_key
+      community.crypto.openssh_keypair:
+        comment: "nova migration"
+        path: >-
+          {{ (cifmw_basedir,
+             'artifacts/nova_migration_key') | path_join
+          }}
+        type: "ecdsa"
+
+    - name: Generate needed facts out of local files
+      vars:
+        _ifaces_vars: >-
+          {{
+            hostvars['controller-0'].ansible_interfaces |
+            map('regex_replace', '^(.*)$', 'ansible_\1')
+          }}
+        _controller_host: "{{ hostvars['controller-0'].ansible_host }}"
+        _ipv4_network_data: >-
+          {{
+            hostvars['controller-0'] | dict2items |
+            selectattr('key', 'in', _ifaces_vars) |
+            selectattr('value.ipv4.address', 'defined') |
+            selectattr('value.ipv4.address', 'equalto', _controller_host) |
+            map(attribute='value.ipv4') | first | default({})
+          }}
+      ansible.builtin.set_fact:
+        cifmw_ci_gen_kustomize_values_ssh_authorizedkeys: >-
+          {{ lookup('file', '~/.ssh/authorized_keys', rstrip=False) }}
+        cifmw_ci_gen_kustomize_values_ssh_private_key: >-
+          {{ lookup('file', '~/.ssh/id_cifw', rstrip=False) }}
+        cifmw_ci_gen_kustomize_values_ssh_public_key: >-
+          {{ lookup('file', '~/.ssh/id_cifw.pub', rstrip=False) }}
+        cifmw_ci_gen_kustomize_values_migration_pub_key: >-
+          {{ lookup('file', _nova_key.filename ~ '.pub', rstrip=False)}}
+        cifmw_ci_gen_kustomize_values_migration_priv_key: >-
+          {{ lookup('file', _nova_key.filename, rstrip=False) }}
+        cifmw_ci_gen_kustomize_values_sshd_ranges: >-
+          {{
+            [cifmw_networking_env_definition.networks.ctlplane.network_v4] +
+            (
+              [
+                 _ipv4_network_data.network + '/' + _ipv4_network_data.prefix
+              ]
+            ) if (_ipv4_network_data | length > 0) else []
+          }}
+
+    - name: Load architecture automation file
+      register: _automation
+      ansible.builtin.slurp:
+        path: "{{ cifmw_architecture_automation_file }}"
+
+    - name: Prepare automation data
+      vars:
+        _parsed: "{{ _automation.content | b64decode | from_yaml }}"
+      ansible.builtin.set_fact:
+        cifmw_deploy_va_steps: >-
+          {{ _parsed['vas'][cifmw_architecture_va_scenario] }}
+
+    - name: Check requirements
+      ansible.builtin.import_role:
+        name: kustomize_deploy
+        tasks_from: check_requirements.yml
+
+    - name: Deploy OSP operators
+      ansible.builtin.import_role:
+        name: kustomize_deploy
+        tasks_from: install_operators.yml
+
+    - name: Configure Storage Class
+      ansible.builtin.include_role:
+        name: ci_local_storage
+
+    - name: Execute deployment steps
+      ansible.builtin.include_role:
+        name: kustomize_deploy
+        tasks_from: execute_step.yml
+      loop: "{{ cifmw_deploy_va_steps.stages }}"
+      loop_control:
+        label: "{{ stage.path }}"
+        loop_var: stage
+        index_var: stage_id
+
+    - name: Extract and install OpenStackControlplane CA
+      ansible.builtin.include_role:
+        role: install_openstack_ca
+
+    - name: Run nova host discover process
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.command: >-
+        oc rsh
+        -n openstack
+        nova-cell0-conductor-0
+        nova-manage cell_v2 discover_hosts --verbose
+
+- name: Run post_deploy hooks
+  vars:
+    hooks: "{{ post_deploy | default([]) }}"
+    step: post_deploy
+  ansible.builtin.import_playbook: ./hooks.yml

--- a/scenarios/reproducers/validated-architecture-1.yml
+++ b/scenarios/reproducers/validated-architecture-1.yml
@@ -11,10 +11,45 @@ cifmw_reproducer_epel_pkgs:
   - python3-bcrypt
   - python3-passlib
 
-# ocpbm network is managed by the dev-scripts 3rd party installer.
-# It replaces the usual "public" network we create - the one providing
-# Internet access for packages, containers and other content.
 cifmw_libvirt_manager_pub_net: ocpbm
+
+# Automation section. Most of those parameters will be passed to the
+# controller-0 as-is and be consumed by the `deploy-va.sh` script.
+# Please note, all paths are on the controller-0, meaning managed by the
+# Framework. Please do not edit them!
+_arch_repo: "/home/zuul/src/github.com/openstack-k8s-operators/architecture"
+cifmw_architecture_va_scenario: hci
+cifmw_ceph_client_vars: /tmp/ceph_client.yml
+cifmw_ceph_client_values_post_ceph_path_src: >-
+  {{ _arch_repo }}/examples/va/hci/values.yaml
+cifmw_ceph_client_values_post_ceph_path_dst: >-
+  {{ cifmw_ceph_client_values_post_ceph_path_src }}
+cifmw_ceph_client_service_values_post_ceph_path_src: >-
+  {{ _arch_repo }}/examples/va/hci/service-values.yaml
+cifmw_ceph_client_service_values_post_ceph_path_dst: >-
+  {{ cifmw_ceph_client_service_values_post_ceph_path_src }}
+
+# HERE if you want to overload kustomization, you can uncomment this parameter
+# and push the data structure you want to apply.
+# cifmw_architecture_user_kustomize:
+#   stage_0:
+#     data:
+#       starwars: Obiwan
+
+# HERE, if you want to stop the deployment loop at any stage, you can uncomment
+# the following parameter and update the value to match the stage you want to
+# reach. Known stages are:
+#   pre_kustomize_stage_INDEX
+#   pre_apply_stage_INDEX
+#   post_apply_stage_INDEX
+#
+# cifmw_deploy_va_stopper:
+
+# What about some tempest?
+cifmw_run_tests: true
+cifmw_run_tempest: true
+cifmw_tempest_tests_allowed:
+  - tempest.scenario.test_network_basic_ops.TestNetworkBasicOps
 
 # This will instruct libvirt_manager to create 3 compute and
 # the ansible-controller, consuming the networks created and


### PR DESCRIPTION
Consuming architecture automation, this patch, with the rest of the
"[automation]" related patches, will allow to deploy VAs directly by
running the deploy-edpm.yml playbook.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1168

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] Content of the docs/source is reflecting the changes
