### PR TITLE
Allow to bump the amount of compute with a parameter

### DIFF
--- a/scenarios/reproducers/3-nodes.yml
+++ b/scenarios/reproducers/3-nodes.yml
@@ -15,7 +15,7 @@ cifmw_use_libvirt: true
 cifmw_libvirt_manager_configuration:
   vms:
     compute:
-      amount: 1
+      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 1] | max }}"
       root_part_id: >-
         {{
           (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |

--- a/scenarios/reproducers/validated-architecture-1.yml
+++ b/scenarios/reproducers/validated-architecture-1.yml
@@ -47,7 +47,7 @@ cifmw_libvirt_manager_configuration:
           (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
           ternary(4, 1)
         }}
-      amount: 3
+      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 3] | max }}"
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"


### PR DESCRIPTION
This patch, with #1181, should allow to easily scale-out the amount of
computes, without having to edit the validated-architecture-1.yml nor
the 3-nodes.yml.

It's taking the same parameter as the libvirt_manager role,
"cifmw_libvirt_manager_compute_amount".

The VA-1 scenario will pick the maximum amount, meaning we'll get at
least 3 computes; the 3-nodes will do the same, meaning we'll get at
least 1 node.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
