### PR TITLE
increase cifw_edpm_deploy_timeout to 60mins

### DIFF
--- a/roles/edpm_deploy/defaults/main.yml
+++ b/roles/edpm_deploy/defaults/main.yml
@@ -22,7 +22,11 @@ cifmw_edpm_deploy_manifests_dir: "{{ cifmw_manifests | default(cifmw_edpm_deploy
 cifmw_edpm_deploy_retries: 100
 cifmw_edpm_deploy_run_validation: false
 cifmw_edpm_deploy_dryrun: false
-cifmw_edpm_deploy_timeout: 40
+# Enableing tls-e extends the time to deploy and if we land on a slighly slower node
+# 40 can fail. So we increase the timeout to 60 minutes, tls will be enabled by default
+# in the future so we bump the default timeout to 60 minutes instead of doing it in a specific
+# job that uses this role.
+cifmw_edpm_deploy_timeout: 60
 cifmw_edpm_deploy_registry_url: "{{ cifmw_install_yamls_defaults['DATAPLANE_REGISTRY_URL'] }}"
 cifmw_edpm_deploy_prepare_run: true
 cifmw_edpm_deploy_nova_compute_extra_config: ""


### PR DESCRIPTION
in ci we see that the current time to deploy the dataplane
can be very close to the current time out of 40m. we are currently
trying to enable tls on the edpm nodes by default which slightly increase
the time to deploy the dataplane. this change increase the default
timeout to 60mins to accomidate that new default.

as this will affect all jobs the change is done in the role
defaults.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running

