### PR TITLE
Update docs related to push_code

### DIFF
--- a/docs/source/reproducers/03-zuul.md
+++ b/docs/source/reproducers/03-zuul.md
@@ -97,7 +97,7 @@ local_base_dir: "{{ local_home_dir }}/src/github.com/openstack-k8s-operators"
 remote_base_dir: "/home/zuul/src/github.com/openstack-k8s-operators"
 cifmw_reproducer_repositories:
   - src: "{{ local_base_dir }}/nova-operator"
-    dest: "{{ remote_base_dir }}/nova-operator"
+    dest: "{{ remote_base_dir }}"
 ~~~
 
 Provided you have the right code branch set in your local repository, the reproducer

--- a/roles/reproducer/README.md
+++ b/roles/reproducer/README.md
@@ -43,9 +43,9 @@ local_base_dir: "{{ local_home_dir }}/src/github.com/openstack-k8s-operators"
 remote_base_dir: "/home/zuul/src/github.com/openstack-k8s-operators"
 cifmw_reproducer_repositories:
   - src: "{{ local_base_dir }}/ci-framework"
-    dest: "{{ remote_base_dir }}/ci-framework"
+    dest: "{{ remote_base_dir }}"
   - src: "{{ local_base_dir }}/install_yamls"
-    dest: "{{ remote_base_dir }}/"
+    dest: "{{ remote_base_dir }}"
 ```
 Notes:
 * `ansible_user_dir` isn't really usable due to the use of `delegate_to` in order to sync those local repositories.


### PR DESCRIPTION
When using the example in the code you end up with a directory like:
`src/github.com/openstack-k8s-operators/ci-framework/ci-framework/`

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
