### PR TITLE
Add default values for ceph playbook in adoption

### DIFF
--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -156,7 +156,7 @@
 
 - name: Fetch network facts of all computes
   tags: cephadm
-  hosts: "{{ groups[cifmw_ceph_target | default('computes')] }}"
+  hosts: "{{ groups[cifmw_ceph_target | default('computes')] | default([]) }}"
   gather_facts: false
   tasks:
     - name: Fetch network facts of all computes


### PR DESCRIPTION
The adoption nodeset does not have any compute nodes, and the empty
computes groups since to crash the ceph playbook that is imported but
not run there.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
