### PR TITLE
Use ansible_user_id instead of ansible_user on podman fix

### DIFF
--- a/roles/virtualbmc/tasks/main.yml
+++ b/roles/virtualbmc/tasks/main.yml
@@ -30,7 +30,7 @@
     state: present
 
 - name: Fix podman issue related mkdir /run/user/1000 permission denied
-  ansible.builtin.command: "loginctl enable-linger {{ ansible_user }}"
+  ansible.builtin.command: "loginctl enable-linger {{ ansible_user_id }}"
 
 - name: Check if container already exists
   register: _vbmc_container_info


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

