### PR TITLE
Add UEFI support for the virtual machines

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -18,6 +18,7 @@ are shared among multiple roles:
 - `cifmw_path`: customized PATH. Defaults to `~/.crc/bin:~/.crc/bin/oc:~/bin:${PATH}`.
 - `cifmw_use_libvirt`: (Bool) toggle libvirt support.
 - `cifmw_use_crc`: (Bool) toggle rhol/crc usage.
+- `cifmw_use_uefi`: (Bool) toggle UEFI support in libvirt_manager provided VMs.
 - `cifmw_use_devscripts`: (Bool) toggle devscripts usage.
 - `cifmw_openshift_kubeconfig`: (String) Path to the kubeconfig file if externally provided. If provided will be the kubeconfig to use and update after login.
 - `cifmw_openshift_api`: (String) Path to the kubeconfig file. If provided will be the API to authenticate against.

--- a/roles/libvirt_manager/templates/domain.xml.j2
+++ b/roles/libvirt_manager/templates/domain.xml.j2
@@ -2,8 +2,16 @@
   <name>cifmw-{{ vm_type }}-{{ vm_id }}</name>
   <memory unit='GB'>{{ vm_data.value.memory | default(2) }}</memory>
   <vcpu placement='static'>{{ vm_data.value.cpus | default(2) }}</vcpu>
+{% if vm_data.value.uefi | default(false) | bool %}
+  <os firmware="efi">
+    <type arch="x86_64" machine="q35">hvm</type>
+    <firmware>
+      <feature enabled="no" name="secure-boot"/>
+    </firmware>
+{% else %}
   <os>
     <type arch='x86_64' machine='q35'>hvm</type>
+{% endif %}
     <boot dev='hd'/>
     <bootmenu enable='no'/>
   </os>

--- a/scenarios/reproducers/3-nodes.yml
+++ b/scenarios/reproducers/3-nodes.yml
@@ -12,10 +12,14 @@ cifmw_rhol_crc_config:
   memory: 24000
 
 cifmw_use_libvirt: true
+cifmw_use_uefi: >-
+  {{ (cifmw_repo_setup_os_release is defined
+      and cifmw_repo_setup_os_release == 'rhel') | bool }}
 cifmw_libvirt_manager_compute_amount: 1
 cifmw_libvirt_manager_configuration:
   vms:
     compute:
+      uefi: "{{ cifmw_use_uefi }}"
       amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 1] | max }}"
       root_part_id: >-
         {{
@@ -33,6 +37,7 @@ cifmw_libvirt_manager_configuration:
         - public
         - osp_trunk
     controller:
+      uefi: "{{ cifmw_use_uefi }}"
       image_url: "{{ cifmw_discovered_image_url }}"
       root_part_id: >-
         {{

--- a/scenarios/reproducers/external-ceph.yml
+++ b/scenarios/reproducers/external-ceph.yml
@@ -15,6 +15,7 @@ cifmw_libvirt_manager_configuration:
       </network>
   vms:
     compute:
+      uefi: "{{ cifmw_use_uefi | default(false) }}"
       root_part_id: >-
         {{
           (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
@@ -32,6 +33,7 @@ cifmw_libvirt_manager_configuration:
         - ocpbm
         - osp_trunk
     ceph:
+      uefi: "{{ cifmw_use_uefi | default(false) }}"
       root_part_id: >-
         {{
           (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
@@ -49,6 +51,7 @@ cifmw_libvirt_manager_configuration:
         - ocpbm
         - osp_trunk
     controller:
+      uefi: "{{ cifmw_use_uefi | default(false) }}"
       root_part_id: >-
         {{
           (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |

--- a/scenarios/reproducers/va-hci.yml
+++ b/scenarios/reproducers/va-hci.yml
@@ -65,6 +65,9 @@ cifmw_test_operator_tempest_include_list: |
 # "public network" as seen in CI.
 cifmw_use_libvirt: true
 cifmw_virtualbmc_daemon_port: 50881
+cifmw_use_uefi: >-
+  {{ (cifmw_repo_setup_os_release is defined
+      and cifmw_repo_setup_os_release == 'rhel') | bool }}
 cifmw_libvirt_manager_compute_amount: 3
 cifmw_libvirt_manager_configuration:
   networks:
@@ -82,6 +85,7 @@ cifmw_libvirt_manager_configuration:
       </network>
   vms:
     compute:
+      uefi: "{{ cifmw_use_uefi }}"
       root_part_id: >-
         {{
           (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
@@ -99,6 +103,7 @@ cifmw_libvirt_manager_configuration:
         - ocpbm
         - osp_trunk
     controller:
+      uefi: "{{ cifmw_use_uefi }}"
       root_part_id: >-
         {{
           (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |


### PR DESCRIPTION
Until now, only BIOS mode was supported for the VM managed by the
libvirt_manager role.

From now on, we add support for UEFI, provided the base image supports
it of course (note: this is NOT the case for the official
CentOS-stream-9 images!).

A quick check/automation allows to detect if the image "is supposed to
support" UEFI based on cifmw_repo_setup_os_release parameter value. RHEL
images do provide UEFI, so let's just use it.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
