### PR TITLE
[repo_setup] Sync generated repos to yum.repos.d directory

### DIFF
--- a/roles/repo_setup/tasks/main.yml
+++ b/roles/repo_setup/tasks/main.yml
@@ -28,3 +28,5 @@
   when: cifmw_repo_setup_enable_rhos_release | bool
 - name: Update generated repos with mirror repos
   ansible.builtin.import_tasks: ci_mirror.yml
+- name: Sync generated repos to yum.repos.d
+  ansible.builtin.import_tasks: sync_repos.yml

--- a/roles/repo_setup/tasks/sync_repos.yml
+++ b/roles/repo_setup/tasks/sync_repos.yml
@@ -1,0 +1,28 @@
+---
+- name: Copy generated repos to /etc/yum.repos.d directory
+  when: not cifmw_repo_setup_output.startswith(ansible_user_dir)
+  block:
+    - name: Find existing repos from /etc/yum.repos.d directory
+      ansible.builtin.find:
+        paths: "/etc/yum.repos.d/"
+        patterns: "*.repo"
+        recurse: false
+      register: _yum_repos
+
+    - name: Remove existing repos from /etc/yum.repos.d directory
+      become: true
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      with_items: "{{ _yum_repos.files|map(attribute='path') }}"
+
+    - name: Cleanup existing metadata
+      become: true
+      ansible.builtin.command: "dnf clean metadata"
+
+    - name: Copy generated repos to /etc/yum.repos.d directory
+      become: true
+      ansible.builtin.copy:
+        remote_src: true
+        src: "{{ cifmw_repo_setup_output }}/"
+        dest: "/etc/yum.repos.d"


### PR DESCRIPTION
We should always sync generated repos to yum.repos.d directory so that the deployment should install all content from same generated repos.

It also make sure that earlier yum contents are removed from /etc/yum.repos.d directory and metadata are cleaned.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1245

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

