### PR TITLE
Ensure conflicting `ansible-core` package is absent

### DIFF
--- a/roles/devscripts/tasks/131_packages.yml
+++ b/roles/devscripts/tasks/131_packages.yml
@@ -28,3 +28,9 @@
   ansible.builtin.import_role:
     name: ci_setup
     tasks_from: epel.yml
+
+- name: Ensure conflicting package does not exist.
+  become: true
+  ansible.builtin.package:
+    name: "ansible-core"
+    state: absent


### PR DESCRIPTION
Some of the downstream environment come with pre-installed `ansible-core=2.14.9` that results in the below error

```
2024-02-23 14:02:31 +(./01_install_requirements.sh:118): ansible-galaxy install -r vm-setup/requirements.yml
2024-02-23 14:02:31 Traceback (most recent call last):
2024-02-23 14:02:31   File "/bin/ansible-galaxy", line 33, in <module>
2024-02-23 14:02:31     sys.exit(load_entry_point('ansible-core==2.14.9', 'console_scripts', 'ansible-galaxy')())
2024-02-23 14:02:31   File "/bin/ansible-galaxy", line 25, in importlib_load_entry_point
2024-02-23 14:02:31     return next(matches).load()
2024-02-23 14:02:31 StopIteration
```

Closes: [OSPRH-5181](https://issues.redhat.com//browse/OSPRH-5181)

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
