### PR TITLE
Revert "Make cifmw_test_operator_*_config modifiable"

### DIFF
--- a/roles/test_operator/tasks/main.yml
+++ b/roles/test_operator/tasks/main.yml
@@ -27,6 +27,14 @@
     run_tempest: "{{ cifmw_run_tempest | default('true') | bool }}"
     run_tobiko: "{{ cifmw_run_tobiko | default('false') | bool }}"
 
+- name: Setup tempest tests
+  ansible.builtin.include_tasks: tempest-tests.yml
+  when: run_tempest
+
+- name: Setup tobiko tests
+  ansible.builtin.include_tasks: tobiko-tests.yml
+  when: run_tobiko
+
 - name: Ensure OperatorGroup for the test-operator is present
   kubernetes.core.k8s:
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"

--- a/roles/test_operator/tasks/run-test-operator-job.yml
+++ b/roles/test_operator/tasks/run-test-operator-job.yml
@@ -29,7 +29,7 @@
     context: "{{ cifmw_openshift_context | default(omit)}}"
     state: present
     wait: true
-    definition: "{{ test_operator_cr }}"
+    definition: "{{ test_operator_config }}"
   when: not cifmw_test_operator_dry_run | bool
 
 - name: Wait for the last job to be Completed - {{ run_test_fw }}

--- a/roles/test_operator/tasks/tempest-tests.yml
+++ b/roles/test_operator/tasks/tempest-tests.yml
@@ -77,14 +77,14 @@
       data:
         ssh-privatekey: "{{ lookup('file', '~/.ssh/id_cifw', rstrip=False) | b64encode }}"
 
-- name: Add SSHKeySecretName section to Tempest CR
+- name: Add SSHKeySecretName section to tobiko CR
   when:
     - not cifmw_test_operator_dry_run | bool
     - cifmw_test_operator_tempest_ssh_key_secret_name is not defined
   ansible.builtin.set_fact:
-    test_operator_cr: >-
+    cifmw_test_operator_tempest_config: >-
       {{
-          test_operator_cr |
+          cifmw_test_operator_tempest_config |
           combine({'spec': {'SSHKeySecretName':
                     cifmw_test_operator_controller_priv_key_secret_name
                   }}, recursive=true)
@@ -98,9 +98,9 @@
     controller_ip: >-
       {{ cifmw_test_operator_controller_ip | default(ansible_default_ipv4.address) | default('') }}
   ansible.builtin.set_fact:
-    test_operator_cr: >-
+    cifmw_test_operator_tempest_config: >-
       {{
-          test_operator_cr |
+          cifmw_test_operator_tempest_config |
           combine({'spec': {'tempestconfRun': {'overrides':
                     (test_operator_cr.spec.tempestconfRun.overrides | default('')) + ' ' +
                     'whitebox_neutron_plugin_options.proxy_host_address ' + controller_ip

--- a/roles/test_operator/tasks/tobiko-tests.yml
+++ b/roles/test_operator/tasks/tobiko-tests.yml
@@ -28,9 +28,9 @@
 
 - name: Add config section to tobiko CR
   ansible.builtin.set_fact:
-    test_operator_cr: >-
+    cifmw_test_operator_tobiko_config: >-
       {{
-          test_operator_cr |
+          cifmw_test_operator_tobiko_config |
           combine({'spec': {'config':
                              lookup('file',
                                     cifmw_test_operator_artifacts_basedir + '/tobiko.conf')
@@ -56,9 +56,9 @@
         keyname: "{{ item }}Key"
         keyfilename: "id_{{ cifmw_test_operator_tobiko_ssh_keytype }}{{ '.pub' if item == 'public' else '' }}"
       ansible.builtin.set_fact:
-        test_operator_cr: >-
+        cifmw_test_operator_tobiko_config: >-
           {{
-              test_operator_cr |
+              cifmw_test_operator_tobiko_config |
               combine({'spec': {keyname:
                                 lookup('file',
                                        cifmw_test_operator_artifacts_basedir + '/' + keyfilename)
@@ -70,9 +70,9 @@
 
 - name: Add preventCreate if it is defined
   ansible.builtin.set_fact:
-    test_operator_cr: >-
+    cifmw_test_operator_tobiko_config: >-
       {{
-          test_operator_cr |
+          cifmw_test_operator_tobiko_config |
           combine({'spec': {'preventCreate': cifmw_test_operator_tobiko_prevent_create | bool}},
                   recursive=true)
       }}
@@ -80,9 +80,9 @@
 
 - name: Add numProcesses if it is defined
   ansible.builtin.set_fact:
-    test_operator_cr: >-
+    cifmw_test_operator_tobiko_config: >-
       {{
-          test_operator_cr |
+          cifmw_test_operator_tobiko_config |
           combine({'spec': {'numProcesses': cifmw_test_operator_tobiko_num_processes | int}},
                   recursive=true)
       }}


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
