### PR TITLE
Simplify checks on the src_file

### DIFF
--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -18,8 +18,6 @@
       register: _src
       when:
         - item.src_file is defined
-        - item.src_file is not none
-        - item.src_file != 'none'
       ansible.builtin.stat:
         path: >-
           {{
@@ -53,8 +51,6 @@
     - name: "Generate values.yaml for {{ stage.path }}"
       when:
         - _val.src_file is defined
-        - _val.src_file is not none
-        - _val.src_file != 'none'
       vars:
         cifmw_ci_gen_kustomize_values_name: >-
           {{ _val['name'] }}
@@ -83,8 +79,6 @@
     - name: "Copy generated values for {{ stage.path }}"
       when:
         - _val.src_file is defined
-        - _val.src_file is not none
-        - _val.src_file != 'none'
       ansible.builtin.copy:
         backup: true
         remote_src: true


### PR DESCRIPTION
With [1] we're now able to remove most of the checks, ensuring we only
rely on defined/undefined instead of lame string comparison.

[1] https://github.com/openstack-k8s-operators/architecture/pull/110

Depends-On: https://github.com/openstack-k8s-operators/architecture/pull/110

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
