### PR TITLE
Increasing the default number attempts to have a successful login and API connectivity check.

### DIFF
--- a/roles/openshift_adm/README.md
+++ b/roles/openshift_adm/README.md
@@ -27,9 +27,9 @@ This role requires the following parameters to be configured.
 * `cifmw_openshift_adm_dry_run` (bool) If enabled, no modifications are
   performed on the cluster.
 * `cifmw_openshift_adm_login_retry_count` (int) The maximum number of attempts
-  to be made for a OpenShift login success. Default is `30`.
+  to be made for a OpenShift login success. Default is `100`.
 * `cifmw_openshift_adm_api_retry_count` (int) The maximum number of attempts to
-  be made for confirming API response. Default is `30`.
+  be made for confirming API response. Default is `100`.
 
 ## Reference
 

--- a/roles/openshift_adm/defaults/main.yml
+++ b/roles/openshift_adm/defaults/main.yml
@@ -26,5 +26,5 @@ cifmw_openshift_adm_cert_expire_date_file: >-
   }}
 cifmw_openshift_adm_op: ""
 cifmw_openshift_adm_dry_run: false
-cifmw_openshift_adm_login_retry_count: 30
-cifmw_openshift_adm_api_retry_count: 30
+cifmw_openshift_adm_login_retry_count: 100
+cifmw_openshift_adm_api_retry_count: 100


### PR DESCRIPTION
We are now waiting for 8 minutes and 20 seconds. This should be sufficient for the OpenShift cluster to settle down.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] Content of the docs/source is reflecting the changes
