### PR TITLE
[install_yamls] Skip setting operators_repo var for repos not in openstack-k8s-operators org

### DIFF
--- a/roles/install_yamls/molecule/default/converge.yml
+++ b/roles/install_yamls/molecule/default/converge.yml
@@ -26,13 +26,20 @@
       items:
         - project:
             short_name: ci-framework
+            name: openstack-k8s-operators/ci-framework
             src_dir: src/github.com/openstack-k8s-operators/ci-framework
         - project:
             short_name: dataplane-operator
+            name: openstack-k8s-operators/dataplane-operator
             src_dir: src/github.com/openstack-k8s-operators/dataplane-operator
         - project:
             short_name: openstack-baremetal-operator
+            name: openstack-k8s-operators/openstack-baremetal-operator
             src_dir: src/github.com/openstack-k8s-operators/openstack-baremetal-operator
+        - project:
+            short_name: service-telemetry-operator
+            name: infrawatch/service-telemetry-operator
+            src_dir: src/github.com/infrawatch/service-telemetry-operator
   roles:
     - role: "install_yamls"
 

--- a/roles/install_yamls/tasks/zuul_set_operators_repo.yml
+++ b/roles/install_yamls/tasks/zuul_set_operators_repo.yml
@@ -22,6 +22,7 @@
   when:
     - zuul is defined
     - "'operator' in zuul_item.project.short_name"
+    - "'openstack-k8s-operators' in zuul_item.project.name"
   vars:
     _repo_operator_name: "{{ zuul_item.project.short_name | regex_search('(?:openstack-)?(.*)-operator', '\\1') | first }}"
     _repo_operator_info:


### PR DESCRIPTION
https://logserver.rdoproject.org/85/585/6d95d205438e4a2a78f43f4606ae2efd0a29c678/github-check/stf-crc-ocp_414-local_build-index_deploy/a646dd6/controller/ci-framework-data/logs/ansible.log-2024-04-04-10:47 2024-04-04 10:47:09,970 p=28890 u=zuul n=ansible | TASK [install_yamls : Get environment structure base_path={{ cifmw_install_yamls_repo }}] ***
2024-04-04 10:47:09,970 p=28890 u=zuul n=ansible | Thursday 04 April 2024  10:47:09 -0400 (0:00:00.036)       0:00:56.974 ********
2024-04-04 10:47:10,143 p=28890 u=zuul n=ansible | fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "/bin/sh: line 1: SERVICE-TELEMETRY_REPO=/home/zuul/src/github.com/infrawatch/service-telemetry-operator: No such file or directory\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 127}

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
