### PR TITLE
Add skip tests missing from test operator role

### DIFF
--- a/roles/test_operator/files/list_skipped.yml
+++ b/roles/test_operator/files/list_skipped.yml
@@ -1100,6 +1100,69 @@ known_failures:
         lp: http://no.bug
     jobs:
       - nova-operator
+  - test: tempest.api.compute.volumes.test_volume_snapshots.VolumesSnapshotsTestJSON.test_volume_snapshot_create_get_list_delete
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.volumes.test_volumes_get.VolumesGetTestJSON.test_volume_create_get_delete
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.volumes.test_volumes_list.VolumesTestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_actions.ServerActionsTestOtherA
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_actions.ServerActionsV293TestJSON
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.servers.test_server_actions.ServerActionsTestOtherB
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
+  - test: tempest.api.compute.admin.test_assisted_volume_snapshots.VolumesAssistedSnapshotsTest.test_volume_assisted_snapshot_create_delete
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - nova-operator
   # TODO (rlandy) remove when https://issues.redhat.com/browse/OSPCIX-126 is fixed
   - test: tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_mtu_sized_frames
     deployment:
@@ -1263,5 +1326,32 @@ known_failures:
       - name: master
         reason: Not supported
         lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.rbac_defaults.test_nodes.TestNodeProjectReader
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.rbac_defaults.test_nodes.TestNodeSystemReader
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_allocations.TestAllocations
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Test bug being fixed in caracal.
+        lp: https://bugs.launchpad.net/ironic/+bug/2054722
     jobs:
       - ironic-operator


### PR DESCRIPTION
These tests were added to the tempest role skip list and are missing from the test opertor skip list.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
