### PR TITLE
Adds a new single node HCI job

### DIFF
--- a/hooks/playbooks/control_plane_ceph_backends.yml
+++ b/hooks/playbooks/control_plane_ceph_backends.yml
@@ -22,7 +22,7 @@
 
     - name: Create kustomization to add Ceph as backend
       ansible.builtin.copy:
-        dest: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/controlplane/98-ceph-backends-kustomization.yaml"
+        dest: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/controlplane/90-ceph-backends-kustomization.yaml"
         content: |-
           apiVersion: kustomize.config.k8s.io/v1beta1
           kind: Kustomization
@@ -86,6 +86,10 @@
                   report_discard_supported=True
                   backend_host=hostgroup
                   rbd_secret_uuid={{ cifmw_ceph_fsid }}
+
+              - op: replace
+                path: /spec/glance/template/glanceAPIs/default/replicas
+                value: {{ cifmw_services_glance_apis_replicas | default(1) }}
 
               - op: add
                 path: /spec/glance/template/customServiceConfig

--- a/hooks/playbooks/control_plane_hci_pre_deploy.yml
+++ b/hooks/playbooks/control_plane_hci_pre_deploy.yml
@@ -1,0 +1,29 @@
+---
+- name: Kustomize ControlPlane for HCI deploy
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Ensure the kustomizations dir exists
+      ansible.builtin.file:
+        path: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/controlplane"
+        state: directory
+
+    - name: Create kustomization for HCI pre deploy step
+      ansible.builtin.copy:
+        dest: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/controlplane/95-hci-pre-kustomization.yaml"
+        content: |-
+          apiVersion: kustomize.config.k8s.io/v1beta1
+          kind: Kustomization
+          resources:
+          namespace: {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+          patches:
+          - target:
+              kind: OpenStackControlPlane
+            patch: |-
+              - op: replace
+                path: /spec/glance/template/glanceAPIs/default/replicas
+                value: 0
+
+              - op: replace
+                path: /spec/glance/template/glanceAPIs/default/type
+                value: split

--- a/scenarios/centos-9/ceph_backends.yml
+++ b/scenarios/centos-9/ceph_backends.yml
@@ -12,10 +12,10 @@ cifmw_make_ceph_environment:
   CEPH_DATASIZE: "10Gi"
 
 pre_deploy:
-  - name: Ceph deploy
+  - name: 61 Ceph deploy
     type: playbook
     source: ceph-deploy.yml
-  - name: Kustomize OpenStack CR with Ceph
+  - name: 62 Kustomize OpenStack CR with Ceph
     type: playbook
     source: control_plane_ceph_backends.yml
 

--- a/scenarios/centos-9/hci_ceph_backends.yml
+++ b/scenarios/centos-9/hci_ceph_backends.yml
@@ -5,13 +5,20 @@ cifmw_install_yamls_vars:
 
 cifmw_edpm_prepare_skip_crc_storage_creation: true
 
+pre_deploy:
+  - name: 61 HCI pre deploy kustomizations
+    type: playbook
+    source: control_plane_hci_pre_deploy.yml
+
 post_deploy:
-  - name: Kustomize OpenStack CR with Ceph
+  - name: 81 Kustomize OpenStack CR with Ceph
     type: playbook
     source: control_plane_ceph_backends.yml
-  - name: Kustomize and update Control Plane
+  - name: 82 Kustomize and update Control Plane
     type: playbook
     source: control_plane_kustomize_deploy.yml
+
+cifmw_block_device_size: 20G
 
 cifmw_services_manila_enabled: true
 

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -167,6 +167,84 @@
                 config_nm: false
 
 - job:
+    name: podified-multinode-hci-deployment-crc-1comp
+    parent: podified-multinode-edpm-deployment-crc
+    nodeset: centos-9-medium-centos-9-crc-extracted-2.30-3xl
+    vars:
+      cifmw_edpm_deploy_hci: true
+      cifmw_cephadm_single_host_defaults: true
+      crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"
+      crc_ci_bootstrap_networking:
+        networks:
+          default:
+            mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
+            router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            range: 192.168.122.0/24
+          internal-api:
+            vlan: 20
+            range: 172.17.0.0/24
+          storage:
+            vlan: 21
+            range: 172.18.0.0/24
+          tenant:
+            vlan: 22
+            range: 172.19.0.0/24
+          storage-mgmt:
+            vlan: 23
+            range: 172.20.0.0/24
+        instances:
+          controller:
+            networks:
+              default:
+                ip: 192.168.122.11
+          crc:
+            networks:
+              default:
+                ip: 192.168.122.10
+              internal-api:
+                ip: 172.17.0.5
+              storage:
+                ip: 172.18.0.5
+              tenant:
+                ip: 172.19.0.5
+              storage-mgmt:
+                ip: 172.20.0.5
+          compute-0:
+            networks:
+              default:
+                ip: 192.168.122.100
+              internal-api:
+                ip: 172.17.0.100
+                config_nm: false
+              storage:
+                ip: 172.18.0.100
+                config_nm: false
+              tenant:
+                ip: 172.19.0.100
+                config_nm: false
+              storage-mgmt:
+                ip: 172.20.0.100
+                config_nm: false
+
+# HCI jobs with Ceph backends
+- job:
+    name: podified-multinode-hci-deployment-crc-1comp-backends
+    parent: podified-multinode-hci-deployment-crc-1comp
+    description: |
+       EDPM multinode job that deploy a single HCI node and
+       configure storage backends (cinder, manila, glance) to
+       use Ceph.
+    vars:
+      cifmw_extras:
+        - '@scenarios/centos-9/multinode-ci.yml'
+        - '@scenarios/centos-9/hci_ceph_backends.yml'
+      # Manila still more fixes and tests to be enabled
+      cifmw_tempest_default_groups: &tempest_tests_single_hci
+        - keystone-operator
+        - cinder-operator
+      cifmw_tempest_default_jobs: *tempest_tests_single_hci
+
+- job:
     name: podified-multinode-edpm-deployment-crc
     parent: cifmw-podified-multinode-edpm-base-crc
     vars:


### PR DESCRIPTION
Adds a new single node HCI job and a job that uses the single
node HCI and configures control plane to use Ceph as backend.
Adds a pre_deploy kustomization for HCI environment, to set to
zero the number of GlanceAPIs replicas, since we can start it only
after deploying Ceph, in post_deploy phase.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
