### PR TITLE
Always Enable file logging for a Ceph cluster

### DIFF
--- a/roles/cifmw_cephadm/tasks/cephadm_config_set.yml
+++ b/roles/cifmw_cephadm/tasks/cephadm_config_set.yml
@@ -19,6 +19,20 @@
     - cifmw_cephadm_ceph_cli is not defined
   ansible.builtin.include_tasks: ceph_cli.yml
 
+- name: Setup Ceph cluster log to file
+  become: true
+  ansible.builtin.command:
+    cmd: |-
+      {{ cifmw_cephadm_ceph_cli }} config set global log_to_file true
+  changed_when: false
+
+- name: Setup Ceph cluster mon log to file
+  become: true
+  ansible.builtin.command:
+    cmd: |-
+      {{ cifmw_cephadm_ceph_cli }} config set global mon_cluster_log_to_file true
+  changed_when: false
+
 - name: Set cephadm debug level
   become: true
   when:


### PR DESCRIPTION
There are many scenarios where inspecting the Ceph logs is useful. This patch enables file logging for all the daemons deployed by cephadm.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
- [x] README in the role
- [x] Content of the docs/source is reflecting the changes
