### PR TITLE
Add flag to skip fetching code in the reproducer

### DIFF
--- a/roles/reproducer/README.md
+++ b/roles/reproducer/README.md
@@ -15,6 +15,9 @@ None
 * `cifmw_reproducer_dns_servers`: List of dns servers which should be used by the CRC VM as upstream dns servers. Defaults to 1.1.1.1, 8.8.8.8.
 * `cifmw_reproducer_hp_rhos_release`: (Bool) Allows to consume rhos-release on the hypervisor. Defaults to `false`.
 * `cifmw_reproducer_dnf_tweaks`: (List) Options you want to inject in dnf.conf, both on controller-0 and hypervisor. Defaults to `[]`.
+* `cifmw_reproducer_skip_fetch_repositories`: (Bool) Skip fetching repositories from zuul var and simply copy the code from the ansible controller. Defaults to `false`.
+* `cifmw_reproducer_repositories_path`: (String) Path where the repositories are found in the ansible controller, relative to $HOME. Only has any effect if
+`cifmw_reproducer_skip_fetch_repositories` is set to `true`. Defaults to `src`.
 
 ### run_job and run_content_provider booleans and risks.
 

--- a/roles/reproducer/defaults/main.yml
+++ b/roles/reproducer/defaults/main.yml
@@ -29,3 +29,4 @@ cifmw_reproducer_repositories: []
 cifmw_reproducer_hp_rhos_release: false
 cifmw_reproducer_dnf_tweaks: []
 cifmw_reproducer_compute_repos: []
+cifmw_reproducer_repositories_path: "src"

--- a/roles/reproducer/tasks/push_code.yml
+++ b/roles/reproducer/tasks/push_code.yml
@@ -4,6 +4,7 @@
     - zuul is defined
     - zuul.items is defined
     - zuul.projects is defined
+    - not cifmw_reproducer_skip_fetch_repositories | default(false)
   delegate_to: controller-0
   delegate_facts: true
   block:
@@ -73,6 +74,8 @@
 - name: Push random code into the proper location
   vars:
     repo_base_dir: '/home/zuul/src'
+  when:
+    - not cifmw_reproducer_skip_fetch_repositories | default(false)
   block:
     - name: Create target directories beforehand
       delegate_to: controller-0
@@ -122,6 +125,26 @@
       loop_control:
         loop_var: repository
         label: "{{ repository.src | basename }}"
+
+- name: Push code in from the ansible controller to the controller-0
+  when:
+    - cifmw_reproducer_skip_fetch_repositories | default(false)
+  vars:
+    _source_path: "{{ cifmw_reproducer_repositories_path | regex_replace('/$', '') }}"
+  block:
+    - name: Ensure repositories path exists in the controller-0
+      delegate_to: controller-0
+      ansible.builtin.file:
+        path: "/home/zuul/{{ _source_path }}"
+        state: directory
+
+    - name: Copy code from ansible controller to controller-0
+      delegate_to: localhost
+      ansible.builtin.command:  # noqa: command-instead-of-module
+        cmd: >-
+          rsync -ar
+          {{ ansible_user_dir }}/{{ _source_path }}/
+          zuul@controller-0:/home/zuul/{{ _source_path }}
 
 # installing the cifmw collection will pull it's dependencies alongside it
 - name: Install collections on controller-0


### PR DESCRIPTION
Add a flag to skip fetching code from the zuul var, and instead simply
push whatever is in ~/src in the ansible controller. This allows to rely
on zuul cloning required projects and depends-on and not repeat the same
process.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
