### PR TITLE
Ensure we create CRC and OCP first

### DIFF
--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -199,7 +199,11 @@
     _init_admin_user: "{{ vm_data.value.admin_user | default('root') }}"
   ansible.builtin.include_tasks:
     file: create_vms.yml
-  loop: "{{ _layout.vms | dict2items }}"
+  loop: >-
+    {{
+      _layout.vms | dictsort(reverse=true) |
+      community.general.dict | dict2items
+    }}
   loop_control:
     label: "{{ vm_data.key }}"
     loop_var: vm_data

--- a/scenarios/reproducers/3-nodes.yml
+++ b/scenarios/reproducers/3-nodes.yml
@@ -24,6 +24,16 @@ cifmw_root_partition_id: >-
 cifmw_libvirt_manager_compute_amount: 1
 cifmw_libvirt_manager_configuration:
   vms:
+    crc:
+      admin_user: core
+      image_local_dir: "{{ ansible_user_dir }}/.crc/machines/crc/"
+      disk_file_name: "crc.qcow2"
+      disksize: 150
+      memory: 32
+      cpus: 24
+      nets:
+        - public
+        - osp_trunk
     compute:
       uefi: "{{ cifmw_use_uefi }}"
       amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 1] | max }}"
@@ -48,16 +58,6 @@ cifmw_libvirt_manager_configuration:
       disksize: 50
       memory: 8
       cpus: 4
-      nets:
-        - public
-        - osp_trunk
-    crc:
-      admin_user: core
-      image_local_dir: "{{ ansible_user_dir }}/.crc/machines/crc/"
-      disk_file_name: "crc.qcow2"
-      disksize: 150
-      memory: 32
-      cpus: 24
       nets:
         - public
         - osp_trunk

--- a/scenarios/reproducers/external-ceph.yml
+++ b/scenarios/reproducers/external-ceph.yml
@@ -14,6 +14,18 @@ cifmw_libvirt_manager_configuration:
         </ip>
       </network>
   vms:
+    ocp:
+      amount: 3
+      admin_user: core
+      image_local_dir: "/home/dev-scripts/pool"
+      disk_file_name: "ocp_master"
+      disksize: "105"
+      xml_paths:
+        - /home/dev-scripts/ocp_master_0.xml
+        - /home/dev-scripts/ocp_master_1.xml
+        - /home/dev-scripts/ocp_master_2.xml
+      nets:
+        - osp_trunk
     compute:
       uefi: "{{ cifmw_use_uefi | default(false) }}"
       root_part_id: >-
@@ -66,16 +78,4 @@ cifmw_libvirt_manager_configuration:
       cpus: 4
       nets:
         - ocpbm
-        - osp_trunk
-    ocp:
-      amount: 3
-      admin_user: core
-      image_local_dir: "/home/dev-scripts/pool"
-      disk_file_name: "ocp_master"
-      disksize: "105"
-      xml_paths:
-        - /home/dev-scripts/ocp_master_0.xml
-        - /home/dev-scripts/ocp_master_1.xml
-        - /home/dev-scripts/ocp_master_2.xml
-      nets:
         - osp_trunk

--- a/scenarios/reproducers/va-hci.yml
+++ b/scenarios/reproducers/va-hci.yml
@@ -92,6 +92,18 @@ cifmw_libvirt_manager_configuration:
         </ip>
       </network>
   vms:
+    ocp:
+      amount: 3
+      admin_user: core
+      image_local_dir: "/home/dev-scripts/pool"
+      disk_file_name: "ocp_master"
+      disksize: "105"
+      xml_paths:
+        - /home/dev-scripts/ocp_master_0.xml
+        - /home/dev-scripts/ocp_master_1.xml
+        - /home/dev-scripts/ocp_master_2.xml
+      nets:
+        - osp_trunk
     compute:
       uefi: "{{ cifmw_use_uefi }}"
       root_part_id: "{{ cifmw_root_partition_id }}"
@@ -118,18 +130,6 @@ cifmw_libvirt_manager_configuration:
       cpus: 4
       nets:
         - ocpbm
-        - osp_trunk
-    ocp:
-      amount: 3
-      admin_user: core
-      image_local_dir: "/home/dev-scripts/pool"
-      disk_file_name: "ocp_master"
-      disksize: "105"
-      xml_paths:
-        - /home/dev-scripts/ocp_master_0.xml
-        - /home/dev-scripts/ocp_master_1.xml
-        - /home/dev-scripts/ocp_master_2.xml
-      nets:
         - osp_trunk
 
 


### PR DESCRIPTION
By sorting the libvirt_manager.vms content using dictsort, we have a way
to more or less ensure "crc" and "ocp" will be first.

Doing so, we give some more time to the OpenShift services to start
before hitting them - meaning we'll see less `retries` in the logs,
since we launched computes and controller.

This should allow to "lose less time".

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
