### PR TITLE
Dump dlrn md5 hash in cifmw_repo_setup_output path

### DIFF
--- a/roles/repo_setup/tasks/sync_repos.yml
+++ b/roles/repo_setup/tasks/sync_repos.yml
@@ -1,6 +1,6 @@
 ---
 - name: Copy generated repos to /etc/yum.repos.d directory
-  when: not cifmw_repo_setup_output.startswith(ansible_user_dir)
+  when: cifmw_repo_setup_output.startswith(ansible_user_dir)
   block:
     - name: Find existing repos from /etc/yum.repos.d directory
       ansible.builtin.find:


### PR DESCRIPTION
Currently dlrn md5 hash is written in a hardcoded directory. If cifmw_repo_setup_output is set to something else then dlrn md5 file will not be generated in cifmw_repo_setup_output directory and any role depending on the cifmw_repo_setup_output dlrn md5 file breaks.

Generating it in cifmw_repo_setup_output directory fixes the issue.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

