### PR TITLE
Add new top-level parameter to skip stage

### DIFF
--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -11,8 +11,23 @@
       - stage['values'] | length > 0
 
 - name: Group tasks under the same tag
+  vars:
+    _stage: "deploy_architecture_stage_{{ stage_id }}"
+    _skip_tags: >-
+      {% if cifmw_deploy_architecture_skip_stages is defined and
+         cifmw_deploy_architecture_skip_stages is string -%}
+      {{ cifmw_deploy_architecture_skip_stages | ansible.builtin.split(",") }}
+      {% elif cifmw_deploy_architecture_skip_stages is defined and
+         cifmw_deploy_architecture_skip_stages is not string and
+         cifmw_deploy_architecture_skip_stages is iterable -%}
+      {{ cifmw_deploy_architecture_skip_stages }}
+      {% else -%}
+      {{ [] }}
+      {% endif -%}
   tags:
     - "deploy_architecture_stage_{{ stage_id }}"
+  when:
+    - _stage not in _skip_tags
   block:
     - name: Ensure source files exists
       register: _src


### PR DESCRIPTION
Until now, we could skip a stage only by leveraging `--skip-tags`
ansible parameter.

With this patch, we create a new parameter, allowing to list the stages
we want to skip. If passed inline
(-e cifmw_deploy_architecture_skip_stages=deploy_architecture_stage_0)
it will be `|split(',')` in order to support multiple stages to skip.

The tag is still supported.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
