### PR TITLE
Add tripleo controllers into adoption multinode source nodeset

### DIFF
--- a/ci/playbooks/multinode-customizations.yml
+++ b/ci/playbooks/multinode-customizations.yml
@@ -270,7 +270,7 @@
         mode: "0640"
 
 - name: Set some fancy hostname
-  hosts: all,!crc
+  hosts: all,!crc,!rh-subscription
   tasks:
     - name: Inject hostname in configuration file
       become: true

--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -162,6 +162,9 @@
           storage_mgmt:
             vlan: 23
             range: 172.20.0.0/24
+          external:
+            vlan: 44
+            range: 172.21.0.0/24
         instances:
           controller:
             networks:
@@ -187,6 +190,8 @@
                 ip: 172.19.0.5
               storage_mgmt:
                 ip: 172.20.0.5
+              external:
+                ip: 172.21.0.5
           undercloud:
             networks:
               default:
@@ -204,72 +209,86 @@
               storage_mgmt:
                 ip: 172.20.0.100
                 config_nm: false
-# TODO(marios): uncomment node config as needed
-#          tripleo-controller-1:
-#            networks:
-#              default:
-#                ip: 192.168.122.110
-#                config_nm: false
-#              internal-api:
-#                ip: 172.17.0.110
-#                config_nm: false
-#              storage:
-#                ip: 172.18.0.110
-#                config_nm: false
-#              tenant:
-#                ip: 172.19.0.110
-#                config_nm: false
-#              storage_mgmt:
-#                ip: 172.20.0.110
-#                config_nm: false
-#          tripleo-compute-1:
-#            networks:
-#              default:
-#                ip: 192.168.122.111
-#                config_nm: false
-#              internal-api:
-#                ip: 172.17.0.111
-#                config_nm: false
-#              storage:
-#                ip: 172.18.0.111
-#                config_nm: false
-#              tenant:
-#                ip: 172.19.0.111
-#                config_nm: false
-#              storage_mgmt:
-#                ip: 172.20.0.111
-#                config_nm: false
-#          tripleo-controller-2:
-#            networks:
-#              default:
-#                ip: 192.168.122.102
-#                config_nm: false
-#              internal-api:
-#                ip: 172.17.0.102
-#                config_nm: false
-#              storage:
-#                ip: 172.18.0.102
-#                config_nm: false
-#              tenant:
-#                ip: 172.19.0.102
-#                config_nm: false
-#              storage_mgmt:
-#                ip: 172.20.0.102
-#                config_nm: false
-#          tripleo-controller-3:
-#            networks:
-#              default:
-#                ip: 192.168.122.103
-#                config_nm: false
-#              internal-api:
-#                ip: 172.17.0.103
-#                config_nm: false
-#              storage:
-#                ip: 172.18.0.103
-#                config_nm: false
-#              tenant:
-#                ip: 172.19.0.103
-#                config_nm: false
-#              storage_mgmt:
-#                ip: 172.20.0.103
-#                config_nm: false
+              external:
+                ip: 172.21.0.100
+                config_nm: false
+          overcloud-controller-0:
+            networks:
+              default:
+                ip: 192.168.122.103
+                config_nm: false
+              internal-api:
+                ip: 172.17.0.103
+                config_nm: false
+              storage:
+                ip: 172.18.0.103
+                config_nm: false
+              tenant:
+                ip: 172.19.0.103
+                config_nm: false
+              storage_mgmt:
+                ip: 172.20.0.103
+                config_nm: false
+              external:
+                ip: 172.21.0.103
+                config_nm: false
+          overcloud-controller-1:
+            networks:
+              default:
+                ip: 192.168.122.104
+                config_nm: false
+              internal-api:
+                ip: 172.17.0.104
+                config_nm: false
+              storage:
+                ip: 172.18.0.104
+                config_nm: false
+              tenant:
+                ip: 172.19.0.104
+                config_nm: false
+              storage_mgmt:
+                ip: 172.20.0.104
+                config_nm: false
+              external:
+                ip: 172.21.0.104
+                config_nm: false
+          overcloud-controller-2:
+            networks:
+              default:
+                ip: 192.168.122.105
+                config_nm: false
+              internal-api:
+                ip: 172.17.0.105
+                config_nm: false
+              storage:
+                ip: 172.18.0.105
+                config_nm: false
+              tenant:
+                ip: 172.19.0.105
+                config_nm: false
+              storage_mgmt:
+                ip: 172.20.0.105
+                config_nm: false
+              external:
+                ip: 172.21.0.105
+                config_nm: false
+          overcloud-novacompute-0:
+            networks:
+              default:
+                ip: 192.168.122.106
+                config_nm: false
+              internal-api:
+                ip: 172.17.0.106
+                config_nm: false
+              storage:
+                ip: 172.18.0.106
+                config_nm: false
+              tenant:
+                ip: 172.19.0.106
+                config_nm: false
+              storage_mgmt:
+                ip: 172.20.0.106
+                config_nm: false
+              external:
+                ip: 172.21.0.106
+                config_nm: false

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -70,16 +70,15 @@
       - name: crc
         label: coreos-crc-extracted-2-30-0-3xl
       - name: undercloud
-        label: cloud-rhel-9-2
-      # TODO(marios): uncomment nodes as needed
-      # - name: tripleo-controller-1
-      #  label: cloud-rhel-9-2
-      # - name: tripleo-compute-1
-      #  label: cloud-rhel-9-2
-      # - name: tripleo-controller-2
-      #   label: cloud-rhel-9-2
-      # - name: tripleo-controller-3
-      #   label: cloud-rhel-9-2
+        label: cloud-rhel-9-2-tripleo
+      - name: overcloud-controller-0
+        label: cloud-rhel-9-2-tripleo
+      - name: overcloud-controller-1
+        label: cloud-rhel-9-2-tripleo
+      - name: overcloud-controller-2
+        label: cloud-rhel-9-2-tripleo
+      - name: overcloud-novacompute-0
+        label: cloud-rhel-9-2-tripleo
     groups:
       - name: computes
         nodes: []
@@ -88,7 +87,11 @@
           - crc
       - name: rh-subscription
         nodes:
-          - undercloud # TODO(marios) add overcloud nodes
+          - undercloud
+          - overcloud-controller-0
+          - overcloud-controller-1
+          - overcloud-controller-2
+          - overcloud-novacompute-0
 
 - nodeset:
     name: centos-9-medium-centos-9-crc-extracted-2.30-3xl


### PR DESCRIPTION
As part of [1] this adds the tripleo_controller nodes into the centos-9-multinode-rhel-9-2-crc-extracted-2.30-3xl nodeset used by the multinode source adoption job. It sets the required crc_ci_bootstrap_networking into the job vars as well as the nodes into the rh-subscription group.

https://issues.redhat.com/browse/OSPRH-5278

[1] https://issues.redhat.com/browse/OSPRH-3038

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
