### PR TITLE
[EDPM]Switch to test_operator for running tempest tests

### DIFF
--- a/scenarios/centos-9/edpm_periodic.yml
+++ b/scenarios/centos-9/edpm_periodic.yml
@@ -9,6 +9,6 @@ cifmw_set_openstack_containers_namespace: "podified-master-centos9"
 cifmw_edpm_deploy_baremetal_update_os_containers: true
 cifmw_run_tests: true
 cifmw_edpm_deploy_registry_url: "{{ cifmw_set_openstack_containers_registry }}/{{ cifmw_set_openstack_containers_namespace }}"
-cifmw_tempest_registry: "{{ cifmw_set_openstack_containers_registry }}"
-cifmw_tempest_namespace: "{{ cifmw_set_openstack_containers_namespace }}"
-cifmw_tempest_image_tag: "{{ cifmw_repo_setup_full_hash }}"
+cifmw_test_operator_tempest_registry: "{{ cifmw_set_openstack_containers_registry }}"
+cifmw_test_operator_tempest_namespace: "{{ cifmw_set_openstack_containers_namespace }}"
+cifmw_test_operator_tempest_image_tag: "{{ cifmw_repo_setup_full_hash }}"

--- a/scenarios/centos-9/multinode-ci.yml
+++ b/scenarios/centos-9/multinode-ci.yml
@@ -23,5 +23,9 @@ cifmw_install_yamls_vars:
 
 # Deploy EDPM in multinode scenario
 cifmw_deploy_edpm: true
-cifmw_tempest_tests_allowed:
-  - tempest.scenario.test_network_basic_ops.TestNetworkBasicOps
+
+# Tempest vars
+cifmw_run_test_role: test_operator
+cifmw_test_operator_tempest_tests_exclude_override_scenario: true
+cifmw_test_operator_tempest_include_list: |
+  tempest.scenario.test_network_basic_ops.TestNetworkBasicOps

--- a/scenarios/reproducers/va-hci.yml
+++ b/scenarios/reproducers/va-hci.yml
@@ -51,6 +51,7 @@ cifmw_run_tests: true
 cifmw_run_tempest: true
 cifmw_run_test_role: test_operator
 cifmw_test_operator_timeout: 7200
+cifmw_test_operator_tempest_tests_exclude_override_scenario: true
 cifmw_test_operator_tempest_include_list: |
   tempest.scenario.test_network_basic_ops.TestNetworkBasicOps
 


### PR DESCRIPTION
Since most of the downstream jobs are using test_operator to run tempest. Let's enable the same it in upstream.
Set `cifmw_test_operator_tempest_tests_exclude_override_scenario` to true to pick the default skipped list tests. It is updated for va-hci and multinode job.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1402

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

