### PR TITLE
Set tenant MTU to 1500 for shift on stack

### DIFF
--- a/scenarios/reproducers/shift-on-stack-overrides.yml
+++ b/scenarios/reproducers/shift-on-stack-overrides.yml
@@ -4,3 +4,7 @@ cifmw_libvirt_manager_compute_cpus: 8
 cifmw_allow_vms_to_reach_osp_api: true
 # HCI requires bigger size to hold OCP on OSP disks
 cifmw_block_device_size: 100G
+cifmw_networking_mapper_definition_patches_01:
+  networks:
+    tenant:
+      mtu: 1500


### PR DESCRIPTION
For enabling the communication between VMs and considering that the MTU for the tenant network that openshift-installer creates is 1442, the tenant VLAN should be set to 1500 so the geneve tunnel works as expected.

This change is making the tenant vlan MTU configurable and it is setting it to 1500 on the shift-on-stack-overrides.yml

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
