### PR TITLE
Add new role to install and configure Sushy Emulator

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -62,3 +62,6 @@
 - job:
     name: cifmw-molecule-openshift_obs
     nodeset: centos-9-crc-2-30-0-xxl
+- job:
+    name: cifmw-molecule-sushy_emulator
+    nodeset: centos-9-crc-2-30-0-xl

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -447,6 +447,7 @@ subnet
 subnets
 sudo
 sudoers
+sushy
 svc
 svg
 svgrepo

--- a/roles/sushy_emulator/README.md
+++ b/roles/sushy_emulator/README.md
@@ -1,0 +1,40 @@
+# sushy_emulator
+
+This role installs, configures and tests the deployment of the Sushi Emulator service.
+
+Sushi Emulator is a virtual Redfish BMC, this role supports both the OpenStack and Libvirt driver.
+
+Baremetal instances must be configured prior to running this role, for the Libvirt driver, the `libvirt_manager` role can be used.
+
+## Privilege escalation
+
+Required to installed required packages.
+
+## Parameters
+
+* `cifmw_sushy_emulator_driver`: (String) Select between `openstack` and `libvirt` sushy emulator driver. Defaults to `libvirt`
+* `cifmw_sushy_emulator_sshkey_path`: (String) Path of SSH key used by sushy emulator to talk to libvirt socket. Defaults to `"{{ ansible_user_dir }}/.ssh/id_cifw"`
+* `cifmw_sushy_emulator_libvirt_user`: (String) Username used by Sushi Emulator to connect to Libvirt socket. Defaults to `zuul`
+* `cifmw_sushy_emulator_listen_ip`: (String) IP Sushi Emulator service listens on. Defaults to `0.0.0.0`
+* `cifmw_sushy_emulator_driver_openstack_client_config_file`: (String) Path to OpenStack config file, used by OpenStack Sushi Emulator driver. Defaults to `/etc/openstack/clouds.yaml`
+* `cifmw_sushy_emulator_driver_openstack_cloud`: (String) Cloud key reference in OpenStack config file. Defaults to `None`
+* `cifmw_sushy_emulator_namespace`: (String) Namespace Sushi Emulator is deployed into when using the `ocp` install method. Defaults to `sushy-emulator`
+* `cifmw_sushy_emulator_redfish_username`: (String) Redfish username. Defaults to `admin`
+* `cifmw_sushy_emulator_redfish_password`: (String) Redfish password. Defaults to `password`
+* `cifmw_sushy_emulator_resource_directory`: (String) Path where resource files will be written. Defaults to `"{{ (ansible_user_dir, 'ci-framework-data', 'artifacts', 'sushy_emulator') | path_join }}"`
+* `cifmw_sushy_emulator_image`: (String) Container image used when deploying Sushi Emulator container and pod. Defaults to `quay.io/metal3-io/sushy-tools:latest`
+* `cifmw_sushy_emulator_instance_node_name_prefix`: (String) String used to find instances created for baremetal use. Defaults to `cifmw-`
+* `cifmw_sushy_emulator_container_name`: (String) Name of Podman container created. Defaults to `cifmw-sushy_emulator`
+* `cifmw_sushy_emulator_install_type`: (String) Install type can either be `ocp` or `podman` and dictates where Sushi Emulator will be installed. Defaults to `ocp`
+
+## Examples
+
+```yaml
+- hosts: all
+  vars:
+    cifmw_baremetal_hypervisor_target: baremetal-hypervisor
+  tasks:
+    - name: Deploy and configure sushy-emulator
+      ansible.builtin.import_role:
+        name: 'sushy_emulator'
+```

--- a/roles/sushy_emulator/defaults/main.yml
+++ b/roles/sushy_emulator/defaults/main.yml
@@ -1,0 +1,34 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_sushy_emulator"
+
+cifmw_sushy_emulator_driver: libvirt
+cifmw_sushy_emulator_sshkey_path: "{{ ansible_user_dir }}/.ssh/id_cifw"
+cifmw_sushy_emulator_libvirt_user: zuul
+cifmw_sushy_emulator_listen_ip: 0.0.0.0
+cifmw_sushy_emulator_driver_openstack_client_config_file: /etc/openstack/clouds.yaml
+cifmw_sushy_emulator_driver_openstack_cloud: None
+cifmw_sushy_emulator_namespace: sushy-emulator
+cifmw_sushy_emulator_redfish_username: admin
+cifmw_sushy_emulator_redfish_password: password
+cifmw_sushy_emulator_resource_directory: "{{ (ansible_user_dir, 'ci-framework-data', 'artifacts', 'sushy_emulator') | path_join }}"
+cifmw_sushy_emulator_image: quay.io/metal3-io/sushy-tools:latest
+cifmw_sushy_emulator_instance_node_name_prefix: cifmw-
+cifmw_sushy_emulator_container_name: "cifmw-sushy_emulator"
+cifmw_sushy_emulator_install_type: 'ocp'

--- a/roles/sushy_emulator/meta/main.yml
+++ b/roles/sushy_emulator/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- sushy_emulator
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: cifmw
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - cifmw
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/sushy_emulator/molecule/default/converge.yml
+++ b/roles/sushy_emulator/molecule/default/converge.yml
@@ -1,0 +1,39 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  vars:
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+    cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+    cifmw_baremetal_hypervisor_target: instance
+    cifmw_sushy_emulator_sshkey_path: "{{ ansible_user_dir }}/.ssh/id_rsa"
+  tasks:
+    - name: Add instance anisble_host
+      ansible.builtin.add_host:
+        name: "{{ cifmw_baremetal_hypervisor_target }}"
+        ansible_host: "{{ hostvars[cifmw_baremetal_hypervisor_target]['ansible_default_ipv4']['address'] }}"
+
+    - name: Run Sushy Emulator role against OCP
+      ansible.builtin.include_role:
+        name: sushy_emulator
+
+    - name: Run Sushy Emulator role against podman
+      vars:
+        cifmw_sushy_emulator_install_type: "podman"
+      ansible.builtin.include_role:
+        name: sushy_emulator

--- a/roles/sushy_emulator/molecule/default/molecule.yml
+++ b/roles/sushy_emulator/molecule/default/molecule.yml
@@ -1,0 +1,26 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/roles/sushy_emulator/molecule/default/prepare.yml
+++ b/roles/sushy_emulator/molecule/default/prepare.yml
@@ -1,0 +1,74 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  vars:
+    cifmw_baremetal_hypervisor_target: instance
+    cifmw_libvirt_manager_configuration:
+      vms:
+        compute:
+          amount: 2
+          disk_file_name: "blank"
+          disksize: 50
+          memory: 8
+          cpus: 4
+          nets:
+            - public
+            - default
+  roles:
+    - role: test_deps
+  tasks:
+    - name: Ensure CRC is started
+      ansible.builtin.command:
+        cmd: crc start
+
+    - name: Inject crc hostname/IP in hosts
+      become: true
+      ansible.builtin.lineinfile:
+        path: /etc/hosts
+        line: "192.168.130.11 crc"
+
+    - name: Add the crc host dynamically
+      ansible.builtin.add_host:
+        name: crc
+        ansible_ssh_private_key_file: "{{ ansible_user_dir }}/.crc/machines/crc/id_ecdsa"
+        ansible_ssh_user: core
+
+    - name: Add instance anisble_host
+      ansible.builtin.add_host:
+        name: instance
+        ansible_host: "{{ hostvars[cifmw_baremetal_hypervisor_target]['ansible_default_ipv4']['address'] }}"
+
+    - name: "Add host key to {{ cifmw_baremetal_hypervisor_target }}"
+      ansible.builtin.shell:
+        cmd: ssh-keyscan {{ hostvars[cifmw_baremetal_hypervisor_target].ansible_host }} >> ~/.ssh/known_hosts
+
+    - name: "Add SSH key to authorized_keys"
+      ansible.builtin.shell:
+        cmd: 'cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys'
+
+    - name: Setup and create virtual baremetal
+      block:
+        - name: Ensure libvirt is present/configured
+          ansible.builtin.import_role:
+            name: libvirt_manager
+
+        - name: Create virtual baremetal VMs
+          ansible.builtin.include_role:
+            name: libvirt_manager
+            tasks_from: deploy_layout

--- a/roles/sushy_emulator/tasks/apply_resources.yml
+++ b/roles/sushy_emulator/tasks/apply_resources.yml
@@ -1,0 +1,51 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Create the sushy-emulator namespace
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    name: "{{ cifmw_sushy_emulator_namespace }}"
+    kind: Namespace
+    state: present
+
+- name: Apply Sushy Emulator resources
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    state: present
+    src: "{{ (cifmw_sushy_emulator_resource_directory, item+'.yaml') | path_join }}"
+  with_items:
+    - secret
+    - configmap
+    - service
+    - route
+
+- name: Apply Sushy Emulator pod resource
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    state: present
+    src: "{{ (cifmw_sushy_emulator_resource_directory, 'pod.yaml') | path_join }}"
+    wait: yes  # noqa: yaml[truthy]
+    wait_sleep: 10
+    wait_timeout: 360
+    wait_condition:
+      type: Ready
+      status: "True"

--- a/roles/sushy_emulator/tasks/collect_details.yml
+++ b/roles/sushy_emulator/tasks/collect_details.yml
@@ -1,0 +1,93 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Get ingresses domain
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: 'oc get ingresses.config/cluster -o jsonpath={.spec.domain}'
+  register: _ingress_domain
+  when: cifmw_sushy_emulator_install_type == 'ocp'
+
+- name: Set sushy url for ocp installation
+  ansible.builtin.set_fact:
+    sushy_url: "http://sushy-emulator.{{ _ingress_domain.stdout }}"
+  when: cifmw_sushy_emulator_install_type == 'ocp'
+
+- name: Base64 encode ssh private key
+  ansible.builtin.slurp:
+    src: "{{ cifmw_sushy_emulator_sshkey_path }}"
+  register: _cifmw_sushy_emulator_private_key_b64
+  no_log: true
+
+- name: Base64 encode ssh public key
+  ansible.builtin.slurp:
+    src: "{{ cifmw_sushy_emulator_sshkey_path }}.pub"
+  register: _cifmw_sushy_emulator_public_key_b64
+  no_log: true
+
+- name: Run ssh-keyscan
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      ssh-keyscan -H {{ hostvars[cifmw_baremetal_hypervisor_target].ansible_host }} 2>/dev/null | base64 -w 0
+  register: _cifmw_sushy_emulator_ssh_known_hosts_b64
+
+- name: Write known hosts for later use
+  ansible.builtin.copy:
+    content: "{{ _cifmw_sushy_emulator_ssh_known_hosts_b64.stdout | b64decode }}"
+    dest: "{{ cifmw_sushy_emulator_resource_directory }}/known_hosts"
+    mode: '0644'
+
+- name: Get details for Libvirt driver
+  when: cifmw_sushy_emulator_driver == 'libvirt'
+  block:
+    - name: Set vars
+      ansible.builtin.set_fact:
+        _libvirt_uri: "qemu+ssh://{{ cifmw_sushy_emulator_libvirt_user }}@{{ hostvars[cifmw_baremetal_hypervisor_target].ansible_host }}/system"
+
+    # todo(Lewis): Once changes are made to the libvirt_manager role, the baremetal-info.yml can be consumed to gather required info
+    - name: Get Libvirt instance UUIDs
+      ansible.builtin.shell:
+        cmd: |
+          set -o pipefail
+          virsh --connect={{ _libvirt_uri }} list --all --uuid --name | grep {{ cifmw_sushy_emulator_instance_node_name_prefix }} | cut -d' ' -f1
+      register: _virsh_list_uuid
+
+    - name: Set instance_uuid variable
+      ansible.builtin.set_fact:
+        _cifmw_sushy_emulator_instances: "{{ _virsh_list_uuid.stdout_lines | regex_replace('\n(?!.*\n)', ', ')}}"
+
+# todo(Lewis): The OpenStack driver is currently untested waiting for changes being implemented upstream by sbaker.
+- name: Gather details for Openstack driver
+  when:
+    - cifmw_sushy_emulator_driver == 'openstack'
+  block:
+    - name: Get Openstack instance UUIDs
+      ansible.builtin.command:
+        cmd: "openstack --os-cloud={{ cifmw_sushy_emulator_driver_openstack_cloud }} server list --name {{ cifmw_sushy_emulator_instance_node_name_prefix }}.* -f json -c ID | jq -c [.[].ID])"
+      register: _openstack_server_list_uuid
+
+    - name: Set instance_uuid variable for openstack driver
+      ansible.builtin.set_fact:
+        _cifmw_sushy_emulator_instances: "{{ _openstack_server_list_uuid }}"
+        _libvirt_uri: None
+
+    - name: Base64 encode openstack clouds.yaml file
+      ansible.builtin.slurp:
+        src: "{{ cifmw_sushy_emulator_driver_openstack_client_config_file }}"
+      register: _cifmw_sushy_emulator_driver_openstack_client_config_file_b64

--- a/roles/sushy_emulator/tasks/create_container.yml
+++ b/roles/sushy_emulator/tasks/create_container.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Pull Sushy Emulator container image
+  containers.podman.podman_image:
+    name: "{{ cifmw_sushy_emulator_image }}"
+    state: present
+
+- name: Create and start Sushy Emulator container
+  vars:
+    dest_dir: "{{ cifmw_sushy_emulator_resource_directory }}"
+  containers.podman.podman_container:
+    image: "{{ cifmw_sushy_emulator_image }}"
+    name: "{{ cifmw_sushy_emulator_container_name }}"
+    network: host
+    state: started
+    env:
+      SUSHY_TOOLS_CONFIG: '/etc/sushy-emulator/config.conf'
+    volumes:
+      - "{{ dest_dir }}/known_hosts:/root/.ssh/known_hosts:ro,Z"
+      - "{{ cifmw_sushy_emulator_sshkey_path }}:/root/.ssh/id_rsa:ro,Z"
+      - "{{ cifmw_sushy_emulator_sshkey_path }}.pub:/root/.ssh/id_rsa.pub:ro,Z"
+      - "{{ dest_dir }}/config.conf:/etc/sushy-emulator/config.conf:ro,Z"
+      - "{{ dest_dir }}/.htpasswd:/etc/sushy-emulator/.htpasswd:ro,Z"
+
+- name: Set sushy url for podman installation
+  ansible.builtin.set_fact:
+    sushy_url: "http://localhost:8000"

--- a/roles/sushy_emulator/tasks/main.yml
+++ b/roles/sushy_emulator/tasks/main.yml
@@ -1,0 +1,54 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Create Sushy Emulator resource directory
+  ansible.builtin.file:
+    path: "{{ cifmw_sushy_emulator_resource_directory }}"
+    state: directory
+
+- name: Install required packages
+  become: true
+  ansible.builtin.package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - httpd-tools
+    - libvirt-client
+
+- name: Collect details for Sushy Emulator config
+  ansible.builtin.import_tasks: collect_details.yml
+
+- name: Render resource files for Sushy Emulator
+  ansible.builtin.import_tasks: render_resources.yml
+
+- name: Deploy Sushy Emulator to OCP
+  ansible.builtin.import_tasks: apply_resources.yml
+  when: cifmw_sushy_emulator_install_type == 'ocp'
+
+- name: Deploy Sushy Emulator into Podman container
+  ansible.builtin.import_tasks: create_container.yml
+  when: cifmw_sushy_emulator_install_type == 'podman'
+
+# todo(Lewis): Once vms deployed by libvirt_manager are working we should
+# add one more basic fuctional test like checking power status
+- name: Test sushy Emulator and connection to hypervisor libvirt socket
+  ansible.builtin.uri:
+    url: "{{ sushy_url}}/redfish/v1/Managers"
+    return_content: true
+    user: admin
+    password: password
+  retries: 5
+  delay: 5

--- a/roles/sushy_emulator/tasks/render_resources.yml
+++ b/roles/sushy_emulator/tasks/render_resources.yml
@@ -1,0 +1,47 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Generate htpasswd string
+  ansible.builtin.command:
+    cmd: "htpasswd -nbB {{ cifmw_sushy_emulator_redfish_username | quote}} {{ cifmw_sushy_emulator_redfish_password | quote }}"
+  register: _htpasswd
+
+- name: Write sushy emulator resource loop
+  ansible.builtin.template:
+    src: "{{ item }}_yaml.j2"
+    dest: "{{ (cifmw_sushy_emulator_resource_directory, item+'.yaml') | path_join }}"
+    mode: '0644'
+  with_items:
+    - secret
+    - configmap
+    - pod
+    - service
+    - route
+  when: cifmw_sushy_emulator_install_type == 'ocp'
+
+- name: Write sushy emulator config
+  ansible.builtin.template:
+    src: 'config_conf.j2'
+    dest: "{{ (cifmw_sushy_emulator_resource_directory, 'config.conf') | path_join }}"
+    mode: '0644'
+  when: cifmw_sushy_emulator_install_type == 'podman'
+
+- name: Write htpasswd string to file
+  ansible.builtin.copy:
+    content: "{{ _htpasswd.stdout }}"
+    dest: "{{ (cifmw_sushy_emulator_resource_directory, '.htpasswd') | path_join }}"
+    mode: '0644'
+  when: cifmw_sushy_emulator_install_type == 'podman'

--- a/roles/sushy_emulator/templates/config_conf.j2
+++ b/roles/sushy_emulator/templates/config_conf.j2
@@ -1,0 +1,33 @@
+# Listen on all local IP interfaces
+SUSHY_EMULATOR_LISTEN_IP = '{{ cifmw_sushy_emulator_listen_ip }}'
+
+# Bind to TCP port 8000
+SUSHY_EMULATOR_LISTEN_PORT = 8000
+
+# Serve this SSL certificate to the clients
+SUSHY_EMULATOR_SSL_CERT = None
+
+# If SSL certificate is being served, this is its RSA private key
+SUSHY_EMULATOR_SSL_KEY = None
+
+# If authentication is desired, set this to an htpasswd file.
+SUSHY_EMULATOR_AUTH_FILE = '/etc/sushy-emulator/.htpasswd'
+
+# The OpenStack cloud ID to use. This option enables OpenStack driver.
+SUSHY_EMULATOR_OS_CLOUD = {{ cifmw_sushy_emulator_driver_openstack_cloud }}
+
+# The libvirt URI to use. This option enables libvirt driver.
+SUSHY_EMULATOR_LIBVIRT_URI = '{{ _libvirt_uri }}'
+
+# Instruct the libvirt driver to ignore any instructions to
+# set the boot device. Allowing the UEFI firmware to instead
+# rely on the EFI Boot Manager
+# Note: This sets the legacy boot element to dev="fd"
+# and relies on the floppy not existing, it likely wont work
+# your VM has a floppy drive.
+SUSHY_EMULATOR_IGNORE_BOOT_DEVICE = False
+
+# This list contains the identities of instances that the driver will filter by.
+# It is useful in a tenant environment where only some instances represent
+# virtual baremetal.
+SUSHY_EMULATOR_ALLOWED_INSTANCES = {{ _cifmw_sushy_emulator_instances }}

--- a/roles/sushy_emulator/templates/configmap_yaml.j2
+++ b/roles/sushy_emulator/templates/configmap_yaml.j2
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sushy-emulator-config
+  namespace: {{ cifmw_sushy_emulator_namespace }}
+data:
+  htpasswd: |
+    {{ _htpasswd.stdout }}
+  config: |
+{% filter indent(width=4, first=True) %}
+{% include 'config_conf.j2' %}
+{% endfilter %}

--- a/roles/sushy_emulator/templates/pod_yaml.j2
+++ b/roles/sushy_emulator/templates/pod_yaml.j2
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sushy-emulator
+  namespace: {{ cifmw_sushy_emulator_namespace }}
+  labels:
+    name: sushy-emulator
+spec:
+  selector:
+    app.kubernetes.io/name: sushy-emulator
+  containers:
+  - name: sushy-emulator
+    image: {{ cifmw_sushy_emulator_image }}
+    command: ["/usr/local/bin/sushy-emulator", "--config", "/etc/sushy-emulator/config.conf"]
+    ports:
+    - containerPort: 8000
+    volumeMounts:
+    - name: ssh-secret
+      mountPath: /root/.ssh
+      readOnly: true
+    - name: sushy-emulator-config
+      mountPath: /etc/sushy-emulator/
+{% if cifmw_sushy_emulator_driver == 'openstack' %}
+    - name: os-client-config
+      mountPath: /etc/openstack/
+{% endif %}
+    readinessProbe:
+      httpGet:
+        path: redfish/v1
+        port: 8000
+        initialDelaySeconds: 5
+        periodSeconds: 5
+    livenessProbe:
+      httpGet:
+        path: redfish/v1
+        port: 8000
+        initialDelaySeconds: 10
+        failureThreshold: 30
+        periodSeconds: 10
+    startupProbe:
+      httpGet:
+        path: redfish/v1
+        port: 8000
+        failureThreshold: 30
+        initialDelaySeconds: 10
+  volumes:
+  - name: ssh-secret
+    secret:
+      secretName: sushy-emulator-secret
+      defaultMode: 0644 # u=rw,g=r,o=r
+      items:
+      - key: ssh-privatekey
+        path: id_rsa
+        mode: 0600 # u=rw,g=,o=
+      - key: ssh-publickey
+        path: id_rsa.pub
+        mode: 0644 # u=rw,g=r,o=r
+      - key: ssh-known-hosts
+        path: known_hosts
+        mode: 0644 # u=rw,g=r,o=r
+  - name: sushy-emulator-config
+    configMap:
+      name: sushy-emulator-config
+      defaultMode: 0644 # u=rw,g=r,o=r
+      items:
+      - key: config
+        path: config.conf
+      - key: htpasswd
+        path: .htpasswd
+        mode: 0600 # u=rw,g=r,o=r
+{% if cifmw_sushy_emulator_driver == 'openstack' %}
+  - name: os-client-config
+    secret:
+      secretName: os-client-config
+      defaultMode: 0644 # u=rw,g=r,o=r
+      items:
+      - key: openstack-clouds-yaml
+        path: clouds.yaml
+  restartPolicy: OnFailure
+{% endif %}

--- a/roles/sushy_emulator/templates/route_yaml.j2
+++ b/roles/sushy_emulator/templates/route_yaml.j2
@@ -1,0 +1,14 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: sushy-emulator-route
+  namespace: {{ cifmw_sushy_emulator_namespace }}
+  labels:
+    name: sushy-emulator
+spec:
+  host: sushy-emulator.{{ _ingress_domain.stdout }}
+  port:
+    targetPort: 8000
+  to:
+    kind: Service
+    name: sushy-emulator-service

--- a/roles/sushy_emulator/templates/secret_yaml.j2
+++ b/roles/sushy_emulator/templates/secret_yaml.j2
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: sushy-emulator-secret
+    namespace: {{ cifmw_sushy_emulator_namespace }}
+data:
+    ssh-publickey: |
+        {{ _cifmw_sushy_emulator_public_key_b64.content | default('""') | trim }}
+    ssh-privatekey: |
+        {{ _cifmw_sushy_emulator_private_key_b64.content | default('""') | trim }}
+    ssh-known-hosts: |
+        {{ _cifmw_sushy_emulator_ssh_known_hosts_b64.stdout | default('""') | trim }}
+{% if cifmw_sushy_emulator_driver == 'openstack' %}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: os-client-config
+    namespace: {{ cifmw_sushy_emulator_namespace }}
+data:
+    openstack-clouds-yaml: |
+        {{ _cifmw_sushy_emulator_driver_openstack_client_config_file_b64 | default('""') | trim }}
+{% endif %}

--- a/roles/sushy_emulator/templates/service_yaml.j2
+++ b/roles/sushy_emulator/templates/service_yaml.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sushy-emulator-service
+  namespace: {{ cifmw_sushy_emulator_namespace }}
+  labels:
+    name: sushy-emulator
+spec:
+  selector:
+    name: sushy-emulator
+  ports:
+  - protocol: TCP
+    port: 8000
+    targetPort: 8000

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -614,6 +614,18 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/sushy_emulator/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-sushy_emulator
+    nodeset: centos-9-crc-2-30-0-xl
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: sushy_emulator
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/tempest/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -62,6 +62,7 @@
       - cifmw-molecule-rhol_crc
       - cifmw-molecule-run_hook
       - cifmw-molecule-set_openstack_containers
+      - cifmw-molecule-sushy_emulator
       - cifmw-molecule-tempest
       - cifmw-molecule-test_deps
       - cifmw-molecule-test_operator


### PR DESCRIPTION
When provided a list of instances from either openstack or libvirt and
an operational OpenShift environment, this role will install and
configure a Sushy Emulator pod to be used in testing baremetal tasks with
virtual baremetal servers.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
