### PR TITLE
Run e2e log collection in tcib jobs

### DIFF
--- a/zuul.d/tcib.yaml
+++ b/zuul.d/tcib.yaml
@@ -16,7 +16,11 @@
       - ci/playbooks/dump_zuul_data.yml
     run:
       - ci/playbooks/tcib/run.yml
-    post-run: ci/playbooks/collect-logs.yml
+    post-run:
+      - ci/playbooks/e2e-collect-logs.yml
+      - ci/playbooks/collect-logs.yml
+    vars:
+      zuul_log_collection: true
 
 - job:
     name: cifmw-tcib


### PR DESCRIPTION
It will help to collect all the required files
in order to make the tcib debugging easier.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

