### PR TITLE
Updates dataplane services in hci_prepare role

### DIFF
--- a/roles/hci_prepare/README.md
+++ b/roles/hci_prepare/README.md
@@ -11,6 +11,7 @@ None.
 * `cifmw_hci_prepare_skip_load_parameters`: Skip the initial `load_parameters` step, which load vars to gather network information. Defaults to `False`.
 * `cifmw_hci_prepare_ceph_secret_path`: "/tmp/k8s_ceph_secret.yml"
 * `cifmw_hci_prepare_enable_storage_mgmt`: (Boolean) Creates a kustomization file to include `storage-mgmt` network in DataPlane deployment. Defaults to `True`.
+* `cifmw_hci_prepare_enable_repo_setup_service`: (Boolean) Optionally adds `repo-setup` service to OpenStackDataPlaneNodeSet in both phase1 and phase2. Defaults to `True`.
 * `cifmw_hci_prepare_storage_mgmt_mtu`: (Int) Storage-Management network MTU. Defaults to `1500`.
 * `cifmw_hci_prepare_storage_mgmt_vlan`: (Int) Storage-Management network VLAn. Defaults to `23`.
 

--- a/roles/hci_prepare/defaults/main.yml
+++ b/roles/hci_prepare/defaults/main.yml
@@ -20,5 +20,6 @@ cifmw_hci_prepare_dryrun: false
 cifmw_hci_prepare_skip_load_parameters: false
 cifmw_hci_prepare_ceph_secret_path: "/tmp/k8s_ceph_secret.yml"
 cifmw_hci_prepare_enable_storage_mgmt: true
+cifmw_hci_prepare_enable_repo_setup_service: true
 cifmw_hci_prepare_storage_mgmt_mtu: 1500
 cifmw_hci_prepare_storage_mgmt_vlan: 23

--- a/roles/hci_prepare/tasks/phase1.yml
+++ b/roles/hci_prepare/tasks/phase1.yml
@@ -60,15 +60,17 @@
           - op: replace
             path: /spec/services
             value:
+      {% if cifmw_hci_prepare_enable_repo_setup_service|bool %}
               - repo-setup
+      {% endif %}
               - bootstrap
-              - download-cache
               - configure-network
               - validate-network
               - install-os
               - ceph-hci-pre
               - configure-os
               - run-os
+              - reboot-os
 
 - name: Disable discover_hosts when deploying hci on phase1
   ansible.builtin.set_fact:

--- a/roles/hci_prepare/tasks/phase2.yml
+++ b/roles/hci_prepare/tasks/phase2.yml
@@ -93,15 +93,20 @@
           - op: replace
             path: /spec/services
             value:
-              - download-cache
+      {% if cifmw_hci_prepare_enable_repo_setup_service|bool %}
+              - repo-setup
+      {% endif %}
+              - bootstrap
               - configure-network
               - validate-network
               - install-os
-              - configure-os
               - ceph-hci-pre
+              - configure-os
               - run-os
+              - reboot-os
               - ceph-client
               - ovn
+              - neutron-metadata
               - libvirt
               - nova-custom-ceph
 


### PR DESCRIPTION
This patch updates the list of services kustomized by the hci_prepare role. Since phase1 and phase2 have different services we need to replace the entire service list.
This list is now in sync with VA content[1][2]
This patch also adds a flag to optionally remove 'repo-setup' service from the list, since some jobs don't require this step.

[1] https://github.com/openstack-k8s-operators/architecture/blob/main/examples/va/hci/edpm-pre-ceph/values.yaml
[2] https://github.com/openstack-k8s-operators/architecture/blob/main/examples/va/hci/values.yaml

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
