### PR TITLE
Add new role: virtualbmc

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -192,6 +192,7 @@ installyamls
 ipaddr
 ipam
 ipi
+ipmi
 ips
 ipv
 iscsi
@@ -231,9 +232,9 @@ lacp
 ldp
 libguestfs
 libvirt
-libvirt's
 libvirtd
 libvirterror
+libvirt's
 ljaumtawojy
 ljaumtaxojy
 ljaumtayojy
@@ -461,6 +462,7 @@ usr
 utils
 uuid
 vbibob
+vbmc
 vcgvuc
 vcpu
 vcpus
@@ -473,6 +475,7 @@ virt
 virthosts
 virtproxy
 virtproxyd
+virtualbmc
 virtualized
 virtualmedia
 virtuser

--- a/roles/virtualbmc/README.md
+++ b/roles/virtualbmc/README.md
@@ -1,0 +1,30 @@
+# virtualbmc
+Deploy and manage VirtualBMC in a container.
+
+It creates a dedicated keypair to allow SSH accesses from the container onto the
+hypervisor. The keypair is shared in the container, and removed when we clean the
+service.
+
+## Privilege escalation
+None
+
+## Parameters
+* `cifmw_virtualbmc_image`: (String) VirtualBMC container image. Defaults to `quay.io/metal3-io/vbmc:latest`.
+* `cifmw_virtualbmc_container_name`: (String) VirtualBMC container name. Defaults to `cifmw-vbmc`.
+* `+cifmw_virtualbmc_listen_address`: (String) VirtualBMC listen address. Defaults to `127.0.0.1`.
+* `cifmw_virtualbmc_machine`: (String) Virtual machine to manage in VirtualBMC. Mandatory. Defaults to `null`.
+* `cifmw_virtualbmc_action`: (String) VirtualBMC action. Must be either `add` or `delete`. Mandatory. Defaults to `null`.
+* `cifmw_virtualbmc_sshkey_path`: (String) SSH keypair path for VirtualBMC. Defaults to `{{ ansible_user_dir }}/.ssh/vbmc-key`.
+* `cifmw_virtualbmc_sshkey_type`: (String) Type of SSH keypair. Defaults to `{{ cifmw_ssh_keytype | default('ecdsa') }}`.
+* `cifmw_virtualbmc_sshkey_size`: (Integer) Size of the SSH keypair. Defaults to `{{ cifmw_ssh_keysize | default(521) }}`.
+* `cifmw_virtualbmc_ipmi_key_path`: (String) SSH private key location in the VBMC container. Defaults to `/root/ssh/id_rsa_virt_power`.
+* `cifmw_virtualbmc_ipmi_address`: (String) IP address for Hypervisor connection. Defaults to `127.0.0.1`.
+* `cifmw_virtualbmc_ipmi_password`: (String) IPMI password. Defaults to `password`.
+* `cifmw_virtualbmc_ipmi_user`: (String) IPMI username. Defaults to `admin`.
+* `cifmw_virtualbmc_ipmi_base_port`: (Integer) IPMI base port, used to calculate further ports for hosts. Defaults to `6240`.
+* `cifmw_virtualbmc_ipmi_uri`: (String) Internal VBMC URI to access qemu daemon. Defaults to
+  `qemu+ssh://{{ ansible_user_id }}@{{ cifmw_virtualbmc_ipmi_address }}/system?&keyfile={{ cifmw_virtualbmc_ipmi_key_path }}&no_verify=1&no_tty=1`.
+
+
+## Examples
+Refer to the molecule tests for usage examples.

--- a/roles/virtualbmc/defaults/main.yml
+++ b/roles/virtualbmc/defaults/main.yml
@@ -1,0 +1,37 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_virtualbmc"
+cifmw_virtualbmc_image: "quay.io/metal3-io/vbmc:latest"
+cifmw_virtualbmc_container_name: "cifmw-vbmc"
+cifmw_virtualbmc_listen_address: "127.0.0.1"
+
+cifmw_virtualbmc_machine: null
+cifmw_virtualbmc_action: null
+
+cifmw_virtualbmc_sshkey_path: "{{ ansible_user_dir }}/.ssh/vbmc-key"
+cifmw_virtualbmc_sshkey_type: "{{ cifmw_ssh_keytype | default('ecdsa') }}"
+cifmw_virtualbmc_sshkey_size: "{{ cifmw_ssh_keysize | default(521) }}"
+
+cifmw_virtualbmc_ipmi_key_path: "/root/ssh/id_rsa_virt_power"
+cifmw_virtualbmc_ipmi_password: "password"
+cifmw_virtualbmc_ipmi_address: "{{ cifmw_virtualbmc_listen_address }}"
+cifmw_virtualbmc_ipmi_user: "admin"
+cifmw_virtualbmc_ipmi_base_port: 6240
+cifmw_virtualbmc_ipmi_uri: >-
+  qemu+ssh://{{ ansible_user_id }}@{{ cifmw_virtualbmc_ipmi_address }}/system?&keyfile={{ cifmw_virtualbmc_ipmi_key_path }}&no_verify=1&no_tty=1

--- a/roles/virtualbmc/meta/main.yml
+++ b/roles/virtualbmc/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- virtualbmc
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: cifmw
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - cifmw
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/virtualbmc/molecule/default/cleanup.yml
+++ b/roles/virtualbmc/molecule/default/cleanup.yml
@@ -1,0 +1,29 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Cleanup
+  hosts: all
+  tasks:
+    - name: Clean libvirt layout
+      ansible.builtin.import_role:
+        name: libvirt_manager
+        tasks_from: clean_layout.yml
+
+    - name: Clean vbmc
+      ansible.builtin.import_role:
+        name: virtualbmc
+        tasks_from: cleanup.yml

--- a/roles/virtualbmc/molecule/default/converge.yml
+++ b/roles/virtualbmc/molecule/default/converge.yml
@@ -1,0 +1,82 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  roles:
+    - role: virtualbmc
+  tasks:
+    - name: Inject compute-0 in VBMC
+      vars:
+        cifmw_virtualbmc_machine: "cifmw-compute-0"
+        cifmw_virtualbmc_ipmi_port: >-
+          {{ cifmw_virtualbmc_ipmi_base_port + 1 }}
+        cifmw_virtualbmc_action: 'add'
+      ansible.builtin.import_role:
+        name: virtualbmc
+        tasks_from: manage_host
+
+    - name: Stop VM using IPMI
+      ansible.builtin.command:
+        cmd: >-
+          ipmitool -I lanplus -U admin -P password
+          -H 127.0.0.1 -p 6241 power off
+
+    - name: List VMs from the hypervisor
+      register: _vms
+      community.libvirt.virt:
+        command: info
+        name: "cifmw-compute-0"
+
+    - name: Ensure VM is stopped
+      ansible.builtin.assert:
+        that:
+          - _vms['cifmw-compute-0'].state == 'shutdown'
+
+    - name: Get known hosts
+      ansible.builtin.import_role:
+        name: virtualbmc
+        tasks_from: list_hosts.yml
+
+    - name: Ensure we have the needed fact
+      ansible.builtin.assert:
+        that:
+          - cifmw_virtualbmc_known_hosts is defined
+          - cifmw_virtualbmc_known_hosts | length != 0
+
+    - name: Expose known hosts
+      ansible.builtin.debug:
+        var: cifmw_virtualbmc_known_hosts
+
+    - name: Remove compute-0 from VBMC
+      vars:
+        cifmw_virtualbmc_machine: "cifmw-compute-0"
+        cifmw_virtualbmc_action: 'delete'
+      ansible.builtin.import_role:
+        name: virtualbmc
+        tasks_from: manage_host
+
+    - name: Get known hosts
+      ansible.builtin.import_role:
+        name: virtualbmc
+        tasks_from: list_hosts.yml
+
+    - name: Ensure we have the needed fact
+      ansible.builtin.assert:
+        that:
+          - cifmw_virtualbmc_known_hosts is defined
+          - cifmw_virtualbmc_known_hosts | length == 0

--- a/roles/virtualbmc/molecule/default/molecule.yml
+++ b/roles/virtualbmc/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/roles/virtualbmc/molecule/default/prepare.yml
+++ b/roles/virtualbmc/molecule/default/prepare.yml
@@ -1,0 +1,59 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  vars:
+    cifmw_basedir: "{{ ansible_user_dir }}/ci-framework-data"
+    test_deps_extra_packages:
+      - ipmitool
+  roles:
+    - role: test_deps
+    - role: libvirt_manager
+    - role: discover_latest_image
+  tasks:
+    - name: Deploy a single VM
+      vars:
+        cifmw_libvirt_manager_configuration:
+          vms:
+            compute:
+              amount: 1
+              image_url: "{{ cifmw_discovered_image_url }}"
+              sha256_image_name: "{{ cifmw_discovered_hash }}"
+              image_local_dir: "{{ cifmw_basedir }}/images/"
+              disk_file_name: "centos-stream-9.qcow2"
+              disksize: 15
+              memory: 4
+              cpus: 2
+              nets:
+                - public
+          networks:
+            public: |-
+              <network>
+                <name>public</name>
+                <forward mode='nat'/>
+                <bridge name='public' stp='on' delay='0'/>
+                <mac address='52:54:00:6a:f2:dc'/>
+                <ip family='ipv4' address='192.168.110.1' prefix='24'>
+                  <dhcp>
+                    <range start='192.168.110.10' end='192.168.110.100'/>
+                  </dhcp>
+                </ip>
+              </network>
+      ansible.builtin.import_role:
+        name: libvirt_manager
+        tasks_from: deploy_layout.yml

--- a/roles/virtualbmc/tasks/cleanup.yml
+++ b/roles/virtualbmc/tasks/cleanup.yml
@@ -1,0 +1,46 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Stop and remove vbmc container
+  containers.podman.podman_container:
+    name: "{{ cifmw_virtualbmc_container_name }}"
+    state: absent
+
+- name: Remove vbmc container image
+  containers.podman.podman_image:
+    name: "{{ cifmw_virtualbmc_image }}"
+    state: absent
+
+- name: Revoke VBMC temporary key
+  block:
+    - name: Slurp key
+      register: _vbmc_key
+      ansible.builtin.slurp:
+        path: "{{ cifmw_virtualbmc_sshkey_path }}.pub"
+
+    - name: Revoke VBMC SSH access
+      ansible.posix.authorized_key:
+        user: "{{ ansible_user_id }}"
+        key: "{{ _vbmc_key.content | b64decode }}"
+        state: absent
+
+- name: Remove generated SSH keypair
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ cifmw_virtualbmc_sshkey_path }}"
+    - "{{ cifmw_virtualbmc_sshkey_path }}.pub"

--- a/roles/virtualbmc/tasks/list_hosts.yml
+++ b/roles/virtualbmc/tasks/list_hosts.yml
@@ -1,0 +1,29 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Get existing known VBMC nodes
+  register: _known_vbmc
+  ansible.builtin.command:
+    cmd: >-
+      podman exec {{ cifmw_virtualbmc_container_name}}
+      vbmc list -f json
+
+- name: Expose known hosts
+  ansible.builtin.set_fact:
+    cifmw_virtualbmc_known_hosts: >-
+      {{
+        _known_vbmc.stdout | from_json
+      }}

--- a/roles/virtualbmc/tasks/main.yml
+++ b/roles/virtualbmc/tasks/main.yml
@@ -1,0 +1,52 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure needed directories exist
+  ansible.builtin.file:
+    path: "{{ item.key }}"
+    state: directory
+    mode: "{{ item.mode | default(omit) }}"
+  loop:
+    - key: "{{ cifmw_virtualbmc_sshkey_path | dirname }}"
+      mode: "0700"
+
+- name: Create ssh key for VBMC
+  register: _vbmc_key
+  community.crypto.openssh_keypair:
+    path: "{{ cifmw_virtualbmc_sshkey_path }}"
+    type: "{{ cifmw_virtualbmc_sshkey_type }}"
+    size: "{{ cifmw_virtualbmc_sshkey_size }}"
+    regenerate: full_idempotence
+
+- name: Pull vbmc container image
+  containers.podman.podman_image:
+    name: "{{ cifmw_virtualbmc_image }}"
+    state: present
+
+- name: Allow VBMC temporary key
+  ansible.posix.authorized_key:
+    user: "{{ ansible_user_id }}"
+    key: "{{ _vbmc_key.public_key }}"
+    state: present
+
+- name: Create and start vbmc container
+  containers.podman.podman_container:
+    image: "{{ cifmw_virtualbmc_image }}"
+    name: "{{ cifmw_virtualbmc_container_name }}"
+    network: host
+    state: started
+    volumes:
+      - "{{ cifmw_virtualbmc_sshkey_path }}:{{ cifmw_virtualbmc_ipmi_key_path }}:ro,Z"

--- a/roles/virtualbmc/tasks/manage_host.yml
+++ b/roles/virtualbmc/tasks/manage_host.yml
@@ -1,0 +1,72 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Assert we have required data
+  ansible.builtin.assert:
+    that:
+      - cifmw_virtualbmc_action is not none
+      - cifmw_virtualbmc_action in ['add', 'delete']
+      - cifmw_virtualbmc_machine is not none
+
+- name: List existing hosts
+  ansible.builtin.import_tasks: list_hosts.yml
+
+- name: Manage host in VBMC if needed
+  vars:
+    _known_hosts: >-
+      {{
+        cifmw_virtualbmc_known_hosts |
+        selectattr('Domain name', 'equalto', cifmw_virtualbmc_machine) |
+        length
+      }}
+  when:
+    - (cifmw_virtualbmc_action == 'add' and (_known_hosts | int) == 0) or
+      (cifmw_virtualbmc_action == 'delete' and (_known_hosts | int) == 1)
+  block:
+    - name: Stop host in VBMC
+      when:
+        - cifmw_virtualbmc_action == 'delete'
+      ansible.builtin.command:
+        cmd: >-
+          podman exec {{ cifmw_virtualbmc_container_name }}
+          vbmc stop {{ cifmw_virtualbmc_machine }}
+
+    - name: Add new host to VBMC
+      vars:
+        _port: >-
+          {{
+            cifmw_virtualbmc_ipmi_base_port + _known_hosts
+          }}
+      ansible.builtin.command:
+        cmd: >-
+          podman exec {{ cifmw_virtualbmc_container_name }} vbmc
+          {{ cifmw_virtualbmc_action }}
+          {% if cifmw_virtualbmc_action == 'add' -%}
+          --username "{{ cifmw_virtualbmc_ipmi_user }}"
+          --password "{{ cifmw_virtualbmc_ipmi_password }}"
+          --libvirt-uri "{{ cifmw_virtualbmc_ipmi_uri }}"
+          --port "{{ cifmw_virtualbmc_ipmi_port }}"
+          --address "{{ cifmw_virtualbmc_ipmi_address }}"
+          {% endif -%}
+          {{ cifmw_virtualbmc_machine }}
+
+    - name: Start new host in VBMC
+      when:
+        - cifmw_virtualbmc_action == 'add'
+      ansible.builtin.command:
+        cmd: >-
+          podman exec {{ cifmw_virtualbmc_container_name }}
+          vbmc start {{ cifmw_virtualbmc_machine }}

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -585,3 +585,13 @@
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: update
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
+    - ^roles/virtualbmc/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    name: cifmw-molecule-virtualbmc
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: virtualbmc

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -64,6 +64,7 @@
       - cifmw-molecule-test_operator
       - cifmw-molecule-tofu
       - cifmw-molecule-update
+      - cifmw-molecule-virtualbmc
     name: openstack-k8s-operators/ci-framework
     templates:
     - podified-multinode-edpm-pipeline


### PR DESCRIPTION
In order to properly manage blank images, we'll rely on vbmc[1] -
it will provide an IPMI-like interface for sushy, ensuring we're
able to properly test BM-like deployments with plain virtual machines.

[1] https://docs.openstack.org/virtualbmc/latest/user/index.html

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
