### PR TITLE
Add cifmw_ceph_daemons_layout to VA1

### DIFF
--- a/scenarios/reproducers/validated-architecture-1.yml
+++ b/scenarios/reproducers/validated-architecture-1.yml
@@ -146,3 +146,9 @@ cifmw_devscripts_enable_ocp_nodes_host_routing: true
 # type and size of ssh keys injected into the OCP workers and compute nodes
 cifmw_ssh_keytype: ecdsa
 cifmw_ssh_keysize: 521
+
+# Test Ceph file and object storage (block is enabled by default)
+cifmw_ceph_daemons_layout:
+  rgw_enabled: true
+  dashboard_enabled: false
+  cephfs_enabled: true


### PR DESCRIPTION
The ceph playbook was updated to not deploy all ceph services by default (dashboard, object, file) [1]. Since VA1 does not deploy Swift let's enable RGW (object). Since VA1 does deploy Manila let's enable FS (file).

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/1208

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
