### PR TITLE
[link2file] Replace given links with source files.

### DIFF
--- a/hooks/playbooks/README.md
+++ b/hooks/playbooks/README.md
@@ -51,3 +51,14 @@ It doesn't have any output.
 Ensure podified deployment is successful by checking the running pods/services.
 
 It doesn't have any output.
+
+## link2file.yml
+
+This play replaces the given soft links with their respective source files. It
+is required to avoid kustomize errors when using symbolic links. This play has
+no output.
+
+### Required variables - link2file
+
+* `cifmw_link2file_files` (str) A comma separated string of file names to be
+  replaced.

--- a/hooks/playbooks/link2file.yml
+++ b/hooks/playbooks/link2file.yml
@@ -1,0 +1,63 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Replace soft link files with source files.
+  gather_facts: false
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+
+  vars:
+    _base_dir: >-
+      {{
+        (
+          ansible_user_dir,
+          "src/github.com/openstack-k8s-operators/architecture"
+        ) | ansible.builtin.path_join
+      }}
+    _link_files: "{{ cifmw_link2file_files | split(',') }}"
+
+  tasks:
+    - name: Gather the file details
+      vars:
+        _file_path: "{{ (_base_dir, item) | ansible.builtin.path_join }}"
+      ansible.builtin.stat:
+        path: "{{ _file_path }}"
+      register: _file_info
+      loop: "{{ _link_files }}"
+      loop_control:
+        label: "{{ item }}"
+
+    - name: Remove all links
+      when:
+        - item.stat.islnk | default(false)
+      ansible.builtin.file:
+        path: "{{ item.stat.path }}"
+        state: absent
+      loop: "{{ _file_info.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+
+    - name: Replace link with actual file.
+      when:
+        - item.stat.islnk | default(false)
+      vars:
+        _file_path: "{{ (_base_dir, item.item) | ansible.builtin.path_join }}"
+      ansible.builtin.copy:
+        src: "{{ item.stat.lnk_source }}"
+        dest: "{{ _file_path }}"
+      loop: "{{ _file_info.results }}"
+      loop_control:
+        label: "{{ item.item }}"


### PR DESCRIPTION
Adds a playbook that would replace the provided link files with the linked source file. This is to workaround the limitation with kustomize load restrictions.

At the same time maintain reference to a single source.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

*Testing results*

_Tasks snippet_
```
TASK [run_hook : Run Replace resource links with files from library.] ************************************************************************************************************************************************************************
Friday 12 April 2024  05:54:04 -0400 (0:00:00.141)       0:02:15.710 ********** 
Follow script's output here: /home/zuul/ci-framework-data/logs/ci_script_006_run_replace_resource_links.log
changed: [localhost]
```

_Log snippet_
```
PLAY [Replace soft link files with source files.] ******************************

TASK [Gather the file details path={{ _file_path }}] ***************************
Friday 12 April 2024  05:54:05 -0400 (0:00:00.045)       0:00:00.045 ********** 
ok: [localhost] => (item=dt/uni01alpha/networker/dataplane-ssh-secret.yaml)
ok: [localhost] => (item=dt/uni01alpha/networker/openstackdataplanenodeset.yaml)
ok: [localhost] => (item=dt/uni01alpha/networker/openstackdataplanedeployment.yaml)

TASK [Remove all links path={{ item.stat.path }}, state=absent] ****************
Friday 12 April 2024  05:54:05 -0400 (0:00:00.463)       0:00:00.508 ********** 
changed: [localhost] => (item=dt/uni01alpha/networker/dataplane-ssh-secret.yaml)
changed: [localhost] => (item=dt/uni01alpha/networker/openstackdataplanenodeset.yaml)
changed: [localhost] => (item=dt/uni01alpha/networker/openstackdataplanedeployment.yaml)

TASK [Replace link with actual file. src={{ item.stat.lnk_source }}, dest={{ _file_path }}] ***
Friday 12 April 2024  05:54:06 -0400 (0:00:00.480)       0:00:00.989 ********** 
changed: [localhost] => (item=dt/uni01alpha/networker/dataplane-ssh-secret.yaml)
changed: [localhost] => (item=dt/uni01alpha/networker/openstackdataplanenodeset.yaml)
changed: [localhost] => (item=dt/uni01alpha/networker/openstackdataplanedeployment.yaml)

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

Friday 12 April 2024  05:54:07 -0400 (0:00:00.854)       0:00:01.844 ********** 
=============================================================================== 
Replace link with actual file. ------------------------------------------ 0.85s
Remove all links -------------------------------------------------------- 0.48s
Gather the file details ------------------------------------------------- 0.46s
```

