### PR TITLE
Allow to set a specific port for VBMC daemon

### DIFF
--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -170,7 +170,7 @@
     cifmw_virtualbmc_machine: "cifmw-{{ vm_type }}-{{ index }}"
     cifmw_virtualbmc_ipmi_port: >-
       {{
-        cifmw_virtualbmc_ipmi_base_port + family_id + index
+        cifmw_virtualbmc_ipmi_base_port + (family_id*10) + index
       }}
     cifmw_virtualbmc_action: "add"
     _ipmi_host: >-

--- a/roles/virtualbmc/README.md
+++ b/roles/virtualbmc/README.md
@@ -11,7 +11,8 @@ None
 ## Parameters
 * `cifmw_virtualbmc_image`: (String) VirtualBMC container image. Defaults to `quay.io/metal3-io/vbmc:latest`.
 * `cifmw_virtualbmc_container_name`: (String) VirtualBMC container name. Defaults to `cifmw-vbmc`.
-* `+cifmw_virtualbmc_listen_address`: (String) VirtualBMC listen address. Defaults to `127.0.0.1`.
+* `cifmw_virtualbmc_listen_address`: (String) VirtualBMC listen address. Defaults to `127.0.0.1`.
+* `cifmw_virtualbmc_daemon_port`: (Integer) VirtualBMC daemon listen port. Default to `50891`.
 * `cifmw_virtualbmc_machine`: (String) Virtual machine to manage in VirtualBMC. Mandatory. Defaults to `null`.
 * `cifmw_virtualbmc_action`: (String) VirtualBMC action. Must be either `add` or `delete`. Mandatory. Defaults to `null`.
 * `cifmw_virtualbmc_sshkey_path`: (String) SSH keypair path for VirtualBMC. Defaults to `{{ ansible_user_dir }}/.ssh/vbmc-key`.

--- a/roles/virtualbmc/defaults/main.yml
+++ b/roles/virtualbmc/defaults/main.yml
@@ -20,6 +20,7 @@
 cifmw_virtualbmc_image: "quay.io/metal3-io/vbmc:latest"
 cifmw_virtualbmc_container_name: "cifmw-vbmc"
 cifmw_virtualbmc_listen_address: "127.0.0.1"
+cifmw_virtualbmc_daemon_port: 50891
 
 cifmw_virtualbmc_machine: null
 cifmw_virtualbmc_action: null

--- a/roles/virtualbmc/tasks/cleanup.yml
+++ b/roles/virtualbmc/tasks/cleanup.yml
@@ -44,10 +44,13 @@
         key: "{{ _vbmc_key.content | b64decode }}"
         state: absent
 
-- name: Remove generated SSH keypair
+- name: Remove vbmc files
+  vars:
+    dest_dir: "{{ cifmw_virtualbmc_sshkey_path | dirname }}"
   ansible.builtin.file:
     path: "{{ item }}"
     state: absent
   loop:
     - "{{ cifmw_virtualbmc_sshkey_path }}"
     - "{{ cifmw_virtualbmc_sshkey_path }}.pub"
+    - "{{ dest_dir }}/virtualbmc.conf"

--- a/roles/virtualbmc/tasks/main.yml
+++ b/roles/virtualbmc/tasks/main.yml
@@ -51,7 +51,19 @@
         key: "{{ _vbmc_key.public_key }}"
         state: present
 
+    - name: Create vbmc server configuration file
+      vars:
+        dest_dir: "{{ cifmw_virtualbmc_sshkey_path | dirname }}"
+      ansible.builtin.copy:
+        dest: "{{ dest_dir }}/virtualbmc.conf"
+        content: |
+          [default]
+          server_port={{ cifmw_virtualbmc_daemon_port }}
+        mode: "0644"
+
     - name: Create and start vbmc container
+      vars:
+        dest_dir: "{{ cifmw_virtualbmc_sshkey_path | dirname }}"
       containers.podman.podman_container:
         image: "{{ cifmw_virtualbmc_image }}"
         name: "{{ cifmw_virtualbmc_container_name }}"
@@ -59,3 +71,4 @@
         state: started
         volumes:
           - "{{ cifmw_virtualbmc_sshkey_path }}:{{ cifmw_virtualbmc_ipmi_key_path }}:ro,Z"
+          - "{{ dest_dir }}/virtualbmc.conf:/etc/virtualbmc/virtualbmc.conf:ro,Z"

--- a/scenarios/reproducers/va-hci.yml
+++ b/scenarios/reproducers/va-hci.yml
@@ -64,6 +64,7 @@ cifmw_test_operator_tempest_include_list: |
 # provides access to Internet. This will be the equivalent of the
 # "public network" as seen in CI.
 cifmw_use_libvirt: true
+cifmw_virtualbmc_daemon_port: 50881
 cifmw_libvirt_manager_compute_amount: 3
 cifmw_libvirt_manager_configuration:
   networks:


### PR DESCRIPTION
This port wasn't documented, and of course may conflict if you have a
pre-existing VBMC service running on the host (especially in devscripts
scenario).

This patch adds a minimalistic VirtualBMC configuration file to the
container, allowing to set a specific port for the main daemon.

The patch also updates the va-hci.yml scenario file to allow a smoother
deployment.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
   [X] README in the role
