### PR TITLE
Integrate virtualbmc in libvirt_manager

### DIFF
--- a/roles/devscripts/tasks/cleanup.yml
+++ b/roles/devscripts/tasks/cleanup.yml
@@ -14,14 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
-- name: Clean libvirt resources
-  tags:
-    - always
-  ansible.builtin.import_role:
-    name: libvirt_manager
-    tasks_from: clean_layout
-
 - name: Scrub the existence of dev-scripts deployed OCP cluster.
   tags:
     - never

--- a/roles/libvirt_manager/molecule/deploy_layout/converge.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/converge.yml
@@ -29,7 +29,7 @@
         range: "192.168.140.0/24"
         mtu: 1500
       public:
-        range: "192.168.100.0/24"
+        range: "192.168.110.0/24"
       internal-api:
         range: "172.17.0.0/24"
         vlan: 20
@@ -280,7 +280,7 @@
         range: "192.168.140.0/24"
         mtu: 1500
       public:
-        range: "192.168.100.0/24"
+        range: "192.168.110.0/24"
       internal-api:
         range: "172.17.0.0/24"
         vlan: 20

--- a/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/roles/libvirt_manager/tasks/clean_layout.yml
@@ -154,3 +154,8 @@
         - workload
         - images
         - volumes
+
+    - name: Clean virtualBMC
+      ansible.builtin.import_role:
+        name: virtualbmc
+        tasks_from: cleanup.yml

--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -162,6 +162,35 @@
       cifmw_libvirt_manager_pub_net ({{ cifmw_libvirt_manager_pub_net }}).
       Please double-check your scenario!
 
+- name: Create VBMC entity
+  when:
+    - _vbmc_available is defined
+    - _vbmc_available | bool
+  vars:
+    cifmw_virtualbmc_machine: "cifmw-{{ vm_type }}-{{ index }}"
+    cifmw_virtualbmc_ipmi_port: >-
+      {{
+        cifmw_virtualbmc_ipmi_base_port + family_id + index
+      }}
+    cifmw_virtualbmc_action: "add"
+    _ipmi_host: >-
+      {%- if cifmw_libvirt_manager_configuration.vms.crc.target is defined -%}
+      {{ cifmw_libvirt_manager_configuration.vms.crc.target }}
+      {%- elif cifmw_libvirt_manager_configuration.vms.ocp.target is defined -%}
+      {{ cifmw_libvirt_manager_configuration.vms.ocp.target }}
+      {%- else -%}
+      {{ inventory_hostname }}
+      {%- endif -%}
+    cifmw_virtualbmc_ipmi_address: >-
+      {{ hostvars[_ipmi_host].ansible_default_ipv4.address }}
+  ansible.builtin.include_role:
+    name: virtualbmc
+    tasks_from: manage_host
+  loop: "{{ _vm_ports.results }}"
+  loop_control:
+    index_var: index
+    label: "{{ vm_type }}-{{ index }}"
+
 - name: "Start and grab IP if image is not blank for {{ vm_type }}"
   when:
     - vm_data.value.disk_file_name != 'blank'

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -1,4 +1,29 @@
 ---
+# Deploy VBMC only on the hypervisor running OpenShift services,
+# being OCP cluster or single CRC.
+- name: Deploy VirtualBMC service container
+  tags:
+    - bootstrap
+    - bootstrap_layout
+  when:
+    - (cifmw_libvirt_manager_configuration.vms.crc.target is defined and
+       cifmw_libvirt_manager_configuration.vms.crc.target == inventory_hostname) or
+      (cifmw_libvirt_manager_configuration.vms.crc is defined and
+       cifmw_libvirt_manager_configuration.vms.crc.target is undefined) or
+      (cifmw_libvirt_manager_configuration.vms.ocp.target is defined and
+       cifmw_libvirt_manager_configuration.vms.ocp.target == inventory_hostname) or
+      (cifmw_libvirt_manager_configuration.vms.ocp is defined and
+       cifmw_libvirt_manager_configuration.vms.ocp.target is undefined)
+  block:
+    - name: Deploy virtualbmc
+      ansible.builtin.include_role:
+        name: virtualbmc
+
+    - name: Let the project know we have vbmc available
+      ansible.builtin.set_fact:
+        _vbmc_available: true
+        _vbmc_host: "{{ inventory_hostname }}"
+
 - name: Create needed workload directory
   ansible.builtin.file:
     path: "{{ cifmw_libvirt_manager_basedir }}/{{ item }}"
@@ -166,6 +191,7 @@
   loop_control:
     label: "{{ vm_data.key }}"
     loop_var: vm_data
+    index_var: family_id
 
 - name: Create "all" group inventory file
   ansible.builtin.template:
@@ -193,6 +219,33 @@
   ansible.builtin.copy:
     dest: "{{ cifmw_libvirt_manager_basedir }}/artifacts/interfaces-info.yml"
     content: "{{ cifmw_libvirt_manager_mac_map | to_nice_yaml }}"
+
+- name: Refresh and dump vbmc hosts
+  when:
+    - _vbmc_host is defined
+    - _vbmc_host == inventory_hostname
+  block:
+    - name: Ensure fresh vbmc listing
+      ansible.builtin.include_role:
+        name: virtualbmc
+        tasks_from: list_hosts.yml
+
+    - name: Dump vbmc known hosts
+      vars:
+        _auth:
+          username: "{{ cifmw_virtualbmc_ipmi_user | default('admin') }}"
+          password: "{{ cifmw_virtualbmc_ipmi_password | default('password') }}"
+        _mapped: >-
+          {{
+            cifmw_virtualbmc_known_hosts |
+            map('combine', _auth)
+          }}
+        content:
+          cifmw_virtualbmc_known_hosts: "{{ _mapped }}"
+      ansible.builtin.copy:
+        dest: >-
+          {{ cifmw_libvirt_manager_basedir }}/artifacts/virtualbmc-nodes.yml
+        content: "{{ content | to_nice_yaml }}"
 
 - name: Ensure we get proper access to CRC
   when:

--- a/roles/libvirt_manager/tasks/main.yml
+++ b/roles/libvirt_manager/tasks/main.yml
@@ -26,6 +26,7 @@
   tags:
     - bootstrap
     - bootstrap_layout
+    - bootstrap_libvirt
   ansible.builtin.import_tasks: virtualization_prerequisites.yml
 
 - name: Install packages and dependencies
@@ -33,16 +34,19 @@
     - packages
     - bootstrap
     - bootstrap_layout
+    - bootstrap_libvirt
   ansible.builtin.import_tasks: packages.yml
 
 - name: Add polkit rules
   tags:
     - bootstrap
     - bootstrap_layout
+    - bootstrap_libvirt
   ansible.builtin.import_tasks: polkit_rules.yml
 
 - name: Check Virsh usage
   tags:
     - bootstrap
     - bootstrap_layout
+    - bootstrap_libvirt
   ansible.builtin.import_tasks: virsh_checks.yml

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -59,8 +59,6 @@
   ansible.builtin.include_tasks: ci_data.yml
 
 - name: Bootstrap libvirt if needed
-  tags:
-    - bootstrap_libvirt
   when:
     - cifmw_use_libvirt | default(false) | bool
   ansible.builtin.include_role:

--- a/roles/virtualbmc/tasks/cleanup.yml
+++ b/roles/virtualbmc/tasks/cleanup.yml
@@ -24,7 +24,14 @@
     name: "{{ cifmw_virtualbmc_image }}"
     state: absent
 
+- name: Check if VBMC key exists
+  register: _vbmc_ssh_stat
+  ansible.builtin.stat:
+    path: "{{ cifmw_virtualbmc_sshkey_path }}.pub"
+
 - name: Revoke VBMC temporary key
+  when:
+    - _vbmc_ssh_stat.stat.exists
   block:
     - name: Slurp key
       register: _vbmc_key

--- a/roles/virtualbmc/tasks/main.yml
+++ b/roles/virtualbmc/tasks/main.yml
@@ -23,30 +23,39 @@
     - key: "{{ cifmw_virtualbmc_sshkey_path | dirname }}"
       mode: "0700"
 
-- name: Create ssh key for VBMC
-  register: _vbmc_key
-  community.crypto.openssh_keypair:
-    path: "{{ cifmw_virtualbmc_sshkey_path }}"
-    type: "{{ cifmw_virtualbmc_sshkey_type }}"
-    size: "{{ cifmw_virtualbmc_sshkey_size }}"
-    regenerate: full_idempotence
-
-- name: Pull vbmc container image
-  containers.podman.podman_image:
-    name: "{{ cifmw_virtualbmc_image }}"
-    state: present
-
-- name: Allow VBMC temporary key
-  ansible.posix.authorized_key:
-    user: "{{ ansible_user_id }}"
-    key: "{{ _vbmc_key.public_key }}"
-    state: present
-
-- name: Create and start vbmc container
-  containers.podman.podman_container:
-    image: "{{ cifmw_virtualbmc_image }}"
+- name: Check if container already exists
+  register: _vbmc_container_info
+  containers.podman.podman_container_info:
     name: "{{ cifmw_virtualbmc_container_name }}"
-    network: host
-    state: started
-    volumes:
-      - "{{ cifmw_virtualbmc_sshkey_path }}:{{ cifmw_virtualbmc_ipmi_key_path }}:ro,Z"
+
+- name: Run tasks only if container does not exist
+  when:
+    - _vbmc_container_info.containers | length == 0
+  block:
+    - name: Create ssh key for VBMC
+      register: _vbmc_key
+      community.crypto.openssh_keypair:
+        path: "{{ cifmw_virtualbmc_sshkey_path }}"
+        type: "{{ cifmw_virtualbmc_sshkey_type }}"
+        size: "{{ cifmw_virtualbmc_sshkey_size }}"
+        regenerate: full_idempotence
+
+    - name: Pull vbmc container image
+      containers.podman.podman_image:
+        name: "{{ cifmw_virtualbmc_image }}"
+        state: present
+
+    - name: Allow VBMC temporary key
+      ansible.posix.authorized_key:
+        user: "{{ ansible_user_id }}"
+        key: "{{ _vbmc_key.public_key }}"
+        state: present
+
+    - name: Create and start vbmc container
+      containers.podman.podman_container:
+        image: "{{ cifmw_virtualbmc_image }}"
+        name: "{{ cifmw_virtualbmc_container_name }}"
+        network: host
+        state: started
+        volumes:
+          - "{{ cifmw_virtualbmc_sshkey_path }}:{{ cifmw_virtualbmc_ipmi_key_path }}:ro,Z"


### PR DESCRIPTION
This patch allows to configure the virtualbmc service and inject all of
the created virtual machines in it.

Since we want to get only one instance of virtualbmc, even in a
multi-hypervisor layout, we have to be sure to properly target the one
hosting the OpenShift services, being OCP cluster or single CRC.

This patch also remove a duplicated call to the
libvirt_manager/clean_layout tasks from the devscripts role.

This patch also correct some indempotency issues in virtualbmc,
preventing a nice integration.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1284

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
