### PR TITLE
Change top-level parameters

### DIFF
--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -39,14 +39,14 @@
 
 - name: Import deploy edpm playbook
   when:
-    - cifmw_architecture_va_scenario is undefined
+    - cifmw_architecture_scenario is undefined
   ansible.builtin.import_playbook: playbooks/06-deploy-edpm.yml
   tags:
     - edpm
 
 - name: Import VA deployment playbook
   when:
-    - cifmw_architecture_va_scenario is defined
+    - cifmw_architecture_scenario is defined
   ansible.builtin.import_playbook: playbooks/06-deploy-architecture.yml
   tags:
     - edpm

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -37,7 +37,7 @@ are shared among multiple roles:
 - `cifmw_ssh_keysize`: (Integer) Size of ssh keys that will be injected into the controller in order to connect to the rest of the nodes. Defaults to 521.
 - `cifmw_architecture_repo`: (String) Path of the architecture repository on the controller node.
   Defaults to `~/src/github.com/openstack-k8s-operators/architecture`
-- `cifmw_architecture_va_scenario`: (String) The selected VA scenario to deploy.
+- `cifmw_architecture_scenario`: (String) The selected VA scenario to deploy.
 - `cifmw_ceph_target`: (String) the Ansible inventory group where ceph is deployed. Defaults to `computes`.
 - `cifmw_run_tests`: (Bool) Specifies whether tests should be executed.
   Defaults to false.

--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -76,8 +76,8 @@
       vars:
         _parsed: "{{ _automation.content | b64decode | from_yaml }}"
       ansible.builtin.set_fact:
-        cifmw_deploy_va_steps: >-
-          {{ _parsed['vas'][cifmw_architecture_va_scenario] }}
+        cifmw_deploy_architecture_steps: >-
+          {{ _parsed['vas'][cifmw_architecture_scenario] }}
 
     - name: Check requirements
       ansible.builtin.import_role:
@@ -97,7 +97,7 @@
       ansible.builtin.include_role:
         name: kustomize_deploy
         tasks_from: execute_step.yml
-      loop: "{{ cifmw_deploy_va_steps.stages }}"
+      loop: "{{ cifmw_deploy_architecture_steps.stages }}"
       loop_control:
         label: "{{ stage.path }}"
         loop_var: stage

--- a/roles/ci_gen_kustomize_values/README.md
+++ b/roles/ci_gen_kustomize_values/README.md
@@ -7,7 +7,7 @@ None
 ## Parameters
 
 ```{warning}
-The top level parameter `cifmw_architecture_va_scenario` is required in order
+The top level parameter `cifmw_architecture_scenario` is required in order
 to select the proper VA scenario to deploy. If not provided, the role will fail
 with a message.
 ```
@@ -17,7 +17,7 @@ with a message.
 * `cifmw_ci_gen_kustomize_values_architecture_repo`: (String) architecture repository location.
   Defaults to `cifmw_architecture_repo` (`~/src/github.com/openstack-k8s-operators/architecture`).
 * `cifmw_ci_gen_kustomize_values_src_file`: (String) Absolute path to the `values.yaml` file you want to edit.
-  Defaults to `cifmw_ci_gen_kustomize_values_architecture_repo/cifmw_ci_gen_kustomize_values_architecture_examples_va_path/cifmw_architecture_va_scenario/values.yaml`
+  Defaults to `cifmw_ci_gen_kustomize_values_architecture_repo/cifmw_ci_gen_kustomize_values_architecture_examples_path/cifmw_architecture_scenario/values.yaml`
 * `cifmw_ci_gen_kustomize_values_snippets_basedir`: (String) Location for the values snippets.
   Defaults to `~/ci-framework-data/artifacts/ci_k8s_snippets`.
 * `cifmw_ci_gen_kustomize_values_snippets_dir_prefix`: (String) Prefix for snippet directory. Defaults to `""`.
@@ -54,7 +54,7 @@ Note that all of the SSH keys should be in `ecdsa` format to comply with FIPS di
 
 - name: Generate controlplane without any custom user input
   vars:
-    cifmw_architecture_va_scenario: "nfv/sriov"
+    cifmw_architecture_scenario: "nfv/sriov"
     cifmw_networking_env_definition: "{{ _net_env.content | b64decode | from_yaml }}"
   ansible.builtin.import_role:
     name: ci_gen_kustomize_values
@@ -68,7 +68,7 @@ Note that all of the SSH keys should be in `ecdsa` format to comply with FIPS di
 
 - name: Generate controlplane with custom user input
   vars:
-    cifmw_architecture_va_scenario: "nfv/sriov"
+    cifmw_architecture_scenario: "nfv/sriov"
     cifmw_networking_env_definition: "{{ _net_env.content | b64decode | from_yaml }}"
     cifmw_ci_gen_kustomize_values_userdata:
       data:
@@ -88,7 +88,7 @@ Note that all of the SSH keys should be in `ecdsa` format to comply with FIPS di
 
 - name: Generate dataplane without any custom user input
   vars:
-    cifmw_architecture_va_scenario: "nfv/sriov/edpm"
+    cifmw_architecture_scenario: "nfv/sriov/edpm"
     cifmw_networking_env_definition: "{{ _net_env.content | b64decode | from_yaml }}"
   ansible.builtin.import_role:
     name: ci_gen_kustomize_values

--- a/roles/ci_gen_kustomize_values/defaults/main.yml
+++ b/roles/ci_gen_kustomize_values/defaults/main.yml
@@ -15,7 +15,7 @@
 # under the License.
 
 # Top-level parameter shared with deploy_kustomize role
-cifmw_architecture_va_scenario: null
+cifmw_architecture_scenario: null
 
 cifmw_ci_gen_kustomize_values_basedir: >-
   {{
@@ -33,13 +33,13 @@ cifmw_ci_gen_kustomize_values_architecture_repo: >-
       'architecture'] | path_join)
   }}
 
-cifmw_ci_gen_kustomize_values_architecture_examples_va_path: 'examples/va'
+cifmw_ci_gen_kustomize_values_architecture_examples_path: 'examples/va'
 cifmw_ci_gen_kustomize_values_src_file: >-
   {{
     (
     cifmw_ci_gen_kustomize_values_architecture_repo,
-    cifmw_ci_gen_kustomize_values_architecture_examples_va_path,
-    cifmw_architecture_va_scenario,
+    cifmw_ci_gen_kustomize_values_architecture_examples_path,
+    cifmw_architecture_scenario,
     'values.yaml'
     ) | path_join
   }}

--- a/roles/ci_gen_kustomize_values/molecule/default/converge.yml
+++ b/roles/ci_gen_kustomize_values/molecule/default/converge.yml
@@ -80,7 +80,7 @@
 
     - name: Generate network-values
       vars:
-        cifmw_architecture_va_scenario: "hci/control-plane/nncp"
+        cifmw_architecture_scenario: "hci/control-plane/nncp"
       ansible.builtin.include_role:
         name: ci_gen_kustomize_values
 

--- a/roles/ci_gen_kustomize_values/tasks/generate_snippets.yml
+++ b/roles/ci_gen_kustomize_values/tasks/generate_snippets.yml
@@ -2,10 +2,10 @@
 - name: Ensure needed parameter is properly set
   ansible.builtin.assert:
     that:
-      - cifmw_architecture_va_scenario is defined
-      - cifmw_architecture_va_scenario is not none
+      - cifmw_architecture_scenario is defined
+      - cifmw_architecture_scenario is not none
     msg: >-
-      cifmw_architecture_va_scenario must be provided.
+      cifmw_architecture_scenario must be provided.
 
 - name: Ensure source original values file exists
   ansible.builtin.assert:
@@ -79,7 +79,7 @@
       {{ cifmw_ci_gen_kustomize_values_src_file | basename }}.j2
     _tmpl_path: >-
       {{
-        (cifmw_architecture_va_scenario, values_datatype, _tmpl_name) | path_join
+        (cifmw_architecture_scenario, values_datatype, _tmpl_name) | path_join
       }}
     _tmpl_check_path: >-
       {{

--- a/roles/kustomize_deploy/README.md
+++ b/roles/kustomize_deploy/README.md
@@ -5,7 +5,7 @@ Ansible role designed to deploy VA scenarios using the kustomize tool.
 ## Parameters
 
 ```{warning}
-The top level parameter `cifmw_architecture_va_scenario` is required in order
+The top level parameter `cifmw_architecture_scenario` is required in order
 to select the proper VA scenario to deploy. If not provided, the role will fail
 with a message.
 ```
@@ -25,7 +25,7 @@ with a message.
 - `cifmw_kustomize_deploy_architecture_examples_common_path`: _(string)_
   Relative path of the common CRs in the architecture repo. Defaults to
   `/examples/common`
-- `cifmw_kustomize_deploy_architecture_examples_va_path`: _(string)_ Relative
+- `cifmw_kustomize_deploy_architecture_examples_path`: _(string)_ Relative
   path of the VA scenario list in the operator repo. Defaults to `/examples/va`
 - `cifmw_kustomize_deploy_kustomizations_dest_dir`: _(string)_ Path for the
   generated CR files. Defaults to
@@ -82,8 +82,8 @@ with a message.
 - `cifmw_kustomize_deploy_dp_source_files`: _(string)_ Path of the
   dataplane kustomize source files. Defaults to
   `cifmw_kustomize_deploy_architecture_repo_dest_dir +`
-  `cifmw_kustomize_deploy_architecture_examples_va_path +`
-  `cifmw_architecture_va_scenario`
+  `cifmw_kustomize_deploy_architecture_examples_path +`
+  `cifmw_architecture_scenario`
 - `cifmw_kustomize_deploy_dp_values_src_file`: _(string)_ Path of the
   generated `values.yaml` for dataplane resources. Defaults to
   `~/ci-framework-data/artifacts/ci_gen_kustomize_values/edpm-values/values.yaml`
@@ -105,13 +105,13 @@ to `ansible-playbook`:
 $ ansible-playbook deploy-edpm.yml \
   -e @scenarios/reproducers/validated-architecture-1.yml \
   -e @scenarios/reproducers/networking-definition.yml \
-  --skip-tags deploy_va_stage_0
+  --skip-tags deploy_architecture_stage_0
 ```
 This would skip the first stage described in the automation file.
 
 ### Break point
 
-You can also stop the automated deploy by setting `cifmw_deploy_va_stopper`
+You can also stop the automated deploy by setting `cifmw_deploy_architecture_stopper`
 parameter to a specific value.
 
 Break point names are built using the stage ID, and the code currently supports
@@ -125,7 +125,7 @@ three different stopper:
 
 ```Bash
 $ ansible-playbook deploy-edpm.yml [...] \
-  -e cifmw_deploy_va_stopper=post_kustomize_stage_3
+  -e cifmw_deploy_architecture_stopper=post_kustomize_stage_3
 ```
 
 ## Examples
@@ -134,7 +134,7 @@ $ ansible-playbook deploy-edpm.yml [...] \
 - name: Call kustomize_deploy role
   vars:
     cifmw_kustomize_deploy_nncp_values_src_file: /tmp/values.yml
-    cifmw_architecture_va_scenario: hci
+    cifmw_architecture_scenario: hci
   ansible.builtin.include_role:
     name: "kustomize_deploy"
 ```

--- a/roles/kustomize_deploy/defaults/main.yml
+++ b/roles/kustomize_deploy/defaults/main.yml
@@ -41,7 +41,7 @@ cifmw_kustomize_deploy_architecture_repo_dest_dir: >-
 cifmw_kustomize_deploy_architecture_repo_version: "HEAD"
 
 cifmw_kustomize_deploy_architecture_examples_common_path: "examples/common/"
-cifmw_kustomize_deploy_architecture_examples_va_path: "examples/va/"
+cifmw_kustomize_deploy_architecture_examples_path: "examples/va/"
 
 cifmw_kustomize_deploy_kustomizations_dest_dir: >-
   {{
@@ -138,8 +138,8 @@ cifmw_kustomize_deploy_cp_source_files: >-
   {{
     [
       cifmw_kustomize_deploy_architecture_repo_dest_dir,
-      cifmw_kustomize_deploy_architecture_examples_va_path,
-      cifmw_architecture_va_scenario,
+      cifmw_kustomize_deploy_architecture_examples_path,
+      cifmw_architecture_scenario,
       'control-plane'
     ] | path_join
   }}
@@ -169,8 +169,8 @@ cifmw_kustomize_deploy_dp_source_files: >-
   {{
     [
       cifmw_kustomize_deploy_architecture_repo_dest_dir,
-      cifmw_kustomize_deploy_architecture_examples_va_path,
-      cifmw_architecture_va_scenario
+      cifmw_kustomize_deploy_architecture_examples_path,
+      cifmw_architecture_scenario
     ] | path_join
   }}
 

--- a/roles/kustomize_deploy/molecule/flexible_loop/converge.yml
+++ b/roles/kustomize_deploy/molecule/flexible_loop/converge.yml
@@ -36,7 +36,7 @@
           }}
         _file: "{{ lookup('file', _automation) }}"
       ansible.builtin.set_fact:
-        cifmw_deploy_va_steps: >-
+        cifmw_deploy_architecture_steps: >-
           {{
             _file | from_yaml
           }}
@@ -56,7 +56,7 @@
       ansible.builtin.include_role:
         name: "kustomize_deploy"
         tasks_from: execute_step.yml
-      loop: "{{ cifmw_deploy_va_steps.vas.hci.stages }}"
+      loop: "{{ cifmw_deploy_architecture_steps.vas.hci.stages }}"
       loop_control:
         label: "{{ stage.path }}"
         loop_var: "stage"

--- a/roles/kustomize_deploy/molecule/flexible_loop/resources/vars.yml
+++ b/roles/kustomize_deploy/molecule/flexible_loop/resources/vars.yml
@@ -1,5 +1,5 @@
 ---
-cifmw_architecture_va_scenario: hci
+cifmw_architecture_scenario: hci
 cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/foo"
 cifmw_path: >-
   {{ ':'.join([ansible_user_dir ~ '/.crc/bin',

--- a/roles/kustomize_deploy/tasks/check_requirements.yml
+++ b/roles/kustomize_deploy/tasks/check_requirements.yml
@@ -27,7 +27,7 @@
       {{
         [
           cifmw_kustomize_deploy_architecture_repo_dest_dir,
-          cifmw_kustomize_deploy_architecture_examples_va_path
+          cifmw_kustomize_deploy_architecture_examples_path
         ] | path_join
       }}
   block:
@@ -40,11 +40,11 @@
     - name: Check if scenario is in the list
       ansible.builtin.fail:
         msg: >
-          You need to properly set the `cifmw_architecture_va_scenario` variable
+          You need to properly set the `cifmw_architecture_scenario` variable
           in order to select the VA scenario to deploy. You can take a list of
           scenario in the `examples/va` folder in the architecture repo.
       when:
-        - cifmw_architecture_va_scenario is not defined
+        - cifmw_architecture_scenario is not defined
         - cifmw_kustomize_deploy_architecture_repo_version not in \
           _va_scenario_dir.results.path | dirname | relpath(_va_scenario_dir)
 

--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -12,7 +12,7 @@
 
 - name: Group tasks under the same tag
   tags:
-    - "deploy_va_stage_{{ stage_id }}"
+    - "deploy_architecture_stage_{{ stage_id }}"
   block:
     - name: Ensure source files exists
       register: _src
@@ -102,12 +102,12 @@
 
     - name: Stop before building kustomization if requested
       when:
-        - cifmw_deploy_va_stopper is defined
-        - cifmw_deploy_va_stopper == _stage_stopper
+        - cifmw_deploy_architecture_stopper is defined
+        - cifmw_deploy_architecture_stopper == _stage_stopper
       vars:
         _stage_stopper: "pre_kustomize_stage_{{ stage_id }}"
       ansible.builtin.fail:
-        msg: "Failing on demand {{ cifmw_deploy_va_stopper }}"
+        msg: "Failing on demand {{ cifmw_deploy_architecture_stopper }}"
 
     - name: "Build kustomized content for {{ stage.path }}"
       vars:
@@ -136,12 +136,12 @@
 
     - name: Stop after building kustomization if requested
       when:
-        - cifmw_deploy_va_stopper is defined
-        - cifmw_deploy_va_stopper == _stage_stopper
+        - cifmw_deploy_architecture_stopper is defined
+        - cifmw_deploy_architecture_stopper == _stage_stopper
       vars:
         _stage_stopper: "post_kustomize_stage_{{ stage_id }}"
       ansible.builtin.fail:
-        msg: "Failing on demand {{ cifmw_deploy_va_stopper }}"
+        msg: "Failing on demand {{ cifmw_deploy_architecture_stopper }}"
 
     - name: "Apply generated content for {{ stage.path }}"
       when:
@@ -174,12 +174,12 @@
 
     - name: Stop after applying CRs if requested
       when:
-        - cifmw_deploy_va_stopper is defined
-        - cifmw_deploy_va_stopper == _stage_stopper
+        - cifmw_deploy_architecture_stopper is defined
+        - cifmw_deploy_architecture_stopper == _stage_stopper
       vars:
         _stage_stopper: "post_apply_stage_{{ stage_id }}"
       ansible.builtin.fail:
-        msg: "Failing on demand {{ cifmw_deploy_va_stopper }}"
+        msg: "Failing on demand {{ cifmw_deploy_architecture_stopper }}"
 
     - name: "Executing post_deploy step for {{ stage.path }}"
       when:

--- a/roles/reproducer/tasks/configure_architecture.yml
+++ b/roles/reproducer/tasks/configure_architecture.yml
@@ -4,13 +4,14 @@
   block:
     - name: Push script
       ansible.builtin.copy:
-        dest: "/home/zuul/deploy-va.sh"
+        dest: "/home/zuul/deploy-architecture.sh"
         mode: "0755"
         owner: "zuul"
         group: "zuul"
         content: |-
+          #!/bin/bash
           pushd src/github.com/openstack-k8s-operators/ci-framework
-          export ANSIBLE_LOG_PATH="~/ansible-deploy-va.log"
+          export ANSIBLE_LOG_PATH="~/ansible-deploy-architecture.log"
           ansible-playbook -i ~/ci-framework-data/artifacts/zuul_inventory.yml \
             -e @~/ci-framework-data/artifacts/parameters/custom-params.yml \
             -e @~/openshift-environment.yml \
@@ -22,11 +23,11 @@
         - always
       ansible.builtin.include_tasks: rotate_log.yml
       loop:
-        - ansible-deploy-va.log
+        - ansible-deploy-architecture.log
 
     - name: Run deployment if instructed to
       when:
-        - cifmw_deploy_va | default(false) | bool
-      no_log: true
+        - cifmw_deploy_architecture | default(false) | bool
+      no_log: false
       ansible.builtin.command:
-        cmd: "/home/zuul/deploy-va.sh"
+        cmd: "/home/zuul/deploy-architecture.sh"

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -132,5 +132,5 @@
 
     - name: Prepare VA deployment
       when:
-        - cifmw_architecture_va_scenario is defined
-      ansible.builtin.import_tasks: configure_va.yml
+        - cifmw_architecture_scenario is defined
+      ansible.builtin.import_tasks: configure_architecture.yml

--- a/scenarios/reproducers/validated-architecture-1.yml
+++ b/scenarios/reproducers/validated-architecture-1.yml
@@ -18,7 +18,7 @@ cifmw_libvirt_manager_pub_net: ocpbm
 # Please note, all paths are on the controller-0, meaning managed by the
 # Framework. Please do not edit them!
 _arch_repo: "/home/zuul/src/github.com/openstack-k8s-operators/architecture"
-cifmw_architecture_va_scenario: hci
+cifmw_architecture_scenario: hci
 cifmw_ceph_client_vars: /tmp/ceph_client.yml
 cifmw_ceph_client_values_post_ceph_path_src: >-
   {{ _arch_repo }}/examples/va/hci/values.yaml
@@ -43,7 +43,7 @@ cifmw_ceph_client_service_values_post_ceph_path_dst: >-
 #   pre_apply_stage_INDEX
 #   post_apply_stage_INDEX
 #
-# cifmw_deploy_va_stopper:
+# cifmw_deploy_architecture_stopper:
 
 # What about some tempest?
 cifmw_run_tests: true


### PR DESCRIPTION
The CI Framework shouldn't care about scenario type - VAs and DTs are
mostly the same. We want to care about defined automation only.

This patch removes most of the "va" from parameter names to be agnostic.

We also correct a bug introduced in the latest patches related to
automation: the missing shebang in the `deploy-architecture.sh` script
prevented using `ansible.builtin.command`.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
