### PR TITLE
Allow compound command

### DIFF
--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -182,7 +182,7 @@
       environment:
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
-      ansible.builtin.command:
+      ansible.builtin.shell:
         cmd: "{{ validation }}"
       loop: "{{ stage['validations'] }}"
       loop_control:


### PR DESCRIPTION
Use shell module instead of cmd in order to
allow compound command (pipes).

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
