### PR TITLE
[polarion] Include last jump changes

### DIFF
--- a/roles/polarion/README.md
+++ b/roles/polarion/README.md
@@ -6,9 +6,11 @@ Role to setup jump tool and upload XML test results to Polarion.
 * `cifmw_polarion_jump_repo_dir`: (String) Jump repo directory. Defaults to `~/ci-framework-data/polarion-jump`.
 * `cifmw_polarion_jump_result_dir`: (String) Test results directory. Defaults to `~/ci-framework-data/tests/tempest/`.
 * `cifmw_polarion_jump_repo_url`: (String) URL of jump repository.
-* `cifmw_polarion_test_id`: (String) A test-id provided by Polarion test case.
+* `cifmw_polarion_testrun_id`: (String) A test run identification provided by Polarion test case.
 * `cifmw_polarion_update_testcases`: (Boolean) A value of True/False to update the testcases.
 * `cifmw_polarion_jump_extra_vars`: (String) A list of extra_vars that are being passed to the jump script. Defaults to empty.
+* `cifmw_polarion_use_stage`: (Bool) Flag for using the staging instance of Polarion. Default is False meaning the production instance gets updated. Don't forget to change for testing on stage instance.
+
 
 ## Examples
 ```YAML
@@ -16,8 +18,9 @@ Role to setup jump tool and upload XML test results to Polarion.
   hosts: localhost
   vars:
     cifmw_polarion_jump_repo_url: "https://example.com/repo.git"
-    cifmw_polarion_test_id: "20230101-0001"
+    cifmw_polarion_testrun_id: "20230101-0001"
     cifmw_polarion_update_testcases: true
+    cifmw_polarion_use_stage: true  # uploading to the staging instance
     cifmw_polarion_jump_extra_vars: >-
       "--dfg '' --jenkins_build_url='' --puddle-id='' --custom-fields build='' --remove-old-tests='' --update-existing-test-cases=''"
   roles:

--- a/roles/polarion/defaults/main.yml
+++ b/roles/polarion/defaults/main.yml
@@ -22,3 +22,4 @@ cifmw_polarion_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-fram
 cifmw_polarion_jump_repo_dir: "{{ cifmw_polarion_basedir }}/polarion-jump"
 cifmw_polarion_jump_result_dir: "{{ cifmw_polarion_basedir }}/tests/tempest/"
 cifmw_polarion_jump_repo_branch: "master"
+cifmw_polarion_use_stage: false

--- a/roles/polarion/tasks/main.yml
+++ b/roles/polarion/tasks/main.yml
@@ -18,7 +18,7 @@
   ansible.builtin.assert:
     that:
       - cifmw_polarion_jump_repo_url is defined and cifmw_polarion_jump_repo_url != ""
-      - cifmw_polarion_test_id is defined and cifmw_polarion_test_id != ""
+      - cifmw_polarion_testrun_id is defined and cifmw_polarion_testrun_id != ""
       - cifmw_polarion_update_testcases is defined and cifmw_polarion_update_testcases | bool
 
 - name: Ensure deps are installed
@@ -66,6 +66,7 @@
 
     - name: Use polarion-staging
       when:
+        - cifmw_polarion_use_stage
         - cifmw_polarion_fqdn is defined and cifmw_polarion_fqdn != ""
         - cifmw_polarion_stage_fqdn is defined and cifmw_polarion_stage_fqdn != ""
       ansible.builtin.replace:
@@ -73,7 +74,6 @@
         regexp: "{{ cifmw_polarion_fqdn }}"
         replace: "{{ cifmw_polarion_stage_fqdn }}"
       loop:
-        - "helpers.py"
         - ".pylero"
 
     - name: Run prepare_pylero.sh
@@ -97,10 +97,10 @@
         cmd: >-
           source "{{ cifmw_polarion_jump_repo_dir }}/jump-venv/bin/activate" &&
           {{ cifmw_polarion_jump_repo_dir }}/jump-venv/bin/python jump.py
-            --testrun-id={{ cifmw_polarion_test_id }}
-            --xml-file={{ found_xml_files }}
-            --update_testcases={{ cifmw_polarion_update_testcases | default(false) }}
-            {{ cifmw_polarion_jump_extra_vars | default ('') }}
+          --testrun-id={{ cifmw_polarion_testrun_id }}
+          --xml-file={{ found_xml_files }}
+          --update_testcases={{ cifmw_polarion_update_testcases | default(false) }}
+          {{ cifmw_polarion_jump_extra_vars | default ('') }}
       register: jump_script
 
     - name: Output of jump


### PR DESCRIPTION
- The helpers.py does not need to be updated for switching between stage and production.
- Also added a parameter for explicit using the stage Polarion instance.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
