### PR TITLE
[libvirt_manager] Add support for setting static address

### DIFF
--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -90,6 +90,10 @@ cifmw_libvirt_manager_configuration:
       disksize: 50
       memory: 4
       cpus: 2
+      ip_address:
+        address: "192.168.111.9/24"
+        gw: "192.168.111.1"
+        dns: "192.168.111.1"
       nets:
         - public
         - osp_trunk

--- a/roles/libvirt_manager/defaults/main.yml
+++ b/roles/libvirt_manager/defaults/main.yml
@@ -64,3 +64,9 @@ cifmw_libvirt_manager_fixed_networks: []
 
 cifmw_libvirt_manager_reproducer_key_type: "{{ cifmw_ssh_keytype | default('ecdsa') }}"
 cifmw_libvirt_manager_reproducer_key_size: "{{ cifmw_ssh_keysize | default(521) }}"
+
+# VM sysprep IP configuration script
+cifmw_libvirt_manager_ip_script_basedir: >-
+  {{
+    (cifmw_libvirt_manager_basedir, 'artifacts') | ansible.builtin.path_join
+  }}

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -79,6 +79,27 @@
     user: "{{ ansible_user_id }}"
     key: "{{ pub_ssh_key['content'] | b64decode }}"
 
+- name: Prepare the static IP address for controller.
+  when:
+    - _layout.vms.controller.ip_address is defined
+  vars:
+    _ip_address: >-
+      {{
+        _layout.vms.controller.ip_address.address
+      }}
+    _ip_gw: "{{ _layout.vms.controller.ip_address.gw }}"
+    _ip_dns: "{{ _layout.vms.controller.ip_address.dns }}"
+  ansible.builtin.template:
+    src: templates/static_ip.j2
+    dest: >-
+      {{
+        (cifmw_libvirt_manager_ip_script_basedir, 'static-ip-controller.sh') |
+        ansible.builtin.path_join
+      }}
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_id }}"
+    mode: "0755"
+
 - name: Prepare disk image with SSH and growing volume  # noqa: risky-shell-pipe
   when:
     - item.value.disk_file_name != 'blank'
@@ -86,6 +107,13 @@
   vars:
     _admin_user: "{{ item.value.admin_user | default('root') }}"
     _root_part: "{{ item.value.root_part_id | default('1') }}"
+    _static_ip_script: >-
+      {{
+        (
+          cifmw_libvirt_manager_ip_script_basedir,
+          'static-ip-' + item.key + '.sh'
+        ) | ansible.builtin.path_join
+      }}
   ansible.builtin.shell:
     cmd: >-
       set -o pipefail;
@@ -93,6 +121,9 @@
       --selinux-relabel
       --firstboot-command "growpart /dev/sda {{ _root_part }}"
       --firstboot-command "xfs_growfs /"
+      {% if item.value.ip_address is defined %}
+      --firstboot {{ _static_ip_script }}
+      {% endif %}
       --root-password "password:{{ item.value.password | default('fooBar') }}"
       --ssh-inject {{ _admin_user }}:file:{{ ansible_user_dir }}/.ssh/authorized_keys
       | tee -a {{ item.value.image_local_dir }}/{{ item.value.disk_file_name }}.log

--- a/roles/libvirt_manager/templates/static_ip.j2
+++ b/roles/libvirt_manager/templates/static_ip.j2
@@ -1,0 +1,10 @@
+#!/usr/bin/bash
+nmcli connection add connection.type 802-3-ethernet \
+    connection.id eth0 \
+    connection.interface-name eth0 \
+    ipv4.method manual \
+    ipv4.addresses {{ _ip_address }} \
+    ipv4.gateway {{ _ip_gw }} \
+    ipv4.dns {{ _ip_dns }}
+
+nmcli connection up eth0


### PR DESCRIPTION
Support configuring of static IP address when the public DHCP server does not lease IP addresses to unknown MAC ranges or when there is no DHCP service available.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes

*Testing logs*
```
[   5.7] Setting a random seed
[   5.7] Setting the machine ID in /etc/machine-id
[   5.7] Installing firstboot command: growpart /dev/sda 4
[   5.7] Installing firstboot command: xfs_growfs /
[   5.8] Installing firstboot command: nmcli con add connection.type 802-3-ethernet connection.id eth0 connection.interface-name eth0 ipv4.method manual ipv4.addresses 192.168.51.9/24 ipv4.gateway 192.168.51.1 ipv4.dns 192.168.51.1
[   5.8] Installing firstboot command: nmcli connection up eth0
[   5.8] SSH key inject: root
[   7.4] Setting passwords
[   8.7] SELinux relabelling
[  24.3] Performing "lvm-uuids" ...
```

_Using firstboot_
```
[   5.3] Setting the machine ID in /etc/machine-id
[   5.3] Installing firstboot command: growpart /dev/sda 4
[   5.4] Installing firstboot command: xfs_growfs /
[   5.4] Installing firstboot script: /tmp/controller_0_static_ip.sh
[   5.4] SSH key inject: root
[   6.9] Setting passwords
[   8.2] SELinux relabelling
[  23.5] Performing "lvm-uuids" ...

# ping -c 1 192.168.51.9
PING 192.168.51.9 (192.168.51.9) 56(84) bytes of data.
64 bytes from 192.168.51.9: icmp_seq=1 ttl=64 time=0.334 ms

--- 192.168.51.9 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.334/0.334/0.334/0.000 ms

cat virt-sysprep-firstboot.log 
/usr/lib/virt-sysprep/firstboot.sh start
Scripts dir: /usr/lib/virt-sysprep/scripts
=== Running /usr/lib/virt-sysprep/scripts/5000-0001-growpart--dev-sda-4 ===
CHANGED: partition=4 start=1437696 old: size=19533791 end=20971486 new: size=103419871 end=104857566
=== Running /usr/lib/virt-sysprep/scripts/5000-0002-xfs_growfs-- ===
meta-data=/dev/sda4              isize=512    agcount=4, agsize=610431 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=0
         =                       reflink=1    bigtime=0 inobtcount=0
data     =                       bsize=4096   blocks=2441723, imaxpct=25
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1
log      =internal log           bsize=4096   blocks=2560, version=2
         =                       sectsz=512   sunit=0 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
data blocks changed from 2441723 to 12927483
=== Running /usr/lib/virt-sysprep/scripts/5000-0003--tmp-controller_0_static_ip-sh ===
Connection 'eth0' (0d6be120-03ac-43f9-81de-c62a7a0ae2f2) successfully added.
Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/4)
```