### PR TITLE
Fix a syntax error in reproducer configure_controller.yml

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -294,7 +294,7 @@
               (
                 ansible_user_dir,
                 'src/github.com/openstack-k8s-operators',
-                'architecture/automation/vars'
+                'architecture/automation/vars',
                 cifmw_arch_automation_file | default('default.yaml')
               ) | ansible.builtin.path_join
             }}


### PR DESCRIPTION
Fixes a syntax error in the `cifmw_architecture_automation_file` variable created in `/home/zuul/openshift-environment.yml`.  Without this, `./deploy_architecture.sh` hits this error when run on `controller-0`:

```
TASK [Get customized parameters ci_framework_params={{
  hostvars[inventory_hostname] |
  dict2items |
  selectattr("key", "match", "^(cifmw|pre|post)_(?!install_yamls|openshift_token|openshift_login).*") |
  list | items2dict
}}] ***********************************************************************************************************************************************************
task path: /home/zuul/src/github.com/openstack-k8s-operators/ci-framework/playbooks/01-bootstrap.yml:14
Friday 29 March 2024  05:58:27 -0400 (0:00:00.051)       0:00:00.716 ********** 
fatal: [localhost]: FAILED! => {
    "msg": "template error while templating string: expected token ')', got 'cifmw_arch_automation_file'. String: {{\n  (\n    ansible_user_dir,\n    'src/github.com/openstack-k8s-operators',\n    'architecture/automation/vars'\n    cifmw_arch_automation_file | default('default.yaml')\n  ) | ansible.builtin.path_join\n}}. expected token ')', got 'cifmw_arch_automation_file'"
}
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
