### PR TITLE
OpenShift cluster post deployment configurations required for uni-alpha

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -269,6 +269,7 @@ mountpoints
 mtcylje
 mtu
 multinode
+multipath
 multus
 myorg
 mytest

--- a/roles/devscripts/README.md
+++ b/roles/devscripts/README.md
@@ -34,6 +34,8 @@ networks.
   host for OCP nodes in case of OVNKubernetes. Defaults to `false`.
 * `cifmw_devscripts_enable_iscsi_on_ocp_nodes` (bool) Enable iSCSI services on
   the OpenShift nodes having role as `worker`. Defaults to `false`.
+* `cifmw_devscripts_enable_multipath_on_ocp_nodes` (bool) Enable multipath
+  services on the OpenShift nodes. Defaults to `false`.
 * `cifmw_devscripts_host_bm_net_ip_addr` (str) The IP address of the host to be
   assigned. Must be from the specified external network.
 * `cifmw_devscripts_use_static_ip_addr` (bool) Use static IP addresses for the

--- a/roles/devscripts/README.md
+++ b/roles/devscripts/README.md
@@ -36,6 +36,8 @@ networks.
   the OpenShift nodes having role as `worker`. Defaults to `false`.
 * `cifmw_devscripts_enable_multipath_on_ocp_nodes` (bool) Enable multipath
   services on the OpenShift nodes. Defaults to `false`.
+* `cifmw_devscripts_create_logical_volume` (bool) Create a logical volume with
+  the name cinder-volumes on all OCP nodes. Defaults to `false`.
 * `cifmw_devscripts_host_bm_net_ip_addr` (str) The IP address of the host to be
   assigned. Must be from the specified external network.
 * `cifmw_devscripts_use_static_ip_addr` (bool) Use static IP addresses for the

--- a/roles/devscripts/README.md
+++ b/roles/devscripts/README.md
@@ -196,6 +196,48 @@ If you provide neither, or both, it will fail.
     worker_vcpu: 10
   ```
 
+* Sample custom variable file for customizing the deployment with add-on configurations.
+
+  ```YAML
+  cifmw_use_libvirt: true
+  cifmw_libvirt_manager_configuration:
+    networks:
+      osp_trunk: |
+        <network>
+          <name>osp_trunk</name>
+          <forward mode='nat'/>
+          <bridge name='osp_trunk' stp='on' delay='0'/>
+          <ip family='ipv4' address='192.168.122.1' prefix='24'> </ip>
+        </network>
+    vms:
+      ocp:
+        amount: 3
+        admin_user: core
+        image_local_dir: "/home/dev-scripts/pool"
+        disk_file_name: "ocp_master"
+        disksize: "105"
+        xml_paths:
+          - /home/dev-scripts/ocp_master_0.xml
+          - /home/dev-scripts/ocp_master_1.xml
+          - /home/dev-scripts/ocp_master_2.xml
+        nets:
+          - osp_trunk
+
+  cifmw_manage_secrets_citoken_content: REDACTED
+  cifmw_manage_secrets_pullsecret_content: |
+    REDACTED
+  cifmw_use_devscripts: true
+  cifmw_devscripts_enable_ocp_nodes_host_routing: true
+  cifmw_devscripts_enable_iscsi_on_ocp_nodes: true
+  cifmw_devscripts_enable_multipath_on_ocp_nodes: true
+  cifmw_devscripts_create_logical_volume: true
+  cifmw_devscripts_config_overrides:
+    openshift_version: "4.16.0"
+    vm_extradisks: "true"
+    vm_extradisks_list: "vdb vdc vdd"
+    vm_extradisks_size: "10G"
+  ```
+
 ## References
 
 * [dev-scripts](https://github.com/openshift-metal3/dev-scripts)

--- a/roles/devscripts/defaults/main.yml
+++ b/roles/devscripts/defaults/main.yml
@@ -58,6 +58,7 @@ cifmw_devscripts_debug: false
 cifmw_devscripts_dry_run: false
 cifmw_devscripts_enable_ocp_nodes_host_routing: false
 cifmw_devscripts_enable_iscsi_on_ocp_nodes: false
+cifmw_devscripts_enable_multipath_on_ocp_nodes: false
 cifmw_devscripts_remove_libvirt_net_default: false
 cifmw_devscripts_use_static_ip_addr: false
 

--- a/roles/devscripts/defaults/main.yml
+++ b/roles/devscripts/defaults/main.yml
@@ -59,6 +59,7 @@ cifmw_devscripts_dry_run: false
 cifmw_devscripts_enable_ocp_nodes_host_routing: false
 cifmw_devscripts_enable_iscsi_on_ocp_nodes: false
 cifmw_devscripts_enable_multipath_on_ocp_nodes: false
+cifmw_devscripts_create_logical_volume: false
 cifmw_devscripts_remove_libvirt_net_default: false
 cifmw_devscripts_use_static_ip_addr: false
 

--- a/roles/devscripts/files/lv-cinder-volumes.sh
+++ b/roles/devscripts/files/lv-cinder-volumes.sh
@@ -1,0 +1,18 @@
+#! /usr/bin/bash
+set -euo pipefail
+
+if [[ $(lvdisplay /dev/cinder_volumes_vg/cinder-volumes) ]]; then
+    echo "cinder-volumes vg exists."
+    exit 0
+fi
+
+disks=$(lsblk -o NAME,TYPE | awk '{ if ($2 == "disk" && $1 != "sda") print "/dev/"$1}')
+disk_str=''
+
+for disk in ${disks}; do
+    pvcreate ${disk}
+    disk_str="${disk_str} ${disk}"
+done
+
+vgcreate cinder_volumes_vg ${disk_str}
+lvcreate -l 100%FREE -n cinder-volumes cinder_volumes_vg

--- a/roles/devscripts/files/multipath.conf
+++ b/roles/devscripts/files/multipath.conf
@@ -1,0 +1,8 @@
+defaults {
+  user_friendly_names    no
+  recheck_wwid    yes
+  skip_kpartx    yes
+  find_multipaths  yes
+}
+blacklist {
+}

--- a/roles/devscripts/tasks/137_custom_install.yml
+++ b/roles/devscripts/tasks/137_custom_install.yml
@@ -57,3 +57,24 @@
     owner: "{{ cifmw_devscripts_user }}"
     group: "{{ cifmw_devscripts_user }}"
     mode: "0644"
+
+- name: Enable multipath services on the OpenShift nodes.
+  when: cifmw_devscripts_enable_multipath_on_ocp_nodes | bool
+  vars:
+    _mpath_conf: >-
+      {{
+        lookup('ansible.builtin.file', 'files/multipath.conf') |
+        ansible.builtin.b64encode
+      }}
+  ansible.builtin.template:
+    src: templates/multipath.j2
+    dest: >-
+      {{
+        (
+          cifmw_devscripts_config['assets_extra_folder'],
+          'enable_mpath.yaml'
+        ) | ansible.builtin.path_join
+      }}
+    owner: "{{ cifmw_devscripts_user }}"
+    group: "{{ cifmw_devscripts_user }}"
+    mode: "0644"

--- a/roles/devscripts/tasks/137_custom_install.yml
+++ b/roles/devscripts/tasks/137_custom_install.yml
@@ -36,10 +36,17 @@
     group: "{{ cifmw_devscripts_user }}"
     mode: "0644"
 
+- name: Set the custom ocp role based on cluster configuration.
+  ansible.builtin.set_fact:
+    ocp_role: >-
+      {{
+        (cifmw_devscripts_config.num_workers > 0) | ternary('worker', 'master')
+      }}
+
 - name: Enable iSCSI services on the OpenShift Nodes.
   when: cifmw_devscripts_enable_iscsi_on_ocp_nodes | bool
-  ansible.builtin.copy:
-    src: files/iscsi.yml
+  ansible.builtin.template:
+    src: templates/iscsi.j2
     dest: >-
       {{
         [

--- a/roles/devscripts/tasks/137_custom_install.yml
+++ b/roles/devscripts/tasks/137_custom_install.yml
@@ -78,3 +78,31 @@
     owner: "{{ cifmw_devscripts_user }}"
     group: "{{ cifmw_devscripts_user }}"
     mode: "0644"
+
+- name: Add cinder-volumes lv customization
+  when:
+    - cifmw_devscripts_create_logical_volume | bool
+    - cifmw_devscripts_config.vm_extradisks | default(false) | bool
+    - cifmw_devscripts_config.vm_extradisks_list is defined
+  vars:
+    _script_file: >-
+      {{
+        lookup('ansible.builtin.file', 'files/lv-cinder-volumes.sh') |
+        ansible.builtin.b64encode
+      }}
+    _disk_names: >-
+      {{
+        cifmw_devscripts_config.vm_extradisks_list | split
+      }}
+  ansible.builtin.template:
+    src: templates/lv.j2
+    dest: >-
+      {{
+        (
+          cifmw_devscripts_config['assets_extra_folder'],
+          'create_logical_volume.yaml'
+        ) | ansible.builtin.path_join
+      }}
+    owner: "{{ cifmw_devscripts_user }}"
+    group: "{{ cifmw_devscripts_user }}"
+    mode: "0644"

--- a/roles/devscripts/templates/iscsi.j2
+++ b/roles/devscripts/templates/iscsi.j2
@@ -4,7 +4,7 @@ kind: MachineConfig
 metadata:
   name: 90-enable-iscsi
   labels:
-    machineconfiguration.openshift.io/role: worker
+    machineconfiguration.openshift.io/role: {{ ocp_role }}
     service: cinder
 spec:
   config:

--- a/roles/devscripts/templates/lv.j2
+++ b/roles/devscripts/templates/lv.j2
@@ -1,0 +1,44 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 92-create-logical-volume
+  labels:
+    machineconfiguration.openshift.io/role: {{ ocp_role }}
+    service: cinder
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      disks:
+{% for _disk in _disk_names %}
+        - device: "/dev/{{ _disk }}"
+          wipeTable: true
+{% endfor %}
+      files:
+        - path: /usr/local/bin/lv-cinder-volumes.sh
+          overwrite: false
+          mode: 493
+          user:
+            name: root
+          group:
+            name: root
+          contents:
+            source: data:text/plain;charset=utf-8;base64,{{ _script_file }}
+    systemd:
+      units:
+        - name: lv-cinder-volumes.service
+          enabled: true
+          contents: |
+            [Unit]
+            Description=Create logical volume with name cinder-volumes.
+            After=var.mount systemd-udev-settle.service
+
+            [Service]
+            Type=oneshot
+            ExecStart=/usr/local/bin/lv-cinder-volumes.sh
+            RemainAfterExit=yes
+
+            [Install]
+            WantedBy=multi-user.target

--- a/roles/devscripts/templates/multipath.j2
+++ b/roles/devscripts/templates/multipath.j2
@@ -1,0 +1,27 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 91-mpath-conf
+  labels:
+    machineconfiguration.openshift.io/role: {{ ocp_role }}
+    service: cinder
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+        - path: /etc/multipath.conf
+          overwrite: false
+          mode: 344
+          user:
+            name: root
+          group:
+            name: root
+          contents:
+            source: data:text/plain;charset=utf-8;base64,{{ _mpath_conf }}
+    systemd:
+      units:
+        - enabled: true
+          name: multipathd.service


### PR DESCRIPTION
This change set introduces the following changes

- Deploys iSCSI service based on master if in Compact mode else worker
- Enables multipath service
- Creates a logical volume `cinder-volumes` 

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1261

*Testing Results*
```
[core@master-0 ~]$ lsblk
NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
sda      8:0    0  100G  0 disk 
├─sda1   8:1    0    1M  0 part 
├─sda2   8:2    0  127M  0 part 
├─sda3   8:3    0  384M  0 part /boot
└─sda4   8:4    0 79.5G  0 part /var/lib/kubelet/pods/4ae34818-70eb-4e02-8b79-91f013e3752b/volume-subpaths/nginx-conf/monitoring-plugin/1
                                /var
                                /sysroot/ostree/deploy/rhcos/var
                                /usr
                                /etc
                                /
                                /sysroot
vda    252:0    0   10G  0 disk 
vdb    252:16   0   10G  0 disk 
[core@master-0 ~]$ systemctl list-units | grep iscsi
  iscsi-shutdown.service                                                                                                                                                       loaded active exited    Logout off all iSCSI sessions on shutdown
  iscsid.service                                                                                                                                                               loaded active running   Open-iSCSI
  iscsid.socket                                                                                                                                                                loaded active running   Open-iSCSI iscsid Socket
  iscsiuio.socket                                                                                                                                                              loaded active listening Open-iSCSI iscsiuio Socket

[core@master-0 ~]$ systemctl list-units | grep multipath
  multipathd.service                                                                                                                                                           loaded active running   Device-Mapper Multipath Device Controller
  multipathd.socket                                                                                                                                                            loaded active running   multipathd control socket
```

_Rerunning test scenario_
```
PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
hypervisor                 : ok=382  changed=130  unreachable=0    failed=0    skipped=163  rescued=1    ignored=0   

Monday 11 March 2024  00:09:45 -0400 (0:00:00.134)       0:17:47.440 ********** 
=============================================================================== 
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 53.16s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 52.18s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 52.06s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 51.82s
reproducer : Install some tools ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 37.75s
libvirt_manager : Configure ssh access on type ocp ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 36.97s
libvirt_manager : Prepare disk image with SSH and growing volume --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 35.86s
networking_mapper : Ensure that networking and hostname facts are in place ----------------------------------------------------------------------------------------------------------------------------------------------------------- 32.80s
reproducer : Bootstrap environment on controller-0 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 32.35s
libvirt_manager : Grab IPs for nodes type compute ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 26.57s
libvirt_manager : Grab IPs for nodes type ocp ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 26.42s
reproducer : Install collections on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 25.64s
libvirt_manager : Grab IPs for nodes type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.98s
reproducer : Inject ProxyJump configuration for remote hypervisor VMs ---------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.46s
libvirt_manager : Wait for SSH on VMs type ocp --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 17.89s
libvirt_manager : Wait for SSH on VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 17.75s
reproducer : Wait for OCP nodes to be ready ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 16.93s
libvirt_manager : Configure VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 16.46s
reproducer : Install ansible dependencies -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 13.65s
openshift_adm : Wait unit the OpenShift cluster is stable. --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 12.82s
```

*LV service testing result*
```
[root@master-1 ~]# systemctl -l status lv-cinder-volumes.service
● lv-cinder-volumes.service - Create logical volume with name cinder-volumes.
     Loaded: loaded (/etc/systemd/system/lv-cinder-volumes.service; enabled; preset: disabled)
     Active: active (exited) since Tue 2024-03-12 07:19:51 UTC; 11s ago
    Process: 63623 ExecStart=/usr/local/bin/lv-cinder-volumes.sh (code=exited, status=0/SUCCESS)
   Main PID: 63623 (code=exited, status=0/SUCCESS)
        CPU: 107ms

Mar 12 07:19:51 master-1 systemd[1]: Starting Create logical volume with name cinder-volumes....
Mar 12 07:19:51 master-1 lv-cinder-volumes.sh[63624]:   Volume group "cinder_volumes_vg" not found
Mar 12 07:19:51 master-1 lv-cinder-volumes.sh[63624]:   Cannot process volume group cinder_volumes_vg
Mar 12 07:19:51 master-1 lv-cinder-volumes.sh[63628]:   Physical volume "/dev/vda" successfully created.
Mar 12 07:19:51 master-1 lv-cinder-volumes.sh[63631]:   Physical volume "/dev/vdb" successfully created.
Mar 12 07:19:51 master-1 lv-cinder-volumes.sh[63633]:   Volume group "cinder_volumes_vg" successfully created
Mar 12 07:19:51 master-1 lv-cinder-volumes.sh[63638]:   Logical volume "cinder-volumes" created.
Mar 12 07:19:51 master-1 systemd[1]: Finished Create logical volume with name cinder-volumes..
[root@master-1 ~]# 
[root@master-1 ~]# lvs
  LV             VG                Attr       LSize  Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
  cinder-volumes cinder_volumes_vg -wi-a----- 19.99g
---
[root@master-2 ~]# pvs
  PV         VG                Fmt  Attr PSize   PFree
  /dev/vda   cinder_volumes_vg lvm2 a--  <10.00g    0 
  /dev/vdb   cinder_volumes_vg lvm2 a--  <10.00g    0 
[root@master-2 ~]# vgs
  VG                #PV #LV #SN Attr   VSize  VFree
  cinder_volumes_vg   2   1   0 wz--n- 19.99g    0 
[root@master-2 ~]# lvs
  LV             VG                Attr       LSize  Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
  cinder-volumes cinder_volumes_vg -wi-a----- 19.99g                                                    
```