### PR TITLE
[devscripts] Configure the firewall and iptables for user provided networks

### DIFF
--- a/roles/devscripts/README.md
+++ b/roles/devscripts/README.md
@@ -42,6 +42,9 @@ networks.
   assigned. Must be from the specified external network.
 * `cifmw_devscripts_use_static_ip_addr` (bool) Use static IP addresses for the
   OCP nodes. Defaults to `false`
+* `cifmw_devscripts_external_net` (dict) Key/value pair containing information
+  about the network infrastructure.
+  Refer [section](#supported-keys-in-cifmw_devscripts_external_net).
 
 ### Secrets management
 
@@ -118,6 +121,13 @@ If you provide neither, or both, it will fail.
 | extra_worker_memory_mb | |  The amount of memory to be set for the extra nodes. |
 | extra_worker_disk | | The disk size to be set for each extra nodes. |
 | extra_worker_vcpu | | The number of vCPUs to be configured for each extra nodes. |
+
+### Support keys in cifmw_devscripts_external_net
+
+| Key | Description |
+| --- | ----------- |
+| gw | IP address of the external network gateway. |
+| dns | IP address of the external DNS service. |
 
 ## Examples
 

--- a/roles/devscripts/tasks/133_host_network.yml
+++ b/roles/devscripts/tasks/133_host_network.yml
@@ -36,14 +36,84 @@
     name: ci_network
     tasks_from: apply-dns.yml
 
-- name: Ensure virtual networks are created.
+- name: Create and apply virtual network configuration.
+  become: true
   when:
     - cifmw_devscripts_config.manage_br_bridge is defined
     - cifmw_devscripts_config.manage_br_bridge == 'n'
   vars:
-    cifmw_libvirt_manager_net_prefix_add: false
-    _layout:
-      networks: "{{ cifmw_libvirt_manager_configuration.networks }}"
-  ansible.builtin.include_role:
-    name: libvirt_manager
-    tasks_from: create_networks.yml
+    _nets: >-
+      {{
+        cifmw_libvirt_manager_configuration.networks |
+        dict2items |
+        map(attribute='key') |
+        list
+      }}
+  block:
+    - name: Ensure br_netfilter module is loaded.
+      community.general.modprobe:
+        name: br_netfilter
+        state: present
+
+    - name: Ensure IP forwarding is enabled.
+      ansible.posix.sysctl:
+        name: net.ipv4.ip_forward
+        value: 1
+        state: present
+
+    - name: Ensure the required parameters are loaded.
+      ansible.posix.sysctl:
+        name: "net.bridge.bridge-nf-call-{{ item }}"
+        value: 0
+        state: present
+      loop:
+        - arptables
+        - iptables
+        - ip6tables
+      loop_control:
+        label: "{{ item }}"
+
+    - name: Ensure firewall service is enabled and started.
+      ansible.builtin.service:
+        name: firewalld
+        enabled: true
+        state: started
+
+    - name: Create the virtual networks.
+      vars:
+        cifmw_libvirt_manager_net_prefix_add: false
+        _layout:
+          networks: "{{ cifmw_libvirt_manager_configuration.networks }}"
+      ansible.builtin.include_role:
+        name: libvirt_manager
+        tasks_from: create_networks.yml
+
+    - name: Ensure masquerading for external network
+      become: true
+      vars:
+        ext_interface: >-
+          {{
+            ansible_default_ipv4.interface
+            if cifmw_devscripts_config.ip_stack == 'v4'
+            else
+            ansible_default_ipv6.interface
+          }}
+      ansible.builtin.iptables:
+        action: "insert"
+        chain: "POSTROUTING"
+        out_interface: "{{ ext_interface }}"
+        state: present
+        table: "nat"
+        jump: "MASQUERADE"
+
+    - name: Ensure forwarding of traffic to all networks.
+      become: true
+      ansible.builtin.iptables:
+        action: "insert"
+        chain: "FORWARD"
+        in_interface: "{{ item }}"
+        jump: "ACCEPT"
+        state: present
+      loop: "{{ _nets }}"
+      loop_control:
+        label: "{{ item }}"

--- a/roles/devscripts/tasks/138_static_ip_addr.yml
+++ b/roles/devscripts/tasks/138_static_ip_addr.yml
@@ -66,8 +66,16 @@
         default(omit) |
         ansible.utils.ipaddr('prefix')
       }}
-    dns_server: "{{ cifmw_devscripts_host_bm_net_ip_addr }}"
-    net_gateway: "{{ cifmw_devscripts_host_bm_net_ip_addr }}"
+    dns_server: >-
+      {{
+        cifmw_devscripts_external_net.dns |
+        default(cifmw_devscripts_host_bm_net_ip_addr)
+      }}
+    net_gateway: >-
+      {{
+        cifmw_devscripts_external_net.gw |
+        default(cifmw_devscripts_host_bm_net_ip_addr)
+      }}
   ansible.builtin.template:
     src: "templates/nmstate.j2"
     dest: >-
@@ -114,8 +122,16 @@
         default(omit) |
         ansible.utils.ipaddr('prefix')
       }}
-    dns_server: "{{ cifmw_devscripts_host_bm_net_ip_addr }}"
-    net_gateway: "{{ cifmw_devscripts_host_bm_net_ip_addr }}"
+    dns_server: >-
+      {{
+        cifmw_devscripts_external_net.dns |
+        default(cifmw_devscripts_host_bm_net_ip_addr)
+      }}
+    net_gateway: >-
+      {{
+        cifmw_devscripts_external_net.gw |
+        default(cifmw_devscripts_host_bm_net_ip_addr)
+      }}
   ansible.builtin.template:
     src: "templates/nmstate.j2"
     dest: >-

--- a/roles/libvirt_manager/tasks/create_networks.yml
+++ b/roles/libvirt_manager/tasks/create_networks.yml
@@ -80,3 +80,23 @@
   loop: "{{ networks }}"
   loop_control:
     label: "{{ item.name }}"
+
+- name: Gather the status of firewall service.
+  become: true
+  ansible.builtin.service:
+    name: firewalld
+  register: _fw_info
+
+- name: Ensure network is in libvirt zone
+  become: true
+  when:
+    - _fw_info.status.SubState | default('') == "running"
+  ansible.posix.firewalld:
+    zone: libvirt
+    interface: "{{ item.name }}"
+    state: enabled
+    permanent: true
+    immediate: true
+  loop: "{{ networks }}"
+  loop_control:
+    label: "{{ item.name }}"


### PR DESCRIPTION
dev-scripts based deployment relies on `firewalld` services for managing the network traffic. In this PR, we ensure the user managed (provided) networks are placed in `libvirt` zone. 

In case of user managed external network, ensure internet connectivity is available on this network by using `iptables`.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

*Testing Results of Hybrid scenario*
```
Tuesday 12 March 2024  23:10:08 -0400 (0:00:00.098)       0:21:05.884 ********* 
=============================================================================== 
openshift_adm : Wait until OCP login succeeds. -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 297.44s
reproducer : Bootstrap environment on controller-0 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 146.54s
reproducer : Install internal CA ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 71.23s
reproducer : Install some tools ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 71.00s
openshift_adm : Wait unit the OpenShift cluster is stable. --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 55.67s
reproducer : Install collections on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 40.95s
libvirt_manager : Prepare disk image with SSH and growing volume --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 38.47s
reproducer : Install ansible dependencies -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 27.32s
libvirt_manager : Grab IPs for nodes type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 26.36s
libvirt_manager : Wait for SSH on VMs type ocp --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 25.76s
devscripts : Login to the deployed OpenShift cluster. -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 19.44s
reproducer : Wait for OCP nodes to be ready ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 17.83s
networking_mapper : Ensure that networking and hostname facts are in place ----------------------------------------------------------------------------------------------------------------------------------------------------------- 15.39s
openshift_adm : Ensure the nodes are in ready state. --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 10.02s
libvirt_manager : Download base image ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 8.99s
libvirt_manager : Start VMs for type ocp ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 8.13s
reproducer : Enable RHEL repos -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 7.88s
ci_setup : Install needed packages ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 7.66s
networking_mapper : Write the Networking Environment Definition to file --------------------------------------------------------------------------------------------------------------------------------------------------------------- 6.25s
libvirt_manager : Configure ssh access on type ocp ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 6.25s
[ciuser@devci-01 ci-framework]$ 

```
