### PR TITLE
Add role to deploy mirror-registry

### DIFF
--- a/roles/mirror_registry/README.md
+++ b/roles/mirror_registry/README.md
@@ -1,0 +1,28 @@
+# mirror_registry
+This role can be used to deploy mirror-registry:
+https://github.com/quay/mirror-registry
+
+This is the tool used facilitate disconnected deployments of OpenShift.
+
+## Privilege escalation
+This role requires privilege escalation to facilitate the following two objectives:
+
+- It escalates privileges to create a directory under /opt that will be used to store
+  artefacts from the mirror-registry deployment; and,
+- mirror-registry leverages podman, and podman volumes. It is necessary to run podman
+  as root to create the podman volume for Quay and it's Database.
+
+## Parameters
+`cifmw_mirror_registry_basedir`: /opt/mirror-registry
+`cifmw_mirror_registry_fqdn`: quay.openstack.lab
+`cifmw_mirror_registry_release_version`: v1.3.10
+
+## Examples
+- host: localhost
+  roles:
+    - mirror-registry
+  vars:
+    cifmw_mirror_registry_basedir: /home/m3/basedir
+    cifmw_mirror_registry_fqdn: quay.openstack.dev
+    cifmw_mirror_registry_install_dir: /opt/mirror-registry
+    cifmw_mirror_registry_release_version: v1.3.10

--- a/roles/mirror_registry/defaults/main.yml
+++ b/roles/mirror_registry/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_mirror-registry"
+#
+cifmw_mirror_registry_install_dir: /opt/mirror-registry
+cifmw_mirror_registry_fqdn: quay.openstack.lab
+cifmw_mirror_registry_release_version: v1.3.10
+cifmw_mirror_registry_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"

--- a/roles/mirror_registry/meta/main.yml
+++ b/roles/mirror_registry/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- mirror_registry
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: cifmw
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - cifmw
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/mirror_registry/molecule/default/converge.yml
+++ b/roles/mirror_registry/molecule/default/converge.yml
@@ -1,0 +1,32 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  roles:
+    - role: "mirror_registry"
+
+  tasks:
+    - name: Try to login to mirror registry
+      ansible.builtin.shell: |
+        podman login {{ cifmw_mirror_registry_fqdn }}:8443 --tls-verify=false -u init -p {{ _cifmw_mirror_registry_init_password }}
+      register: login_result
+
+    - name: Assert that loging succeeded
+      ansible.builtin.assert:
+        that:
+          - "'Login Succeeded!' in login_result.stdout"

--- a/roles/mirror_registry/molecule/default/molecule.yml
+++ b/roles/mirror_registry/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/roles/mirror_registry/molecule/default/prepare.yml
+++ b/roles/mirror_registry/molecule/default/prepare.yml
@@ -1,0 +1,21 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps

--- a/roles/mirror_registry/tasks/cleanup.yml
+++ b/roles/mirror_registry/tasks/cleanup.yml
@@ -1,0 +1,38 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Uninstall mirror-registry
+  become: true
+  cifmw.general.ci_script:
+    output_dir: "{{ cifmw_mirror_registry_basedir }}/artifacts"
+    script: |
+      set -o pipefail echo y | {{ cifw_mirror_registry_install_dir }}/mirror-registry uninstall -v
+
+- name: Remove hosts entry in /etc/hosts for mirror-registry
+  become: true
+  ansible.builtin.lineinfile:
+    dest: /etc/hosts
+    line: "127.0.0.1 {{ cifw_mirror_registry_fqdn }}"
+    state: absent
+
+- name: Remove mirror-registry directory
+  become: true
+  ansible.builtin.file:
+    path: "{{ cifw_mirror_registry_install_dir }}/registry"
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_id }}"
+    state: absent
+    recurse: true

--- a/roles/mirror_registry/tasks/main.yml
+++ b/roles/mirror_registry/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Set random auth cred for duration of QE run
+  ansible.builtin.set_fact:
+    # For QE purposes, this only needs to exist for the duration of a single execution.
+    # Randomly generating a string saves us from pulling the randomly generated init password
+    # from the stdout of mirror-registry install.
+    _cifmw_mirror_registry_init_password: "{{ lookup('community.general.random_string', length=12, special=false) }}"
+
+- name: Make directory for mirror-registry to use
+  become: true
+  ansible.builtin.file:
+    path: "{{ cifmw_mirror_registry_install_dir }}/registry"
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_id }}"
+    state: directory
+
+- name: Download mirror-registry tools
+  ansible.builtin.unarchive:
+    remote_src: true
+    src: "https://github.com/quay/mirror-registry/releases/download/{{ cifmw_mirror_registry_release_version }}/mirror-registry-offline.tar.gz"
+    dest: "{{ cifmw_mirror_registry_install_dir }}"
+
+- name: Add hosts entry in /etc/hosts for mirror-registry
+  become: true
+  ansible.builtin.lineinfile:
+    dest: /etc/hosts
+    line: "127.0.0.1 {{ cifmw_mirror_registry_fqdn }}"
+    state: present
+
+- name: Install mirror-registry
+  become: true
+  cifmw.general.ci_script:
+    output_dir: "{{ cifmw_mirror_registry_basedir }}/artifacts"
+    script: |
+      {{ cifmw_mirror_registry_install_dir }}/mirror-registry install -v --quayHostname {{ cifmw_mirror_registry_fqdn }} --quayRoot {{ cifmw_mirror_registry_install_dir }}/registry --initPassword {{ _cifmw_mirror_registry_init_password }}

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -468,6 +468,17 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/mirror_registry/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-mirror_registry
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: mirror_registry
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/nat64_appliance/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -52,6 +52,7 @@
       - cifmw-molecule-kustomize_deploy
       - cifmw-molecule-libvirt_manager
       - cifmw-molecule-manage_secrets
+      - cifmw-molecule-mirror_registry
       - cifmw-molecule-nat64_appliance
       - cifmw-molecule-networking_mapper
       - cifmw-molecule-openshift_adm


### PR DESCRIPTION
This commit adds a playbook to deploy mirror-registry. This can be leveraged to validate disconnected deployments.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
