### PR TITLE
[FIPS] Allow to deploy VA-HCI with FIPS enabled

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -48,6 +48,7 @@ are shared among multiple roles:
 - `cifmw_nfs_target`: (String) The Ansible inventory group where the nfs server is deployed. Defaults to `computes`. Only has an effect if `cifmw_edpm_deploy_nfs` is set to `true`.
 - `cifmw_nfs_network`: (String) The network the deployed nfs server will be accessible from. Defaults to `storage`. Only has an effect if `cifmw_edpm_deploy_nfs` is set to `true`.
 - `cifmw_nfs_shares`: (List) List of the shares that will be setup in the nfs server.  Only has an effect if `cifmw_edpm_deploy_nfs` is set to `true`.
+- `cifmw_fips_enabled`: (Bool) Specifies whether FIPS should be enabled in the deployment. Note that not all deployment methods support this functionality. Defaults to `false`.
 
 ```{admonition} Words of caution
 :class: danger

--- a/roles/ci_gen_kustomize_values/templates/hci/edpm-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/hci/edpm-values/values.yaml.j2
@@ -21,6 +21,7 @@ data:
     ansible:
       ansibleUser: "zuul"
       ansibleVars:
+        edpm_fips_mode: "{{ 'enabled' if cifmw_fips_enabled|default(false)|bool else 'check' }}"
         timesync_ntp_servers:
           - hostname: "{{ cifmw_ci_gen_kustomize_values_ntp_srv | default('pool.ntp.org') }}"
         edpm_network_config_os_net_config_mappings:

--- a/scenarios/reproducers/va-hci.yml
+++ b/scenarios/reproducers/va-hci.yml
@@ -135,6 +135,7 @@ cifmw_devscripts_config_overrides:
   worker_disk: 100
   worker_vcpu: 10
   num_extra_workers: 0
+  fips_mode: "{{ cifmw_fips_enabled | default(false) | bool }}"
 # Required for egress traffic from pods to the osp_trunk network
 cifmw_devscripts_enable_ocp_nodes_host_routing: true
 


### PR DESCRIPTION
This patch adds parameters to enabled FIPS in VA-HCI scenario. A new top level parameter was added to allow users to enable FIPS in scenarios that supports it.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
