### PR TITLE
Reduce ceph resources to support single node jobs

### DIFF
--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -266,6 +266,7 @@
         tasks_from: pools
 
     - name: Deploy RGW
+      when: cifmw_ceph_daemons_layout.rgw_enabled | default(true) | bool
       ansible.builtin.import_role:
         name: cifmw_cephadm
         tasks_from: rgw
@@ -274,6 +275,7 @@
         cifmw_cephadm_rgw_vip: "{{ cifmw_cephadm_vip }}/24"
 
     - name: Configure Monitoring Stack
+      when: cifmw_ceph_daemons_layout.dashboard_enabled  | default(false) | bool
       ansible.builtin.import_role:
         name: cifmw_cephadm
         tasks_from: monitoring
@@ -282,8 +284,8 @@
         cifmw_cephadm_dashboard_crt: "{{ cifmw_cephadm_certificate }}"
         cifmw_cephadm_dashboard_key: "{{ cifmw_cephadm_key }}"
 
-
     - name: Create cephfs volume
+      when: cifmw_ceph_daemons_layout.cephfs_enabled  | default(true) | bool
       ansible.builtin.import_role:
         name: cifmw_cephadm
         tasks_from: cephfs

--- a/roles/cifmw_cephadm/templates/ceph_rgw.yml.j2
+++ b/roles/cifmw_cephadm/templates/ceph_rgw.yml.j2
@@ -19,19 +19,21 @@ spec:
     {{ rgw_frontend_cert | indent( width=4 ) }}
 {% endif %}
 ---
-service_type: ingress
-service_id: rgw.default
-service_name: ingress.rgw.default
-placement:
-  count: 1
-spec:
-  backend_service: rgw.rgw
-  frontend_port: 8080
-  monitor_port: 8999
-  virtual_ip: {{ cifmw_cephadm_rgw_vip }}
-  virtual_interface_networks:
-  - {{ cifmw_cephadm_rgw_network }}
-{% if rgw_frontend_cert is defined %}
-  ssl_cert: |
-    {{ rgw_frontend_cert | indent( width=4 ) }}
+{% if _hosts|length > 1 %}
+  service_type: ingress
+  service_id: rgw.default
+  service_name: ingress.rgw.default
+  placement:
+    count: 1
+  spec:
+    backend_service: rgw.rgw
+    frontend_port: 8080
+    monitor_port: 8999
+    virtual_ip: {{ cifmw_cephadm_rgw_vip }}
+    virtual_interface_networks:
+    - {{ cifmw_cephadm_rgw_network }}
+  {% if rgw_frontend_cert is defined %}
+    ssl_cert: |
+      {{ rgw_frontend_cert | indent( width=4 ) }}
+  {% endif %}
 {% endif %}


### PR DESCRIPTION
This patch limits the default set of ceph services to be run to avoid issues in single node setup.

Changes made in this patch are
- Dashbaord service will be disabled by default and can be enabled by updating the parameter 'cifmw_cephadm_dashboard_enabled'

- ingress service will be deployed if the edpm nodes > 1

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
