### PR TITLE
update cert_manager role with configureable timout

### DIFF
--- a/roles/cert_manager/defaults/main.yml
+++ b/roles/cert_manager/defaults/main.yml
@@ -64,3 +64,5 @@ cifmw_cert_manager_crds:
   - Challenge
   - ClusterIssuer
   - Issuer
+
+cifmw_cert_manager_verify_timeout: 10m

--- a/roles/cert_manager/tasks/validate_certs.yml
+++ b/roles/cert_manager/tasks/validate_certs.yml
@@ -31,4 +31,4 @@
   environment:
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
     PATH: "{{ cifmw_path }}"
-  ansible.builtin.command: "{{ lookup('env', 'HOME') }}/bin/cmctl check api --wait=2m"
+  ansible.builtin.command: "{{ lookup('env', 'HOME') }}/bin/cmctl check api --wait={{ cifmw_cert_manager_verify_timeout }}"


### PR DESCRIPTION
This change add a new cifmw_cert_manager_verify_timeout
variable to the cert_manager role and set its default to 10m

This is larger then the previous hardcoded 2m value because
we were seeing that timeout in ci.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
