### PR TITLE
Remove unused cifmw_operator_build_meta_image_base variable

### DIFF
--- a/roles/operator_build/README.md
+++ b/roles/operator_build/README.md
@@ -16,7 +16,6 @@ you want to build meta-operator too, so the role can properly replace api refere
 * `cifmw_operator_build_meta_name`: (String) Meta operator's name. Defaults to `openstack-operator`.
 * `cifmw_operator_build_meta_src`: (String) Directory with src code for meta operator. Defaults to `"{{ ansible_user_dir }}/src/github.com/{{ cifmw_operator_build_org }}/{{ cifmw_operator_build_meta_name }}"`
 * `cifmw_operator_build_meta_build`: (Boolean) When set to `true` updates meta-operator's go.mod when build operators and builds meta-operator in the end. Default to `true`.
-* `cifmw_operator_build_meta_image_base`: (String) Name of the service added to be added to meta-operator build. Still limited to a single service (and operator). Default to `""`
 * `cifmw_operator_build_push_registry_tls_verify`: (Boolean) Variable to control whether to enable/disable TLS verification for push registry . Defaults to `true`.
 
 ## TODO

--- a/roles/operator_build/defaults/main.yml
+++ b/roles/operator_build/defaults/main.yml
@@ -33,8 +33,6 @@ cifmw_operator_build_meta_build: true
 cifmw_operator_build_meta_name: "openstack-operator"
 # Directory with src code for meta operator
 cifmw_operator_build_meta_src: "{{ ansible_user_dir }}/src/github.com/{{ cifmw_operator_build_org }}/{{ cifmw_operator_build_meta_name }}"
-# Default base image name, used to build meta operator bundle
-cifmw_operator_build_meta_image_base: ""
 # Set vars for Local Registry
 cifmw_operator_build_local_registry: 0
 cifmw_operator_build_push_registry_tls_verify: true


### PR DESCRIPTION
This pr cleansup unused variable cifmw_operator_build_meta_image_base not used in the operator_build role

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

