### PR TITLE
[Test-operator] Fix detection of failures

### DIFF
--- a/roles/test_operator/tasks/main.yml
+++ b/roles/test_operator/tasks/main.yml
@@ -156,7 +156,7 @@
   when: not cifmw_test_operator_dry_run | bool
   ansible.builtin.assert:
     that:
-      - item.value == "Succeeded"
+      - item.value
     success_msg: "{{ item.key }} tests passed"
     fail_msg: "{{ item.key }} tests failed"
   loop: "{{ test_operator_results | default({}) | dict2items }}"

--- a/roles/test_operator/tasks/run-test-operator-job.yml
+++ b/roles/test_operator/tasks/run-test-operator-job.yml
@@ -118,39 +118,34 @@
   register: pod_list
   when: not cifmw_test_operator_dry_run | bool
 
-- name: Get full name of the pod - {{ test_operator_job_name }}
-  ansible.builtin.set_fact:
-    test_pod_name: >-
-      {{ pod_list | json_query('resources[*].metadata.name') | select('match', test_operator_job_name) | first }}
-  when: not cifmw_test_operator_dry_run | bool
-
-- name: Save stdout from pod - {{ run_test_fw }}
-  environment:
-    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-    PATH: "{{ cifmw_path }}"
-  ansible.builtin.shell: |
-    oc logs -n {{ cifmw_test_operator_namespace }} pod/{{ test_pod_name }} > \
-      {{ cifmw_test_operator_artifacts_basedir }}/{{ run_test_fw }}_pod_stdout.txt
-  when: not cifmw_test_operator_dry_run | bool
-
-- name: Get test result (Success / Fail)
-  register: test_pod
+- name: Get test results from all test pods (Success / Fail)
+  register: test_pod_results
   kubernetes.core.k8s_info:
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
     api_key: "{{ cifmw_openshift_token | default(omit) }}"
     context: "{{ cifmw_openshift_context | default(omit) }}"
     namespace: "{{ cifmw_test_operator_namespace }}"
     kind: Pod
-    name: "{{ test_pod_name }}"
+    label_selectors:
+      - "instanceName={{ test_operator_job_name }}"
   when: not cifmw_test_operator_dry_run | bool
 
-- name: Fail fast if the pod did not succeed - {{ run_test_fw }}
+- name: Get status from test pods
+  when: not cifmw_test_operator_dry_run | bool
+  ansible.builtin.set_fact:
+    pod_status: "{{ test_pod_results | json_query('resources[*].status.phase') | list | unique }}"
+
+- name: Check whether test pods finished successfully
+  when: not cifmw_test_operator_dry_run | bool
+  ansible.builtin.set_fact:
+    successful_execution: "{{ pod_status | length == 1 and pod_status | first == 'Succeeded' }}"
+
+- name: Fail fast if a pod did not succeed - {{ run_test_fw }}
   when:
     - not cifmw_test_operator_dry_run | bool
     - cifmw_test_operator_fail_fast | bool
   ansible.builtin.assert:
-    that:
-      - test_pod.resources[0].status.phase == "Succeeded"
+    that: successful_execution
 
 - name: Save result - {{ run_test_fw }}
   when: not cifmw_test_operator_dry_run | bool
@@ -158,7 +153,7 @@
     test_operator_results: >-
       {{
           test_operator_results | default({}) |
-          combine({run_test_fw: test_pod.resources[0].status.phase})
+          combine({run_test_fw: successful_execution})
       }}
 
 - name: Delete tempest and/or tobiko pods


### PR DESCRIPTION
With the introduction of the the tobiko workflows there might be more than one pod spawned by the test-operator to execute tobiko tests. This patch makes sure that we detect failures of all pods. Previously, the role was always checking status of only one pod.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
