### PR TITLE
Exclude bots PR from checklist workflow

### DIFF
--- a/.github/workflows/require-checklist.yaml
+++ b/.github/workflows/require-checklist.yaml
@@ -1,11 +1,22 @@
+---
 name: Require Checklist
 
-on: # noqa: yaml[truthy]
+on:  # noqa: yaml[truthy]
   pull_request:
     types: [opened, edited, synchronize]
 
+# According to github, the "actor" for dependabot is dependabot[bot]:
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events
+# This should allow us to NOT require checklist from that bot anymore.
+# Since we're considering Renovate bot instead, we also exclude it from that
+# workflow, using https://github.com/renovatebot/renovate/discussions/13704 as
+# github.actor value.
+
 jobs:
   check-main-comment:
+    if: |
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'renovate[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: mheap/require-checklist-action@v2


### PR DESCRIPTION
With this PR, dependabot[bot] and renovate[bot] PR shouldn't require the
checklist workflow anymore.

- [X] according to the doc, it should work.
