### PR TITLE
Ensure we keep track of generated content

### DIFF
--- a/roles/ci_gen_kustomize_values/tasks/generate_snippets.yml
+++ b/roles/ci_gen_kustomize_values/tasks/generate_snippets.yml
@@ -88,6 +88,7 @@
         [_tmpl_path, _common_tmpl_path] | select('exists')
       }}
   ansible.builtin.template:
+    backup: true
     dest: >-
       {{
         (snippet_datadir,
@@ -98,6 +99,7 @@
 
 - name: Push user provided dataset
   ansible.builtin.copy:
+    backup: true
     dest: >-
       {{
         (snippet_datadir,

--- a/roles/ci_gen_kustomize_values/tasks/generate_values.yml
+++ b/roles/ci_gen_kustomize_values/tasks/generate_values.yml
@@ -42,6 +42,7 @@
       register: _snippets
       ansible.builtin.find:
         paths: "{{ _dir_path }}"
+        patterns: "*.yml,*.yaml"
         recurse: false
 
     - name: Assert we do have content to combine
@@ -99,6 +100,7 @@
 
     - name: Output values file
       ansible.builtin.copy:
+        backup: true
         dest: >-
           {{
             (_destdir,


### PR DESCRIPTION
It may happen we want to generate twice the same values.yaml, but with
maybe different content - this is especially true in the VA automation,
for instance two stages share the same `src_file` and the same
`value.name`, but the output is different.

In such as case, we want to consume the exact same `values.yaml`
(untouched), the same CI generaged content, and maybe a different user
provided kustomization.

While it was 100% supported, we may lose track of the history of the
changes. This patch therefore ensures we:
- backup the files before override
- exclude those backup files from the final `values.yaml` generation

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
