### PR TITLE
[Test-operator] Introduce Tempest workflow

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -30,6 +30,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_tempest_tests_exclude_override_scenario`: (Boolean) Whether to override the scenario `cifmw_tempest_tests_skipped` definition. Default value: `false`
 * `cifmw_test_operator_tempest_ssh_key_secret_name`: (String) Name of a secret that contains ssh-privatekey field with a private key. The private key is mounted to `/var/lib/tempest/.ssh/id_ecdsa`
 * `cifmw_test_operator_tempest_config_overwrite`: (Dict) Dictionary where key is name of a file and value is content of the file. All files mentioned in this field are mounted to `/etc/test_operator/<filename>`
+* `cifmw_test_operator_tempest_workflow`: (List) Definition of a Tempest workflow that consists of multiple steps. Each step can contain all values from Spec section of [Tempest CR](https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource).
 * `cifmw_test_operator_tempest_config`: (Object) Definition of Tempest CRD instance that is passed to the test-operator (see [the test-operator documentation](https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource)). Default value:
 ```
   apiVersion: test.openstack.org/v1beta1

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -41,6 +41,7 @@ cifmw_test_operator_tempest_image: "{{ cifmw_test_operator_tempest_registry }}/{
 cifmw_test_operator_tempest_image_tag: current-podified
 cifmw_test_operator_tempest_tests_include_override_scenario: false
 cifmw_test_operator_tempest_tests_exclude_override_scenario: false
+cifmw_test_operator_tempest_workflow: []
 # Please refer to https://openstack-k8s-operators.github.io/test-operator/guide.html#executing-tempest-tests
 cifmw_test_operator_tempest_config:
   apiVersion: test.openstack.org/v1beta1
@@ -60,6 +61,7 @@ cifmw_test_operator_tempest_config:
       concurrency: "{{ cifmw_test_operator_concurrency }}"
       externalPlugin: "{{ cifmw_test_operator_tempest_external_plugin | default([]) }}"
     tempestconfRun: "{{ cifmw_tempest_tempestconf_config | default(omit) }}"
+    workflow: "{{ cifmw_test_operator_tempest_workflow }}"
 
 # Section 3: tobiko parameters - used when run_test_fw is 'tobiko'
 cifmw_test_operator_tobiko_registry: quay.io


### PR DESCRIPTION
Introduce the cifmw_test_operator_tempest_workflow variable which is equivalent to the cifmw_test_operator_tobiko_workflow variable.

This option enables the specification of a value for the workflow field in the Tempest CR. Using the workflow, the user can specify multiple executions of Tempest in a specific order.

Depends-On: https://github.com/openstack-k8s-operators/test-operator/pull/67

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
