### PR TITLE
Stop ceph playbooks as early as possible

### DIFF
--- a/playbooks/06-deploy-edpm.yml
+++ b/playbooks/06-deploy-edpm.yml
@@ -85,7 +85,7 @@
 
         - name: Prepare for HCI deploy phase 1
           when: cifmw_edpm_deploy_hci | default('false') | bool
-          ansible.builtin.import_role:
+          ansible.builtin.include_role:
             name: hci_prepare
             tasks_from: phase1.yml
 
@@ -107,10 +107,12 @@
       ansible.builtin.meta: clear_facts
 
 - name: Deploy Ceph on target nodes
-  when:
-    - cifmw_edpm_deploy_hci | default('false') | bool
-    - cifmw_architecture_scenario is undefined
   vars:
+    _deploy_ceph: >-
+      {{
+        (cifmw_edpm_deploy_hci | default('false') | bool) and
+        cifmw_architecture_scenario is undefined
+      }}
     ceph_spec_fqdn: true
     storage_network_range: 172.18.0.0/24
     storage_mgmt_network_range: 172.20.0.0/24
@@ -130,12 +132,12 @@
       when: cifmw_edpm_deploy_hci | default('false') | bool
       block:
         - name: Prepare for HCI deploy phase 2
-          ansible.builtin.import_role:
+          ansible.builtin.include_role:
             name: hci_prepare
             tasks_from: phase2.yml
 
         - name: Continue HCI deployment
-          ansible.builtin.import_role:
+          ansible.builtin.include_role:
             name: edpm_deploy
           vars:
             cifmw_edpm_deploy_prepare_run: false

--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -20,6 +20,13 @@
   gather_facts: false
   vars:
     cifmw_admin_user: ceph-admin
+  pre_tasks:
+    # end_play will end this current playbook and go the the next
+    # imported play.
+    - name: Early stop ceph related work
+      when:
+        - not _deploy_ceph | default(true)
+      ansible.builtin.meta: end_play
   tasks:
     - name: Set ssh key path facts
       ansible.builtin.set_fact:
@@ -58,6 +65,13 @@
     cifmw_admin_user: ceph-admin
     ansible_ssh_private_key_file: "{{ lookup('env', 'ANSIBLE_SSH_PRIVATE_KEY') }}"
   pre_tasks:
+    # end_play will end this current playbook and go the the next
+    # imported play.
+    - name: Early stop ceph related work
+      when:
+        - not _deploy_ceph | default(true)
+      ansible.builtin.meta: end_play
+
     - name: Get local private key
       ansible.builtin.slurp:
         src: "{{ lookup('env', 'HOME') }}/.ssh/{{ cifmw_admin_user }}-id_rsa"
@@ -83,6 +97,13 @@
   hosts: "{{ cifmw_ceph_target | default('computes')  }}"
   gather_facts: true
   become: true
+  pre_tasks:
+    # end_play will end this current playbook and go the the next
+    # imported play.
+    - name: Early stop ceph related work
+      when:
+        - not _deploy_ceph | default(true)
+      ansible.builtin.meta: end_play
   tasks:
     - name: Set cifmw_num_osds_perhost
     # By defualt 1 OSD is created per node in case of multinode.
@@ -120,6 +141,13 @@
     # storage_mgmt_network_range: 172.20.0.0/24
     all_addresses: ansible_all_ipv4_addresses # change if you need IPv6
   pre_tasks:
+    # end_play will end this current playbook and go the the next
+    # imported play.
+    - name: Early stop ceph related work
+      when:
+        - not _deploy_ceph | default(true)
+      ansible.builtin.meta: end_play
+
     - name: Use ansible_fqdn when ceph_spec_fqdn parameter is true
       when: ceph_spec_fqdn | default(false)
       ansible.builtin.set_fact:
@@ -180,6 +208,13 @@
   tags: cephadm
   hosts: "{{ groups[cifmw_ceph_target | default('computes')] | default([]) }}"
   gather_facts: false
+  pre_tasks:
+    # end_play will end this current playbook and go the the next
+    # imported play.
+    - name: Early stop ceph related work
+      when:
+        - not _deploy_ceph | default(true)
+      ansible.builtin.meta: end_play
   tasks:
     - name: Fetch network facts of all computes
       ansible.builtin.setup:
@@ -226,6 +261,13 @@
         pg_autoscale_mode: true
         application: cephfs
   pre_tasks:
+    # end_play will end this current playbook and go the the next
+    # imported play.
+    - name: Early stop ceph related work
+      when:
+        - not _deploy_ceph | default(true)
+      ansible.builtin.meta: end_play
+
     - name: Generate a cephx key
       cephx_key:
       register: cephx
@@ -356,6 +398,13 @@
     cifmw_ceph_client_fetch_dir: /tmp
     cifmw_ceph_client_k8s_secret_name: ceph-conf-files
     cifmw_ceph_client_k8s_namespace: openstack
+  pre_tasks:
+    # end_play will end this current playbook and go the the next
+    # imported play.
+    - name: Early stop ceph related work
+      when:
+        - not _deploy_ceph | default(true)
+      ansible.builtin.meta: end_play
   tasks:
     - name: Export configuration for ceph client
       ansible.builtin.import_role:


### PR DESCRIPTION
With `import_playbook` ansible stills goes through all of the tasks
listed in the plays, but will `skip` them, leading to some time loss,
and potential issues with the expected inventory we have to consume.

We also ensure the HCI path of 06-deploy-edpm.yml isn't `imported` in
case we don't want to run it, switching to `include_*` instead. This
will ensure we don't have a long list of skipped tasks in the logs.

The default bahavior of the `ceph.yml` playbook isn't affected, meaning
we don't need to pass any parameter to NOT deploy it.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
