### PR TITLE
Copy yum.repos.d directory to logs

### DIFF
--- a/roles/artifacts/tasks/environment.yml
+++ b/roles/artifacts/tasks/environment.yml
@@ -19,6 +19,7 @@
     cmd: |-
       cp /etc/resolv.conf /etc/hosts {{ cifmw_artifacts_basedir }}/artifacts/
       cp -r /etc/NetworkManager/system-connections {{ cifmw_artifacts_basedir }}/artifacts/NetworkManager
+      cp -r /etc/yum.repos.d {{ cifmw_artifacts_basedir }}/artifacts/yum_repos
       test -d /etc/ci/env && cp -r /etc/ci/env {{ cifmw_artifacts_basedir }}/artifacts/ci-env
       test -d /var/log/bmaas_console_logs && cp -r /var/log/bmaas_console_logs {{ cifmw_artifacts_basedir }}/logs
       ip ro ls > {{ cifmw_artifacts_basedir }}/artifacts/ip-network.txt


### PR DESCRIPTION
In EDPM image build and container build jobs, we are generating repos in /etc/yum.repos.d directory. If these jobs breaks, Devs looks for repos in the logs which does not get collected. It makes debugging hard.

Copying the repos in the logs will make the life easier.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

