### PR TITLE
Complete the removal of cloud specific labels

### DIFF
--- a/docs/source/cookbooks/zuul-job-nodeset.md
+++ b/docs/source/cookbooks/zuul-job-nodeset.md
@@ -17,12 +17,7 @@ job parameter:
 - job:
     name: my-job-with-2-nodes
     parent: podified-multinode-edpm-deployment-crc
-    nodeset:
-      nodes:
-        - name: controller
-          label: cloud-centos-9-stream-tripleo-vexxhost
-        - name: crc
-          label: coreos-crc-extracted-xxl
+    nodeset: centos-9-medium-crc-extracted-2-30-0-3xl
     vars:
       cifmw_deploy_edpm: false
       podified_validation: true

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -20,6 +20,9 @@
 #
 #  CONTENT PROVIDER
 #
+
+# Content provider job needs to use -vexxhost label
+# as Vexxhost assign publix IP address's.
 - job:
     name: openstack-k8s-operators-content-provider
     parent: cifmw-base-minimal

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -54,17 +54,6 @@
         nodes: []
 
 - nodeset:
-    name: multinode-centos-9-stream-crc
-    nodes:
-      - name: controller
-        label: cloud-centos-9-stream-tripleo-vexxhost-medium
-      - name: crc
-        label: coreos-crc-extracted-2-19-0-3xl
-    groups:
-      - name: computes
-        nodes: []
-
-- nodeset:
     name: centos-9-medium-crc-extracted-2-30-0-3xl
     nodes:
       - name: controller


### PR DESCRIPTION
Most of the -vexxhost labels were removed as part of the work to update
to crc 2.30, this patch:
- Adds comment to content provider job no to remove -vexxhost label.
- Removes unused nodeset `multinode-centos-9-stream-crc`
- Updates documentation to remove reference to -vexxhost label

Related patch: https://github.com/openstack-k8s-operators/ci-framework/pull/1024
Jira: https://issues.redhat.com/browse/OSPRH-5165

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date: