### PR TITLE
[Test-operator] Introduce option for nt-plugin extra image

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -513,6 +513,7 @@ vxlan
 vynxgdagahaac
 vzcg
 wget
+whitebox
 wljewmdozmzawlzasdje
 wljewmjozmzawlzasdje
 wljewmtozmzawlzasdje

--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -31,6 +31,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_tempest_ssh_key_secret_name`: (String) Name of a secret that contains ssh-privatekey field with a private key. The private key is mounted to `/var/lib/tempest/.ssh/id_ecdsa`
 * `cifmw_test_operator_tempest_config_overwrite`: (Dict) Dictionary where key is name of a file and value is content of the file. All files mentioned in this field are mounted to `/etc/test_operator/<filename>`
 * `cifmw_test_operator_tempest_workflow`: (List) Definition of a Tempest workflow that consists of multiple steps. Each step can contain all values from Spec section of [Tempest CR](https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource).
+* `cifmw_test_operator_tempest_ntp_extra_image`: (String) URL that points to an extra image that is used by [whitebox-neutron-tempest-plugin](https://opendev.org/x/whitebox-neutron-tempest-plugin). Default value: `''`
 * `cifmw_test_operator_tempest_config`: (Object) Definition of Tempest CRD instance that is passed to the test-operator (see [the test-operator documentation](https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource)). Default value:
 ```
   apiVersion: test.openstack.org/v1beta1

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -60,6 +60,7 @@ cifmw_test_operator_tempest_config:
         {{ cifmw_test_operator_tempest_exclude_list | default('') }}
       concurrency: "{{ cifmw_test_operator_concurrency }}"
       externalPlugin: "{{ cifmw_test_operator_tempest_external_plugin | default([]) }}"
+      neutronExtraImage: "{{ cifmw_test_operator_tempest_ntp_extra_image | default('') }}"
     tempestconfRun: "{{ cifmw_tempest_tempestconf_config | default(omit) }}"
     workflow: "{{ cifmw_test_operator_tempest_workflow }}"
 


### PR DESCRIPTION
neutron-tempest-plugin requires an extra image [1] in order to be able to execute certain tests. This patch introduces cifmw_test_operator_tempest_ntp_extra_image option that can be used to specify URL of an extra image that should be used for testing.


[1] https://opendev.org/openstack/neutron-tempest-plugin/src/branch/master/neutron_tempest_plugin/config.py#L118

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
