### PR TITLE
Use a bigger flavor for standalone node in adoption

### DIFF
--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -51,7 +51,7 @@
       - name: crc
         label: coreos-crc-extracted-2-30-0-3xl
       - name: standalone
-        label: cloud-rhel-9-2
+        label: cloud-rhel-9-2-tripleo
     groups:
       - name: computes
         nodes: []


### PR DESCRIPTION
The standalone deployment seems to fail with what seems to be
resource-related conditions, so trying to use a biggere flavor there
with more RAM.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
