### PR TITLE
Move again NFS server after EDPM deploy

### DIFF
--- a/playbooks/06-deploy-edpm.yml
+++ b/playbooks/06-deploy-edpm.yml
@@ -1,7 +1,4 @@
 ---
-- name: Deploy NFS server on target nodes
-  ansible.builtin.import_playbook: "nfs.yml"
-
 - name: Run pre_deploy hooks
   when:
     - cifmw_architecture_scenario is not defined
@@ -95,6 +92,9 @@
         - name: Deploy EDPM
           ansible.builtin.import_role:
             name: edpm_deploy
+
+- name: Deploy NFS server on target nodes
+  ansible.builtin.import_playbook: "nfs.yml"
 
 - name: Clear ceph target hosts facts to force refreshing in HCI deployments
   hosts: "{{ cifmw_ceph_target | default('computes')  }}"


### PR DESCRIPTION
Otherwise the target EDPM node has no full networking setup, which means the choosen VLAN where to expose

This means that any usage of NFS should be moved to the post_deploy phase, possibly reconfiguring an existing control plane.

This mirror the similar mechanism used to configure and use Ceph on EDPM nodes.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] Content of the docs/source is reflecting the changes
