### PR TITLE
Ensure we know all the hosts beforehand

### DIFF
--- a/ci/playbooks/edpm_baremetal_deployment/run.yml
+++ b/ci/playbooks/edpm_baremetal_deployment/run.yml
@@ -15,6 +15,40 @@
         path: "{{ ansible_user_dir }}/ci-framework-data/artifacts/edpm-ansible.yml"
       register: edpm_file
 
+    - name: Add crc node in local inventory
+      ansible.builtin.add_host:
+        name: crc
+        ansible_ssh_private_key_file: "{{ ansible_user_dir }}/.crc/machines/crc/id_ecdsa"
+        ansible_ssh_user: core
+        ansible_host: api.crc.testing
+
+    - name: Ensure we know ssh hosts
+      ansible.builtin.shell:
+        cmd: "ssh-keyscan {{ hostvars[item].ansible_host }} >> ~/.ssh/known_hosts"
+      loop: "{{ hostvars.keys() | reject('equalto', 'localhost') }}"
+
+    - name: Inject CRC in zuul_inventory
+      block:
+        - name: Load zuul_inventory
+          register: _inventory
+          ansible.builtin.slurp:
+            path: "{{ ansible_user_dir }}/ci-framework-data/artifacts/zuul_inventory.yml"
+
+        - name: Inject CRC in zuul_inventory.yml
+          vars:
+            _crc:
+              all:
+                hosts:
+                  crc: "{{ dict(hostvars.crc) }}"
+            _updated: >-
+              {{
+                _inventory.content | b64decode | from_yaml | combine(_crc, recursive=true)
+              }}
+          ansible.builtin.copy:
+            dest: "{{ ansible_user_dir }}/ci-framework-data/artifacts/zuul_inventory.yml"
+            content: "{{ _updated | to_nice_yaml }}"
+            mode: "0644"
+
     - name: Perform Podified and EDPM deployment on compute nodes with virtual baremetal
       ansible.builtin.command:
         chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"

--- a/zuul.d/end-to-end.yaml
+++ b/zuul.d/end-to-end.yaml
@@ -67,5 +67,6 @@
       - scenarios/centos-9/edpm_baremetal_deployment_ci.yml
       - ^plugins/action/ci_script.py
       - ^plugins/modules/generate_make_tasks.py
+      - ci/playbooks/edpm_baremetal_deployment/run.yml
 
     run: ci/playbooks/edpm_baremetal_deployment/run.yml


### PR DESCRIPTION
Since #1343, ci_local_storage is using plain ansible to create the
persistent storage on the OpenShift node (in this case, CRC).

This means it's using SSH - and since the job never connects to the
nested CRC instance, it's failing due to the unknown remote host key.

Having ssh-keyscan populating the known_hosts should prevent this issue.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
