### PR TITLE
Include install-certs dataplane service

### DIFF
--- a/roles/hci_prepare/tasks/phase2.yml
+++ b/roles/hci_prepare/tasks/phase2.yml
@@ -104,6 +104,7 @@
               - configure-os
               - run-os
               - reboot-os
+              - install-certs
               - ceph-client
               - ovn
               - neutron-metadata

--- a/roles/hci_prepare/templates/dpservice-nova-custom-ceph.yml.j2
+++ b/roles/hci_prepare/templates/dpservice-nova-custom-ceph.yml.j2
@@ -12,3 +12,11 @@ spec:
     - nova-cell1-compute-config
     - nova-migration-ssh-key
   playbook: osp.edpm.nova
+  tlsCert:
+    contents:
+    - dnsnames
+    - ips
+    networks:
+    - ctlplane
+    issuer: osp-rootca-issuer-internal
+  caCerts: combined-ca-bundle


### PR DESCRIPTION
It's required with tls enabled, [1] already enabled tls by default so need to include the install-certs service before the services requiring the certs.
The issue should be visible once dataplane-operator is updated[2] or tlsEnabled flag is explicitly set in the nodeset.

Also update nova-custom-ceph dataplane service to
include missing tls params.

[1] openstack-k8s-operators/dataplane-operator#754
[2] openstack-k8s-operators/openstack-operator#732

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
