### PR TITLE
Fix example for cifmw_reproducer_repositories config

### DIFF
--- a/roles/reproducer/README.md
+++ b/roles/reproducer/README.md
@@ -45,7 +45,7 @@ cifmw_reproducer_repositories:
   - src: "{{ local_base_dir }}/ci-framework"
     dest: "{{ remote_base_dir }}/ci-framework"
   - src: "{{ local_base_dir }}/install_yamls"
-    dest: "{{ remote_base_dir }}/install_yamls"
+    dest: "{{ remote_base_dir }}/"
 ```
 Notes:
 * `ansible_user_dir` isn't really usable due to the use of `delegate_to` in order to sync those local repositories.


### PR DESCRIPTION
The destination param should be the base directory where the source directory is copied. If we followed the example, we would have had the `install_yamls` repository located in `/home/zuul/src/github.com/openstack-k8s-operators/install_yamls/install_yamls", which in turn causes the deployment to fail with:

    ERROR! the playbook: playbooks/01-bootstrap.yml could not be found

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
