### PR TITLE
Add missing default vars for compute disk,mem and cpu for va-hci

### DIFF
--- a/scenarios/reproducers/va-hci.yml
+++ b/scenarios/reproducers/va-hci.yml
@@ -74,6 +74,9 @@ cifmw_root_partition_id: >-
     ternary(4, 1)
   }}
 cifmw_libvirt_manager_compute_amount: 3
+cifmw_libvirt_manager_compute_disksize: 20
+cifmw_libvirt_manager_compute_memory: 4
+cifmw_libvirt_manager_compute_cpus: 1
 cifmw_libvirt_manager_configuration:
   networks:
     osp_trunk: |


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/ci-framework/pull/1259 adds the VA-HCI var for shiftstack. But it does not add the default values for compute disk,mem and cpu in va-hci scenario reproducer var file.

It broke the ci with following error:
```
You cannot get both OpenShift cluster types. Please chose between CRC and OCP cluster
```

After digging deep we found that, cifmw_libvirt_manager_configuration is undefined as cifmw_libvirt_manager_compute_disksize' is undefined.

Defining default vars of these vars fixes the issue.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

