### PR TITLE
Keep epel repo dependency in rescue mode for openstack_buid_packages role

### DIFF
--- a/roles/build_openstack_packages/tasks/install_dlrn.yml
+++ b/roles/build_openstack_packages/tasks/install_dlrn.yml
@@ -14,33 +14,25 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Install epel-release repo
-  become: true
-  tags:
-    - bootstrap
-    - packages
-  ansible.builtin.package:
-    state: present
-    name: epel-release
-  when: ansible_distribution | lower == 'centos'
-
 - name: Install mock
-  become: true
   tags:
     - bootstrap
     - packages
-  ansible.builtin.package:
-    state: present
-    name: mock
+  block:
+    - name: Install Mock from DLRN repos
+      become: true
+      ansible.builtin.package:
+        name: mock
+        state: present
 
-- name: Remove epel-repos
-  become: true
-  tags:
-    - bootstrap
-    - packages
-  ansible.builtin.shell: |
-    sudo rm -rf /etc/yum.repos.d/epel*;
-    sudo rpm -e epel-release || true;
+  rescue:
+    - name: Install mock from epel repos
+      vars:
+        cifmw_ci_setup_epel_pkgs:
+          - mock
+      ansible.builtin.import_role:
+        name: ci_setup
+        tasks_from: epel.yml
 
 - name: Ensure DLRN package dependencies
   become: true

--- a/roles/ci_setup/tasks/epel.yml
+++ b/roles/ci_setup/tasks/epel.yml
@@ -6,12 +6,9 @@
 
 - name: Install EPEL
   become: true
-  vars:
-    rhel_uri: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
-    pkg: "{{ (ansible_facts['distribution'] == 'RedHat') | ternary(rhel_uri, 'epel-release')}}"
   ansible.builtin.dnf:
-    name: "{{ pkg }}"
-    disable_gpg_check: "{{ (pkg != 'epel-release') }}"
+    name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
+    disable_gpg_check: false
 
 - name: Deactivate all of EPEL repositories
   become: true

--- a/zuul.d/tcib.yaml
+++ b/zuul.d/tcib.yaml
@@ -3,7 +3,7 @@
     name: cifmw-tcib-base
     parent: container-tcib-build-base
     timeout: 3500
-    nodeset: centos-stream-9
+    nodeset: centos-stream-9-vexxhost
     required-projects:
       - opendev.org/zuul/zuul-jobs
       - github.com/openstack-k8s-operators/ci-framework


### PR DESCRIPTION
Mock package is needed by dlrn to build openstack package and is shipped by delorean-antelope-build-deps repo.
    
Rest of the deps is already provided by repo-setup repos. So we donot need to enable repos here.

This pr move the epel package installation in rescue mode.
  
https://github.com/openstack-k8s-operators/ci-framework/pull/1246 syncs the repo-setup repos to /etc/yum.repos.d directory and drops existing repos.
    
epel-release package comes from extra-commons centos repo defined in centos-addons.repo. Since repo-setup deletes the existing repos. So the epel-release package installation fails which is expected.
    
In order to fix, we are going to install epel-release from urlinstead of packages.


As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

