### PR TITLE
Append git version to cifmw galaxy collection

### DIFF
--- a/scripts/setup_molecule
+++ b/scripts/setup_molecule
@@ -44,4 +44,11 @@ esac
 # Install requirements
 ${PIP} install ${PIP_INSTALL_ARGUMENTS}
 
+# append git hash to cifmw collection version (if detected)
+GITVER=$(git -C "${PROJECT_DIR}" rev-parse --short HEAD 2>/dev/null || true)
+[[ "" == "${GITVER}" ]] || sed -ri "s/^(version: [0-9.]+).*/\1-${GITVER}/" "${PROJECT_DIR}/galaxy.yml"
+
 ${GALAXY} collection install --upgrade --force --timeout=120 ${PROJECT_DIR}
+
+# remove git hash from version to keep git status clean (not doing checkout to not revert any other manual change)
+[[ "" == "${GITVER}" ]] || sed -ri "s/^(version: [0-9.]+)-${GITVER}/\1/" "${PROJECT_DIR}/galaxy.yml"


### PR DESCRIPTION
As setup_molecule is usually main installation method for installing cifmw.general galaxy collection,
append short git hash to its version for easier identification what code version is (or was) used,
otherwise it always states only:

  $ ansible-galaxy collection list |grep cifmw
  cifmw.general                 1.0.0

This change makes it slightly more useful
(as long as there is git command and git repo available, ignored otherwise):

  cifmw.general                 1.0.0-a44ca164

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
