### PR TITLE
[devscripts] add cert check and graceful shutdown

### DIFF
--- a/roles/devscripts/tasks/110_check_ocp.yml
+++ b/roles/devscripts/tasks/110_check_ocp.yml
@@ -19,6 +19,12 @@
   ansible.builtin.set_fact:
     cifmw_devscripts_ocp_exists: false
     cifmw_devscripts_ocp_online: false
+    cifmw_openshift_adm_cert_expire_date_file: >-
+      {{
+        (
+          cifmw_devscripts_config.working_dir, '.ocp_cert_not_after'
+        ) | ansible.builtin.path_join
+      }}
 
 - name: Check for pre-existences of OpenShift cluster.
   ansible.builtin.find:
@@ -54,34 +60,10 @@
   when:
     - _kubeconfig_result.stat is defined
     - _kubeconfig_result.stat.exists
-  block:
-    - name: Gather the deployed cluster authentication information.
-      ansible.builtin.import_tasks: set_cluster_fact.yml
+  ansible.builtin.include_tasks: 111_verify_cluster.yml
 
-    - name: Login to the deployed OpenShift cluster.
-      kubernetes.core.k8s_auth:
-        host: "{{ cifmw_openshift_api }}"
-        password: "{{ cifmw_openshift_password }}"
-        state: present
-        username: "{{ cifmw_openshift_user }}"
-        validate_certs: false
-      register: _login_result
-      failed_when: false
-
-    - name: Authentication successful to existing cluster.
-      when:
-        - _login_result.k8s_auth.api_key is defined
-      ansible.builtin.set_fact:
-        cifmw_devscripts_ocp_online: true
-
-    - name: Print the encountered error.
-      when:
-        - _login_result.failed
-      ansible.builtin.debug:
-        var: _login_result
-
-    - name: Executing cleanup of stale OpenShift cluster.
-      when:
-        - _login_result.failed
-        - "'No route to host' not in _login.result.msg"
-      ansible.builtin.include_tasks: cleanup.yml
+- name: Verify the golden image.
+  when:
+    - cifmw_devscripts_ocp_exists
+    - not cifmw_devscripts_ocp_online
+  ansible.builtin.include_tasks: 112_verify_golden_image.yml

--- a/roles/devscripts/tasks/111_verify_cluster.yml
+++ b/roles/devscripts/tasks/111_verify_cluster.yml
@@ -1,0 +1,54 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Gather the deployed cluster authentication information.
+  ansible.builtin.import_tasks: set_cluster_fact.yml
+
+- name: Login to the deployed OpenShift cluster.
+  kubernetes.core.k8s_auth:
+    host: "{{ cifmw_openshift_api }}"
+    password: "{{ cifmw_openshift_password }}"
+    state: present
+    username: "{{ cifmw_openshift_user }}"
+    validate_certs: false
+  register: _login_result
+  failed_when: false
+
+- name: Authentication successful to existing cluster.
+  when:
+    - _login_result.k8s_auth.api_key is defined
+  ansible.builtin.set_fact:
+    cifmw_devscripts_ocp_online: true
+
+- name: Print the encountered error.
+  when:
+    - _login_result.failed
+  ansible.builtin.debug:
+    var: _login_result
+
+- name: Executing cleanup of stale OpenShift cluster.
+  when:
+    - _login_result.failed
+    - "'No route to host' not in _login.result.msg"
+  block:
+    - name: Set existences to false
+      ansible.builtin.set_fact:
+        cifmw_devscripts_ocp_exists: false
+        cifmw_devscripts_force_cleanup: true
+
+    - name: Run clean up tasks.
+      ansible.builtin.include_tasks: cleanup.yml

--- a/roles/devscripts/tasks/112_verify_golden_image.yml
+++ b/roles/devscripts/tasks/112_verify_golden_image.yml
@@ -1,0 +1,53 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Check for certificate regeneration file.
+  ansible.builtin.stat:
+    path: "{{ cifmw_openshift_adm_cert_expire_date_file }}"
+  register: _cert_file_stat
+
+- name: Read the certificate expiration date recorded.
+  when:
+    - _cert_file_stat.stat.exists | default(false)
+  ansible.builtin.slurp:
+    src: "{{ cifmw_openshift_adm_cert_expire_date_file }}"
+  register: _cert_file
+
+- name: Ensure the golden image has valid certificate.
+  vars:
+    _expire_date: "{{ _cert_file.content | b64decode }}"
+    _diff_hours: >-
+      {{
+        (
+          (_expire_date | trim | ansible.builtin.to_datetime) -
+          (
+            now(utc=true, fmt="%Y-%m-%d %H:%M:%S") |
+            ansible.builtin.to_datetime
+          )
+        ).total_seconds() / 3600 | int
+      }}
+  when:
+    - _cert_file_stat.stat.exists | default(false)
+    - _diff_hours | int < 2
+  block:
+    - name: Reset golden image exists flag
+      ansible.builtin.set_fact:
+        cifmw_devscripts_ocp_exists: false
+        cifmw_devscripts_force_cleanup: true
+
+    - name: Cleanup the golden image if the certificate has expired.
+      ansible.builtin.include_tasks: cleanup.yml

--- a/roles/devscripts/tasks/310_prepare_overlay.yml
+++ b/roles/devscripts/tasks/310_prepare_overlay.yml
@@ -21,6 +21,18 @@
     uri: "qemu:///system"
   register: _current_vms
 
+- name: Initiate graceful shutdown of the cluster.
+  vars:
+    cifmw_openshift_adm_op: "shutdown"
+    cifmw_openshift_adm_cert_expire_date_file: >-
+      {{
+        (
+          cifmw_devscripts_config.working_dir, '.ocp_cert_not_after'
+        ) | ansible.builtin.path_join
+      }}
+  ansible.builtin.import_role:
+    name: openshift_adm
+
 - name: Stop all the OpenShift nodes.
   failed_when: false
   vars:

--- a/roles/devscripts/tasks/330_wait_ocp.yml
+++ b/roles/devscripts/tasks/330_wait_ocp.yml
@@ -15,27 +15,8 @@
 # under the License.
 
 
-# We would wait till forbidden error is received. It indicates the endpoint
-# is reachable.
-- name: Wait until the OCP API endpoint is reachable.
-  ansible.builtin.uri:
-    url: "{{ cifmw_openshift_api }}"
-    return_content: true
-    validate_certs: false
-    status_code: 403
-  register: ocp_api_result
-  until: ocp_api_result.status == 403
-  retries: 30
-  delay: 5
-
-- name: Wait until OCP login succeeds.
-  kubernetes.core.k8s_auth:
-    host: "{{ cifmw_openshift_api }}"
-    password: "{{ cifmw_openshift_password }}"
-    state: present
-    username: "{{ cifmw_openshift_user }}"
-    validate_certs: false
-  register: _oc_login_result
-  until: _oc_login_result.k8s_auth is defined
-  retries: 30
-  delay: 5
+- name: Wait till the cluster is stable
+  vars:
+    cifmw_openshift_adm_op: "stable"
+  ansible.builtin.import_role:
+    name: openshift_adm

--- a/roles/devscripts/tasks/cleanup.yml
+++ b/roles/devscripts/tasks/cleanup.yml
@@ -26,8 +26,9 @@
   tags:
     - never
     - deepscrub
-  when:
-    - cifmw_devscripts_ocp_exists is undefined
+  when: >-
+    (cifmw_devscripts_ocp_exists is undefined) or
+    (cifmw_devscripts_force_cleanup | default(false) | bool)
   block:
     - name: Gather the configurations to be passed to dev-scripts.
       ansible.builtin.set_fact:

--- a/roles/reproducer/tasks/devscripts_post.yml
+++ b/roles/reproducer/tasks/devscripts_post.yml
@@ -34,3 +34,9 @@
           {{
             (_auth_path, 'kubeadmin-password') | ansible.builtin.path_join
           }}
+
+    - name: Ensure the OpenShift cluster is stable.
+      vars:
+        cifmw_openshift_adm_op: "stable"
+      ansible.builtin.include_role:
+        name: openshift_adm


### PR DESCRIPTION
Currently, the OpenShift cluster is abruptly shutdown before preparing for the golden image. This could lead to the keepalived pod not starting and/or having expired API certificates.

As part of this change set, the following tasks are added
- Splitting `110_check_ocp.yml` into two
- - `111_verify_cluster.yml` contains the login check
- - `112_verify_golden_image.yml` contains the API certificate check
- Call to graceful shutdown as provided by `openshift_adm` role before initiating preparation of the overlay.

_Additional changes_
- `post stage` now should wait for a stable cluster
- Certificate expiration date is compared with today's date and if we have two hours gap... the cluster is brought up.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1213
Closes: [OSPRH-5115](https://issues.redhat.com//browse/OSPRH-5115)

*Testing Results*

_Rerun scenario_
```
PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
titanamd126                : ok=363  changed=126  unreachable=0    failed=0    skipped=160  rescued=0    ignored=0   

Tuesday 05 March 2024  06:36:10 -0500 (0:00:00.172)       0:15:19.135 ********* 
=============================================================================== 
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 51.14s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 50.71s
reproducer : Bootstrap environment on controller-0 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 50.58s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 50.37s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 49.07s
reproducer : Install some tools ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 37.73s
reproducer : Install collections on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 26.80s
libvirt_manager : Grab IPs for nodes type ocp ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 26.55s
libvirt_manager : Grab IPs for nodes type compute ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 20.19s
networking_mapper : Ensure that networking and hostname facts are in place ----------------------------------------------------------------------------------------------------------------------------------------------------------- 19.84s
reproducer : Inject ProxyJump configuration for remote hypervisor VMs ---------------------------------------------------------------------------------------------------------------------------------------------------------------- 19.70s
libvirt_manager : Grab IPs for nodes type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.94s
libvirt_manager : Wait for SSH on VMs type ocp --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.84s
libvirt_manager : Wait for SSH on VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 17.89s
libvirt_manager : Prepare disk image with SSH and growing volume --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 16.75s
libvirt_manager : Configure VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 13.69s
reproducer : Wait for OCP nodes to be ready ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 12.47s
reproducer : Install ansible dependencies -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 12.46s
libvirt_manager : Download base image ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 11.21s
reproducer : Inject kubeconfig content ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 6.56s
```

_Greenfield install_
```
PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
titanamd126                : ok=405  changed=168  unreachable=0    failed=0    skipped=172  rescued=2    ignored=0   

Tuesday 05 March 2024  20:25:38 -0500 (0:00:00.223)       1:12:18.456 ********* 
=============================================================================== 
devscripts : Deploy OpenShift cluster ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 3037.39s
reproducer : Install internal CA ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 152.38s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 79.88s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 78.90s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 78.24s
reproducer : Install some tools ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 46.93s
libvirt_manager : Grab IPs for nodes type ocp ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 32.28s
reproducer : Inject kubeadmin-password if exists ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 31.95s
reproducer : Bootstrap environment on controller-0 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 28.37s
reproducer : Inject devscripts private key if set ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 26.90s
reproducer : Install collections on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 25.16s
networking_mapper : Ensure that networking and hostname facts are in place ----------------------------------------------------------------------------------------------------------------------------------------------------------- 23.57s
libvirt_manager : Prepare disk image with SSH and growing volume --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 20.47s
libvirt_manager : Grab IPs for nodes type compute ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 20.44s
libvirt_manager : Grab IPs for nodes type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 19.04s
libvirt_manager : Wait for SSH on VMs type ocp --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.71s
libvirt_manager : Wait for SSH on VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 17.93s
reproducer : Wait for OCP nodes to be ready ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 13.62s
libvirt_manager : Configure VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 12.94s
reproducer : Install ansible dependencies -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 12.80s
[ciuser@devci-01 ci-framework]$ 

[ciuser@titanamd126 ~]$ oc get nodes
NAME       STATUS                     ROLES                         AGE   VERSION
master-0   Ready,SchedulingDisabled   control-plane,master,worker   84m   v1.28.6+6216ea1
master-1   Ready,SchedulingDisabled   control-plane,master,worker   84m   v1.28.6+6216ea1
master-2   Ready,SchedulingDisabled   control-plane,master,worker   84m   v1.28.6+6216ea1
```

_Rerun 2_
```
PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
titanamd126                : ok=370  changed=128  unreachable=0    failed=0    skipped=160  rescued=0    ignored=0   

Wednesday 06 March 2024  02:42:43 -0500 (0:00:00.138)       0:29:30.895 ******* 
=============================================================================== 
openshift_adm : Wait unit the OpenShift cluster is stable. -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 595.33s
openshift_adm : Wait until OCP login succeeds. -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 233.80s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 52.22s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 52.19s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 51.59s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 51.12s
reproducer : Install some tools ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 38.99s
reproducer : Bootstrap environment on controller-0 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 28.44s
openshift_adm : Wait until the OCP API endpoint is reachable. ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 28.31s
libvirt_manager : Grab IPs for nodes type ocp ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 28.27s
reproducer : Install collections on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 25.74s
networking_mapper : Ensure that networking and hostname facts are in place ----------------------------------------------------------------------------------------------------------------------------------------------------------- 24.28s
libvirt_manager : Grab IPs for nodes type compute ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 20.29s
libvirt_manager : Grab IPs for nodes type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 19.04s
libvirt_manager : Wait for SSH on VMs type ocp --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.70s
libvirt_manager : Wait for SSH on VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 17.91s
libvirt_manager : Prepare disk image with SSH and growing volume --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 16.68s
libvirt_manager : Configure VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.08s
reproducer : Wait for OCP nodes to be ready ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 13.74s
reproducer : Install ansible dependencies -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 13.28s
[ciuser@devci-01 ci-framework]$ 

ciuser@titanamd126 ~]$ oc get nodes
NAME       STATUS   ROLES                         AGE    VERSION
master-0   Ready    control-plane,master,worker   7h9m   v1.28.6+6216ea1
master-1   Ready    control-plane,master,worker   7h9m   v1.28.6+6216ea1
master-2   Ready    control-plane,master,worker   7h9m   v1.28.6+6216ea1
```