### PR TITLE
Allow to manually override the root_partition_id

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -16,6 +16,7 @@ are shared among multiple roles:
 - `cifmw_manifests`: Directory where k8s related manifests will be places. Defaults to
   `{{ cifmw_basedir }}/manifests`.
 - `cifmw_path`: customized PATH. Defaults to `~/.crc/bin:~/.crc/bin/oc:~/bin:${PATH}`.
+- `cifmw_root_partition_id`: (Integer) Root partition ID for virtual machines. Useful for UEFI images.
 - `cifmw_use_libvirt`: (Bool) toggle libvirt support.
 - `cifmw_use_crc`: (Bool) toggle rhol/crc usage.
 - `cifmw_use_uefi`: (Bool) toggle UEFI support in libvirt_manager provided VMs.

--- a/scenarios/reproducers/3-nodes.yml
+++ b/scenarios/reproducers/3-nodes.yml
@@ -15,17 +15,19 @@ cifmw_use_libvirt: true
 cifmw_use_uefi: >-
   {{ (cifmw_repo_setup_os_release is defined
       and cifmw_repo_setup_os_release == 'rhel') | bool }}
+cifmw_root_partition_id: >-
+    {{
+      (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
+      ternary(4, 1)
+    }}
+
 cifmw_libvirt_manager_compute_amount: 1
 cifmw_libvirt_manager_configuration:
   vms:
     compute:
       uefi: "{{ cifmw_use_uefi }}"
       amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 1] | max }}"
-      root_part_id: >-
-        {{
-          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
-          ternary(4, 1)
-        }}
+      root_part_id: "{{ cifmw_root_partition_id }}"
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"
@@ -39,11 +41,7 @@ cifmw_libvirt_manager_configuration:
     controller:
       uefi: "{{ cifmw_use_uefi }}"
       image_url: "{{ cifmw_discovered_image_url }}"
-      root_part_id: >-
-        {{
-          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
-          ternary(4, 1)
-        }}
+      root_part_id: "{{ cifmw_root_partition_id }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"
       disk_file_name: "centos-stream-9.qcow2"

--- a/scenarios/reproducers/va-hci.yml
+++ b/scenarios/reproducers/va-hci.yml
@@ -68,6 +68,11 @@ cifmw_virtualbmc_daemon_port: 50881
 cifmw_use_uefi: >-
   {{ (cifmw_repo_setup_os_release is defined
       and cifmw_repo_setup_os_release == 'rhel') | bool }}
+cifmw_root_partition_id: >-
+  {{
+    (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
+    ternary(4, 1)
+  }}
 cifmw_libvirt_manager_compute_amount: 3
 cifmw_libvirt_manager_configuration:
   networks:
@@ -86,11 +91,7 @@ cifmw_libvirt_manager_configuration:
   vms:
     compute:
       uefi: "{{ cifmw_use_uefi }}"
-      root_part_id: >-
-        {{
-          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
-          ternary(4, 1)
-        }}
+      root_part_id: "{{ cifmw_root_partition_id }}"
       amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 3] | max }}"
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
@@ -104,11 +105,7 @@ cifmw_libvirt_manager_configuration:
         - osp_trunk
     controller:
       uefi: "{{ cifmw_use_uefi }}"
-      root_part_id: >-
-        {{
-          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
-          ternary(4, 1)
-        }}
+      root_part_id: "{{ cifmw_root_partition_id }}"
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"


### PR DESCRIPTION
Since we're about to get UEFI CentOS images, we won't be able to rely
only on the OS detection. Therefore we expose a new top-level parameter,
like we did for the UEFI support itself.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] Content of the docs/source is reflecting the changes
