### PR TITLE
Remove cifmw_extras from the reproducer vars

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -258,6 +258,7 @@
             rejectattr('key', 'equalto', 'cifmw_target_host') |
             rejectattr('key', 'equalto', 'cifmw_basedir') |
             rejectattr('key', 'equalto', 'cifmw_path') |
+            rejectattr('key', 'equalto', 'cifmw_extras') |
             rejectattr('key', 'match', '^cifmw_use.*') |
             rejectattr('key', 'match', '^cifmw_reproducer.*') |
             rejectattr('key', 'match', '^cifmw_rhol.*') |


### PR DESCRIPTION
The cifmw_extras is a variable we use to pass extra variables to the nested ansible-playbooks we usually use in CI. That variable, that has nothing to do with the framework itself, may contain jinja templates, to shortcut the access to zuul project dirs for example. That jinja, that the reproducer takes as a string, it's problematic when playbooks inside the reproducer, like the autogenerated cifmw-bootstrap.yml, tries to resolve it, cause variables, like zuul there, are not available.
To avoid these issues, and based on the fact that cifmw_extras is not a variable that the framework should care about out of our zuul CI, we now filter it out.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
