### PR TITLE
Use --force argument with ansible-galaxy install

### DIFF
--- a/roles/reproducer/tasks/push_code.yml
+++ b/roles/reproducer/tasks/push_code.yml
@@ -151,4 +151,4 @@
   delegate_to: controller-0
   ansible.builtin.command:
     chdir: "/home/zuul/src/github.com/openstack-k8s-operators/ci-framework"
-    cmd: ansible-galaxy collection install -U .
+    cmd: ansible-galaxy collection install --upgrade --force .

--- a/scripts/run_ansible_test
+++ b/scripts/run_ansible_test
@@ -38,7 +38,7 @@ case ${USE_VENV} in
         ;;
 esac
 
-ansible-galaxy collection install -U ${PROJECT_DIR}
+ansible-galaxy collection install --upgrade --force ${PROJECT_DIR}
 
 # Create/append the sanity exceptions for the current ansible version
 ansible_version=$(python3 -c "import ansible; print(ansible.__version__)" | sed 's/\.[^.]*$//')

--- a/scripts/setup_molecule
+++ b/scripts/setup_molecule
@@ -44,4 +44,4 @@ esac
 # Install requirements
 ${PIP} install ${PIP_INSTALL_ARGUMENTS}
 
-${GALAXY} collection install -U --timeout=120 ${PROJECT_DIR}
+${GALAXY} collection install --upgrade --force --timeout=120 ${PROJECT_DIR}


### PR DESCRIPTION
Make sure that a collection is force-installed if already present. This
is done with the baremetal jobs in mind, in case they were not provisioned
recently and might contain older version of the collections.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
