### PR TITLE
Add adoption variant to run minimal without ceph

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -126,6 +126,13 @@
       - .*/*.md
 
 - job:
+    name: cifmw-data-plane-adoption-osp-17-to-extracted-crc-minimal-no-ceph
+    parent: cifmw-data-plane-adoption-osp-17-to-extracted-crc
+    vars:
+      use_ceph: "false"
+      dpa_test_suite: "test-minimal"
+
+- job:
     name: cifmw-adoption-base-source-multinode
     parent: base-extracted-crc
     abstract: true


### PR DESCRIPTION
Add a variant of the cifmw-adoption job to run with a swift backend and
run the test-minimal test-case.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
