### PR TITLE
Allow longer names for hooks related content

### DIFF
--- a/roles/run_hook/tasks/playbook.yml
+++ b/roles/run_hook/tasks/playbook.yml
@@ -5,7 +5,7 @@
       {{ hook.name |
          regex_replace('([^a-zA-Z0-9\-\._])+', '_') |
          lower |
-         truncate(20, false, '') }}
+         truncate(30, true, '') }}
     _play: >-
       {%- if hook.source is not ansible.builtin.abs -%}
       {{ role_path }}/../../hooks/playbooks/{{ hook.source }}
@@ -72,10 +72,6 @@
     path: "{{ cifmw_basedir }}/artifacts"
     state: directory
     mode: "0755"
-
-- name: Point to the generated log file
-  ansible.builtin.debug:
-    msg: "You can follow hook run here: {{ log_path }}"
 
 # We cannot call ansible.builtin.import_playbook from within a play,
 # even less from a task. So the way to run a playbook from within a playbook


### PR DESCRIPTION
The ci_script module is truncating at 30 chars, and keep full words. The
`truncate` filter in ansible allows to do the same, so let's converge.

This patch also removes a now useless `ansible.builtin.debug` tasks:
ci_script module outputs the log location directly, so we don't need to
do it in a dedicated task anymore.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
