### PR TITLE
Make sure podman is installed.

### DIFF
--- a/roles/virtualbmc/tasks/main.yml
+++ b/roles/virtualbmc/tasks/main.yml
@@ -23,6 +23,12 @@
     - key: "{{ cifmw_virtualbmc_sshkey_path | dirname }}"
       mode: "0700"
 
+- name: Ensure podman is installed
+  become: true
+  ansible.builtin.package:
+    name: podman
+    state: present
+
 - name: Check if container already exists
   register: _vbmc_container_info
   containers.podman.podman_container_info:


### PR DESCRIPTION
Currently virtualbmc role is failing on downstream reproducer with following error.
```
TASK [virtualbmc : Check if container already exists name={{ cifmw_virtualbmc_container_name }}] ***
2024-03-28 06:10:57.262714 | controller | Thursday 28 March 2024  06:10:57 -0400 (0:00:00.991)       0:18:46.506 ********
2024-03-28 06:10:58.080148 | controller | fatal: [hypervisor]: FAILED! => {"changed": false, "msg": "Failed to find required executable \"podman\" in paths: /home/zuul/.local/bin:/home/zuul/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin"}
```

We need to make sure podman is installed on the hypervisor before calling the podman module.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

