### PR TITLE
Disable swift in hci job

### DIFF
--- a/hooks/playbooks/control_plane_hci_pre_deploy.yml
+++ b/hooks/playbooks/control_plane_hci_pre_deploy.yml
@@ -27,3 +27,7 @@
               - op: replace
                 path: /spec/glance/template/glanceAPIs/default/type
                 value: split
+
+              - op: add
+                path: /spec/swift/enabled
+                value: {{ cifmw_services_swift_enabled | default('false') }}

--- a/scenarios/centos-9/hci_ceph_backends.yml
+++ b/scenarios/centos-9/hci_ceph_backends.yml
@@ -10,6 +10,8 @@ pre_deploy:
     type: playbook
     source: control_plane_hci_pre_deploy.yml
 
+cifmw_services_swift_enabled: false
+
 post_deploy:
   - name: 81 Kustomize OpenStack CR with Ceph
     type: playbook
@@ -30,9 +32,7 @@ pre_tempest:
 cifmw_run_tests: true
 cifmw_tempest_container: openstack-tempest-all
 cifmw_tempest_default_groups: &test_operator_list
-  - openstack-operator
   - cinder-operator
-  - keystone-operator
   - manila-operator
 cifmw_tempest_default_jobs: *test_operator_list
 

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -268,6 +268,10 @@
 - job:
     name: podified-multinode-hci-deployment-crc
     parent: podified-multinode-hci-deployment-crc-3comp
+    vars:
+      cifmw_extras:
+        - '@scenarios/centos-9/multinode-ci.yml'
+        - '@scenarios/centos-9/hci_ceph_backends.yml'
     files:
       - ^playbooks/06-deploy-edpm.yml
       - ^playbooks/ceph.yml


### PR DESCRIPTION
Currently swift is enabled in thejob 'podified-multinode-hci-deployment-crc' but ceph RGW can be configured as a object store only if swift is disabled by default.

This patch will
- kustomize the control plane to disable swift using new hook playbook
- scenraio 'hci_ceph_backends.yml' is updated to use hook in pre_deploy
- job is updated to use the scenario

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
