### PR TITLE
Avoid incorrect association of OpenShift VMs and their overlay disk

### DIFF
--- a/roles/devscripts/tasks/310_prepare_overlay.yml
+++ b/roles/devscripts/tasks/310_prepare_overlay.yml
@@ -63,6 +63,8 @@
     label: "{{ ocp_node.item }}"
 
 - name: Set matching VM name in XMLs
+  vars:
+    ocp_id: "{{ ocp_node.item | split('_') | last }}"
   community.general.xml:
     path: "{{ cifmw_devscripts_config.working_dir }}/{{ ocp_node.item }}.xml"
     xpath: "/domain/name"
@@ -71,7 +73,6 @@
   loop_control:
     loop_var: "ocp_node"
     label: "{{ ocp_node.item }}"
-    index_var: "ocp_id"
 
 - name: Disable online cluster flag
   when:

--- a/roles/devscripts/tasks/320_prepare_layout.yml
+++ b/roles/devscripts/tasks/320_prepare_layout.yml
@@ -24,14 +24,17 @@
 
 - name: Align the OCP type information.
   when:
-    - not _ctrl_vm_xml.failed | default(true)
+    - _ctrl_vm_xml.matched == cifmw_devscripts_config.num_masters
   vars:
     _data:
       vms:
         ocp:
           amount: "{{ cifmw_devscripts_config.num_masters | int }}"
           image_local_dir: "{{ cifmw_devscripts_config.working_dir }}/pool"
-          xml_paths: "{{ _ctrl_vm_xml.files | map(attribute='path') | list }}"
+          xml_paths: >-
+            {{
+              _ctrl_vm_xml.files | map(attribute='path') | list | sort
+            }}
           disk_file_name: "{{ cifmw_devscripts_config.cluster_name }}_master"
           disksize: "{{ cifmw_devscripts_config.master_disk | int + 20 }}"
   ansible.builtin.set_fact:
@@ -55,7 +58,7 @@
 
     - name: Align the worker data.
       when:
-        - _wrk_vm_xml.failed | default(true)
+        - _wrk_vm_xml.matched == cifmw_devscripts_config.num_workers
       vars:
         _wrk_data:
           vms:
@@ -73,7 +76,7 @@
                 }}
               xml_paths: >-
                 {{
-                  _wrk_vm_xml.files | map(attribute='path') | list
+                  _wrk_vm_xml.files | map(attribute='path') | list | sort
                 }}
       ansible.builtin.set_fact:
         cifmw_libvirt_manager_configuration_gen: >-

--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -56,14 +56,12 @@
 - name: "Manipulate XMLs and load them if provided for {{ vm_type }}"
   when:
     - vm_data.value.xml_paths is defined
-  block:
-    - name: Load OCP VMs
-      ansible.builtin.include_tasks: ocp_xml.yml
-      loop: "{{ vm_data.value.xml_paths }}"
-      loop_control:
-        loop_var: "_xml"
-        index_var: "_xml_id"
-        label: "{{ vm_type }}-{{ _xml_id }}"
+  ansible.builtin.include_tasks: ocp_xml.yml
+  loop: "{{ vm_data.value.xml_paths | sort }}"
+  loop_control:
+    loop_var: "_xml"
+    index_var: "_xml_id"
+    label: "{{ vm_type }}-{{ _xml_id }}"
 
 - name: "Define the requested virtual machines {{ vm_type }}"
   when:


### PR DESCRIPTION
The association of OCP vm with their overlay disk is based on `index_var`. At times, the list of items provided may not be in ascending order. When not in the right order, the cluster would not become stable leading to

```
$ oc get nodes
couldn't get current server API group list: Get "https://api.ocp.openstack.lab:6443/api?timeout=32s": dial tcp 192.168.111.5:6443: connect: no route to host
```

_Root cause_
`keepalived` does not start due to expected IP vs actual IP leading to `kube-apiserver` terminating.

_Solution_
- Gather the VM id based on the xml filename
- Sort the list if there is no deterministic way of gathering the VM id.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

*Testing Results*

_Golden XML file_
```
# grep -E 'master.*qcow2|cifmw-' ocp_master_*.xml
ocp_master_0.xml:  <name>cifmw-ocp-0</name>
ocp_master_0.xml:      <source pool="oooq_pool" volume="ocp_master_0.qcow2"/>
ocp_master_1.xml:  <name>cifmw-ocp-1</name>
ocp_master_1.xml:      <source pool="oooq_pool" volume="ocp_master_1.qcow2"/>
ocp_master_2.xml:  <name>cifmw-ocp-2</name>
ocp_master_2.xml:      <source pool="oooq_pool" volume="ocp_master_2.qcow2"/>
```

_IP address association_
```
TASK [reproducer : Wait for OCP nodes to be ready sleep=2, timeout=300] **********************************************************************************************************************************************************************
Thursday 07 March 2024  08:45:44 -0500 (0:00:01.951)       1:17:29.134 ******** 
ok: [titanamd126 -> ocp-0(192.168.111.20)] => (item=ocp-0)
ok: [titanamd126 -> ocp-1(192.168.111.21)] => (item=ocp-1)
ok: [titanamd126 -> ocp-2(192.168.111.22)] => (item=ocp-2)
```

_End to End_
```
PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
titanamd126                : ok=421  changed=152  unreachable=0    failed=0    skipped=168  rescued=3    ignored=0   

Thursday 07 March 2024  08:51:40 -0500 (0:00:00.131)       1:23:24.670 ******** 
=============================================================================== 
devscripts : Deploy OpenShift cluster ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2656.64s
openshift_adm : Wait unit the OpenShift cluster is stable. -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 760.81s
openshift_adm : Wait till shutdown is completed on all the nodes -------------------------------------------------------------------------------------------------------------------------------------------------------------------- 300.10s
openshift_adm : Wait unit the OpenShift cluster is stable. -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 120.80s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 54.08s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 51.52s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 51.48s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 50.86s
reproducer : Install some tools ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 40.08s
openshift_adm : Wait until OCP login succeeds. --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 38.17s
networking_mapper : Ensure that networking and hostname facts are in place ----------------------------------------------------------------------------------------------------------------------------------------------------------- 32.02s
openshift_adm : Wait until the OCP API endpoint is reachable. ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 30.89s
reproducer : Bootstrap environment on controller-0 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 29.34s
openshift_adm : Initiate shutdown ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 27.31s
reproducer : Install collections on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 26.84s
libvirt_manager : Grab IPs for nodes type ocp ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 26.53s
libvirt_manager : Grab IPs for nodes type compute ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 20.33s
libvirt_manager : Grab IPs for nodes type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.95s
libvirt_manager : Wait for SSH on VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 17.85s
libvirt_manager : Wait for SSH on VMs type ocp --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 17.72s
```

*Rerun testing results*
```
# grep -E 'master.*qcow2|cifmw-' ocp_master_*.xml
ocp_master_0.xml:  <name>cifmw-ocp-0</name>
ocp_master_0.xml:      <source pool="oooq_pool" volume="ocp_master_0.qcow2"/>
ocp_master_1.xml:  <name>cifmw-ocp-1</name>
ocp_master_1.xml:      <source pool="oooq_pool" volume="ocp_master_1.qcow2"/>
ocp_master_2.xml:  <name>cifmw-ocp-2</name>
ocp_master_2.xml:      <source pool="oooq_pool" volume="ocp_master_2.qcow2"/>

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
titanamd126                : ok=370  changed=128  unreachable=0    failed=0    skipped=160  rescued=0    ignored=0   

Thursday 07 March 2024  23:26:42 -0500 (0:00:00.148)       0:17:53.496 ******** 
=============================================================================== 
openshift_adm : Wait unit the OpenShift cluster is stable. --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 96.86s
openshift_adm : Wait until OCP login succeeds. --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 52.10s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 51.65s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 51.63s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 51.54s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 50.54s
reproducer : Install some tools ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 36.35s
openshift_adm : Wait until the OCP API endpoint is reachable. ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 34.05s
reproducer : Bootstrap environment on controller-0 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 29.09s
reproducer : Install collections on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 28.94s
libvirt_manager : Grab IPs for nodes type ocp ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 26.27s
networking_mapper : Ensure that networking and hostname facts are in place ----------------------------------------------------------------------------------------------------------------------------------------------------------- 24.04s
libvirt_manager : Grab IPs for nodes type compute ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 20.21s
libvirt_manager : Grab IPs for nodes type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.98s
libvirt_manager : Wait for SSH on VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 17.89s
libvirt_manager : Wait for SSH on VMs type ocp --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 17.79s
libvirt_manager : Prepare disk image with SSH and growing volume --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 16.64s
reproducer : Wait for OCP nodes to be ready ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 13.45s
reproducer : Install ansible dependencies -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 12.90s
libvirt_manager : Configure VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 12.69s
```