### PR TITLE
Rework include/import usage in reproducer role

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -158,7 +158,7 @@
         dest: "/home/zuul/.kube/config"
         content: >-
           {{
-            (cifmw_use_devscripts | default(false) | bool) |
+            (cifmw_libvirt_manager_configuration.vms.ocp is defined) |
             ternary(_devscripts_kubeconfig.content, _crc_kubeconfig.content) |
             b64decode
           }}

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -25,9 +25,9 @@
   ansible.builtin.assert:
     that:
       - (cifmw_libvirt_manager_configuration.vms.crc is defined) or
-        (cifmw_use_devscripts | default(false) | bool)
+        (cifmw_libvirt_manager_configuration.vms.ocp is defined)
       - not ((cifmw_libvirt_manager_configuration.vms.crc is defined) and
-             (cifmw_use_devscripts | default(false) | bool))
+             (cifmw_libvirt_manager_configuration.vms.ocp is defined))
     quiet: true
     msg: >-
       You cannot get both OpenShift cluster types.
@@ -46,14 +46,14 @@
 - name: Load CI job environment
   when:
     - cifmw_job_uri is defined
-  ansible.builtin.import_tasks: ci_data.yml
+  ansible.builtin.include_tasks: ci_data.yml
 
 - name: Bootstrap libvirt if needed
   tags:
     - bootstrap_libvirt
   when:
     - cifmw_use_libvirt | default(false) | bool
-  ansible.builtin.import_role:
+  ansible.builtin.include_role:
     name: libvirt_manager
 
 - name: Deploy CRC if needed
@@ -68,7 +68,7 @@
     - bootstrap
     - bootstrap_layout
     - crc_layout
-  ansible.builtin.import_tasks: crc_layout.yml
+  ansible.builtin.include_tasks: crc_layout.yml
 
 - name: Consume dev-scripts for OCP cluster
   when:
@@ -81,7 +81,7 @@
   tags:
     - bootstrap
     - boostrap_layout
-  ansible.builtin.import_tasks: devscripts_layout.yml
+  ansible.builtin.include_tasks: devscripts_layout.yml
 
 - name: Consume libvirt_manager
   when:
@@ -89,7 +89,7 @@
   tags:
     - bootstrap
     - bootstrap_layout
-  ansible.builtin.import_tasks: libvirt_layout.yml
+  ansible.builtin.include_tasks: libvirt_layout.yml
 
 - name: Run only on hypervisor with controller-0
   when:
@@ -103,7 +103,7 @@
       tags:
         - bootstrap_repositories
         - bootstrap
-      ansible.builtin.import_tasks: push_code.yml
+      ansible.builtin.include_tasks: push_code.yml
 
     - name: Rotate some logs
       tags:
@@ -128,9 +128,9 @@
     - name: Emulate CI job
       when:
         - cifmw_job_uri is defined
-      ansible.builtin.import_tasks: ci_job.yml
+      ansible.builtin.include_tasks: ci_job.yml
 
     - name: Prepare VA deployment
       when:
         - cifmw_architecture_scenario is defined
-      ansible.builtin.import_tasks: configure_architecture.yml
+      ansible.builtin.include_tasks: configure_architecture.yml

--- a/scenarios/reproducers/3-nodes.yml
+++ b/scenarios/reproducers/3-nodes.yml
@@ -12,6 +12,7 @@ cifmw_rhol_crc_config:
   memory: 24000
 
 cifmw_use_libvirt: true
+cifmw_libvirt_manager_compute_amount: 1
 cifmw_libvirt_manager_configuration:
   vms:
     compute:

--- a/scenarios/reproducers/validated-architecture-1.yml
+++ b/scenarios/reproducers/validated-architecture-1.yml
@@ -62,6 +62,7 @@ cifmw_tempest_tests_allowed:
 # provides access to Internet. This will be the equivalent of the
 # "public network" as seen in CI.
 cifmw_use_libvirt: true
+cifmw_libvirt_manager_compute_amount: 3
 cifmw_libvirt_manager_configuration:
   networks:
     osp_trunk: |


### PR DESCRIPTION
In order to make the whole reproducer slightly faster, a small rework in
the way we call roles has to be done.

`import_role` and `import_tasks` are embedding the content while building
the catalog, at the very beginning, and any `when` conditions are then
added to the subsequent tasks, leading to a lot of tasks being evaluated
and "skipped", clogging the logs and taking more time than necessary.

Switching "conditioned" imports to `include` are ensuring we don't face
that same behavior.

With this, we need to set the `cifmw_libvirt_manager_compute_amount`
parameter in the scenario files, since the libvirt_manager role isn't
*imported* anymore, but dynamically included.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
