### PR TITLE
Updating the kuttl jobs to run for the operators that are passing currently

### DIFF
--- a/zuul.d/kuttl.yaml
+++ b/zuul.d/kuttl.yaml
@@ -28,7 +28,10 @@
       - ^zuul.d/kuttl.yaml
     vars:
       cifmw_kuttl_tests_operator_list:
-        - ansibleee
+        - openstack
+        - barbican
+        - keystone
+        - horizon
       commands_before_kuttl_run:
         - oc get pv
         - oc get all

--- a/zuul.d/kuttl_multinode.yaml
+++ b/zuul.d/kuttl_multinode.yaml
@@ -60,10 +60,10 @@
       cifmw_extras:
         - '@scenarios/centos-9/kuttl_multinode.yml'
       cifmw_kuttl_tests_operator_list:
-        - ansibleee
-        - cinder
-        - keystone
         - openstack
+        - barbican
+        - keystone
+        - horizon
       commands_before_kuttl_run:
         - oc get pv
         - oc get all


### PR DESCRIPTION
As a next step I will look at ansibleee and cinder to see if we can add them back to the list

TP: cifmw-multinode-kuttl-testing https://review.rdoproject.org/zuul/build/81da1b337f9e4bdabe049acb1292c8aa : SUCCESS in 1h 06m 54s 

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
