### PR TITLE
Generate a script for deploy-edpm.yml run

### DIFF
--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -134,3 +134,19 @@
       when:
         - cifmw_architecture_scenario is defined
       ansible.builtin.include_tasks: configure_architecture.yml
+
+    - name: Prepare ci-like EDPM deploy
+      ansible.builtin.copy:
+        dest: "/home/zuul/deploy-edpm.sh"
+        mode: "0755"
+        owner: "zuul"
+        group: "zuul"
+        content: |-
+          #!/bin/bash
+          pushd src/github.com/openstack-k8s-operators/ci-framework
+          export ANSIBLE_LOG_PATH="~/ansible-deploy-edpm.log"
+          ansible-playbook deploy-edpm.yml \
+            -e @scenarios/centos-9/base.yml \
+            -e @scenarios/centos-9/edpm_ci.yml \
+            -e cifmw_openshift_password=12345678 $@
+          popd


### PR DESCRIPTION
This deploy-edpm.yml run is the easiest one: it will be a "close to CI"
deployment, without much specificities.

It will NOT deploy any VA/DT - just plain edpm, like we'd do in
install_yamls project.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
