### PR TITLE
Patch ManilaAPI when Ceph is applied as a backend

### DIFF
--- a/hooks/playbooks/control_plane_ceph_backends.yml
+++ b/hooks/playbooks/control_plane_ceph_backends.yml
@@ -109,6 +109,12 @@
                 value: {{ cifmw_services_manila_enabled | default('false') }}
 
               - op: add
+                path: /spec/manila/template/manilaAPI/customServiceConfig
+                value: |
+                  [DEFAULT]
+                  enabled_share_protocols=nfs,cephfs
+
+              - op: add
                 path: /spec/manila/template/customServiceConfig
                 value: |
                   [DEFAULT]


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
- [x] README in the role
- [x] Content of the docs/source is reflecting the changes
