### PR TITLE
Correct generated scripts from reproducer role

### DIFF
--- a/roles/reproducer/tasks/configure_architecture.yml
+++ b/roles/reproducer/tasks/configure_architecture.yml
@@ -13,7 +13,7 @@
           pushd src/github.com/openstack-k8s-operators/ci-framework
           export ANSIBLE_LOG_PATH="~/ansible-deploy-architecture.log"
           ansible-playbook -i ~/ci-framework-data/artifacts/zuul_inventory.yml \
-            -e @~/ci-framework-data/artifacts/parameters/custom-params.yml \
+            -e @~/reproducer-variables.yml \
             -e @~/openshift-environment.yml \
             deploy-edpm.yml $@
           popd

--- a/roles/reproducer/tasks/crc_layout.yml
+++ b/roles/reproducer/tasks/crc_layout.yml
@@ -34,3 +34,10 @@
   register: _crc_kubeconfig
   ansible.builtin.slurp:
     path: "{{ cifmw_reproducer_kubecfg }}"
+
+- name: Ensure we expose openshift_login related facts
+  when:
+    - _crc_available.stat.exists
+  ansible.builtin.import_role:
+    name: rhol_crc
+    tasks_from: set_cluster_fact.yml

--- a/roles/reproducer/tasks/devscripts_post.yml
+++ b/roles/reproducer/tasks/devscripts_post.yml
@@ -35,6 +35,11 @@
             (_auth_path, 'kubeadmin-password') | ansible.builtin.path_join
           }}
 
+    - name: Ensure we expose openshift_login related facts
+      ansible.builtin.import_role:
+        name: devscripts
+        tasks_from: set_cluster_fact.yml
+
     - name: Ensure the OpenShift cluster is stable.
       vars:
         cifmw_openshift_adm_op: "stable"

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -136,6 +136,7 @@
       ansible.builtin.include_tasks: configure_architecture.yml
 
     - name: Prepare ci-like EDPM deploy
+      delegate_to: controller-0
       ansible.builtin.copy:
         dest: "/home/zuul/deploy-edpm.sh"
         mode: "0755"
@@ -148,5 +149,6 @@
           ansible-playbook deploy-edpm.yml \
             -e @scenarios/centos-9/base.yml \
             -e @scenarios/centos-9/edpm_ci.yml \
-            -e cifmw_openshift_password=12345678 $@
+            -e cifmw_openshift_password="{{ cifmw_openshift_password }}" \
+            $@
           popd


### PR DESCRIPTION
`deploy-architecture.sh` was loading a generated parameter file, leading
to potential issues when a user is iterating deploys directly on
controller-0 and is passing parameters to the deployment: those
parameters would end in that generated file, and therefore would be
loaded on each run.
This patch corrects this, and ensure we're loading a "vanilla" generated
file, from the reproducer run itself.

`deploy-edpm.sh` script wasn't properly installed on the controller-0
due to a missing `delegate_to: controller-0` on the task. This wasn't
caught in CI, since we're using `zuul` user for both "hypervisor" and
"controller-0".
This patch adds the missing instruction, and the script lands in the
right place now.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1281

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
