### PR TITLE
Ensure install_yamls "download_tools.yml" play is run early

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -357,12 +357,6 @@
             {{ ansible_user_dir }}/.kube/config
           cifmw_openshift_user: "kubeadmin"
           cifmw_openshift_skip_tls_verify: true
-          cifmw_installyamls_repos: >-
-            {{
-              (ansible_user_dir,
-               'src/github.com/openstack-k8s-operators',
-               'install_yamls') | path_join
-            }}
           cifmw_architecture_automation_file: >-
             {{
               (
@@ -372,13 +366,6 @@
                 cifmw_arch_automation_file | default('default.yaml')
               ) | ansible.builtin.path_join
             }}
-          pre_infra:
-            - name: Download needed tools
-              inventory: 'localhost,'
-              connection: local
-              type: playbook
-              source: >-
-                {{ cifmw_installyamls_repos }}/devsetup/download_tools.yaml
           {% endraw %}
 
     - name: Get interfaces-info content

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -176,6 +176,18 @@
           -e @scenarios/reproducers/networking-definition.yml
           playbooks/01-bootstrap.yml
 
+    - name: Install dev tools from install_yamls on controller-0
+      delegate_to: controller-0
+      environment:
+        ANSIBLE_LOG_PATH: "~/ansible-bootstrap.log"
+      no_log: true
+      ansible.builtin.command:
+        chdir: "/home/zuul/src/github.com/openstack-k8s-operators/install_yamls/devsetup"
+        cmd: >-
+          ansible-playbook -i ~/ci-framework-data/artifacts/zuul_inventory.yml
+          download_tools.yaml
+        creates: "/home/zuul/bin/operator-sdk"
+
     - name: Emulate CI job
       when:
         - cifmw_job_uri is defined


### PR DESCRIPTION
This playbook is usually injected via a hook. We can make things
slightly faster by calling it once for all from the main deployment.

Since we don't import hooks in the nested ansible-playbooks call, we
should therefore get a slightly faster deployment.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
