### PR TITLE
Enable zuul pods for light checks

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -12,8 +12,10 @@ exclude_paths:
   - ci/
   - roles/ci_gen_kustomize_values/molecule/default/files/networking-environment-definition.yml  # Generated
   - roles/ci_gen_kustomize_values/molecule/default/converge.yml  # invalid due to calls to "lookup('file')"
+  - roles/ci_gen_kustomize_values/molecule/default/prepare.yml  # import_playbook
   - roles/reproducer/files/cifmw-bootstrap.yml  # invalid due to calls to "lookup('file')"
   - roles/kustomize_deploy/molecule/flexible_loop/files/networking-environment-definition.yml  # Generated
+  - roles/kustomize_deploy/molecule/flexible_loop/prepare.yml  # import_playbook
 strict: true
 quiet: false
 verbosity: 1

--- a/ci/playbooks/pre-commit.yml
+++ b/ci/playbooks/pre-commit.yml
@@ -1,0 +1,32 @@
+---
+- name: Run pre-commit tests
+  hosts: all
+  tasks:
+    - name: Install packages
+      become: true
+      ansible.builtin.package:
+        name:
+          - make
+          - python3
+          - python3-pip
+
+    - name: Run makes target
+      vars:
+        src_dir: >-
+          {{
+            zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir
+          }}
+      block:
+        - name: Instal dependencies
+          community.general.make:
+            chdir: "{{ src_dir }}"
+            target: setup_molecule
+            params:
+              USE_VENV: "no"
+
+        - name: Run pre-commit
+          community.general.make:
+            chdir: "{{ src_dir }}"
+            target: pre_commit_nodeps
+            params:
+              USE_VENV: "no"

--- a/ci/templates/projects.yaml
+++ b/ci/templates/projects.yaml
@@ -10,6 +10,7 @@
     github-check:
       jobs:
         - noop
+        - cifmw-pod-pre-commit
         - cifmw-baremetal-nested-crc
         - cifmw-content-provider-build-images
         - cifmw-edpm-build-images

--- a/roles/devscripts/tasks/111_verify_cluster.yml
+++ b/roles/devscripts/tasks/111_verify_cluster.yml
@@ -19,7 +19,7 @@
   ansible.builtin.import_tasks: set_cluster_fact.yml
 
 - name: Login to the deployed OpenShift cluster.
-  kubernetes.core.k8s_auth:
+  community.okd.openshift_auth:
     host: "{{ cifmw_openshift_api }}"
     password: "{{ cifmw_openshift_password }}"
     state: present

--- a/roles/openshift_adm/tasks/api_cert.yml
+++ b/roles/openshift_adm/tasks/api_cert.yml
@@ -69,7 +69,7 @@
     mode: "0440"
 
 - name: Read the certificate details.
-  openssl_certificate_info:
+  community.crypto.openssl_certificate_info:
     path: "/tmp/gen_api.crt"
   register: _gen_api_cert
 

--- a/roles/openshift_adm/tasks/wait_for_cluster.yml
+++ b/roles/openshift_adm/tasks/wait_for_cluster.yml
@@ -68,7 +68,7 @@
       oc adm wait-for-stable-cluster --minimum-stable-period=5s --timeout=30m
 
 - name: Wait until OCP login succeeds.
-  kubernetes.core.k8s_auth:
+  community.okd.openshift_auth:
     host: "{{ cifmw_openshift_api }}"
     password: "{{ cifmw_openshift_password }}"
     state: present

--- a/roles/test_operator/tasks/main.yml
+++ b/roles/test_operator/tasks/main.yml
@@ -93,14 +93,22 @@
   register: csv_list
   delay: 10
   retries: 20
-  until: |
-    csv_list | json_query('resources[*].metadata.name') | select('match', 'test-operator')
+  until: >-
+    {{
+      csv_list |
+      map(attribute='metadata.name') |
+      select('match', 'test-operator')
+    }}
   when: not cifmw_test_operator_dry_run | bool
 
 - name: Get full name of the test-operator csv
   ansible.builtin.set_fact:
     test_operator_csv_name: >-
-      {{ csv_list | json_query('resources[*].metadata.name') | select('match', 'test-operator') | first }}
+      {{
+        csv_list |
+        map(attribute='metadata.name') |
+        select('match', 'test-operator') | first
+      }}
   when: not cifmw_test_operator_dry_run | bool
 
 - name: Wait for the test-operator csv to Succeed

--- a/roles/test_operator/tasks/run-test-operator-job.yml
+++ b/roles/test_operator/tasks/run-test-operator-job.yml
@@ -140,12 +140,21 @@
 - name: Get status from test pods
   when: not cifmw_test_operator_dry_run | bool
   ansible.builtin.set_fact:
-    pod_status: "{{ test_pod_results | json_query('resources[*].status.phase') | list | unique }}"
+    pod_status: >-
+      {{
+        test_pod_results |
+        map(attribute='status.phase') |
+        list | unique
+      }}
 
 - name: Check whether test pods finished successfully
   when: not cifmw_test_operator_dry_run | bool
   ansible.builtin.set_fact:
-    successful_execution: "{{ pod_status | length == 1 and pod_status | first == 'Succeeded' }}"
+    successful_execution: >-
+      {{
+        pod_status | length == 1 and
+        pod_status | first == 'Succeeded'
+      }}
 
 - name: Fail fast if a pod did not succeed - {{ run_test_fw }}
   when:

--- a/zuul.d/pods.yaml
+++ b/zuul.d/pods.yaml
@@ -1,0 +1,11 @@
+---
+- job:
+    name: cifmw-pod-pre-commit
+    voting: false
+    nodeset:
+      nodes:
+        - name: container
+          label: pod-centos-9-stream
+    description: |
+      Run pre-commit against ci-framework
+    run: ci/playbooks/pre-commit.yml

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -2,6 +2,7 @@
     github-check:
       jobs:
       - noop
+      - cifmw-pod-pre-commit
       - cifmw-baremetal-nested-crc
       - cifmw-content-provider-build-images
       - cifmw-edpm-build-images


### PR DESCRIPTION
Zuul pods are containers, allowing to get lightweight checks running
with less resources (like Prow CI).

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
