### PR TITLE
[Test-operator] Fix mounting of ssh key

### DIFF
--- a/roles/test_operator/tasks/tempest-tests.yml
+++ b/roles/test_operator/tasks/tempest-tests.yml
@@ -75,7 +75,7 @@
         name: "{{ cifmw_test_operator_controller_priv_key_secret_name }}"
         namespace: "{{ cifmw_test_operator_namespace }}"
       data:
-        ssh-privatekey: "{{ lookup('file', '~/.ssh/id_cifw') | b64encode }}"
+        ssh-privatekey: "{{ lookup('file', '~/.ssh/id_cifw', rstrip=False) | b64encode }}"
 
 - name: Add SSHKeySecretName section to Tempest CR
   when:


### PR DESCRIPTION
Currently, the private key specified using the default value for the SSHKeySecretName is the content of ~/.ssh/id_cifw. The file is mounted to the test pod as a secret that is generated using the test-operator role. The content of the file is loaded using lookup function that strips the newline at the end of the file by default. This fix ensures that the newline is kept omitting the newline breaks the usage of the key with ssh.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
