### PR TITLE
[reproducer] Add reproducer validations

### DIFF
--- a/docs/source/quickstart/02_prepare_env.md
+++ b/docs/source/quickstart/02_prepare_env.md
@@ -6,7 +6,7 @@ The following operating systems were successfully tested:
 
 - Fedora Core 38, 39 (for laptop/desktop)
 - CentOS Stream 9 (for the hypervisor, laptop/desktop)
-- Red Hat Enterprise Linux 9.2 (for the hypervisor, laptop/desktop)
+- Red Hat Enterprise Linux 9.4 (for the hypervisor, laptop/desktop)
 
 ## On your laptop/desktop
 
@@ -27,7 +27,7 @@ On the hypervisor, please ensure you have:
 - a non-root user, with passwordless SSH access (use SSH keys)
 - `sudo` configuration allowing that non-root user to run any random command, with or without password
 - at least 400G of free space in /home
-- an up-to-date CentOS Stream 9 or RHEL-9.2 system
+- an up-to-date CentOS Stream 9 or RHEL-9.4 system
 
 Note: if you chose to require a password for `sudo`, please ensure to pass the `-K` option to any
 `ansible-playbook` command running against the hypervisor.

--- a/reproducer.yml
+++ b/reproducer.yml
@@ -4,15 +4,10 @@
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: true
   pre_tasks:
-    - name: Ensure we pass needed parameter
-      ansible.builtin.assert:
-        that:
-          - cifmw_use_libvirt is defined
-          - cifmw_use_libvirt | bool
-        msg: >-
-          Please ensure you pass "cifmw_use_libvirt: true" to the
-          deployment!
-        quiet: true
+    - name: Run reproducer validations
+      ansible.builtin.import_role:
+        name: reproducer
+        tasks_from: validations.yml
 
     - name: Gather OS facts
       ansible.builtin.setup:

--- a/roles/reproducer/README.md
+++ b/roles/reproducer/README.md
@@ -5,6 +5,7 @@ Role to deploy close to CI layout on a hypervisor.
 None
 
 ## Parameters
+
 * `cifmw_reproducer_basedir`: (String) Base directory. Defaults to `cifmw_basedir`, which defaults to `~/ci-framework-data`.
 * `cifmw_reproducer_compute_repos`: (List[mapping]) List of yum repository that must be deployed on the compute nodes during their creation. Defaults to `[]`.
 * `cifmw_reproducer_play_extravars`: (List[string]) List of extra-vars you want to pass down to the EDPM deployment playbooks. Defaults to `[]`.
@@ -17,6 +18,7 @@ None
 * `cifmw_reproducer_hp_rhos_release`: (Bool) Allows to consume rhos-release on the hypervisor. Defaults to `false`.
 * `cifmw_reproducer_dnf_tweaks`: (List) Options you want to inject in dnf.conf, both on controller-0 and hypervisor. Defaults to `[]`.
 * `cifmw_reproducer_skip_fetch_repositories`: (Bool) Skip fetching repositories from zuul var and simply copy the code from the ansible controller. Defaults to `false`.
+* `cifmw_reproducer_supported_hypervisor_os`: (List) List of supported hypervisor operating systems and their minimum version.
 
 ### run_job and run_content_provider booleans and risks.
 

--- a/roles/reproducer/defaults/main.yml
+++ b/roles/reproducer/defaults/main.yml
@@ -31,3 +31,8 @@ cifmw_reproducer_dnf_tweaks: []
 cifmw_reproducer_compute_repos: []
 cifmw_reproducer_repositories_path: "src"
 cifmw_reproducer_play_extravars: []
+cifmw_reproducer_supported_hypervisor_os:
+  CentOS:
+    minimum_version: 9
+  RedHat:
+    minimum_version: 9.4

--- a/roles/reproducer/tasks/validations.yml
+++ b/roles/reproducer/tasks/validations.yml
@@ -1,0 +1,40 @@
+---
+- name: Ensure we pass needed parameter
+  ansible.builtin.assert:
+    that:
+      - cifmw_use_libvirt is defined
+      - cifmw_use_libvirt | bool
+    msg: >-
+      Please ensure you pass "cifmw_use_libvirt: true" to the
+      deployment!
+    quiet: true
+
+- name: Verify ansible_host is defined in inventory
+  when: cifmw_target_host != 'localhost'
+  delegate_to: localhost
+  ansible.builtin.assert:
+    that: ansible_host != 'localhost'
+    msg: >-
+      Please ensure you define your ansible_host in your inventory file
+      https://ci-framework.readthedocs.io/en/latest/quickstart/03_deploy_infra.html#inventory-file
+    quiet: true
+
+- name: Verify ansible_connection is set to "local" in provided inventory
+  delegate_to: localhost
+  ansible.builtin.assert:
+    that: ansible_connection == 'local'
+    msg: >-
+      Please ensure you define your ansible_connection to local for localhost in your inventory file
+      https://ci-framework.readthedocs.io/en/latest/quickstart/03_deploy_infra.html#inventory-file
+    quiet: true
+
+- name: Verify we are running on a supported hypervisor OS version
+  ansible.builtin.assert:
+    that:
+      - ansible_distribution in cifmw_reproducer_supported_hypervisor_os
+      - ansible_distribution_version | float  >= cifmw_reproducer_supported_hypervisor_os[ansible_distribution].minimum_version
+    msg: >-
+      Please ensure host: {{ cifmw_target_host }} is running a supported OS.
+      {{ ansible_distribution_version }} is less than the minimum supported version of
+      {{ cifmw_reproducer_supported_hypervisor_os[ansible_distribution].minimum_version }}
+      https://ci-framework.readthedocs.io/en/latest/quickstart/02_prepare_env.html#tested-environment


### PR DESCRIPTION
This patch adds a common place for reproducer validates, allowing us to enforce, in code, thing steps documented and fail fast with helpful messages.

This patch:
- Adds reproducer validation task file
- Moves `cifmw_use_libvirt` check to validation task file
- Adds new check for ansible_host being defined
- Adds new check for ansible_connection being set to local
- Adds new check to ensure correct OS version is used for hypervisor

The ansible_host and ansible_connection checks can be tested locally by simply commenting them out in your inventory file.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running