### PR TITLE
[ci_gen_kustomize_values] Add mac address mapping for `nic1`

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/hci/edpm-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/hci/edpm-values/values.yaml.j2
@@ -27,6 +27,9 @@ data:
         edpm_network_config_os_net_config_mappings:
 {% for instance in instances_names                                                     %}
           edpm-{{ instance }}:
+{%   if hostvars[instance] is defined                                                  %}
+            nic1: "{{ hostvars[instance].ansible_default_ipv4.macaddress }}"
+{%   endif                                                                             %}
             nic2: "{{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.mac_addr }}"
 {% endfor                                                                              %}
 {% if cifmw_ci_gen_kustomize_values_sshd_ranges | default([]) | length > 0             %}


### PR DESCRIPTION
This patch allow the mapping of the `nic1` to the mac address of the default interface in compute node and is required due to [1]

[1] https://github.com/openstack-k8s-operators/architecture/pull/157

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
