### PR TITLE
[ci_script] Print log location to allow easy following of it

### DIFF
--- a/tests/integration/targets/script/tasks/main.yml
+++ b/tests/integration/targets/script/tasks/main.yml
@@ -73,25 +73,25 @@
 - name: Set files attributes
   ansible.builtin.set_fact:
     files_to_check:
-      "/tmp/artifacts/ci_script_008_run_simple_no_failing_script.sh":
-        bc43101e80bb1eff0c49d572fb20527c7e3a9d0b
-      "/tmp/artifacts/ci_script_009_run_simple_failing_script.sh":
-        dba40c73eb61fbf09c40da7f66b67d78953f1fcf
-      "/tmp/artifacts/ci_script_010_run_with_global_debug_enabled.sh":
-        defedbe625d823d0d499bb8b2f8d893df15649b9
-      "/tmp/artifacts/ci_script_011_run_with_action_debug_enabled.sh":
-        009a5da41869d419c24c305ad6cbe4c644f9aea5
-      "/tmp/artifacts/ci_script_012_run_using_chdir_option.sh":
-        26a353fd5989a27902412fcd20891d584cb1050f
-      "/tmp/logs/ci_script_008_run_simple_no_failing_script.log":
+      "/tmp/artifacts/ci_script_008_run_simple_no_failing.sh":
+        65f8bf5f39f42bef9d127cdaee5dba2ff5319ea3
+      "/tmp/artifacts/ci_script_009_run_simple_failing.sh":
+        020d32682ff902f46f987e9e31a00c4202918f94
+      "/tmp/artifacts/ci_script_010_run_with_global_debug.sh":
+        70b4ea1a3e5190a4cfb0d405fbf7182c56dce9b3
+      "/tmp/artifacts/ci_script_011_run_with_action_debug.sh":
+        71ec17b1f9e674261c18d8103aedd0e0ddbdc3bd
+      "/tmp/artifacts/ci_script_012_run_using_chdir.sh":
+        1364e7f0a086c27267fa7dea9c919d9d7d127224
+      "/tmp/logs/ci_script_008_run_simple_no_failing.log":
         1382103331d56fa62a3f0b12388aad5cdb36389d
-      "/tmp/logs/ci_script_009_run_simple_failing_script.log":
+      "/tmp/logs/ci_script_009_run_simple_failing.log":
         67dd35c6c747cc9614633e32694fe9eb5e4a53d1
-      "/tmp/logs/ci_script_010_run_with_global_debug_enabled.log":
+      "/tmp/logs/ci_script_010_run_with_global_debug.log":
         b76a03852f2d614a63af5bc6ac3e9d61a113a34b
-      "/tmp/logs/ci_script_011_run_with_action_debug_enabled.log":
+      "/tmp/logs/ci_script_011_run_with_action_debug.log":
         bb7199b9b6842f10081dc307e0fe4cf9d0ef340a
-      "/tmp/logs/ci_script_012_run_using_chdir_option.log":
+      "/tmp/logs/ci_script_012_run_using_chdir.log":
         3588d48b41e8aa6b8e19f3507abfd8770aba7f6d
       "/tmp/dummy/test/test-file.txt":
         cff41d666ec6fd5404d5d2fd89136a40ba43671e


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date