### PR TITLE
Allow to retry "Ensure the nodes are in ready state."

### DIFF
--- a/roles/openshift_adm/tasks/wait_for_cluster.yml
+++ b/roles/openshift_adm/tasks/wait_for_cluster.yml
@@ -48,6 +48,8 @@
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
     validate_certs: false
   loop: "{{ _nodes.resources | map(attribute='metadata.name') | list }}"
+  retries: "{{ cifmw_openshift_adm_node_retry_count }}"
+  delay: 5
 
 - name: Check for pending certificate approval.
   when:


### PR DESCRIPTION
On some systems, we may face some issues with this task. A `retry`
allows to pass it, usually after only one failure.

As a pull request owner and reviewers, I checked that:
- [X] Locally tested, it allows to pass a one-time failure.
