### PR TITLE
Debug the tempest_skip_module

### DIFF
--- a/plugins/modules/tempest_list_skipped.py
+++ b/plugins/modules/tempest_list_skipped.py
@@ -93,8 +93,13 @@ def run_module():
 
 
 def _filter_skipped_tests(jobs, release, yaml_file):
+    print("Received jobs:", jobs)
+    print("Received release:", release)
+    print("Received YAML file:", yaml_file)
+
     if len(yaml_file) > 0:
         tests = yaml_file.get("known_failures", [])
+        print("Loaded tests from YAML file:", tests)
 
         if jobs:
             tests = [
@@ -103,6 +108,7 @@ def _filter_skipped_tests(jobs, release, yaml_file):
                 if (not test.get("jobs", []))
                 or ([job for job in jobs if job in test.get("jobs", [])])
             ]
+            print("Filtered tests based on jobs:", tests)
 
         if release:
             tests = [
@@ -110,9 +116,12 @@ def _filter_skipped_tests(jobs, release, yaml_file):
                 for test in tests
                 if [rel for rel in test.get("releases", []) if rel["name"] == release]
             ]
+            print("Filtered tests based on release:", tests)
 
         if len(tests) > 0:
-            return [test.get("test") for test in tests]
+            filtered_tests = [test.get("test") for test in tests]
+            print("Filtered tests:", filtered_tests)
+            return filtered_tests
     return []
 
 


### PR DESCRIPTION
It seems the test_operator propogates +2 values for unknown reason.
This is an attempt to debug this issue in more detail
For more info please refer:-
- https://logserver.rdoproject.org/91/1391/daa1bcfefd4447c9dd964b7de2f97436ce12f0e2/github-check/podified-multinode-edpm-deployment-crc/052c29b/controller/ci-framework-data/logs/openstack-k8s-operators-openstack-must-gather/namespaces/openstack/crs/tempests.test.openstack.org/tempest-tests.yaml

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
