### PR TITLE
[libvirt_manager] Fix ssh config creation

### DIFF
--- a/roles/libvirt_manager/tasks/start_manage_vms.yml
+++ b/roles/libvirt_manager/tasks/start_manage_vms.yml
@@ -54,7 +54,6 @@
   delegate_to: localhost
   vars:
     extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
-    proxy_hostname: "{{ ansible_host | default(inventory_hostname) }}"
   ansible.builtin.blockinfile:
     create: true
     path: "{{ lookup('env', 'HOME') }}/.ssh/config"
@@ -62,7 +61,7 @@
     mode: "0600"
     block: |-
       Host {{ vm_ip.nic.host }} cifmw-{{ vm_ip.nic.host }} {{ extracted_ip }}
-        ProxyJump {{ ansible_user | default(lookup('env', 'USER')) }}@{{ proxy_hostname }}
+        ProxyJump {{ ansible_user | default(lookup('env', 'USER')) }}@{{ inventory_hostname }}
         Hostname {{ extracted_ip }}
         User {{ 'core' if vm_ip.nic.host is match('^(crc|ocp).*') else 'zuul' }}
         StrictHostKeyChecking no


### PR DESCRIPTION
When running from laptop i.e `inventory_hostname != 'localhost'` deploying the reproducer, the `Inject ssh jumpers` task runs delegated to localhost. This causes `ansible_host` var is to be overriden to `localhost` causing the generated ssh config to be broken and cause the deployment to fail.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
