### PR TITLE
Allow to inject custom wait_conditions during stages

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -42,6 +42,8 @@ are shared among multiple roles:
 - `cifmw_arch_automation_file`: (String) Name of the workflow automation file
   in the architecture repository. Defaults to `default.yaml`
 - `cifmw_architecture_scenario`: (String) The selected VA scenario to deploy.
+- `cifmw_architecture_wait_condition`: (Dict) Structure defining custom wait_conditions for the automation.
+- `cifmw_architecture_user_kustomize`: (Dict) Structure defining user provided kustomization for automation.
 - `cifmw_ceph_target`: (String) The Ansible inventory group where ceph is deployed. Defaults to `computes`.
 - `cifmw_run_tests`: (Bool) Specifies whether tests should be executed.
   Defaults to false.

--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -185,18 +185,32 @@
       ansible.builtin.command:
         cmd: "oc apply -f {{ _cr }}"
 
-    - name: "Run Wait Conditions for {{ stage.path }}"
+    - name: "Build Wait Conditions for {{ stage.path }}"
       when:
         - not cifmw_kustomize_deploy_generate_crs_only | bool
+      vars:
+        _stage_name: "stage_{{ stage_id }}"
+        _custom_conditions: >-
+          {{
+            cifmw_architecture_wait_condition[_stage_name] |
+            default([])
+          }}
+        ## TODO: remove "validations" once architecture is up-to-date
+        _commands: >-
+          {{
+            (stage['wait_conditions'] |
+             default(stage['validations'])) + _custom_conditions
+           }}
       environment:
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
-      ansible.builtin.command:
-        cmd: "{{ wait_condition }}"
-      ## TODO: remove "validations" once architecture is up-to-date
-      loop: "{{ stage['wait_conditions'] | default(stage['validations']) }}"
-      loop_control:
-        loop_var: wait_condition
+      block:
+        - name: "Run Wait Conditions for {{ stage.path }}"
+          ansible.builtin.command:
+            cmd: "{{ wait_condition }}"
+          loop: "{{ _commands }}"
+          loop_control:
+            loop_var: wait_condition
 
     - name: Stop after applying CRs if requested
       when:


### PR DESCRIPTION
This feature is needed, especially in HCI scenario, when we want to
scale-out the deployment:
in order to do so, we have to create a new OpenStackDataPlaneDeployment
resource, with a new name to trigger the deployment of the new
compute(s).

In such a use-case, using [1] and the following parameters, we're able
to wait for the right resource to be ready:

```YAML
cifmw_architecture_user_kustomize:
  stage_2:
    edpm-values:
      data:
        deployment:
          name: edpm-scale-out
cifmw_architecture_wait_condition:
  stage_2:
    - >-
      oc -n openstack wait
      osdpd edpm-scale-out --for condition=Ready
      --timeout=1500s
```

In this example, the first snippet will inject a user kustomization in
the ci_gen_kustomize_values role in order to override the resource name.
The second snippet will then inject a new wait_condition to the existing
one.
When the deployment hits the wait_conditions loop, it will pass over the
first one (since it's already done), and run the second condition until
it ends.

[1] https://github.com/openstack-k8s-operators/architecture/pull/158

As a pull request owner and reviewers, I checked that:
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] Content of the docs/source is reflecting the changes
- [X] I could run this on my local env, and it correctly generated the contents
