### PR TITLE
Update edpm_deploy_baremetal README

### DIFF
--- a/roles/edpm_deploy_baremetal/README.md
+++ b/roles/edpm_deploy_baremetal/README.md
@@ -1,8 +1,6 @@
 # edpm_deploy_baremetal
 
-This Ansible role deploys compute nodes with BMAAS, installs the OpenStack operator and services,
-and provision the compute nodes for further deployment by toggling the deploy:true flag in the openstackdataplane CR,
-and waits for the necessary components to be available.
+This Ansible role deploys compute nodes with BMAAS, installs the OpenStack operator services then waits for the necessary components to be available.
 
 ## Privilege escalation
 


### PR DESCRIPTION
`deploy:true` was removed from the CRD and code to patch the CR was already removed from this role in [1]

[1] https://github.com/openstack-k8s-operators/ci-framework/commit/a9841bf26cdde724dcda3934e85b47775266a472

As a pull request owner and reviewers, I checked that:
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role

