### PR TITLE
[libvirtmanager] Allow layout configuration patching

### DIFF
--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -33,6 +33,7 @@ Used for checking if:
 * `cifmw_libvirt_manager_fixed_networks`: (List) Network names you don't want to prefix with `cifmw-`. It will be concatenated with cifmw_libvirt_manager_fixed_networks_defaults. Defaults to`[]`.
 * `cifmw_libvirt_manager_reproducer_key_type`: (String) Type of ssh key that will be injected into the controller VMs. Defaults to `cifmw_ssh_keytype` which default to `ecdsa`.
 * `cifmw_libvirt_manager_reproducer_key_size`: (Integer) Size of the ecdsa ssh keys that will be injected into the controller VMs. Defaults to `cifmw_ssh_keysize` which default to 521.
+* `cifmw_libvirt_manager_configuration_patch(.)*`: (Dict) Structure describing the patch to combine on top of `cifmw_libvirt_manager_configuration`.
 
 ### Structure for `cifmw_libvirt_manager_configuration`
 
@@ -148,6 +149,13 @@ In order to do so, you have to provide specific variables:
   * `name`: (String) Network or bridge name. Mandatory.
   * `cidr`: (String) Network CIDR. Mandatory.
 * `cifmw_libvirt_manager_net_prefix_add`: (Bool) Toggle this to `true` if the network name needs to get the `cifmw-` prefix (advanced usage). Optional. Defaults to `true`.
+
+## Layout patching
+This role allows to use a base layout, given by `cifmw_libvirt_manager_configuration` and patch it
+with other values, ie. patch it for another environment, by declaring variables prefixed that matches the
+`^cifmw_libvirt_manager_configuration_patch.*` regex. Each of those variables, after sorting them by name,
+will be combined on top of the original `cifmw_libvirt_manager_configuration` and that will be the final
+layout used by the role.
 
 ### Example of a task
 

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -6,6 +6,21 @@
       {{ cifmw_libvirt_manager_configuration_gen |
          default(cifmw_libvirt_manager_configuration) }}
 
+- name: Patch the layout if needed
+  vars:
+    _layout_patches: >-
+      {{
+        hostvars[inventory_hostname] |
+        dict2items |
+        selectattr("key", "match", "^cifmw_libvirt_manager_configuration_patch.*") |
+        sort(attribute='key')
+      }}
+  ansible.builtin.set_fact:
+    _layout: "{{ _layout | combine(item.value, recursive=True) }}"
+  loop: "{{ _layout_patches }}"
+  loop_control:
+    label: "{{ item.key }}"
+
 # Deploy VBMC only on the hypervisor running OpenShift services,
 # being OCP cluster or single CRC.
 - name: Deploy VirtualBMC service container


### PR DESCRIPTION
By providing variables that matches `^cifmw_libvirt_manager_configuration_patch.*` the user can patch the `cifmw_libvirt_manager_configuration`. This allows having a common reusable layout and patch it with the needed pieces for an environment.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
