### PR TITLE
Add nova-extra-config to dpservice nova ceph

### DIFF
--- a/roles/hci_prepare/templates/dpservice-nova-custom-ceph.yml.j2
+++ b/roles/hci_prepare/templates/dpservice-nova-custom-ceph.yml.j2
@@ -8,6 +8,7 @@ spec:
   label: dataplane-deployment-nova-custom-ceph
   configMaps:
     - ceph-nova
+    - nova-extra-config
   secrets:
     - nova-cell1-compute-config
     - nova-migration-ssh-key


### PR DESCRIPTION
Add the 'nova-extra-config' ConfigMap to allow for additional nova configuration overwrites to be included when deploying with HCI.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
