### PR TITLE
add log collection for systemd services on edpm nodes

### DIFF
--- a/roles/artifacts/tasks/edpm.yml
+++ b/roles/artifacts/tasks/edpm.yml
@@ -63,7 +63,7 @@
         output_dir: "{{ cifmw_artifacts_basedir }}/artifacts"
         script: |-
           ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-            -i {{ ssh_key_file }} {{ ssh_user }}@{{ host_ip }} <<EOF
+            -i {{ ssh_key_file }} {{ ssh_user }}@{{ host_ip }} <<'EOF'
           set -x
           sudo dnf install -y rsync
           mkdir -p /tmp/{{ host_ip }}
@@ -81,6 +81,8 @@
           sudo ip ro ls >> /tmp/{{ host_ip }}/network.txt
           sudo rpm -qa > /tmp/{{ host_ip }}/rpm_qa.txt
           sudo podman images > /tmp/{{ host_ip }}/podman_images.txt
+          mkdir -p /tmp/{{ host_ip }}/service_logs
+          systemctl list-units | awk '/virt|edpm/ {print $1}' | grep -v sys | xargs -I {} sudo bash -c 'journalctl -u {} > /tmp/{{ host_ip }}/service_logs/{}.log'
           sudo ausearch -i | grep denied > /tmp/{{ host_ip }}/selinux-denials.log || true
           sudo journalctl -p warning -t kernel -o short -g DROPPING --no-pager &> /tmp/{{ host_ip }}/firewall-drops.txt || true
           EOF


### PR DESCRIPTION
the edpm node contaienr and host service are now configured to log to the
journal instead of a file. while we do collect /var/log/messages which provides
a combined log that can be less easy to read without downloading it locally
when browsing ci logs.

This change add addtional log collection of each edpm* and *virt* systemd
service and outputs each to there own file for eaiser consumtion in the
the zuul web ui.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
