### PR TITLE
Configure vnet devices with the required vlan ids.

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -291,6 +291,7 @@ nftables
 nic
 nigzpbgugpsavdmfyl
 nlcggvjgnsdxn
+nmcli
 nmstate
 nncp
 nobuild

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -216,3 +216,42 @@ Module that approves pending certificate requests in OpenShift platform.
       approve_csr:
         k8s_config: "{{ k8s_config }}"
 ```
+
+# modules/bridge_vlan
+
+Configures the gathered VLAN ids for all TAP devices attached to the provided
+network(s).
+
+## options - bridge_vlan
+
+```YAML
+* networks
+  * description: List of the networks to be processed.
+    required: true
+    type: list
+    elements: str
+```
+
+### example - bridge_vlan
+
+```YAML
+---
+- name: Configure the TAP attached to trunk ports
+  hosts: hypervisor
+  gather_facts: false
+  vars:
+    networks:
+      osp_trunk: |
+        <network>
+          <name>osp_trunk</name>
+          <forward mode='nat' />
+          <bridge name='osp_trunk' />
+        </network>
+
+  tasks:
+    - name: Apply VLANs to all associated TAP devices.
+      become: true
+      cifmw.general.bridge_vlan:
+        networks: "{{ networks.keys() | list }}"
+      register: _bridge_results
+```

--- a/plugins/modules/bridge_vlan.py
+++ b/plugins/modules/bridge_vlan.py
@@ -1,0 +1,279 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2024, Pragadeeswaran <psathyan@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: bridge_vlan
+
+short_description: Attach VLAN ids to virtual network interfaces.
+description: |
+    This module adds VLAN ids to all virtual network interfaces attached
+    to the specified virtual network. The virtual network has a physical
+    network interface that is configured as a VLAN trunk port.
+
+    The module sets the tasks return elements like changed and success
+    to true when
+
+        - Physical interface is configured for trunk VLAN
+        - There are TAPs attached to the virtual network
+        - All identified VLAN ids were applied to all identified interfaces
+
+    The module sets the tasks to failed when
+
+        - Physical interface is configured to forward multiple VLAN ids
+        - There are TAPs attached to the virtual network
+        - There was a failure allowing VLAN ids for one or more TAPs
+
+    For any other conditions, the changed is marked as false and success is
+    marked as true.
+
+requirements:
+  - nmcli
+  - bridge
+  - ip
+
+options:
+    networks:
+        description: The name of the virtual networks.
+        required: true
+        type: list
+        elements: str
+
+author:
+  - Pragadeeswaran (@psathyan)
+"""
+
+
+EXAMPLES = r"""
+- name: Attach all configured VLANs to the interfaces of osp_trunk
+  become: true
+  bridge_vlan:
+    networks:
+      - osp_trunk
+"""  # noqa
+
+
+RETURN = r"""
+success:
+    description: Status of the execution
+    type: bool
+    returned: always
+    sample: true
+"""
+
+
+from copy import deepcopy
+from typing import Any, Dict, List, Optional
+
+import json
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def get_taps(details: List[Dict[str, Any]]) -> List[str]:
+    """Gather the list of TAP devices found in the given network details.
+
+    Args:
+        details: A list of mapping containing details of the ports attached to
+                 a virtual network.
+
+    Returns:
+        A list of virtual network interface names having suffix as vnet.
+    """
+    return [_net["ifname"] for _net in details if _net["ifname"].startswith("vnet")]
+
+
+def get_physical_iface(details: List[Dict[str, Any]]) -> Optional[str]:
+    """Return the physical interface found in the given network details.
+
+    Args:
+        details: A list of mapping containing details of the ports attached to
+                 a virtual network.
+
+    Returns:
+        A string representing the first interface name not having vnet suffix.
+    """
+    for _net in details:
+        if not _net["ifname"].startswith("vnet"):
+            return _net["ifname"]
+
+    return None
+
+
+class BridgeVlanCLI(object):
+    """BridgeVlanCLI class acts as an interface to bridge vlan subcommand."""
+
+    def __init__(self, module: AnsibleModule) -> None:
+        self.module = module
+        self.vnet_names = module.params["networks"]
+
+    def execute_command(self, cmd, use_unsafe_shell=False, data=None) -> Any:
+        return self.module.run_command(
+            cmd, use_unsafe_shell=use_unsafe_shell, data=data
+        )
+
+    def _get_net_info(self, name: str) -> Any:
+        """Collect the details of the provided network.
+
+        Args:
+            name: name of the network
+
+        Returns:
+            Tuple (rc, stdout, stderr) command execution information.
+        """
+        _cmd = [
+            self.module.get_bin_path("ip", True),
+            "-json",
+            "link",
+            "show",
+            "master",
+            name,
+        ]
+        return self.execute_command(cmd=_cmd)
+
+    def _get_vlan_ids(self, name: str) -> List[str]:
+        """Gather the VLAN IDs associated to the given iface.
+
+        Args:
+            name: name of the physical interface.
+
+        Returns:
+            A list containing VLAN ids in form of 3, 4, 5, 6-10
+        """
+        _cmd = [
+            self.module.get_bin_path("nmcli", True),
+            "-t",
+            "-f",
+            "bridge-port.vlans",
+            "connection",
+            "show",
+            name,
+        ]
+        (rc, out, _) = self.execute_command(_cmd)
+        _possible_vlans = out.strip().split(":")[1]
+
+        if rc != 0 or not _possible_vlans:
+            return []
+
+        # Output: bridge-port.vlans:120-129, 502 pvid untagged
+        # Output: bridge-port.vlans:120-129
+        # Output: bridge-port.vlans:120, 121, 122, 123
+        _vlans = _possible_vlans.split(",")
+        if "pvid" in _vlans[-1]:
+            # Remove the x pvid untagged which is the last
+            _vlans.pop()
+
+        return _vlans
+
+    def _apply_vlans(self, vlans: List[Any], taps: List[Any]) -> bool:
+        """Applies the provided VLANs for the given TAPs.
+
+        Args:
+            vlans: A list containing a string of VLAN ids
+            taps: A list containing the names of TAP devices to which VLANs are applied.
+
+        Return:
+            True if successful else False
+        """
+        _success = True
+        _base_cmd = [self.module.get_bin_path("bridge", True), "vlan", "add", "dev"]
+        for _tap in taps:
+            _tap_cmd = _base_cmd + [_tap, "vid"]
+            for _vlan in vlans:
+                _vlan_cmd = _tap_cmd + [_vlan]
+                (_rc, _, _) = self.execute_command(_vlan_cmd)
+
+                _success = _success and _rc != 0
+
+        return _success
+
+    def add_vlans(self) -> Dict[str, Any]:
+        """Add the VLAN ids to the associated network.
+
+        Returns:
+            A mapping holding results of each network.
+        """
+        _result = dict(changed=False, failed=True, networks=dict())
+        _success = None
+        for _net in self.vnet_names:
+            _rc, _out, _err = self._get_net_info(_net)
+            if _rc != 0:
+                _result["networks"][_net] = dict(failed=False, error=_err)
+                continue
+
+            net_info = json.loads(_out)
+            taps = get_taps(net_info)
+            if not taps:
+                _result["networks"][_net] = dict(
+                    error="No TAP interfaces found.",
+                    failed=False,
+                    changed=False,
+                )
+                continue
+
+            iface = get_physical_iface(net_info)
+            if not iface:
+                _result["networks"][_net] = dict(
+                    error="No physical interface found.", failed=False, changed=False
+                )
+                continue
+
+            vlans = self._get_vlan_ids(iface)
+            if not vlans:
+                _result["networks"][_net] = dict(
+                    error="Failed to gather the VLAN information.",
+                    failed=False,
+                    changed=False,
+                )
+                continue
+
+            if self._apply_vlans(vlans, taps):
+                _result["networks"][_net] = dict(iface=deepcopy(net_info))
+                _result["networks"][_net]["result"] = {
+                    "changed": True,
+                    "success": True,
+                    "failed": False,
+                }
+                _success = True if _success is None else _success
+            else:
+                _result["networks"][_net] = dict(iface=deepcopy(net_info))
+                _result["networks"][_net]["result"] = {
+                    "changed": False,
+                    "success": False,
+                    "failed": True,
+                }
+                _success = False
+
+        # Set task level results
+        _result["changed"] = False if _success is None else _success
+        _result["success"] = True if _success is None else _success
+        _result["failed"] = False if _success is None else not _success
+
+        return _result
+
+
+def run_module():
+    _args = dict(networks=dict(required=True, type="list", elements="str"))
+
+    _result = dict(success=True, changed=False, failed=False)
+
+    _module = AnsibleModule(argument_spec=_args, supports_check_mode=True)
+
+    if _module.check_mode:
+        _module.exit_json(**_result)
+
+    bridge = BridgeVlanCLI(_module)
+    _result = bridge.add_vlans()
+
+    _module.exit_json(**_result)
+
+
+if __name__ == "__main__":
+    run_module()

--- a/roles/devscripts/tasks/300_post.yml
+++ b/roles/devscripts/tasks/300_post.yml
@@ -53,6 +53,19 @@
         name: libvirt_manager
         tasks_from: deploy_layout
 
+    - name: Apply VLAN configuration for vnet interfaces.
+      tags:
+        - devscripts_post
+      when:
+        - cifmw_libvirt_manager_configuration_gen.networks is defined
+      become: true
+      cifmw.general.bridge_vlan:
+        networks: >-
+          {{
+            cifmw_libvirt_manager_configuration_gen.networks.keys() | list
+          }}
+      failed_when: false
+
     - name: Ensure the OpenShift cluster is accessible.
       tags:
         - devscripts_post

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -99,6 +99,26 @@
     - bootstrap_layout
   ansible.builtin.include_tasks: libvirt_layout.yml
 
+- name: Apply VLAN ids to TAP type interfaces.
+  when:
+    - cifmw_libvirt_manager_configuration.networks is defined
+    - cifmw_libvirt_manager_configuration.vms.ocp is defined
+    - (
+        cifmw_libvirt_manager_configuration.vms.ocp.target is defined and
+        cifmw_libvirt_manager_configuration.vms.ocp.target == inventory_hostname
+      ) or
+      cifmw_libvirt_manager_configuration.vms.ocp.target is undefined
+  tags:
+    - bootstrap
+    - bootstrap_layout
+  become: true
+  cifmw.general.bridge_vlan:
+    networks: >-
+      {{
+        cifmw_libvirt_manager_configuration.networks.keys() | list
+      }}
+  failed_when: false
+
 - name: Run only on hypervisor with controller-0
   when:
     - (

--- a/tests/unit/modules/test_bridge_vlan.py
+++ b/tests/unit/modules/test_bridge_vlan.py
@@ -1,0 +1,165 @@
+# Copyright: (c) 2024, Red Hat
+
+# GNU General Public License v3.0+ (see COPYING or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+import json
+
+from unittest.mock import patch
+
+from ansible_collections.cifmw.general.tests.unit.utils import (
+    ModuleBaseTestCase,
+    set_module_args,
+    AnsibleExitJson,
+    AnsibleFailJson,
+)
+from ansible_collections.cifmw.general.plugins.modules import bridge_vlan
+
+
+class TestBridgeVLAN(ModuleBaseTestCase):
+    """Test core functionality of configuring TAP."""
+
+    def test_negative_missing_params(self):
+        """Check failure when missing parameters."""
+        with self.assertRaises(AnsibleFailJson):
+            set_module_args({})
+            bridge_vlan.run_module()
+
+    def test_negative_invalid_network(self):
+        """Test when an invalid network is provided."""
+        set_module_args({"networks": ["test-net"]})
+
+        with patch.object(bridge_vlan.BridgeVlanCLI, "_get_net_info") as patch_func:
+            _rc = -1
+            _err = "Failed to gather network"
+            patch_func.return_value = (_rc, "", _err)
+
+            with self.assertRaises(AnsibleExitJson) as rst:
+                bridge_vlan.run_module()
+
+            result = rst.exception.args[0]
+            self.assertFalse(result["failed"])
+
+    def test_negative_network_with_no_physical_port(self):
+        """Test when there is no port attached to the network."""
+        set_module_args({"networks": ["test-net"]})
+        _msg = "No physical interface found."
+
+        with patch.object(bridge_vlan.BridgeVlanCLI, "_get_net_info") as patch_func:
+            _rc = 0
+            _data = [
+                dict(ifindex=0, ifname="vnet0", master="test-net"),
+                dict(ifindex=1, ifname="vnet1", master="test-net"),
+            ]
+            _out = json.dumps(_data)
+            patch_func.return_value = (_rc, _out, None)
+
+            with self.assertRaises(AnsibleExitJson) as rst:
+                bridge_vlan.run_module()
+
+            result = rst.exception.args[0]
+            self.assertFalse(result["changed"])
+            self.assertIn("test-net", result["networks"])
+            self.assertEquals(result["networks"]["test-net"]["error"], _msg)
+
+    def test_negative_network_with_no_tap(self):
+        """Test when there is no port attached to the network."""
+        set_module_args({"networks": ["test-net"]})
+        _msg = "No TAP interfaces found."
+
+        with patch.object(bridge_vlan.BridgeVlanCLI, "_get_net_info") as patch_func:
+            _rc = 0
+            _data = [dict(ifindex=0, ifname="ens1", master="test-net")]
+            _out = json.dumps(_data)
+            patch_func.return_value = (_rc, _out, None)
+
+            with self.assertRaises(AnsibleExitJson) as rst:
+                bridge_vlan.run_module()
+
+            result = rst.exception.args[0]
+            self.assertFalse(result["changed"])
+            self.assertEquals(result["networks"]["test-net"]["error"], _msg)
+
+    def test_negative_no_vlan_ids(self):
+        """Test when there is no VLAN ids associated with the physical interface."""
+        set_module_args({"networks": ["test-net"]})
+        _msg = "Failed to gather the VLAN information."
+
+        with patch.object(bridge_vlan.BridgeVlanCLI, "_get_net_info") as patch_func:
+            _rc = 0
+            _data = [
+                dict(ifindex=0, ifname="vnet0", master="test-net"),
+                dict(ifindex=1, ifname="vnet1", master="test-net"),
+                dict(ifindex=2, ifname="ens1", master="test-net"),
+            ]
+            _out = json.dumps(_data)
+            patch_func.return_value = (_rc, _out, None)
+
+            with patch.object(bridge_vlan.BridgeVlanCLI, "_get_vlan_ids") as patch_vlan:
+                patch_vlan.return_value = []
+                with self.assertRaises(AnsibleExitJson) as rst:
+                    bridge_vlan.run_module()
+
+                result = rst.exception.args[0]
+                self.assertFalse(result["changed"])
+                self.assertEquals(result["networks"]["test-net"]["error"], _msg)
+
+    def test_negative_failed_to_apply_vlan(self):
+        """Test failure on applying VLANs to TAP."""
+        set_module_args({"networks": ["test-net"]})
+
+        with patch.object(bridge_vlan.BridgeVlanCLI, "_get_net_info") as patch_func:
+            _rc = 0
+            _data = [
+                dict(ifindex=0, ifname="vnet0", master="test-net"),
+                dict(ifindex=1, ifname="vnet1", master="test-net"),
+                dict(ifindex=2, ifname="ens1", master="test-net"),
+            ]
+            _out = json.dumps(_data)
+            patch_func.return_value = (_rc, _out, None)
+
+            with patch.object(bridge_vlan.BridgeVlanCLI, "_get_vlan_ids") as patch_vlan:
+                patch_vlan.return_value = [10]
+
+                with patch.object(
+                    bridge_vlan.BridgeVlanCLI, "_apply_vlans"
+                ) as patch_apply:
+                    patch_apply.return_value = False
+                    with self.assertRaises(AnsibleExitJson) as rst:
+                        bridge_vlan.run_module()
+
+                    result = rst.exception.args[0]
+                    self.assertFalse(result["changed"])
+                    self.assertTrue(result["failed"])
+
+    def test_apply_vlan_on_success(self):
+        """Test apply vlan on success."""
+        set_module_args({"networks": ["test-net"]})
+
+        with patch.object(bridge_vlan.BridgeVlanCLI, "_get_net_info") as patch_func:
+            _rc = 0
+            _data = [
+                dict(ifindex=0, ifname="vnet0", master="test-net"),
+                dict(ifindex=1, ifname="vnet1", master="test-net"),
+                dict(ifindex=2, ifname="ens1", master="test-net"),
+            ]
+            _out = json.dumps(_data)
+            patch_func.return_value = (_rc, _out, None)
+
+            with patch.object(bridge_vlan.BridgeVlanCLI, "_get_vlan_ids") as patch_vlan:
+                patch_vlan.return_value = [10]
+
+                with patch.object(
+                    bridge_vlan.BridgeVlanCLI, "_apply_vlans"
+                ) as patch_apply:
+                    patch_apply.return_value = True
+                    with self.assertRaises(AnsibleExitJson) as rst:
+                        bridge_vlan.run_module()
+
+                    result = rst.exception.args[0]
+
+                    self.assertTrue(result["changed"])
+                    self.assertTrue(result["success"])
+                    self.assertFalse(result["failed"])
+                    self.assertIn("test-net", result["networks"])


### PR DESCRIPTION
When the libvirt network is created outside of dev-scripts purview, then we need to ensure the proper VLAN tagging of the vnet interfaces. If the interfaces are not configured then the communication in the tagged networks is broken.

This change set ensures when apply the gathered VLAN ids from the given networks and configured those interfaces attached to it.

A new `module` name `bridge_vlan` is introduced to support this functionality.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] Content of the docs/source is reflecting the changes

Closes: [OSPRH-5656](https://issues.redhat.com//browse/OSPRH-5656)

*Testing Results*
_Playbook run_
```
Wednesday 20 March 2024  20:33:41 -0400 (0:00:00.040)       0:20:57.924 ******* 
changed: [hypervisor -> controller-0(10.46.22.139)]

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
hypervisor                 : ok=303  changed=91   unreachable=0    failed=0    skipped=74   rescued=1    ignored=0   

Wednesday 20 March 2024  20:33:47 -0400 (0:00:05.808)       0:21:03.733 ******* 
=============================================================================== 
openshift_adm : Wait until OCP login succeeds. -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 257.91s
reproducer : Bootstrap environment on controller-0 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 145.66s
reproducer : Install some tools ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 110.51s
openshift_adm : Wait unit the OpenShift cluster is stable. --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 43.72s
libvirt_manager : Grab IPs for nodes type ocp ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 40.89s
libvirt_manager : Prepare disk image with SSH and growing volume --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 39.19s
reproducer : Install collections on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 39.09s
reproducer : Install ansible dependencies -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 28.18s
libvirt_manager : Grab IPs for nodes type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 26.43s
reproducer : Wait for OCP nodes to be ready ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 21.18s
networking_mapper : Ensure that networking and hostname facts are in place ----------------------------------------------------------------------------------------------------------------------------------------------------------- 20.33s
libvirt_manager : Wait for SSH on VMs type ocp --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.61s
libvirt_manager : Download base image ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 13.86s
reproducer : Inject ProxyJump configuration for remote hypervisor VMs ---------------------------------------------------------------------------------------------------------------------------------------------------------------- 12.45s
openshift_adm : Ensure the nodes are in ready state. ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 9.84s
reproducer : Enable RHEL repos -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 8.88s
reproducer : Ensure directories exist ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 8.76s
reproducer : Get rhos-release --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 7.87s
libvirt_manager : Inject private key on hosts controller ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 7.68s
libvirt_manager : Configure VMs type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 7.64s
[ciuser@devci-01 ci-framework]$ 
```

_Task snippet_
```
TASK [reproducer : Apply VLAN ids to TAP type interfaces. networks={{
  cifmw_libvirt_manager_configuration.networks.keys() | list
}}] *********************************************************************************************************                                                                                                                                 
Wednesday 20 March 2024  20:30:14 -0400 (0:00:00.058)       0:17:30.448 ******* 
changed: [hypervisor]
```

_Target vlan configuration_
```
bridge vlan show
port              vlan-id  
ens1f1            1 Egress Untagged
                  120
                  121
                  122
                  123
                  124
                  125
                  126
                  127
                  128
                  129
                  502 PVID Egress Untagged
ens1f0.312        1 PVID Egress Untagged
osp_trunk         1 PVID Egress Untagged
podman0           1 PVID Egress Untagged
veth0             1 PVID Egress Untagged
vnet24            1 PVID Egress Untagged
vnet25            1 PVID Egress Untagged
vnet26            1 PVID Egress Untagged
                  120
                  121
                  122
                  123
                  124
                  125
                  126
                  127
                  128
                  129
vnet27            1 PVID Egress Untagged
vnet28            1 PVID Egress Untagged
vnet29            1 PVID Egress Untagged
                  120
                  121
                  122
                  123
                  124
                  125
                  126
                  127
                  128
                  129
vnet30            1 PVID Egress Untagged
vnet31            1 PVID Egress Untagged
vnet32            1 PVID Egress Untagged
                  120
                  121
                  122
                  123
                  124
                  125
                  126
                  127
                  128
                  129
vnet33            1 PVID Egress Untagged
vnet34            1 PVID Egress Untagged
                  120
                  121
                  122
                  123
                  124
                  125
                  126
                  127
                  128
                  129
```

_VM interfaces_
```
[root@titan03 ~]# for i in {0..2}; do virsh domiflist cifmw-ocp-${i}; done
 Interface   Type     Source        Model    MAC
----------------------------------------------------------------
 vnet24      bridge   osasinfrapr   virtio   00:49:24:6d:36:1a
 vnet25      bridge   osasinfrabm   virtio   00:49:24:6d:36:1c
 vnet26      bridge   osp_trunk     virtio   52:54:00:cc:65:74

 Interface   Type     Source        Model    MAC
----------------------------------------------------------------
 vnet27      bridge   osasinfrapr   virtio   00:49:24:6d:36:1e
 vnet28      bridge   osasinfrabm   virtio   00:49:24:6d:36:20
 vnet29      bridge   osp_trunk     virtio   52:54:00:92:78:8b

 Interface   Type     Source        Model    MAC
----------------------------------------------------------------
 vnet30      bridge   osasinfrapr   virtio   00:49:24:6d:36:22
 vnet31      bridge   osasinfrabm   virtio   00:49:24:6d:36:24
 vnet32      bridge   osp_trunk     virtio   52:54:00:38:4e:d5

[root@titan03 ~]# 
````