### PR TITLE
Copy ansible logs from user's home dir to artifacts log dir

### DIFF
--- a/roles/artifacts/tasks/ansible_logs.yml
+++ b/roles/artifacts/tasks/ansible_logs.yml
@@ -1,0 +1,13 @@
+---
+- name: Generate list of ansible logs to collect in home directory
+  ansible.builtin.find:
+    paths: "{{ ansible_user_dir }}"
+    patterns: "*ansible*.log"
+  register: files_to_copy
+
+- name: Copy ansible logs to logs directory
+  ansible.builtin.copy:
+    src: "{{ item.path }}"
+    dest: "{{ cifmw_artifacts_basedir }}/logs/"
+    remote_src: true
+  loop: "{{ files_to_copy.files }}"

--- a/roles/artifacts/tasks/main.yml
+++ b/roles/artifacts/tasks/main.yml
@@ -74,6 +74,9 @@
   ignore_errors: true  # noqa: ignore-errors
   ansible.builtin.import_tasks: edpm.yml
 
+- name: Copy ansible logs
+  ansible.builtin.import_tasks: ansible_logs.yml
+
 - name: Ensure we have proper rights on the gathered content
   ignore_errors: true  # noqa: ignore-errors
   become: true


### PR DESCRIPTION
We run artifacts role on controller-0 in the BM reproducer job. We generate different ansible log files for nested ansible call done via reproducer.

This pr will help to collect these logs in the log collection and make debugging easier.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

