### PR TITLE
Use test operator for running tempest

### DIFF
--- a/scenarios/reproducers/va-hci.yml
+++ b/scenarios/reproducers/va-hci.yml
@@ -49,8 +49,10 @@ cifmw_ceph_client_service_values_post_ceph_path_dst: >-
 # What about some tempest?
 cifmw_run_tests: true
 cifmw_run_tempest: true
-cifmw_tempest_tests_allowed:
-  - tempest.scenario.test_network_basic_ops.TestNetworkBasicOps
+cifmw_run_test_role: test_operator
+cifmw_test_operator_timeout: 7200
+cifmw_test_operator_tempest_include_list: |
+  tempest.scenario.test_network_basic_ops.TestNetworkBasicOps
 
 # This will instruct libvirt_manager to create 3 compute and
 # the ansible-controller, consuming the networks created and


### PR DESCRIPTION
tempest role does not give much info about what tests are running before exit.
Tempest container gets stuck for longer period of time.

test_operator is going to be the way to run tempest. Let's use that one. It has better error message and reporting via k8s jobs.

Let's use that one for running.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

