### PR TITLE
Add shiftstack role

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -65,3 +65,6 @@
 - job:
     name: cifmw-molecule-sushy_emulator
     nodeset: centos-9-crc-2-30-0-xl
+- job:
+    name: cifmw-molecule-shiftstack
+    nodeset: centos-9-crc-2-30-0-xl

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -427,6 +427,7 @@ scp
 sdk
 selinux
 sha
+shiftstack
 sig
 skbg
 skiplist

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -48,7 +48,7 @@ are shared among multiple roles:
 - `cifmw_ceph_target`: (String) The Ansible inventory group where ceph is deployed. Defaults to `computes`.
 - `cifmw_run_tests`: (Bool) Specifies whether tests should be executed.
   Defaults to false.
-- `cifmw_run_test_role`: (String) Specifies which ci-framework role will be used to run tests. Allowed options are `test_operator` and `tempest`. Defaults to `tempest`.
+- `cifmw_run_test_role`: (String) Specifies which ci-framework role will be used to run tests. Allowed options are `test_operator`, `tempest` and `shiftstack`. Defaults to `tempest`.
 - `cifmw_run_tempest`: (Bool) Specifies whether tempest tests should be run.  Notice tempest tests can be executed with either `test_operator` or `tempest` roles. Defaults to true.
 - `cifmw_run_tobiko`: (Bool) Specifies whether tobiko tests should be run. Notice tobiko tests can only be executed with the `test_operator` role. Defaults to false.
 - `cifmw_edpm_deploy_nfs`: (Bool) Specifies whether an nfs server should be deployed.

--- a/roles/shiftstack/README.md
+++ b/roles/shiftstack/README.md
@@ -1,0 +1,22 @@
+# shiftstack
+Role for triggering Openshift on Openstack QA automation (installation and tests).
+
+## Parameters
+* `cifmw_shiftstack_artifacts_dir`: (*string*) Directory name for the role artifacts. Defaults to `artifacts`.
+* `cifmw_shiftstack_basedir`: (*string*) Base directory for the role artifacts and logs. Defaults to `{{ cifmw_basedir }}/tests/shiftstack` (which defaults to `~/ci-framework-data/tests/shiftstack`.
+* `cifmw_shiftstack_client_pod_name`: (*string*) Pod name for the pod running the Openshift installer and tests. Defaults to `shiftstackclient`.
+* `cifmw_shiftstack_client_pod_namespace`: (*string*) The namespace where the `cifmw_shiftstack_client_pod_name` will be deployed. Defaults to `openstack`.
+* `cifmw_shiftstack_client_pod_image`: (*string*) The image for the container running in the `cifmw_shiftstack_client_pod_name` pod. Defaults to `quay.io/shiftstack-qe/shiftstack-client:latest`.
+* `cifmw_shiftstack_qa_repo`: (*string*) The repository containing the Openshift on Openstack QA automation. Defaults to `https://review.gerrithub.io/shiftstack/shiftstack-qa`.
+* `cifmw_shiftstack_run_playbook`: (*string*) The playbook to be run from the `cifmw_shiftstack_qa_repo` repository. Defaults to `ocp_testing.yaml`.
+
+## Examples
+The role is imported in the test playbook, i.e. when:
+```
+cifmw_run_tests: true
+cifmw_run_tempest: false
+cifmw_run_test_role: shiftstack
+cifmw_run_test_shiftstack_testconfig: 4.15_ovnkubernetes_ipi_va1.yaml
+
+$ ansible-playbook deploy-edpm.yml --extra-vars "cifmw_run_tests=true cifmw_run_tempest=false cifmw_run_test_role=shiftstack cifmw_openshift_kubeconfig={{ ansible_user_dir }}/.kube/config cifmw_run_test_shiftstack_testconfig=4.15_ovnkubernetes_ipi_va1.yaml"
+```

--- a/roles/shiftstack/defaults/main.yml
+++ b/roles/shiftstack/defaults/main.yml
@@ -1,0 +1,26 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_shiftstack"
+cifmw_shiftstack_artifacts_dir: "artifacts"
+cifmw_shiftstack_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}/tests/shiftstack"
+cifmw_shiftstack_client_pod_image: "quay.io/shiftstack-qe/shiftstack-client:latest"
+cifmw_shiftstack_client_pod_name: "shiftstackclient"
+cifmw_shiftstack_client_pod_namespace: "openstack"
+cifmw_shiftstack_qa_repo: "https://review.gerrithub.io/shiftstack/shiftstack-qa"
+cifmw_shiftstack_run_playbook: "ocp_testing.yaml"

--- a/roles/shiftstack/meta/main.yml
+++ b/roles/shiftstack/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- shiftstack
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: cifmw
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - cifmw
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/shiftstack/molecule/default/cleanup.yml
+++ b/roles/shiftstack/molecule/default/cleanup.yml
@@ -1,0 +1,38 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Cleanup
+  hosts: all
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+    cifmw_openshift_kubeconfig: "{{ ansible_user_dir  }}/.crc/machines/crc/kubeconfig"
+    openstack_namespace_name: openstack
+  tasks:
+    - name: Include the shiftstack role and run the cleanup
+      ansible.builtin.include_role:
+        name: "shiftstack"
+        tasks_from: cleanup.yml
+
+    - name: Delete the openstack namespace
+      k8s:
+        state: absent
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        definition:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: "{{ openstack_namespace_name }}"

--- a/roles/shiftstack/molecule/default/converge.yml
+++ b/roles/shiftstack/molecule/default/converge.yml
@@ -1,0 +1,29 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+    cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+    cifmw_shiftstack_run_playbook: cifmw-gate.yaml
+    cifmw_run_test_shiftstack_testconfig: cifmw-gate.yaml
+  tasks:
+    - name: Include the shiftstack role
+      ansible.builtin.include_role:
+        name: "shiftstack"

--- a/roles/shiftstack/molecule/default/molecule.yml
+++ b/roles/shiftstack/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/roles/shiftstack/molecule/default/prepare.yml
+++ b/roles/shiftstack/molecule/default/prepare.yml
@@ -1,0 +1,88 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+    cifmw_openshift_kubeconfig: "{{ ansible_user_dir  }}/.crc/machines/crc/kubeconfig"
+    openstack_namespace_name: openstack
+    openstack_config_name: openstack-config
+    openstack_config_secret_name: openstack-config-secret
+    openstack_root_ca_secret_name: rootca-public
+  roles:
+    - role: test_deps
+    - role: ci_setup
+  tasks:
+    - name: Ensure CRC is started
+      ansible.builtin.command:
+        cmd: crc start
+
+    - name: Create the openstack namespace
+      kubernetes.core.k8s:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: "{{ openstack_namespace_name }}"
+
+    - name: Create a dummy configmap
+      kubernetes.core.k8s:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        state: present
+        definition:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: "{{ openstack_config_name }}"
+            namespace: "{{ openstack_namespace_name }}"
+          data:
+            key1: dummy1
+            key2: dummy2
+
+    - name: Create a dummy openstack config secret
+      kubernetes.core.k8s:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ openstack_config_secret_name }}"
+            namespace: "{{ openstack_namespace_name }}"
+          type: Opaque
+          data:
+            secure.yaml: ZHVtbXkK # Base64 encoded value of "dummy"
+
+    - name: Create dummy openstack root ca secret
+      kubernetes.core.k8s:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ openstack_root_ca_secret_name }}"
+            namespace: "{{ openstack_namespace_name }}"
+          type: Opaque
+          data:
+            ca.crt: ZHVtbXkK # Base64 encoded value of "dummy"
+            tls.crt: ZHVtbXkK # Base64 encoded value of "dummy"
+            tls.key: ZHVtbXkK # Base64 encoded value of "dummy"

--- a/roles/shiftstack/tasks/cleanup.yml
+++ b/roles/shiftstack/tasks/cleanup.yml
@@ -1,0 +1,29 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Destroy the Openshift cluster
+  ansible.builtin.debug:
+    msg: "TODO: to be added once it's supported in shiftstack-qa automation"
+
+- name: Delete the pod '{{ cifmw_shiftstack_client_pod_name }}'
+  kubernetes.core.k8s:
+    state: absent
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_version: v1
+    kind: Pod
+    namespace: "{{ cifmw_shiftstack_client_pod_namespace }}"
+    name: "{{ cifmw_shiftstack_client_pod_name }}"
+    wait: true

--- a/roles/shiftstack/tasks/deploy_shiftstackclient_pod.yml
+++ b/roles/shiftstack/tasks/deploy_shiftstackclient_pod.yml
@@ -1,0 +1,31 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Render the pod manifest from a template
+  ansible.builtin.template:
+    src: "templates/shiftstackclient_pod.yml.j2"
+    dest: "{{ cifmw_shiftstack_basedir }}/{{ cifmw_shiftstack_client_pod_name }}_pod.yml"
+    mode: "0644"
+
+- name: Apply the manifest for the pod creation
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    src: "{{ cifmw_shiftstack_basedir }}/{{ cifmw_shiftstack_client_pod_name }}_pod.yml"
+    wait: true
+    wait_condition:
+      type: Ready
+      status: "True"

--- a/roles/shiftstack/tasks/exec_command_in_pod.yml
+++ b/roles/shiftstack/tasks/exec_command_in_pod.yml
@@ -1,0 +1,51 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Command execution block
+  block:
+    - name: Execute in the pod the command '{{ command }}'
+      environment:
+        PATH: "{{ cifmw_path }}"
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+      ansible.builtin.command:
+        cmd: "oc rsh -n {{ namespace }} {{ pod }} bash -c '{{ command }}'"
+      register: command_result
+
+  rescue:
+    - name: Fail when the command module fails
+      ansible.builtin.fail:
+        msg: "'{{ command }}' command execution failed, see logs for more information."
+
+  always:
+    - name: Command execution log saving block
+      when: log_file_name | default(false)
+      block:
+        - name: Get current date and time
+          ansible.builtin.command:
+            cmd: date +"%Y_%m_%d-%H_%M_%S"
+          register: current_date
+
+        - name: Save the command execution information in the log file in '{{ cifmw_shiftstack_basedir }}'
+          vars:
+            command_info:
+              namespace: "{{ namespace }}"
+              pod: "{{ pod }}"
+              command: "{{ command }}"
+              command_result: "{{ command_result }}"
+          ansible.builtin.copy:
+            content: "{{ command_info | to_nice_yaml }}"
+            dest: "{{ cifmw_shiftstack_basedir }}/{{ current_date.stdout }}.{{ log_file_name }}"
+            mode: "0644"

--- a/roles/shiftstack/tasks/main.yml
+++ b/roles/shiftstack/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Include pre test shiftstack tasks
+  ansible.builtin.include_tasks: pre_test_shiftstack.yml
+
+- name: Deploy the pod '{{ cifmw_shiftstack_client_pod_name }}'
+  ansible.builtin.include_tasks: deploy_shiftstackclient_pod.yml
+
+- name: Test Openshift on Openstack
+  ansible.builtin.include_tasks: test_shiftstack.yml
+
+# Cleanup not needed for now
+# - name: Shiftstack role cleanup
+#   ansible.builtin.include_tasks: cleanup.yml

--- a/roles/shiftstack/tasks/pre_test_shiftstack.yml
+++ b/roles/shiftstack/tasks/pre_test_shiftstack.yml
@@ -1,0 +1,25 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Remove the shiftstack role artifacts/logs directory (if exists)
+  ansible.builtin.file:
+    path: "{{ cifmw_shiftstack_basedir }}"
+    state: absent
+
+- name: Create the directory for shiftstack role artifacts/logs ({{ cifmw_shiftstack_basedir }})
+  ansible.builtin.file:
+    path: "{{ cifmw_shiftstack_basedir }}"
+    state: directory

--- a/roles/shiftstack/tasks/test_shiftstack.yml
+++ b/roles/shiftstack/tasks/test_shiftstack.yml
@@ -1,0 +1,84 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Clone the repository '{{ cifmw_shiftstack_qa_repo }}'
+  ansible.builtin.include_tasks: exec_command_in_pod.yml
+  vars:
+    namespace: "{{ cifmw_shiftstack_client_pod_namespace }}"
+    pod: "{{ cifmw_shiftstack_client_pod_name }}"
+    command: >
+      git clone {{ cifmw_shiftstack_qa_repo }}
+    log_file_name: "clone_shiftstack_qa_repo.log"
+
+- name: Install the ansible collections
+  ansible.builtin.include_tasks: exec_command_in_pod.yml
+  vars:
+    namespace: "{{ cifmw_shiftstack_client_pod_namespace }}"
+    pod: "{{ cifmw_shiftstack_client_pod_name }}"
+    command: >
+      cd shiftstack-qa && ansible-galaxy collection install -f -r requirements.yaml
+    log_file_name: "install_collections.log"
+
+- name: Check the playbook to be run exists in the repository
+  ansible.builtin.include_tasks: exec_command_in_pod.yml
+  vars:
+    namespace: "{{ cifmw_shiftstack_client_pod_namespace }}"
+    pod: "{{ cifmw_shiftstack_client_pod_name }}"
+    command: >
+      test -f shiftstack-qa/playbooks/{{ cifmw_shiftstack_run_playbook }}
+    log_file_name: "find_playbook.log"
+
+- name: Check the test configuration file exists in the repository
+  ansible.builtin.include_tasks: exec_command_in_pod.yml
+  vars:
+    namespace: "{{ cifmw_shiftstack_client_pod_namespace }}"
+    pod: "{{ cifmw_shiftstack_client_pod_name }}"
+    command: >
+      test -f shiftstack-qa/jobs_definitions/{{ cifmw_run_test_shiftstack_testconfig }}
+    log_file_name: "find_test_config.log"
+
+- name: OCP install and test block
+  block:
+    - name: Test Openshift on Openstack with the test configuration '{{ cifmw_run_test_shiftstack_testconfig }}'
+      ansible.builtin.include_tasks: exec_command_in_pod.yml
+      vars:
+        namespace: "{{ cifmw_shiftstack_client_pod_namespace }}"
+        pod: "{{ cifmw_shiftstack_client_pod_name }}"
+        command: >-
+          cd shiftstack-qa && ANSIBLE_LOG_PATH=~/artifacts/ansible-log.txt
+          ansible-navigator run playbooks/{{ cifmw_shiftstack_run_playbook }} -e @jobs_definitions/{{ cifmw_run_test_shiftstack_testconfig }}
+
+  rescue:
+    - name: Fail task when OCP installation/test fails
+      ansible.builtin.fail:
+        msg: "OCP install/test block failed, see logs for more information."
+
+  always:
+    - name: Create the directory for the artifacts
+      ansible.builtin.file:
+        path: "{{ cifmw_shiftstack_basedir }}/{{ cifmw_shiftstack_artifacts_dir }}"
+        state: directory
+        mode: "0755"
+
+    - name: Copy the artifacts from the pod '{{ cifmw_shiftstack_client_pod_name }}'
+      environment:
+        PATH: "{{ cifmw_path }}"
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+      ansible.builtin.command:
+        cmd: >
+          oc rsync -n {{ cifmw_shiftstack_client_pod_namespace }}
+          {{ cifmw_shiftstack_client_pod_name }}:/home/cloud-admin/{{ cifmw_shiftstack_artifacts_dir }}/
+          {{ cifmw_shiftstack_basedir }}/{{ cifmw_shiftstack_artifacts_dir }}/

--- a/roles/shiftstack/templates/shiftstackclient_pod.yml.j2
+++ b/roles/shiftstack/templates/shiftstackclient_pod.yml.j2
@@ -1,0 +1,60 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ cifmw_shiftstack_client_pod_name }}
+  namespace: {{ cifmw_shiftstack_client_pod_namespace }}
+spec:
+  containers:
+  - args:
+    - infinity
+    command:
+    - /bin/sleep
+    image: {{ cifmw_shiftstack_client_pod_image }}
+    imagePullPolicy: Always
+    name: {{ cifmw_shiftstack_client_pod_name }}
+    resources: {}
+    securityContext:
+      privileged: true
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /home/cloud-admin/.original-config/openstack/clouds.yaml
+      name: openstack-config
+      subPath: clouds.yaml
+    - mountPath: /home/cloud-admin/.original-config/openstack/secure.yaml
+      name: openstack-config-secret
+      subPath: secure.yaml
+    - mountPath: /home/cloud-admin/.original-config/cert/
+      name: openstack-cert
+      readOnly: true
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  terminationGracePeriodSeconds: 0
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+    tolerationSeconds: 300
+  volumes:
+  - configMap:
+      defaultMode: 420
+      name: openstack-config
+    name: openstack-config
+  - name: openstack-config-secret
+    secret:
+      defaultMode: 420
+      secretName: openstack-config-secret
+  - name: openstack-cert
+    secret:
+      defaultMode: 292
+      secretName: rootca-public

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -614,6 +614,18 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/shiftstack/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-shiftstack
+    nodeset: centos-9-crc-2-30-0-xl
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: shiftstack
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/sushy_emulator/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -62,6 +62,7 @@
       - cifmw-molecule-rhol_crc
       - cifmw-molecule-run_hook
       - cifmw-molecule-set_openstack_containers
+      - cifmw-molecule-shiftstack
       - cifmw-molecule-sushy_emulator
       - cifmw-molecule-tempest
       - cifmw-molecule-test_deps


### PR DESCRIPTION
The shiftstack role provides support for running Openshift on Openstack QA automation (installation and testing) on top of RHOSO deployments.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
