### PR TITLE
[Test operator] Fix skiplist generation

### DIFF
--- a/roles/test_operator/tasks/tempest-tests.yml
+++ b/roles/test_operator/tasks/tempest-tests.yml
@@ -34,7 +34,13 @@
 
     - name: Set variable
       ansible.builtin.set_fact:
-        cifmw_test_operator_tempest_include_list: "{{ list_allowed.allowed_tests | join('\n') }}"
+        test_operator_cr: >-
+          {{
+              test_operator_cr |
+              combine({'spec': {'tempestRun': { 'includeList':
+                      list_allowed.allowed_tests | join('\n')
+                      }}}, recursive=true)
+          }}
 
 - name: Configuring tests to be skipped via skiplist
   when: >
@@ -55,7 +61,13 @@
 
     - name: Set variable
       ansible.builtin.set_fact:
-        cifmw_test_operator_tempest_exclude_list: "{{ list_skipped.skipped_tests | join('\n') }}"
+        test_operator_cr: >-
+          {{
+              test_operator_cr |
+              combine({'spec': {'tempestRun': { 'excludeList':
+                      list_skipped.skipped_tests | join('\n')
+                      }}}, recursive=true)
+          }}
 
 - name: Ensure a secret for the cifmw private key file exists
   when:


### PR DESCRIPTION
The test_operator_cr is a copy of the cifmw_test_operator_tempest_config therefore it does not contain a reference to the cifmw_test_operator_exclude_list variable.

Because of that, we have to specify the value for excludeList directly in the test_operator_cr.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
