### PR TITLE
Add more tags to deploy architecture playbook

### DIFF
--- a/playbooks/02-infra.yml
+++ b/playbooks/02-infra.yml
@@ -54,6 +54,8 @@
         name: devscripts
 
     - name: Login into Openshift cluster
+      tags:
+        - always
       vars:
         cifmw_openshift_login_force_refresh: true
       ansible.builtin.include_role:

--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -95,10 +95,14 @@
       ansible.builtin.import_role:
         name: kustomize_deploy
         tasks_from: install_operators.yml
+      tags:
+        - operator
 
     - name: Configure Storage Class
       ansible.builtin.include_role:
         name: ci_local_storage
+      tags:
+        - storage
 
     - name: Execute deployment steps
       ansible.builtin.include_role:
@@ -109,10 +113,14 @@
         label: "{{ stage.path }}"
         loop_var: stage
         index_var: stage_id
+      tags:
+        - edpm_deploy
 
     - name: Extract and install OpenStackControlplane CA
       ansible.builtin.include_role:
         role: install_openstack_ca
+      tags:
+        - openstack_ca
 
     - name: Run nova host discover process
       environment:


### PR DESCRIPTION
This pr adds operator, storage, edpm_deploy, openstack_ca
tag to control the deplpoyment while debugging.

It also adds `always` for the `openstack_login` call nested in the
02-infra playbook to ensure it's always run.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running

