### PR TITLE
Store nfs related facts to artifacts/parameters

### DIFF
--- a/playbooks/06-deploy-edpm.yml
+++ b/playbooks/06-deploy-edpm.yml
@@ -1,13 +1,13 @@
 ---
+- name: Deploy NFS server on target nodes
+  ansible.builtin.import_playbook: "nfs.yml"
+
 - name: Run pre_deploy hooks
   when:
     - cifmw_architecture_scenario is not defined
   vars:
     step: pre_deploy
   ansible.builtin.import_playbook: ./hooks.yml
-
-- name: Deploy NFS server on target nodes
-  ansible.builtin.import_playbook: "nfs.yml"
 
 - name: Deploy podified control plane
   hosts: "{{ cifmw_target_host | default('localhost') }}"

--- a/playbooks/nfs.yml
+++ b/playbooks/nfs.yml
@@ -56,13 +56,25 @@
         _nfs_network_name: "{{ cifmw_nfs_network | default('storage') }}"
         _nfs_host: "{{ groups[cifmw_nfs_target | default('computes')][0] | default('') }}"
       ansible.builtin.set_fact:
-        _nfs_network_range: >-
+        cifmw_nfs_network_range: >-
           {{
             crc_ci_bootstrap_networking.networks[_nfs_network_name].range
           }}
-        _nfs_ip: >-
+        cifmw_nfs_ip: >-
           {{
             crc_ci_bootstrap_networking.instances[_nfs_host].networks[_nfs_network_name].ip
+          }}
+
+    - name: Store nfs network vars
+      delegate_to: controller
+      ansible.builtin.copy:
+        dest: "{{ cifmw_basedir }}/artifacts/parameters/nfs-params.yml"
+        content: >-
+          {{
+            {
+            'cifmw_nfs_ip': cifmw_nfs_ip,
+            'cifmw_nfs_network_range': cifmw_nfs_network_range
+            } | to_nice_yaml
           }}
 
     - name: Add nfs ports to firewall
@@ -74,7 +86,7 @@
           - "2049"
           - "111"
         jump: "ACCEPT"
-        source: "{{ _nfs_network_range }}"
+        source: "{{ cifmw_nfs_network_range }}"
         protocol: "{{ item }}"
       loop:
         - tcp
@@ -85,7 +97,7 @@
         path: /etc/nfs.conf
         section: nfsd
         option: host
-        value: "{{ _nfs_ip }}"
+        value: "{{ cifmw_nfs_ip }}"
         backup: true
 
     - name: Enable and restart nfs-server service
@@ -97,7 +109,7 @@
     - name: Add shares to /etc/exports
       ansible.builtin.lineinfile:
         path: /etc/exports
-        line: "/data/{{ item }} {{ _nfs_network_range }}(rw,sync,no_root_squash)"
+        line: "/data/{{ item }} {{ cifmw_nfs_network_range }}(rw,sync,no_root_squash)"
       loop: "{{ cifmw_nfs_shares }}"
       register: _export_shares
 


### PR DESCRIPTION
Store the nfs server ip and network range to the parameters folder so it
can be later consumed by hooks.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
