### PR TITLE
Ensure MAC addresses are quoted in the generated CI snippet

### DIFF
--- a/roles/ci_gen_kustomize_values/molecule/default/converge.yml
+++ b/roles/ci_gen_kustomize_values/molecule/default/converge.yml
@@ -18,6 +18,7 @@
 - name: Converge
   hosts: all
   vars:
+    cifmw_architecture_scenario: hci
     cifmw_ci_gen_kustomize_values_basedir: >-
       {{ ansible_user_dir }}/ci-framework-data
     architecture_repo: >-
@@ -27,10 +28,10 @@
       }}
     artifacts: "{{ cifmw_ci_gen_kustomize_values_basedir }}/artifacts"
     to_kustomize:
-      - name: 'dataplane'
-        path: 'examples/va/nfv/sriov/edpm'
       - name: 'ctlplane'
-        path: 'examples/va/nfv/sriov'
+        path: 'examples/va/hci/control-plane/nncp'
+      - name: 'dataplane'
+        path: 'examples/va/hci/edpm-pre-ceph'
   tasks:
     - name: Ensure architecture repository is building
       ansible.builtin.shell:
@@ -80,7 +81,23 @@
 
     - name: Generate network-values
       vars:
-        cifmw_architecture_scenario: "hci/control-plane/nncp"
+        cifmw_ci_gen_kustomize_values_name: "network-values"
+        cifmw_ci_gen_kustomize_values_src_file: >-
+          {{
+            [architecture_repo,
+             "examples/va/hci/control-plane/nncp/values.yaml"] | path_join
+          }}
+      ansible.builtin.include_role:
+        name: ci_gen_kustomize_values
+
+    - name: Generate edpm-values
+      vars:
+        cifmw_ci_gen_kustomize_values_name: "edpm-values"
+        cifmw_ci_gen_kustomize_values_src_file: >-
+          {{
+            [architecture_repo,
+             "examples/va/hci/edpm-pre-ceph/values.yaml"] | path_join
+          }}
       ansible.builtin.include_role:
         name: ci_gen_kustomize_values
 
@@ -97,6 +114,7 @@
              path_join }}
       loop:
         - network-values
+        - edpm-values
 
     - name: Assert generated values.yaml exists
       ansible.builtin.assert:
@@ -104,7 +122,17 @@
           - item.stat.exists
       loop: "{{ stat_values.results }}"
       loop_control:
-        label: "{{ item.item }}"
+        label: "{{ item.stat.path }}"
+
+    - name: Ensure we do not case MAC anymore
+      vars:
+        _val_file: "{{ artifacts }}/ci_gen_kustomize_values/edpm-values/values.yaml"
+        _edpm_val: "{{ lookup('file', _val_file) | from_yaml }}"
+      ansible.builtin.assert:
+        that:
+          - _edpm_val.data.nodeset.ansible.ansibleVars.edpm_network_config_os_net_config_mappings['edpm-compute-0'].nic2 == '52:54:00:17:05:43'
+        msg: >-
+          Got {{ _edpm_val.data.nodeset.ansible.ansibleVars.edpm_network_config_os_net_config_mappings['edpm-compute-0'].nic2 }}
 
     - name: Copy generated values to correct location
       ansible.builtin.copy:
@@ -114,6 +142,8 @@
       loop:
         - key: 'network-values'
           value: 'examples/va/hci/control-plane/nncp/values.yaml'
+        - key: 'edpm-values'
+          value: 'examples/va/hci/edpm-pre-ceph/values.yaml'
 
     - name: Ensure kustomize is able to build
       ansible.builtin.shell:

--- a/roles/ci_gen_kustomize_values/molecule/default/files/networking-environment-definition.yml
+++ b/roles/ci_gen_kustomize_values/molecule/default/files/networking-environment-definition.yml
@@ -6,14 +6,14 @@ instances:
             ctlplane:
                 interface_name: eth1
                 ip_v4: 192.168.122.100
-                mac_addr: 0a:02:d5:e5:d9:0b
+                mac_addr: '52:54:00:17:05:43'
                 mtu: 1500
                 network_name: ctlplane
                 skip_nm: false
             internalapi:
                 interface_name: eth1.20
                 ip_v4: 172.17.0.100
-                mac_addr: 52:54:00:05:da:ef
+                mac_addr: '52:54:00:05:da:ef'
                 mtu: 1500
                 network_name: internalapi
                 parent_interface: eth1
@@ -22,7 +22,7 @@ instances:
             storage:
                 interface_name: eth1.21
                 ip_v4: 172.18.0.100
-                mac_addr: 52:54:00:59:8a:4c
+                mac_addr: '52:54:00:59:8a:4c'
                 mtu: 1500
                 network_name: storage
                 parent_interface: eth1
@@ -31,7 +31,7 @@ instances:
             tenant:
                 interface_name: eth1.22
                 ip_v4: 172.19.0.100
-                mac_addr: 52:54:00:0b:1c:d7
+                mac_addr: '52:54:00:0b:1c:d7'
                 mtu: 1500
                 network_name: tenant
                 parent_interface: eth1
@@ -44,7 +44,7 @@ instances:
             ctlplane:
                 interface_name: eth1
                 ip_v4: 192.168.122.9
-                mac_addr: 0a:02:a0:63:cb:1c
+                mac_addr: '0a:02:a0:63:cb:1c'
                 mtu: 1500
                 network_name: ctlplane
                 skip_nm: false
@@ -55,14 +55,14 @@ instances:
             ctlplane:
                 interface_name: enp6s0
                 ip_v4: 192.168.122.10
-                mac_addr: 0a:02:ca:be:0b:38
+                mac_addr: '0a:02:ca:be:0b:38'
                 mtu: 1500
                 network_name: ctlplane
                 skip_nm: false
             internalapi:
                 interface_name: enp6s0.20
                 ip_v4: 172.17.0.10
-                mac_addr: 52:54:00:1b:6e:a3
+                mac_addr: '52:54:00:1b:6e:a3'
                 mtu: 1500
                 network_name: internalapi
                 parent_interface: enp6s0
@@ -71,7 +71,7 @@ instances:
             storage:
                 interface_name: enp6s0.21
                 ip_v4: 172.18.0.10
-                mac_addr: 52:54:00:56:fa:88
+                mac_addr: '52:54:00:56:fa:88'
                 mtu: 1500
                 network_name: storage
                 parent_interface: enp6s0
@@ -80,7 +80,7 @@ instances:
             tenant:
                 interface_name: enp6s0.22
                 ip_v4: 172.19.0.10
-                mac_addr: 52:54:00:18:a0:f6
+                mac_addr: '52:54:00:18:a0:f6'
                 mtu: 1500
                 network_name: tenant
                 parent_interface: enp6s0

--- a/roles/ci_gen_kustomize_values/templates/hci/edpm-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/hci/edpm-values/values.yaml.j2
@@ -26,7 +26,7 @@ data:
         edpm_network_config_os_net_config_mappings:
 {% for instance in instances_names                                                     %}
           edpm-{{ instance }}:
-            nic2: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.mac_addr }}
+            nic2: "{{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.mac_addr }}"
 {% endfor                                                                              %}
 {% if cifmw_ci_gen_kustomize_values_sshd_ranges | default([]) | length > 0             %}
         edpm_sshd_allowed_ranges:


### PR DESCRIPTION
Apparently, something in the journey of the MAC is casting it into some
integer, leading to a nice crash.

Let's just ensure this is a string in the generated content we handle,
and see how it goes further down the path.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
