### PR TITLE
[openshift_adm] Replace removed `openssl_certificate_info`

### DIFF
--- a/roles/openshift_adm/tasks/api_cert.yml
+++ b/roles/openshift_adm/tasks/api_cert.yml
@@ -69,7 +69,7 @@
     mode: "0440"
 
 - name: Read the certificate details.
-  community.crypto.openssl_certificate_info:
+  community.crypto.x509_certificate_info:
     path: "/tmp/gen_api.crt"
   register: _gen_api_cert
 


### PR DESCRIPTION
In version 2.0.0 of `community.crypto` collection, the `openssl_certificate_info` has been replaced with
`x509_certificate_info` module which caused this error during `openshift_adm` role invocation

```bash
TASK [openshift_adm : Regenerate the API certificates. _raw_params=api_cert.yml] **************************************************************************************************************************************************************
lunedì 08 aprile 2024  10:49:40 +0200 (0:00:00.554)       0:48:20.821 *********
fatal: [hypervisor-1]: FAILED! => {"reason": "[DEPRECATED]: community.crypto.openssl_certificate_info has been removed. The 'community.crypto.openssl_certificate_info' module has been renamed to 'community.crypto.x509_certificate_info'. This feature was removed from community.crypto in version 2.0.0. Please update your playbooks."}
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
