### PR TITLE
[test-operator] Configure when test-operator asserts results

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -14,6 +14,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_default_groups`: (List) List of groups in the include list to search for tests to be executed. Default value: `[ 'default' ]`
 * `cifmw_test_operator_default_jobs`: (List) List of jobs in the exclude list to search for tests to be excluded. Default value: `[ 'default' ]`
 * `cifmw_test_operator_dry_run`: (Boolean) Whether test-operator should run or not. Default value: `false`
+* `cifmw_test_operator_fail_fast`: (Boolean) Whether the test results are evaluated when each test framework execution finishes or when all test frameworks are done. Default value: `false`
 
 ## Tempest specific parameters
 * `cifmw_test_operator_tempest_registry`: (String) The registry where to pull tempest container. Default value: `quay.io`

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -31,6 +31,7 @@ cifmw_test_operator_default_groups:
   - default
 cifmw_test_operator_default_jobs:
   - default
+cifmw_test_operator_fail_fast: false
 
 # Section 2: tempest parameters - used when run_test_fw is 'tempest'
 cifmw_test_operator_tempest_registry: quay.io

--- a/roles/test_operator/tasks/main.yml
+++ b/roles/test_operator/tasks/main.yml
@@ -149,3 +149,12 @@
 - name: Delete all resources created by the role
   ansible.builtin.include_tasks: cleanup.yml
   when: cifmw_test_operator_cleanup | bool and not cifmw_test_operator_dry_run | bool
+
+- name: Fail when any tests failed
+  when: not cifmw_test_operator_dry_run | bool
+  ansible.builtin.assert:
+    that:
+      - item.value == "Succeeded"
+    success_msg: "{{ item.key }} tests passed"
+    fail_msg: "{{ item.key }} tests failed"
+  loop: "{{ test_operator_results | default({}) | dict2items }}"

--- a/roles/test_operator/tasks/run-test-operator-job.yml
+++ b/roles/test_operator/tasks/run-test-operator-job.yml
@@ -153,11 +153,22 @@
     name: "{{ test_pod_name }}"
   when: not cifmw_test_operator_dry_run | bool
 
-- name: Fail if the pod did not succeed - {{ run_test_fw }}
-  when: not cifmw_test_operator_dry_run | bool
+- name: Fail fast if the pod did not succeed - {{ run_test_fw }}
+  when:
+    - not cifmw_test_operator_dry_run | bool
+    - cifmw_test_operator_fail_fast | bool
   ansible.builtin.assert:
     that:
       - test_pod.resources[0].status.phase == "Succeeded"
+
+- name: Save result - {{ run_test_fw }}
+  when: not cifmw_test_operator_dry_run | bool
+  ansible.builtin.set_fact:
+    test_operator_results: >-
+      {{
+          test_operator_results | default({}) |
+          combine({run_test_fw: test_pod.resources[0].status.phase})
+      }}
 
 - name: Delete tempest and/or tobiko pods
   when:


### PR DESCRIPTION
With this patch, when the test-operator runs tests from different test frameworks, by default the results are asserted when all the execution from all the tests frameworks is completed.
By configuring cifmw_test_operator_fail_fast to true, the role will raise an error as soon as tests from a test framework fail.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role

