### PR TITLE
Pass openstack namespace to configure_object oc command

### DIFF
--- a/roles/cifmw_cephadm/README.md
+++ b/roles/cifmw_cephadm/README.md
@@ -91,6 +91,9 @@ need to be changed for a typical EDPM deployment.
   a fully qualified domain name (e.g. server1.bar.com). When false, the
   Ceph spec should use a short hostname (e.g. server1).
 
+* `cifmw_cephadm_ns`: Name of the OpenStack controlplane namespace
+   used in configuring swift objects.
+
 Use the `cifmw_cephadm_pools` list of dictionaries to define pools for
 Nova (vms), Cinder (volumes), Cinder-backups (backups), and Glance (images).
 ```

--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -102,3 +102,4 @@ cifmw_cephadm_alertmanager_container_image: "{{ cifmw_cephadm_prometheus_contain
 cifmw_cephadm_grafana_container_image: "{{ cifmw_cephadm_container_ns }}/ceph-grafana:9.4.7"
 cifmw_cephadm_node_exporter_container_image: "{{ cifmw_cephadm_prometheus_container_ns }}/node-exporter:v1.5.0"
 cifmw_cephadm_prometheus_container_image: "{{ cifmw_cephadm_prometheus_container_ns }}/prometheus:v2.43.0"
+cifmw_cephadm_ns: openstack

--- a/roles/cifmw_cephadm/tasks/configure_object.yml
+++ b/roles/cifmw_cephadm/tasks/configure_object.yml
@@ -21,12 +21,12 @@
   when: cifmw_openshift_kubeconfig is defined
   block:
     - name: Check if swift is enabled in deployed controlplane
-      ansible.builtin.shell: "set -o pipefail && oc get $(oc get oscp -n openstack -o name) -o json| jq .spec.swift.enabled"
+      ansible.builtin.shell: "set -o pipefail && oc -n {{ cifmw_cephadm_ns }}  get $(oc get oscp -n openstack -o name) -o json| jq .spec.swift.enabled"
       register: swift_in_ctlplane
 
     # checking swift_endpoints_count will avoid unnecessary errors during ceph deployment re-run
     - name: Check if swift endpoint is already created
-      ansible.builtin.shell: "set -o pipefail && oc rsh openstackclient openstack endpoint list | grep 'swift.*object-store' | wc -l"
+      ansible.builtin.shell: "set -o pipefail && oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack endpoint list | grep 'swift.*object-store' | wc -l"
       register: swift_endpoints_count
       ignore_errors: true
 
@@ -44,15 +44,15 @@
       KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
     output_dir: "/home/zuul/ci-framework-data/artifacts"
     script: |-
-      oc rsh openstackclient openstack service create --name swift --description 'OpenStack Object Storage' object-store
-      oc rsh openstackclient openstack user create --project service --password {{ cifmw_ceph_rgw_keystone_psw }}  swift
-      oc rsh openstackclient openstack role create swiftoperator
-      oc rsh openstackclient openstack role create ResellerAdmin
-      oc rsh openstackclient openstack role add --user swift --project service member
-      oc rsh openstackclient openstack role add --user swift --project service admin
-      oc rsh openstackclient openstack endpoint create --region regionOne object-store public http://{{ cifmw_cephadm_vip }}:8080/swift/v1/AUTH_%\(tenant_id\)s
-      oc rsh openstackclient openstack endpoint create --region regionOne object-store internal http://{{ cifmw_cephadm_vip }}:8080/swift/v1/AUTH_%\(tenant_id\)s
-      oc rsh openstackclient openstack role add --project admin --user admin swiftoperator
+      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack service create --name swift --description 'OpenStack Object Storage' object-store
+      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack user create --project service --password {{ cifmw_ceph_rgw_keystone_psw }}  swift
+      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack role create swiftoperator
+      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack role create ResellerAdmin
+      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack role add --user swift --project service member
+      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack role add --user swift --project service admin
+      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack endpoint create --region regionOne object-store public http://{{ cifmw_cephadm_vip }}:8080/swift/v1/AUTH_%\(tenant_id\)s
+      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack endpoint create --region regionOne object-store internal http://{{ cifmw_cephadm_vip }}:8080/swift/v1/AUTH_%\(tenant_id\)s
+      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack role add --project admin --user admin swiftoperator
   delegate_to: localhost
   when:
     - cifmw_openshift_kubeconfig is defined


### PR DESCRIPTION
Currently all oc commands defined in configure_object.yml task files are failing with following error
```
Error from server (NotFound): openstackcontrolplanes.core.openstack.org \"controlplane\" not found"
```
Passing namespace to oc command fixes the issue.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

