### PR TITLE
[FIPS] Adding small fixes/alternatives to avoid issues in FIPS mode

### DIFF
--- a/ci/playbooks/multinode-customizations.yml
+++ b/ci/playbooks/multinode-customizations.yml
@@ -171,9 +171,11 @@
         state: present
 
     - name: Ensure we know compute host keys
-      ansible.builtin.shell:
-        cmd: |
-          ssh-keyscan {{ hostvars[item].ansible_host }} >> ~/.ssh/known_hosts
+      # Using a dumb ssh command to get host keys
+      # ssh-keyscan is failing when running under FIPS mode
+      ansible.builtin.command: >-
+          ssh -o StrictHostKeyChecking=no
+          {{ hostvars[item].ansible_user }}@{{ hostvars[item].ansible_host }} uptime
       loop: >-
         {{
           hostvars | dict2items |

--- a/hooks/playbooks/fetch_compute_facts.yml
+++ b/hooks/playbooks/fetch_compute_facts.yml
@@ -238,9 +238,9 @@
                     value: ["0.0.0.0/0"]
 
         - name: Ensure we know about the private host keys
-          ansible.builtin.shell:
-            cmd: |
-              ssh-keyscan {{ cifmw_edpm_deploy_extra_vars.DATAPLANE_COMPUTE_IP }} >> ~/.ssh/known_hosts
+          ansible.builtin.command: >-
+              ssh -o StrictHostKeyChecking=no
+              {{ cifmw_edpm_deploy_extra_vars.DATAPLANE_COMPUTE_IP }} uptime
 
     - name: Save compute info
       vars:

--- a/roles/artifacts/tasks/crc.yml
+++ b/roles/artifacts/tasks/crc.yml
@@ -8,9 +8,11 @@
 - name: Ensure controller knows CRC ssh keys
   ignore_errors: true  # noqa: ignore-errors
   register: crc_host_key
-  ansible.builtin.shell:
-    cmd: >-
-      ssh-keyscan {{ cifmw_artifacts_crc_host }} >> ~/.ssh/known_hosts
+  # Using a dumb ssh command to get host keys since
+  # ssh-keyscan is failing when running under FIPS mode
+  ansible.builtin.command: >-
+      ssh -o StrictHostKeyChecking=no
+      {{ cifmw_artifacts_crc_user }}@{{ cifmw_artifacts_crc_host }} uptime
 - name: Get CRC things only if we know it
   when:
     - crc_host_key is defined

--- a/roles/reproducer/files/pre-ci-play.yml
+++ b/roles/reproducer/files/pre-ci-play.yml
@@ -112,17 +112,17 @@
           cifmw_crc_hostname: crc-0
 
     - name: Ensure controller-0 knows about remote SSH key
+      # Using a dumb ssh command to get host keys since
+      # ssh-keyscan is failing when running under FIPS mode
       block:
         - name: Inject localhost key
-          ansible.builtin.shell:
-            cmd: >-
-              ssh-keyscan localhost > ~/.ssh/known_hosts
+          ansible.builtin.command: >-
+            ssh -o StrictHostKeyChecking=no localhost uptime
 
         - name: Loop on all hosts to get their host SSH key
-          ansible.builtin.shell:
-            cmd: >-
-              ssh-keyscan {{ hostvars[item].ansible_host }}
-              >> ~/.ssh/known_hosts
+          ansible.builtin.command: >-
+            ssh -o StrictHostKeyChecking=no
+            {{ hostvars[item].ansible_user }}@{{ hostvars[item].ansible_host }} uptime
           loop: >-
             {{
               hostvars | dict2items |


### PR DESCRIPTION
* ssh-keyscan is failing even with two FIPS-enabled nodes. Needs further investigation. For now, try to replace with a simple ssh operation.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
