### PR TITLE
[devscripts] Fix static external network scenario

### DIFF
--- a/roles/devscripts/README.md
+++ b/roles/devscripts/README.md
@@ -35,7 +35,7 @@ networks.
 * `cifmw_devscripts_enable_iscsi_on_ocp_nodes` (bool) Enable iSCSI services on
   the OpenShift nodes having role as `worker`. Defaults to `false`.
 * `cifmw_devscripts_host_bm_net_ip_addr` (str) The IP address of the host to be
-  assigned.
+  assigned. Must be from the specified external network.
 * `cifmw_devscripts_use_static_ip_addr` (bool) Use static IP addresses for the
   OCP nodes. Defaults to `false`
 

--- a/roles/devscripts/tasks/138_static_ip_addr.yml
+++ b/roles/devscripts/tasks/138_static_ip_addr.yml
@@ -16,7 +16,6 @@
 
 
 - name: Ensure the network config directory exists.
-  become: true
   ansible.builtin.file:
     path: "{{ cifmw_devscripts_config.working_dir }}/net_config"
     state: "directory"
@@ -46,51 +45,40 @@
     ipv4_address: >-
       {{
         cifmw_devscripts_config.external_subnet_v4 |
-        ansible.utils.nthhost(item | int + 6) |
-        default(omit)
+        default(omit) |
+        ansible.utils.nthhost(item | int + 4)
       }}
     ipv4_prefix: >-
       {{
         cifmw_devscripts_config.external_subnet_v4 |
-        ansible.utils.ipaddr('prefix') |
-        default(omit)
+        default(omit) |
+        ansible.utils.ipaddr('prefix')
       }}
     ipv6_address: >-
       {{
         cifmw_devscripts_config.external_subnet_v6 |
-        ansible.utils.nthhost(item | int + 6) |
-        default(omit)
+        default(omit) |
+        ansible.utils.nthhost(item | int + 4)
       }}
     ipv6_prefix: >-
       {{
         cifmw_devscripts_config.external_subnet_v6 |
-        ansible.utils.ipaddr('prefix') |
-        default(omit)
+        default(omit) |
+        ansible.utils.ipaddr('prefix')
       }}
-    dns_server: >-
-      {{
-        (cifmw_devscripts_config.external_subnet_v4 is defined) |
-        ternary(cifmw_devscripts_config.external_subnet_v4,
-        cifmw_devscripts_config.external_subnet_v6) |
-        ansible.utils.nthhost(1)
-      }}
-    net_gateway: >-
-      {{
-        (cifmw_devscripts_config.external_subnet_v4 is defined) |
-        ternary(cifmw_devscripts_config.external_subnet_v4,
-        cifmw_devscripts_config.external_subnet_v6) |
-        ansible.utils.nthhost(1)
-      }}
+    dns_server: "{{ cifmw_devscripts_host_bm_net_ip_addr }}"
+    net_gateway: "{{ cifmw_devscripts_host_bm_net_ip_addr }}"
   ansible.builtin.template:
     src: "templates/nmstate.j2"
-    path: >-
+    dest: >-
       {{
         (
           cifmw_devscripts_config.working_dir,
           'net_config',
           cifmw_devscripts_config.cluster_name +
-          '_cifmw_master_' +
-          item + '.yaml'
+          '-master-' +
+          (item | string) +
+          '.yaml'
         ) | ansible.builtin.path_join
       }}
     owner: "{{ cifmw_devscripts_user }}"
@@ -105,51 +93,40 @@
     ipv4_address: >-
       {{
         cifmw_devscripts_config.external_subnet_v4 |
-        ansible.utils.nthhost(item | int + 10) |
-        default(omit)
+        default(omit) |
+        ansible.utils.nthhost(item | int + 7)
       }}
     ipv4_prefix: >-
       {{
         cifmw_devscripts_config.external_subnet_v4 |
-        ansible.utils.ipaddr('prefix') |
-        default(omit)
+        default(omit) |
+        ansible.utils.ipaddr('prefix')
       }}
     ipv6_address: >-
       {{
         cifmw_devscripts_config.external_subnet_v6 |
-        ansible.utils.nthhost(item | int + 10) |
-        default(omit)
+        default(omit) |
+        ansible.utils.nthhost(item | int + 7)
       }}
     ipv6_prefix: >-
       {{
         cifmw_devscripts_config.external_subnet_v6 |
-        ansible.utils.ipaddr('prefix') |
-        default(omit)
+        default(omit) |
+        ansible.utils.ipaddr('prefix')
       }}
-    dns_server: >-
-      {{
-        (cifmw_devscripts_config.external_subnet_v4 is defined) |
-        ternary(cifmw_devscripts_config.external_subnet_v4,
-        cifmw_devscripts_config.external_subnet_v6) |
-        ansible.utils.nthhost(1)
-      }}
-    net_gateway: >-
-      {{
-        (cifmw_devscripts_config.external_subnet_v4 is defined) |
-        ternary(cifmw_devscripts_config.external_subnet_v4,
-        cifmw_devscripts_config.external_subnet_v6) |
-        ansible.utils.nthhost(1)
-      }}
+    dns_server: "{{ cifmw_devscripts_host_bm_net_ip_addr }}"
+    net_gateway: "{{ cifmw_devscripts_host_bm_net_ip_addr }}"
   ansible.builtin.template:
     src: "templates/nmstate.j2"
-    path: >-
+    dest: >-
       {{
         (
           cifmw_devscripts_config.working_dir,
           'net_config',
           cifmw_devscripts_config.cluster_name +
-          '-cifmw-worker-' +
-          item + '.yaml'
+          '-worker-' +
+          (item | string) +
+          '.yaml'
         ) | ansible.builtin.path_join
       }}
     owner: "{{ cifmw_devscripts_user }}"

--- a/roles/devscripts/templates/nmstate.j2
+++ b/roles/devscripts/templates/nmstate.j2
@@ -1,21 +1,20 @@
----
 networkConfig:
   interfaces:
     - name: enp2s0
       type: ethernet
       state: up
-{% if cifmw_devscripts_config.ip_stack != 'ipv6' %}
+{% if cifmw_devscripts_config.ip_stack != 'v6' %}
       ipv4:
         address:
           - ip: "{{ ipv4_address }}"
-            prefix-length: "{{ ipv4_prefix }}"
+            prefix-length: {{ ipv4_prefix }}
         enabled: true
 {% endif %}
-{% if cifmw_devscripts_config.ip_stack != 'ipv4' %}
+{% if cifmw_devscripts_config.ip_stack != 'v4' %}
       ipv6:
         address:
           - ip: "{{ ipv6_address }}"
-            prefix-length: "{{ ipv6_prefix }}"
+            prefix-length: {{ ipv6_prefix }}
         enabled: true
 {% endif %}
   dns-resolver:


### PR DESCRIPTION
dev-scripts looks for this format `<cluster-name>-<role>-<index>`. In the patch set, we align the file naming. 

Second change is related to `dns-server` and `gateway`. The primary scenario for using static IP address is when there is no DHCP services on the external network. Hosting the DNS allows us to configure the OpenShift API IP and ingress address without dependency. Hence the change for pointing to the system hosting the cluster.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes

*Log snippet*
```
TASK [devscripts : Write the static configuration for master nodes. src=templates/nmstate.j2, dest={{
  (
    cifmw_devscripts_config.working_dir,
    'net_config',
    cifmw_devscripts_config.cluster_name +
    '-master-' +
    (item | string) +
    '.yaml'
  ) | ansible.builtin.path_join
}}, owner={{ cifmw_devscripts_user }}, group={{ cifmw_devscripts_user }}, mode=0644] ***
Monday 26 February 2024  01:11:09 -0500 (0:00:00.084)       0:05:06.547 ******* 
changed: [hypervisor] => (item=0)
changed: [hypervisor] => (item=1)
changed: [hypervisor] => (item=2)
```

Deployment snippet
```
TASK [devscripts : Gather the deployed OCP configuration. path={{ kube_file }}] **************************************************************************************************************************************************************
Monday 26 February 2024  06:10:45 -0500 (0:00:01.670)       1:03:42.237 ******* 
ok: [hypervisor]

TASK [devscripts : Parse the OpenShift configuration file. kubeconfig={{ _kubeconfig['source'] }}, kubeconf={{ _kubeconfig['content'] | b64decode | from_yaml }}] ****************************************************************************
Monday 26 February 2024  06:10:47 -0500 (0:00:01.847)       1:03:44.085 ******* 
ok: [hypervisor]

TASK [devscripts : Set the OpenShift platform access information. cifmw_openshift_api={{ kubeconf.clusters[0].cluster.server }}, cifmw_openshift_user=kubeadmin, cifmw_openshift_password={{ kubeadmin_password.content | b64decode }}, cifmw_openshift_kubeconfig={{ kubeconfig }}, cacheable=True] ***
Monday 26 February 2024  06:10:47 -0500 (0:00:00.048)       1:03:44.133 ******* 
ok: [hypervisor]

TASK [devscripts : Prepare for disk overlay configuration. _raw_params=310_prepare_overlay.yml] **********************************************************************************************************************************************
Monday 26 February 2024  06:10:47 -0500 (0:00:00.056)       1:03:44.190 ******* 
included: /home/ciuser/src/ci-framework/roles/devscripts/tasks/310_prepare_overlay.yml for hypervisor
```
