### PR TITLE
Ensure we're using the right VM layout

### DIFF
--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -174,10 +174,10 @@
       }}
     cifmw_virtualbmc_action: "add"
     _ipmi_host: >-
-      {%- if cifmw_libvirt_manager_configuration.vms.crc.target is defined -%}
-      {{ cifmw_libvirt_manager_configuration.vms.crc.target }}
-      {%- elif cifmw_libvirt_manager_configuration.vms.ocp.target is defined -%}
-      {{ cifmw_libvirt_manager_configuration.vms.ocp.target }}
+      {%- if _layout.vms.crc.target is defined -%}
+      {{ _layout.vms.crc.target }}
+      {%- elif _layout.vms.ocp.target is defined -%}
+      {{ _layout.vms.ocp.target }}
       {%- else -%}
       {{ inventory_hostname }}
       {%- endif -%}

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -1,4 +1,11 @@
 ---
+- name: Chose right parameter for layout definition
+  ansible.builtin.set_fact:
+    cacheable: true
+    _layout: >-
+      {{ cifmw_libvirt_manager_configuration_gen |
+         default(cifmw_libvirt_manager_configuration) }}
+
 # Deploy VBMC only on the hypervisor running OpenShift services,
 # being OCP cluster or single CRC.
 - name: Deploy VirtualBMC service container
@@ -6,14 +13,14 @@
     - bootstrap
     - bootstrap_layout
   when:
-    - (cifmw_libvirt_manager_configuration.vms.crc.target is defined and
-       cifmw_libvirt_manager_configuration.vms.crc.target == inventory_hostname) or
-      (cifmw_libvirt_manager_configuration.vms.crc is defined and
-       cifmw_libvirt_manager_configuration.vms.crc.target is undefined) or
-      (cifmw_libvirt_manager_configuration.vms.ocp.target is defined and
-       cifmw_libvirt_manager_configuration.vms.ocp.target == inventory_hostname) or
-      (cifmw_libvirt_manager_configuration.vms.ocp is defined and
-       cifmw_libvirt_manager_configuration.vms.ocp.target is undefined)
+    - (_layout.vms.crc.target is defined and
+       _layout.vms.crc.target == inventory_hostname) or
+      (_layout.vms.crc is defined and
+       _layout.vms.crc.target is undefined) or
+      (_layout.vms.ocp.target is defined and
+       _layout.vms.ocp.target == inventory_hostname) or
+      (_layout.vms.ocp is defined and
+       _layout.vms.ocp.target is undefined)
   block:
     - name: Deploy virtualbmc
       ansible.builtin.include_role:
@@ -45,11 +52,6 @@
   loop:
     - workload
     - volumes
-
-- name: Chose right parameter for layout definition
-  ansible.builtin.set_fact:
-    cacheable: true
-    _layout: "{{ cifmw_libvirt_manager_configuration_gen | default(cifmw_libvirt_manager_configuration) }}"
 
 - name: Manage networks if needed
   when:

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -14,10 +14,10 @@
 - name: Configure controller-0
   when:
     - (
-        cifmw_libvirt_manager_configuration.vms.controller.target is defined and
-        cifmw_libvirt_manager_configuration.vms.controller.target == inventory_hostname
+        _layout.vms.controller.target is defined and
+        _layout.vms.controller.target == inventory_hostname
       ) or
-      cifmw_libvirt_manager_configuration.vms.controller.target is undefined
+      _layout.vms.controller.target is undefined
   delegate_to: controller-0
   delegate_facts: false
   block:
@@ -106,7 +106,7 @@
         - hostvars[host]['ansible_host'] is defined
       vars:
         _vm_type: "{{ host | regex_replace('\\-[0-9]*', '') }}"
-        _vm_data: "{{ cifmw_libvirt_manager_configuration['vms'][_vm_type] }}"
+        _vm_data: "{{ _layout['vms'][_vm_type] }}"
         _proxy_user: >-
           {{
             (hostvars[_vm_data.target]['ansible_user'] |
@@ -158,7 +158,7 @@
         dest: "/home/zuul/.kube/config"
         content: >-
           {{
-            (cifmw_libvirt_manager_configuration.vms.ocp is defined) |
+            (_layout.vms.ocp is defined) |
             ternary(_devscripts_kubeconfig.content, _crc_kubeconfig.content) |
             b64decode
           }}

--- a/roles/reproducer/tasks/libvirt_layout.yml
+++ b/roles/reproducer/tasks/libvirt_layout.yml
@@ -8,8 +8,8 @@
 
 - name: Get all generated inventory on remote hypervisors
   when:
-    - cifmw_libvirt_manager_configuration.vms.controller.target is defined
-    - cifmw_libvirt_manager_configuration.vms.controller.target != inventory_hostname
+    - _layout.vms.controller.target is defined
+    - _layout.vms.controller.target != inventory_hostname
   block:
     - name: Get deployed VM group inventories
       register: _inventories
@@ -22,7 +22,7 @@
           }}
       loop: >-
           {{
-            cifmw_libvirt_manager_configuration.vms |
+            _layout.vms |
             dict2items |
             selectattr('value.target', 'equalto', inventory_hostname) |
             map(attribute="key")
@@ -31,10 +31,10 @@
 - name: Run tasks on controller-0 hypervisor
   when:
     - (
-        cifmw_libvirt_manager_configuration.vms.controller.target is defined and
-        cifmw_libvirt_manager_configuration.vms.controller.target == inventory_hostname
+        _layout.vms.controller.target is defined and
+        _layout.vms.controller.target == inventory_hostname
       ) or
-      cifmw_libvirt_manager_configuration.vms.controller.target is undefined
+      _layout.vms.controller.target is undefined
   block:
     - name: Inject remote inventories onto main hypervisor
       ansible.builtin.include_tasks: gather_inventories.yml
@@ -50,12 +50,12 @@
 
 - name: Run post tasks in devscripts case
   when:
-    - cifmw_libvirt_manager_configuration.vms.ocp is defined
+    - _layout.vms.ocp is defined
     - (
-        cifmw_libvirt_manager_configuration.vms.ocp.target is defined and
-        cifmw_libvirt_manager_configuration.vms.ocp.target == inventory_hostname
+        _layout.vms.ocp.target is defined and
+        _layout.vms.ocp.target == inventory_hostname
       ) or
-      cifmw_libvirt_manager_configuration.vms.ocp.target is undefined
+      _layout.vms.ocp.target is undefined
   tags:
     - boostrap
     - bootstrap_layout
@@ -73,12 +73,12 @@
 
 - name: Configure CRC node if available
   when:
-    - cifmw_libvirt_manager_configuration.vms.crc is defined
+    - _layout.vms.crc is defined
     - (
-        cifmw_libvirt_manager_configuration.vms.crc.target is defined and
-        cifmw_libvirt_manager_configuration.vms.crc.target == inventory_hostname
+        _layout.vms.crc.target is defined and
+        _layout.vms.crc.target == inventory_hostname
       ) or
-      cifmw_libvirt_manager_configuration.vms.crc.target is undefined
+      _layout.vms.crc.target is undefined
   tags:
     - bootstrap
     - bootstrap_layout

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -102,10 +102,10 @@
 - name: Run only on hypervisor with controller-0
   when:
     - (
-        cifmw_libvirt_manager_configuration.vms.controller.target is defined and
-        cifmw_libvirt_manager_configuration.vms.controller.target == inventory_hostname
+        _layout.vms.controller.target is defined and
+        _layout.vms.controller.target == inventory_hostname
       ) or
-      cifmw_libvirt_manager_configuration.vms.controller.target is undefined
+      _layout.vms.controller.target is undefined
   block:
     - name: Push local code
       tags:


### PR DESCRIPTION
In the `libvirt_manager/deploy_layout.yml` we select the "layout" we
want to deploy. It generates a cached fact named `_layout`, and should
be using this one exclusively.

In parallel, the `reproducer` role should also use the correct layout,
as soon as the fact is available.

For the records, in the "zuul reproducer" path, the layout may be
updated by ansible in order to reflect the correct amount of computes,
using an internal parameter named
`cifmw_libvirt_manager_configuration_gen` - `libvirt_manager` then
selects either that parameter if exists, or defaults to the standard
`cifmw_libvirt_manager_configuration`, creating that `_layout` internal
fact.

This patch reconcile the parameter usage.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
