### PR TITLE
Establish framework for QE Validation jobs

### DIFF
--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -153,3 +153,7 @@
   vars:
     step: post_deploy
   ansible.builtin.import_playbook: ./hooks.yml
+
+- name: Validations workflow
+  ansible.builtin.import_playbook: validations.yml
+  when: cifmw_execute_validations | default('false') | bool

--- a/playbooks/06-deploy-edpm.yml
+++ b/playbooks/06-deploy-edpm.yml
@@ -151,3 +151,7 @@
   vars:
     step: post_deploy
   ansible.builtin.import_playbook: ./hooks.yml
+
+- name: Validations workflow
+  ansible.builtin.import_playbook: validations.yml
+  when: cifmw_execute_validations | default('false') | bool

--- a/playbooks/validations.yml
+++ b/playbooks/validations.yml
@@ -1,0 +1,8 @@
+- name: Execute the validations role
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+
+    - name: Run validations
+      ansible.builtin.include_role:
+        name: validations

--- a/roles/validations/README.md
+++ b/roles/validations/README.md
@@ -1,0 +1,29 @@
+# validations
+The Validations role provides a framework for performing state verification.
+This is useful for QE purposes and will be leveraged post-deployment to assert
+that required conditions have been satisfied. For example, if I update a certain
+value in my `OpenStackDataPlaneNodeSet`. I want to validate that the change has
+been applied as per my expectations on the relevant OpenStack Compute nodes.
+
+## Privilege escalation
+Privilege escalation will be dependent on the specific job being executed. Some jobs
+may require privilege escalation. Check with the individual jobs to determine
+requirements.
+
+## Parameters
+The parameters will ultimately depend on what is implemented in each validation task.
+But in order to launch this role, at a minimum the following should be defined:
+
+- `cifmw_validations_list`: (List) List of validation jobs to run. Found under `roles/validations/tasks/*`
+- `cifmw_validations_run_all`: (Bool) Defaults to false
+- `cifmw_validations_default_path`: (String) Defaults to `"{{ role_path }}/tasks"`
+
+## Examples
+The following variables would be used to trigger the EDPM job for Huge Pages:
+```yaml
+  vars:
+    cifmw_execute_validations: true
+    cifmw_validations_list:
+      - edpm/hugepages_and_reboot.yml
+    cifmw_validations_edpm_check_node: 192.168.122.100
+```

--- a/roles/validations/defaults/main.yml
+++ b/roles/validations/defaults/main.yml
@@ -1,0 +1,34 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_validations"
+
+
+# cifmw_validations_list can be used to provide a list of validations that should
+# be executed For example.
+# cifmw_validations_list:
+#   - edpm/hugepages_and_reboot.yml
+#   - nfv/dpdk_and_sriov.yml
+#   - storage/hci_and_res_mem.yml
+cifmw_validations_list: []
+
+# cifmw_validations_run_all will find all validations under the tasks directory, save
+# them to a variable called found_validations and the sequentially execute each of them.
+cifmw_validations_run_all: false
+
+cifmw_validations_default_path: "{{ role_path }}/tasks"

--- a/roles/validations/meta/main.yml
+++ b/roles/validations/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- validations
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: cifmw
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - cifmw
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/validations/molecule/default/converge.yml
+++ b/roles/validations/molecule/default/converge.yml
@@ -1,0 +1,21 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  roles:
+    - role: "validations"

--- a/roles/validations/molecule/default/molecule.yml
+++ b/roles/validations/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/roles/validations/molecule/default/prepare.yml
+++ b/roles/validations/molecule/default/prepare.yml
@@ -1,0 +1,21 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps

--- a/roles/validations/tasks/compute/main.yml
+++ b/roles/validations/tasks/compute/main.yml
@@ -1,0 +1,19 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Hello World
+  ansible.builtin.debug:
+    msg: "Hello world from {{ role_name }}"

--- a/roles/validations/tasks/edpm/main.yml
+++ b/roles/validations/tasks/edpm/main.yml
@@ -1,0 +1,19 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Hello World
+  ansible.builtin.debug:
+    msg: "Hello world from {{ role_name }}"

--- a/roles/validations/tasks/main.yml
+++ b/roles/validations/tasks/main.yml
@@ -1,0 +1,47 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# We can execute all defined validations when cifmw_validation_run_all is defined.
+# Else, we will skip this and run only the explicitly defined validations from
+# cifmw_validations_list
+- name: Run all validations if required
+  when: cifmw_validations_run_all | bool
+  block:
+    - name: Find all validations
+      register: found_validations
+      ansible.builtin.find:
+        paths: "{{ cifmw_validations_default_path }}"
+        patterns: '*.yml'
+        recurse: true
+
+    - name: Run all found validations
+      ansible.builtin.include_tasks:
+        file: "{{ item.path }}"
+      loop: "{{ found_validations.files }}"
+
+- name: Run selected validations
+  when: not cifmw_validations_run_all | bool
+  block:
+    - name: Assert all listed validations exist
+      ansible.builtin.stat:
+        path: "{{ cifmw_validations_default_path }}{{ item }}"
+      loop: "{{ cifmw_validations_list }}"
+      register: validation_exists
+      failed_when: not validation_exists.stat.exists
+
+    - name: Run validations
+      ansible.builtin.include_tasks: "{{ item }}"
+      loop: "{{ cifmw_validations_list }}"

--- a/roles/validations/tasks/networking/main.yml
+++ b/roles/validations/tasks/networking/main.yml
@@ -1,0 +1,19 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Hello World
+  ansible.builtin.debug:
+    msg: "Hello world from {{ role_name }}"

--- a/roles/validations/tasks/nfv/main.yml
+++ b/roles/validations/tasks/nfv/main.yml
@@ -1,0 +1,19 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Hello World
+  ansible.builtin.debug:
+    msg: "Hello world from {{ role_name }}"

--- a/roles/validations/tasks/storage/main.yml
+++ b/roles/validations/tasks/storage/main.yml
@@ -1,0 +1,19 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Hello World
+  ansible.builtin.debug:
+    msg: "Hello world from {{ role_name }}"

--- a/roles/validations/tasks/telemetry/main.yml
+++ b/roles/validations/tasks/telemetry/main.yml
@@ -1,0 +1,19 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Hello World
+  ansible.builtin.debug:
+    msg: "Hello world from {{ role_name }}"

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -657,6 +657,17 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/validations/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-validations
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: validations
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/virtualbmc/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -66,6 +66,7 @@
       - cifmw-molecule-test_operator
       - cifmw-molecule-tofu
       - cifmw-molecule-update
+      - cifmw-molecule-validations
       - cifmw-molecule-virtualbmc
     name: openstack-k8s-operators/ci-framework
     templates:


### PR DESCRIPTION
We have differing requirements for QE validation jobs depending on the team. This change aims to establish a framework by which each team will be able to define their QE validation job. In doing so, the ci-framework will be the extensible "tool to rule them all" from upstream CI to downstream QE.

Accordingly, we establish a new role called `qe_validations`. Under which we have tasks/<team> directories where validation jobs can be defined. We can call these are part of a post-deployment execution in the ci-framework. Essentially this would look like:

1. Normal deployment job is executed - as it would be today in ci
2. Post deployment will call a task from the qe_validations role to validate that certain conditions have been satisfied.
3. These qe_validation tasks should `assert` a state is satisfied. Assuming all assertions are satisfied, the job will be considered passed.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
