### PR TITLE
Ensure we have an undying virtualbmc

### DIFF
--- a/roles/virtualbmc/tasks/cleanup.yml
+++ b/roles/virtualbmc/tasks/cleanup.yml
@@ -54,3 +54,4 @@
     - "{{ cifmw_virtualbmc_sshkey_path }}"
     - "{{ cifmw_virtualbmc_sshkey_path }}.pub"
     - "{{ dest_dir }}/virtualbmc.conf"
+    - "{{ dest_dir }}/vbmcd.sh"

--- a/roles/virtualbmc/tasks/main.yml
+++ b/roles/virtualbmc/tasks/main.yml
@@ -37,6 +37,8 @@
 - name: Run tasks only if container does not exist
   when:
     - _vbmc_container_info.containers | length == 0
+  vars:
+    dest_dir: "{{ cifmw_virtualbmc_sshkey_path | dirname }}"
   block:
     - name: Create ssh key for VBMC
       register: _vbmc_key
@@ -58,8 +60,6 @@
         state: present
 
     - name: Create vbmc server configuration file
-      vars:
-        dest_dir: "{{ cifmw_virtualbmc_sshkey_path | dirname }}"
       ansible.builtin.copy:
         dest: "{{ dest_dir }}/virtualbmc.conf"
         content: |
@@ -67,14 +67,28 @@
           server_port={{ cifmw_virtualbmc_daemon_port }}
         mode: "0644"
 
-    - name: Create and start vbmc container
-      vars:
-        dest_dir: "{{ cifmw_virtualbmc_sshkey_path | dirname }}"
-      containers.podman.podman_container:
-        image: "{{ cifmw_virtualbmc_image }}"
-        name: "{{ cifmw_virtualbmc_container_name }}"
-        network: host
-        state: started
-        volumes:
-          - "{{ cifmw_virtualbmc_sshkey_path }}:{{ cifmw_virtualbmc_ipmi_key_path }}:ro,Z"
-          - "{{ dest_dir }}/virtualbmc.conf:/etc/virtualbmc/virtualbmc.conf:ro,Z"
+    - name: Create undying vbmcd service script
+      ansible.builtin.copy:
+        dest: "{{ dest_dir }}/vbmcd.sh"
+        content: |-
+          #!/bin/sh
+          while true; do
+            /usr/local/bin/vbmcd --foreground;
+            echo "Dying... restarting vbmcd"
+            sleep 1;
+          done
+        mode: "0755"
+
+- name: Create and start vbmc container
+  vars:
+    dest_dir: "{{ cifmw_virtualbmc_sshkey_path | dirname }}"
+  containers.podman.podman_container:
+    image: "{{ cifmw_virtualbmc_image }}"
+    name: "{{ cifmw_virtualbmc_container_name }}"
+    network: host
+    state: started
+    command: "/vbmcd.sh"
+    volumes:
+      - "{{ cifmw_virtualbmc_sshkey_path }}:{{ cifmw_virtualbmc_ipmi_key_path }}:ro,Z"
+      - "{{ dest_dir }}/virtualbmc.conf:/etc/virtualbmc/virtualbmc.conf:ro,Z"
+      - "{{ dest_dir }}/vbmcd.sh:/vbmcd.sh:ro,Z"


### PR DESCRIPTION
It seems vbmcd process dies on its own without much log after a period
of time.
Overriding the CMD of the container with an infinite loop corrects the
issue for the time being, and would allow to access the container for
debugging in case of a crash.

The container logs as shown by `podman logs <container>` don't help,
since we just learn that vbmcd "stopped", without error. We may be able
to find something in the container itself, if vbmcd is writing logs on
its own.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
