### PR TITLE
Donot generate nova migration key if exists

### DIFF
--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -27,14 +27,24 @@
       delegate_to: controller-0
       delegate_facts: true
 
-    - name: Create nova migration keypair
+    - name: Look for nova migration keypair file
+      register: _nova_key_file
+      ansible.builtin.stat:
+        path: "{{ cifmw_basedir }}/artifacts/nova_migration_key"
+
+    - name: Set _nova_key var when nova migration keypair exists
+      when: _nova_key_file.stat.exists
+      ansible.builtin.set_fact:
+        _nova_key:
+          filename: "{{ cifmw_basedir }}/artifacts/nova_migration_key"
+
+    - name: Create nova migration keypair if does not exists
+      when:
+        - not _nova_key_file.stat.exists
       register: _nova_key
       community.crypto.openssh_keypair:
         comment: "nova migration"
-        path: >-
-          {{ (cifmw_basedir,
-             'artifacts/nova_migration_key') | path_join
-          }}
+        path: "{{ cifmw_basedir }}/artifacts/nova_migration_key"
         type: "ecdsa"
 
     - name: Generate needed facts out of local files


### PR DESCRIPTION
If we re-run the deploy-architecture.sh script. Then Create nova migration keypair task fails with error:
```
Unable to read the key. The key is protected with a passphrase or broken.
```

In order to fix this issue, we donot need to regenerate the key but to reuse it.

This pr checks for nova migration key if exists. Reuse the same.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

