### PR TITLE
Fix the jq error caused by containers list ordering

### DIFF
--- a/roles/set_openstack_containers/templates/update_env_vars.sh.j2
+++ b/roles/set_openstack_containers/templates/update_env_vars.sh.j2
@@ -36,7 +36,7 @@ oc get csv -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} \
    {% for key, value in containers_dict.items() -%}
    | jq '(.spec.install.spec.deployments[0].spec.template.spec.containers[1].env[] | select(.name=={{ '\"' + key + '\"' }})) |= (.value={{ '\"' + value + '\"' }})' \
    {% if operator_name == 'openstack' -%}
-   | jq '(.spec.install.spec.deployments[1].spec.template.spec.containers[1].env[] | select(.name=={{ '\"' + key + '\"' }})) |= (.value={{ '\"' + value + '\"' }})' \
+   | jq '(.spec.install.spec.deployments[1].spec.template.spec.containers[0].env[] | select(.name=={{ '\"' + key + '\"' }})) |= (.value={{ '\"' + value + '\"' }})' \
    {% endif -%}
    {% endfor -%}
    > {{ cifmw_set_openstack_containers_basedir }}/artifacts/update_containers_patch.out


### PR DESCRIPTION
This pr fixes the following jq issue.
```
oc get csv -n openstack-operators    -l operators.coreos.com/openstack-operator.openstack-operators -o=jsonpath='{.items[0]}' | jq '(.spec.install.spec.deployments[1].spec.template.spec.containers[1].env[] | select(.name=="RELATED_IMAGE_RABBITMQ_IMAGE_URL_DEFAULT")) |= (.value="38.102.83.6:5001/podified-antelope-centos9/openstack-rabbitmq:2fb21c9cd4251727b2f260ca5d6f2ebb")'
jq: error (at <stdin>:0): Cannot iterate over null (null)
```

The container list got changed from 1 to 0 breaking the set_openstack_containers role due to update in kubeproxy or operator sdk. Shifting it to 0 fixes the issue.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running

