### PR TITLE
Add a new parameter to inject extravars in nested plays

### DIFF
--- a/roles/reproducer/README.md
+++ b/roles/reproducer/README.md
@@ -7,6 +7,7 @@ None
 ## Parameters
 * `cifmw_reproducer_basedir`: (String) Base directory. Defaults to `cifmw_basedir`, which defaults to `~/ci-framework-data`.
 * `cifmw_reproducer_compute_repos`: (List[mapping]) List of yum repository that must be deployed on the compute nodes during their creation. Defaults to `[]`.
+* `cifmw_reproducer_play_extravars`: (List[string]) List of extra-vars you want to pass down to the EDPM deployment playbooks. Defaults to `[]`.
 * `cifmw_reproducer_kubecfg`: (String) Path to the CRC kubeconfig file. Defaults to the image_local_dir defined in the cifmw_libvirt_manager_configuration dict.
 * `cifmw_reproducer_repositories`: (List[mapping]) List of repositories you want to synchronize from your local machine to the ansible controller.
 * `cifmw_reproducer_run_job`: (Bool) Run actual CI job. Defaults to `true`.

--- a/roles/reproducer/defaults/main.yml
+++ b/roles/reproducer/defaults/main.yml
@@ -30,3 +30,4 @@ cifmw_reproducer_hp_rhos_release: false
 cifmw_reproducer_dnf_tweaks: []
 cifmw_reproducer_compute_repos: []
 cifmw_reproducer_repositories_path: "src"
+cifmw_reproducer_play_extravars: []

--- a/roles/reproducer/tasks/configure_architecture.yml
+++ b/roles/reproducer/tasks/configure_architecture.yml
@@ -3,21 +3,21 @@
   delegate_to: controller-0
   block:
     - name: Push script
-      ansible.builtin.copy:
+      vars:
+        run_directory: "src/github.com/openstack-k8s-operators/ci-framework"
+        exports:
+          ANSIBLE_LOG_PATH: "~/ansible-deploy-architecture.log"
+        default_extravars:
+          - "@~/reproducer-variables.yml"
+          - "@~/openshift-environment.yml"
+        extravars: "{{ cifmw_reproducer_play_extravars }}"
+        playbook: "deploy-edpm.yml"
+      ansible.builtin.template:
         dest: "/home/zuul/deploy-architecture.sh"
+        src: "script.sh.j2"
         mode: "0755"
         owner: "zuul"
         group: "zuul"
-        content: |-
-          #!/bin/bash
-          set -e
-          pushd src/github.com/openstack-k8s-operators/ci-framework
-          export ANSIBLE_LOG_PATH="~/ansible-deploy-architecture.log"
-          ansible-playbook -i ~/ci-framework-data/artifacts/zuul_inventory.yml \
-            -e @~/reproducer-variables.yml \
-            -e @~/openshift-environment.yml \
-            deploy-edpm.yml --flush-cache $@
-          popd
 
     - name: Rotate some logs
       tags:

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -194,19 +194,19 @@
 
     - name: Prepare ci-like EDPM deploy
       delegate_to: controller-0
-      ansible.builtin.copy:
+      vars:
+        run_directory: "src/github.com/openstack-k8s-operators/ci-framework"
+        exports:
+          ANSIBLE_LOG_PATH: "~/ansible-deploy-edpm.log"
+        default_extravars:
+          - "@scenarios/centos-9/base.yml"
+          - "@scenarios/centos-9/edpm_ci.yml"
+          - "cifmw_openshift_password='{{ cifmw_openshift_password }}'"
+        extravars: "{{ cifmw_reproducer_play_extravars }}"
+        playbook: "deploy-edpm.yml"
+      ansible.builtin.template:
         dest: "/home/zuul/deploy-edpm.sh"
+        src: "script.sh.j2"
         mode: "0755"
         owner: "zuul"
         group: "zuul"
-        content: |-
-          #!/bin/bash
-          set -e
-          pushd src/github.com/openstack-k8s-operators/ci-framework
-          export ANSIBLE_LOG_PATH="~/ansible-deploy-edpm.log"
-          ansible-playbook deploy-edpm.yml \
-            -e @scenarios/centos-9/base.yml \
-            -e @scenarios/centos-9/edpm_ci.yml \
-            -e cifmw_openshift_password="{{ cifmw_openshift_password }}" \
-            --flush-cache $@
-          popd

--- a/roles/reproducer/templates/script.sh.j2
+++ b/roles/reproducer/templates/script.sh.j2
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+pushd {{ run_directory}}
+{% for export in exports | dict2items %}
+export {{ export.key }}="{{ export.value }}"
+{% endfor %}
+
+ansible-playbook -i ~/ci-framework-data/artifacts/zuul_inventory.yml \
+{% for extravar in default_extravars %}
+  -e {{ extravar }} \
+{% endfor %}
+{% for extravar in extravars %}
+  -e {{ extravar }} \
+{% endfor %}
+  {{ playbook }} --flush-cache $@
+popd


### PR DESCRIPTION
It may happen we want to inject extra ansible variables in the nested
calls to ansible-playbook.

The new `cifmw_reproducer_play_extravars` parameter allows to list any
"extra-vars" you want.

By leveraging it, you can for instance inject a crafted scenario file
listing a series of hooks directly in the application deployment.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
