### PR TITLE
Correct issues due to cached facts and k8s core module

### DIFF
--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -162,7 +162,14 @@
       ansible.builtin.fail:
         msg: "Failing on demand {{ cifmw_deploy_architecture_stopper }}"
 
+    # We have to use plain `oc apply -f` here due to the
+    # way kubernetes.core.k8s module works: we can't use
+    # - `state: present` and expect it to update the resource;
+    # - `state: present force: true` since it would replace the resource completly
+    # - `state: patched` if the resource doesn't exist
     - name: "Apply generated content for {{ stage.path }}"
+      register: oc_apply
+      changed_when: "'unchanged' not in oc_apply.stdout"
       when:
         - not cifmw_kustomize_deploy_generate_crs_only | bool
       vars:
@@ -172,12 +179,11 @@
              stage['path'], stage['build_output']
              ) | path_join
           }}
-      kubernetes.core.k8s:
-        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
-        api_key: "{{ cifmw_openshift_token | default(omit) }}"
-        context: "{{ cifmw_openshift_context | default(omit) }}"
-        state: present
-        src: "{{ _cr }}"
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.command:
+        cmd: "oc apply -f {{ _cr }}"
 
     - name: "Run Wait Conditions for {{ stage.path }}"
       when:

--- a/roles/reproducer/tasks/ci_job.yml
+++ b/roles/reproducer/tasks/ci_job.yml
@@ -138,4 +138,4 @@
         cmd: >-
           ansible-playbook
           -i ~/ci-framework-data/artifacts/zuul_inventory.yml
-          {{ job_id }}_play.yml
+          {{ job_id }}_play.yml --flush-cache

--- a/roles/reproducer/tasks/configure_architecture.yml
+++ b/roles/reproducer/tasks/configure_architecture.yml
@@ -16,7 +16,7 @@
           ansible-playbook -i ~/ci-framework-data/artifacts/zuul_inventory.yml \
             -e @~/reproducer-variables.yml \
             -e @~/openshift-environment.yml \
-            deploy-edpm.yml $@
+            deploy-edpm.yml --flush-cache $@
           popd
 
     - name: Rotate some logs

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -179,5 +179,5 @@
             -e @scenarios/centos-9/base.yml \
             -e @scenarios/centos-9/edpm_ci.yml \
             -e cifmw_openshift_password="{{ cifmw_openshift_password }}" \
-            $@
+            --flush-cache $@
           popd


### PR DESCRIPTION
First issue was related to cached facts. It ended up with a weird
situation where the controller-0 was using facts that weren't
up-to-date, especially visible in a scale-out scenario (adding some
computes).

The second issue is related to `kubernetes.core.k8s` module not updating
the resources:
we would need to first check for the resource existence before deciding
if we would use `present` or `patched` for the state parameter.

Using plain `oc apply` with a valid `change_when` allows to get rid of
that issue.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
