### PR TITLE
Workaround to install OKD opearators

### DIFF
--- a/scenarios/centos-9/ceph_backends.yml
+++ b/scenarios/centos-9/ceph_backends.yml
@@ -3,7 +3,7 @@ cifmw_control_plane_ceph_backend_include_vars: "{{ cifmw_basedir }}/artifacts/pr
 
 cifmw_install_yamls_vars:
   BMO_SETUP: false
-  INSTALL_CERT_MANAGER: false
+  OKD: "true"
 
 cifmw_edpm_prepare_skip_crc_storage_creation: true
 

--- a/scenarios/centos-9/ci.yml
+++ b/scenarios/centos-9/ci.yml
@@ -31,6 +31,7 @@ post_ctlplane_deploy:
 
 cifmw_install_yamls_vars:
   BMO_SETUP: false
+  OKD: "true"
 
 # Enable tempest
 cifmw_run_tests: true

--- a/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
+++ b/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
@@ -9,7 +9,7 @@ cifmw_install_yamls_vars:
   BMAAS_INSTANCE_VCPUS: 6
   BMAAS_INSTANCE_DISK_SIZE: 40
   DATAPLANE_GROWVOLS_ARGS: "/=8GB /tmp=1GB /home=1GB /var=8GB"
-  INSTALL_CERT_MANAGER: false
+  OKD: "true"
 
 pre_infra:
   - name: Download needed tools
@@ -32,7 +32,7 @@ cifmw_openshift_setup_skip_internal_registry: true
 cifmw_use_crc: true
 cifmw_rhol_crc_use_installyamls: true
 
-cifmw_config_certmanager: true
+cifmw_config_certmanager: false
 
 # openshift_login role vars
 cifmw_openshift_user: "kubeadmin"

--- a/scenarios/centos-9/edpm_ci.yml
+++ b/scenarios/centos-9/edpm_ci.yml
@@ -4,7 +4,7 @@ cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-o
 cifmw_install_yamls_vars:
   DATAPLANE_REPO: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/dataplane-operator"
   BMO_SETUP: false
-  INSTALL_CERT_MANAGER: false
+  OKD: "true"
 
 # edpm_prepare role vars
 cifmw_operator_build_meta_name: "openstack-operator"
@@ -23,7 +23,7 @@ cifmw_openshift_api: api.crc.testing:6443
 cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.kube/config"
 cifmw_openshift_skip_tls_verify: true
 
-cifmw_config_certmanager: true
+cifmw_config_certmanager: false
 
 pre_deploy:
   - name: Disable openstack marketplace

--- a/scenarios/centos-9/hci_ceph_backends.yml
+++ b/scenarios/centos-9/hci_ceph_backends.yml
@@ -1,7 +1,7 @@
 ---
 cifmw_install_yamls_vars:
   BMO_SETUP: false
-  INSTALL_CERT_MANAGER: false
+  OKD: "true"
 
 cifmw_edpm_prepare_skip_crc_storage_creation: true
 

--- a/scenarios/centos-9/kuttl.yml
+++ b/scenarios/centos-9/kuttl.yml
@@ -2,4 +2,5 @@
 cifmw_install_yamls_vars:
   OPERATOR_BASE_DIR: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators"
   BMO_SETUP: false
+  OKD: "true"
 cifmw_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"

--- a/scenarios/centos-9/multinode-ci.yml
+++ b/scenarios/centos-9/multinode-ci.yml
@@ -20,6 +20,7 @@ cifmw_run_tests: true
 
 cifmw_install_yamls_vars:
   BMO_SETUP: false
+  OKD: "true"
 
 # Deploy EDPM in multinode scenario
 cifmw_deploy_edpm: true

--- a/scenarios/centos-9/podified_common.yml
+++ b/scenarios/centos-9/podified_common.yml
@@ -18,7 +18,7 @@ cifmw_run_tests: true
 
 cifmw_install_yamls_vars:
   BMO_SETUP: false
-  INSTALL_CERT_MANAGER: false
+  OKD: "true"
 
 pre_infra:
   - name: Download needed tools


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
