### PR TITLE
Adapt VA-HCI for shiftstack

### DIFF
--- a/reproducer.yml
+++ b/reproducer.yml
@@ -55,3 +55,10 @@
   roles:
     - role: ci_setup
     - role: reproducer
+
+  post_tasks:
+    - name: Allow traffic from OSP VMs to OSP API (needed for shiftstack)
+      become: true
+      when: cifmw_allow_vms_to_reach_osp_api | default ('false') | bool
+      ansible.builtin.command: # noqa: command-instead-of-module
+        cmd: iptables -I LIBVIRT_FWI 1 -o ocpbm -j ACCEPT

--- a/scenarios/reproducers/shift-on-stack-overrides.yml
+++ b/scenarios/reproducers/shift-on-stack-overrides.yml
@@ -1,0 +1,6 @@
+cifmw_libvirt_manager_compute_disksize: 200
+cifmw_libvirt_manager_compute_memory: 50
+cifmw_libvirt_manager_compute_cpus: 8
+cifmw_allow_vms_to_reach_osp_api: true
+# HCI requires bigger size to hold OCP on OSP disks
+cifmw_block_device_size: 100G

--- a/scenarios/reproducers/va-hci.yml
+++ b/scenarios/reproducers/va-hci.yml
@@ -89,9 +89,9 @@ cifmw_libvirt_manager_configuration:
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"
       disk_file_name: "base-os.qcow2"
-      disksize: 50
-      memory: 8
-      cpus: 4
+      disksize: "{{ [cifmw_libvirt_manager_compute_disksize|int, 50] | max }}"
+      memory: "{{ [cifmw_libvirt_manager_compute_memory|int, 8] | max }}"
+      cpus: "{{ [cifmw_libvirt_manager_compute_cpus|int, 4] | max }}"
       nets:
         - ocpbm
         - osp_trunk


### PR DESCRIPTION
Adapt reproducer to include the needed changes to support openshift as workload on RHOSP18.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
