### PR TITLE
[test-operator] Fix k8s_info metadata parsing

### DIFF
--- a/roles/test_operator/tasks/main.yml
+++ b/roles/test_operator/tasks/main.yml
@@ -95,7 +95,7 @@
   retries: 20
   until: >-
     {{
-      csv_list |
+      csv_list.resources |
       map(attribute='metadata.name') |
       select('match', 'test-operator')
     }}
@@ -105,7 +105,7 @@
   ansible.builtin.set_fact:
     test_operator_csv_name: >-
       {{
-        csv_list |
+        csv_list.resources |
         map(attribute='metadata.name') |
         select('match', 'test-operator') | first
       }}

--- a/roles/test_operator/tasks/run-test-operator-job.yml
+++ b/roles/test_operator/tasks/run-test-operator-job.yml
@@ -142,7 +142,7 @@
   ansible.builtin.set_fact:
     pod_status: >-
       {{
-        test_pod_results |
+        test_pod_results.resources |
         map(attribute='status.phase') |
         list | unique
       }}


### PR DESCRIPTION
This PR introduced a bug [1] when replacing the json_query call with map call. The PR omits the fact that the variable csv_list contains the requested data (name) in the resources field.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/1313

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
