### PR TITLE
[devscripts] set go version to avoid error during rerun

### DIFF
--- a/scenarios/reproducers/validated-architecture-1.yml
+++ b/scenarios/reproducers/validated-architecture-1.yml
@@ -127,6 +127,7 @@ cifmw_libvirt_manager_configuration:
 ## devscript support for OCP deploy
 cifmw_use_devscripts: true
 cifmw_devscripts_config_overrides:
+  goversion: "1.20"
   worker_memory: 16384
   worker_disk: 100
   worker_vcpu: 10


### PR DESCRIPTION
A recent change in `dev-scripts` caused failures in ci-frameworks' `devscripts` role. This change proposes a workaround to the issue till the upstream pull request is merged.

The workaround is to forcibly set `GOVERSION=1.20` via the `config_<user>.sh` file.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

Closes: [OSPRH-5401](https://issues.redhat.com//browse/OSPRH-5401)
Upstream: https://github.com/openshift-metal3/dev-scripts/pull/1640

_Testing Results of rerun_
```
PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
titanamd126                : ok=378  changed=130  unreachable=0    failed=0    skipped=170  rescued=1    ignored=0   

Tuesday 05 March 2024  05:15:13 -0500 (0:00:00.192)       0:16:49.500 ********* 
=============================================================================== 
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 51.68s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 50.99s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 50.91s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 50.87s
reproducer : Bootstrap environment on controller-0 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 48.74s
reproducer : Install some tools ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 40.09s
networking_mapper : Ensure that networking and hostname facts are in place ----------------------------------------------------------------------------------------------------------------------------------------------------------- 27.63s
reproducer : Install collections on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 26.50s
libvirt_manager : Grab IPs for nodes type ocp ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 26.23s
libvirt_manager : Wait for SSH on VMs type ocp --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 22.06s
libvirt_manager : Grab IPs for nodes type compute ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 20.32s
reproducer : Inject ProxyJump configuration for remote hypervisor VMs ---------------------------------------------------------------------------------------------------------------------------------------------------------------- 19.36s
libvirt_manager : Grab IPs for nodes type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.94s
libvirt_manager : Prepare disk image with SSH and growing volume --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.58s
libvirt_manager : Wait for SSH on VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 17.87s
libvirt_manager : Configure VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 17.16s
reproducer : Wait for OCP nodes to be ready ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 15.90s
reproducer : Install ansible dependencies -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 13.42s
reproducer : Inject other Hypervisor SSH keys ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 12.39s
devscripts : Dump XMLs in a file for all nodes part of OpenShift platform ------------------------------------------------------------------------------------------------------------------------------------------------------------ 12.28s
[ciuser@devci-01 ci-framework]$
```