### PR TITLE
Fix reproducer directory creation

### DIFF
--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -37,7 +37,7 @@
   tags:
     - always
   ansible.builtin.file:
-    path: "{{ cifmw_reproducer_basedir }}"
+    path: "{{ cifmw_reproducer_basedir }}/{{ item }}"
     state: directory
   loop:
     - artifacts


### PR DESCRIPTION
Current task doesn't correctly loop over items so it only ensures
`cifmw_reproducer_basedir` is created, not
`cifmw_reproducer_basedir/artifacts` and `cifmw_reproducer_basedir/logs`

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running