### PR TITLE
Ensure we properly detect if we want net prefix

### DIFF
--- a/roles/libvirt_manager/tasks/net_to_vms.yml
+++ b/roles/libvirt_manager/tasks/net_to_vms.yml
@@ -5,9 +5,14 @@
 # them to the current "item", which is an actual VM.o
 - name: "Attach {{ vm_item }} to {{ net_item }}"  # noqa: name[template]
   vars:
+    _fixed_nets_list: >-
+      {{
+        cifmw_libvirt_manager_fixed_networks_defaults +
+        cifmw_libvirt_manager_fixed_networks
+      }}
     cifmw_libvirt_manager_net_prefix_add: >-
       {{
-        net_item is not match('^ocp.*')
+        net_item is not in _fixed_nets_list
       }}
     vm_name: "cifmw-{{ vm_item }}"
     network:


### PR DESCRIPTION
Until now, we couldn't properly match existing networks such as the
`default` one provided by Libvirt, due to a wrong test that wasn't
checking the network name against the expected content.

From now on, if anyone wants to consume `default` or any pre-existing
network without having the prefix it with `cifmw-`, they can just list
those networks as follow:

```YAML
cifmw_libvirt_manager_fixed_networks:
  - default
  - my-network
  - ...
```

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
