### PR TITLE
Allow users to inject their own custom hooks

### DIFF
--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -38,13 +38,13 @@
       loop_control:
         label: "{{ item.stat.path | default('none') | basename }}"
 
-    - name: "Executing pre_deploy step for {{ stage.path }}"
+    - name: "Executing pre_stage hooks for {{ stage.path }}"
       when:
         - not cifmw_kustomize_deploy_generate_crs_only | bool
         - stage.pre_stage_run is defined
       vars:
         hooks: "{{ stage.pre_stage_run }}"
-        step: "pre_stage_run"
+        step: "pre_stage_{{ stage_id }}_run"
       ansible.builtin.include_role:
         name: run_hook
 
@@ -182,12 +182,12 @@
       ansible.builtin.fail:
         msg: "Failing on demand {{ cifmw_deploy_architecture_stopper }}"
 
-    - name: "Executing post_deploy step for {{ stage.path }}"
+    - name: "Executing post_stage hooks for {{ stage.path }}"
       when:
         - not cifmw_kustomize_deploy_generate_crs_only | bool
         - stage.post_stage_run is defined
       vars:
         hooks: "{{ stage.post_stage_run }}"
-        step: "post_stage_run"
+        step: "post_stage_{{ stage_id }}_run"
       ansible.builtin.include_role:
         name: run_hook


### PR DESCRIPTION
This change empowers users with custom hooks injections during specific
stages in the Architecture deployment loop.

For instance, if a user wants to add their own hook as a "pre_stage",
for stage_id 2, they can create a custom parameter named:
`pre_stage_2_run_my_super_hook`. It will then be injected directly in
the existing pre_hook list of the stage.

If the user uses an index (0-9+ or a-z+) in the hook name, they can even ensure
the place their hook kicks in in the hook list:
`pre_stage_2_run_00_my_super_hook` has all the chances to be the very
first one, while `pre_stage_2_run_ZZ_my_super_hook` would be the last
one to run.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
