### PR TITLE
Add extra skip tests to nova-operator

### DIFF
--- a/roles/tempest/files/list_skipped.yml
+++ b/roles/tempest/files/list_skipped.yml
@@ -1127,6 +1127,42 @@ known_failures:
         lp: http://no.bug
     jobs:
       - nova-operator
+  - test: tempest.api.compute.servers.test_server_actions.ServerActionsTestOtherA
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_actions.ServerActionsV293TestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_actions.ServerActionsTestOtherB
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_assisted_volume_snapshots.VolumesAssistedSnapshotsTest.test_volume_assisted_snapshot_create_delete
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
   # TODO (rlandy) remove when https://issues.redhat.com/browse/OSPCIX-126 is fixed
   - test: tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_mtu_sized_frames
     deployment:


### PR DESCRIPTION
Add additional tempest tests to exclude from the nova-operator that are
currently not supported with default deployment. [1]

These tests fail because the default deployment doesn't have a compute node.

[1] https://sf.hosted.upshift.rdu2.redhat.com/logs/55/55260f435033f8469699ecba87475748a8bc0790/openstack-operators-periodic-integration-osp18-rhel9/podified-multinode-tempest-internal-integration-rhel9-osp18/942bb62/controller/ci-framework-data/tests/tempest/stestr_results.html

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
