### PR TITLE
Use nodeset_networks ansible var

### DIFF
--- a/hooks/playbooks/fetch_compute_facts.yml
+++ b/hooks/playbooks/fetch_compute_facts.yml
@@ -186,7 +186,7 @@
                         {%- raw %}
                         ---
                         {% set mtu_list = [ctlplane_mtu] %}
-                        {% for network in role_networks %}
+                        {% for network in nodeset_networks %}
                         {{ mtu_list.append(lookup("vars", networks_lower[network] ~ "_mtu")) }}
                         {%- endfor %}
                         {% set min_viable_mtu = mtu_list | max %}
@@ -205,7 +205,7 @@
                             mtu: {{ min_viable_mtu }}
                             # force the MAC address of the bridge to this interface
                             primary: true
-                        {% for network in role_networks %}
+                        {% for network in nodeset_networks %}
                           - type: vlan
                             mtu: {{ min_viable_mtu - 4 }}
                             vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}


### PR DESCRIPTION
There is no concept of role, use nodeset_networks instead.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/725
