### PR TITLE
Use zuul_inventory to find out edpm vms ip

### DIFF
--- a/roles/artifacts/tasks/edpm.yml
+++ b/roles/artifacts/tasks/edpm.yml
@@ -23,31 +23,29 @@
   when:
     - not cifmw_is_nested_virt | default(false) | bool
   block:
-    - name: Check for CI env directory
-      register: network_env_dir
-      ansible.builtin.stat:
-        path: /etc/ci/env
+    - name: Slurp zuul inventory file
+      ansible.builtin.slurp:
+        path: "{{ ansible_user_dir }}/ci-framework-data/artifacts/zuul_inventory.yml"
+      register: _inv
 
-    - name: Extract data from network env file if available
+    - name: Extract Compute from zuul mapping if any
       when:
-        - network_env_dir.stat.exists
-      block:
-        - name: Load network env file
-          ansible.builtin.include_vars:
-            dir: /etc/ci/env/
-
-        - name: Extract Compute from zuul mapping if any
-          when:
-            - crc_ci_bootstrap_networks_out is defined
-            - cifmw_edpm_deploy_extra_vars is defined
-          ansible.builtin.set_fact:
-            ssh_key_file: "{{ cifmw_edpm_deploy_extra_vars.SSH_KEY_FILE }}"
-            ssh_user: "{{ hostvars['compute-0'].ansible_user | default('zuul') }}"
-            edpm_vms: >-
+        - cifmw_edpm_deploy_extra_vars is defined
+      vars:
+        _inv_data: "{{ _inv['content'] | b64decode | from_yaml }}"
+        _edpm_vms_data: >-
+                      {{ _inv_data['computes']['hosts']
+                        if 'computes' in _inv_data
+                        else _inv_data['all']['hosts']
+                       }}
+      ansible.builtin.set_fact:
+        ssh_key_file: "{{ cifmw_edpm_deploy_extra_vars.SSH_KEY_FILE }}"
+        ssh_user: "{{ hostvars['compute-0'].ansible_user | default('zuul') }}"
+        edpm_vms: >-
               {{
-                crc_ci_bootstrap_networks_out | dict2items |
+                _edpm_vms_data | dict2items |
                 selectattr('key', 'match', '^compute.*$') |
-                map(attribute='value.default.ip') | default([])
+                map(attribute='value.ansible_host') | default([])
               }}
 
 - name: Generate logs on EDPM vms

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -55,6 +55,7 @@
     files:
       - ^playbooks/*
       - ^roles/edpm_deploy_baremetal/(?!meta|README).*
+      - ^roles/artifacts/tasks/edpm.yml
       - ^ci/playbooks/edpm_baremetal_deployment/run.yml
       - ^deploy-edpm.yml
       - ^scenarios/centos-9/edpm_baremetal_deployment_ci.yml


### PR DESCRIPTION
crc_ci_bootstrap_networks_out is defined in extracted crc EDPM Zuul job vars. crc_ci_bootstrap_networks_out var is used in artifacts edpm task files to find out the compute ip.
    
The value of crc_ci_bootstrap_networks_out is written in /etc/ci/env networking-info.yml file.
    
In Devscript reproducer environment, we donot pass crc_ci_bootstrap_networks_out var in the var file. that's why this
content is not available.
    
In VA HCI job, we run log collection from the controller. Since crc_ci_bootstrap_networks_out is not defined, that's why
edpm log collection does not happen.
    
In order to fix that, let' use zuul inventory to find out the edpm vms ip and perform log collection on that.

The format of extracted crc EDPM job inventory is like this
```
all:
    hosts:
        compute-0:
            ansible_host: x.x.x.x

```
and reproducer inventory is
```
all:
computes:
  hosts:
    compute-0:
      ansible_host: x.x.x.x
```
We are filtering out proper compute ips based on above format and setting the proper var.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

