### PR TITLE
Make sure component repos in update jobs are setup during update phase only

### DIFF
--- a/roles/repo_setup/tasks/main.yml
+++ b/roles/repo_setup/tasks/main.yml
@@ -20,7 +20,8 @@
   ansible.builtin.import_tasks: configure.yml
 - name: Include component repo if required
   ansible.builtin.import_tasks: component_repo.yml
-  when: cifmw_repo_setup_component_name|length > 0
+  when: ( cifmw_repo_setup_component_name|length > 0 and update_playbook_run is undefined and not cifmw_run_update|default(false)) or
+        ( cifmw_repo_setup_component_name|length > 0 and update_playbook_run is defined and cifmw_run_update|default(false))
 - name: Generate additional artifacts
   ansible.builtin.import_tasks: artifacts.yml
 - name: Generate downstream base os repos


### PR DESCRIPTION
Add conditionals to skip setting component repos during deployment phase
in update jobs and only update these repos during update playbook run.
This is required to be able to test update from previously deployed repos
to updated component repos.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1227

Signed-off-by: Mikołaj Ciecierski <mikolaj.ciecierski@redhat.com>

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
