### PR TITLE
Shutdown OpenShift cluster gracefully.

### DIFF
--- a/roles/openshift_adm/README.md
+++ b/roles/openshift_adm/README.md
@@ -1,0 +1,32 @@
+# openshift_adm
+
+This role performs OpenShift cluster operations like wait for a stable
+environment, shutdown and force regeneration of cluster certificate. The main
+purpose of this role is perform administrative actions on the OpenShift
+cluster.
+
+## Privilege escalation
+
+No privilege escalation is required on the executing host. However, it
+requires administrator level privileges for the deployed OpenShift.
+
+## General Parameters
+
+This role requires the following parameters to be configured.
+
+* `cifmw_openshift_api` (str) Cluster endpoint to be used for communication.
+* `cifmw_openshift_user` (str) Name of the user to be used for authentication.
+* `cifmw_openshift_password` (str) Password of the provided user.
+* `cifmw_openshift_kubeconfig` (str) Absolute path to the kubeconfig file.
+* `cifmw_base_dir` (str) Absolute path to the base directory
+* `cifmw_path` (str) containing information for environment.path.
+
+## Parameters - Role
+
+* `cifmw_openshift_adm_op` (str) The operation to be performed on the cluster.
+* `cifmw_openshift_adm_dry_run` (bool) If enabled, no modifications are
+  performed on the cluster.
+
+## Reference
+
+* [Stop and resume cluster](https://www.redhat.com/en/blog/enabling-openshift-4-clusters-to-stop-and-resume-cluster-vms)

--- a/roles/openshift_adm/defaults/main.yml
+++ b/roles/openshift_adm/defaults/main.yml
@@ -1,0 +1,28 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_openshift_adm"
+
+
+cifmw_openshift_adm_cert_expire_date_file: >-
+  {{
+    (cifmw_base_dir, 'artifacts', '.ocp_cert_not_after') |
+    ansible.builtin.path_join
+  }}
+cifmw_openshift_adm_op: ""
+cifmw_openshift_adm_dry_run: false

--- a/roles/openshift_adm/files/regenerate-certificate.yml
+++ b/roles/openshift_adm/files/regenerate-certificate.yml
@@ -1,0 +1,109 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kubelet-bootstrap-cred-manager
+  namespace: openshift-machine-config-operator
+  labels:
+    k8s-app: kubelet-bootrap-cred-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: kubelet-bootstrap-cred-manager
+  template:
+    metadata:
+      labels:
+        k8s-app: kubelet-bootstrap-cred-manager
+    spec:
+      containers:
+        - name: kubelet-bootstrap-cred-manager
+          image: quay.io/openshift/origin-cli:v4.0
+          command: ['/bin/bash', '-ec']
+          args:
+            - |
+              #!/bin/bash
+
+              set -eoux pipefail
+
+              while true; do
+                unset KUBECONFIG
+
+                echo "---------------------------------"
+                echo "Gather info..."
+                echo "---------------------------------"
+                # context
+                intapi=$(oc get infrastructures.config.openshift.io cluster -o "jsonpath={.status.apiServerInternalURI}")
+                context="$(oc --config=/etc/kubernetes/kubeconfig config current-context)"
+                # cluster
+                cluster="$(oc --config=/etc/kubernetes/kubeconfig config view -o "jsonpath={.contexts[?(@.name==\"$context\")].context.cluster}")"
+                server="$(oc --config=/etc/kubernetes/kubeconfig config view -o "jsonpath={.clusters[?(@.name==\"$cluster\")].cluster.server}")"
+                # token
+                ca_crt_data="$(oc get secret -n openshift-machine-config-operator node-bootstrapper-token -o "jsonpath={.data.ca\.crt}" | base64 --decode)"
+                namespace="$(oc get secret -n openshift-machine-config-operator node-bootstrapper-token  -o "jsonpath={.data.namespace}" | base64 --decode)"
+                token="$(oc get secret -n openshift-machine-config-operator node-bootstrapper-token -o "jsonpath={.data.token}" | base64 --decode)"
+
+                echo "---------------------------------"
+                echo "Generate kubeconfig"
+                echo "---------------------------------"
+
+                export KUBECONFIG="$(mktemp)"
+                kubectl config set-credentials "kubelet" --token="$token" >/dev/null
+                ca_crt="$(mktemp)"; echo "$ca_crt_data" > $ca_crt
+                kubectl config set-cluster $cluster --server="$intapi" --certificate-authority="$ca_crt" --embed-certs >/dev/null
+                kubectl config set-context kubelet --cluster="$cluster" --user="kubelet" >/dev/null
+                kubectl config use-context kubelet >/dev/null
+
+                echo "---------------------------------"
+                echo "Print kubeconfig"
+                echo "---------------------------------"
+                cat "$KUBECONFIG"
+
+                echo "---------------------------------"
+                echo "Whoami?"
+                echo "---------------------------------"
+                oc whoami
+                whoami
+
+                echo "---------------------------------"
+                echo "Moving to real kubeconfig"
+                echo "---------------------------------"
+                cp /etc/kubernetes/kubeconfig /etc/kubernetes/kubeconfig.prev
+                chown root:root ${KUBECONFIG}
+                chmod 0644 ${KUBECONFIG}
+                mv "${KUBECONFIG}" /etc/kubernetes/kubeconfig
+
+                echo "---------------------------------"
+                echo "Sleep 60 seconds..."
+                echo "---------------------------------"
+                sleep 60
+              done
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          volumeMounts:
+            - mountPath: /etc/kubernetes/
+              name: kubelet-dir
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
+      restartPolicy: Always
+      securityContext:
+        runAsUser: 0
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node.kubernetes.io/unreachable"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 120
+        - key: "node.kubernetes.io/not-ready"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 120
+      volumes:
+        - hostPath:
+            path: /etc/kubernetes/
+            type: Directory
+          name: kubelet-dir

--- a/roles/openshift_adm/meta/main.yml
+++ b/roles/openshift_adm/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- openshift_adm
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: cifmw
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - cifmw
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/openshift_adm/tasks/api_cert.yml
+++ b/roles/openshift_adm/tasks/api_cert.yml
@@ -1,0 +1,95 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Copy the daemon set to the target host
+  ansible.builtin.copy:
+    src: "files/regenerate-certificate.yml"
+    dest: "/tmp/regenerate-certificate.yaml"
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_id }}"
+    mode: "0640"
+
+- name: Generate new certificate.
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: "oc apply -f /tmp/regenerate-certificate.yaml"
+
+- name: Removing csr-signer certs
+  kubernetes.core.k8s:
+    kind: secret
+    namespace: openshift-kube-controller-manager-operator
+    name: "{{ item }}"
+    state: absent
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    validate_certs: false
+  loop:
+    - csr-signer-signer
+    - csr-signer
+  loop_control:
+    label: "{{ item }}"
+
+- name: Wait unit the OpenShift cluster is stable.
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: "oc adm wait-for-stable-cluster --minimum-stable-period=3m"
+
+- name: Gather the kubelet signer secret.
+  kubernetes.core.k8s_info:
+    kind: secret
+    namespace: openshift-kube-controller-manager-operator
+    name: csr-signer-signer
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    validate_certs: false
+  register: _api_cert
+
+- name: Ensure certificate regenerated file exists.
+  ansible.builtin.copy:
+    content: "{{ _api_cert.resources[0].data['tls.crt'] | b64decode }}"
+    dest: "/tmp/gen_api.crt"
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_id }}"
+    mode: "0440"
+
+- name: Read the certificate details.
+  openssl_certificate_info:
+    path: "/tmp/gen_api.crt"
+  register: _gen_api_cert
+
+- name: Write the expiration date of the generated certificate.
+  ansible.builtin.copy:
+    content: >-
+      {{
+        _gen_api_cert.not_after | ansible.builtin.to_datetime("%Y%m%d%H%M%SZ")
+      }}
+    dest: "{{ cifmw_openshift_adm_cert_expire_date_file }}"
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_id }}"
+    mode: "0440"
+
+- name: Remove all the temporary files created.
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "/tmp/regenerate-certificate.yaml"
+    - "/tmp/gen_api.crt"
+  loop_control:
+    label: "{{ item }}"

--- a/roles/openshift_adm/tasks/main.yml
+++ b/roles/openshift_adm/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Ensure required variables are defined.
+  ansible.builtin.assert:
+    that:
+      - cifmw_basedir is defined
+      - cifmw_path is defined
+      - cifmw_openshift_api is defined
+      - cifmw_openshift_user is defined
+      - cifmw_openshift_password is defined
+      - cifmw_openshift_kubeconfig is defined
+
+- name: Prepare and shutdown the OpenShift cluster.
+  when:
+    - cifmw_openshift_adm_op == 'shutdown'
+  ansible.builtin.include_tasks:
+    file: shutdown.yml
+
+- name: Wait for the OpenShift cluster to become stable.
+  when:
+    - cifmw_openshift_adm_op == 'stable'
+  ansible.builtin.include_tasks:
+    file: wait_for_cluster.yml

--- a/roles/openshift_adm/tasks/shutdown.yml
+++ b/roles/openshift_adm/tasks/shutdown.yml
@@ -1,0 +1,83 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Initiates a graceful shutdown of the OpenShift cluster.
+
+
+- name: Check for regenerated certificate file.
+  when:
+    - not cifmw_openshift_adm_dry_run
+  ansible.builtin.stat:
+    path: "{{ cifmw_openshift_adm_cert_expire_date_file }}"
+  register: _regenerated_file
+
+# Current implementation works only once hence the check.
+- name: Regenerate the API certificates.
+  when:
+    - not _regenerated_file.stat.exists | default(false)
+    - not cifmw_openshift_adm_dry_run
+  ansible.builtin.include_tasks: api_cert.yml
+
+- name: Gather the list of nodes
+  kubernetes.core.k8s_info:
+    kind: Node
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    validate_certs: false
+  register: _nodes
+
+- name: Shutdown the nodes participating in the cluster.
+  when:
+    - not cifmw_openshift_adm_dry_run
+  vars:
+    _node_names: >-
+      {{
+        _nodes.resources | map(attribute='metadata.name') | list
+      }}
+    _node_ips: >-
+      {{
+        _nodes.resources |
+        map(attribute='status.addresses') |
+        flatten |
+        selectattr('type', 'match', 'InternalIP') |
+        map(attribute='address') |
+        list
+      }}
+  block:
+    - name: Mark the nodes as unschedulable.
+      kubernetes.core.k8s_drain:
+        name: "{{ item }}"
+        state: cordon
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        validate_certs: false
+      loop: "{{ _node_names }}"
+
+    - name: Initiate shutdown
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.shell:
+        cmd: >-
+          for node in $(oc get nodes -o jsonpath='{.items[*].metadata.name}');
+          do oc debug node/${node} -- chroot /host shutdown -h 3; done
+
+    - name: Wait till SSH connection is closed.
+      ansible.builtin.wait_for:
+        host: "{{ item }}"
+        port: 22
+        state: drained
+      loop: "{{ _node_ips }}"
+      loop_control:
+        label: "{{ item }}"

--- a/roles/openshift_adm/tasks/wait_for_cluster.yml
+++ b/roles/openshift_adm/tasks/wait_for_cluster.yml
@@ -1,0 +1,67 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# We would wait till forbidden error is received. It indicates the endpoint
+# is reachable.
+
+- name: Wait until the OCP API endpoint is reachable.
+  ansible.builtin.uri:
+    url: "{{ cifmw_openshift_api }}"
+    return_content: true
+    validate_certs: false
+    status_code: 403
+  register: ocp_api_result
+  until: ocp_api_result.status == 403
+  retries: 30
+  delay: 5
+
+- name: Wait until OCP login succeeds.
+  kubernetes.core.k8s_auth:
+    host: "{{ cifmw_openshift_api }}"
+    password: "{{ cifmw_openshift_password }}"
+    state: present
+    username: "{{ cifmw_openshift_user }}"
+    validate_certs: false
+  register: _oc_login_result
+  until: _oc_login_result.k8s_auth is defined
+  retries: 30
+  delay: 5
+
+- name: Gather the list of nodes
+  kubernetes.core.k8s_info:
+    kind: Node
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    validate_certs: false
+  register: _nodes
+
+- name: Ensure the nodes are in ready state.
+  when:
+    - not cifmw_openshift_adm_dry_run
+  kubernetes.core.k8s_drain:
+    name: "{{ item }}"
+    state: uncordon
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    validate_certs: false
+  loop: "{{ _nodes.resources | map(attribute='metadata.name') | list }}"
+
+- name: Wait unit the OpenShift cluster is stable.
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: >-
+      oc adm wait-for-stable-cluster --minimum-stable-period=5s --timeout=15m


### PR DESCRIPTION
This change set adds support for performing the necessary tasks for shutting down the OpenShift cluster gracefully. It also adds task for regenerating the API server certificate.

Adds two new tasks
- shutdown the ocp cluster
- wait till the cluster is stable

_Shutdown the OCP cluster_
1. Check if we have regenerated the API certificate
2. If no, generate the certificate as outlined in the [blog](https://www.redhat.com/en/blog/enabling-openshift-4-clusters-to-stop-and-resume-cluster-vms)
3. Remove the API certifcate secrets
4. Wait the cluster is stable using `oc adm wait-for-stable-cluster`
5. Gather the expiration date of the cluster and right it to a file.
6. Gather the list of all the nodes participating in the cluster
7. For each cluster disable scheduling and shutdown

_Wait for stable cluster_
1. Check if the endpoint is reachable
2. Check if authentication endpoint is working
3. Ensure the nodes are enabled for scheduling
4. Wait for the cluster operators to be stable.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes

*Testing Results*

_Rerun scenario_
```
PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
titanamd126                : ok=363  changed=126  unreachable=0    failed=0    skipped=160  rescued=0    ignored=0   

Tuesday 05 March 2024  06:36:10 -0500 (0:00:00.172)       0:15:19.135 ********* 
=============================================================================== 
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 51.14s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 50.71s
reproducer : Bootstrap environment on controller-0 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 50.58s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 50.37s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 49.07s
reproducer : Install some tools ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 37.73s
reproducer : Install collections on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 26.80s
libvirt_manager : Grab IPs for nodes type ocp ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 26.55s
libvirt_manager : Grab IPs for nodes type compute ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 20.19s
networking_mapper : Ensure that networking and hostname facts are in place ----------------------------------------------------------------------------------------------------------------------------------------------------------- 19.84s
reproducer : Inject ProxyJump configuration for remote hypervisor VMs ---------------------------------------------------------------------------------------------------------------------------------------------------------------- 19.70s
libvirt_manager : Grab IPs for nodes type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.94s
libvirt_manager : Wait for SSH on VMs type ocp --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.84s
libvirt_manager : Wait for SSH on VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 17.89s
libvirt_manager : Prepare disk image with SSH and growing volume --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 16.75s
libvirt_manager : Configure VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 13.69s
reproducer : Wait for OCP nodes to be ready ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 12.47s
reproducer : Install ansible dependencies -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 12.46s
libvirt_manager : Download base image ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 11.21s
reproducer : Inject kubeconfig content ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 6.56s
```

_Greenfield install_
```
PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
titanamd126                : ok=405  changed=168  unreachable=0    failed=0    skipped=172  rescued=2    ignored=0   

Tuesday 05 March 2024  20:25:38 -0500 (0:00:00.223)       1:12:18.456 ********* 
=============================================================================== 
devscripts : Deploy OpenShift cluster ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 3037.39s
reproducer : Install internal CA ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 152.38s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 79.88s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 78.90s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 78.24s
reproducer : Install some tools ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 46.93s
libvirt_manager : Grab IPs for nodes type ocp ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 32.28s
reproducer : Inject kubeadmin-password if exists ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 31.95s
reproducer : Bootstrap environment on controller-0 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 28.37s
reproducer : Inject devscripts private key if set ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 26.90s
reproducer : Install collections on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 25.16s
networking_mapper : Ensure that networking and hostname facts are in place ----------------------------------------------------------------------------------------------------------------------------------------------------------- 23.57s
libvirt_manager : Prepare disk image with SSH and growing volume --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 20.47s
libvirt_manager : Grab IPs for nodes type compute ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 20.44s
libvirt_manager : Grab IPs for nodes type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 19.04s
libvirt_manager : Wait for SSH on VMs type ocp --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.71s
libvirt_manager : Wait for SSH on VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 17.93s
reproducer : Wait for OCP nodes to be ready ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 13.62s
libvirt_manager : Configure VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 12.94s
reproducer : Install ansible dependencies -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 12.80s
```

However, the nodes should be set to `uncordon` after reboot as
```
[ciuser@titanamd126 ~]$ oc get nodes
NAME       STATUS                     ROLES                         AGE   VERSION
master-0   Ready,SchedulingDisabled   control-plane,master,worker   84m   v1.28.6+6216ea1
master-1   Ready,SchedulingDisabled   control-plane,master,worker   84m   v1.28.6+6216ea1
master-2   Ready,SchedulingDisabled   control-plane,master,worker   84m   v1.28.6+6216ea1
```

_Stable wait tasks_
```
TASK [openshift_adm : Wait for the OpenShift cluster to become stable. _raw_params=wait_for_cluster.yml] *************************************************************************************************************************************
Wednesday 06 March 2024  00:40:43 -0500 (0:00:00.103)       0:06:23.705 ******* 
included: /home/ciuser/src/ci-framework/roles/openshift_adm/tasks/wait_for_cluster.yml for titanamd126

TASK [openshift_adm : Wait until the OCP API endpoint is reachable. url={{ cifmw_openshift_api }}, return_content=True, validate_certs=False, status_code=403] *******************************************************************************
Wednesday 06 March 2024  00:40:43 -0500 (0:00:00.129)       0:06:23.834 ******* 
FAILED - RETRYING: [titanamd126]: Wait until the OCP API endpoint is reachable. (30 retries left).
FAILED - RETRYING: [titanamd126]: Wait until the OCP API endpoint is reachable. (29 retries left).
ok: [titanamd126]

TASK [openshift_adm : Wait until OCP login succeeds. host={{ cifmw_openshift_api }}, password={{ cifmw_openshift_password }}, state=present, username={{ cifmw_openshift_user }}, validate_certs=False] **************************************
Wednesday 06 March 2024  00:41:18 -0500 (0:00:34.813)       0:06:58.647 ******* 
FAILED - RETRYING: [titanamd126]: Wait until OCP login succeeds. (30 retries left).
FAILED - RETRYING: [titanamd126]: Wait until OCP login succeeds. (29 retries left).
FAILED - RETRYING: [titanamd126]: Wait until OCP login succeeds. (28 retries left).
FAILED - RETRYING: [titanamd126]: Wait until OCP login succeeds. (27 retries left).
FAILED - RETRYING: [titanamd126]: Wait until OCP login succeeds. (26 retries left).
FAILED - RETRYING: [titanamd126]: Wait until OCP login succeeds. (25 retries left).
FAILED - RETRYING: [titanamd126]: Wait until OCP login succeeds. (24 retries left).
FAILED - RETRYING: [titanamd126]: Wait until OCP login succeeds. (23 retries left).
FAILED - RETRYING: [titanamd126]: Wait until OCP login succeeds. (22 retries left).
FAILED - RETRYING: [titanamd126]: Wait until OCP login succeeds. (21 retries left).
FAILED - RETRYING: [titanamd126]: Wait until OCP login succeeds. (20 retries left).
FAILED - RETRYING: [titanamd126]: Wait until OCP login succeeds. (19 retries left).
FAILED - RETRYING: [titanamd126]: Wait until OCP login succeeds. (18 retries left).
FAILED - RETRYING: [titanamd126]: Wait until OCP login succeeds. (17 retries left).
FAILED - RETRYING: [titanamd126]: Wait until OCP login succeeds. (16 retries left).
ok: [titanamd126]

TASK [openshift_adm : Wait unit the OpenShift cluster is stable. _raw_params=oc adm wait-for-stable-cluster --minimum-stable-period=5s --timeout=15m] ****************************************************************************************
Wednesday 06 March 2024  00:44:18 -0500 (0:03:00.419)       0:09:59.067 ******* 
```

_Rerun scenario 2 - with latest changes_

```
PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
titanamd126                : ok=370  changed=128  unreachable=0    failed=0    skipped=160  rescued=0    ignored=0   

Wednesday 06 March 2024  02:42:43 -0500 (0:00:00.138)       0:29:30.895 ******* 
=============================================================================== 
openshift_adm : Wait unit the OpenShift cluster is stable. -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 595.33s
openshift_adm : Wait until OCP login succeeds. -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 233.80s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 52.22s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 52.19s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 51.59s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 51.12s
reproducer : Install some tools ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 38.99s
reproducer : Bootstrap environment on controller-0 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 28.44s
openshift_adm : Wait until the OCP API endpoint is reachable. ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 28.31s
libvirt_manager : Grab IPs for nodes type ocp ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 28.27s
reproducer : Install collections on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 25.74s
networking_mapper : Ensure that networking and hostname facts are in place ----------------------------------------------------------------------------------------------------------------------------------------------------------- 24.28s
libvirt_manager : Grab IPs for nodes type compute ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 20.29s
libvirt_manager : Grab IPs for nodes type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 19.04s
libvirt_manager : Wait for SSH on VMs type ocp --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.70s
libvirt_manager : Wait for SSH on VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 17.91s
libvirt_manager : Prepare disk image with SSH and growing volume --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 16.68s
libvirt_manager : Configure VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.08s
reproducer : Wait for OCP nodes to be ready ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 13.74s
reproducer : Install ansible dependencies -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 13.28s
[ciuser@devci-01 ci-framework]$ 

ciuser@titanamd126 ~]$ oc get nodes
NAME       STATUS   ROLES                         AGE    VERSION
master-0   Ready    control-plane,master,worker   7h9m   v1.28.6+6216ea1
master-1   Ready    control-plane,master,worker   7h9m   v1.28.6+6216ea1
master-2   Ready    control-plane,master,worker   7h9m   v1.28.6+6216ea1
```

*Cert expiration date*
```
# ls -l .cert.regenerated 
-r--r-----. 1 ciuser ciuser 19 Mar  7 15:28 .cert.regenerated

# cat .cert.regenerated 
2024-05-06 13:15:14
```
