### PR TITLE
Run nmstate on OCP nodes only if accessible

### DIFF
--- a/roles/ci_nmstate/tasks/main.yml
+++ b/roles/ci_nmstate/tasks/main.yml
@@ -99,6 +99,7 @@
     cacheable: true
 
 - name: Provision k8s workers with nmstate
+  when: cifmw_openshift_kubeconfig is defined
   ansible.builtin.include_tasks: nmstate_k8s_install.yml
 
 - name: Provision unmanaged nodes with nmstate


### PR DESCRIPTION
`ci_nmstate` is used for configuring the system hosting the OpenShift cluster. Hence, OCP is unavailable at this point of time. This PR adds a check to OCP node configuration.

*Error snippet*
```
TASK [ci_nmstate : Create the nmstate namespace kubeconfig={{ cifmw_openshift_kubeconfig }}, api_key={{ cifmw_openshift_token | default(omit)}}, context={{ cifmw_openshift_context | default(omit) }}, name={{ cifmw_ci_nmstate_namespace }}, kind=Namespace, state=present] ***
Friday 23 February 2024  04:57:21 -0500 (0:00:00.081)       0:03:47.860 ******* 
fatal: [hypervisor]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'cifmw_openshift_kubeconfig' is undefined. 'cifmw_openshift_kubeconfig' is undefined\n\nThe error appears to be in '/home/ciuser/src/ci-framework/roles/ci_nmstate/tasks/nmstate_k8s_install.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: Create the nmstate namespace\n  ^ here\n"}
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

Closes: [OSPRH-4447](https://issues.redhat.com//browse/OSPRH-4447)