### PR TITLE
Support end to end run for deployed topologies.

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -38,6 +38,8 @@ are shared among multiple roles:
 - `cifmw_ssh_keysize`: (Integer) Size of ssh keys that will be injected into the controller in order to connect to the rest of the nodes. Defaults to 521.
 - `cifmw_architecture_repo`: (String) Path of the architecture repository on the controller node.
   Defaults to `~/src/github.com/openstack-k8s-operators/architecture`
+- `cifmw_arch_automation_file`: (String) Name of the workflow automation file
+  in the architecture repository. Defaults to `default.yaml`
 - `cifmw_architecture_scenario`: (String) The selected VA scenario to deploy.
 - `cifmw_ceph_target`: (String) The Ansible inventory group where ceph is deployed. Defaults to `computes`.
 - `cifmw_run_tests`: (Bool) Specifies whether tests should be executed.

--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -32,55 +32,62 @@
       ansible.builtin.stat:
         path: "{{ cifmw_basedir }}/artifacts/nova_migration_key"
 
-    - name: Create nova migration keypair if does not exists
-      when:
-        - not _nova_key_file.stat.exists
-      community.crypto.openssh_keypair:
-        comment: "nova migration"
-        path: "{{ _nova_key_file.stat.path }}"
-        type: "{{ cifmw_ssh_keytype | default('ecdsa') }}"
-        size: "{{ cifmw_ssh_keysize | default(521) }}"
-
-    - name: Generate needed facts out of local files
+    - name: Ensure nova migration keypair details are propagated
       vars:
-        _ifaces_vars: >-
+        _ssh_file: >-
           {{
-            hostvars['controller-0'].ansible_interfaces |
-            map('regex_replace', '^(.*)$', 'ansible_\1')
+            _nova_key_file.stat.path |
+            default(
+              (cifmw_basedir, 'artifacts', 'nova_migration_key') |
+              ansible.builtin.path_join
+            )
           }}
-        _controller_host: "{{ hostvars['controller-0'].ansible_host }}"
-        _ipv4_network_data: >-
-          {{
-            hostvars['controller-0'] | dict2items |
-            selectattr('key', 'in', _ifaces_vars) |
-            selectattr('value.ipv4.address', 'defined') |
-            selectattr('value.ipv4.address', 'equalto', _controller_host) |
-            map(attribute='value.ipv4') | first | default({})
-          }}
-        _sshkey: >-
-          {{
-            _nova_key_file.stat.path
-          }}
-      ansible.builtin.set_fact:
-        cifmw_ci_gen_kustomize_values_ssh_authorizedkeys: >-
-          {{ lookup('file', '~/.ssh/authorized_keys', rstrip=False) }}
-        cifmw_ci_gen_kustomize_values_ssh_private_key: >-
-          {{ lookup('file', '~/.ssh/id_cifw', rstrip=False) }}
-        cifmw_ci_gen_kustomize_values_ssh_public_key: >-
-          {{ lookup('file', '~/.ssh/id_cifw.pub', rstrip=False) }}
-        cifmw_ci_gen_kustomize_values_migration_pub_key: >-
-          {{ lookup('file', _sshkey ~ '.pub', rstrip=False)}}
-        cifmw_ci_gen_kustomize_values_migration_priv_key: >-
-          {{ lookup('file', _sshkey, rstrip=False) }}
-        cifmw_ci_gen_kustomize_values_sshd_ranges: >-
-          {{
-            [cifmw_networking_env_definition.networks.ctlplane.network_v4] +
-            (
-              [
-                 _ipv4_network_data.network + '/' + _ipv4_network_data.prefix
-              ]
-            ) if (_ipv4_network_data | length > 0) else []
-          }}
+      block:
+        - name: Create nova migration keypair if does not exists
+          when:
+            - not _nova_key_file.stat.exists | default(false)
+          community.crypto.openssh_keypair:
+            comment: "nova migration"
+            path: "{{ _ssh_file }}"
+            type: "{{ cifmw_ssh_keytype | default('ecdsa') }}"
+            size: "{{ cifmw_ssh_keysize | default(521) }}"
+
+        - name: Generate needed facts out of local files
+          vars:
+            _ifaces_vars: >-
+              {{
+                hostvars['controller-0'].ansible_interfaces |
+                map('regex_replace', '^(.*)$', 'ansible_\1')
+              }}
+            _controller_host: "{{ hostvars['controller-0'].ansible_host }}"
+            _ipv4_network_data: >-
+              {{
+                hostvars['controller-0'] | dict2items |
+                selectattr('key', 'in', _ifaces_vars) |
+                selectattr('value.ipv4.address', 'defined') |
+                selectattr('value.ipv4.address', 'equalto', _controller_host) |
+                map(attribute='value.ipv4') | first | default({})
+              }}
+          ansible.builtin.set_fact:
+            cifmw_ci_gen_kustomize_values_ssh_authorizedkeys: >-
+              {{ lookup('file', '~/.ssh/authorized_keys', rstrip=False) }}
+            cifmw_ci_gen_kustomize_values_ssh_private_key: >-
+              {{ lookup('file', '~/.ssh/id_cifw', rstrip=False) }}
+            cifmw_ci_gen_kustomize_values_ssh_public_key: >-
+              {{ lookup('file', '~/.ssh/id_cifw.pub', rstrip=False) }}
+            cifmw_ci_gen_kustomize_values_migration_pub_key: >-
+              {{ lookup('file', _ssh_file ~ '.pub', rstrip=False)}}
+            cifmw_ci_gen_kustomize_values_migration_priv_key: >-
+              {{ lookup('file', _ssh_file, rstrip=False) }}
+            cifmw_ci_gen_kustomize_values_sshd_ranges: >-
+              {{
+                [cifmw_networking_env_definition.networks.ctlplane.network_v4] +
+                (
+                  [
+                    _ipv4_network_data.network + '/' + _ipv4_network_data.prefix
+                  ]
+                ) if (_ipv4_network_data | length > 0) else []
+              }}
 
     - name: Load architecture automation file
       register: _automation

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -291,10 +291,12 @@
             }}
           cifmw_architecture_automation_file: >-
             {{
-              (ansible_user_dir,
-               'src/github.com/openstack-k8s-operators',
-               'architecture/automation/vars/default.yaml') |
-               path_join
+              (
+                ansible_user_dir,
+                'src/github.com/openstack-k8s-operators',
+                'architecture/automation/vars'
+                cifmw_arch_automation_file | default('default.yaml')
+              ) | ansible.builtin.path_join
             }}
           pre_infra:
             - name: Download needed tools


### PR DESCRIPTION
Currently, default.yaml is being referenced as the default workflow steps. Here, we take it as user input via arch_workflow_file.

Fix an issue with nova_migration key path.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

Fixes: https://github.com/openstack-k8s-operators/ci-framework/pull/1357