### PR TITLE
Retry SSH command execution after the VM is created.

### DIFF
--- a/roles/libvirt_manager/tasks/start_manage_vms.yml
+++ b/roles/libvirt_manager/tasks/start_manage_vms.yml
@@ -144,6 +144,10 @@
       set -o pipefail;
       cat ~/.ssh/authorized_keys |
       ssh {{ _user }}@{{ vm_ip.nic.host }} "cat >> ~/.ssh/authorized_keys"
+  retries: 5
+  delay: 10
+  register: _ssh_access
+  until: _ssh_access.rc == 0
   loop: "{{ vm_ips.results }}"
   loop_control:
     loop_var: "vm_ip"


### PR DESCRIPTION
In case of OpenShift nodes, the SSH access may not fully available despite port `22` is open. This patch adds a retry to avoid the below error

```
$ ssh -l core -i ~/ci-framework-data/artifacts/cifmw_ocp_access_key 192.168.111.20
Warning: Permanently added '192.168.111.20' (ED25519) to the list of known hosts.
"System is booting up. Unprivileged users are not permitted to log in yet. Please come back later. For technical details, see pam_nologin(8)."
Connection closed by 192.168.111.20 port 2
```

leading to the below failure

```
2024-03-10 23:42:51,905 p=174480 u=ciuser n=ansible | TASK [libvirt_manager : Configure ssh access on type ocp _raw_params=set -o pipefail; cat ~/.ssh/authorized_keys | ssh {{ _user }}@{{ vm_ip.nic.host }} "cat >> ~/.ssh/authorized_keys"] *****************************************************
2024-03-10 23:42:51,905 p=174480 u=ciuser n=ansible | Sunday 10 March 2024  23:42:51 -0400 (0:00:17.870)       1:07:47.011 **********
2024-03-10 23:42:53,117 p=174480 u=ciuser n=ansible | failed: [hypervisor] (item=ocp-0) => {"ansible_loop_var": "vm_ip", "changed": true, "cmd": "set -o pipefail; cat ~/.ssh/authorized_keys | ssh core@ocp-0 \"cat >> ~/.ssh/authorized_keys\"", "delta": "0:00:00.161749", "end": "2024-03-11 05:43:09.563884", "msg": "non-zero return code", "rc": 255, "start": "2024-03-11 05:43:09.402135", "stderr": "Warning: Permanently added '192.168.111.20' (ED25519) to the list of known hosts.\r\n\"System is booting up. Unprivileged users are not permitted to log in yet. Please come back later. For technical details, see pam_nologin(8).\"\nConnection closed by 192.168.111.20 port 22", "stderr_lines": ["Warning: Permanently added '192.168.111.20' (ED25519) to the list of known hosts.", "\"System is booting up. Unprivileged users are not permitted to log in yet. Please come back later. For technical details, see pam_nologin(8).\"", "Connection closed by 192.168.111.20 port 22"], "stdout": "", "stdout_lines": [], "vm_ip": {"ansible_loop_var": "nic", "attempts": 5, "changed": true, "cmd": "virsh -c qemu:///system -q domifaddr --source arp cifmw-ocp-0 | grep \"00:0e:61:ec:7a:57\"", "delta": "0:00:00.036544", "end": "2024-03-11 05:42:42.101050", "failed": false, "invocation": {"module_args": {"_raw_params": "virsh -c qemu:///system -q domifaddr --source arp cifmw-ocp-0 | grep \"00:0e:61:ec:7a:57\"", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "stdin_add_newline": true, "strip_empty_ends": true}}, "msg": "", "nic": {"driver": "virtio", "host": "ocp-0", "mac": "00:0e:61:ec:7a:57", "network": "ocpbm", "nic": "-", "type": "bridge"}, "rc": 0, "start": "2024-03-11 05:42:42.064506", "stderr": "", "stderr_lines": [], "stdout": " vnet15     00:0e:61:ec:7a:57    ipv4         192.168.111.20/0", "stdout_lines": [" vnet15     00:0e:61:ec:7a:57    ipv4         192.168.111.20/0"]}}
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

*Testing results*
```
2024-03-10 23:56:06,286 p=175696 u=ciuser n=ansible | TASK [libvirt_manager : Configure ssh access on type ocp _raw_params=set -o pipefail; cat ~/.ssh/authorized_keys | ssh {{ _user }}@{{ vm_ip.nic.host }} "cat >> ~/.ssh/authorized_keys"] *****************************************************
2024-03-10 23:56:06,286 p=175696 u=ciuser n=ansible | Sunday 10 March 2024  23:56:06 -0400 (0:00:17.889)       0:04:08.670 **********
2024-03-10 23:56:41,133 p=175696 u=ciuser n=ansible | changed: [hypervisor] => (item=ocp-0)
2024-03-10 23:56:42,192 p=175696 u=ciuser n=ansible | changed: [hypervisor] => (item=ocp-1)
2024-03-10 23:56:43,242 p=175696 u=ciuser n=ansible | changed: [hypervisor] => (item=ocp-2)
```