### PR TITLE
Add "Disable openstack marketplace" to ironic scenario

### DIFF
--- a/scenarios/centos-9/ironic.yml
+++ b/scenarios/centos-9/ironic.yml
@@ -1,5 +1,8 @@
 ---
 pre_deploy:
+  - name: Disable openstack marketplace
+    type: playbook
+    source: disable_os_marketplace.yml
   - name: Kustomize OpenStack CR
     type: playbook
     source: control_plane_ironic.yml


### PR DESCRIPTION
Hooks do not merge.

When job is defined with:
     cifmw_extras:
        - '@scenarios/centos-9/podified_common.yml'
        - '@scenarios/centos-9/ironic.yml'

Only the `pre_deploy` hook from '@scenarios/centos-9/ironic.yml' is actually included.

I believe the intent was to also run the `pre_deploy` hook defined in `podified_common.yml` - but that is not the case without this change.
https://logserver.rdoproject.org/73/1173/a3f0cc7fdb15980777a6cabc307cc6b6d3f8bd00/github-check/podified-multinode-ironic-deployment/64dd9b0/controller/ci-framework-data/artifacts/ansible-vars.yml

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running