### PR TITLE
Fix syntax issue with automation file

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -294,7 +294,7 @@
               (
                 ansible_user_dir,
                 'src/github.com/openstack-k8s-operators',
-                'architecture/automation/vars'
+                'architecture/automation/vars',
                 cifmw_arch_automation_file | default('default.yaml')
               ) | ansible.builtin.path_join
             }}


### PR DESCRIPTION
Missing , during path templating.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

