### PR TITLE
Map `nic2` to correct interface via MAC address

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/hci/edpm-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/hci/edpm-values/values.yaml.j2
@@ -1,3 +1,12 @@
+{% set instances_names = []                                                            %}
+{% set _original_nodeset = (original_content.data | default({})).nodeset | default({}) %}
+{% set _original_nodes = _original_nodeset.nodes | default({})                         %}
+{% set _vm_type = (_original_nodes.keys() | first).split('-')[1]                       %}
+{% for _inst in cifmw_networking_env_definition.instances.keys()                       %}
+{%   if _inst.startswith(_vm_type)                                                     %}
+{%     set _ = instances_names.append(_inst)                                           %}
+{%   endif                                                                             %}
+{% endfor                                                                              %}
 data:
   ssh_keys:
     authorized: {{ cifmw_ci_gen_kustomize_values_ssh_authorizedkeys | b64encode }}
@@ -15,26 +24,18 @@ data:
         timesync_ntp_servers:
           - hostname: "{{ cifmw_ci_gen_kustomize_values_ntp_srv | default('pool.ntp.org') }}"
         edpm_network_config_os_net_config_mappings:
-          edpm-compute:
-            nic2: {{ (cifmw_networking_env_definition.instances | dict2items | selectattr('key', 'match', '^compute') | first).value.networks['ctlplane']['interface_name']  }}
-{% if cifmw_ci_gen_kustomize_values_sshd_ranges | default([]) | length > 0 %}
+{% for instance in instances_names                                                     %}
+          edpm-{{ instance }}:
+            nic2: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.mac_addr }}
+{% endfor                                                                              %}
+{% if cifmw_ci_gen_kustomize_values_sshd_ranges | default([]) | length > 0             %}
         edpm_sshd_allowed_ranges:
-{%   for range in cifmw_ci_gen_kustomize_values_sshd_ranges %}
+{%   for range in cifmw_ci_gen_kustomize_values_sshd_ranges                            %}
           - "{{ range }}"
-{%  endfor %}
-{% endif %}
+{%   endfor                                                                            %}
+{% endif                                                                               %}
     nodes:
-{% set instances_names = []                                                                             %}
-{% set _original_nodeset = (original_content.data | default({})).nodeset | default({})                  %}
-{% set _original_nodes = _original_nodeset.nodes | default({})                                          %}
-{% set _has_computes = _original_nodes.keys() | select('contains', 'compute') | length > 0                %}
-{% set _has_cephs = _original_nodes.keys() | select('contains', 'ceph') | length > 0                      %}
-{% for _inst in cifmw_networking_env_definition.instances.keys()                                        %}
-{%   if _inst.startswith('compute') and _has_computes or  _inst.startswith('ceph') and _has_cephs       %}
-{%     set _ = instances_names.append(_inst)                                                            %}
-{%   endif                                                                                              %}
-{%- endfor %}
-{% for instance in instances_names %}
+{% for instance in instances_names                                                     %}
       edpm-{{ instance }}:
         ansible:
           host: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.ip_v4 }}
@@ -43,9 +44,9 @@ data:
 {%      for net in cifmw_networking_env_definition.instances[instance].networks.keys() %}
           - name: {{ net }}
             subnetName: subnet1
-{%        if net is match('ctlplane') %}
+{%        if net is match('ctlplane')                                                  %}
             defaultRoute: true
             fixedIP: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.ip_v4 }}
-{%        endif%}
-{%      endfor %}
-{% endfor %}
+{%        endif                                                                        %}
+{%      endfor                                                                         %}
+{% endfor                                                                              %}


### PR DESCRIPTION
To reflect changes introduced in architecture repo [1], we are now using MAC address instead of interface names to configure the mapping used by`os-net-config`
    
Also, a better approach to filter host names has been used
    
[1] https://github.com/openstack-k8s-operators/architecture/pull/128/files


As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
