### PR TITLE
Upgrade how hooks are defined

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -71,7 +71,11 @@ The framework is able to leverage hooks located in various locations. Using
 proper parameter name, you may run arbitrary playbook or load custom CRDs at
 specific points in the standard run.
 
-Allowed parameter names are:
+Hooks may be presented in two ways:
+- as a list
+- as a single hook in a parameter
+
+If you want to list multiple hooks, you have to use the following parameter names:
 
 - `pre_infra`: before bootstrapping the infrastructure
 - `post_infra`: after bootstrapping the infrastructure
@@ -88,6 +92,13 @@ Allowed parameter names are:
 - `post_admin_setup`: before admin setup
 - `pre_reporting`: before running reporting
 - `post_reporting`: after running reporting
+
+Since we're already providing hooks as list, you may want to just add one or two hooks
+using your own environment file. Parameter structure is simple: `PREFIX_HOOKNAME: {hook struct}`
+
+PREFIX must match the above parameters (`pre_infra`, `post_reporting` and so on).
+
+The `{hook struct}` is the same as a listed hook, but you'll remove the `name` entry.
 
 Since steps may be skipped, we must ensure proper post/pre exists for specific
 steps.

--- a/playbooks/02-infra.yml
+++ b/playbooks/02-infra.yml
@@ -1,6 +1,5 @@
 - name: Run pre_infra hooks
   vars:
-    hooks: "{{ pre_infra | default([]) }}"
     step: pre_infra
   ansible.builtin.import_playbook: ./hooks.yml
 
@@ -87,6 +86,5 @@
 
 - name: Run post_infra hooks
   vars:
-    hooks: "{{ post_infra | default([]) }}"
     step: post_infra
   ansible.builtin.import_playbook: ./hooks.yml

--- a/playbooks/03-build-packages.yml
+++ b/playbooks/03-build-packages.yml
@@ -1,6 +1,5 @@
 - name: Run pre_package_build hooks
   vars:
-    hooks: "{{ pre_package_build | default([]) }}"
     step: pre_package_build
   ansible.builtin.import_playbook: ./hooks.yml
 
@@ -22,6 +21,5 @@
 
 - name: Run post_package_build hooks
   vars:
-    hooks: "{{ post_package_build | default([]) }}"
     step: post_package_build
   ansible.builtin.import_playbook: ./hooks.yml

--- a/playbooks/04-build-containers.yml
+++ b/playbooks/04-build-containers.yml
@@ -1,6 +1,5 @@
 - name: Run pre_container_build hooks
   vars:
-    hooks: "{{ pre_container_build | default([]) }}"
     step: pre_container_build
   ansible.builtin.import_playbook: ./hooks.yml
 
@@ -18,6 +17,5 @@
 
 - name: Run post_container_build hooks
   vars:
-    hooks: "{{ post_container_build | default([]) }}"
     step: post_container_build
   ansible.builtin.import_playbook: ./hooks.yml

--- a/playbooks/05-build-operators.yml
+++ b/playbooks/05-build-operators.yml
@@ -1,6 +1,5 @@
 - name: Run pre_operator_build hooks
   vars:
-    hooks: "{{ pre_operator_build | default([]) }}"
     step: pre_operator_build
   ansible.builtin.import_playbook: ./hooks.yml
 
@@ -23,6 +22,5 @@
 
 - name: Run post_operator_build hooks
   vars:
-    hooks: "{{ post_operator_build | default([]) }}"
     step: post_operator_build
   ansible.builtin.import_playbook: ./hooks.yml

--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -1,7 +1,6 @@
 ---
 - name: Run pre_deploy hooks
   vars:
-    hooks: "{{ pre_deploy | default([]) }}"
     step: pre_deploy
   ansible.builtin.import_playbook: ./hooks.yml
 
@@ -119,6 +118,5 @@
 
 - name: Run post_deploy hooks
   vars:
-    hooks: "{{ post_deploy | default([]) }}"
     step: post_deploy
   ansible.builtin.import_playbook: ./hooks.yml

--- a/playbooks/06-deploy-edpm.yml
+++ b/playbooks/06-deploy-edpm.yml
@@ -1,6 +1,5 @@
 - name: Run pre_deploy hooks
   vars:
-    hooks: "{{ pre_deploy | default([]) }}"
     step: pre_deploy
   ansible.builtin.import_playbook: ./hooks.yml
 
@@ -22,7 +21,6 @@
 
 - name: Run post_ctlplane_deploy hooks
   vars:
-    hooks: "{{ post_ctlplane_deploy | default([]) }}"
     step: post_ctlplane_deploy
   ansible.builtin.import_playbook: ./hooks.yml
 
@@ -107,6 +105,5 @@
 
 - name: Run post_deploy hooks
   vars:
-    hooks: "{{ post_deploy | default([]) }}"
     step: post_deploy
   ansible.builtin.import_playbook: ./hooks.yml

--- a/playbooks/07-admin-setup.yml
+++ b/playbooks/07-admin-setup.yml
@@ -1,6 +1,5 @@
 - name: Run pre_admin_setup hooks
   vars:
-    hooks: "{{ pre_admin_setup | default([]) }}"
     step: pre_admin_setup
   ansible.builtin.import_playbook: ./hooks.yml
 
@@ -18,6 +17,5 @@
 
 - name: Run post_admin_setup hooks
   vars:
-    hooks: "{{ post_admin_setup | default([]) }}"
     step: post_admin_setup
   ansible.builtin.import_playbook: ./hooks.yml

--- a/playbooks/08-run-tests.yml
+++ b/playbooks/08-run-tests.yml
@@ -1,6 +1,5 @@
 - name: "Run pre_tests hooks"
   vars:
-    hooks: "{{ pre_tests | default([]) }}"
     step: pre_tests
   ansible.builtin.import_playbook: ./hooks.yml
 
@@ -16,6 +15,5 @@
 
 - name: "Run post_tests hooks"
   vars:
-    hooks: "{{ post_tests | default([]) }}"
     step: post_tests
   ansible.builtin.import_playbook: ./hooks.yml

--- a/playbooks/hooks.yml
+++ b/playbooks/hooks.yml
@@ -1,10 +1,8 @@
+---
 - name: Hook playbook
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
     - name: Run hook
-      when:
-        - hooks is defined
-        - hooks | length > 0
       ansible.builtin.import_role:
         name: run_hook

--- a/playbooks/update.yml
+++ b/playbooks/update.yml
@@ -1,6 +1,5 @@
 - name: Run pre_update hooks
   vars:
-    hooks: "{{ pre_update | default([]) }}"
     step: pre_update
   ansible.builtin.import_playbook: ./hooks.yml
 
@@ -20,6 +19,5 @@
 
 - name: Run post_update hooks
   vars:
-    hooks: "{{ post_update | default([]) }}"
     step: post_update
   ansible.builtin.import_playbook: ./hooks.yml

--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -44,7 +44,7 @@
         - stage.pre_stage_run is defined
       vars:
         hooks: "{{ stage.pre_stage_run }}"
-        step: "pre_stage_run_{{ stage_id }}"
+        step: "pre_stage_run"
       ansible.builtin.include_role:
         name: run_hook
 
@@ -188,6 +188,6 @@
         - stage.post_stage_run is defined
       vars:
         hooks: "{{ stage.post_stage_run }}"
-        step: "post_stage_run_{{ stage_id }}"
+        step: "post_stage_run"
       ansible.builtin.include_role:
         name: run_hook

--- a/roles/run_hook/README.md
+++ b/roles/run_hook/README.md
@@ -9,10 +9,31 @@ play has a great chance of failure.
 
 ## Parameters
 * `hooks`: A list of hooks
+* `step`: (String) Prefix for the hooks you want to run. Mandatory.
+
+## Hook sorting
+
+The "name" is taken as a key to sort the various hooks in a selected step.
+
+In case of "single hook in its own parameter", the `name` is computed from the parameter
+name:
+
+* `pre_infra_01_my_hook` will end as `01 my hook`
+* `post_infra_my_hook` will end as `My hook`
 
 ## Hooks expected format
 ### Playbook
-In such a case, the following data can be provided to the hook:
+
+#### Single hook in its own parameter
+* `config_file`: (String) Ansible configuration file. Defaults to `ansible_config_file`.
+* `connection`: (String) Set the connection type for ansible. Defaults to `omit`.
+* `creates`: (String) Refer to the `ansible.builtin.command` "creates" parameter. Defaults to `omit`.
+* `inventory`: (String) Refer to the `--inventory` option for `ansible-playbook`. Defaults to `inventory_file`.
+* `source`: (String) Source of the playbook. If it's a filename, the playbook is expected in `hooks/playbooks`. It can be an absolute path.
+* `type`: (String) Type of the hook. In this case, set it to `playbook`.
+* `extra_vars`: (Dict) Structure listing the extra variables you want to pass down
+
+#### Multiple hooks in a list
 * `config_file`: (String) Ansible configuration file. Defaults to `ansible_config_file`.
 * `connection`: (String) Set the connection type for ansible. Defaults to `omit`.
 * `creates`: (String) Refer to the `ansible.builtin.command` "creates" parameter. Defaults to `omit`.
@@ -52,14 +73,30 @@ pre_deploy:
       type: playbook
       extra_vars:
         UUID: <some generated UUID>
+
+pre_infra_my_nice_hook:
+    source: noop.yml
+    type: playbook
 ```
 
 
 ### CRD
-In such a case, the following data can be provided to the hook:
+
+#### Single hook in its own parameter
 * `type`: (String) Type of the hook. In this case, set it to `crd`.
 * `source`: (String) Source of the CRD. If it's a filename, the CRD is expected in `hooks/crds`. It can be an absolute path.
 * `host`: (String) Cluster API endpoint. Defaults to `https://api.crc.testing:6443`.
+* `username`: (String) Username for authentication against the cluster. Defaults to `kubeadmin`.
+* `password`: (String) Password for authentication against the cluster. Defaults to `12345678`.
+* `state`: (String) State of the service. Can be `present` or `absent`. Defaults to `present`.
+* `validate_certs`: (Boolean) Whether to validate or not the cluster certificates.
+* `wait_condition`: (Dict) Wait condition for the service.
+
+#### Multiple hooks in a list
+* `type`: (String) Type of the hook. In this case, set it to `crd`.
+* `source`: (String) Source of the CRD. If it's a filename, the CRD is expected in `hooks/crds`. It can be an absolute path.
+* `host`: (String) Cluster API endpoint. Defaults to `https://api.crc.testing:6443`.
+* `name`: (String) Describe the hook.
 * `username`: (String) Username for authentication against the cluster. Defaults to `kubeadmin`.
 * `password`: (String) Password for authentication against the cluster. Defaults to `12345678`.
 * `state`: (String) State of the service. Can be `present` or `absent`. Defaults to `present`.

--- a/roles/run_hook/molecule/default/converge.yml
+++ b/roles/run_hook/molecule/default/converge.yml
@@ -17,21 +17,23 @@
 
 - name: Converge
   hosts: all
-  vars:
-    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
-    step: molecule
-    hooks:
-      - name: Default noop hook
-        source: noop.yml
-        type: playbook
-      - name: With extra-vars
-        source: /tmp/dummy.yml
-        type: playbook
-        extra_vars:
-          foo: bar
-          file: '/tmp/dummy-env.yml'
+  vars_files:
+    - ./resources/vars.yml
   tasks:
-    - name: Hook project provided noop.yml
+    - name: No hook
+      vars:
+        step: no_hook
+      ansible.builtin.include_role:
+        name: run_hook
+
+    - name: Ensure we do not have ceph_uuid
+      ansible.builtin.assert:
+        that:
+          - ceph_uuid is undefined
+
+    - name: Combined hooks
+      vars:
+        step: run_molecule
       ansible.builtin.include_role:
         name: run_hook
 
@@ -39,3 +41,60 @@
       ansible.builtin.assert:
         that:
           - ceph_uuid is defined
+          - ceph_uuid == 'dummy-1.yml'
+
+    - name: Only listed hooks
+      vars:
+        step: list_hooks
+      ansible.builtin.include_role:
+        name: run_hook
+
+    - name: Ensure we have the ceph_uuid variable now
+      ansible.builtin.assert:
+        that:
+          - ceph_uuid is defined
+          - ceph_uuid == 'dummy-3.yml'
+
+    - name: Only filtered hooks
+      vars:
+        step: filtered_hooks
+      ansible.builtin.include_role:
+        name: run_hook
+
+    - name: Ensure we have the ceph_uuid variable now
+      ansible.builtin.assert:
+        that:
+          - ceph_uuid is defined
+          - ceph_uuid == 'dummy-4.yml'
+
+    - name: Direct hooks
+      vars:
+        step: no_hook
+        hooks:
+          - name: Dummy-5
+            source: /tmp/dummy-5.yml
+            type: playbook
+            extra_vars:
+              foo: bar
+              file: '/tmp/dummy-env.yml'
+      ansible.builtin.include_role:
+        name: run_hook
+
+    - name: Ensure we have the ceph_uuid variable now
+      ansible.builtin.assert:
+        that:
+          - ceph_uuid is defined
+          - ceph_uuid == 'dummy-5.yml'
+
+    - name: Direct hooks as param
+      vars:
+        step: no_hook
+        hooks: "{{ my_hook }}"
+      ansible.builtin.include_role:
+        name: run_hook
+
+    - name: Ensure we have the ceph_uuid variable now
+      ansible.builtin.assert:
+        that:
+          - ceph_uuid is defined
+          - ceph_uuid == 'dummy-6.yml'

--- a/roles/run_hook/molecule/default/molecule.yml
+++ b/roles/run_hook/molecule/default/molecule.yml
@@ -7,3 +7,45 @@ log: true
 provisioner:
   name: ansible
   log: true
+  inventory:
+    host_vars:
+      instance:
+        # Ensure vars are properly interpreted
+        _tmp: "/tmp"
+        # Fill only _list_hooks
+        list_hooks:
+          - name: Run dummy-2
+            source: "{{ _tmp }}/dummy-2.yml"
+            type: playbook
+            extra_vars:
+              foo: bar
+              file: '/tmp/dummy-env.yml'
+          - name: Run dummy-3
+            source: /tmp/dummy-3.yml
+            type: playbook
+            extra_vars:
+              foo: bar
+              file: '/tmp/dummy-env.yml'
+        # fill up _list_hooks and _filtered_hooks
+        # Also ensure ordering is properly taken
+        run_molecule:
+          - name: 01 Default noop hook
+            source: noop.yml
+            type: playbook
+          - name: 02 Re-run noop
+            source: noop.yml
+            type: playbook
+        run_molecule_03_single_hook:
+          source: "{{ _tmp }}/dummy-1.yml"
+          type: playbook
+          extra_vars:
+            foo: bar
+            file: '/tmp/dummy-env.yml'
+
+        # Fill only _filtered_hooks
+        filtered_hooks_01_my_hook:
+          source: "{{ _tmp }}/dummy-4.yml"
+          type: playbook
+          extra_vars:
+            foo: bar
+            file: '/tmp/dummy-env.yml'

--- a/roles/run_hook/molecule/default/prepare.yml
+++ b/roles/run_hook/molecule/default/prepare.yml
@@ -19,9 +19,6 @@
   hosts: all
   vars:
     ansible_user_dir: "{{ lookup('env', 'HOME') }}"
-  roles:
-    - role: test_deps
-
   tasks:
     - name: Create dummy env file
       ansible.builtin.copy:
@@ -29,23 +26,15 @@
         content: |
           star: wars
           other_star: trek
+
     - name: Create dummy playbook
-      ansible.builtin.copy:
-        dest: /tmp/dummy.yml
-        content: |-
-          - hosts: localhost
-            gather_facts: true
-            tasks:
-          {% raw %}
-              - name: Hello world
-                ansible.builtin.debug:
-                  msg: 'Hello {{ foo }}'
-              - name: Debug some vars from file
-                ansible.builtin.debug:
-                  msg: "{{ star }} and {{ other_star }} are on a boat..."
-              - name: Generate some output file
-                ansible.builtin.copy:
-                  dest: "{{ cifmw_basedir }}/artifacts/{{ step }}_{{ hook_name }}.yml"
-                  content: |
-                    ceph_uuid: 2107eea0-2344-43bf-9013-3d7ca67fc71e
-          {% endraw %}
+      ansible.builtin.template:
+        dest: "/tmp/{{ item }}"
+        src: "dummy.yml.j2"
+      loop:
+        - dummy-1.yml
+        - dummy-2.yml
+        - dummy-3.yml
+        - dummy-4.yml
+        - dummy-5.yml
+        - dummy-6.yml

--- a/roles/run_hook/molecule/default/resources/vars.yml
+++ b/roles/run_hook/molecule/default/resources/vars.yml
@@ -1,0 +1,9 @@
+---
+# Passing hook as a jinja2 parameter
+my_hook:
+  - name: Hook as param
+    source: /tmp/dummy-6.yml
+    type: playbook
+    extra_vars:
+      foo: bar
+      file: '/tmp/dummy-env.yml'

--- a/roles/run_hook/molecule/default/templates/dummy.yml.j2
+++ b/roles/run_hook/molecule/default/templates/dummy.yml.j2
@@ -1,0 +1,19 @@
+---
+- hosts: localhost
+  gather_facts: true
+  tasks:
+{% raw %}
+    - name: Hello world
+      ansible.builtin.debug:
+        msg: 'Hello {{ foo }}'
+
+    - name: Debug some vars from file
+      ansible.builtin.debug:
+        msg: "{{ star }} and {{ other_star }} are on a boat..."
+
+    - name: Generate some output file
+      ansible.builtin.copy:
+        dest: "{{ cifmw_basedir }}/artifacts/{{ step }}_{{ hook_name }}.yml"
+        content: |
+{% endraw %}
+          ceph_uuid: {{ item }}

--- a/roles/run_hook/tasks/crd.yml
+++ b/roles/run_hook/tasks/crd.yml
@@ -8,13 +8,13 @@
       {{ hook.source }}
       {%- endif -%}
 
-- name: "Load and run {{ crd_path }}"
+- name: "Load and run {{ crd_path | realpath }}"
   kubernetes.core.k8s:
     host: "{{ hook.host | default('https://api.crc.testing:6443') }}"
     username: "{{ hook.username | default('kubeadmin') }}"
     password: "{{ hook.password | default('12345678') }}"
     state: "{{ hook.state | default(present) }}"
-    src: "{{ hook.source }}"
+    src: "{{ crd_path | realpath }}"
     validate:
       fail_on_error: true
     validate_certs: "{{ hook.validate_certs | default(omit) }}"

--- a/roles/run_hook/tasks/main.yml
+++ b/roles/run_hook/tasks/main.yml
@@ -14,8 +14,52 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Loop on the passed hooks and call correct action
-  ansible.builtin.include_tasks: "{{ hook.type }}.yml"
-  loop: "{{ hooks }}"
-  loop_control:
-    loop_var: 'hook'
+- name: "Combine hooks and run them for {{ step }}"
+  vars:
+    _list_hooks: >-
+      {{
+        hostvars[inventory_hostname][step] |
+        default([])
+      }}
+    _matcher: "^{{ step }}_(.*)$"
+    _filtered_hooks: >-
+      {{
+        hostvars[inventory_hostname] |
+        dict2items |
+        selectattr('key', 'match', _matcher)
+      }}
+    _single_hooks: >-
+      {% for _hook in _filtered_hooks -%}
+      - name: {{ _hook.key | regex_replace(_matcher, '\1') |
+                 replace('_', ' ') | capitalize }}
+      {{ _hook.value | to_nice_yaml | indent(width=2, first=true) }}
+      {% endfor -%}
+  block:
+    - name: Assert parameters are valid
+      ansible.builtin.assert:
+        quiet: true
+        that:
+          - _filtered_hooks is not string
+          - _filtered_hooks is not mapping
+          - _filtered_hooks is iterable
+          - _list_hooks is not string
+          - _list_hooks is not mapping
+          - _list_hooks is iterable
+          - (hooks | default([])) is not string
+          - (hooks | default([])) is not mapping
+          - (hooks | default([])) is iterable
+
+    - name: "Loop on hooks for {{ step }}"
+      vars:
+        _hooks: >-
+          {{
+            (
+              (_single_hooks | from_yaml | default([], true)) +
+              (hooks | default([], true)) +
+              _list_hooks
+            ) | sort(attribute='name')
+          }}
+      ansible.builtin.include_tasks: "{{ hook.type }}.yml"
+      loop: "{{ _hooks }}"
+      loop_control:
+        loop_var: 'hook'


### PR DESCRIPTION
There's a need to add single hooks to a list of existing ones, depending
on the scenario we want to run.

Until now, this wasn't possible, since parameters override themselves
and only the last occurrence wins.

This patch introduces a notion of "single hook definition" using crafted
parameters names, consuming specific prefixes.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
