### PR TITLE
Allow single hooks to be a list

### DIFF
--- a/roles/run_hook/tasks/main.yml
+++ b/roles/run_hook/tasks/main.yml
@@ -29,19 +29,20 @@
         selectattr('key', 'match', _matcher)
       }}
     _single_hooks: >-
-      {% for _hook in _filtered_hooks -%}
-      - name: {{ _hook.key | regex_replace(_matcher, '\1') |
-                 replace('_', ' ') | capitalize }}
-      {{ _hook.value | to_nice_yaml | indent(width=2, first=true) }}
+      {% set hooks_list = [] -%}
+      {% for hook_element in (_filtered_hooks | default([])) -%}
+      {%   set hook_definitions = [hook_element] if hook_element is mapping else hook_element -%}
+      {%   for hook_definition in hook_definitions -%}
+      {%     set name = hook_definition.key | regex_replace(_matcher, '\\1') | replace('_', ' ') | capitalize -%}
+      {%     set _ = hooks_list.append(hook_definition.value | combine({'name': name})) -%}
+      {%   endfor -%}
       {% endfor -%}
+      {{ hooks_list }}
   block:
     - name: Assert parameters are valid
       ansible.builtin.assert:
         quiet: true
         that:
-          - _filtered_hooks is not string
-          - _filtered_hooks is not mapping
-          - _filtered_hooks is iterable
           - _list_hooks is not string
           - _list_hooks is not mapping
           - _list_hooks is iterable
@@ -49,12 +50,25 @@
           - (hooks | default([])) is not mapping
           - (hooks | default([])) is iterable
 
+    - name: Assert single hooks are all mappings
+      vars:
+        _not_mapping_hooks: >-
+          {{
+            _single_hooks | reject('mapping') | list
+          }}
+      ansible.builtin.assert:
+        quiet: true
+        that:
+          - _not_mapping_hooks | length == 0
+        msg: >-
+          All single hooks must be a list of mappings or a mapping.
+
     - name: "Loop on hooks for {{ step }}"
       vars:
         _hooks: >-
           {{
             (
-              (_single_hooks | from_yaml | default([], true)) +
+              _single_hooks +
               (hooks | default([], true)) +
               _list_hooks
             ) | sort(attribute='name')


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
