### PR TITLE
Fix lvm-iscsi volume group name

### DIFF
--- a/roles/devscripts/files/lv-cinder-volumes.sh
+++ b/roles/devscripts/files/lv-cinder-volumes.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/bash
 set -euo pipefail
 
-if [[ $(lvdisplay /dev/cinder_volumes_vg/cinder-volumes) ]]; then
+if [[ $(vgdisplay cinder-volumes) ]]; then
     echo "cinder-volumes vg exists."
     exit 0
 fi
@@ -14,5 +14,4 @@ for disk in ${disks}; do
     disk_str="${disk_str} ${disk}"
 done
 
-vgcreate cinder_volumes_vg ${disk_str}
-lvcreate -l 100%FREE -n cinder-volumes cinder_volumes_vg
+vgcreate cinder-volumes ${disk_str}


### PR DESCRIPTION
The volume group that is observed by cinder-lvm is cinder-volumes. This changes the volume group name to cinder-volumes and does not create the logical volume. The initial check condition is also modified to look for volume group instead.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

*Logs*

_Playbook run_
```
2024-03-29 06:03:07,580 p=290406 u=ciuser n=ansible | NO MORE HOSTS LEFT ***********************************************************************************************************************************************************************************************************************************************************************************************************
2024-03-29 06:03:07,582 p=290406 u=ciuser n=ansible | PLAY RECAP *******************************************************************************************************************************************************************************************************************************************************************************************************************
2024-03-29 06:03:07,582 p=290406 u=ciuser n=ansible | hypervisor                 : ok=575  changed=242  unreachable=0    failed=1    skipped=111  rescued=2    ignored=0   
2024-03-29 06:03:07,582 p=290406 u=ciuser n=ansible | Friday 29 March 2024  06:03:07 -0400 (0:00:02.156)       1:22:06.373 ********** 
2024-03-29 06:03:07,583 p=290406 u=ciuser n=ansible | =============================================================================== 
2024-03-29 06:03:07,584 p=290406 u=ciuser n=ansible | devscripts : Deploy OpenShift cluster ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 2752.95s
2024-03-29 06:03:07,584 p=290406 u=ciuser n=ansible | openshift_adm : Wait unit the OpenShift cluster is stable. ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 730.72s
2024-03-29 06:03:07,584 p=290406 u=ciuser n=ansible | reproducer : Bootstrap environment on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 82.34s
2024-03-29 06:03:07,584 p=290406 u=ciuser n=ansible | reproducer : Install some tools -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 66.97s
2024-03-29 06:03:07,584 p=290406 u=ciuser n=ansible | libvirt_manager : Prepare disk image with SSH and growing volume ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 52.07s
2024-03-29 06:03:07,584 p=290406 u=ciuser n=ansible | networking_mapper : Ensure that networking and hostname facts are in place ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 44.35s
2024-03-29 06:03:07,584 p=290406 u=ciuser n=ansible | libvirt_manager : Grab IPs for nodes type ocp ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 32.45s
2024-03-29 06:03:07,584 p=290406 u=ciuser n=ansible | reproducer : Configure rhos-release ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 31.20s
2024-03-29 06:03:07,584 p=290406 u=ciuser n=ansible | reproducer : Configure rhos-release ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 31.11s
2024-03-29 06:03:07,584 p=290406 u=ciuser n=ansible | libvirt_manager : Configure ssh access on type ocp ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 26.95s
2024-03-29 06:03:07,584 p=290406 u=ciuser n=ansible | libvirt_manager : Ensure file ownership and rights for networker ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 26.36s
2024-03-29 06:03:07,584 p=290406 u=ciuser n=ansible | reproducer : Install collections on controller-0 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 26.32s
2024-03-29 06:03:07,584 p=290406 u=ciuser n=ansible | openshift_adm : Initiate shutdown ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 25.69s
2024-03-29 06:03:07,584 p=290406 u=ciuser n=ansible | libvirt_manager : Grab IPs for nodes type networker ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 20.35s
2024-03-29 06:03:07,584 p=290406 u=ciuser n=ansible | libvirt_manager : Grab IPs for nodes type controller ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 19.13s
2024-03-29 06:03:07,584 p=290406 u=ciuser n=ansible | reproducer : Inject ProxyJump configuration for remote hypervisor VMs ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 19.06s
2024-03-29 06:03:07,585 p=290406 u=ciuser n=ansible | libvirt_manager : Grab IPs for nodes type compute -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.02s
2024-03-29 06:03:07,585 p=290406 u=ciuser n=ansible | libvirt_manager : Wait for SSH on VMs type networker ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 17.72s
2024-03-29 06:03:07,585 p=290406 u=ciuser n=ansible | libvirt_manager : Wait for SSH on VMs type ocp ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 17.72s
2024-03-29 06:03:07,585 p=290406 u=ciuser n=ansible | reproducer : Wait for OCP nodes to be ready -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 16.83s
```

Failure occurred during deployment of architecture (post the OCP installation)

_Snippet for OCP node_
```
[core@master-0 ~]$ sudo vgdisplay 
  --- Volume group ---
  VG Name               cinder-volumes
  System ID             
  Format                lvm2
  Metadata Areas        2
  Metadata Sequence No  1
  VG Access             read/write
  VG Status             resizable
  MAX LV                0
  Cur LV                0
  Open LV               0
  Max PV                0
  Cur PV                2
  Act PV                2
  VG Size               19.99 GiB
  PE Size               4.00 MiB
  Total PE              5118
  Alloc PE / Size       0 / 0   
  Free  PE / Size       5118 / 19.99 GiB
  VG UUID               4NUPsm-2AAN-quL6-7zO4-iQsT-S4sv-yNjMTC

[core@master-0 ~]$ sudo systemctl -l status lv-cinder-volumes.service 
● lv-cinder-volumes.service - Create logical volume with name cinder-volumes.
     Loaded: loaded (/etc/systemd/system/lv-cinder-volumes.service; enabled; preset: disabled)
     Active: active (exited) since Fri 2024-03-29 09:46:52 UTC; 18h ago
   Main PID: 1035 (code=exited, status=0/SUCCESS)
        CPU: 21ms

Mar 29 09:46:52 master-0 systemd[1]: Starting Create logical volume with name cinder-volumes....
Mar 29 09:46:52 master-0 lv-cinder-volumes.sh[1035]: cinder-volumes vg exists.
Mar 29 09:46:52 master-0 systemd[1]: Finished Create logical volume with name cinder-volumes..
```