### PR TITLE
Try to get a faster re-run for libvirt_manager

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -1,3 +1,4 @@
+---
 - job:
     name: cifmw-molecule-openshift_login
     nodeset: centos-9-crc-2-30-0-xl

--- a/roles/libvirt_manager/molecule/deploy_layout/converge.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/converge.yml
@@ -47,7 +47,7 @@
           extra_disks_num: 1
           extra_disks_size: 1G
         compute:
-          amount: 2
+          amount: 1
           image_url: "{{ cifmw_discovered_image_url }}"
           sha256_image_name: "{{ cifmw_discovered_hash }}"
           image_local_dir: "{{ cifmw_basedir }}/images/"
@@ -153,7 +153,6 @@
             compare_vms: >-
               {{
                 ['cifmw-compute-0',
-                 'cifmw-compute-1',
                  'cifmw-baremetal-0'] | sort
               }}
           ansible.builtin.assert:

--- a/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/roles/libvirt_manager/tasks/clean_layout.yml
@@ -27,6 +27,12 @@
       ansible.builtin.debug:
         var: cleanup_vms
 
+    - name: Clean ssh known_hosts
+      ansible.builtin.known_hosts:
+        name: "{{ item }}"
+        state: absent
+      loop: "{{ cleanup_vms }}"
+
     - name: Destroy machine
       register: vm_destroy
       community.libvirt.virt:
@@ -56,7 +62,7 @@
         vm: "{{ item | replace('cifmw-', '') }}"
       ansible.builtin.blockinfile:
         path: "{{ lookup('env', 'HOME') }}/.ssh/config"
-        marker: "## {mark} {{ vm }}"
+        marker: "## {mark} {{ vm }} {{ inventory_hostname }}"
         state: absent
         create: true
       loop: "{{ cleanup_vms }}"
@@ -66,7 +72,7 @@
         vm: "{{ item | replace('cifmw-', '') }}"
       ansible.builtin.blockinfile:
         path: "{{ ansible_user_dir }}/.ssh/config"
-        marker: "## {mark} {{ vm }}"
+        marker: "## {mark} {{ vm }} {{ inventory_hostname }}"
         state: absent
         create: true
       loop: "{{ cleanup_vms }}"

--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -22,6 +22,7 @@
     - name: "Create VM overlay for {{ vm_type }}"
       vars:
         _vm_img: "{{ vm_type }}-{{ vm_id }}.qcow2"
+      register: _create_overlays
       ansible.builtin.command:
         cmd: >-
           qemu-img create
@@ -92,7 +93,9 @@
         index_var: vm_id
         label: "{{ vm_type }}-{{ vm_id }}"
 
-- name: "Attach listed networks to the VMs {{ vm_type }}"
+- name: "Attach listed networks to the VMs {{ vm_type }}"  # noqa: no-handler
+  when:
+    - _create_overlays is changed
   vars:
     vm_item: "{{ vm_type }}-{{ vm_id }}"
     networks: "{{ vm_data.value.nets }}"
@@ -194,4 +197,6 @@
 - name: "Start and grab IP if image is not blank for {{ vm_type }}"
   when:
     - vm_data.value.disk_file_name != 'blank'
+  vars:
+    _need_start: "{{ _create_overlays is changed }}"
   ansible.builtin.include_tasks: start_manage_vms.yml

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -186,7 +186,7 @@
 
 - name: Create fact holding network data for VMs
   ansible.builtin.set_fact:
-    cacheable: true
+    cacheable: false
     cifmw_reproducer_network_data: {}
 
 - name: List existing networks

--- a/roles/libvirt_manager/tasks/start_manage_vms.yml
+++ b/roles/libvirt_manager/tasks/start_manage_vms.yml
@@ -51,6 +51,8 @@
 - name: "(localhost) Inject ssh jumpers for {{ vm_type }}"
   when:
     - inventory_hostname != 'localhost'
+    - inventory_hostname != 'instance'  # needed for molecule
+    - _need_start | bool
   delegate_to: localhost
   vars:
     extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
@@ -58,10 +60,10 @@
   ansible.builtin.blockinfile:
     create: true
     path: "{{ lookup('env', 'HOME') }}/.ssh/config"
-    marker: "## {mark} {{ vm_ip.nic.host }}"
+    marker: "## {mark} {{ vm_ip.nic.host }} {{ inventory_hostname }}"
     mode: "0600"
     block: |-
-      Host {{ vm_ip.nic.host }} cifmw-{{ vm_ip.nic.host }} {{ extracted_ip }}
+      Host {{ vm_ip.nic.host }} {{ vm_ip.nic.host }}.{{ inventory_hostname }} cifmw-{{ vm_ip.nic.host }} {{ extracted_ip }}
         ProxyJump {{ ansible_user | default(lookup('env', 'USER')) }}@{{ proxy_hostname }}
         Hostname {{ extracted_ip }}
         User {{ 'core' if vm_ip.nic.host is match('^(crc|ocp).*') else 'zuul' }}
@@ -73,6 +75,8 @@
     label: "{{ vm_ip.nic.host }}"
 
 - name: "({{ inventory_hostname }}) Inject ssh jumpers for {{ vm_type }}"  # noqa: name[template]
+  when:
+    - _need_start | bool
   vars:
     extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
     identity_file: >-
@@ -87,7 +91,7 @@
     marker: "## {mark} {{ vm_ip.nic.host }}"
     mode: "0600"
     block: |-
-      Host {{ vm_ip.nic.host }} cifmw-{{ vm_ip.nic.host }} {{ extracted_ip }}
+      Host {{ vm_ip.nic.host }} {{ vm_ip.nic.host }}.{{ inventory_hostname }} cifmw-{{ vm_ip.nic.host }} {{ extracted_ip }}
         Hostname {{ extracted_ip }}
         User {{ 'core' if vm_ip.nic.host is match('^(crc|ocp)') else 'zuul' }}
         IdentityFile {{ identity_file }}
@@ -121,6 +125,8 @@
     src: inventory.yml.j2
 
 - name: "Wait for SSH on VMs type {{ vm_type }}"
+  when:
+    - _need_start | bool
   vars:
     extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
   ansible.builtin.wait_for:
@@ -133,6 +139,8 @@
     label: "{{ extracted_ip }}"
 
 - name: "Configure ssh access on type {{ vm_type }}"
+  when:
+    - _need_start | bool
   vars:
     _user: >-
       {{
@@ -143,7 +151,7 @@
     cmd: >-
       set -o pipefail;
       cat ~/.ssh/authorized_keys |
-      ssh {{ _user }}@{{ vm_ip.nic.host }} "cat >> ~/.ssh/authorized_keys"
+      ssh -v {{ _user }}@{{ vm_ip.nic.host }} "cat >> ~/.ssh/authorized_keys"
   retries: 5
   delay: 10
   register: _ssh_access
@@ -156,6 +164,7 @@
 - name: "Configure VMs type {{ vm_type }}"
   when:
     - vm_type is not match('^(crc|ocp).*$')
+    - _need_start | bool
   delegate_to: "{{ vm_ip.nic.host }}"
   remote_user: "{{ _init_admin_user }}"
   ansible.builtin.shell:
@@ -178,6 +187,7 @@
 - name: "Inject private key on hosts {{ vm_type }}"
   when:
     - vm_type is match('^controller.*$')
+    - _need_start | bool
   delegate_to: "{{ vm_ip.nic.host }}"
   remote_user: "{{ _init_admin_user }}"
   ansible.builtin.copy:
@@ -194,6 +204,7 @@
 - name: "Inject public key on hosts {{ vm_type }}"
   when:
     - vm_type is match('^controller.*$')
+    - _need_start | bool
   delegate_to: "{{ vm_ip.nic.host }}"
   remote_user: "{{ _init_admin_user }}"
   ansible.builtin.copy:

--- a/roles/virtualbmc/molecule/default/prepare.yml
+++ b/roles/virtualbmc/molecule/default/prepare.yml
@@ -32,10 +32,7 @@
           vms:
             compute:
               amount: 1
-              image_url: "{{ cifmw_discovered_image_url }}"
-              sha256_image_name: "{{ cifmw_discovered_hash }}"
-              image_local_dir: "{{ cifmw_basedir }}/images/"
-              disk_file_name: "centos-stream-9.qcow2"
+              disk_file_name: "blank"
               disksize: 15
               memory: 4
               cpus: 2


### PR DESCRIPTION
By registering `overlay` state, we should be able to avoid a long list
of tasks that are useless against an already created VM.

We also slightly amend the way we generated the SSH configuration for
the ProxyJump in order to allow running multiple "labs" on multiple
hypervisor, while avoiding overriding the whole ssh configuration and
losing access to the VMs.

With this patch, in case you're deploying two labs on two distinct
machines, you'll be able to reach either of them by using, for instance,
`ssh controller-0.hypervisor-1` or `ssh compute-0.hypervisor-2`.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
