### PR TITLE
Add more ceph OSDs to support single node jobs

### DIFF
--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -83,10 +83,32 @@
   hosts: "{{ cifmw_ceph_target | default('computes')  }}"
   gather_facts: true
   become: true
-  vars:
-    ansible_ssh_private_key_file: "{{ lookup('env', 'ANSIBLE_SSH_PRIVATE_KEY') }}"
-  roles:
-    - role: cifmw_block_device
+  tasks:
+    - name: Set cifmw_num_osds_perhost
+    # By defualt 1 OSD is created per node in case of multinode.
+    # 3 OSDS will be created for single node env to accomodate
+    # more ceph resources and avoid PG errors.
+      ansible.builtin.set_fact:
+        cifmw_num_osds_perhost: |
+          {% if groups[cifmw_ceph_target | default('computes')] | length == 1 %}
+          {% set num_osds =  3 %}
+          {% else %}
+          {% set num_osds = 1 %}
+          {% endif %}
+          {{ num_osds }}
+    - name: Create Block Device on EDPM Nodes
+      vars:
+        ansible_ssh_private_key_file: "{{ lookup('env', 'ANSIBLE_SSH_PRIVATE_KEY') }}"
+        cifmw_block_device_image_file: /var/lib/ceph-osd-{{ i }}.img
+        cifmw_block_device_loop: /dev/loop{{ i + 3 }}
+        cifmw_block_lv_name: ceph_lv{{ i }}
+        cifmw_block_vg_name: ceph_vg{{ i }}
+        cifmw_block_systemd_unit_file: /etc/systemd/system/ceph-osd-losetup-{{ i }}.service
+      ansible.builtin.include_role:
+        name: cifmw_block_device
+      loop_control:
+        loop_var: i
+      loop: "{{ range(0, cifmw_num_osds_perhost|int) }}"
 
 - name: Build Ceph spec and conf from gathered IPs of the target inventory group
   tags: spec

--- a/roles/cifmw_block_device/tasks/main.yml
+++ b/roles/cifmw_block_device/tasks/main.yml
@@ -65,4 +65,4 @@
   ansible.builtin.systemd:
     state: started
     enabled: true
-    name: ceph-osd-losetup
+    name: "{{ cifmw_block_systemd_unit_file | regex_replace('/etc/systemd/system/', '') }}"

--- a/roles/cifmw_ceph_spec/defaults/main.yml
+++ b/roles/cifmw_ceph_spec/defaults/main.yml
@@ -25,10 +25,7 @@ cifmw_ceph_spec_host_to_ip:
 
 # The ceph spec data devices. Should be passed as a YAML multiline string.
 # Use the default from the cifmw_block_device role:
-cifmw_ceph_spec_data_devices: >-
-  data_devices:
-    paths:
-    - /dev/ceph_vg/ceph_lv_data
+cifmw_ceph_spec_data_devices:
 
 # The path of the rendered spec file
 cifmw_ceph_spec_path: /tmp/ceph_spec.yml

--- a/roles/cifmw_ceph_spec/molecule/default/converge.yml
+++ b/roles/cifmw_ceph_spec/molecule/default/converge.yml
@@ -17,6 +17,9 @@
 
 - name: Converge without network isolation
   hosts: all
+  vars:
+    cifmw_ceph_target: 'all'
+    computes: 'all'
   roles:
     - role: "cifmw_ceph_spec"
   post_tasks:
@@ -29,6 +32,8 @@
   hosts: all
   vars:
     cifmw_ceph_spec_public_network: 172.18.0.0/24
+    cifmw_ceph_target: 'all'
+    computes: 'all'
   roles:
     - role: "cifmw_ceph_spec"
   post_tasks:
@@ -40,6 +45,8 @@
   vars:
     cifmw_ceph_spec_public_network: 172.18.0.0/24
     cifmw_ceph_spec_private_network: 172.20.0.0/24
+    cifmw_ceph_target: 'all'
+    computes: 'all'
   roles:
     - role: "cifmw_ceph_spec"
   post_tasks:

--- a/roles/cifmw_ceph_spec/molecule/default/tasks/verify_spec.yml
+++ b/roles/cifmw_ceph_spec/molecule/default/tasks/verify_spec.yml
@@ -61,6 +61,7 @@
       - item.service_name == 'osd.default_drive_group'
       - item.data_devices == expected_devices
   when:
+    - cifmw_num_osds_perhost  == "1"
     - item.service_type == 'osd'
   loop: "{{ cat_ceph_spec.stdout | from_yaml_all | list }}"
   vars:

--- a/roles/cifmw_ceph_spec/tasks/main.yml
+++ b/roles/cifmw_ceph_spec/tasks/main.yml
@@ -14,6 +14,19 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Set cifmw_num_osds_perhost
+# By defualt 1 OSD is created per node in case of multinode.
+# 3 OSDS will be created for single node env to accomodate
+# more ceph resources and avoid PG errors.
+  ansible.builtin.set_fact:
+    cifmw_num_osds_perhost: |
+      {% if groups[cifmw_ceph_target | default('computes')] | length == 1 %}
+      {% set num_osds =  3 %}
+      {% else %}
+      {% set num_osds = 1 %}
+      {% endif %}
+      {{ num_osds }}
+
 - name: Create a Ceph spec
   ansible.builtin.template:
     src: templates/ceph_spec.yml.j2

--- a/roles/cifmw_ceph_spec/templates/ceph_spec.yml.j2
+++ b/roles/cifmw_ceph_spec/templates/ceph_spec.yml.j2
@@ -28,7 +28,15 @@ service_id: mgr
 service_name: mgr
 service_type: mgr
 ---
+{% if cifmw_ceph_spec_data_devices %}
 {{ cifmw_ceph_spec_data_devices }}
+{% else %}
+data_devices:
+  paths:
+{% for i in range(0, cifmw_num_osds_perhost|int) %}
+  - /dev/ceph_vg{{ i }}/ceph_lv{{ i }}
+{% endfor %}
+{% endif %}
 placement:
   hosts:
 {% for key, value in cifmw_ceph_spec_host_to_ip.items() %}


### PR DESCRIPTION
This patch add more block devices there by adding more OSDs in the ceph cluster to accomodate more ceph resources

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
