### PR TITLE
Enable checkout from openstack_ref flag in install_yamls

### DIFF
--- a/roles/edpm_deploy/tasks/main.yml
+++ b/roles/edpm_deploy/tasks/main.yml
@@ -14,14 +14,27 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Define minimal set of repo variables when not running on Zuul
+  when:
+    - zuul is not defined
+    - cifmw_operator_build_output is defined
+    - "'dataplane-operator' in operators_build_output.operators"
+  tags:
+    - always
+  vars:
+    operators_build_output: "{{ (cifmw_operator_build_output | default({'operators':{}})).operators }}"
+  ansible.builtin.set_fact:
+    _install_yamls_repos:
+      DATAPLANE_BRANCH: ""
+      GIT_CLONE_OPTS': "-l"
+      DATAPLANE_REPO': "{{ operators_build_output['dataplane-operator'].git_src_dir }}"
+
 - name: Set EDPM related vars
   when:
     - cifmw_install_yamls_environment is defined
     - cifmw_install_yamls_defaults is defined
   tags:
     - always
-  vars:
-    operators_build_output: "{{ (cifmw_operator_build_output | default({'operators':{}})).operators }}"
   ansible.builtin.set_fact:
     cifmw_edpm_deploy_env: >-
       {{
@@ -30,13 +43,7 @@
         combine({'DATAPLANE_REGISTRY_URL': cifmw_edpm_deploy_registry_url }) |
         combine({'DATAPLANE_CONTAINER_TAG': cifmw_repo_setup_full_hash | default(cifmw_install_yamls_defaults['DATAPLANE_CONTAINER_TAG']) }) |
         combine(cifmw_edpm_deploy_extra_vars | default({})) |
-        combine(
-          {
-            'DATAPLANE_BRANCH': '',
-            'GIT_CLONE_OPTS': '-l',
-            'DATAPLANE_REPO': operators_build_output['dataplane-operator'].git_src_dir,
-          } if ('dataplane-operator' in operators_build_output) else {}
-        )
+        combine(_install_yamls_repos | default({}))
       }}
     cacheable: true
 

--- a/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -14,17 +14,16 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Set install_yamls Makefile environment variables
+- name: Define minimal set of repo variables when not running on Zuul
+  when:
+    - zuul is not defined
   vars:
     operators_build_output: "{{ (cifmw_operator_build_output | default({'operators':{}})).operators }}"
   ansible.builtin.set_fact:
-    cifmw_edpm_deploy_baremetal_common_env: "{{ cifmw_install_yamls_environment | combine({'PATH': cifmw_path}) }}"
-    cifmw_edpm_deploy_baremetal_make_openstack_env: >-
+    _install_yamls_repos: >-
       {{
-        cifmw_edpm_deploy_baremetal_make_openstack_env | default({}) |
-        combine(
+        (
           {
-            'OPENSTACK_IMG': operators_build_output[cifmw_operator_build_meta_name].image_catalog,
             'OPENSTACK_REPO': operators_build_output[cifmw_operator_build_meta_name].git_src_dir,
             'OPENSTACK_BRANCH': '',
             'GIT_CLONE_OPTS': '-l',
@@ -37,6 +36,27 @@
             'DATAPLANE_BRANCH': '',
             'GIT_CLONE_OPTS': '-l',
           } if ('dataplane-operator' in operators_build_output)
+          else {}
+        )
+      }}
+
+- name: Set install_yamls Makefile environment variables
+  vars:
+    operators_build_output: "{{ (cifmw_operator_build_output | default({'operators':{}})).operators }}"
+  ansible.builtin.set_fact:
+    cifmw_edpm_deploy_baremetal_common_env: >-
+      {{
+        cifmw_install_yamls_environment |
+        combine({'PATH': cifmw_path}) |
+        combine(_install_yamls_repos | default({}))
+      }}
+    cifmw_edpm_deploy_baremetal_make_openstack_env: >-
+      {{
+        cifmw_edpm_deploy_baremetal_make_openstack_env | default({}) |
+        combine(
+          {
+            'OPENSTACK_IMG': operators_build_output[cifmw_operator_build_meta_name].image_catalog,
+          } if (cifmw_operator_build_meta_name is defined and cifmw_operator_build_meta_name in operators_build_output)
           else {}
         )
       }}

--- a/roles/edpm_prepare/tasks/main.yml
+++ b/roles/edpm_prepare/tasks/main.yml
@@ -14,6 +14,21 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Define minimal set of repo variables when not running on Zuul
+  when:
+    - zuul is not defined
+    - cifmw_operator_build_output is defined
+    - cifmw_operator_build_meta_name in operators_build_output.operators
+  tags:
+    - always
+  vars:
+    operators_build_output: "{{ (cifmw_operator_build_output | default({'operators':{}})).operators }}"
+  ansible.builtin.set_fact:
+    _install_yamls_repos:
+      OPENSTACK_BRANCH: ""
+      GIT_CLONE_OPTS': "-l"
+      OPENSTACK_REPO': "{{ operators_build_output[cifmw_operator_build_meta_name].git_src_dir  }}"
+
 - name: Set install_yamls Makefile environment variables
   tags:
     - always
@@ -24,6 +39,7 @@
       {{
         cifmw_install_yamls_environment |
         combine({'PATH': cifmw_path}) |
+        combine(_install_yamls_repos | default({})) |
         combine(cifmw_edpm_prepare_extra_vars | default({}))
       }}
     cifmw_edpm_prepare_make_openstack_env: |
@@ -32,11 +48,6 @@
       {% endif %}
     cifmw_edpm_prepare_make_openstack_deploy_prep_env: |
       CLEANUP_DIR_CMD: "true"
-      {% if cifmw_operator_build_meta_name is defined and cifmw_operator_build_meta_name in operators_build_output %}
-      OPENSTACK_BRANCH: ""
-      GIT_CLONE_OPTS: "-l"
-      OPENSTACK_REPO: {{ operators_build_output[cifmw_operator_build_meta_name].git_src_dir }}
-      {% endif %}
     cifmw_edpm_prepare_operators_build_output: "{{ operators_build_output }}"
 
 - name: Prepare storage in CRC

--- a/roles/install_yamls/README.md
+++ b/roles/install_yamls/README.md
@@ -10,6 +10,8 @@ It contains a set of playbooks to deploy podified control plane.
 * `cifmw_install_yamls_repo`: (String) `install_yamls` repo path. Defaults to `{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls`.
 * `cifmw_install_yamls_whitelisted_vars`: (List) Allowed variables in `cifmw_install_yamls_vars` that are not part of `install_yamls` Makefiles.
 * `cifmw_install_yamls_edpm_dir`: (String) Output directory for EDPM related artifacts (OUTPUT_BASEDIR). Defaults to `{{ cifmw_install_yamls_out_dir_basedir ~ '/artifacts/edpm' }}`
+* `cifmw_install_yamls_checkout_openstack_ref`: (String) Enable the checkout from openstack-operator references
+when cloning operator's repository using install_yamls make targets. Defaults to `"true"`
 
 ## Use case
 This module uses [a custom plugin](https://github.com/openstack-k8s-operators/ci-framework/blob/main/plugins/modules/generate_make_tasks.py) created to generate the role with tasks from Makefile.

--- a/roles/install_yamls/defaults/main.yml
+++ b/roles/install_yamls/defaults/main.yml
@@ -35,3 +35,6 @@ cifmw_install_yamls_whitelisted_vars:
   - OUTPUT_BASEDIR
   - OUTPUT_DIR
   - SSH_KEY_FILE
+# Defines in install_yamls when we should clone and checkout based on
+# openstack-operator references.
+cifmw_install_yamls_checkout_openstack_ref: "true"

--- a/roles/install_yamls/molecule/default/converge.yml
+++ b/roles/install_yamls/molecule/default/converge.yml
@@ -22,6 +22,17 @@
       namespace: foobar
     ansible_user_dir: "{{ lookup('env', 'HOME') }}"
     cifmw_install_yamls_repo: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
+    zuul:
+      items:
+        - project:
+            short_name: ci-framework
+            src_dir: src/github.com/openstack-k8s-operators/ci-framework
+        - project:
+            short_name: dataplane-operator
+            src_dir: src/github.com/openstack-k8s-operators/dataplane-operator
+        - project:
+            short_name: openstack-baremetal-operator
+            src_dir: src/github.com/openstack-k8s-operators/openstack-baremetal-operator
   roles:
     - role: "install_yamls"
 
@@ -47,3 +58,14 @@
           - item.stat.exists is defined
           - item.stat.exists | bool
       loop: "{{ make_files.results }}"
+
+    - name: Validate zuul_set_operators_repo output
+      vars:
+        expected_output:
+          DATAPLANE_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/dataplane-operator"
+          DATAPLANE_BRANCH: ""
+          BAREMETAL_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/openstack-baremetal-operator"
+          BAREMETAL_BRANCH: ""
+      ansible.builtin.assert:
+        that:
+          - cifmw_install_yamls_operators_repo == expected_output

--- a/roles/install_yamls/tasks/main.yml
+++ b/roles/install_yamls/tasks/main.yml
@@ -25,11 +25,19 @@
     - "{{ cifmw_install_yamls_tasks_out }}"
     - "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts/parameters"
 
+- name: Create variables with local repos based on Zuul items
+  tags:
+    - bootstrap
+  ansible.builtin.include_role:
+    name: install_yamls
+    tasks_from: zuul_set_operators_repo.yml
+
 - name: Set environment override cifmw_install_yamls_environment fact
   tags:
     - bootstrap
   vars:
     install_yamls_override_vars: "{{ cifmw_install_yamls_vars| default({}) }}"
+    install_yamls_operators_repos: "{{ cifmw_install_yamls_operators_repo | default({}) }}"
   ansible.builtin.set_fact:
     cifmw_install_yamls_environment: >-
       {{
@@ -39,8 +47,10 @@
         items2dict(key_name=0, value_name=1) |
         combine({
           'OUT': cifmw_install_yamls_manifests_dir,
-          'OUTPUT_DIR': cifmw_install_yamls_edpm_dir
-        })
+          'OUTPUT_DIR': cifmw_install_yamls_edpm_dir,
+          'CHECKOUT_FROM_OPENSTACK_REF': cifmw_install_yamls_checkout_openstack_ref
+        }) |
+        combine(install_yamls_operators_repos)
       }}
     cacheable: true
 

--- a/roles/install_yamls/tasks/zuul_set_operators_repo.yml
+++ b/roles/install_yamls/tasks/zuul_set_operators_repo.yml
@@ -1,0 +1,36 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# When using CI (Zuul) to deploy operators and its dependencies with install_yamls,
+#  it may be needed to set operator's repo variable to properly clone PR's
+#  code, instead of getting latest promoted content. This task search for all
+#  modified operators in zuul.items[] and set install_yaml variables.
+- name: Create variables with local repos based on Zuul items
+  when:
+    - zuul is defined
+    - "'operator' in zuul_item.project.short_name"
+  vars:
+    _repo_operator_name: "{{ zuul_item.project.short_name | regex_search('(?:openstack-)?(.*)-operator', '\\1') | first }}"
+    _repo_operator_info:
+      - key: "{{ _repo_operator_name | upper }}_REPO"
+        value: "{{ ansible_user_dir }}/{{ zuul_item.project.src_dir }}"
+      - key: "{{ _repo_operator_name | upper }}_BRANCH"
+        value: ""
+  ansible.builtin.set_fact:
+    cifmw_install_yamls_operators_repo: "{{ cifmw_install_yamls_operators_repo | default({}) | combine(_repo_operator_info | items2dict) }}"
+  loop: "{{ zuul['items'] }}"
+  loop_control:
+    loop_var: zuul_item

--- a/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
+++ b/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
@@ -3,8 +3,6 @@ ansible_user_dir: "{{ lookup('env', 'HOME') }}"
 cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
 cifmw_install_yamls_vars:
   DEPLOY_DIR: "{{ cifmw_basedir }}/artifacts/edpm_compute" # used during Baremetal deployment
-  DATAPLANE_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/dataplane-operator"
-  INFRA_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/infra-operator"
   BMAAS_INSTANCE_MEMORY: 8192
   BMAAS_INSTANCE_VCPUS: 6
   BMAAS_INSTANCE_DISK_SIZE: 40

--- a/scenarios/centos-9/edpm_ci.yml
+++ b/scenarios/centos-9/edpm_ci.yml
@@ -2,7 +2,6 @@
 ansible_user_dir: "{{ lookup('env', 'HOME') }}"
 cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
 cifmw_install_yamls_vars:
-  DATAPLANE_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/dataplane-operator"
   BMO_SETUP: false
   INSTALL_CERT_MANAGER: false
 


### PR DESCRIPTION
By enabling this flag in install_yamls, all repo cloning process will consider the commit hash set in `openstack-operator go.mod` instead of the HEAD of main branch. This process will fix issues that we face when operator's sample CR change in a repo, but openstack-operators wasn't bumped yet.
In order to have this working against PR proposals, we need to also guarantee that we set the ${OPERATOR_NAME}_REPO for all operators which code change in a PR. Using Zuul we can do this by checking zuul.items for projects that are *-operators and set ${OPERATOR_NAME}_REPO to point to the source code cloned by Zuul. Note that we this change, we are also removing *_REPO definitions from scenario files since it is not correct too, since the cloned code could just point to the cloned content from job's required project.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/732