### PR TITLE
Allow to properly scale nodes

### DIFF
--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -162,7 +162,6 @@
   ansible.builtin.copy:
     dest: "{{ cifmw_libvirt_manager_basedir }}/artifacts/interfaces-info.yml"
     content: "{{ cifmw_libvirt_manager_mac_map | to_nice_yaml }}"
-    force: false
 
 - name: Ensure we get proper access to CRC
   when:

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -51,7 +51,6 @@
       ansible.builtin.copy:
         dest: "{{ _ctl_reproducer_basedir }}/parameters/interfaces-info.yml"
         content: "{{ cifmw_libvirt_manager_mac_map | to_nice_yaml }}"
-        force: false
 
     - name: Inject other Hypervisor SSH keys
       when:


### PR DESCRIPTION
Until now, the network-info.yml wasn't updated in case of re-deploy.
While it was OK with the first iteration of its generation, it doesn't
make sense anymore: we're gathering all the interfaces, always, for old
and new VM.

Removing the "force: false" will ensure we're properly populating the VM
interfaces, even in case of a scale-out, meaning a second run.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
