### PR TITLE
Ensure we install the dependencies soon enough

### DIFF
--- a/docs/source/build-docs.sh
+++ b/docs/source/build-docs.sh
@@ -5,6 +5,7 @@ DOCS_DIR="./docs"
 VENV_DIR=${DOCS_DIR}/_venv
 
 python -m venv ${VENV_DIR} && source ${VENV_DIR}/bin/activate
+pip3 install -r ${DOCS_DIR}/doc-requirements.txt
 
 cd ${DOCS_DIR}/source
 
@@ -15,8 +16,6 @@ SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[0])')
 ansible-galaxy collection install -U -n ../.. -p "${SITE_PACKAGES}"
 
 make clean
-
-pip install -r ../doc-requirements.txt
 make html
 
 deactivate


### PR DESCRIPTION
The `pip install` happened too late, we need dependencies in order to
get ansible related libraries in

- [X] Appropriate testing is done and actually running
