### PR TITLE
Deprecate cifmw_reproducer_internal_ca parameter

### DIFF
--- a/roles/install_ca/tasks/main.yml
+++ b/roles/install_ca/tasks/main.yml
@@ -50,7 +50,11 @@
         mode: "0644"
 
     - name: Update ca bundle
+      vars:
+        _ca_bundle_changed: ca_bundle is defined and ca_bundle is changed
+        _ca_inline_changed: ca_inline is defined and ca_inline is changed
+        _ca_url_changed: cifmw_install_ca_url is defined
       when:
-        - (ca_bundle is defined and ca_bundle is changed) or (ca_inline is defined and ca_inline is changed)
+        - _ca_url_changed or _ca_bundle_changed or _ca_inline_changed
       ansible.builtin.command:
         cmd: update-ca-trust

--- a/roles/reproducer/tasks/configure_computes.yml
+++ b/roles/reproducer/tasks/configure_computes.yml
@@ -42,7 +42,7 @@
       when:
         - cifmw_repo_setup_rhos_release_rpm is defined
       block:
-        - name: Get rhos-release and CA
+        - name: Get rhos-release
           ansible.builtin.import_tasks: rhos_release.yml
 
         - name: Configure rhos-release

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -216,7 +216,7 @@
       when:
         - cifmw_repo_setup_rhos_release_rpm is defined
       block:
-        - name: Get rhos-release and CA
+        - name: Get rhos-release
           ansible.builtin.import_tasks: rhos_release.yml
 
         - name: Create bundle for CRC

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -33,6 +33,16 @@
       You cannot get both OpenShift cluster types.
       Please chose between CRC and OCP cluster.
 
+- name: Assert that deprecated cifmw_reproducer_internal_ca parameters was not passed
+  ansible.builtin.assert:
+    that:
+      - cifmw_reproducer_internal_ca is not defined
+    msg: >-
+      The parameter cifmw_reproducer_internal_ca to install additional CAs is
+      deprecated, please use parameters from the install_ca role instead, like
+      cifmw_install_ca_url to download from a url or cifmw_install_ca_bundle_src
+      to use a file present on the host.
+
 - name: Ensure directories are present
   tags:
     - always

--- a/roles/reproducer/tasks/rhos_release.yml
+++ b/roles/reproducer/tasks/rhos_release.yml
@@ -8,8 +8,3 @@
 - name: Enable RHEL repos
   ansible.builtin.command:
     cmd: "rhos-release rhel"
-
-- name: Install internal CA
-  ansible.builtin.dnf:
-    name: "{{ cifmw_reproducer_internal_ca }}"
-    disable_gpg_check: true


### PR DESCRIPTION
Deprecate cifmw_reproducer_internal_ca parameter in the reproducer to
use the install_ca role. We can use cifmw_install_ca_url to download
a CA bundle from a url, or cifmw_install_ca_bundle_src to use a local CA
bundle file.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
