### PR TITLE
Sync repos only non yum.repos.d cifmw_repo_setup_output directory

### DIFF
--- a/roles/repo_setup/tasks/sync_repos.yml
+++ b/roles/repo_setup/tasks/sync_repos.yml
@@ -1,6 +1,6 @@
 ---
 - name: Copy generated repos to /etc/yum.repos.d directory
-  when: not cifmw_repo_setup_output.startswith(ansible_user_dir)
+  when: cifmw_repo_setup_output.startswith(ansible_user_dir)
   block:
     - name: Find existing repos from /etc/yum.repos.d directory
       ansible.builtin.find:


### PR DESCRIPTION
We need to sync repos in yum.repos.d directory only when cifmw_repo_setup_output is different from yum.repos.d directory.

Otherwise the job will fail with missing packages.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

