### PR TITLE
[repo_setup] Update generated repos with nodepool mirror repos

### DIFF
--- a/roles/repo_setup/tasks/ci_mirror.yml
+++ b/roles/repo_setup/tasks/ci_mirror.yml
@@ -1,0 +1,17 @@
+---
+- name: Check for /etc/ci/mirror_info.sh
+  ansible.builtin.stat:
+    path: "/etc/ci/mirror_info.sh"
+  register: mirror_path
+
+- name: Use proxy mirrors
+  become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"
+  when:
+    - mirror_path.stat.exists
+  ansible.builtin.shell: |
+    set -o pipefail
+    source /etc/ci/mirror_info.sh
+    sed -i -e "s|https://trunk.rdoproject.org|$NODEPOOL_RDO_PROXY|g" *.repo
+    sed -i -e "s|http://mirror.stream.centos.org|$NODEPOOL_CENTOS_MIRROR|g" *.repo
+  args:
+    chdir: "{{ cifmw_repo_setup_output }}"

--- a/roles/repo_setup/tasks/main.yml
+++ b/roles/repo_setup/tasks/main.yml
@@ -26,3 +26,5 @@
 - name: Generate downstream base os repos
   ansible.builtin.import_tasks: rhos_release.yml
   when: cifmw_repo_setup_enable_rhos_release | bool
+- name: Update generated repos with mirror repos
+  ansible.builtin.import_tasks: ci_mirror.yml


### PR DESCRIPTION
The nodepool mirror repos variables are stored in `/etc/ci/mirror_info.sh` file. Let's source this file and replace the centos and rdo trunk urls with nodepool provided mirror urls.

It will help to avoid mirror timeout issue in CI.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

Closes: https://issues.redhat.com/browse/OSPCIX-212
