### PR TITLE
Add additional extra var to update plyabook run

### DIFF
--- a/ci/playbooks/edpm/update.yml
+++ b/ci/playbooks/edpm/update.yml
@@ -15,7 +15,7 @@
         path: "{{ ansible_user_dir }}/ci-framework-data/artifacts/edpm-ansible.yml"
       register: edpm_file
 
-    - name: Run Podified EDPM deployment
+    - name: Run Podified EDPM update
       ansible.builtin.command:
         chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
         cmd: >-
@@ -31,5 +31,6 @@
           -e "{{   extra_var }}"
           {%-   endfor %}
           {%- endif %}
+          -e update_playbook_run=true
           -e "@{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml"
           -e "cifmw_repo_setup_promotion={{ cifmw_repo_setup_promotion_target }}"


### PR DESCRIPTION
Add additional extra var to update-edpm.yml playbook run
named update_playbook_run to make it possible to skip some
ansible tasks on deployment and run them on update only.

Signed-off-by: Mikołaj Ciecierski <mikolaj.ciecierski@redhat.com>

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
