### PR TITLE
net-mapper: is_trunk_parent, trunk_parent, routers

### DIFF
--- a/plugins/module_utils/net_map/exceptions.py
+++ b/plugins/module_utils/net_map/exceptions.py
@@ -38,3 +38,19 @@ class HostNetworkRangeCollisionValidationError(NetworkMappingValidationError):
 
     def __str__(self):
         return str(vars(self))
+
+
+class NetworkMappingTrunkParentValidationError(NetworkMappingValidationError):
+    def __init__(
+        self,
+        message,
+        field=None,
+        invalid_value=None,
+        parent_name=None,
+        parent_type=None,
+    ) -> None:
+        super().__init__(message)
+        self.field = field
+        self.invalid_value = invalid_value
+        self.parent_name = parent_name
+        self.parent_type = parent_type

--- a/plugins/module_utils/net_map/networking_env_definitions.py
+++ b/plugins/module_utils/net_map/networking_env_definitions.py
@@ -80,6 +80,8 @@ class MappedInstanceNetwork:
     mtu: typing.Optional[int] = None
     parent_interface: typing.Optional[str] = None
     vlan_id: typing.Optional[int] = None
+    is_trunk_parent: typing.Optional[bool] = None
+    trunk_parent: typing.Optional[str] = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -187,6 +189,20 @@ class MappedNetwork:
 
 
 @dataclasses.dataclass(frozen=True)
+class MappedRouter:
+    """Defines all the settings for a router
+    Attributes:
+        router_name: The name of the router
+        networks: Networks attached to the router
+        external_network: The external gateway network
+    """
+
+    router_name: str
+    networks: typing.List[str]
+    external_network: typing.Optional[str] = None
+
+
+@dataclasses.dataclass(frozen=True)
 class NetworkingEnvironmentDefinition:
     """Mapped Networking Environment Definition
 
@@ -195,8 +211,10 @@ class NetworkingEnvironmentDefinition:
     Attributes:
         networks: The existing networks in the environment.
         instances: Networking related information for each instance.
+        routers: Routers in the environment
 
     """
 
     networks: typing.Dict[str, MappedNetwork]
     instances: typing.Dict[str, typing.Dict[str, MappedInstance]]
+    routers: typing.Dict[str, MappedRouter]

--- a/scripts/run_ansible_test
+++ b/scripts/run_ansible_test
@@ -47,10 +47,10 @@ cat  "${HOME}/.ansible/collections/ansible_collections/cifmw/general/tests/sanit
 
 pushd ${HOME}/.ansible/collections/ansible_collections/cifmw/general
 
+if [ -d tests/unit ]; then
+    ${ansible_test} units --color=yes --requirements -vv
+fi
 ${ansible_test} sanity --test validate-modules
 if [ -d tests/integration ]; then
     ${ansible_test} integration --color=yes
-fi
-if [ -d tests/unit ]; then
-    ${ansible_test} units --color=yes --requirements
 fi

--- a/tests/unit/module_utils/net_map/test_networking_mapper.py
+++ b/tests/unit/module_utils/net_map/test_networking_mapper.py
@@ -51,6 +51,29 @@ def test_networking_mapper_basic_networks_map_ok(
 
 
 @pytest.mark.parametrize(
+    "test_input_config_file,test_golden_file",
+    [
+        (
+            "network-definition-valid-router-template.yml",
+            "network-definition-valid-router-template-out.json",
+        ),
+    ],
+)
+def test_networking_mapper_basic_routers_map_ok(
+    test_input_config_file, test_golden_file
+):
+    mapper = networking_mapper.NetworkingDefinitionMapper(
+        net_map_stub_data.TEST_HOSTVARS, net_map_stub_data.TEST_GROUPS
+    )
+    mapped_content = mapper.map_routers(
+        net_map_stub_data.get_test_file_yaml_content(test_input_config_file)
+    )
+    assert mapped_content == net_map_stub_data.get_test_file_json_content(
+        test_golden_file
+    )
+
+
+@pytest.mark.parametrize(
     "test_input_config_file,test_golden_file,reduced_hosts",
     [
         pytest.param(
@@ -134,6 +157,10 @@ def test_networking_mapper_full_partial_map_ok(
         (
             "networking-definition-valid-all-tools.yml",
             "networking-definition-valid-all-tools-full-map-out.json",
+        ),
+        (
+            "network-definition-valid-all-tools-no-group-templates.yml",
+            "network-definition-valid-all-tools-no-group-templates-out.json",
         ),
     ],
 )

--- a/tests/unit/module_utils/test_files/network-definition-valid-all-tools-no-group-templates-out.json
+++ b/tests/unit/module_utils/test_files/network-definition-valid-all-tools-no-group-templates-out.json
@@ -1,0 +1,165 @@
+{
+  "instances": {
+    "instance-1": {
+      "hostname": "instance-1-hostname",
+      "name": "instance-1",
+      "networks": {
+        "ctlplane": {
+          "interface_name": "eth1",
+          "ip_v4": "192.168.122.100",
+          "mac_addr": "27:b9:47:74:b3:02",
+          "mtu": 1500,
+          "netmask_v4": "255.255.255.0",
+          "network_name": "ctlplane",
+          "prefix_length_v4": 24,
+          "skip_nm": false,
+          "is_trunk_parent": true
+        },
+        "internal-api": {
+          "interface_name": "eth1.20",
+          "ip_v4": "172.17.0.100",
+          "mac_addr": "52:54:00:57:a5:bd",
+          "mtu": 1496,
+          "netmask_v4": "255.255.255.0",
+          "network_name": "internal-api",
+          "parent_interface": "eth1",
+          "prefix_length_v4": 24,
+          "skip_nm": false,
+          "vlan_id": 20,
+          "trunk_parent": "ctlplane"
+        },
+        "storage": {
+          "interface_name": "eth1.21",
+          "ip_v4": "172.18.0.100",
+          "mac_addr": "52:54:00:3b:4c:47",
+          "mtu": 1496,
+          "netmask_v4": "255.255.255.0",
+          "network_name": "storage",
+          "parent_interface": "eth1",
+          "prefix_length_v4": 24,
+          "skip_nm": false,
+          "vlan_id": 21,
+          "trunk_parent": "ctlplane"
+        },
+        "tenant": {
+          "interface_name": "eth1.22",
+          "ip_v4": "172.19.0.100",
+          "mac_addr": "52:54:00:5b:40:e3",
+          "mtu": 1496,
+          "netmask_v4": "255.255.255.0",
+          "network_name": "tenant",
+          "parent_interface": "eth1",
+          "prefix_length_v4": 24,
+          "skip_nm": false,
+          "vlan_id": 22,
+          "trunk_parent": "ctlplane"
+        }
+      }
+    },
+    "instance-2": {
+      "hostname": "instance-2-hostname",
+      "name": "instance-2",
+      "networks": {
+        "ctlplane": {
+          "interface_name": "eth2",
+          "ip_v4": "192.168.122.101",
+          "mac_addr": "a1:69:da:21:aa:03",
+          "mtu": 1500,
+          "netmask_v4": "255.255.255.0",
+          "network_name": "ctlplane",
+          "prefix_length_v4": 24,
+          "skip_nm": false,
+          "is_trunk_parent": true
+        },
+        "internal-api": {
+          "interface_name": "eth2.20",
+          "ip_v4": "172.17.0.101",
+          "mac_addr": "52:54:00:67:13:df",
+          "mtu": 1496,
+          "netmask_v4": "255.255.255.0",
+          "network_name": "internal-api",
+          "parent_interface": "eth2",
+          "prefix_length_v4": 24,
+          "skip_nm": false,
+          "vlan_id": 20,
+          "trunk_parent": "ctlplane"
+        },
+        "storage": {
+          "interface_name": "eth2.21",
+          "ip_v4": "172.18.0.101",
+          "mac_addr": "52:54:00:69:83:6c",
+          "mtu": 1496,
+          "netmask_v4": "255.255.255.0",
+          "network_name": "storage",
+          "parent_interface": "eth2",
+          "prefix_length_v4": 24,
+          "skip_nm": false,
+          "vlan_id": 21,
+          "trunk_parent": "ctlplane"
+        },
+        "tenant": {
+          "interface_name": "eth2.22",
+          "ip_v4": "172.19.0.101",
+          "mac_addr": "52:54:00:51:4f:fb",
+          "mtu": 1496,
+          "netmask_v4": "255.255.255.0",
+          "network_name": "tenant",
+          "parent_interface": "eth2",
+          "prefix_length_v4": 24,
+          "skip_nm": false,
+          "vlan_id": 22,
+          "trunk_parent": "ctlplane"
+        }
+      }
+    }
+  },
+  "networks": {
+      "ctlplane": {
+        "dns_v4": [],
+        "dns_v6": [],
+        "gw_v4": "192.168.122.1",
+        "mtu": 1500,
+        "network_name": "ctlplane",
+        "network_v4": "192.168.122.0/24",
+        "search_domain": "ctlplane.example.com",
+        "tools": {}
+      },
+        "internal-api": {
+        "dns_v4": [],
+        "dns_v6": [],
+        "mtu": 1496,
+        "network_name": "internal-api",
+        "network_v4": "172.17.0.0/24",
+        "search_domain": "internal-api.example.com",
+        "tools": {},
+        "vlan_id": 20
+      },
+      "storage": {
+        "dns_v4": [],
+        "dns_v6": [],
+        "mtu": 1496,
+        "network_name": "storage",
+        "network_v4": "172.18.0.0/24",
+        "search_domain": "storage.example.com",
+        "tools": {},
+        "vlan_id": 21
+      },
+      "tenant": {
+        "dns_v4": [],
+        "dns_v6": [],
+        "mtu": 1496,
+        "network_name": "tenant",
+        "network_v4": "172.19.0.0/24",
+        "search_domain": "tenant.example.com",
+        "tools": {},
+        "vlan_id": 22
+      }
+  },
+  "routers": {
+    "default": {
+        "router_name": "default",
+        "external_network": "provider",
+        "networks": ["ctlplane"]
+    }
+  }
+}

--- a/tests/unit/module_utils/test_files/network-definition-valid-all-tools-no-group-templates.yml
+++ b/tests/unit/module_utils/test_files/network-definition-valid-all-tools-no-group-templates.yml
@@ -1,0 +1,51 @@
+routers:
+  default:
+    external_network: provider
+    networks:
+      - ctlplane
+networks:
+  ctlplane:
+    network: "192.168.122.0/24"
+    gateway: "192.168.122.1"
+    mtu: 1500
+  internal-api:
+    network: "172.17.0.0/24"
+    vlan: 20
+    mtu: 1496
+  storage:
+    network: "172.18.0.0/24"
+    vlan: 21
+    mtu: 1496
+  tenant:
+    network: "172.19.0.0/24"
+    vlan: 22
+    mtu: 1496
+instances:
+  instance-1:
+    networks:
+      ctlplane:
+        ip: "192.168.122.100"
+        is_trunk_parent: true
+      internal-api:
+        ip: "172.17.0.100"
+        trunk_parent: "ctlplane"
+      storage:
+        ip: "172.18.0.100"
+        trunk_parent: "ctlplane"
+      tenant:
+        ip: "172.19.0.100"
+        trunk_parent: "ctlplane"
+  instance-2:
+    networks:
+      ctlplane:
+        ip: "192.168.122.101"
+        is_trunk_parent: true
+      internal-api:
+        ip: "172.17.0.101"
+        trunk_parent: "ctlplane"
+      storage:
+        ip: "172.18.0.101"
+        trunk_parent: "ctlplane"
+      tenant:
+        ip: "172.19.0.101"
+        trunk_parent: "ctlplane"

--- a/tests/unit/module_utils/test_files/network-definition-valid-router-template-out.json
+++ b/tests/unit/module_utils/test_files/network-definition-valid-router-template-out.json
@@ -1,0 +1,17 @@
+{
+  "my_router": {
+    "external_network": "provider",
+    "networks": [
+      "private"
+    ],
+    "router_name": "my_router"
+  },
+  "isolated": {
+    "networks": [
+      "isolated01",
+      "isolated02",
+      "isolated03"
+    ],
+    "router_name": "isolated"
+  }
+}

--- a/tests/unit/module_utils/test_files/network-definition-valid-router-template.yml
+++ b/tests/unit/module_utils/test_files/network-definition-valid-router-template.yml
@@ -1,0 +1,11 @@
+---
+routers:
+  my_router:
+    external_network: provider
+    networks:
+      - private
+  isolated:
+    networks:
+      - isolated01
+      - isolated02
+      - isolated03

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-dual-stack-full-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-dual-stack-full-map-out.json
@@ -1,4 +1,5 @@
 {
+  "routers": {},
   "networks": {
     "network-1": {
       "network_name": "network-1",

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-dual-stack-partial-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-dual-stack-partial-map-out.json
@@ -1,4 +1,5 @@
 {
+  "routers": {},
   "networks": {
     "network-1": {
       "network_name": "network-1",

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-dual-stack-partial-reduced-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-dual-stack-partial-reduced-map-out.json
@@ -1,4 +1,5 @@
 {
+  "routers": {},
   "networks": {
     "network-1": {
       "network_name": "network-1",

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-full-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-full-map-out.json
@@ -1,4 +1,5 @@
 {
+  "routers": {},
   "networks": {
     "ctlplane": {
       "network_name": "ctlplane",
@@ -228,7 +229,8 @@
           "ip_v4": "192.168.122.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
-          "mtu": 1500
+          "mtu": 1500,
+          "is_trunk_parent": true
         },
         "internal-api": {
           "network_name": "internal-api",
@@ -240,7 +242,8 @@
           "prefix_length_v4": 24,
           "mtu": 1496,
           "parent_interface": "eth1",
-          "vlan_id": 20
+          "vlan_id": 20,
+          "trunk_parent": "ctlplane"
         },
         "storage": {
           "network_name": "storage",
@@ -252,7 +255,8 @@
           "prefix_length_v4": 24,
           "mtu": 1496,
           "parent_interface": "eth1",
-          "vlan_id": 21
+          "vlan_id": 21,
+          "trunk_parent": "tenant"
         },
         "tenant": {
           "network_name": "tenant",
@@ -264,7 +268,8 @@
           "prefix_length_v4": 24,
           "mtu": 1496,
           "parent_interface": "eth1",
-          "vlan_id": 22
+          "vlan_id": 22,
+          "is_trunk_parent": true
         }
       },
       "hostname": "instance-1-hostname"
@@ -280,7 +285,8 @@
           "ip_v4": "192.168.122.11",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
-          "mtu": 1500
+          "mtu": 1500,
+          "is_trunk_parent": true
         },
         "internal-api": {
           "network_name": "internal-api",
@@ -292,7 +298,8 @@
           "prefix_length_v4": 24,
           "mtu": 1496,
           "parent_interface": "eth2",
-          "vlan_id": 20
+          "vlan_id": 20,
+          "trunk_parent": "ctlplane"
         },
         "storage": {
           "network_name": "storage",
@@ -304,7 +311,8 @@
           "prefix_length_v4": 24,
           "mtu": 1496,
           "parent_interface": "eth2",
-          "vlan_id": 21
+          "vlan_id": 21,
+          "trunk_parent": "tenant"
         },
         "tenant": {
           "network_name": "tenant",
@@ -316,7 +324,8 @@
           "prefix_length_v4": 24,
           "mtu": 1496,
           "parent_interface": "eth2",
-          "vlan_id": 22
+          "vlan_id": 22,
+          "is_trunk_parent": true
         }
       },
       "hostname": "instance-2-hostname"
@@ -334,7 +343,8 @@
           "prefix_length_v4": 24,
           "mtu": 1496,
           "parent_interface": "eth0",
-          "vlan_id": 21
+          "vlan_id": 21,
+          "trunk_parent": "tenant"
         },
         "tenant": {
           "network_name": "tenant",
@@ -346,7 +356,8 @@
           "prefix_length_v4": 24,
           "mtu": 1496,
           "parent_interface": "eth0",
-          "vlan_id": 22
+          "vlan_id": 22,
+          "is_trunk_parent": true
         }
       },
       "hostname": "instance-3-hostname"

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-full-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-full-map-out.json
@@ -1,4 +1,5 @@
 {
+  "routers": {},
   "networks": {
     "network-1": {
       "network_name": "network-1",

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-partial-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-partial-map-out.json
@@ -1,4 +1,5 @@
 {
+  "routers": {},
   "networks": {
     "network-1": {
       "network_name": "network-1",

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-partial-reduced-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-partial-reduced-map-out.json
@@ -1,4 +1,5 @@
 {
+  "routers": {},
   "networks": {
     "network-1": {
       "network_name": "network-1",

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-partial-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-partial-map-out.json
@@ -1,4 +1,5 @@
 {
+  "routers": {},
   "networks": {
     "ctlplane": {
       "network_name": "ctlplane",
@@ -226,7 +227,8 @@
           "ip_v4": "192.168.122.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
-          "mtu": 1500
+          "mtu": 1500,
+          "is_trunk_parent": true
         },
         "internal-api": {
           "network_name": "internal-api",
@@ -235,7 +237,8 @@
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
-          "vlan_id": 20
+          "vlan_id": 20,
+          "trunk_parent": "ctlplane"
         },
         "storage": {
           "network_name": "storage",
@@ -244,7 +247,8 @@
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
-          "vlan_id": 21
+          "vlan_id": 21,
+          "trunk_parent": "tenant"
         },
         "tenant": {
           "network_name": "tenant",
@@ -253,7 +257,8 @@
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
-          "vlan_id": 22
+          "vlan_id": 22,
+          "is_trunk_parent": true
         }
       },
       "hostname": "instance-1-hostname"
@@ -267,7 +272,8 @@
           "ip_v4": "192.168.122.11",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
-          "mtu": 1500
+          "mtu": 1500,
+          "is_trunk_parent": true
         },
         "internal-api": {
           "network_name": "internal-api",
@@ -276,7 +282,8 @@
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
-          "vlan_id": 20
+          "vlan_id": 20,
+          "trunk_parent": "ctlplane"
         },
         "storage": {
           "network_name": "storage",
@@ -285,7 +292,8 @@
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
-          "vlan_id": 21
+          "vlan_id": 21,
+          "trunk_parent": "tenant"
         },
         "tenant": {
           "network_name": "tenant",
@@ -294,7 +302,8 @@
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
-          "vlan_id": 22
+          "vlan_id": 22,
+          "is_trunk_parent": true
         }
       },
       "hostname": "instance-2-hostname"
@@ -309,7 +318,8 @@
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
-          "vlan_id": 21
+          "vlan_id": 21,
+          "trunk_parent": "tenant"
         },
         "tenant": {
           "network_name": "tenant",
@@ -318,7 +328,8 @@
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
-          "vlan_id": 22
+          "vlan_id": 22,
+          "is_trunk_parent": true
         }
       },
       "hostname": "instance-3-hostname"

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools.yml
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools.yml
@@ -81,18 +81,22 @@ group-templates:
         range:
           start: 10
           length: 5
+        is_trunk_parent: true
       internal-api:
         range:
           start: 10
           length: 30
+        trunk_parent: ctlplane
   group-3:
     network-template:
       range:
         start: 10
         length: 5
     networks:
-      tenant: { }
-      storage: { }
+      tenant:
+        is_trunk_parent: true
+      storage:
+        trunk_parent: tenant
 instances:
   instance-3:
     skip-nm-configuration: true

--- a/tests/unit/module_utils/test_files/networking-definition-valid-full-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-full-map-out.json
@@ -1,4 +1,5 @@
 {
+  "routers": {},
   "networks": {
     "ctlplane": {
       "network_name": "ctlplane",
@@ -61,7 +62,8 @@
           "ip_v4": "192.168.122.100",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
-          "mtu": 1500
+          "mtu": 1500,
+          "is_trunk_parent": true
         },
         "internal-api": {
           "network_name": "internal-api",
@@ -73,7 +75,8 @@
           "prefix_length_v4": 24,
           "mtu": 1496,
           "parent_interface": "eth1",
-          "vlan_id": 20
+          "vlan_id": 20,
+          "trunk_parent": "ctlplane"
         },
         "storage": {
           "network_name": "storage",
@@ -85,7 +88,8 @@
           "prefix_length_v4": 24,
           "mtu": 1496,
           "parent_interface": "eth1",
-          "vlan_id": 21
+          "vlan_id": 21,
+          "trunk_parent": "ctlplane"
         },
         "tenant": {
           "network_name": "tenant",
@@ -97,7 +101,8 @@
           "prefix_length_v4": 24,
           "mtu": 1496,
           "parent_interface": "eth1",
-          "vlan_id": 22
+          "vlan_id": 22,
+          "trunk_parent": "ctlplane"
         }
       },
       "hostname": "instance-1-hostname"

--- a/tests/unit/module_utils/test_files/networking-definition-valid-network-template.yml
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-network-template.yml
@@ -21,14 +21,20 @@ group-templates:
         start: 10
         length: 5
     networks:
-      ctlplane: { }
-      internal-api: { }
-      tenant: { }
-      storage: { }
+      ctlplane:
+        is_trunk_parent: true
+      internal-api:
+        trunk_parent: ctlplane
+      tenant:
+        trunk_parent: ctlplane
+      storage:
+        trunk_parent: ctlplane
 instances:
   instance-1:
     networks:
       ctlplane:
         ip: "192.168.122.100"
+        is_trunk_parent: true
       storage:
         ip: "172.18.0.100"
+        trunk_parent: "ctlplane"

--- a/tests/unit/module_utils/test_files/networking-definition-valid-partial-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-partial-map-out.json
@@ -1,4 +1,5 @@
 {
+  "routers": {},
   "networks": {
     "ctlplane": {
       "network_name": "ctlplane",
@@ -59,7 +60,8 @@
           "ip_v4": "192.168.122.100",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
-          "mtu": 1500
+          "mtu": 1500,
+          "is_trunk_parent": true
         },
         "internal-api": {
           "network_name": "internal-api",
@@ -68,7 +70,9 @@
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
-          "vlan_id": 20
+          "vlan_id": 20,
+          "trunk_parent": "ctlplane"
+
         },
         "storage": {
           "network_name": "storage",
@@ -77,7 +81,8 @@
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
-          "vlan_id": 21
+          "vlan_id": 21,
+          "trunk_parent": "ctlplane"
         },
         "tenant": {
           "network_name": "tenant",
@@ -86,7 +91,8 @@
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
-          "vlan_id": 22
+          "vlan_id": 22,
+          "trunk_parent": "ctlplane"
         }
       },
       "hostname": "instance-1-hostname"

--- a/tests/unit/module_utils/test_files/networking-definition-valid.yml
+++ b/tests/unit/module_utils/test_files/networking-definition-valid.yml
@@ -30,22 +30,28 @@ group-templates:
     networks:
       ctlplane:
         range: "192.168.122.10-192.168.122.14"
+        is_trunk_parent: true
       internal-api:
         range: "10-14"
+        trunk_parent: ctlplane
       tenant:
         skip-nm-configuration: true
         range:
           start: 10
           length: 5
+        trunk_parent: ctlplane
       storage:
         range:
           start: 10
           length: 5
+        trunk_parent: ctlplane
 instances:
   instance-1:
     networks:
       ctlplane:
         ip: "192.168.122.100"
+        is_trunk_parent: true
       storage:
         skip-nm-configuration: true
         ip: "172.18.0.100"
+        trunk_parent: ctlplane


### PR DESCRIPTION
Adds the new parameters used by ci-bootstrap to control instance trunk port creation in:
  https://github.com/openstack-k8s-operators/ci-bootstrap/pull/33

It also adds the routers definition which enable creating one or more routers, for example to simulate DCN/Spine-and-Leaf architecture.

Related: https://issues.redhat.com/browse/OSPRH-5089
Partial: https://issues.redhat.com/browse/OSPRH-3376
Partial: https://issues.redhat.com/browse/OSPRH-2994

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
