### PR TITLE
Precisely target values.yaml file for user kustomization

### DIFF
--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -52,8 +52,9 @@
       when:
         - _val.src_file is defined
       vars:
-        cifmw_ci_gen_kustomize_values_name: >-
-          {{ _val['name'] }}
+        _stage_id: "stage_{{ stage_id }}"
+        _name: "{{ _val['name'] }}"
+        cifmw_ci_gen_kustomize_values_name: "{{ _name }}"
         cifmw_ci_gen_kustomize_values_src_file: >-
           {{
             (cifmw_kustomize_deploy_architecture_repo_dest_dir,
@@ -64,8 +65,8 @@
         cifmw_ci_gen_kustomize_values_userdata: >-
           {{
             (cifmw_architecture_user_kustomize is defined and
-             cifmw_architecture_user_kustomize['stage_' ~ stage_id] is defined
-            ) | ternary(cifmw_architecture_user_kustomize['stage_' ~ stage_id],
+             cifmw_architecture_user_kustomize[_stage_id][_name] is defined
+            ) | ternary(cifmw_architecture_user_kustomize[_stage_id][_name],
                         {})
           }}
       ansible.builtin.include_role:

--- a/scenarios/reproducers/validated-architecture-1.yml
+++ b/scenarios/reproducers/validated-architecture-1.yml
@@ -33,8 +33,9 @@ cifmw_ceph_client_service_values_post_ceph_path_dst: >-
 # and push the data structure you want to apply.
 # cifmw_architecture_user_kustomize:
 #   stage_0:
-#     data:
-#       starwars: Obiwan
+#     'network-values':
+#       data:
+#         starwars: Obiwan
 
 # HERE, if you want to stop the deployment loop at any stage, you can uncomment
 # the following parameter and update the value to match the stage you want to


### PR DESCRIPTION
Until now, the user provided kustomization would be applied to all of
the values.yaml files in a specific stage. This may lead to errors, and
isn't the right way.

This patch now adds a level of precision, so that we can target the
right file without leaking any data outside of it.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
