### PR TITLE
Add storage_mgmt network to adoption job

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -49,6 +49,9 @@
           tenant:
             vlan: 22
             range: 172.19.0.0/24
+          storage_mgmt:
+            vlan: 23
+            range: 172.20.0.0/24
         instances:
           controller:
             networks:
@@ -60,6 +63,8 @@
                 ip: 172.18.0.4
               tenant:
                 ip: 172.19.0.4
+              storage_mgmt:
+                ip: 172.20.0.4
           crc:
             networks:
               default:
@@ -70,6 +75,8 @@
                 ip: 172.18.0.5
               tenant:
                 ip: 172.19.0.5
+              storage_mgmt:
+                ip: 172.20.0.5
           standalone:
             networks:
               default:
@@ -83,6 +90,9 @@
                 config_nm: false
               tenant:
                 ip: 172.19.0.100
+                config_nm: false
+              storage_mgmt:
+                ip: 172.20.0.100
                 config_nm: false
 
 - job:
@@ -149,6 +159,9 @@
           tenant:
             vlan: 22
             range: 172.19.0.0/24
+          storage_mgmt:
+            vlan: 23
+            range: 172.20.0.0/24
         instances:
           controller:
             networks:
@@ -160,6 +173,8 @@
                 ip: 172.18.0.4
               tenant:
                 ip: 172.19.0.4
+              storage_mgmt:
+                ip: 172.20.0.4
           crc:
             networks:
               default:
@@ -170,6 +185,8 @@
                 ip: 172.18.0.5
               tenant:
                 ip: 172.19.0.5
+              storage_mgmt:
+                ip: 172.20.0.5
           undercloud:
             networks:
               default:
@@ -183,6 +200,9 @@
                 config_nm: false
               tenant:
                 ip: 172.19.0.100
+                config_nm: false
+              storage_mgmt:
+                ip: 172.20.0.100
                 config_nm: false
 # TODO(marios): uncomment node config as needed
 #          tripleo-controller-1:
@@ -199,6 +219,9 @@
 #              tenant:
 #                ip: 172.19.0.110
 #                config_nm: false
+#              storage_mgmt:
+#                ip: 172.20.0.110
+#                config_nm: false
 #          tripleo-compute-1:
 #            networks:
 #              default:
@@ -212,6 +235,9 @@
 #                config_nm: false
 #              tenant:
 #                ip: 172.19.0.111
+#                config_nm: false
+#              storage_mgmt:
+#                ip: 172.20.0.111
 #                config_nm: false
 #          tripleo-controller-2:
 #            networks:
@@ -227,6 +253,9 @@
 #              tenant:
 #                ip: 172.19.0.102
 #                config_nm: false
+#              storage_mgmt:
+#                ip: 172.20.0.102
+#                config_nm: false
 #          tripleo-controller-3:
 #            networks:
 #              default:
@@ -240,4 +269,7 @@
 #                config_nm: false
 #              tenant:
 #                ip: 172.19.0.103
+#                config_nm: false
+#              storage_mgmt:
+#                ip: 172.20.0.103
 #                config_nm: false


### PR DESCRIPTION
Add the storage_mgmt network to adoption job and connnect its nodes to
it.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
