### PR TITLE
[libvirt_manager] Remove filter on list vms task

### DIFF
--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -217,7 +217,6 @@
 - name: List running virtual machines.
   community.libvirt.virt:
     command: list_vms
-    state: running
     uri: "qemu:///system"
   register: _vms
 


### PR DESCRIPTION
When using the libvirt_manager role to create `blank` vms with no image, in a shutoff state the filter this patch removes prevents the code following it from executing as the list returns no results leading to the `libvirt-uuids.yml` file not being generated for example.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
