### PR TITLE
nfs server: install also iptables on the node

### DIFF
--- a/playbooks/nfs.yml
+++ b/playbooks/nfs.yml
@@ -23,9 +23,11 @@
         - not cifmw_edpm_deploy_nfs | default('false') | bool
       ansible.builtin.meta: end_play
   tasks:
-    - name: Install nfs-utils package
+    - name: Install required packages
       ansible.builtin.package:
-        name: "nfs-utils"
+        name:
+          - nfs-utils
+          - iptables
 
     - name: Configure nfs to use v4 only
       community.general.ini_file:


### PR DESCRIPTION
The iptables package on the target node is required by the ansible.builtin.iptables module.
On EL9 iptables does not exist but it is provided by iptables-nft, but keep iptables for now.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
