### PR TITLE
Deploy BGP Spine/Leaf infrastructure on a HV

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/bgp/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp/edpm-nodeset-values/values.yaml.j2
@@ -1,0 +1,72 @@
+---
+# source: bgp/edpm-nodeset-values/values.yaml.j2
+{% set instances_names = []                                                            %}
+{% set _original_nodeset = (original_content.data | default({})).nodeset | default({}) %}
+{% set _original_nodes = _original_nodeset.nodes | default({})                         %}
+{% set _vm_type = (_original_nodes.keys() | first).split('-')[1]                       %}
+{% for _inst in cifmw_networking_env_definition.instances.keys()                       %}
+{%   if _inst.startswith(_vm_type)                                                     %}
+{%     set _ = instances_names.append(_inst)                                           %}
+{%   endif                                                                             %}
+{% endfor                                                                              %}
+data:
+  ssh_keys:
+    authorized: {{ cifmw_ci_gen_kustomize_values_ssh_authorizedkeys | b64encode }}
+    private: {{ cifmw_ci_gen_kustomize_values_ssh_private_key | b64encode }}
+    public: {{ cifmw_ci_gen_kustomize_values_ssh_public_key | b64encode }}
+  nova:
+    migration:
+      ssh_keys:
+        private: {{ cifmw_ci_gen_kustomize_values_migration_priv_key | b64encode }}
+        public: {{ cifmw_ci_gen_kustomize_values_migration_pub_key | b64encode }}
+  nodeset:
+    ansible:
+      ansibleUser: "zuul"
+      ansibleVars:
+        edpm_fips_mode: "{{ 'enabled' if cifmw_fips_enabled|default(false)|bool else 'check' }}"
+        timesync_ntp_servers:
+          - hostname: "{{ cifmw_ci_gen_kustomize_values_ntp_srv | default('pool.ntp.org') }}"
+{% if cifmw_ci_gen_kustomize_values_sshd_ranges | default([]) | length > 0             %}
+        edpm_sshd_allowed_ranges:
+{%   for range in cifmw_ci_gen_kustomize_values_sshd_ranges                            %}
+          - "{{ range }}"
+{%   endfor                                                                            %}
+{% endif                                                                               %}
+    nodes:
+{% for instance in instances_names                                                     %}
+      {{ instance }}:
+        ansibleVars:
+{%        set rack_number = instance.split('-')[1]                                     %}
+          edpm_ovn_bgp_agent_local_ovn_peer_ips:
+            - 100.64.{{ rack_number }}.1
+            - 100.65.{{ rack_number }}.1
+          edpm_frr_bgp_peers:
+            - 100.64.{{ rack_number }}.1
+            - 100.65.{{ rack_number }}.1
+        ansible:
+          host: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.ip_v4 }}
+        hostName: {{ instance }}
+        networks:
+{%      for net in cifmw_networking_env_definition.instances[instance].networks.keys() %}
+{%        if net is not match('storagemgmt')                                           %}
+          - name: {{ net }}
+            subnetName: subnet1
+{%          if net is match('ctlplane')                                                %}
+            defaultRoute: true
+            fixedIP: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.ip_v4 }}
+{%          endif                                                                      %}
+{%        endif                                                                        %}
+{%      endfor                                                                         %}
+          - name: BgpNet0
+            subnetName: subnet{{ rack_number }}
+            fixedIP: 100.64.{{ rack_number }}.2
+          - name: BgpNet1
+            subnetName: subnet{{ rack_number }}
+            fixedIP: 100.65.{{ rack_number }}.2
+          - name: BgpMainNet
+            subnetName: subnet{{ rack_number }}
+            fixedIP: 172.30.{{ rack_number }}.2
+          - name: BgpMainNetV6
+            subnetName: subnet{{ rack_number }}
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:00{{ (rack_number | int) + 1 }}2
+{% endfor                                                                              %}

--- a/roles/ci_gen_kustomize_values/templates/bgp/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp/network-values/values.yaml.j2
@@ -1,0 +1,145 @@
+---
+# source: bgp/network-values/values.yaml.j2
+{% set ns = namespace(interfaces={},
+                      ocp_index=0,
+                      lb_tools={}) %}
+data:
+{% for host in cifmw_networking_env_definition.instances.keys() -%}
+{%   for network in cifmw_networking_env_definition.instances[host]['networks'].values() -%}
+{%     set ns.interfaces = ns.interfaces |
+                           combine({network.network_name: (network.parent_interface |
+                                                           default(network.interface_name)
+                                                          )
+                                   },
+                                   recursive=true) -%}
+{%   endfor -%}
+{%   if host is match('^(ocp|crc).*') %}
+  node_{{ ns.ocp_index }}:
+    name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}
+{%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
+    {{ network.network_name }}_ip: {{ network.ip_v4 }}
+{%     endfor %}
+{%     set node_net_orig_content = original_content.data.bgp['net-attach-def']['node' ~ ns.ocp_index] %}
+{%     set node_bgp_net0 = node_net_orig_content.bgpnet0 | from_json %}
+{%     set node_bgp_net1 = node_net_orig_content.bgpnet1 | from_json %}
+    bgp_peers:
+      - {{ node_bgp_net0.ipam.range_start }}
+      - {{ node_bgp_net1.ipam.range_start }}
+    bgp_ip:
+      - {{ node_bgp_net0.ipam.range_start | ansible.utils.ipmath(1) }}
+      - {{ node_bgp_net1.ipam.range_start | ansible.utils.ipmath(1) }}
+{#     loopback_ip and loopback_ipv6 correspond to subnet3 because all ocp nodes are deployed on rack3 #}
+{%     set loopback_ip = original_content.data.bgp.subnets.bgpmainnet[3].allocationRanges[0].start |
+                         ansible.utils.ipmath(ns.ocp_index) %}
+{%     set loopback_ipv6 = original_content.data.bgp.subnets.bgpmainnetv6[3].allocationRanges[0].start |
+                           ansible.utils.ipmath(ns.ocp_index) %}
+    loopback_ip: {{ loopback_ip }}
+    loopback_ipv6: {{ loopback_ipv6 }}
+{%     set ns.ocp_index = ns.ocp_index+1 %}
+{%   endif %}
+{% endfor %}
+
+{% for network in cifmw_networking_env_definition.networks.values() %}
+{% set ns.lb_tools = {} %}
+  {{ network.network_name }}:
+    dnsDomain: {{ network.search_domain }}
+{%  if network.tools is defined and network.tools.keys() | length > 0 %}
+    subnets:
+{%    for tool in network.tools.keys() %}
+{%      if tool is match('.*lb$') %}
+{%        set _ = ns.lb_tools.update({tool: []}) %}
+{%      endif %}
+{%    endfor %}
+      - allocationRanges:
+{%    for range in network.tools.netconfig.ipv4_ranges %}
+        - end: {{ range.end }}
+          start: {{ range.start }}
+{%    endfor %}
+        cidr: {{ network.network_v4 }}
+{%      if network.gw_v4 is defined %}
+        gateway: {{ network.gw_v4 }}
+{%      endif %}
+        name: subnet1
+{%  if network.vlan_id is defined  %}
+        vlan: {{ network.vlan_id }}
+{%  endif %}
+{%    if ns.lb_tools | length > 0 %}
+    lb_addresses:
+{%      for tool in ns.lb_tools.keys() %}
+{%        for lb_range in network.tools[tool].ipv4_ranges %}
+      - {{ lb_range.start }}-{{ lb_range.end }}
+{%          set _ = ns.lb_tools[tool].append(lb_range.start) %}
+{%        endfor %}
+    endpoint_annotations:
+      {{ tool }}.universe.tf/address-pool: {{ network.network_name }}
+      {{ tool }}.universe.tf/allow-shared-ip: {{ network.network_name }}
+      {{ tool }}.universe.tf/loadBalancerIPs: {{ ','.join(ns.lb_tools[tool]) }}
+{%      endfor %}
+{%    endif %}
+{%  endif %}
+    prefix-length: {{ network.network_v4 | ansible.utils.ipaddr('prefix') }}
+    mtu: {{ network.mtu | default(1500) }}
+{%  if network.vlan_id is defined  %}
+    vlan: {{ network.vlan_id }}
+{%    if ns.interfaces[network.network_name] is defined %}
+    iface: {{ network.network_name }}
+    base_iface: {{ ns.interfaces[network.network_name] }}
+{%    endif %}
+{%  else %}
+{%    if ns.interfaces[network.network_name] is defined %}
+    iface: {{ ns.interfaces[network.network_name] }}
+{%    endif %}
+{%  endif %}
+{%  if network.tools.multus is defined %}
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "{{ network.network_name }}",
+        "type": "macvlan",
+{%  if network.vlan_id is defined%}
+        "master": "{{ network.network_name }}",
+{%  elif network.network_name == "ctlplane" %}
+        "master": "ospbr",
+{%  else %}
+        "master": "{{ ns.interfaces[network.network_name] }}",
+{%  endif %}
+        "ipam": {
+          "type": "whereabouts",
+          "range": "{{ network.network_v4 }}",
+          "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
+          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}"
+        }
+      }
+{%  endif %}
+{% endfor %}
+
+  dns-resolver:
+    config:
+      server:
+        - "{{ cifmw_networking_env_definition.networks.ctlplane.gw_v4 }}"
+      search: []
+    options:
+      - key: server
+        values:
+          - {{ cifmw_networking_env_definition.networks.ctlplane.gw_v4 }}
+{% for nameserver in cifmw_ci_gen_kustomize_values_nameservers %}
+      - key: server
+        values:
+          - {{ nameserver }}
+{% endfor %}
+
+  routes:
+    config: []
+
+# Hardcoding the last IP bit since we don't have support for endpoint_annotations in the networking_mapper output
+  rabbitmq:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(85) }}
+  rabbitmq-cell1:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(86) }}
+
+  lbServiceType: LoadBalancer
+  storageClass: local-storage

--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -33,6 +33,8 @@ Used for checking if:
 * `cifmw_libvirt_manager_fixed_networks`: (List) Network names you don't want to prefix with `cifmw-`. It will be concatenated with cifmw_libvirt_manager_fixed_networks_defaults. Defaults to`[]`.
 * `cifmw_libvirt_manager_reproducer_key_type`: (String) Type of ssh key that will be injected into the controller VMs. Defaults to `cifmw_ssh_keytype` which default to `ecdsa`.
 * `cifmw_libvirt_manager_reproducer_key_size`: (Integer) Size of the ecdsa ssh keys that will be injected into the controller VMs. Defaults to `cifmw_ssh_keysize` which default to 521.
+* `cifmw_libvirt_manager_spineleaf_setup`: (Boolean) Whether the VMs deployed are connected to a spine/leaf virtual infrastructure or not. When set to `true`, the interfaces of the instances from a certain type of VM are not connected to the same networks, but they can be defined per VM using the `spineleafnets` list (except for the `controller`). Defaults to `false`.
+* `cifmw_libvirt_manager_network_interface_types`: (Dict) By default, interfaces attached to VMs are created with `--type bridge`, but with this parameter, those interfaces can be configured with any other types. Defaults to empty dictionary.
 * `cifmw_libvirt_manager_configuration_patch(.)*`: (Dict) Structure describing the patch to combine on top of `cifmw_libvirt_manager_configuration`.
 
 ### Structure for `cifmw_libvirt_manager_configuration`

--- a/roles/libvirt_manager/defaults/main.yml
+++ b/roles/libvirt_manager/defaults/main.yml
@@ -70,3 +70,6 @@ cifmw_libvirt_manager_ip_script_basedir: >-
   {{
     (cifmw_libvirt_manager_basedir, 'artifacts') | ansible.builtin.path_join
   }}
+
+cifmw_libvirt_manager_network_interface_types: {}
+cifmw_libvirt_manager_spineleaf_setup: false

--- a/roles/libvirt_manager/molecule/spine_leaf/cleanup.yml
+++ b/roles/libvirt_manager/molecule/spine_leaf/cleanup.yml
@@ -1,0 +1,24 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Cleanup
+  hosts: instance
+  gather_facts: true
+  tasks:
+    - name: Clean layout
+      ansible.builtin.import_role:
+        name: libvirt_manager
+        tasks_from: clean_layout.yml

--- a/roles/libvirt_manager/molecule/spine_leaf/converge.yml
+++ b/roles/libvirt_manager/molecule/spine_leaf/converge.yml
@@ -1,0 +1,225 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Spine/leaf test
+  hosts: instance
+  gather_facts: true
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_basedir: "/opt/basedir"
+    cifmw_libvirt_manager_spineleaf_setup: true
+    cifmw_libvirt_manager_network_interface_types:
+      intnet-0: network
+      intnet-1: network
+    cifmw_libvirt_manager_vm_net_ip_set:
+      sl-compute: 100
+    _networks:
+      osp_trunk:
+        default: true
+        range: "192.168.140.0/24"
+        mtu: 1500
+      public:
+        range: "192.168.110.0/24"
+      intnet-0:
+        mtu: 1500
+      intnet-1:
+        mtu: 1500
+    cifmw_libvirt_manager_configuration:
+      vms:
+        sl-compute:
+          amount: 2
+          image_url: "{{ cifmw_discovered_image_url }}"
+          sha256_image_name: "{{ cifmw_discovered_hash }}"
+          image_local_dir: "{{ cifmw_basedir }}/images/"
+          disk_file_name: "spineleaf-centos-stream-9.qcow2"
+          disksize: 20
+          memory: 1
+          cpus: 1
+          spineleafnets:
+            - # sl-compute-0 interfaces
+              - public
+              - osp_trunk
+              - intnet-0
+            - # sl-compute-1 interfaces
+              - public
+              - osp_trunk
+              - intnet-1
+          extra_disks_num: 1
+          extra_disks_size: 1G
+      networks:
+        public: |-
+          <network>
+            <name>public</name>
+            <forward mode='nat'/>
+            <bridge name='public' stp='on' delay='0'/>
+            <ip
+             family='ipv4'
+             address='{{ _networks.public.range | ansible.utils.nthhost(1) }}'
+             prefix='24'>
+              <dhcp>
+                <range start='{{ _networks.public.range | ansible.utils.nthhost(10) }}'
+                end='{{ _networks.public.range | ansible.utils.nthhost(100) }}'/>
+              </dhcp>
+            </ip>
+          </network>
+        osp_trunk: |-
+          <network>
+            <name>osp_trunk</name>
+            <forward mode='nat'/>
+            <bridge name='osp_trunk' stp='on' delay='0'/>
+            <ip
+             family='ipv4'
+             address='{{ _networks.osp_trunk.range | ansible.utils.nthhost(1) }}'
+             prefix='24'>
+            </ip>
+          </network>
+        intnet-0: |
+          <network>
+            <name>intnet-0</name>
+            <bridge name='intnet-0' stp='on' delay='0'/>
+          </network>
+        intnet-1: |
+          <network>
+            <name>intnet-1</name>
+            <bridge name='intnet-1' stp='on' delay='0'/>
+          </network>
+  roles:
+    - role: "discover_latest_image"
+  tasks:
+    - name: Deploy layout
+      ansible.builtin.import_role:
+        name: libvirt_manager
+        tasks_from: deploy_layout
+
+    - name: Check files and deployed resources
+      block:
+        - name: Get wanted files
+          register: generated_files
+          ansible.builtin.stat:
+            path: "{{ cifmw_basedir }}/{{ item }}"
+          loop:
+            - reproducer-inventory/sl-compute-group.yml
+
+        - name: Assert file availability
+          ansible.builtin.assert:
+            that:
+              - item.stat.exists | bool
+          loop: "{{ generated_files.results }}"
+          loop_control:
+            label: "{{ item.stat.path }}"
+
+        - name: Get virtual network list
+          register: nets
+          community.libvirt.virt_net:
+            command: list_nets
+
+        - name: Get virtual machines
+          register: vms
+          community.libvirt.virt:
+            command: "list_vms"
+
+        - name: Output network list
+          ansible.builtin.debug:
+            msg:
+              - "{{ nets.list_nets | sort }}"
+              - >-
+                {{
+                  ['cifmw-public', 'cifmw-osp_trunk', 'default', 'cifmw-intnet-0', 'cifmw-intnet-1'] |
+                  sort
+                }}
+
+        - name: Assert resource lists
+          vars:
+            sorted_nets: "{{ nets.list_nets | sort }}"
+            compare_nets: >-
+              {{
+                ['cifmw-public', 'cifmw-osp_trunk', 'default', 'cifmw-intnet-0', 'cifmw-intnet-1'] |
+                sort
+              }}
+            sorted_vms: "{{ vms.list_vms | sort }}"
+            compare_vms: >-
+              {{
+                ['cifmw-sl-compute-0',
+                 'cifmw-sl-compute-1'] | sort
+              }}
+          ansible.builtin.assert:
+            that:
+              - sorted_nets == compare_nets
+              - sorted_vms == compare_vms
+
+        - name: Get sl-compute-0 network interfaces
+          register: cmp_nics_cmp_0
+          ansible.builtin.command:
+            cmd: >-
+              virsh -c qemu:///system -q
+              domiflist cifmw-sl-compute-0
+
+        - name: Ensure sl-compute-0 connections
+          vars:
+            _vals: >-
+              {{
+                cmp_nics_cmp_0.stdout_lines |
+                product([' sl-compute-0']) |
+                map('join') |
+                map('split')
+              }}
+            _nics: >-
+              {{
+                _vals |
+                map('zip',
+                    ['nic', 'type', 'network', 'driver', 'mac', 'host' ]) |
+                map('map', 'reverse') |
+                map('community.general.dict')
+              }}
+          ansible.builtin.assert:
+            that:
+              - item.network in ['cifmw-public', 'cifmw-osp_trunk', 'cifmw-intnet-0']
+          loop: "{{ _nics }}"
+
+        - name: Get sl-compute-1 network interfaces
+          register: cmp_nics_cmp_1
+          ansible.builtin.command:
+            cmd: >-
+              virsh -c qemu:///system -q
+              domiflist cifmw-sl-compute-1
+
+        - name: Ensure sl-compute-1 connections
+          vars:
+            _vals: >-
+              {{
+                cmp_nics_cmp_1.stdout_lines |
+                product([' sl-compute-1']) |
+                map('join') |
+                map('split')
+              }}
+            _nics: >-
+              {{
+                _vals |
+                map('zip',
+                    ['nic', 'type', 'network', 'driver', 'mac', 'host' ]) |
+                map('map', 'reverse') |
+                map('community.general.dict')
+              }}
+          ansible.builtin.assert:
+            that:
+              - item.network in ['cifmw-public', 'cifmw-osp_trunk', 'cifmw-intnet-1']
+          loop: "{{ _nics }}"
+
+        - name: Get osp_trunk network XML
+          register: _net_xml
+          community.libvirt.virt_net:
+            command: "get_xml"
+            name: "cifmw-osp_trunk"

--- a/roles/libvirt_manager/molecule/spine_leaf/molecule.yml
+++ b/roles/libvirt_manager/molecule/spine_leaf/molecule.yml
@@ -1,0 +1,6 @@
+---
+log: true
+
+provisioner:
+  name: ansible
+  log: true

--- a/roles/libvirt_manager/molecule/spine_leaf/prepare.yml
+++ b/roles/libvirt_manager/molecule/spine_leaf/prepare.yml
@@ -1,0 +1,34 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: instance
+  vars:
+    cifmw_basedir: "/opt/basedir"
+  pre_tasks:
+    - name: Create custom basedir
+      become: true
+      ansible.builtin.file:
+        path: "{{ cifmw_basedir }}"
+        state: directory
+        owner: zuul
+        group: zuul
+        mode: "0755"
+  roles:
+    - role: "test_deps"
+    - role: "ci_setup"
+    - role: "libvirt_manager"

--- a/roles/libvirt_manager/tasks/attach_interface.yml
+++ b/roles/libvirt_manager/tasks/attach_interface.yml
@@ -73,10 +73,12 @@
         (_net_name not in _net_bridge_map.keys()) |
         ternary(_net_name, _net_bridge_map[_net_name])
       }}
+    _type: "{{ cifmw_libvirt_manager_network_interface_types[network.name] | default('bridge') }}"
     _attached_bridges: >-
       {{
         _extracted_xml.matches | default([]) |
-        selectattr('source.bridge', 'equalto', _local_bridge_name) | default([])
+        selectattr('source.' + _type, 'defined') |
+        selectattr('source.' + _type, 'equalto', _local_bridge_name)
       }}
   when:
     - _attached_bridges | length == 0
@@ -85,7 +87,7 @@
       virsh -c qemu:///system
       attach-interface "{{ vm_name }}"
       --source "{{ _local_bridge_name }}"
-      --type bridge
+      --type "{{ _type }}"
       --mac "{{ _lm_mac_address }}"
       --model virtio
       --config

--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -96,9 +96,26 @@
 - name: "Attach listed networks to the VMs {{ vm_type }}"  # noqa: no-handler
   when:
     - _create_overlays is changed
+    - >-
+      not cifmw_libvirt_manager_spineleaf_setup or
+      'controller' in vm_type
   vars:
     vm_item: "{{ vm_type }}-{{ vm_id }}"
     networks: "{{ vm_data.value.nets }}"
+  ansible.builtin.include_tasks: net_to_vms.yml
+  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
+  loop_control:
+    index_var: vm_id
+    label: "{{ vm_type }}-{{ vm_id }}"
+
+- name: "Attach spines/leafs networks to the VMs {{ vm_type }}"
+  when:
+    - _create_overlays is changed
+    - cifmw_libvirt_manager_spineleaf_setup
+    - "'controller' not in vm_type"
+  vars:
+    vm_item: "{{ vm_type }}-{{ vm_id }}"
+    networks: "{{ vm_data.value.spineleafnets[vm_id] }}"
   ansible.builtin.include_tasks: net_to_vms.yml
   loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
   loop_control:

--- a/scenarios/reproducers/bgp-4-racks-3-ocps.yml
+++ b/scenarios/reproducers/bgp-4-racks-3-ocps.yml
@@ -1,0 +1,402 @@
+---
+cifmw_run_tests: true
+cifmw_run_tempest: true
+cifmw_run_test_role: test_operator
+cifmw_test_operator_timeout: 7200
+cifmw_test_operator_tempest_include_list: |
+  tempest.scenario.test_network_basic_ops.TestNetworkBasicOps
+
+cifmw_use_devscripts: true
+cifmw_use_libvirt: true
+cifmw_virtualbmc_daemon_port: 50881
+cifmw_use_uefi: >-
+  {{ (cifmw_repo_setup_os_release is defined
+      and cifmw_repo_setup_os_release == 'rhel') | bool }}
+cifmw_libvirt_manager_compute_amount: 3
+cifmw_libvirt_manager_pub_net: ocpbm
+cifmw_libvirt_manager_spineleaf_setup: true
+cifmw_libvirt_manager_network_interface_types:
+  l00-s0: network
+  l01-s0: network
+  l00-s1: network
+  l01-s1: network
+  l10-s0: network
+  l11-s0: network
+  l10-s1: network
+  l11-s1: network
+  l20-s0: network
+  l21-s0: network
+  l20-s1: network
+  l21-s1: network
+  l30-s0: network
+  l31-s0: network
+  l30-s1: network
+  l31-s1: network
+  l00-node0: network
+  l01-node0: network
+  l10-node0: network
+  l11-node0: network
+  l20-node0: network
+  l21-node0: network
+  l30-ocp0: network
+  l31-ocp0: network
+  l30-ocp1: network
+  l31-ocp1: network
+  l30-ocp2: network
+  l31-ocp2: network
+
+cifmw_libvirt_manager_configuration:
+  networks:
+    osp_trunk: |
+      <network>
+        <name>osp_trunk</name>
+        <forward mode='nat'/>
+        <bridge name='osp_trunk' stp='on' delay='0'/>
+        <ip family='ipv4'
+        address='{{ cifmw_networking_definition.networks.ctlplane.network |
+                    ansible.utils.nthhost(1) }}'
+        prefix='{{ cifmw_networking_definition.networks.ctlplane.network |
+                   ansible.utils.ipaddr('prefix') }}'>
+        </ip>
+      </network>
+    # leafs to spines networks
+    ## rack0
+    l00-s0: |
+      <network>
+        <name>l00-s0</name>
+        <bridge name='l00-s0' stp='on' delay='0'/>
+      </network>
+    l00-s1: |
+      <network>
+        <name>l00-s1</name>
+        <bridge name='l00-s1' stp='on' delay='0'/>
+      </network>
+    l01-s0: |
+      <network>
+        <name>l01-s0</name>
+        <bridge name='l01-s0' stp='on' delay='0'/>
+      </network>
+    l01-s1: |
+      <network>
+        <name>l01-s1</name>
+        <bridge name='l01-s1' stp='on' delay='0'/>
+      </network>
+    ## rack1
+    l10-s0: |
+      <network>
+        <name>l10-s0</name>
+        <bridge name='l10-s0' stp='on' delay='0'/>
+      </network>
+    l10-s1: |
+      <network>
+        <name>l10-s1</name>
+        <bridge name='l10-s1' stp='on' delay='0'/>
+      </network>
+    l11-s0: |
+      <network>
+        <name>l11-s0</name>
+        <bridge name='l11-s0' stp='on' delay='0'/>
+      </network>
+    l11-s1: |
+      <network>
+        <name>l11-s1</name>
+        <bridge name='l11-s1' stp='on' delay='0'/>
+      </network>
+    ## rack2
+    l20-s0: |
+      <network>
+        <name>l20-s0</name>
+        <bridge name='l20-s0' stp='on' delay='0'/>
+      </network>
+    l20-s1: |
+      <network>
+        <name>l20-s1</name>
+        <bridge name='l20-s1' stp='on' delay='0'/>
+      </network>
+    l21-s0: |
+      <network>
+        <name>l21-s0</name>
+        <bridge name='l21-s0' stp='on' delay='0'/>
+      </network>
+    l21-s1: |
+      <network>
+        <name>l21-s1</name>
+        <bridge name='l21-s1' stp='on' delay='0'/>
+      </network>
+    ## rack3
+    l30-s0: |
+      <network>
+        <name>l30-s0</name>
+        <bridge name='l30-s0' stp='on' delay='0'/>
+      </network>
+    l30-s1: |
+      <network>
+        <name>l30-s1</name>
+        <bridge name='l30-s1' stp='on' delay='0'/>
+      </network>
+    l31-s0: |
+      <network>
+        <name>l31-s0</name>
+        <bridge name='l31-s0' stp='on' delay='0'/>
+      </network>
+    l31-s1: |
+      <network>
+        <name>l31-s1</name>
+        <bridge name='l31-s1' stp='on' delay='0'/>
+      </network>
+    # leafs to nodes
+    ## rack0
+    l00-node0: |
+      <network>
+        <name>l00-node0</name>
+        <bridge name='l00-node0' stp='on' delay='0'/>
+      </network>
+    l01-node0: |
+      <network>
+        <name>l01-node0</name>
+        <bridge name='l01-node0' stp='on' delay='0'/>
+      </network>
+    ## rack1
+    l10-node0: |
+      <network>
+        <name>l10-node0</name>
+        <bridge name='l10-node0' stp='on' delay='0'/>
+      </network>
+    l11-node0: |
+      <network>
+        <name>l11-node0</name>
+        <bridge name='l11-node0' stp='on' delay='0'/>
+      </network>
+    ## rack2
+    l20-node0: |
+      <network>
+        <name>l20-node0</name>
+        <bridge name='l20-node0' stp='on' delay='0'/>
+      </network>
+    l21-node0: |
+      <network>
+        <name>l21-node0</name>
+        <bridge name='l21-node0' stp='on' delay='0'/>
+      </network>
+    # leafs to ocp
+    ## rack3
+    l30-ocp0: |
+      <network>
+        <name>l30-ocp0</name>
+        <bridge name='l30-ocp0' stp='on' delay='0'/>
+      </network>
+    l30-ocp1: |
+      <network>
+        <name>l30-ocp1</name>
+        <bridge name='l30-ocp1' stp='on' delay='0'/>
+      </network>
+    l30-ocp2: |
+      <network>
+        <name>l30-ocp2</name>
+        <bridge name='l30-ocp2' stp='on' delay='0'/>
+      </network>
+    l31-ocp0: |
+      <network>
+        <name>l31-ocp0</name>
+        <bridge name='l31-ocp0' stp='on' delay='0'/>
+      </network>
+    l31-ocp1: |
+      <network>
+        <name>l31-ocp1</name>
+        <bridge name='l31-ocp1' stp='on' delay='0'/>
+      </network>
+    l31-ocp2: |
+      <network>
+        <name>l31-ocp2</name>
+        <bridge name='l31-ocp2' stp='on' delay='0'/>
+      </network>
+  vms:
+    controller:
+      root_part_id: >-
+        {{
+          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
+          ternary(4, 1)
+        }}
+      image_url: "{{ cifmw_discovered_image_url }}"
+      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "base-os.qcow2"
+      disksize: 50
+      memory: 8
+      cpus: 4
+      nets:
+        - ocpbm
+        - osp_trunk
+    compute:
+      amount: "{{ cifmw_libvirt_manager_compute_amount }}"
+      root_part_id: >-
+        {{
+          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
+          ternary(4, 1)
+        }}
+      image_url: "{{ cifmw_discovered_image_url }}"
+      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "centos-stream-9.qcow2"
+      disksize: 50
+      memory: 8
+      cpus: 4
+      spineleafnets:
+        - # rack0 - compute0
+          - "ocpbm"
+          - "osp_trunk"
+          - "l00-node0"
+          - "l01-node0"
+        - # rack1 - compute1
+          - "ocpbm"
+          - "osp_trunk"
+          - "l10-node0"
+          - "l11-node0"
+        - # rack2 - compute2
+          - "ocpbm"
+          - "osp_trunk"
+          - "l20-node0"
+          - "l21-node0"
+    ocp:
+      amount: 3
+      admin_user: core
+      image_local_dir: "/home/dev-scripts/pool"
+      disk_file_name: "ocp_master"
+      disksize: "105"
+      xml_paths:
+        - /home/dev-scripts/ocp_master_0.xml
+        - /home/dev-scripts/ocp_master_1.xml
+        - /home/dev-scripts/ocp_master_2.xml
+      spineleafnets:
+        - # rack3 - ocp0
+          - "l30-ocp0"
+          - "l31-ocp0"
+          - "osp_trunk"
+        - # rack3 - ocp1
+          - "l30-ocp1"
+          - "l31-ocp1"
+          - "osp_trunk"
+        - # rack3 - ocp2
+          - "l30-ocp2"
+          - "l31-ocp2"
+          - "osp_trunk"
+    spine:
+      amount: 2
+      root_part_id: >-
+        {{
+          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
+          ternary(4, 1)
+        }}
+      image_url: "{{ cifmw_discovered_image_url }}"
+      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "spine-centos-stream-9.qcow2"
+      disksize: 25
+      memory: 4
+      cpus: 2
+      spineleafnets:
+        - # spine0
+          - "l00-s0"
+          - "l01-s0"
+          - "l10-s0"
+          - "l11-s0"
+          - "l20-s0"
+          - "l21-s0"
+          - "l30-s0"
+          - "l31-s0"
+          - "ocpbm"
+        - # spine1
+          - "l00-s1"
+          - "l01-s1"
+          - "l10-s1"
+          - "l11-s1"
+          - "l20-s1"
+          - "l21-s1"
+          - "l30-s1"
+          - "l31-s1"
+          - "ocpbm"
+    leaf:
+      amount: 8
+      root_part_id: >-
+        {{
+          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
+          ternary(4, 1)
+        }}
+      image_url: "{{ cifmw_discovered_image_url }}"
+      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "leaf-centos-stream-9.qcow2"
+      disksize: 25
+      memory: 4
+      cpus: 2
+      spineleafnets:
+        - # rack0 - leaf00
+          - "l00-s0"
+          - "l00-s1"
+          - "l00-node0"
+          - "ocpbm"
+        - # rack0 - leaf01
+          - "l01-s0"
+          - "l01-s1"
+          - "l01-node0"
+          - "ocpbm"
+        - # rack1 - leaf10
+          - "l10-s0"
+          - "l10-s1"
+          - "l10-node0"
+          - "ocpbm"
+        - # rack1 - leaf11
+          - "l11-s0"
+          - "l11-s1"
+          - "l11-node0"
+          - "ocpbm"
+        - # rack2 - leaf20
+          - "l20-s0"
+          - "l20-s1"
+          - "l20-node0"
+          - "ocpbm"
+        - # rack2 - leaf21
+          - "l21-s0"
+          - "l21-s1"
+          - "l21-node0"
+          - "ocpbm"
+        - # rack3 - leaf30
+          - "l30-s0"
+          - "l30-s1"
+          - "l30-ocp0"
+          - "l30-ocp1"
+          - "l30-ocp2"
+          - "ocpbm"
+        - # rack3 - leaf31
+          - "l31-s0"
+          - "l31-s1"
+          - "l31-ocp0"
+          - "l31-ocp1"
+          - "l31-ocp2"
+          - "ocpbm"
+
+## devscript support for OCP deploy
+cifmw_devscripts_config_overrides:
+  worker_memory: 16384
+  worker_disk: 100
+  worker_vcpu: 10
+  num_extra_workers: 0
+# Required for egress traffic from pods to the osp_trunk network
+cifmw_devscripts_enable_ocp_nodes_host_routing: true
+
+# Automation section. Most of those parameters will be passed to the
+# controller-0 as-is and be consumed by the `deploy-va.sh` script.
+# Please note, all paths are on the controller-0, meaning managed by the
+# Framework. Please do not edit them!
+_arch_repo: "/home/zuul/src/github.com/openstack-k8s-operators/architecture"
+cifmw_architecture_scenario: bgp
+cifmw_kustomize_deploy_architecture_examples_path: "examples/dt/"
+cifmw_arch_automation_file: "bgp.yaml"
+cifmw_architecture_automation_file: >-
+  {{
+    (ansible_user_dir,
+     'src/github.com/openstack-k8s-operators',
+     'architecture/automation/vars',
+     cifmw_arch_automation_file) |
+     path_join
+  }}


### PR DESCRIPTION
This patch includes changes in the libvirt_manager role to deploy VM
that simulate a spine/leaf infrastructure using the reproducer.yaml
playbook.
The main change is that the VMs created on the hypervisor from a certain
type (computes, ocp, etc) can have interfaces connected to different
networks. Example:
- compute-0 is connected to leaf-0
- compute-1 is connected to leaf-1
- ocp-0 is connected to leaf-2
- ocp-1 is connected to leaf-3
etc

This patch also includes values.yaml.j2 templates included in the
ci_gen_kustomize_values role that will be used to generate BGP CRs using
kustomize.

Finally, a new scenario file, bgp-4-racks-crc.yml, is included with the
parameters necessary to use the previously described changes.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role

