### PR TITLE
[ci_setup] Fix error pertaining to GPG signature keys for EPEL repositories.

### DIFF
--- a/roles/ci_setup/tasks/epel.yml
+++ b/roles/ci_setup/tasks/epel.yml
@@ -8,7 +8,7 @@
   become: true
   ansible.builtin.dnf:
     name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
-    disable_gpg_check: false
+    disable_gpg_check: true
 
 - name: Deactivate all of EPEL repositories
   become: true


### PR DESCRIPTION
This change should resolve the below error

```
TASK [ci_setup : Install EPEL] *************************************************
fatal: [instance]: FAILED! => changed=false
  msg: 'Failed to validate GPG signature for epel-release-9-7.el9.noarch: Public key for epel-release-latest-9.noarch10woiruw.rpm is not installed'
```
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
