### PR TITLE
Revert "Try ssh command and freshly booting vms"

### DIFF
--- a/roles/libvirt_manager/tasks/start_manage_vms.yml
+++ b/roles/libvirt_manager/tasks/start_manage_vms.yml
@@ -170,10 +170,6 @@
       sudo -u zuul mkdir -p /home/zuul/.ssh /home/zuul/src/github.com/openstack-k8s-operators;
       sudo cp ${HOME}/.ssh/authorized_keys /home/zuul/.ssh/;
       chown -R zuul: /home/zuul/.ssh;
-  retries: 30
-  delay: 1
-  register: _ssh_login_access
-  until: _ssh_login_access.rc == 0
   loop: "{{ vm_ips.results }}"
   loop_control:
     loop_var: "vm_ip"


### PR DESCRIPTION
The change does not helps and the root cause was not related,
The provisioning system had an ansible role which run after
provisioning late, copied the authorized_keys from ~root/.ssh to
~zuul/.ssh nuking the key generated on the nodepool node.
The flow kept working because the ControlPerist
until a new session had to created for the delegte_to,
however the authorized_keys was based long long before.

This reverts commit 29799ab0f8f1388707e713c7791a170e2dcf5181.

As a pull request owner and reviewers, I checked that:
- [X] No checklist is needed.
