### PR TITLE
Set content_provider_dlrn_md5_hash default to empty string

### DIFF
--- a/ci/playbooks/tcib/run.yml
+++ b/ci/playbooks/tcib/run.yml
@@ -64,7 +64,7 @@
         msg: >-
           Running Content provider registry on
           {{ node_ip | default('nowhere') }} with dlrn md5 hash
-          {{ _dlrn_md5 | default('nowhere') }}
+          {{ _dlrn_md5 | default('') }}
 
     - name: Set up content registry IP address
       zuul_return:
@@ -72,4 +72,4 @@
           zuul:
             pause: true
           content_provider_registry_ip: "{{ node_ip | default('nowhere') }}"
-          content_provider_dlrn_md5_hash: "{{ _dlrn_md5 | default('nowhere') }}"
+          content_provider_dlrn_md5_hash: "{{ _dlrn_md5 | default('') }}"

--- a/roles/repo_setup/tasks/configure.yml
+++ b/roles/repo_setup/tasks/configure.yml
@@ -2,7 +2,9 @@
 - name: Set cifmw_repo_setup_dlrn_hash_tag from content provider
   ansible.builtin.set_fact:
     cifmw_repo_setup_dlrn_hash_tag: "{{ content_provider_dlrn_md5_hash }}"
-  when: content_provider_dlrn_md5_hash is defined
+  when:
+    - content_provider_dlrn_md5_hash is defined
+    - content_provider_dlrn_md5_hash | length > 0
 
 - name: Run repo-setup
   become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"


### PR DESCRIPTION
Earlier we set content_provider_dlrn_md5_hash to nowhere, it breaks the tcib content provider dependent EDPM job saying nowhere repo not found.

Returning it to empty string and make sure we set the dlrn_hash_tag value on non empty string content_provider_dlrn_md5_hash value fixes the issue.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

Tested on this pr: https://github.com/openstack-k8s-operators/tcib/pull/140 and https://review.rdoproject.org/zuul/buildset/eb97b694edad4091bd32fd7fe3bf7454

[Passed zuul vars](https://review.rdoproject.org/zuul/build/c3fd3329dd1a47259a38e64f5f0e64e9/log/zuul-info/inventory.yaml#34..35):
```
 content_provider_dlrn_md5_hash: ''
 content_provider_registry_ip: 192.168.25.2
```
and repo-setup[ execution on child job](https://review.rdoproject.org/zuul/build/c3fd3329dd1a47259a38e64f5f0e64e9/log/job-output.txt#2314)
```
2024-02-26 08:17:01.986625 | controller | TASK [repo_setup : Run repo-setup _raw_params={{ cifmw_repo_setup_basedir }}/venv/bin/repo-setup {{ cifmw_repo_setup_promotion }} {{ cifmw_repo_setup_additional_repos }} -d {{ cifmw_repo_setup_os_release }}{{ cifmw_repo_setup_dist_major_version }} -b {{ cifmw_repo_setup_branch }} --rdo-mirror {{ cifmw_repo_setup_rdo_mirror }} {% if cifmw_repo_setup_dlrn_hash_tag | length > 0 %} --dlrn-hash-tag {{ cifmw_repo_setup_dlrn_hash_tag }} {% endif %} -o {{ cifmw_repo_setup_output }}] ***
2024-02-26 08:17:01.986630 | controller | Monday 26 February 2024  08:17:01 -0500 (0:00:00.024)       0:00:13.451 *******
2024-02-26 08:17:02.775075 | controller | changed: [localhost]
```
