### PR TITLE
Ensure script properly reports failure in reproducer

### DIFF
--- a/roles/reproducer/tasks/configure_architecture.yml
+++ b/roles/reproducer/tasks/configure_architecture.yml
@@ -10,6 +10,7 @@
         group: "zuul"
         content: |-
           #!/bin/bash
+          set -e
           pushd src/github.com/openstack-k8s-operators/ci-framework
           export ANSIBLE_LOG_PATH="~/ansible-deploy-architecture.log"
           ansible-playbook -i ~/ci-framework-data/artifacts/zuul_inventory.yml \

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -152,6 +152,7 @@
         group: "zuul"
         content: |-
           #!/bin/bash
+          set -e
           pushd src/github.com/openstack-k8s-operators/ci-framework
           export ANSIBLE_LOG_PATH="~/ansible-deploy-edpm.log"
           ansible-playbook deploy-edpm.yml \


### PR DESCRIPTION
Until now, if the deploy-architecture.sh was failing, it was silent:
ansible didn't know about that failure, and just reported green.

Adding the `set -e` seems to ensure we're reporting the state correctly.

This flag is therefore added to the deploy-architecture.sh and
deploy-edpm.sh scripts (even though the second isn't called by the
reproducer - let's just be consistent).

As a pull request owner and reviewers, I checked that:
- [X] Tested in my env, we don't have CI for architecture deploy
