### PR TITLE
Fix cifmw_block_device cleanup

### DIFF
--- a/roles/cifmw_block_device/tasks/cleanup.yml
+++ b/roles/cifmw_block_device/tasks/cleanup.yml
@@ -20,7 +20,7 @@
   ansible.builtin.systemd:
     state: stopped
     enabled: false
-    name: ceph-osd-losetup
+    name: "{{ cifmw_block_systemd_unit_file | basename }}"
 
 - name: Remove unit file
   become: true


### PR DESCRIPTION
The name of the systemd unit can vary based on the cifmw_block_systemd_unit_file parameter. Update the cleanup.yml tasks file to use this parameter when
stopping the systemd unit.

Follow up patch to 1fe248a5c73bf6e99fbef838a8052d953223e5f4

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
