### PR TITLE
 Discover controller IP address and priv key

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -15,6 +15,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_default_jobs`: (List) List of jobs in the exclude list to search for tests to be excluded. Default value: `[ 'default' ]`
 * `cifmw_test_operator_dry_run`: (Boolean) Whether test-operator should run or not. Default value: `false`
 * `cifmw_test_operator_fail_fast`: (Boolean) Whether the test results are evaluated when each test framework execution finishes or when all test frameworks are done. Default value: `false`
+* `cifmw_test_operator_controller_ip`: (String) An ip address of the controller node. Default value: `ansible_default_ipv4.address` which defaults to (`""`).
 
 ## Tempest specific parameters
 * `cifmw_test_operator_tempest_registry`: (String) The registry where to pull tempest container. Default value: `quay.io`

--- a/roles/test_operator/tasks/main.yml
+++ b/roles/test_operator/tasks/main.yml
@@ -27,14 +27,6 @@
     run_tempest: "{{ cifmw_run_tempest | default('true') | bool }}"
     run_tobiko: "{{ cifmw_run_tobiko | default('false') | bool }}"
 
-- name: Setup tempest tests
-  ansible.builtin.include_tasks: tempest-tests.yml
-  when: run_tempest
-
-- name: Setup tobiko tests
-  ansible.builtin.include_tasks: tobiko-tests.yml
-  when: run_tobiko
-
 - name: Ensure OperatorGroup for the test-operator is present
   kubernetes.core.k8s:
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
@@ -134,6 +126,7 @@
     test_operator_kind_name: "{{ cifmw_test_operator_tempest_kind_name }}"
     test_operator_crd_name: "{{ cifmw_test_operator_tempest_crd_name }}"
     test_operator_workflow: []
+    test_operator_config_playbook: tempest-tests.yml
   ansible.builtin.include_tasks: run-test-operator-job.yml
   when: run_tempest
 
@@ -145,6 +138,7 @@
     test_operator_kind_name: "{{ cifmw_test_operator_tobiko_kind_name }}"
     test_operator_crd_name: "{{ cifmw_test_operator_tobiko_crd_name }}"
     test_operator_workflow: "{{ cifmw_test_operator_tobiko_workflow }}"
+    test_operator_config_playbook: tobiko-tests.yml
   ansible.builtin.include_tasks: run-test-operator-job.yml
   when: run_tobiko
 

--- a/roles/test_operator/tasks/run-test-operator-job.yml
+++ b/roles/test_operator/tasks/run-test-operator-job.yml
@@ -15,6 +15,13 @@
 # under the License.
 #
 
+- name: Set variable containing the test-operator CR
+  ansible.builtin.set_fact:
+    test_operator_cr: "{{ test_operator_config }}"
+
+- name: Prepare test configuration - {{ run_test_fw }}
+  ansible.builtin.include_tasks: "{{ test_operator_config_playbook }}"
+
 - name: Start tests - {{ run_test_fw }}
   kubernetes.core.k8s:
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
@@ -22,7 +29,7 @@
     context: "{{ cifmw_openshift_context | default(omit)}}"
     state: present
     wait: true
-    definition: "{{ test_operator_config }}"
+    definition: "{{ test_operator_cr }}"
   when: not cifmw_test_operator_dry_run | bool
 
 - name: Wait for the last job to be Completed - {{ run_test_fw }}
@@ -77,7 +84,7 @@
         volumes:
           - name: logs-volume
             persistentVolumeClaim:
-              claimName: "{{ test_operator_config.metadata.name }}"
+              claimName: "{{ test_operator_cr.metadata.name }}"
 
 - name: Ensure that the test-operator-logs-pod is Running
   kubernetes.core.k8s_info:

--- a/roles/test_operator/tasks/tempest-tests.yml
+++ b/roles/test_operator/tasks/tempest-tests.yml
@@ -56,3 +56,52 @@
     - name: Set variable
       ansible.builtin.set_fact:
         cifmw_test_operator_tempest_exclude_list: "{{ list_skipped.skipped_tests | join('\n') }}"
+
+- name: Ensure a secret for the cifmw private key file exists
+  when:
+    - not cifmw_test_operator_dry_run | bool
+    - cifmw_test_operator_tempest_ssh_key_secret_name is not defined
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    state: present
+    wait: true
+    definition:
+      apiVersion: v1
+      kind: Secret
+      type: Opaque
+      metadata:
+        name: "{{ cifmw_test_operator_controller_priv_key_secret_name }}"
+        namespace: "{{ cifmw_test_operator_namespace }}"
+      data:
+        ssh-privatekey: "{{ lookup('file', '~/.ssh/id_cifw') | b64encode }}"
+
+- name: Add SSHKeySecretName section to tobiko CR
+  when:
+    - not cifmw_test_operator_dry_run | bool
+    - cifmw_test_operator_tempest_ssh_key_secret_name is not defined
+  ansible.builtin.set_fact:
+    cifmw_test_operator_tempest_config: >-
+      {{
+          cifmw_test_operator_tempest_config |
+          combine({'spec': {'SSHKeySecretName':
+                    cifmw_test_operator_controller_priv_key_secret_name
+                  }}, recursive=true)
+      }}
+
+- name: Add controller IP to the overrides section in Tempest CR
+  when:
+    - not cifmw_test_operator_dry_run | bool
+    - controller_ip != ""
+  vars:
+    controller_ip: >-
+      {{ cifmw_test_operator_controller_ip | default(ansible_default_ipv4.address) | default('') }}
+  ansible.builtin.set_fact:
+    cifmw_test_operator_tempest_config: >-
+      {{
+          cifmw_test_operator_tempest_config |
+          combine({'spec': {'tempestconfRun': {'overrides':
+                    'whitebox_neutron_plugin_options.proxy_host_address ' + controller_ip
+                  }}}, recursive=true)
+      }}

--- a/roles/test_operator/tasks/tempest-tests.yml
+++ b/roles/test_operator/tasks/tempest-tests.yml
@@ -77,14 +77,14 @@
       data:
         ssh-privatekey: "{{ lookup('file', '~/.ssh/id_cifw') | b64encode }}"
 
-- name: Add SSHKeySecretName section to tobiko CR
+- name: Add SSHKeySecretName section to Tempest CR
   when:
     - not cifmw_test_operator_dry_run | bool
     - cifmw_test_operator_tempest_ssh_key_secret_name is not defined
   ansible.builtin.set_fact:
-    cifmw_test_operator_tempest_config: >-
+    test_operator_cr: >-
       {{
-          cifmw_test_operator_tempest_config |
+          test_operator_cr |
           combine({'spec': {'SSHKeySecretName':
                     cifmw_test_operator_controller_priv_key_secret_name
                   }}, recursive=true)
@@ -98,10 +98,11 @@
     controller_ip: >-
       {{ cifmw_test_operator_controller_ip | default(ansible_default_ipv4.address) | default('') }}
   ansible.builtin.set_fact:
-    cifmw_test_operator_tempest_config: >-
+    test_operator_cr: >-
       {{
-          cifmw_test_operator_tempest_config |
+          test_operator_cr |
           combine({'spec': {'tempestconfRun': {'overrides':
+                    (test_operator_cr.spec.tempestconfRun.overrides | default('')) + ' ' +
                     'whitebox_neutron_plugin_options.proxy_host_address ' + controller_ip
                   }}}, recursive=true)
       }}

--- a/roles/test_operator/tasks/tobiko-tests.yml
+++ b/roles/test_operator/tasks/tobiko-tests.yml
@@ -28,9 +28,9 @@
 
 - name: Add config section to tobiko CR
   ansible.builtin.set_fact:
-    cifmw_test_operator_tobiko_config: >-
+    test_operator_cr: >-
       {{
-          cifmw_test_operator_tobiko_config |
+          test_operator_cr |
           combine({'spec': {'config':
                              lookup('file',
                                     cifmw_test_operator_artifacts_basedir + '/tobiko.conf')
@@ -56,9 +56,9 @@
         keyname: "{{ item }}Key"
         keyfilename: "id_{{ cifmw_test_operator_tobiko_ssh_keytype }}{{ '.pub' if item == 'public' else '' }}"
       ansible.builtin.set_fact:
-        cifmw_test_operator_tobiko_config: >-
+        test_operator_cr: >-
           {{
-              cifmw_test_operator_tobiko_config |
+              test_operator_cr |
               combine({'spec': {keyname:
                                 lookup('file',
                                        cifmw_test_operator_artifacts_basedir + '/' + keyfilename)
@@ -70,9 +70,9 @@
 
 - name: Add preventCreate if it is defined
   ansible.builtin.set_fact:
-    cifmw_test_operator_tobiko_config: >-
+    test_operator_cr: >-
       {{
-          cifmw_test_operator_tobiko_config |
+          test_operator_cr |
           combine({'spec': {'preventCreate': cifmw_test_operator_tobiko_prevent_create | bool}},
                   recursive=true)
       }}
@@ -80,9 +80,9 @@
 
 - name: Add numProcesses if it is defined
   ansible.builtin.set_fact:
-    cifmw_test_operator_tobiko_config: >-
+    test_operator_cr: >-
       {{
-          cifmw_test_operator_tobiko_config |
+          test_operator_cr |
           combine({'spec': {'numProcesses': cifmw_test_operator_tobiko_num_processes | int}},
                   recursive=true)
       }}

--- a/roles/test_operator/vars/main.yml
+++ b/roles/test_operator/vars/main.yml
@@ -13,6 +13,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+cifmw_test_operator_controller_priv_key_secret_name: "test-operator-controller-priv-key"
 cifmw_test_operator_tempest_name: "tempest-tests"
 cifmw_test_operator_tobiko_name: "tobiko-tests"
 cifmw_test_operator_tempest_kind_name: "Tempest"


### PR DESCRIPTION
**Discover controller IP address and private key**

Whitebox-neutron-tempest-plugin requires controller node IP address and
private key that can be used to connect to it. This patch discovers
these values and passes them to the Tempest CR so that they can be
consumed by the plugin.

**Make cifmw_test_operator_*_config modifiable**

When a consumer of the role runs the test_operator role with:

-e cifmw_test_operator_tempest_config=value

then the role can not update the value of the variable as extra vars
have higher precedence in ansible. This patch changes the structure
of the test_operator role so that we always work with a copy of this
variable.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
