### PR TITLE
Rework a bit conditions on playbook imports

### DIFF
--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -38,15 +38,11 @@
     - build-operators
 
 - name: Import deploy edpm playbook
-  when:
-    - cifmw_architecture_scenario is undefined
   ansible.builtin.import_playbook: playbooks/06-deploy-edpm.yml
   tags:
     - edpm
 
 - name: Import VA deployment playbook
-  when:
-    - cifmw_architecture_scenario is defined
   ansible.builtin.import_playbook: playbooks/06-deploy-architecture.yml
   tags:
     - edpm
@@ -61,8 +57,6 @@
   vars:
     pre_tests: "{{ (lookup('vars', 'pre_tempest', default=[])) }}"
     post_tests: "{{ (lookup('vars', 'post_tempest', default=[])) }}"
-  when:
-    - cifmw_run_tests | default('false') | bool
   tags:
     - run-tests
 
@@ -76,6 +70,5 @@
 
 - name: Run log related tasks
   ansible.builtin.import_playbook: playbooks/99-logs.yml
-  when: not zuul_log_collection | default('false') | bool
   tags:
     - logs

--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -1,5 +1,7 @@
 ---
 - name: Run pre_deploy hooks
+  when:
+    - cifmw_architecture_scenario is defined
   vars:
     step: pre_deploy
   ansible.builtin.import_playbook: ./hooks.yml
@@ -7,6 +9,12 @@
 - name: Deploy VA
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   tasks:
+    # end_play will end only current play, not the main edpm-deploy.yml
+    - name: Early end if not architecture deploy
+      when:
+        - cifmw_architecture_scenario is not defined
+      ansible.builtin.meta: end_play
+
     - name: Load Networking Environment Definition
       ansible.builtin.include_role:
         name: networking_mapper
@@ -117,6 +125,8 @@
         nova-manage cell_v2 discover_hosts --verbose
 
 - name: Run post_deploy hooks
+  when:
+    - cifmw_architecture_scenario is defined
   vars:
     step: post_deploy
   ansible.builtin.import_playbook: ./hooks.yml

--- a/playbooks/06-deploy-edpm.yml
+++ b/playbooks/06-deploy-edpm.yml
@@ -1,4 +1,7 @@
+---
 - name: Run pre_deploy hooks
+  when:
+    - cifmw_architecture_scenario is not defined
   vars:
     step: pre_deploy
   ansible.builtin.import_playbook: ./hooks.yml
@@ -7,6 +10,12 @@
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
+    # end_play will end only current play, not the main edpm-deploy.yml
+    - name: Early end if architecture deploy
+      when:
+        - cifmw_architecture_scenario is defined
+      ansible.builtin.meta: end_play
+
     - name: Load parameters files
       ansible.builtin.include_vars:
         dir: "{{ cifmw_basedir }}/artifacts/parameters"
@@ -20,6 +29,8 @@
         name: edpm_prepare
 
 - name: Run post_ctlplane_deploy hooks
+  when:
+    - cifmw_architecture_scenario is undefined
   vars:
     step: post_ctlplane_deploy
   ansible.builtin.import_playbook: ./hooks.yml
@@ -28,6 +39,12 @@
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
+    # end_play will end only current play, not the main edpm-deploy.yml
+    - name: Early end if architecture deploy
+      when:
+        - cifmw_architecture_scenario is defined
+      ansible.builtin.meta: end_play
+
     - name: Load parameters files
       ansible.builtin.include_vars:
         dir: "{{ cifmw_basedir }}/artifacts/parameters"
@@ -43,6 +60,12 @@
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
+    # end_play will end only current play, not the main edpm-deploy.yml
+    - name: Early end if architecture deploy
+      when:
+        - cifmw_architecture_scenario is defined
+      ansible.builtin.meta: end_play
+
     - name: Load parameters files
       ansible.builtin.include_vars:
         dir: "{{ cifmw_basedir }}/artifacts/parameters"
@@ -73,22 +96,36 @@
 - name: Clear ceph target hosts facts to force refreshing in HCI deployments
   hosts: "{{ cifmw_ceph_target | default('computes')  }}"
   tasks:
+    # end_play will end only current play, not the main edpm-deploy.yml
+    - name: Early end if architecture deploy
+      when:
+        - cifmw_architecture_scenario is defined
+      ansible.builtin.meta: end_play
+
     - name: Clear ceph target hosts facts
       when: cifmw_edpm_deploy_hci | default('false') | bool
       ansible.builtin.meta: clear_facts
 
 - name: Deploy Ceph on target nodes
+  when:
+    - cifmw_edpm_deploy_hci | default('false') | bool
+    - cifmw_architecture_scenario is undefined
   vars:
     ceph_spec_fqdn: true
     storage_network_range: 172.18.0.0/24
     storage_mgmt_network_range: 172.20.0.0/24
   ansible.builtin.import_playbook: ceph.yml
-  when: cifmw_edpm_deploy_hci | default('false') | bool
 
 - name: Continue HCI deploy
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
+    # end_play will end only current play, not the main edpm-deploy.yml
+    - name: Early end if architecture deploy
+      when:
+        - cifmw_architecture_scenario is defined
+      ansible.builtin.meta: end_play
+
     - name: Create Ceph secrets and retrieve FSID info
       when: cifmw_edpm_deploy_hci | default('false') | bool
       block:
@@ -104,6 +141,8 @@
             cifmw_edpm_deploy_prepare_run: false
 
 - name: Run post_deploy hooks
+  when:
+    - cifmw_architecture_scenario is not defined
   vars:
     step: post_deploy
   ansible.builtin.import_playbook: ./hooks.yml

--- a/playbooks/08-run-tests.yml
+++ b/playbooks/08-run-tests.yml
@@ -7,6 +7,12 @@
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
+    # end_play will end only current play, not the main edpm-deploy.yml
+    - name: Early exit if no tests
+      when:
+        - not cifmw_run_tests | default('false') | bool
+      ansible.builtin.meta: end_play
+
     - name: "Run tests"
       tags:
         - tests

--- a/playbooks/99-logs.yml
+++ b/playbooks/99-logs.yml
@@ -2,6 +2,12 @@
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: true
   tasks:
+    # end_play will end only current play, not the main edpm-deploy.yml
+    - name: Early exit if no tests
+      when:
+        - zuul_log_collection | default('false') | bool
+      ansible.builtin.meta: end_play
+
     - name: Ensure cifmw_basedir param is set
       when:
         - cifmw_basedir is not defined


### PR DESCRIPTION
With import_*, the catalog is built with all the content flattened, and
any conditions or vars/environment are applied on any of the flattened
content.

This means ansible will go through all of the tasks in the included
playbooks and "skip" them - instead of skipping the playbook import.

This patch should make things slightly more readable in the logs, with
an early end_play whenever we're able to apply it.

Note about the (pre|post)_deploy hooks:
we can't move them to the main `deploy-edpm.yml` playbook, because the
`06-deploy-edpm.yml` sub-play is directly imported in the adoption jobs.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
