### PR TITLE
Allow to override libvirt_manager_configuration

### DIFF
--- a/roles/devscripts/README.md
+++ b/roles/devscripts/README.md
@@ -45,6 +45,8 @@ networks.
 * `cifmw_devscripts_external_net` (dict) Key/value pair containing information
   about the network infrastructure.
   Refer [section](#supported-keys-in-cifmw_devscripts_external_net).
+* `cifmw_libvirt_manager_configuration_overrides` (dict) key/value pairs to be
+  used to override cifmw_libvirt_manager_configuration.
 
 ### Secrets management
 

--- a/roles/devscripts/tasks/320_prepare_layout.yml
+++ b/roles/devscripts/tasks/320_prepare_layout.yml
@@ -22,6 +22,17 @@
     recurse: false
   register: _ctrl_vm_xml
 
+- name: Override libvirt manager configuration
+  when:
+    - cifmw_libvirt_manager_configuration_overrides is defined
+  ansible.builtin.set_fact:
+    cifmw_libvirt_manager_configuration_gen: >-
+      {{
+        cifmw_libvirt_manager_configuration_gen |
+        default(cifmw_libvirt_manager_configuration) |
+        combine(cifmw_libvirt_manager_configuration_overrides, recursive=True)
+      }}
+
 - name: Align the OCP type information.
   when:
     - _ctrl_vm_xml.matched == cifmw_devscripts_config.num_masters


### PR DESCRIPTION
This commit allows the user to modify the default/common configuration provided in `cifmw_libvirt_manager_configuration` by setting the `cifmw_libvirt_manager_configuration_overrides` variable.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [ ] Content of the docs/source is reflecting the changes
