### PR TITLE
Ensure we're able to get OpenShift cluster facts

### DIFF
--- a/roles/openshift_login/defaults/main.yml
+++ b/roles/openshift_login/defaults/main.yml
@@ -25,3 +25,7 @@ cifmw_openshift_login_assume_cert_system_user: true
 cifmw_openshift_login_retries: 10
 cifmw_openshift_login_retries_delay: 10
 cifmw_openshift_login_skip_tls_verify: "{{ cifmw_openshift_skip_tls_verify | default(false) }}"
+
+# Dedicated parameters for the set_cluster_fact.yml tasks
+cifmw_openshift_login_load_kubeconfig: null
+cifmw_openshift_login_load_kubeadmin: null

--- a/roles/openshift_login/tasks/set_cluster_fact.yml
+++ b/roles/openshift_login/tasks/set_cluster_fact.yml
@@ -1,0 +1,67 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Assert we have needed parameters
+  ansible.builtin.assert:
+    that:
+      - cifmw_openshift_login_load_kubeconfig is defined
+      - cifmw_openshift_login_load_kubeconfig is not none
+      - cifmw_openshift_login_load_kubeadmin is defined
+      - cifmw_openshift_login_load_kubeadmin is not none
+
+- name: Ensure files exists
+  block:
+    - name: Stat kubeconfig
+      register: _stat_config
+      ansible.builtin.stat:
+        path: "{{ cifmw_openshift_login_load_kubeconfig }}"
+        get_attributes: false
+        get_checksum: false
+        get_mime: false
+
+    - name: Stat kubeadmin
+      register: _stat_admin
+      ansible.builtin.stat:
+        path: "{{ cifmw_openshift_login_load_kubeadmin }}"
+        get_attributes: false
+        get_checksum: false
+        get_mime: false
+
+    - name: Assert files exist
+      ansible.builtin.assert:
+        that:
+          - _stat_config.stat.exists
+          - _stat_admin.stat.exists
+
+- name: Gather the password of the deployed cluster.
+  register: kubeadmin_password
+  ansible.builtin.slurp:
+    src: "{{ cifmw_openshift_login_load_kubeadmin }}"
+
+- name: Gather the deployed OCP configuration.
+  register: _kubeconfig
+  ansible.builtin.slurp:
+    path: "{{ cifmw_openshift_login_load_kubeconfig }}"
+
+- name: Set the OpenShift platform access information.
+  vars:
+    kubeconf: "{{ _kubeconfig['content'] | b64decode | from_yaml }}"
+  ansible.builtin.set_fact:
+    cifmw_openshift_api: "{{ kubeconf.clusters[0].cluster.server }}"
+    cifmw_openshift_user: "kubeadmin"
+    cifmw_openshift_password: "{{ kubeadmin_password.content | b64decode }}"
+    cifmw_openshift_kubeconfig: "{{ cifmw_openshift_login_load_kubeconfig }}"
+    cacheable: true

--- a/roles/rhol_crc/tasks/main.yml
+++ b/roles/rhol_crc/tasks/main.yml
@@ -132,11 +132,7 @@
       ansible.builtin.import_tasks: sudoers_revoke.yml
 
 - name: Set OpenShift CRC credentials
-  ansible.builtin.set_fact:
-    cifmw_openshift_kubeconfig: "{{ cifmw_rhol_crc_kubeconfig }}"
-    cifmw_openshift_user: "kubeadmin"
-    cifmw_openshift_password: "{{ cifmw_rhol_crc_kubeadmin_pwd }}"
-    cacheable: true
+  ansible.builtin.import_tasks: set_cluster_fact.yml
 
 - name: Add crc kubeconfig
   when: cifmw_rhol_crc_creds | bool

--- a/roles/rhol_crc/tasks/set_cluster_fact.yml
+++ b/roles/rhol_crc/tasks/set_cluster_fact.yml
@@ -18,24 +18,11 @@
 - name: Set OpenShift platform access information
   vars:
     cifmw_openshift_login_load_kubeconfig: >-
-      {{
-        (
-          cifmw_devscripts_repo_dir,
-          'ocp',
-          cifmw_devscripts_config['cluster_name'],
-          'auth',
-          'kubeconfig'
-        ) | path_join
-      }}
+      {{ cifmw_rhol_crc_kubeconfig }}
     cifmw_openshift_login_load_kubeadmin: >-
       {{
-        (
-          cifmw_devscripts_repo_dir,
-          'ocp',
-          cifmw_devscripts_config['cluster_name'],
-          'auth',
-          'kubeadmin-password'
-        ) | path_join
+        (cifmw_rhol_crc_kubeconfig | dirname,
+        'kubeadmin-password') | path_join
       }}
   ansible.builtin.import_role:
     name: openshift_login


### PR DESCRIPTION
devscripts role had a nice way to re-inject the OpenShift cluster
credentials in the facts. While role_crc also did it, it was only
"runtime".

With this patch, we add a new tasks file to openshift_login, allowing to
load/read the various files, and inject the needed values as facts.

This ensures we can export those needed facts even in the case of a
re-deployement (this is for a follow-up).

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
