### PR TITLE
Switch kuttl to ci_local_storage

### DIFF
--- a/ci/playbooks/kuttl/run-kuttl-tests.yml
+++ b/ci/playbooks/kuttl/run-kuttl-tests.yml
@@ -13,20 +13,14 @@
         combine({'PATH': cifmw_path})
       }}
 
-- name: 'Run make crc_storage_cleanup_with_retries'
-  vars:
-    make_crc_storage_cleanup_with_retries_env: "{{ cifmw_kuttl_tests_env }}"
+- name: Clean storage beforehand
   ansible.builtin.include_role:
-    name: 'install_yamls_makes'
-    tasks_from: 'make_crc_storage_cleanup_with_retries.yml'
+    name: 'ci_local_storage'
+    tasks_from: 'cleanup.yml'
 
-- name: 'Run make crc_storage_with_retries'
-  vars:
-    make_crc_storage_with_retries_env: "{{ cifmw_kuttl_tests_env }}"
+- name: Create storage
   ansible.builtin.include_role:
-    name: 'install_yamls_makes'
-    tasks_from: 'make_crc_storage_with_retries.yml'
-
+    name: 'ci_local_storage'
 
 - name: 'Get resource status before {{ operator }}_kuttl run'
   environment:


### PR DESCRIPTION
The `make crc_storage` and its derivatives is using a `debug` container,
leading to issues with authenticated operator provider.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
