### PR TITLE
[Test-operator] Change default image

### DIFF
--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -36,7 +36,7 @@ cifmw_test_operator_fail_fast: false
 # Section 2: tempest parameters - used when run_test_fw is 'tempest'
 cifmw_test_operator_tempest_registry: quay.io
 cifmw_test_operator_tempest_namespace: podified-antelope-centos9
-cifmw_test_operator_tempest_container: openstack-tempest
+cifmw_test_operator_tempest_container: openstack-tempest-all
 cifmw_test_operator_tempest_image: "{{ cifmw_test_operator_tempest_registry }}/{{ cifmw_test_operator_tempest_namespace }}/{{ cifmw_test_operator_tempest_container }}"
 cifmw_test_operator_tempest_image_tag: current-podified
 cifmw_test_operator_tempest_tests_include_override_scenario: false


### PR DESCRIPTION
Let's enable the openstack-tempest-all image by default as big portion of the jobs requires tests from a plugin. This requires a manual enabling of the openstack-tempest-all image for each such a job.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
