### PR TITLE
Fix the location of authentication

### DIFF
--- a/roles/reproducer/tasks/devscripts_post.yml
+++ b/roles/reproducer/tasks/devscripts_post.yml
@@ -6,7 +6,7 @@
         (
           cifmw_devscripts_repo_dir,
           'ocp',
-          'cifmw_devscripts_config.cluster_name',
+          cifmw_devscripts_config.cluster_name,
           'auth'
         ) | ansible.builtin.path_join
       }}


### PR DESCRIPTION
Due `'`, the location was invalid and this PR should fix it. This was causing

```
TASK [reproducer : Slurp content of the devscripts kubeconfig path={{ (_auth_path, 'kubeconfig') | ansible.builtin.path_join }}] ***
Friday 01 March 2024  06:14:04 -0500 (0:00:01.268)       0:11:11.806 ********** 
fatal: [hypervisor]: FAILED! => {"changed": false, "msg": "file not found: /home/zuul/src/github.com/openshift-metal3/dev-scripts/ocp/cifmw_devscripts_config.cluster_name/auth/kubeconfig"}
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

*Unit Test Results*
```
PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
localhost                  : ok=369  changed=128  unreachable=0    failed=0    skipped=156  rescued=1    ignored=0   

Friday 01 March 2024  13:54:24 +0200 (0:00:00.108)       0:10:11.105 ********** 
=============================================================================== 
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 81.25s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 48.00s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 47.96s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 47.92s
reproducer : Install some tools ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 37.34s
libvirt_manager : Grab IPs for nodes type ocp ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 31.66s
reproducer : Install collections on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 27.32s
reproducer : Bootstrap environment on controller-0 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 27.12s
libvirt_manager : Grab IPs for nodes type compute ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 21.27s
libvirt_manager : Prepare disk image with SSH and growing volume --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 17.34s
libvirt_manager : Grab IPs for nodes type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.76s
libvirt_manager : Wait for SSH on VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.57s
libvirt_manager : Wait for SSH on VMs type ocp --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.48s
reproducer : Install ansible dependencies -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 11.39s
libvirt_manager : Download base image ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 10.64s
libvirt_manager : Wait for SSH on VMs type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 5.20s
ci_setup : Install needed packages ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 5.07s
reproducer : Clone repository if needed: ci-framework --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 3.95s
networking_mapper : Ensure that networking and hostname facts are in place ------------------------------------------------------------------------------------------------------------------------------------------------------------ 3.70s
reproducer : Enable RHEL repos -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 3.55s
[ciuser@titanamd126 ci-framework]$ 
```
