### PR TITLE
Correct spelling by ignoring some new strings

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -8,6 +8,8 @@ ansibleuser
 ansiblevars
 apiversion
 apivips
+appcreds
+applicationcredential
 aqc
 args
 arx
@@ -24,6 +26,7 @@ basedomain
 baseimg
 baseurl
 bashrc
+bd
 blockquote
 bmaas
 bmc
@@ -99,6 +102,7 @@ dataplanenodeset
 dataplanenodesets
 dd'd
 ddr
+ddthh
 deepscrub
 delorean
 deployer
@@ -108,6 +112,7 @@ dev
 devscripts
 devsetup
 dfb
+dfce
 dfg
 dhcp
 dib
@@ -125,6 +130,7 @@ dnsmasq
 dockerfile
 dryrun
 ecdsa
+edecb
 edploy
 edpm
 ee
@@ -169,6 +175,7 @@ gzwu
 haproxy
 hbmfnzwqkcltnbg
 hci
+hfu
 hostkey
 hostname
 hostnames
@@ -207,6 +214,7 @@ jira
 jmespath
 jq
 json
+jxe
 jzxbol
 kcgpby
 keepalived
@@ -230,6 +238,7 @@ kustomized
 kuttl
 kvm
 lacp
+lajly
 ldp
 libguestfs
 libvirt
@@ -243,6 +252,7 @@ lkid
 lmxpynzpcnrdcmfkbwluihnvy
 localhost
 localnet
+logfile
 logserver
 loopback
 losetup
@@ -306,6 +316,7 @@ ntp
 num
 nvme
 nwy
+nzgdh
 oauth
 oc
 ocp
@@ -328,6 +339,7 @@ openstackdataplane
 openstackdataplanenodeset
 openstackdataplanenodesets
 openstackprovisioner
+openstacksdk
 operatorgroup
 opn
 orchestrator
@@ -409,8 +421,10 @@ rsa
 rsync
 runtime
 scp
+sdk
 selinux
 sha
+sig
 skbg
 skiplist
 specificities
@@ -514,6 +528,7 @@ yml
 ytm
 yxivcnvul
 yyoje
+yyyy
 zlcbwcm
 zm
 zpbgugcmjkihbvb


### PR DESCRIPTION
Unfortunately, we can't get a nice pyspelling configuration ignoring
strings with numbers or underscrors/hyphens (tried it, failed it).

And since the ansible-doc building the modules documentation is kind of
dumb, there's no way to ignore standard `code` or some nice `css
class`...

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
