### PR TITLE
[DNM] Debug playbook hook failures

### DIFF
--- a/roles/run_hook/tasks/playbook.yml
+++ b/roles/run_hook/tasks/playbook.yml
@@ -82,7 +82,7 @@
 # is to call a command. Though we may lose some of the data passed to the
 # "main" play.
 - name: "Run {{ hook.name }}"
-  no_log: true
+  no_log: false
   cifmw.general.ci_script:
     output_dir: "{{ cifmw_basedir }}/artifacts"
     extra_args:


### PR DESCRIPTION
Disable no_log: true to triage issues with underlying playbook hook calls in CI.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
