### PR TITLE
[os_net_setup] Update public_subnet default allocation pool

### DIFF
--- a/roles/os_net_setup/defaults/main.yml
+++ b/roles/os_net_setup/defaults/main.yml
@@ -11,8 +11,8 @@ cifmw_os_net_setup_config:
     subnets:
       - name: public_subnet
         cidr: 192.168.122.0/24
-        allocation_pool_start: 192.168.122.200
-        allocation_pool_end: 192.168.122.240
+        allocation_pool_start: 192.168.122.201
+        allocation_pool_end: 192.168.122.250
         gateway_ip: 192.168.122.1
         enable_dhcp: false
 cifmw_os_net_setup_verify_tls: true


### PR DESCRIPTION
192.168.122.200 also configured for netconfig end_range, so for public subnet use 192.168.122.201 as starting range. Also extend end range till 192.168.122.250 to allow more FIPs by default.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
