### PR TITLE
Explicitly deploy MDS from a template spec

### DIFF
--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -65,6 +65,7 @@ cifmw_cephadm_extra_args: ""
 cifmw_cephadm_pacific_filter: "16.*"
 # The path of the rendered rgw spec file
 cifmw_ceph_rgw_spec_path: /tmp/ceph_rgw.yml
+cifmw_ceph_mds_spec_path: /tmp/ceph_mds.yml
 cifmw_ceph_rgw_keystone_ep: "keystone-internal.openstack.svc:5000"
 cifmw_ceph_rgw_keystone_psw: 12345678
 cifmw_ceph_rgw_keystone_user: "swift"

--- a/roles/cifmw_cephadm/tasks/cephfs.yml
+++ b/roles/cifmw_cephadm/tasks/cephfs.yml
@@ -14,11 +14,21 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Use ansible_fqdn when ceph_spec_fqdn parameter is true
+  when: cifmw_cephadm_ceph_spec_fqdn
+  ansible.builtin.set_fact:
+    ceph_hostname_var: 'ansible_fqdn'
+
+- name: Use ansible_hostname when ceph_spec_fqdn parameter is false
+  when: not cifmw_cephadm_ceph_spec_fqdn
+  ansible.builtin.set_fact:
+    ceph_hostname_var: 'ansible_hostname'
+
 - name: Build placement string
   block:
     - name: Collect the host and build the resulting host list
       ansible.builtin.set_fact:
-        _hosts: "{{ _hosts|default([]) + [ hostvars[item]['ansible_hostname'] ] }}"
+        _hosts: "{{ _hosts|default([]) + [ hostvars[item][ceph_hostname_var] ] }}"
       with_items: "{{ groups[cifmw_ceph_target | default('computes')] | default([]) }}"
 
     - name: Collect the target hosts
@@ -29,10 +39,27 @@
 - name: Get ceph_cli
   ansible.builtin.include_tasks: ceph_cli.yml
 
+- name: Create a Ceph MDS spec
+  ansible.builtin.template:
+    src: templates/ceph_mds.yml.j2
+    dest: "{{ cifmw_ceph_mds_spec_path }}"
+    mode: '0644'
+    force: true
+
+- name: Get ceph_cli
+  ansible.builtin.include_tasks: ceph_cli.yml
+  vars:
+    mount_spec: true
+    cifmw_cephadm_spec: "{{ cifmw_ceph_mds_spec_path }}"
+
 - name: Apply cephfs volume
   ansible.builtin.command: |
     {{ cifmw_cephadm_ceph_cli }} fs volume create {{ cifmw_cephadm_cephfs_name }} '--placement={{ placement }}'
   changed_when: false
+  become: true
+
+- name: Apply the MDS spec
+  ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} orch apply --in-file {{ cifmw_cephadm_container_spec }}"
   become: true
 
 # waiting for https://github.com/ceph/ceph/pull/53108

--- a/roles/cifmw_cephadm/templates/ceph_mds.yml.j2
+++ b/roles/cifmw_cephadm/templates/ceph_mds.yml.j2
@@ -1,0 +1,9 @@
+---
+service_type: mds
+service_id: cephfs
+service_name: mds.cephfs
+placement:
+  hosts:
+{% for host in _hosts %}
+  - {{ host }}
+{% endfor %}


### PR DESCRIPTION
This patch is supposed to solve the problem with a single node `Ceph` cluster where despite `ceph fs create ..` is called, we're unable to get a `MDS` deployed, which put the cluster in an `unhealhy` state.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
- [x] README in the role
- [x] Content of the docs/source is reflecting the changes
