### PR TITLE
Revert "Correct ansible content to match new ansible-lint needs"

### DIFF
--- a/roles/devscripts/tasks/111_verify_cluster.yml
+++ b/roles/devscripts/tasks/111_verify_cluster.yml
@@ -19,7 +19,7 @@
   ansible.builtin.import_tasks: set_cluster_fact.yml
 
 - name: Login to the deployed OpenShift cluster.
-  community.okd.openshift_auth:
+  kubernetes.core.k8s_auth:
     host: "{{ cifmw_openshift_api }}"
     password: "{{ cifmw_openshift_password }}"
     state: present

--- a/roles/openshift_adm/tasks/api_cert.yml
+++ b/roles/openshift_adm/tasks/api_cert.yml
@@ -69,7 +69,7 @@
     mode: "0440"
 
 - name: Read the certificate details.
-  community.crypto.x509_certificate_info:
+  openssl_certificate_info:
     path: "/tmp/gen_api.crt"
   register: _gen_api_cert
 

--- a/roles/openshift_adm/tasks/wait_for_cluster.yml
+++ b/roles/openshift_adm/tasks/wait_for_cluster.yml
@@ -68,7 +68,7 @@
       oc adm wait-for-stable-cluster --minimum-stable-period=5s --timeout=30m
 
 - name: Wait until OCP login succeeds.
-  community.okd.openshift_auth:
+  kubernetes.core.k8s_auth:
     host: "{{ cifmw_openshift_api }}"
     password: "{{ cifmw_openshift_password }}"
     state: present

--- a/roles/test_operator/tasks/main.yml
+++ b/roles/test_operator/tasks/main.yml
@@ -93,22 +93,14 @@
   register: csv_list
   delay: 10
   retries: 20
-  until: >-
-    {{
-      csv_list |
-      map(attribute='metadata.name') |
-      select('match', 'test-operator')
-    }}
+  until: |
+    csv_list | json_query('resources[*].metadata.name') | select('match', 'test-operator')
   when: not cifmw_test_operator_dry_run | bool
 
 - name: Get full name of the test-operator csv
   ansible.builtin.set_fact:
     test_operator_csv_name: >-
-      {{
-        csv_list |
-        map(attribute='metadata.name') |
-        select('match', 'test-operator') | first
-      }}
+      {{ csv_list | json_query('resources[*].metadata.name') | select('match', 'test-operator') | first }}
   when: not cifmw_test_operator_dry_run | bool
 
 - name: Wait for the test-operator csv to Succeed

--- a/roles/test_operator/tasks/run-test-operator-job.yml
+++ b/roles/test_operator/tasks/run-test-operator-job.yml
@@ -140,21 +140,12 @@
 - name: Get status from test pods
   when: not cifmw_test_operator_dry_run | bool
   ansible.builtin.set_fact:
-    pod_status: >-
-      {{
-        test_pod_results |
-        map(attribute='status.phase') |
-        list | unique
-      }}
+    pod_status: "{{ test_pod_results | json_query('resources[*].status.phase') | list | unique }}"
 
 - name: Check whether test pods finished successfully
   when: not cifmw_test_operator_dry_run | bool
   ansible.builtin.set_fact:
-    successful_execution: >-
-      {{
-        pod_status | length == 1 and
-        pod_status | first == 'Succeeded'
-      }}
+    successful_execution: "{{ pod_status | length == 1 and pod_status | first == 'Succeeded' }}"
 
 - name: Fail fast if a pod did not succeed - {{ run_test_fw }}
   when:


### PR DESCRIPTION
This reverts commit d9525fad51dcd027514a31e01556c607cedec66f.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
