### PR TITLE
[openshift_obs] Add support for deploying observability operator

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -58,3 +58,6 @@
 - job:
     name: cifmw-molecule-networking_mapper
     nodeset: 4x-centos-9-medium
+- job:
+    name: cifmw-molecule-openshift_obs
+    nodeset: centos-9-crc-2-30-0-xxl

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -319,6 +319,7 @@ nvme
 nwy
 nzgdh
 oauth
+observability
 oc
 ocp
 ocpbm

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -57,6 +57,7 @@ are shared among multiple roles:
 - `cifmw_nfs_shares`: (List) List of the shares that will be setup in the nfs server.  Only has an effect if `cifmw_edpm_deploy_nfs` is set to `true`.
 - `cifmw_fips_enabled`: (Bool) Specifies whether FIPS should be enabled in the deployment. Note that not all deployment methods support this functionality. Defaults to `false`.
 - `cifmw_baremetal_hosts`: (Dict) Baremetal nodes environment details. More details [here](../baremetal/01_baremetal_hosts_data.md)
+- `cifmw_deploy_obs` (Bool) Specifies whether to deploy Cluster Observability operator.
 
 ```{admonition} Words of caution
 :class: danger

--- a/playbooks/02-infra.yml
+++ b/playbooks/02-infra.yml
@@ -65,6 +65,13 @@
       ansible.builtin.import_role:
         name: openshift_setup
 
+    - name: Deploy Observability operator.
+      when:
+        - cifmw_deploy_obs is defined
+        - cifmw_deploy_obs | bool
+      ansible.builtin.include_role:
+        name: openshift_obs
+
     - name: Deploy Metal3 BMHs
       when:
         - cifmw_config_bmh is defined

--- a/roles/openshift_obs/README.md
+++ b/roles/openshift_obs/README.md
@@ -1,0 +1,15 @@
+# openshift_obs
+
+The purpose of this role is to deploy the cluster observability operator.
+
+## Privilege escalation
+
+No, privilege escalation is required for using the role. However,
+`cluster-admin` privileges is required for deploying the operator.
+
+## Parameters
+
+Requires `cifmw_openshift_kubeconfig` variable to point to right configuration.
+
+`cifmw_openshift_obs_definition` (dict) The `Subscription` resource definition to
+be used to install the Cluster Observability Operator.

--- a/roles/openshift_obs/defaults/main.yml
+++ b/roles/openshift_obs/defaults/main.yml
@@ -1,0 +1,31 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+cifmw_openshift_obs_definition:
+  apiVersion: operators.coreos.com/v1alpha1
+  kind: Subscription
+  metadata:
+    name: observability-operator
+    namespace: openshift-operators
+    labels:
+      operators.coreos.com/observability-operator.openshift-operators: ""
+  spec:
+    channel: development
+    installPlanApproval: Automatic
+    name: cluster-observability-operator
+    source: redhat-operators
+    sourceNamespace: openshift-marketplace

--- a/roles/openshift_obs/meta/main.yml
+++ b/roles/openshift_obs/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- openshift_obs
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: cifmw
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - cifmw
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/openshift_obs/molecule/default/converge.yml
+++ b/roles/openshift_obs/molecule/default/converge.yml
@@ -1,0 +1,63 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+
+  vars:
+    cifmw_path: >-
+      {{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{
+      ansible_user_dir }}/bin:{{ ansible_env.PATH }}
+    cifmw_openshift_kubeconfig: >-
+      {{
+        (ansible_user_dir, '.crc/machines/crc/kubeconfig') |
+        ansible.builtin.path_join
+      }}
+
+  tasks:
+    - name: Add crc hostname with it's IP to /etc/hosts
+      become: true
+      ansible.builtin.lineinfile:
+        path: /etc/hosts
+        line: "192.168.130.11 crc"
+
+    - name: Add the crc host dynamically
+      ansible.builtin.add_host:
+        name: crc
+        ansible_ssh_private_key_file: "{{ ansible_user_dir }}/.crc/machines/crc/id_ecdsa"
+        ansible_ssh_user: core
+
+    - name: Deploy Cluster observability Operator
+      ansible.builtin.include_role:
+        name: openshift_obs
+
+    - name: Gather information about observability operator.
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        kind: Operator
+        namespace: openshift-operators
+        name: observability-operator.openshift-operators
+      register: _obs
+
+    - name: For debugging purpose, print the information
+      ansible.builtin.debug:
+        var: _obs
+
+    - name: Ensure the operator was deployed
+      ansible.builtin.assert:
+        that:
+          - _obs.resources | length > 0

--- a/roles/openshift_obs/molecule/default/molecule.yml
+++ b/roles/openshift_obs/molecule/default/molecule.yml
@@ -1,0 +1,9 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true

--- a/roles/openshift_obs/molecule/default/prepare.yml
+++ b/roles/openshift_obs/molecule/default/prepare.yml
@@ -1,0 +1,26 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps
+
+  tasks:
+    - name: Ensure CRC is started
+      ansible.builtin.command:
+        cmd: crc start

--- a/roles/openshift_obs/tasks/cleanup.yml
+++ b/roles/openshift_obs/tasks/cleanup.yml
@@ -1,0 +1,29 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Uninstall the operator
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    kind: "{{ item }}"
+    namespace: openshift-operators
+    label_selectors:
+      - operators.coreos.com/cluster-observability-operator.openshift-operators = ''
+    state: absent
+  loop:
+    - ClusterServiceVersion
+    - installplan
+    - subscription

--- a/roles/openshift_obs/tasks/main.yml
+++ b/roles/openshift_obs/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Install cluster observability operator.
+  kubernetes.core.k8s:
+    definition: "{{cifmw_openshift_obs_definition }}"
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    state: present
+
+- name: Wait for observability-operator pod
+  kubernetes.core.k8s_info:
+    kind: Pod
+    namespace: openshift-operators
+    label_selectors:
+      - app.kubernetes.io/name = observability-operator
+    wait: true
+    wait_timeout: 300
+    wait_condition:
+      type: Ready
+      status: "True"
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+
+- name: Wait for observability operator deployment
+  kubernetes.core.k8s_info:
+    kind: Deployment
+    namespace: openshift-operators
+    name: observability-operator
+    wait: true
+    wait_timeout: 300
+    wait_condition:
+      type: Available
+      status: "True"
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -463,6 +463,18 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/openshift_obs/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-openshift_obs
+    nodeset: centos-9-crc-2-30-0-xxl
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: openshift_obs
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/openshift_provisioner_node/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -49,6 +49,7 @@
       - cifmw-molecule-manage_secrets
       - cifmw-molecule-networking_mapper
       - cifmw-molecule-openshift_login
+      - cifmw-molecule-openshift_obs
       - cifmw-molecule-openshift_provisioner_node
       - cifmw-molecule-openshift_setup
       - cifmw-molecule-operator_build


### PR DESCRIPTION
Cluster Observability Operator is required for OpenStack Telemetry. This change set adds support for installing and configuring the observability operator. The default configuration is used as the Telemetry operator does not required any specific configuration.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
