### PR TITLE
Minor refactor in edpm_prepare and new hook for ceph scenarios

### DIFF
--- a/hooks/playbooks/control_plane_ceph_backends.yml
+++ b/hooks/playbooks/control_plane_ceph_backends.yml
@@ -8,6 +8,13 @@
       ansible.builtin.include_vars:
         file: "{{ cifmw_control_plane_ceph_backend_include_vars }}"
 
+    - name: Set Ceph FSID from HCI deployment
+      when:
+        - cifmw_ceph_fsid is not defined
+        - cifmw_hci_prepare_ceph_fsid is defined
+      ansible.builtin.set_fact:
+        cifmw_ceph_fsid: "{{ cifmw_hci_prepare_ceph_fsid }}"
+
     - name: Ensure the kustomizations dir exists
       ansible.builtin.file:
         path: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/controlplane"

--- a/hooks/playbooks/control_plane_kustomize_deploy.yml
+++ b/hooks/playbooks/control_plane_kustomize_deploy.yml
@@ -1,0 +1,13 @@
+---
+- name: Kustomize and apply Control Plane kustomizations
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Load parameters files
+      ansible.builtin.include_vars:
+        dir: "{{ cifmw_basedir }}/artifacts/parameters"
+
+    - name: Kustomize and apply OpenStack Control Plane
+      ansible.builtin.import_role:
+        name: edpm_prepare
+        tasks_from: kustomize_and_deploy

--- a/roles/edpm_prepare/README.md
+++ b/roles/edpm_prepare/README.md
@@ -17,3 +17,5 @@ This role doesn't need privilege escalation.
 * `cifmw_edpm_prepare_verify_tls`: (Boolean) In case of TLS enabled for OpenStack endpoint, validates against the CA. Defaults to `true`.
 * `cifmw_edpm_prepare_skip_patch_ansible_runner`: (Boolean) Intentionally skips setting ansible runner image to `latest` from quay.io. Defaults to `False`.
 * `cifmw_edpm_prepare_kustomizations`: (List) Kustomizations to apply on top of the controlplane CRs. Defaults to `[]`.
+* `cifmw_edpm_prepare_wait_controplane_status_change_sec`: (Integer) Time, in seconds, to wait before checking
+openstack control plane deployment status. Useful when using the role to only update the control plane resource, scenario where it may be in a `ready` status. Defaults to `30`.

--- a/roles/edpm_prepare/defaults/main.yml
+++ b/roles/edpm_prepare/defaults/main.yml
@@ -28,3 +28,7 @@ cifmw_edpm_prepare_timeout: 30
 cifmw_edpm_prepare_verify_tls: true
 cifmw_edpm_prepare_skip_patch_ansible_runner: false
 cifmw_edpm_prepare_kustomizations: []
+# How long should we wait (in seconds) before checking control plane status. Useful
+#  when we are modifying the control plane, since the check status task can get a
+#  false 'ready' status.
+cifmw_edpm_prepare_wait_controplane_status_change_sec: 30

--- a/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
+++ b/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
@@ -1,0 +1,84 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Perform kustomizations to the OpenStackControlPlane CR
+  vars:
+    cifmw_edpm_prepare_openstack_crs_path: >-
+      {{
+        [
+          cifmw_edpm_prepare_manifests_dir,
+          cifmw_install_yamls_defaults['NAMESPACE'],
+          'openstack',
+          'cr'
+        ] | ansible.builtin.path_join
+      }}
+  ci_kustomize:
+    target_path: "{{ cifmw_edpm_prepare_openstack_crs_path }}"
+    sort_ascending: false
+    kustomizations: "{{ cifmw_edpm_prepare_kustomizations }}"
+    kustomizations_paths: >-
+      {{
+        [
+          (
+            [
+              cifmw_edpm_prepare_manifests_dir,
+              'kustomizations',
+              'controlplane'
+            ] | ansible.builtin.path_join
+          )
+        ]
+      }}
+  register: cifmw_edpm_prepare_crs_kustomize_result
+
+- name: Log the CR that is about to be applied
+  ansible.builtin.debug:
+    var: cifmw_edpm_prepare_crs_kustomize_result
+
+- name: Apply the OpenStackControlPlane CR
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  cifmw.general.ci_script:
+    output_dir: "{{ cifmw_edpm_prepare_basedir }}/artifacts"
+    script: "oc apply -f {{ cifmw_edpm_prepare_crs_kustomize_result.output_path }}"
+
+- name: Wait for control plane to change its status
+  # If we are modifying the control plane, it can be in a 'ready' status, so
+  # we need to wait a few seconds so it changes to a 'non-ready' status first.
+  ansible.builtin.pause:
+    seconds: "{{ cifmw_edpm_prepare_wait_controplane_status_change_sec }}"
+
+- name: Wait for OpenStack controlplane to be deployed
+  vars:
+    cr_name: >-
+      {{
+        (
+          cifmw_edpm_prepare_crs_kustomize_result.result |
+          selectattr('kind', 'defined') |
+          selectattr('metadata.name', 'defined') |
+          selectattr('kind', 'equalto', 'OpenStackControlPlane') |
+          first
+        ).metadata.name
+      }}
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: >-
+      oc wait OpenStackControlPlane {{ cr_name }}
+      --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+      --for=condition=ready
+      --timeout={{ cifmw_edpm_prepare_timeout }}m

--- a/roles/edpm_prepare/tasks/main.yml
+++ b/roles/edpm_prepare/tasks/main.yml
@@ -154,82 +154,17 @@
 - name: Kustomize and deploy OpenStackControlPlane
   tags:
     - control-plane
+  when: not cifmw_edpm_prepare_dry_run
+  ansible.builtin.include_tasks: kustomize_and_deploy.yml
+
+- name: Extract and install OpenStackControlplane CA
+  tags:
+    - control-plane
+  when: not cifmw_edpm_prepare_dry_run
   vars:
-    cifmw_edpm_prepare_openstack_crs_path: >-
-      {{
-        [
-          cifmw_edpm_prepare_manifests_dir,
-          cifmw_install_yamls_defaults['NAMESPACE'],
-          'openstack',
-          'cr'
-        ] | ansible.builtin.path_join
-      }}
-
-  when:
-    - not cifmw_edpm_prepare_dry_run | bool
-  block:
-    - name: Perform kustomizations to the OpenStackControlPlane CR
-      when: not cifmw_edpm_prepare_dry_run
-      ci_kustomize:
-        target_path: "{{ cifmw_edpm_prepare_openstack_crs_path }}"
-        sort_ascending: false
-        kustomizations: "{{ cifmw_edpm_prepare_kustomizations }}"
-        kustomizations_paths: >-
-          {{
-            [
-              (
-                [
-                  cifmw_edpm_prepare_manifests_dir,
-                  'kustomizations',
-                  'controlplane'
-                ] | ansible.builtin.path_join
-              )
-            ]
-          }}
-      register: cifmw_edpm_prepare_crs_kustomize_result
-
-    - name: Log the CR that is about to be applied
-      when: not cifmw_edpm_prepare_dry_run
-      ansible.builtin.debug:
-        var: cifmw_edpm_prepare_crs_kustomize_result
-
-    - name: Apply the OpenStackControlPlane CR
-      environment:
-        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-        PATH: "{{ cifmw_path }}"
-      when: not cifmw_edpm_prepare_dry_run
-      cifmw.general.ci_script:
-        output_dir: "{{ cifmw_edpm_prepare_basedir }}/artifacts"
-        script: "oc apply -f {{ cifmw_edpm_prepare_crs_kustomize_result.output_path }}"
-
-    - name: Wait for OpenStack controlplane to be deployed
-      when: not cifmw_edpm_prepare_dry_run
-      vars:
-        cr_name: >-
-          {{
-            (
-              cifmw_edpm_prepare_crs_kustomize_result.result |
-              selectattr('kind', 'defined') |
-              selectattr('metadata.name', 'defined') |
-              selectattr('kind', 'equalto', 'OpenStackControlPlane') |
-              first
-            ).metadata.name
-          }}
-      environment:
-        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-        PATH: "{{ cifmw_path }}"
-      ansible.builtin.command:
-        cmd: >-
-          oc wait OpenStackControlPlane {{ cr_name }}
-          --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
-          --for=condition=ready
-          --timeout={{ cifmw_edpm_prepare_timeout }}m
-
-    - name: Extract and install OpenStackControlplane CA
-      vars:
-        cifmw_install_openstack_ca_dest_path: "{{ cifmw_edpm_prepare_basedir }}"
-      ansible.builtin.include_role:
-        role: install_openstack_ca
+    cifmw_install_openstack_ca_dest_path: "{{ cifmw_edpm_prepare_basedir }}"
+  ansible.builtin.include_role:
+    role: install_openstack_ca
 
 - name: Wait for keystone to be ready
   tags:

--- a/roles/hci_prepare/tasks/phase2.yml
+++ b/roles/hci_prepare/tasks/phase2.yml
@@ -108,3 +108,12 @@
 - name: Enabled nova discover_hosts after deployment
   ansible.builtin.set_fact:
     cifmw_edpm_deploy_skip_nova_discover_hosts: false
+
+- name: Save HCI info
+  vars:
+    file_content:
+      cifmw_hci_prepare_ceph_fsid: "{{ cifmw_hci_prepare_ceph_fsid }}"
+  when: not cifmw_hci_prepare_dryrun
+  ansible.builtin.copy:
+    dest: "{{ cifmw_hci_prepare_basedir }}/artifacts/parameters/hci_prepare_phase2_params.yml"
+    content: "{{ file_content | to_nice_yaml }}"

--- a/scenarios/centos-9/hci_ceph_backends.yml
+++ b/scenarios/centos-9/hci_ceph_backends.yml
@@ -1,0 +1,42 @@
+---
+cifmw_install_yamls_vars:
+  BMO_SETUP: false
+  INSTALL_CERT_MANAGER: false
+
+cifmw_edpm_prepare_skip_crc_storage_creation: true
+
+post_deploy:
+  - name: Kustomize OpenStack CR with Ceph
+    type: playbook
+    source: control_plane_ceph_backends.yml
+  - name: Kustomize and update Control Plane
+    type: playbook
+    source: control_plane_kustomize_deploy.yml
+
+cifmw_services_manila_enabled: true
+
+pre_tempest:
+  - name: Create manila resources
+    type: playbook
+    source: manila_create_default_resources.yml
+
+cifmw_run_tests: true
+cifmw_tempest_container: openstack-tempest-all
+cifmw_tempest_default_groups: &test_operator_list
+  - openstack-operator
+  - cinder-operator
+  - keystone-operator
+  - manila-operator
+cifmw_tempest_default_jobs: *test_operator_list
+
+cifmw_tempest_tests_allowed_override_scenario: true
+
+cifmw_tempest_tempestconf_profile:
+  create: true
+  debug: true
+  os_cloud: default
+  overrides:
+    identity.v3_endpoint_type: public
+    share.run_share_group_tests: "False"
+    share.capability_storage_protocol: CEPHFS
+    share.suppress_errors_in_cleanup: "True"


### PR DESCRIPTION
When deploying an HCI environment (together with edpm deploy), the
Control Plane resources are already ready and we don't have a chance of
kustomizing them with ceph backends. To enable some storage backend
with Ceph, we need to provide the Ceph FSID, which is available only
after edpm_deploy.
This change refactor edpm_prepare to split a set of tasks used to
kustomize and deploy the control plane again, if needed, after edpm
deploy. These tasks can be called in a hook (added in this PR as example)
to update the Control Plane resources.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
