### PR TITLE
Ensure we keep short file names

### DIFF
--- a/roles/run_hook/tasks/playbook.yml
+++ b/roles/run_hook/tasks/playbook.yml
@@ -2,7 +2,10 @@
 - name: "Set playbook path for {{ hook.name }}"
   vars:
     _hook_name: >-
-      {{ hook.name | regex_replace('([^a-zA-Z0-9\-\._])+', '_') | lower }}
+      {{ hook.name |
+         regex_replace('([^a-zA-Z0-9\-\._])+', '_') |
+         lower |
+         truncate(20, false, '') }}
     _play: >-
       {%- if hook.source is not ansible.builtin.abs -%}
       {{ role_path }}/../../hooks/playbooks/{{ hook.source }}


### PR DESCRIPTION
While system may support long file name (over 250 chars), it seems
ansible doesn't really like that.

Also, it may look really weird having a hook name so long it takes
multiple lines to display.

In order to make it more readable, and avoid any file name length issue,
we're now truncating the hook name to 20 chars. This will lead to better
UX, and may avoid some weird issues.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
