### PR TITLE
Ensure libvirt_manager cleanup is safe when libvirt is not deployed

### DIFF
--- a/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/roles/libvirt_manager/tasks/clean_layout.yml
@@ -1,147 +1,156 @@
 ---
-- name: List all of the existing virtual machines
-  register: vms_list
-  community.libvirt.virt:
-    command: list_vms
-    uri: "qemu:///system"
+- name: Get installed packages list
+  ansible.builtin.package_facts: {}
 
-- name: Get pool configuration
-  community.libvirt.virt_pool:
-    command: facts
-    uri: "qemu:///system"
-
-- name: Filter out target environment
-  ansible.builtin.set_fact:
-    cleanup_vms: "{{ vms_list.list_vms | select('match', '^cifmw-.*$') }}"
-
-- name: Expose cleanup list
-  ansible.builtin.debug:
-    var: cleanup_vms
-
-- name: Destroy machine
-  register: vm_destroy
-  community.libvirt.virt:
-    command: destroy
-    name: "{{ item }}"
-    uri: "qemu:///system"
-  loop: "{{ cleanup_vms }}"
-  failed_when:
-    - vm_destroy.rc is defined
-    - vm_destroy.rc > 1
-
-- name: Undefine machine
-  community.libvirt.virt:
-    command: undefine
-    flags:
-      - keep_nvram
-      - snapshots_metadata
-    name: "{{ item }}"
-    uri: "qemu:///system"
-  loop: "{{ cleanup_vms }}"
-
-- name: "(localhost) Clean ssh jumpers"
-  when:
-    - inventory_hostname != 'localhost'
-  delegate_to: localhost
-  vars:
-    vm: "{{ item | replace('cifmw-', '') }}"
-  ansible.builtin.blockinfile:
-    path: "{{ lookup('env', 'HOME') }}/.ssh/config"
-    marker: "## {mark} {{ vm }}"
-    state: absent
-    create: true
-  loop: "{{ cleanup_vms }}"
-
-- name: "({{ inventory_hostname }}) Clean ssh jumpers"  # noqa: name[template]
-  vars:
-    vm: "{{ item | replace('cifmw-', '') }}"
-  ansible.builtin.blockinfile:
-    path: "{{ ansible_user_dir }}/.ssh/config"
-    marker: "## {mark} {{ vm }}"
-    state: absent
-    create: true
-  loop: "{{ cleanup_vms }}"
-
-- name: Get network list
-  register: nets_list
-  community.libvirt.virt_net:
-    command: list_nets
-    uri: "qemu:///system"
-
-- name: Filter out target nets
-  ansible.builtin.set_fact:
-    cleanup_nets: "{{ nets_list.list_nets | select('match', '^cifmw-.*$') }}"
-
-- name: Expose cleanup list
-  ansible.builtin.debug:
-    var: cleanup_nets
-
-- name: Destroy networks
-  register: net_destroy
-  community.libvirt.virt_net:
-    command: destroy
-    name: "{{ item }}"
-    uri: "qemu:///system"
-  loop: "{{ cleanup_nets }}"
-  failed_when:
-    - net_destroy.rc is defined
-    - net_destroy.rc > 1
-
-- name: Undefine networks
-  community.libvirt.virt_net:
-    command: undefine
-    name: "{{ item }}"
-    uri: "qemu:///system"
-  loop: "{{ cleanup_nets }}"
-
-- name: Remove cifmw storage pool
-  vars:
-    action: "delete"
-  ansible.builtin.include_tasks: storage_pool.yml
-
-- name: Remove custom images from oooq_pool if exists
-  when:
-    - item is match('^ocp-[0-9]\.qcow2+$')
-  ansible.builtin.command:
-    cmd: >-
-      virsh -c qemu:///system vol-delete
-      --vol {{ item }}
-      --pool oooq_pool
-  loop: "{{ ansible_libvirt_pools['oooq_pool'].volumes | default([]) }}"
-
-- name: Get temporary key status
-  register: _tmp_key
-  ansible.builtin.stat:
-    path: "{{ ansible_user_dir }}/.ssh/cifmw_reproducer_key.pub"
-
-- name: Remove temporary ssh key from authorized_keys
-  when:
-    - _tmp_key.stat.exists
+- name: Perform the libvirt cleanup
+  when: >-
+    cifmw_libvirt_manager_dependency_packages |
+    difference(ansible_facts.packages.keys()) |
+    length == 0
   block:
-    - name: Get public key
-      register: _pub_key
-      ansible.builtin.slurp:
+    - name: List all of the existing virtual machines
+      register: vms_list
+      community.libvirt.virt:
+        command: list_vms
+        uri: "qemu:///system"
+
+    - name: Get pool configuration
+      community.libvirt.virt_pool:
+        command: facts
+        uri: "qemu:///system"
+
+    - name: Filter out target environment
+      ansible.builtin.set_fact:
+        cleanup_vms: "{{ vms_list.list_vms | select('match', '^cifmw-.*$') }}"
+
+    - name: Expose cleanup list
+      ansible.builtin.debug:
+        var: cleanup_vms
+
+    - name: Destroy machine
+      register: vm_destroy
+      community.libvirt.virt:
+        command: destroy
+        name: "{{ item }}"
+        uri: "qemu:///system"
+      loop: "{{ cleanup_vms }}"
+      failed_when:
+        - vm_destroy.rc is defined
+        - vm_destroy.rc > 1
+
+    - name: Undefine machine
+      community.libvirt.virt:
+        command: undefine
+        flags:
+          - keep_nvram
+          - snapshots_metadata
+        name: "{{ item }}"
+        uri: "qemu:///system"
+      loop: "{{ cleanup_vms }}"
+
+    - name: "(localhost) Clean ssh jumpers"
+      when:
+        - inventory_hostname != 'localhost'
+      delegate_to: localhost
+      vars:
+        vm: "{{ item | replace('cifmw-', '') }}"
+      ansible.builtin.blockinfile:
+        path: "{{ lookup('env', 'HOME') }}/.ssh/config"
+        marker: "## {mark} {{ vm }}"
+        state: absent
+        create: true
+      loop: "{{ cleanup_vms }}"
+
+    - name: "({{ inventory_hostname }}) Clean ssh jumpers"  # noqa: name[template]
+      vars:
+        vm: "{{ item | replace('cifmw-', '') }}"
+      ansible.builtin.blockinfile:
+        path: "{{ ansible_user_dir }}/.ssh/config"
+        marker: "## {mark} {{ vm }}"
+        state: absent
+        create: true
+      loop: "{{ cleanup_vms }}"
+
+    - name: Get network list
+      register: nets_list
+      community.libvirt.virt_net:
+        command: list_nets
+        uri: "qemu:///system"
+
+    - name: Filter out target nets
+      ansible.builtin.set_fact:
+        cleanup_nets: "{{ nets_list.list_nets | select('match', '^cifmw-.*$') }}"
+
+    - name: Expose cleanup list
+      ansible.builtin.debug:
+        var: cleanup_nets
+
+    - name: Destroy networks
+      register: net_destroy
+      community.libvirt.virt_net:
+        command: destroy
+        name: "{{ item }}"
+        uri: "qemu:///system"
+      loop: "{{ cleanup_nets }}"
+      failed_when:
+        - net_destroy.rc is defined
+        - net_destroy.rc > 1
+
+    - name: Undefine networks
+      community.libvirt.virt_net:
+        command: undefine
+        name: "{{ item }}"
+        uri: "qemu:///system"
+      loop: "{{ cleanup_nets }}"
+
+    - name: Remove cifmw storage pool
+      vars:
+        action: "delete"
+      ansible.builtin.include_tasks: storage_pool.yml
+
+    - name: Remove custom images from oooq_pool if exists
+      when:
+        - item is match('^ocp-[0-9]\.qcow2+$')
+      ansible.builtin.command:
+        cmd: >-
+          virsh -c qemu:///system vol-delete
+          --vol {{ item }}
+          --pool oooq_pool
+      loop: "{{ ansible_libvirt_pools['oooq_pool'].volumes | default([]) }}"
+
+    - name: Get temporary key status
+      register: _tmp_key
+      ansible.builtin.stat:
         path: "{{ ansible_user_dir }}/.ssh/cifmw_reproducer_key.pub"
 
-    - name: Remove public key
-      ansible.posix.authorized_key:
-        user: "{{ ansible_user_id }}"
-        key: "{{ _pub_key['content'] | b64decode }}"
-        state: absent
+    - name: Remove temporary ssh key from authorized_keys
+      when:
+        - _tmp_key.stat.exists
+      block:
+        - name: Get public key
+          register: _pub_key
+          ansible.builtin.slurp:
+            path: "{{ ansible_user_dir }}/.ssh/cifmw_reproducer_key.pub"
 
-    - name: Remove keypair
+        - name: Remove public key
+          ansible.posix.authorized_key:
+            user: "{{ ansible_user_id }}"
+            key: "{{ _pub_key['content'] | b64decode }}"
+            state: absent
+
+        - name: Remove keypair
+          ansible.builtin.file:
+            state: absent
+            path: "{{ ansible_user_dir }}/.ssh/{{ item }}"
+          loop:
+            - cifmw_reproducer_key.pub
+            - cifmw_reproducer_key
+
+    - name: Remove data directories
       ansible.builtin.file:
+        path: "{{ cifmw_libvirt_manager_basedir }}/{{ item }}"
         state: absent
-        path: "{{ ansible_user_dir }}/.ssh/{{ item }}"
       loop:
-        - cifmw_reproducer_key.pub
-        - cifmw_reproducer_key
-
-- name: Remove data directories
-  ansible.builtin.file:
-    path: "{{ cifmw_libvirt_manager_basedir }}/{{ item }}"
-    state: absent
-  loop:
-    - workload
-    - images
-    - volumes
+        - workload
+        - images
+        - volumes


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date: