### PR TITLE
Support cifmw_ceph_client_cluster overrides

### DIFF
--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -398,6 +398,7 @@
     cifmw_ceph_client_fetch_dir: /tmp
     cifmw_ceph_client_k8s_secret_name: ceph-conf-files
     cifmw_ceph_client_k8s_namespace: openstack
+    cifmw_ceph_client_cluster: "{{ cifmw_cephadm_cluster | default('ceph') }}"
   pre_tasks:
     # end_play will end this current playbook and go the the next
     # imported play.

--- a/roles/cifmw_ceph_client/templates/k8s_ceph_secret.yml.j2
+++ b/roles/cifmw_ceph_client/templates/k8s_ceph_secret.yml.j2
@@ -1,8 +1,8 @@
 ---
 apiVersion: v1
 data:
-  ceph.client.openstack.keyring: {{ cifmw_ceph_client_key_file_b64.content }}
-  ceph.conf: {{ cifmw_ceph_client_conf_file_b64.content }}
+  {{ cifmw_ceph_client_cluster | default('ceph') }}.client.openstack.keyring: {{ cifmw_ceph_client_key_file_b64.content }}
+  {{ cifmw_ceph_client_cluster | default('ceph') }}.conf: {{ cifmw_ceph_client_conf_file_b64.content }}
 kind: Secret
 metadata:
   name: {{ cifmw_ceph_client_k8s_secret_name }}


### PR DESCRIPTION
If a user overrides `cifmw_cephadm_cluster`, then the Ceph cluster name is something other than the default of "ceph" and the keyring and conf files are named from the override. However, without this patch the `cifmw_ceph_client` role does not respect this override. Update the role and the call to it from the Ceph playbook so that files consumed by Ceph clients get a name consistent with the server. This feature is useful for deployments with more than one Ceph server.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
