### PR TITLE
[openshift_adm] Support approving of pending certificate requests.

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -86,6 +86,7 @@ cri
 crio
 crs
 crypto
+csr
 csv
 ctl
 ctlplane
@@ -350,6 +351,7 @@ podified
 podman
 polarion
 polkit
+pragadeeswaran
 pre
 prikey
 privatekey
@@ -360,6 +362,7 @@ provisioningdhcprange
 provisioningnetwork
 provisioningnetworkcidr
 provisionserver
+psathyan
 pubkey
 publicdomain
 pullsecret

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -183,3 +183,36 @@ allowing an easy `make_TARGET_status is not failed` condition:
     name: 'install_yamls_makes'
     tasks_from: 'make_crc_storage'
 ```
+
+# modules/approve_csr
+
+Module that approves pending certificate requests in OpenShift platform.
+
+## options - approve_csr
+
+```YAML
+* k8s_config
+  * description: Absolute path to the kube configuration file.
+    required: false
+    type: str
+* quiet_period
+  * description: Maximum amount of time to be observed for no events.
+    required: false
+    type: str
+    default: 3m
+```
+
+## example - approve_csr
+
+```YAML
+- name: Approve pending certificate requests in OpenShift
+  hosts: hypervisor
+  gather_facts: false
+  vars:
+    k8s_config: "/home/zuul/.kube/config"
+
+  tasks:
+    - name: Wait and approve all
+      approve_csr:
+        k8s_config: "{{ k8s_config }}"
+```

--- a/plugins/modules/approve_csr.py
+++ b/plugins/modules/approve_csr.py
@@ -1,0 +1,190 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2024, Red Hat
+# GNU General Public License v3.0+ (see COPYING or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = r"""
+---
+module: approve_csr
+short_description: Automated approval of pending certificate requests in OCP.
+description: |
+    This module approves any pending certificate requests and waits for a
+    specified quiet period, defaulting to 3 minutes if not specified. During
+    this quiet period, any new certificate approval request queued will be
+    automatically approved and the quiet period timer reset. The module
+    exits when no requests are observed for the specified quiet period.
+requirements:
+    - oc
+options:
+    k8s_config:
+        description:
+            - Absolute path to the kube config file.
+            - Defaults to environment defined KUBECONFIG.
+        required: false
+        type: path
+    quiet_period:
+        description: Maximum time in which no events are observed.
+        required: false
+        default: 180
+        type: int
+author:
+    - Pragadeeswaran (@psathyan)
+"""
+
+EXAMPLES = r"""
+- name: Approve all pending certificate requests
+  approve_csr:
+    k8s_config: "{{ lookup('env', 'KUBECONFIG') }}"
+"""
+
+RETURN = r"""
+result:
+    description: status of the execution
+    returned: success
+    type: complex
+    contains:
+        stdout:
+            description: Captured standard output.
+            type: str
+        stderr:
+            description: Captured standard error.
+            type: str
+        rc:
+            description: The returned status code.
+            type: int
+"""
+
+
+from copy import deepcopy
+from datetime import datetime, timedelta
+from time import sleep
+from typing import Any, List
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+class ApproveCSR:
+    """Automatic CSR approval utility."""
+
+    def __init__(self, module: AnsibleModule) -> None:
+        """Instance initialization method."""
+        self.module: AnsibleModule = module
+        self.k8s_config: str = module.params["k8s_config"]
+        self.quiet_period: str = module.params["quiet_period"]
+        self._base_cmd: List[str] = [self.module.get_bin_path("oc", required=True)]
+
+    @property
+    def base_cmd(self) -> List[str]:
+        """Returns the base command."""
+        return deepcopy(self._base_cmd)
+
+    def execute_command(self, cmd, use_unsafe_shell=False, data=None) -> Any:
+        shell_env = None
+        if self.k8s_config:
+            shell_env = dict(KUBECONFIG=self.k8s_config)
+
+        return self.module.run_command(
+            cmd, use_unsafe_shell=use_unsafe_shell, data=data, environ_update=shell_env
+        )
+
+    def _get_pending_requests(self) -> List[str]:
+        """Return the list of pending certificate requests."""
+        _cmd = self.base_cmd + [
+            "get",
+            "csr",
+            "-o",
+            "go-template='{{range.items}}{{if not .status}}"
+            + '{{.metadata.name}}{{"\\n"}}{{end}}{{end}}\'',
+        ]
+        rc, out, err = self.execute_command(_cmd)
+        if rc != 0:
+            self.module.fail_json(
+                msg="Failed to gather the list of pending requests",
+                rc=rc,
+                stdout=out,
+                stderr=err,
+                cmd=_cmd,
+            )
+
+        if not out.strip("'").strip("\n"):
+            return []
+
+        return out.strip("'").splitlines()
+
+    def _approve_csr(self, requests: List[str]) -> bool:
+        """Approve all pending certificate requests.
+
+        Args:
+            requests (list) a list of certificate requests to approve.
+
+        Return:
+            True on success else False
+        """
+        for csr in requests:
+            if not csr.strip("\n"):
+                continue
+
+            _csr_cmd = self.base_cmd + [
+                "adm",
+                "certificate",
+                "approve",
+                csr.strip("\n"),
+            ]
+            r, o, e = self.execute_command(_csr_cmd)
+
+            if r != 0:
+                self.module.fail_json(
+                    msg=f"Unable to approve certificate request - {csr}.",
+                    rc=r,
+                    stdout=o,
+                    stderr=e,
+                    cmd=_csr_cmd,
+                )
+
+        return True
+
+    def wait_on_requests(self) -> None:
+        """Waits on approval request event for specified period."""
+
+        if self.module.check_mode:
+            self.module.exit_json(changed=False, rc=0, stdout="Dry run - no checks.")
+
+        expire_after = datetime.now() + timedelta(seconds=self.quiet_period)
+        while expire_after > datetime.now():
+            cert_approval_list = self._get_pending_requests()
+            if cert_approval_list:
+                approve_status = self._approve_csr(cert_approval_list)
+
+                if not approve_status:
+                    break
+
+                expire_after = datetime.now() + timedelta(seconds=self.quiet_period)
+
+            sleep(10)
+
+        self.module.exit_json(
+            changed=True,
+            rc=0,
+            stdout="Successfully approved all pending certificate requests.",
+        )
+
+
+def run_module():
+    _args = dict(
+        k8s_config=dict(required=False, type="path"),
+        quiet_period=dict(required=False, type="int", default=180),
+    )
+    _module = AnsibleModule(argument_spec=_args, supports_check_mode=True)
+
+    cli = ApproveCSR(_module)
+    cli.wait_on_requests()
+
+
+if __name__ == "__main__":
+    run_module()

--- a/roles/devscripts/tasks/112_verify_golden_image.yml
+++ b/roles/devscripts/tasks/112_verify_golden_image.yml
@@ -20,34 +20,58 @@
     path: "{{ cifmw_openshift_adm_cert_expire_date_file }}"
   register: _cert_file_stat
 
-- name: Read the certificate expiration date recorded.
+- name: Execute all tasks pertaining to standing up the cluster.
   when:
     - _cert_file_stat.stat.exists | default(false)
-  ansible.builtin.slurp:
-    src: "{{ cifmw_openshift_adm_cert_expire_date_file }}"
-  register: _cert_file
-
-- name: Ensure the golden image has valid certificate.
-  vars:
-    _expire_date: "{{ _cert_file.content | b64decode }}"
-    _diff_hours: >-
-      {{
-        (
-          (_expire_date | trim | ansible.builtin.to_datetime) -
-          (
-            now(utc=true, fmt="%Y-%m-%d %H:%M:%S") |
-            ansible.builtin.to_datetime
-          )
-        ).total_seconds() / 3600 | int
-      }}
-  when:
-    - _cert_file_stat.stat.exists | default(false)
-    - _diff_hours | int < 2
   block:
-    - name: Reset golden image exists flag
-      ansible.builtin.set_fact:
-        cifmw_devscripts_ocp_exists: false
-        cifmw_devscripts_force_cleanup: true
+    - name: Read the certificate expiration date recorded.
+      ansible.builtin.slurp:
+        src: "{{ cifmw_openshift_adm_cert_expire_date_file }}"
+      register: _cert_file
 
-    - name: Cleanup the golden image if the certificate has expired.
-      ansible.builtin.include_tasks: cleanup.yml
+    - name: Find if cert expire date file is older than a day.
+      ansible.builtin.find:
+        age: 1d
+        hidden: true
+        path: >-
+          {{
+            cifmw_openshift_adm_cert_expire_date_file | ansible.builtin.dirname
+          }}
+        pattern: >-
+          {{
+            cifmw_openshift_adm_cert_expire_date_file |
+            ansible.builtin.basename
+          }}
+      register: _cert_file_age
+
+    - name: Set cert check if older than 1 day
+      when:
+        - _cert_file_age is defined
+        - _cert_file_age.files | default([]) | length > 0
+      ansible.builtin.set_fact:
+        _openshift_adm_check_cert_approve: true
+
+    - name: Cleanup when there is an expired certificate.
+      vars:
+        _expire_date: "{{ _cert_file.content | b64decode }}"
+        _diff_hours: >-
+          {{
+            (
+              (_expire_date | trim | ansible.builtin.to_datetime) -
+              (
+                now(utc=true, fmt="%Y-%m-%d %H:%M:%S") |
+                ansible.builtin.to_datetime
+              )
+            ).total_seconds() / 3600 | int
+          }}
+      when:
+        - _diff_hours | int < 2
+      block:
+        - name: Reset golden image exists flag
+          ansible.builtin.set_fact:
+            cifmw_devscripts_ocp_exists: false
+            cifmw_devscripts_force_cleanup: true
+            _openshift_adm_check_cert_approve: false
+
+        - name: Cleanup the golden image if the certificate has expired.
+          ansible.builtin.include_tasks: cleanup.yml

--- a/roles/openshift_adm/README.md
+++ b/roles/openshift_adm/README.md
@@ -27,9 +27,11 @@ This role requires the following parameters to be configured.
 * `cifmw_openshift_adm_dry_run` (bool) If enabled, no modifications are
   performed on the cluster.
 * `cifmw_openshift_adm_login_retry_count` (int) The maximum number of attempts
-  to be made for a OpenShift login success. Default is `100`.
+  to be made for a OpenShift login success. Default is `10`.
 * `cifmw_openshift_adm_api_retry_count` (int) The maximum number of attempts to
   be made for confirming API response. Default is `100`.
+* `cifmw_openshift_adm_node_retry_count` (int) The maximum number of attempts
+  to be made for gathering the list of nodes. Default is `60`.
 
 ## Reference
 

--- a/roles/openshift_adm/defaults/main.yml
+++ b/roles/openshift_adm/defaults/main.yml
@@ -26,5 +26,6 @@ cifmw_openshift_adm_cert_expire_date_file: >-
   }}
 cifmw_openshift_adm_op: ""
 cifmw_openshift_adm_dry_run: false
-cifmw_openshift_adm_login_retry_count: 100
+cifmw_openshift_adm_login_retry_count: 10
 cifmw_openshift_adm_api_retry_count: 100
+cifmw_openshift_adm_node_retry_count: 60

--- a/roles/openshift_adm/tasks/wait_for_cluster.yml
+++ b/roles/openshift_adm/tasks/wait_for_cluster.yml
@@ -29,24 +29,15 @@
   retries: "{{ cifmw_openshift_adm_api_retry_count }}"
   delay: 5
 
-- name: Wait until OCP login succeeds.
-  kubernetes.core.k8s_auth:
-    host: "{{ cifmw_openshift_api }}"
-    password: "{{ cifmw_openshift_password }}"
-    state: present
-    username: "{{ cifmw_openshift_user }}"
-    validate_certs: false
-  register: _oc_login_result
-  until: _oc_login_result.k8s_auth is defined
-  retries: "{{ cifmw_openshift_adm_login_retry_count }}"
-  delay: 5
-
 - name: Gather the list of nodes
   kubernetes.core.k8s_info:
     kind: Node
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
     validate_certs: false
   register: _nodes
+  until: _nodes.resources is defined
+  retries: "{{ cifmw_openshift_adm_node_retry_count }}"
+  delay: 10
 
 - name: Ensure the nodes are in ready state.
   when:
@@ -58,6 +49,12 @@
     validate_certs: false
   loop: "{{ _nodes.resources | map(attribute='metadata.name') | list }}"
 
+- name: Check for pending certificate approval.
+  when:
+    - _openshift_adm_check_cert_approve | default(false) | bool
+  approve_csr:
+    k8s_config: "{{ cifmw_openshift_kubeconfig }}"
+
 - name: Wait unit the OpenShift cluster is stable.
   environment:
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
@@ -65,3 +62,15 @@
   ansible.builtin.command:
     cmd: >-
       oc adm wait-for-stable-cluster --minimum-stable-period=5s --timeout=15m
+
+- name: Wait until OCP login succeeds.
+  kubernetes.core.k8s_auth:
+    host: "{{ cifmw_openshift_api }}"
+    password: "{{ cifmw_openshift_password }}"
+    state: present
+    username: "{{ cifmw_openshift_user }}"
+    validate_certs: false
+  register: _oc_login_result
+  until: _oc_login_result.k8s_auth is defined
+  retries: "{{ cifmw_openshift_adm_login_retry_count }}"
+  delay: 5

--- a/tests/unit/modules/test_approve_csr.py
+++ b/tests/unit/modules/test_approve_csr.py
@@ -1,0 +1,95 @@
+# Copyright: (c) 2024, Red Hat
+
+# GNU General Public License v3.0+ (see COPYING or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+from unittest.mock import patch
+
+from ansible_collections.cifmw.general.tests.unit.utils import (
+    ModuleBaseTestCase,
+    set_module_args,
+    AnsibleExitJson,
+    AnsibleFailJson,
+)
+from ansible_collections.cifmw.general.plugins.modules import approve_csr
+
+
+class TestApproveCSRCore(ModuleBaseTestCase):
+    """Test core functionality of approve_csr module."""
+
+    def test_negative_gathering_pending_requests(self):
+        set_module_args({})
+        expected_msg = "Failed to gather the list of pending requests"
+
+        with patch.object(approve_csr.ApproveCSR, "execute_command") as run_cmd:
+            _out = ""
+            _err = "No binary found."
+            rc = -1
+            run_cmd.return_value = (rc, _out, _err)
+
+            with self.assertRaises(AnsibleFailJson) as rst:
+                approve_csr.run_module()
+
+            result = rst.exception.args[0]
+
+            self.assertEquals(result["msg"], expected_msg)
+            self.assertTrue(result["failed"])
+
+    def test_negative_approving_cert_requests(self):
+        set_module_args({})
+        _msg = "Unable to approve certificate request - test-cert-request."
+
+        with patch.object(approve_csr.ApproveCSR, "execute_command") as run_cmd:
+            _side_effect = [
+                (0, "test-cert-request", ""),
+                (1, "", "Unable to approve request."),
+            ]
+            run_cmd.side_effect = _side_effect
+
+            with self.assertRaises(AnsibleFailJson) as rst:
+                approve_csr.run_module()
+
+            result = rst.exception.args[0]
+
+            self.assertEquals(result["msg"], _msg)
+            self.assertTrue(result["failed"])
+
+    def test_one_iteration_on_wait(self):
+        """Test when there is only one certificate request."""
+        set_module_args(dict(quiet_period=2))
+
+        with patch.object(approve_csr.ApproveCSR, "execute_command") as run_cmd:
+            _side_effect = [
+                (0, "test-cert-request", None),
+                (0, "Success", None),
+                (0, "", None),
+            ]
+            run_cmd.side_effect = _side_effect
+
+            with self.assertRaises(AnsibleExitJson) as rst:
+                approve_csr.run_module()
+
+            self.assertTrue(rst.exception.args[0]["changed"])
+
+    def test_multiple_iterations_on_wait(self):
+        """Test when there are multiple certificate requests"""
+        set_module_args(dict(quiet_period=12))
+
+        with patch.object(approve_csr.ApproveCSR, "execute_command") as run_cmd:
+            _side_effect = [
+                (0, "test-cert-request", None),
+                (0, "Success", None),
+                (0, "test-cert-request-1", None),
+                (0, "Success", None),
+                (0, "", None),
+                (0, "", None),
+                (0, "", None),
+            ]
+            run_cmd.side_effect = _side_effect
+
+            with self.assertRaises(AnsibleExitJson) as rst:
+                approve_csr.run_module()
+
+            self.assertTrue(rst.exception.args[0]["changed"])
+            self.assertEquals(rst.exception.args[0]["rc"], 0)

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -1,0 +1,67 @@
+# Copyright: (c) 2024, Red Hat
+
+# GNU General Public License v3.0+ (see COPYING or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+
+__metaclass__ = type
+import json
+import unittest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+
+def set_module_args(args) -> None:
+    """Prepare the arguments so that they are picked during module create."""
+    args["_ansible_remote_tmp"] = "/tmp"
+    args["_ansible_keep_remote_files"] = False
+
+    _args = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(_args)
+
+
+class AnsibleExitJson(Exception):
+    """Exception to be raised by module.exit_json for tests to handle."""
+
+    pass
+
+
+class AnsibleFailJson(Exception):
+    """Exception to be raised by module.fail_json for tests to handle."""
+
+    pass
+
+
+def exit_json(*args, **kwargs):
+    """Patch for AnsibleModule.exit_json."""
+    if "changed" not in kwargs.keys():
+        kwargs["changed"] = False
+
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    """Patch for AnsibleModule.fail_json."""
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def get_bin_path(*args, **kwargs):
+    """Patch for AnsibleModule.get_bin_path."""
+    return "/usr/local/bin/flake-command"
+
+
+class ModuleBaseTestCase(unittest.TestCase):
+    """Base test class for unit testing."""
+
+    def setUp(self) -> None:
+        self.mock_module_helper = unittest.mock.patch.multiple(
+            basic.AnsibleModule,
+            exit_json=exit_json,
+            fail_json=fail_json,
+            get_bin_path=get_bin_path,
+        )
+        self.mock_module_helper.start()
+        self.addClassCleanup(self.mock_module_helper.stop)


### PR DESCRIPTION
When a new cluster is spawned from an golden image older than a day, there would be multiple csr requests coming for approval. The csr approvals come in batches after each request is approved.

In this change request, we add support of approving these requests and waiting for a quiet period of time till when there are no requests.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes

*Testing Results*

_Unit testing_
```
(test-python) [ciuser@devci-01 general]$ ansible-test units --requirements tests/unit/modules/approve_csr/test_approve_csr_basic.py 
WARNING: Using locale "C.UTF-8" instead of "en_US.UTF-8". Tests which depend on the locale may behave unexpectedly.
Installing requirements for Python 3.9
WARNING: Skipping unit tests on Python 3.10 because it could not be found.
WARNING: Skipping unit tests on Python 3.11 because it could not be found.
Unit test controller with Python 3.9
============================= test session starts ==============================
platform linux -- Python 3.9.18, pytest-8.1.1, pluggy-1.4.0
rootdir: /home/ciuser/.ansible/collections/ansible_collections/cifmw/general
configfile: ../../../../../test-python/lib64/python3.9/site-packages/ansible_test/_data/pytest/config/default.ini
plugins: metadata-3.0.0, cov-4.1.0, html-4.1.1, xdist-3.5.0, testinfra-10.1.0, mock-3.14.0, forked-1.6.0
created: 8/8 workers
8 workers [5 items]

.....                                                                    [100%]
- generated xml file: /home/ciuser/.ansible/collections/ansible_collections/cifmw/general/tests/output/junit/python3.9-controller-units.xml -
============================== 5 passed in 21.03s ==============================
```

_Integration testing_
```
[ciuser@titanamd126 ansible-tmp-1711428469.0634916-269877-132853261887761]$ python AnsiballZ_approve_csr.py execute

{"changed": true, "rc": 0, "stdout": "Successfully approved all pending certificate requests.", "invocation": {"module_args": {"k8s_config": "/home/ciuser/src/github.com/openshift-metal3/dev-scripts/ocp/ocp/auth/kubeconfig", "quiet_period": "3m"}}}
```

_End_to_End_testing_
```
TASK [openshift_adm : Ensure the nodes are in ready state. name={{ item }}, state=uncordon, kubeconfig={{ cifmw_openshift_kubeconfig }}, validate_certs=False] *******************************************************************************
Tuesday 26 March 2024  06:12:45 -0400 (0:00:02.723)       0:10:21.878 ********* 
changed: [hypervisor] => (item=master-0)
changed: [hypervisor] => (item=master-1)
changed: [hypervisor] => (item=master-2)

TASK [openshift_adm : Check for pending certificate approval. k8s_config={{ cifmw_openshift_kubeconfig }}] ***********************************************************************************************************************************
Tuesday 26 March 2024  06:12:51 -0400 (0:00:06.699)       0:10:28.578 ********* 
changed: [hypervisor]

TASK [openshift_adm : Wait unit the OpenShift cluster is stable. _raw_params=oc adm wait-for-stable-cluster --minimum-stable-period=5s --timeout=15m] ****************************************************************************************
Tuesday 26 March 2024  06:18:06 -0400 (0:05:14.946)       0:15:43.524 ********* 
```

_Play_recap_
```
PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
hypervisor                 : ok=501  changed=178  unreachable=0    failed=0    skipped=102  rescued=1    ignored=0   

Tuesday 26 March 2024  06:35:45 -0400 (0:00:04.935)       0:33:22.008 ********* 
=============================================================================== 
openshift_adm : Wait unit the OpenShift cluster is stable. -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 565.24s
openshift_adm : Check for pending certificate approval. ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 314.95s
reproducer : Bootstrap environment on controller-0 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 84.39s
reproducer : Install some tools ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 65.18s
libvirt_manager : Prepare disk image with SSH and growing volume --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 48.04s
networking_mapper : Ensure that networking and hostname facts are in place ----------------------------------------------------------------------------------------------------------------------------------------------------------- 37.23s
libvirt_manager : Grab IPs for nodes type ocp ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 32.28s
reproducer : Configure rhos-release -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 31.28s
reproducer : Configure rhos-release -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 30.73s
libvirt_manager : Configure ssh access on type ocp ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 26.57s
reproducer : Install collections on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 25.20s
libvirt_manager : Grab IPs for nodes type compute ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 19.89s
libvirt_manager : Grab IPs for nodes type networker ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 19.74s
libvirt_manager : Grab IPs for nodes type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.96s
libvirt_manager : Wait for SSH on VMs type ocp --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.65s
reproducer : Inject ProxyJump configuration for remote hypervisor VMs ---------------------------------------------------------------------------------------------------------------------------------------------------------------- 17.08s
reproducer : Wait for OCP nodes to be ready ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 16.85s
reproducer : Install ansible dependencies -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 13.47s
libvirt_manager : Configure VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 11.85s
libvirt_manager : Wait for SSH on VMs type networker --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 11.72s
[ciuser@devci-01 ci-framework]$ 
```