### PR TITLE
Make multinode-autohold.yml user other Ansible targets

### DIFF
--- a/ci/playbooks/multinode-autohold.yml
+++ b/ci/playbooks/multinode-autohold.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Run ci/playbooks/multinode-autohold.yml"
-  hosts: controller
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Verify if "success" flag exists after successful tests execution


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
