### PR TITLE
[openshift_adm] Support customizing the retry count for OpenShiftapi and login

### DIFF
--- a/roles/openshift_adm/README.md
+++ b/roles/openshift_adm/README.md
@@ -26,6 +26,10 @@ This role requires the following parameters to be configured.
 * `cifmw_openshift_adm_op` (str) The operation to be performed on the cluster.
 * `cifmw_openshift_adm_dry_run` (bool) If enabled, no modifications are
   performed on the cluster.
+* `cifmw_openshift_adm_login_retry_count` (int) The maximum number of attempts
+  to be made for a OpenShift login success. Default is `30`.
+* `cifmw_openshift_adm_api_retry_count` (int) The maximum number of attempts to
+  be made for confirming API response. Default is `30`.
 
 ## Reference
 

--- a/roles/openshift_adm/defaults/main.yml
+++ b/roles/openshift_adm/defaults/main.yml
@@ -26,3 +26,5 @@ cifmw_openshift_adm_cert_expire_date_file: >-
   }}
 cifmw_openshift_adm_op: ""
 cifmw_openshift_adm_dry_run: false
+cifmw_openshift_adm_login_retry_count: 30
+cifmw_openshift_adm_api_retry_count: 30

--- a/roles/openshift_adm/tasks/wait_for_cluster.yml
+++ b/roles/openshift_adm/tasks/wait_for_cluster.yml
@@ -26,7 +26,7 @@
     status_code: 403
   register: ocp_api_result
   until: ocp_api_result.status == 403
-  retries: 30
+  retries: "{{ cifmw_openshift_adm_api_retry_count }}"
   delay: 5
 
 - name: Wait until OCP login succeeds.
@@ -38,7 +38,7 @@
     validate_certs: false
   register: _oc_login_result
   until: _oc_login_result.k8s_auth is defined
-  retries: 30
+  retries: "{{ cifmw_openshift_adm_login_retry_count }}"
   delay: 5
 
 - name: Gather the list of nodes


### PR DESCRIPTION
This change set introduces two retry count variables so users can customize the number retries is attempted for a particular environment.

- cifmw_openshift_adm_login_retry_count
- cifmw_openshift_adm_api_retry_count

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
