### PR TITLE
Ensure libvirt_manager layout contains correct information

### DIFF
--- a/roles/devscripts/tasks/300_post.yml
+++ b/roles/devscripts/tasks/300_post.yml
@@ -37,7 +37,7 @@
   tags:
     - devscripts_post
   when:
-    - not cifmw_devscripts_ocp_exists | bool
+    - not cifmw_devscripts_ocp_online | bool
   ansible.builtin.include_tasks: 320_prepare_layout.yml
 
 - name: Bringing cluster online.

--- a/roles/devscripts/tasks/320_prepare_layout.yml
+++ b/roles/devscripts/tasks/320_prepare_layout.yml
@@ -18,30 +18,67 @@
 - name: Gather the golden file definition path.
   ansible.builtin.find:
     paths: "{{ cifmw_devscripts_config.working_dir }}"
-    patterns: "{{ cifmw_devscripts_config.cluster_name }}_*.xml"
+    patterns: "{{ cifmw_devscripts_config.cluster_name }}_master_*.xml"
     recurse: false
-  register: _xml_files_result
+  register: _ctrl_vm_xml
 
-- name: Prepare the file path list.
-  when: not _xml_files_result.failed | default(true)
-  ansible.builtin.set_fact:
-    _xml_files: "{{ (_xml_files | default([]) ) + [item.path] }}"
-  loop: "{{ _xml_files_result.files }}"
-
-- name: Override the default xml paths.
+- name: Align the OCP type information.
+  when:
+    - not _ctrl_vm_xml.failed | default(true)
   vars:
     _data:
       vms:
         ocp:
-          amount: >-
-            {{
-              (cifmw_devscripts_config.num_masters | int) +
-              (cifmw_devscripts_config.num_workers | int)
-            }}
-          xml_paths: "{{ _xml_files }}"
+          amount: "{{ cifmw_devscripts_config.num_masters | int }}"
+          image_local_dir: "{{ cifmw_devscripts_config.working_dir }}/pool"
+          xml_paths: "{{ _ctrl_vm_xml.files | map(attribute='path') | list }}"
+          disk_file_name: "{{ cifmw_devscripts_config.cluster_name }}_master"
+          disksize: "{{ cifmw_devscripts_config.master_disk | int + 20 }}"
   ansible.builtin.set_fact:
-    cifmw_libvirt_manager_configuration: >-
+    cifmw_libvirt_manager_configuration_gen: >-
       {{
-        cifmw_libvirt_manager_configuration |
+        cifmw_libvirt_manager_configuration_gen |
+        default(cifmw_libvirt_manager_configuration) |
         combine(_data, recursive=true)
       }}
+
+- name: Ensure OCP worker data is aligned.
+  when:
+    - cifmw_devscripts_config.num_workers > 0
+  block:
+    - name: Gather the worker nodes xml file definitions.
+      ansible.builtin.find:
+        paths: "{{ cifmw_devscripts_config.working_dir }}"
+        patterns: "{{ cifmw_devscripts_config.cluster_name }}_worker_*.xml"
+        recurse: false
+      register: _wrk_vm_xml
+
+    - name: Align the worker data.
+      when:
+        - _wrk_vm_xml.failed | default(true)
+      vars:
+        _wrk_data:
+          vms:
+            ocp_worker:
+              amount: "{{ cifmw_devscripts_config.num_workers | int }}"
+              admin_user: "core"
+              image_local_dir: "{{ cifmw_devscripts_config.working_dir }}/pool"
+              disk_file_name: >-
+                {{
+                  cifmw_devscripts_config.cluster_name + '_worker'
+                }}
+              disksize: >-
+                {{
+                  cifmw_devscripts_config.worker_disk | default(30) | int + 20
+                }}
+              xml_paths: >-
+                {{
+                  _wrk_vm_xml.files | map(attribute='path') | list
+                }}
+      ansible.builtin.set_fact:
+        cifmw_libvirt_manager_configuration_gen: >-
+          {{
+            cifmw_libvirt_manager_configuration_gen |
+            default(cifmw_libvirt_manager_configuration) |
+            combine(_wrk_data, recursive=true)
+          }}


### PR DESCRIPTION
This change ensure `cifmw_libvirt_manager` and `cifmw_devscripts_config` are aligned. Ensuring custom cluster names and configuration are dynamically updated.

Below is the error observed when there is a difference
```
TASK [libvirt_manager : Create VM overlay for ocp creates={{ vm_type }}-{{ vm_id }}.qcow2, chdir={{ _chdir }}, _raw_params=qemu-img create {% if vm_data.value.disk_file_name != 'blank' %} -o backing_file={{ _img }},backing_fmt=qcow2 {% endif %} -f qcow2 "{{ _vm_img }}" "{{ vm_data.value.disksize|default ('40') }}G"] ***
Monday 26 February 2024  06:12:27 -0500 (0:00:00.075)       1:05:23.664 ******* 
failed: [hypervisor] (item=ocp-0) => {"ansible_index_var": "vm_id", "ansible_loop_var": "item", "changed": true, "cmd": ["qemu-img", "create", "-o", "backing_file=/home/dev-scripts/pool/ocp_0.qcow2,backing_fmt=qcow2", "-f", "qcow2", "ocp-0.qcow2", "100G"], "delta": "0:00:00.011585", "end": "2024-02-26 13:12:37.224796", "item": 0, "msg": "non-zero return code", "rc": 1, "start": "2024-02-26 13:12:37.213211", "stderr": "qemu-img: ocp-0.qcow2: Could not open '/home/dev-scripts/pool/ocp_0.qcow2': No such file or directory\nCould not open backing image.", "stderr_lines": ["qemu-img: ocp-0.qcow2: Could not open '/home/dev-scripts/pool/ocp_0.qcow2': No such file or directory", "Could not open backing image."], "stdout": "", "stdout_lines": [], "vm_id": 0}
```

_Change information_
These changes are related to supporting non-default OpenShift cluster name. The onus is on the user to provide the right information in `cifmw_libvirt_manager_configuration`. Specifically the `vms.ocp`... Vanilla runs hold

```
cifmw_libvirt_manager_configuration:
  vms:
    ocp:
      amount: 3
      admin_user: core
      image_local_dir: "/home/dev-scripts/pool"
      disk_file_name: "ocp_master"
      disksize: "105"
      xml_paths:
        - /home/dev-scripts/ocp_master_0.xml
        - /home/dev-scripts/ocp_master_1.xml
        - /home/dev-scripts/ocp_master_2.xml
      nets:
        - osp_trunk
```

In the scenario when `cifmw_devscripts_config_overrides.cluster_name` is set `ocptest` then the expected values of `cifmw_libvirt_manager_configuration` must reflect

```
cifmw_libvirt_manager_configuration:
  vms:
    ocp:
      amount: 3
      admin_user: core
      image_local_dir: "/home/dev-scripts/pool"
      disk_file_name: "ocptest_master"
      disksize: "105"
      xml_paths:
        - /home/dev-scripts/ocptest_master_0.xml
        - /home/dev-scripts/ocptest_master_1.xml
        - /home/dev-scripts/ocptest_master_2.xml
      nets:
        - osp_trunk
```

This PR ensures we don't fail when there is a mismatch in any of the keys for type `ocp` by ensuring the values reflect the actual artifacts. The `nets` key cannot be updated as `devscripts` does not hold information about additional networks.

When `cifmw_devscripts_config_overrides.num_workers` is greater than `0` then, there is a change in pattern. Hence adding a new type called `ocp_worker` so

```
cifmw_libvirt_manager_configuration:
  vms:
    ocp_worker:
      amount: 3
      admin_user: core
      image_local_dir: "/home/dev-scripts/pool"
      disk_file_name: "ocptest_worker"
      disksize: "105"
      xml_paths:
        - /home/dev-scripts/ocptest_worker_0.xml
        - /home/dev-scripts/ocptest_worker_1.xml
        - /home/dev-scripts/ocptest_worker_2.xml
      nets:
        - osp_trunk
```
In case of `ocp_worker`, `libvirt_manager` understand that this is related to `ocp` and creates the backing volumes `image_local_dir`.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

Closes: [OSPRH-5229](https://issues.redhat.com//browse/OSPRH-5229)
