### PR TITLE
Move log_host_url to a proper var

### DIFF
--- a/roles/dlrn_report/README.md
+++ b/roles/dlrn_report/README.md
@@ -19,6 +19,7 @@ This role does not need privilege escalation.
 * `cifmw_dlrn_report_result`: (boolean) Whether to report DLRN results. Can be disabled if a test run should not be registered to DLRN. Default `true`
 * `cifmw_dlrn_report_krb_user_realm`: (string) Name of valid Kerberos REALM.
 * `cifmw_dlrn_report_keytab`: (string) file path to valid keytab file for performing kinit.
+* `cifmw_dlrn_report_zuul_log_path`: (string) Zuul log path url.
 
 ## Dependencies
 

--- a/roles/dlrn_report/defaults/main.yml
+++ b/roles/dlrn_report/defaults/main.yml
@@ -25,3 +25,4 @@ cifmw_dlrn_report_result: true
 cifmw_dlrn_report_dlrnapi_host_principal: ""
 cifmw_dlrn_report_keytab: ""
 cifmw_dlrn_report_krb_user_realm: ""
+cifmw_dlrn_report_zuul_log_path: "https://logserver.rdoproject.org"

--- a/roles/dlrn_report/tasks/dlrn_report_results.yml
+++ b/roles/dlrn_report/tasks/dlrn_report_results.yml
@@ -45,7 +45,7 @@
       --distro_hash {{ cifmw_repo_setup_distro_hash }}
       {% endif -%}
       --job-id {{ zuul.job }}
-      --info-url "{{ log_host_url | default('https://logserver.rdoproject.org') }}/{{ zuul_log_path }}"
+      --info-url "{{ cifmw_dlrn_report_zuul_log_path }}/{{ zuul_log_path }}"
       --timestamp $(date +%s)
       --success {{ zuul_success | bool }}
   environment: |


### PR DESCRIPTION
We started intergrating dlrn_report in downstream and log_host_url in downstream is different.

In order to set it properly and avoid confusion with other role var, we are moving it to a var.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

