### PR TITLE
[run_hook] Support additional types - link2file and cmd

### DIFF
--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -60,6 +60,10 @@
       vars:
         hooks: "{{ stage.pre_stage_run }}"
         step: "pre_stage_{{ stage_id }}_run"
+        _arch_repo_dir: >-
+          {{
+            cifmw_kustomize_deploy_architecture_repo_dest_dir
+          }}
       ansible.builtin.include_role:
         name: run_hook
 

--- a/roles/run_hook/tasks/cmd.yml
+++ b/roles/run_hook/tasks/cmd.yml
@@ -1,0 +1,21 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Executing the instructed command.
+  environment: "{{ hook.environment | default(omit) }}"
+  ansible.builtin.command:
+    cmd: "{{ hook.cmd }}"

--- a/roles/run_hook/tasks/link2file.yml
+++ b/roles/run_hook/tasks/link2file.yml
@@ -1,0 +1,59 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Gather the file details
+  vars:
+    _file_path: >-
+      {{
+        (_arch_repo_dir is defined) |
+        ternary((_arch_repo_dir, item) | ansible.builtin.path_join, item)
+      }}
+  ansible.builtin.stat:
+    path: "{{ _file_path }}"
+  register: _file_info
+  loop: "{{ hook.files }}"
+  loop_control:
+    label: "{{ item }}"
+
+- name: Remove all links
+  when:
+    - item.stat.islnk | default(false)
+  ansible.builtin.file:
+    path: "{{ item.stat.path }}"
+    state: absent
+  loop: "{{ _file_info.results }}"
+  loop_control:
+    label: "{{ item.item}}"
+
+- name: Replace link with actual file.
+  when:
+    - item.stat.islnk | default(false)
+  vars:
+    _file_path: >-
+      {{
+        (_arch_repo_dir is defined) |
+        ternary(
+          (_arch_repo_dir, item.item) | ansible.builtin.path_join,
+          item.item
+        )
+      }}
+  ansible.builtin.copy:
+    src: "{{ item.stat.lnk_source }}"
+    dest: "{{ _file_path }}"
+  loop: "{{ _file_info.results }}"
+  loop_control:
+    label: "{{ item.item }}"


### PR DESCRIPTION
This change set introduces two additional hook types

- link2file
- cmd

`kubernetes.core.kustomize` does not support relaxation of loading restrictions. Relaxing the loading restrictions is required in scenarios when the lib/kustomization.yaml cannot be used and the user wants to reuse the resources from lib folder.

As part of `uni01alpha`, we need to apply a node label as part of the workflow. Hence the need for `cmd`. 

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
