### PR TITLE
Determine jump result dir based on the tempest role

### DIFF
--- a/roles/polarion/README.md
+++ b/roles/polarion/README.md
@@ -4,7 +4,7 @@ Role to setup jump tool and upload XML test results to Polarion.
 ## Parameters
 * `cifmw_polarion_basedir`: (String) Base directory. Defaults to `cifmw_basedir` which defaults to `~/ci-framework-data`.
 * `cifmw_polarion_jump_repo_dir`: (String) Jump repo directory. Defaults to `~/ci-framework-data/polarion-jump`.
-* `cifmw_polarion_jump_result_dir`: (String) Test results directory. Defaults to `~/ci-framework-data/tests/tempest/`.
+* `cifmw_polarion_jump_result_dir`: (String) Test results directory. Based on `cifmw_run_test_role` defaults to `~/ci-framework-data/tests/tempest/` or `~/ci-framework-data/tests/test_operator/`.
 * `cifmw_polarion_jump_repo_url`: (String) URL of jump repository.
 * `cifmw_polarion_testrun_id`: (String) A test run identification provided by Polarion test case.
 * `cifmw_polarion_update_testcases`: (Boolean) A value of True/False to update the testcases.

--- a/roles/polarion/defaults/main.yml
+++ b/roles/polarion/defaults/main.yml
@@ -20,6 +20,6 @@
 
 cifmw_polarion_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_polarion_jump_repo_dir: "{{ cifmw_polarion_basedir }}/polarion-jump"
-cifmw_polarion_jump_result_dir: "{{ cifmw_polarion_basedir }}/tests/tempest/"
+cifmw_polarion_jump_result_dir: "{{ cifmw_polarion_basedir }}/tests/{{ cifmw_run_test_role | default('tempest') }}/"
 cifmw_polarion_jump_repo_branch: "master"
 cifmw_polarion_use_stage: false


### PR DESCRIPTION
If test_operator role is run, the results the jump tool is looking
for are under test_operator dir, not tempest one in case of the
tempest role. This adjusts the dir location based on the role that
is used to run tempest.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
