### PR TITLE
[openshift_adm] Generalize the retry count.

### DIFF
--- a/roles/openshift_adm/README.md
+++ b/roles/openshift_adm/README.md
@@ -26,12 +26,8 @@ This role requires the following parameters to be configured.
 * `cifmw_openshift_adm_op` (str) The operation to be performed on the cluster.
 * `cifmw_openshift_adm_dry_run` (bool) If enabled, no modifications are
   performed on the cluster.
-* `cifmw_openshift_adm_login_retry_count` (int) The maximum number of attempts
-  to be made for a OpenShift login success. Default is `10`.
-* `cifmw_openshift_adm_api_retry_count` (int) The maximum number of attempts to
-  be made for confirming API response. Default is `100`.
-* `cifmw_openshift_adm_node_retry_count` (int) The maximum number of attempts
-  to be made for gathering the list of nodes. Default is `60`.
+* `cifmw_openshift_adm_retry_count` (int) The maximum number of attempts to be
+  made for a command to succeed. Default is `100`.
 
 ## Reference
 

--- a/roles/openshift_adm/defaults/main.yml
+++ b/roles/openshift_adm/defaults/main.yml
@@ -26,6 +26,4 @@ cifmw_openshift_adm_cert_expire_date_file: >-
   }}
 cifmw_openshift_adm_op: ""
 cifmw_openshift_adm_dry_run: false
-cifmw_openshift_adm_login_retry_count: 10
-cifmw_openshift_adm_api_retry_count: 100
-cifmw_openshift_adm_node_retry_count: 60
+cifmw_openshift_adm_retry_count: 100

--- a/roles/openshift_adm/tasks/wait_for_cluster.yml
+++ b/roles/openshift_adm/tasks/wait_for_cluster.yml
@@ -26,7 +26,7 @@
     status_code: 403
   register: ocp_api_result
   until: ocp_api_result.status == 403
-  retries: "{{ cifmw_openshift_adm_api_retry_count }}"
+  retries: "{{ cifmw_openshift_adm_retry_count }}"
   delay: 5
 
 - name: Gather the list of nodes
@@ -36,8 +36,8 @@
     validate_certs: false
   register: _nodes
   until: _nodes.resources is defined
-  retries: "{{ cifmw_openshift_adm_node_retry_count }}"
-  delay: 10
+  retries: "{{ cifmw_openshift_adm_retry_count }}"
+  delay: 2
 
 - name: Ensure the nodes are in ready state.
   when:
@@ -48,7 +48,9 @@
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
     validate_certs: false
   loop: "{{ _nodes.resources | map(attribute='metadata.name') | list }}"
-  retries: "{{ cifmw_openshift_adm_node_retry_count }}"
+  register: _node_status
+  until: _node_status.result is defined
+  retries: "{{ cifmw_openshift_adm_retry_count }}"
   delay: 5
 
 - name: Check for pending certificate approval.
@@ -63,7 +65,7 @@
     PATH: "{{ cifmw_path }}"
   ansible.builtin.command:
     cmd: >-
-      oc adm wait-for-stable-cluster --minimum-stable-period=5s --timeout=15m
+      oc adm wait-for-stable-cluster --minimum-stable-period=5s --timeout=30m
 
 - name: Wait until OCP login succeeds.
   kubernetes.core.k8s_auth:
@@ -74,5 +76,5 @@
     validate_certs: false
   register: _oc_login_result
   until: _oc_login_result.k8s_auth is defined
-  retries: "{{ cifmw_openshift_adm_login_retry_count }}"
-  delay: 5
+  retries: "{{ cifmw_openshift_adm_retry_count }}"
+  delay: 2

--- a/roles/reproducer/tasks/devscripts_post.yml
+++ b/roles/reproducer/tasks/devscripts_post.yml
@@ -10,6 +10,7 @@
           'auth'
         ) | ansible.builtin.path_join
       }}
+    _k8s_config: "{{ (_auth_path, 'kubeconfig') | ansible.builtin.path_join }}"
   block:
     - name: Slurp devscripts private key
       register: _devscript_privkey
@@ -25,7 +26,7 @@
     - name: Slurp content of the devscripts kubeconfig
       register: _devscripts_kubeconfig
       ansible.builtin.slurp:
-        path: "{{ (_auth_path, 'kubeconfig') | ansible.builtin.path_join }}"
+        path: "{{ _k8s_config }}"
 
     - name: Slurp content of the devscripts kubeadmin-password
       register: _devscripts_kubeadm
@@ -43,5 +44,6 @@
     - name: Ensure the OpenShift cluster is stable.
       vars:
         cifmw_openshift_adm_op: "stable"
+        cifmw_openshift_kubeconfig: "{{ _k8s_config }}"
       ansible.builtin.include_role:
         name: openshift_adm


### PR DESCRIPTION
Here, we are generalizing the retry count as the loop is exited on success. The duration is varied via the delay parameter.

Also, we are ensuring the kubeconfig path is pointing to the right one hence avoiding any conflicts.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

_Testing_
```
aturday 30 March 2024  07:07:44 -0400 (0:00:00.085)       1:15:38.805 ******** 
changed: [hypervisor -> controller-0(192.168.111.46)]

PLAY RECAP *********************************************************************
hypervisor                 : ok=504  changed=225  unreachable=0    failed=0    skipped=110  rescued=2    ignored=0   

Saturday 30 March 2024  07:07:45 -0400 (0:00:00.721)       1:15:39.527 ******** 
=============================================================================== 
devscripts : Deploy OpenShift cluster -------------------------------- 2822.59s
openshift_adm : Wait unit the OpenShift cluster is stable. ------------ 780.35s
openshift_adm : Wait until the OCP API endpoint is reachable. --------- 163.36s
openshift_adm : Wait until OCP login succeeds. ------------------------ 158.21s
reproducer : Bootstrap environment on controller-0 --------------------- 49.38s
reproducer : Install some tools ---------------------------------------- 44.35s
libvirt_manager : Grab IPs for nodes type ocp -------------------------- 32.16s
libvirt_manager : Grab IPs for nodes type compute ---------------------- 31.93s
libvirt_manager : Grab IPs for nodes type controller ------------------- 26.31s
libvirt_manager : Prepare disk image with SSH and growing volume ------- 21.82s
openshift_adm : Initiate shutdown -------------------------------------- 20.95s
libvirt_manager : Wait for SSH on VMs type ocp ------------------------- 15.69s
libvirt_manager : Wait for SSH on VMs type compute --------------------- 15.68s
reproducer : Configure rhos-release ------------------------------------ 14.49s
reproducer : Configure rhos-release ------------------------------------ 13.94s
ci_setup : Install packages from EPEL ---------------------------------- 13.90s
reproducer : Configure rhos-release ------------------------------------ 13.47s
libvirt_manager : Download base image ---------------------------------- 12.75s
reproducer : Install collections on controller-0 ----------------------- 12.72s
openshift_adm : Ensure the nodes are in ready state. ------------------- 12.44s
```