### PR TITLE
Enable SwiftSystemReader option for RGW

### DIFF
--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -75,6 +75,7 @@ cifmw_ceph_rgw_config:
   rgw_keystone_api_version: 3
   rgw_keystone_accepted_roles: "\"member, Member, admin\""
   rgw_keystone_accepted_admin_roles: "\"ResellerAdmin, swiftoperator\""
+  rgw_keystone_accepted_reader_roles: "SwiftSystemReader"
   rgw_keystone_admin_domain: default
   rgw_keystone_admin_project: service
   rgw_keystone_admin_user: "{{ cifmw_ceph_rgw_keystone_user }}"


### PR DESCRIPTION
SRBAC is enforced by default in the ctlplane. If RGW is enabled, we should have this option to match the OSP configuration.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
- [x] README in the role
- [x] Content of the docs/source is reflecting the changes

Jira:  [OSPRH-6199](https://issues.redhat.com/browse/OSPRH-6199)
