### PR TITLE
Set cifmw_networking_definition for ci-bootstap staging

### DIFF
--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -283,6 +283,68 @@
     name: podified-multinode-edpm-deployment-crc-bootstrap-staging
     parent: cifmw-podified-multinode-edpm-ci-bootstrap-staging
     extra-vars: *edpm_bootstrap_extra_vars
-    vars: *edpm_bootstrap_vars
+    vars:
+      cifmw_networking_definition:
+        networks:
+          default:
+            network: "192.168.122.0/24"
+            gateway: "192.168.122.1"
+            mtu: 1500
+          internal-api:
+            network: "172.17.0.0/24"
+            gateway: "172.17.0.1"
+            vlan: 20
+          storage:
+            network: "172.18.0.0/24"
+            gateway: "172.18.0.1"
+            vlan: 21
+          tenant:
+            network: "172.19.0.0/24"
+            gateway: "172.19.0.1"
+            vlan: 22
+        routers:
+          ci-router:
+            external_network: public
+            networks:
+              - default
+        group-templates:
+          computes:
+            network-template:
+              range:
+                start: 100
+                length: 21
+            networks:
+              default:
+                is_trunk_parent: true
+              internal-api:
+                trunk_parent: default
+                skip-nm-configuration: true
+              tenant:
+                trunk_parent: default
+                skip-nm-configuration: true
+              storage:
+                trunk_parent: default
+                skip-nm-configuration: true
+        instances:
+          controller:
+            networks:
+              default:
+                ip: "192.168.122.11"
+          crc:
+            networks:
+              default:
+                ip: "192.168.122.10"
+                is_trunk_parent: true
+              internal-api:
+                ip: "172.17.0.5"
+                trunk_parent: default
+              storage:
+                ip: "172.18.0.5"
+                trunk_parent: default
+              tenant:
+                ip: "172.19.0.5"
+                trunk_parent: default
+      cifmw_extras:
+        - '@scenarios/centos-9/multinode-ci.yml'
     run:
       - ci/playbooks/edpm/run.yml


### PR DESCRIPTION
Set cifmw_networking_definition for ci-bootstap staging

Use the new ìs_trunk_parent and trunk_parent hints for ci-bootstrap
to understand how to attach networks.

Ref:
 https://github.com/openstack-k8s-operators/ci-framework/pull/1218
 https://github.com/openstack-k8s-operators/ci-bootstrap/pull/33

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
