### PR TITLE
Adding the capability of customize values.yaml for OLM resources

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/common/olm/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/common/olm/values.yaml.j2
@@ -1,0 +1,2 @@
+data:
+    openstack-operator-image: {{ cifmw_ci_gen_kustomize_values_ooi_image | default('quay.io/openstack-k8s-operators/openstack-operator-index:latest', true) }}

--- a/roles/kustomize_deploy/tasks/install_operators.yml
+++ b/roles/kustomize_deploy/tasks/install_operators.yml
@@ -14,6 +14,43 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Generate values.yaml for OLM resources
+  vars:
+    cifmw_architecture_scenario: 'common/olm'
+    cifmw_ci_gen_kustomize_values_src_file: >-
+      {{
+        (
+          cifmw_kustomize_deploy_olm_source_files,
+          'values.yaml') | path_join
+      }}
+    cifmw_ci_gen_kustomize_values_userdata: >-
+      {{
+        (
+          cifmw_architecture_user_kustomize is defined and
+          cifmw_architecture_user_kustomize['common']['olm-values'] is defined
+        ) |
+        ternary( cifmw_architecture_user_kustomize['common']['olm-values'], {} )
+      }}
+  ansible.builtin.include_role:
+    name: ci_gen_kustomize_values
+
+- name: Copy generated values.yaml for OLM resources
+  ansible.builtin.copy:
+    backup: true
+    remote_src: true
+    src: >-
+      {{
+        (cifmw_kustomize_deploy_basedir,
+          'artifacts', 'ci_gen_kustomize_values',
+          'olm-values', 'values.yaml') | path_join
+      }}
+    dest: >-
+      {{
+        (
+          cifmw_kustomize_deploy_olm_source_files,
+          'values.yaml'
+        ) | path_join
+      }}
 
 - name: Generate the OLM kustomization file
   ansible.builtin.copy:


### PR DESCRIPTION
Since we added the capability of customize OLM resources in the architecture repo, now we can use `ci_gen_kustomize_values` role to customize it for its usage in the `kustomize_deploy` role.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1251

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
