### PR TITLE
fix: remove ironic allocation test from run

### DIFF
--- a/roles/tempest/files/list_skipped.yml
+++ b/roles/tempest/files/list_skipped.yml
@@ -1310,3 +1310,12 @@ known_failures:
         lp: http://no.bug
     jobs:
       - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_allocations.TestAllocations
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Test bug being fixed in caracal.
+        lp: https://bugs.launchpad.net/ironic/+bug/2054722
+    jobs:
+      - ironic-operator


### PR DESCRIPTION
Ironic, internally, has a lightweight allocation engine, originally added for metalsmith usage ages ago. Turns out its unit tests can fail when running automated cleaning combined with default deployment interface which is not the fake driver. This was not detected upstream because only the fake drivers are executed together.

Needed for: https://github.com/openstack-k8s-operators/ironic-operator/pull/401

As a pull request owner and reviewers, I checked that:
  - [x]  Appropriate testing is done and actually running
