### PR TITLE
Extend and generate files based on IPMI data

### DIFF
--- a/roles/libvirt_manager/molecule/deploy_layout/converge.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/converge.yml
@@ -14,7 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Converge
+- name: One hypervisor
   hosts: instance
   gather_facts: true
   vars:
@@ -243,7 +243,7 @@
               - expected_count == found_count
           loop: "{{ volume_count.results }}"
 
-- name: Cleanup
+- name: Cleanup one hypervisor
   hosts: instance
   tasks:
     - name: Clean layout
@@ -251,23 +251,34 @@
         name: libvirt_manager
         tasks_from: clean_layout.yml
 
+    - name: Reload clean inventory
+      ansible.builtin.meta: refresh_inventory
+
+    - name: Expose current hosts
+      ansible.builtin.debug:
+        msg: "{{ hostvars.keys() }}"
+
 - name: Inject fake hosts in inventory
   hosts: instance
   tasks:
-    - name: Inject compute-0 in inventory
+    - name: Inject hypervisor-0 in inventory
       ansible.builtin.add_host:
-        name: compute-0
+        name: hypervisor-0
+        groups:
+          - hypervisors
         ansible_host: localhost
         ansible_connection: local
 
-    - name: Inject compute-1 in inventory
+    - name: Inject hypervisor-1 in inventory
       ansible.builtin.add_host:
-        name: compute-1
+        name: hypervisor-1
+        groups:
+          - hypervisors
         ansible_host: localhost
         ansible_connection: local
 
-- name: Converge
-  hosts: all
+- name: Multiple hypervisors
+  hosts: hypervisors
   vars:
     ansible_user_dir: "{{ lookup('env', 'HOME') }}"
     cifmw_basedir: "/opt/basedir"
@@ -287,7 +298,7 @@
     cifmw_libvirt_manager_configuration:
       vms:
         computecp0:
-          target: compute-0
+          target: hypervisor-0
           amount: 1
           disk_file_name: "blank"
           disksize: 20
@@ -297,7 +308,7 @@
             - public
             - osp_trunk
         computecp1:
-          target: compute-1
+          target: hypervisor-1
           amount: 1
           disk_file_name: "blank"
           disksize: 20

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -84,22 +84,32 @@
   loop_control:
     label: "{{ item.key }}"
 
-- name: Create temporary ssh keypair
-  community.crypto.openssh_keypair:
-    path: "{{ ansible_user_dir }}/.ssh/cifmw_reproducer_key"
-    type: "{{ cifmw_libvirt_manager_reproducer_key_type }}"
-    size: "{{ cifmw_libvirt_manager_reproducer_key_size }}"
-    regenerate: full_idempotence
+- name: Manage SSH key
+  vars:
+    _sshkey: "{{ ansible_user_dir }}/.ssh/cifmw_reproducer_key"
+  block:
+    - name: Get ssh key state
+      register: _keystat
+      ansible.builtin.stat:
+        path: "{{ _sshkey }}"
 
-- name: Slurp public key for later use
-  register: pub_ssh_key
-  ansible.builtin.slurp:
-    path: "{{ ansible_user_dir }}/.ssh/cifmw_reproducer_key.pub"
+    - name: Create temporary ssh keypair
+      when:
+        - not _keystat.stat.exists
+      community.crypto.openssh_keypair:
+        path: "{{ _sshkey }}"
+        type: "{{ cifmw_libvirt_manager_reproducer_key_type }}"
+        size: "{{ cifmw_libvirt_manager_reproducer_key_size }}"
 
-- name: Slurp private key for later use
-  register: priv_ssh_key
-  ansible.builtin.slurp:
-    path: "{{ ansible_user_dir }}/.ssh/cifmw_reproducer_key"
+    - name: Slurp public key for later use
+      register: pub_ssh_key
+      ansible.builtin.slurp:
+        path: "{{ _sshkey }}.pub"
+
+    - name: Slurp private key for later use
+      register: priv_ssh_key
+      ansible.builtin.slurp:
+        path: "{{ _sshkey }}"
 
 - name: Inject cifmw_reproducer_key.pub in hypervisor authorized_keys
   ansible.posix.authorized_key:
@@ -222,6 +232,52 @@
     dest: "{{ cifmw_libvirt_manager_basedir }}/artifacts/interfaces-info.yml"
     content: "{{ cifmw_libvirt_manager_mac_map | to_nice_yaml }}"
 
+- name: Extract VM UUIDs from libvirt
+  block:
+    - name: Get all XMLs
+      register: _all_xmls
+      community.libvirt.virt:
+        command: get_xml
+        name: "{{ item }}"
+      loop: "{{ _vms.list_vms }}"
+
+    - name: Extract UUIDs from all XMLs
+      register: _extracted_uuids
+      community.general.xml:
+        xmlstring: "{{ vm.get_xml }}"
+        xpath: "/domain/uuid"
+        content: text
+      loop: "{{ _all_xmls.results }}"
+      loop_control:
+        label: "{{ vm.item }}"
+        loop_var: vm
+
+    - name: Build UUIDs fact
+      vars:
+        vm_uuid: "{{ xml.matches | first }}"
+      ansible.builtin.set_fact:
+        cifmw_libvirt_manager_uuids: >-
+          {{
+            cifmw_libvirt_manager_uuids | default({}) |
+            combine({xml.vm.item: vm_uuid.uuid})
+          }}
+      loop: "{{ _extracted_uuids.results }}"
+      loop_control:
+        label: "{{ xml.vm.item }}"
+        loop_var: xml
+
+    - name: Dump UUIDs
+      when:
+        - cifmw_libvirt_manager_uuids is defined
+        - cifmw_libvirt_manager_uuids | length > 0
+      vars:
+        _content:
+          libvirt_uuid: "{{ cifmw_libvirt_manager_uuids }}"
+      ansible.builtin.copy:
+        dest: "{{ cifmw_libvirt_manager_basedir }}/artifacts/libvirt-uuids.yml"
+        content: "{{ _content | to_nice_yaml }}"
+        mode: "0644"
+
 - name: Refresh and dump vbmc hosts
   when:
     - _vbmc_host is defined
@@ -232,21 +288,34 @@
         name: virtualbmc
         tasks_from: list_hosts.yml
 
-    - name: Dump vbmc known hosts
+    - name: Update vbmc related fact
       vars:
         _auth:
           username: "{{ cifmw_virtualbmc_ipmi_user | default('admin') }}"
           password: "{{ cifmw_virtualbmc_ipmi_password | default('password') }}"
-        _mapped: >-
+        _map_auth: >-
           {{
             cifmw_virtualbmc_known_hosts |
             map('combine', _auth)
           }}
+        _map_uuid: >-
+          {% set ns = namespace(output=[]) -%}
+          {% for host in _map_auth -%}
+          {%   set _uuid = {'uuid': cifmw_libvirt_manager_uuids[host['Domain name']]} -%}
+          {%   set _host = host | combine(_uuid) -%}
+          {%   set _ = ns.output.append(_host) -%}
+          {% endfor -%}
+          {{ ns.output }}
+      ansible.builtin.set_fact:
+        cifmw_virtualbmc_known_hosts: "{{ _map_uuid }}"
+
+    - name: Dump vbmc known hosts
+      vars:
         content:
-          cifmw_virtualbmc_known_hosts: "{{ _mapped }}"
+          cifmw_virtualbmc_known_hosts: "{{ cifmw_virtualbmc_known_hosts }}"
       ansible.builtin.copy:
         dest: >-
-          {{ cifmw_libvirt_manager_basedir }}/artifacts/virtualbmc-nodes.yml
+          {{ cifmw_libvirt_manager_basedir }}/artifacts/virtual-nodes.yml
         content: "{{ content | to_nice_yaml }}"
 
 - name: Ensure we get proper access to CRC

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -106,6 +106,54 @@
         dest: "{{ _ctl_reproducer_basedir }}/parameters/interfaces-info.yml"
         content: "{{ cifmw_libvirt_manager_mac_map | to_nice_yaml }}"
 
+    # Here, we update the existing cifmw_virtualbmc_known_hosts fact
+    # to inject networking information such as provisioning MAC (if any),
+    # and fixed Boot mode
+    - name: Generate IPMI information
+      block:
+        - name: Convert VBMC list into a dict for better usage
+          vars:
+            keys: "{{ item.keys() | difference(['Domain name']) }}"
+            vals: "{{ keys | map('extract', item) | list }}"
+            value: "{{ dict(keys | map('lower') | zip(vals)) }}"
+            _host: "{{ item['Domain name'] | regex_replace('^cifmw-', '') }}"
+            _nics: >-
+              {{
+                cifmw_libvirt_manager_mac_map[_host]
+              }}
+            _uefi: >-
+              {% set _type = _host | regex_replace('-[0-9]+$', '') -%}
+              {{ _layout.vms[_type].uefi | default(false) | bool }}
+            _boot_mode: "{{ _uefi | ternary('UEFI', 'legacy') }}"
+            ## TODO: add sushy driver address once we get sushy in
+            ## TODO: create new parameter to allow chosing which connection
+            #        to expose in the generated file
+            _connections:
+              ipmi: "ipmi://{{ value.address }}:{{ value.port }}"
+          ansible.builtin.set_fact:
+            _ipmi_dict: >-
+              {{
+                _ipmi_dict | default({}) |
+                combine({_host: value}, recursive=true) |
+                combine({_host: {
+                                 'boot_mode': _boot_mode,
+                                 'nics': _nics,
+                                 'connection': _connections['ipmi']
+                                }
+                        }, recursive=true)
+              }}
+            cacheable: false
+          loop: "{{ cifmw_virtualbmc_known_hosts }}"
+
+        - name: Output IPMI data in a file
+          vars:
+            _content:
+              baremetal_nodes: "{{ _ipmi_dict }}"
+          ansible.builtin.copy:
+            dest: "{{ _ctl_reproducer_basedir }}/parameters/baremetal-info.yml"
+            content: "{{ _content | to_nice_yaml }}"
+            mode: "0644"
+
     - name: Inject other Hypervisor SSH keys
       when:
         - hostvars[host]['priv_ssh_key'] is defined


### PR DESCRIPTION
In earlier patches, VirtualBMC was introduced to the CI Framework, with
an easy and small generated fact and subsequent file on the hypervisor.

This patch extends this fact in order to ensure we're exposing the
credentials, meaning we're now able to consume everything from some
other roles (in the same run).

In the reproducer role, we now take that virtualbmc fact, and extend it
a bit more, in order to add network interfaces information; we also
ensure key consistency by applying a "lower" mapping.

This patch also introduces a better management of the temporary SSH key,
and some better suited names for the molecule "converge" plays. We also
had to correct how the multi-hypervisor molecule check was running, due
to the updated inventory being re-used without any way to remove an
existing host.

The generated file, updated 2024-04-03:
```YAML
baremetal_nodes:
    compute-0:
        address: 10.10.1.12
        boot_mode: legacy
        connection: ipmi://10.10.1.12:6240
        nics:
        -   mac: 52:54:00:ba:51:13
            network: public
        -   mac: 52:54:00:cc:54:84
            network: osp_trunk
        password: password
        port: 6240
        status: running
        username: admin
        uuid: 6677a9e8-9e6d-44d4-a4b8-236720fd70ab
    controller-0:
        address: 10.10.1.12
        boot_mode: legacy
        connection: ipmi://10.10.1.12:6250
        nics:
        -   mac: 52:54:00:7c:3e:11
            network: public
        -   mac: 52:54:00:c9:09:fe
            network: osp_trunk
        password: password
        port: 6250
        status: running
        username: admin
        uuid: 3dc803af-e0f6-4c84-a015-5502da273fd3
    crc-0:
        address: 10.10.1.12
        boot_mode: legacy
        connection: ipmi://10.10.1.12:6260
        nics:
        -   mac: 52:54:00:10:6e:40
            network: public
        -   mac: 52:54:00:d9:33:7b
            network: osp_trunk
        password: password
        port: 6260
        status: running
        username: admin
        uuid: d76a2807-120a-4c5b-a303-6d57b0300a93
```


As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
