### PR TITLE
Split GlanceAPI in the control plane CR when Ceph is applied

### DIFF
--- a/hooks/playbooks/control_plane_ceph_backends.yml
+++ b/hooks/playbooks/control_plane_ceph_backends.yml
@@ -100,6 +100,10 @@
                   rbd_store_pool = images
                   rbd_store_user = openstack
 
+              - op: replace
+                path: /spec/glance/template/glanceAPIs/default/type
+                value: split
+
               - op: add
                 path: /spec/manila/enabled
                 value: {{ cifmw_services_manila_enabled | default('false') }}


### PR DESCRIPTION
When `Ceph` is applied as a `Glance` backend, we should patch the `OpenStackControlPlane` `CR` and update the `glanceAPI` `type` parameter.
This patch fixes the current behavior and aligns `ci-framework` with what has been proposed in `Prow` jobs [1].

[1] https://github.com/openshift/release/blob/master/ci-operator/step-registry/openstack-k8s-operators/deploy/openstack-k8s-operators-deploy-commands.sh#L199

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
- [x] README in the role
- [x] Content of the docs/source is reflecting the changes
