### PR TITLE
Add new feature in the reproducer: molecule jobs

### DIFF
--- a/roles/reproducer/tasks/ci_data.yml
+++ b/roles/reproducer/tasks/ci_data.yml
@@ -20,15 +20,14 @@
         path: "{{ _reproducer_basedir }}/parameters"
         state: directory
 
-    - name: Fetch needed artifacts
-      ansible.builtin.get_url:
-        dest: "{{ _reproducer_basedir }}/{{ item }}"
-        url: "{{ data_baseurl }}/{{ item }}"
-        force: true
-      loop:
-        - parameters/custom-params.yml
-        - parameters/install-yamls-params.yml
-        - parameters/zuul-params.yml
+    - name: Check if we're facing molecule job
+      register: _is_molecule
+      ansible.builtin.uri:
+        url: "{{ cifmw_job_uri }}/report.html"
+        method: HEAD
+        status_code:
+          - 200
+          - 404
 
     - name: Fetch zuul inventory
       ansible.builtin.get_url:
@@ -36,46 +35,20 @@
         url: "{{ cifmw_job_uri }}/zuul-info/inventory.yaml"
         force: true
 
-    - name: Load parameters in current runtime
-      ansible.builtin.include_vars:
-        dir: "{{ _reproducer_basedir }}/parameters"
+    - name: Facing non-molecule job
+      when:
+        - _is_molecule.status == 404
+      ansible.builtin.include_tasks: ci_deploy_data.yml
 
-    - name: Extract compute count
-      vars:
-        zuul_inventory: >-
-          {{
-            lookup('file', _reproducer_basedir ~ '/zuul_inventory.yml') |
-            from_yaml
-           }}
-        compute_count: >-
-          {{
-            zuul_inventory.all.hosts.keys() |
-            select('match', '^compute.*') | length
-           }}
-        zuul_params: >-
-          {{
-            lookup('file', _reproducer_basedir ~ '/parameters/zuul-params.yml') |
-            from_yaml
-          }}
-      ansible.builtin.set_fact:
-        cacheable: true
-        ci_job_networking: "{{ zuul_inventory.all.hosts.crc.crc_ci_bootstrap_networking }}"
-        operator_content_provider: >-
-          {{
-            zuul_params.content_provider_registry_ip is defined
-          }}
-        openstack_content_provider: >-
-          {{
-            zuul_params.content_provider_dlrn_md5_hash is defined
-          }}
-        updated_layout:
-          vms:
-            compute:
-              amount: "{{ compute_count | int }}"
+    - name: Facing molecule job
+      when:
+        - _is_molecule.status == 200
+      ansible.builtin.include_tasks: ci_molecule_data.yml
 
     - name: Update layout
       ansible.builtin.set_fact:
         cacheable: true
+        is_molecule: "{{ _is_molecule.status == 200 }}"
         cifmw_libvirt_manager_configuration_gen: >-
           {{
             cifmw_libvirt_manager_configuration |

--- a/roles/reproducer/tasks/ci_deploy_data.yml
+++ b/roles/reproducer/tasks/ci_deploy_data.yml
@@ -1,0 +1,48 @@
+---
+- name: Fetch needed artifacts
+  ansible.builtin.get_url:
+    dest: "{{ _reproducer_basedir }}/{{ item }}"
+    url: "{{ data_baseurl }}/{{ item }}"
+    force: true
+  loop:
+    - parameters/custom-params.yml
+    - parameters/install-yamls-params.yml
+    - parameters/zuul-params.yml
+
+- name: Load parameters in current runtime
+  ansible.builtin.include_vars:
+    dir: "{{ _reproducer_basedir }}/parameters"
+
+- name: Extract compute count
+  vars:
+    zuul_inventory: >-
+      {{
+        lookup('file', _reproducer_basedir ~ '/zuul_inventory.yml') |
+        from_yaml
+       }}
+    compute_count: >-
+      {{
+        zuul_inventory.all.hosts.keys() |
+        select('match', '^compute.*') | length
+       }}
+    zuul_params: >-
+      {{
+        lookup('file', _reproducer_basedir ~ '/parameters/zuul-params.yml') |
+        from_yaml
+      }}
+  ansible.builtin.set_fact:
+    cacheable: true
+    ci_job_networking: "{{ zuul_inventory.all.hosts.crc.crc_ci_bootstrap_networking }}"
+    operator_content_provider: >-
+      {{
+        zuul_params.content_provider_registry_ip is defined
+      }}
+    openstack_content_provider: >-
+      {{
+        zuul_params.content_provider_dlrn_md5_hash is defined
+      }}
+    zuul_vars: "{{ zuul_inventory.all.vars }}"
+    updated_layout:
+      vms:
+        compute:
+          amount: "{{ compute_count | int }}"

--- a/roles/reproducer/tasks/ci_job.yml
+++ b/roles/reproducer/tasks/ci_job.yml
@@ -3,7 +3,7 @@
   when:
     - cifmw_job_uri is defined
   vars:
-    playbooks: "{{ zuul.playbook_context.playbooks }}"
+    playbooks: "{{ zuul_vars.zuul.playbook_context.playbooks }}"
     extracted: >-
       {{
         (playbooks |
@@ -21,6 +21,14 @@
       when:
         - cifmw_job_uri is defined
       block:
+        - name: Ensure directory exists
+          ansible.builtin.file:
+            path: "/home/zuul/{{ job_id }}-params"
+            mode: "0755"
+            state: directory
+            owner: zuul
+            group: zuul
+
         - name: Copy environment files to controller node
           tags:
             - bootstrap
@@ -53,6 +61,8 @@
             src: "content-provider.yml.j2"
 
         - name: Push extracted network data on controller-0
+          when:
+            - not is_molecule | default(false)
           tags:
             - bootstrap
           ansible.builtin.copy:
@@ -70,17 +80,11 @@
       tags:
         - bootstrap
       block:
-        - name: Get content of zuul-params.yml
-          register: zuul_params
-          ansible.builtin.slurp:
-            path: "/home/zuul/{{ job_id }}-params/zuul-params.yml"
-
         - name: Push extracted content
           vars:
             zuul_params_filtered: >-
               {{
-                (zuul_params['content'] | b64decode | from_yaml) |
-                dict2items |
+                zuul | dict2items |
                 rejectattr('key', 'equalto', 'cifmw_operator_build_output') |
                 rejectattr('key', 'equalto', 'content_provider_registry_ip') |
                 items2dict
@@ -94,10 +98,10 @@
         - always
       ansible.builtin.include_tasks: rotate_log.yml
       loop:
-        - "ansible.log"
-        - "ansible-pre-ci.log"
-        - "ansible-{{ job_id }}.log"
-        - "ansible-content-provider-bootstrap.log"
+        - "/home/zuul/ansible.log"
+        - "/home/zuul/ansible-pre-ci.log"
+        - "/home/zuul/ansible-{{ job_id }}.log"
+        - "/home/zuul/ansible-content-provider-bootstrap.log"
 
     - name: Generate and run scripts
       vars:
@@ -142,6 +146,8 @@
             src: "script.sh.j2"
 
         - name: Run pre-ci-play
+          when:
+            - not is_molecule | default(false)
           tags:
             - bootstrap
           no_log: true

--- a/roles/reproducer/tasks/ci_molecule_data.yml
+++ b/roles/reproducer/tasks/ci_molecule_data.yml
@@ -1,0 +1,32 @@
+---
+- name: Update libvirt layout
+  vars:
+    zuul_inventory: >-
+      {{
+        lookup('file',  _reproducer_basedir ~ '/zuul_inventory.yml') |
+        from_yaml
+      }}
+    compute_amount: >-
+      {{
+        zuul_inventory.all.hosts.keys() |
+        select('match', '^compute.*') | length
+      }}
+    crc_amount: >-
+      {{
+        zuul_inventory.all.hosts.keys() |
+        select('match', '^crc.*') | length
+      }}
+  ansible.builtin.set_fact:
+    operator_content_provider: false
+    openstack_content_provider: false
+    zuul_vars: "{{ zuul_inventory.all.vars }}"
+    updated_layout:
+      vms:
+        compute:
+          amount: "{{ compute_amount | int }}"
+        crc:
+          amount: "{{ crc_amount | int }}"
+
+- name: Debug
+  ansible.builtin.debug:
+    var: updated_layout

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -397,6 +397,8 @@
     # consumed by the networking_mapper - it will connect to all of the nodes
     # in order to gather some facts of interest.
     - name: Wait for OCP nodes to be ready
+      when:
+        - groups.ocps is defined
       delegate_to: "{{ item }}"
       ansible.builtin.wait_for_connection:
         sleep: 2
@@ -431,6 +433,9 @@
     - name: Inject CRC related content if needed
       when:
         - _layout.vms.crc is defined
+        - (_layout.vms.crc.amount is defined and
+           (_layout.vms.crc.amount | int ) > 0) or
+          _layout.vms.crc.amount is undefined
       block:
         - name: Inject CRC ssh key
           ansible.builtin.copy:

--- a/roles/reproducer/tasks/libvirt_layout.yml
+++ b/roles/reproducer/tasks/libvirt_layout.yml
@@ -75,6 +75,9 @@
 - name: Configure CRC node if available
   when:
     - _layout.vms.crc is defined
+    - (_layout.vms.crc.amount is defined and
+       (_layout.vms.crc.amount | int) > 0) or
+      _layout.vms.crc.amount is undefined
     - (
         _layout.vms.crc.target is defined and
         _layout.vms.crc.target == inventory_hostname

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -161,7 +161,7 @@
         - always
       ansible.builtin.include_tasks: rotate_log.yml
       loop:
-        - ansible-bootstrap.log
+        - "/home/zuul/ansible-bootstrap.log"
 
     - name: Bootstrap environment on controller-0
       delegate_to: controller-0
@@ -175,8 +175,12 @@
           -e @~/reproducer-variables.yml
           -e @scenarios/reproducers/networking-definition.yml
           playbooks/01-bootstrap.yml
+        creates: "/home/zuul/ansible-bootstrap.log"
 
     - name: Install dev tools from install_yamls on controller-0
+      when: >
+         (operator_content_provider| default(false) | bool) or
+         (openstack_content_provider| default(false) | bool)
       delegate_to: controller-0
       environment:
         ANSIBLE_LOG_PATH: "~/ansible-bootstrap.log"

--- a/roles/reproducer/tasks/push_code.yml
+++ b/roles/reproducer/tasks/push_code.yml
@@ -1,19 +1,21 @@
 ---
 - name: Sync zuul content if available
   when:
-    - zuul is defined
-    - zuul.items is defined
-    - zuul.projects is defined
+    - zuul_vars.zuul is defined
+    - zuul_vars.zuul.items is defined
+    - zuul_vars.zuul.projects is defined
     - not cifmw_reproducer_skip_fetch_repositories | default(false)
   delegate_to: controller-0
   delegate_facts: true
+  vars:
+    _zuul: "{{ zuul_vars.zuul }}"
   block:
     - name: Check if repository directories already exist
       when: job_id is defined
       ansible.builtin.stat:
         path: "{{ item.project.src_dir }}"
       register: repos_dir_stats
-      with_items: "{{ zuul['items'] }}"
+      with_items: "{{ _zuul['items'] }}"
 
     - name: Ensure we are not in the job_id branch
       when:
@@ -25,7 +27,7 @@
         repo: "https://{{ item.0.project.canonical_name }}"
         version: "origin/main"
         force: true
-      loop: "{{ zuul['items'] | zip(repos_dir_stats.results) | list }}"
+      loop: "{{ _zuul['items'] | zip(repos_dir_stats.results) | list }}"
 
     - name: Fetch zuul.items repositories
       block:
@@ -38,7 +40,7 @@
             refspec: "{{ omit if _skip_refspec else repo | reproducer_refspec ~ ':' ~ job_id }}"
             version: "{{ omit if _skip_refspec else job_id }}"
             force: true
-          loop: "{{ zuul['items'] }}"
+          loop: "{{ _zuul['items'] }}"
           loop_control:
             loop_var: repo
             label: "{{ repo.project.name }}"
@@ -60,13 +62,13 @@
 
     - name: Fetch zuul.projects repositories for dependencies
       when:
-        - "repo.key not in (zuul['items'] | map(attribute='project.canonical_name'))"
+        - "repo.key not in (_zuul['items'] | map(attribute='project.canonical_name'))"
       ansible.builtin.git:
         dest: "{{ repo.value.src_dir }}"
         repo: "https://{{ repo.value.canonical_hostname }}/{{ repo.value.canonical_hostname | reproducer_gerrit_infix }}{{ repo.value.name }}"
         version: "{{ repo.value.commit }}"
         force: true
-      loop: "{{ zuul['projects'] | dict2items }}"
+      loop: "{{ _zuul['projects'] | dict2items }}"
       loop_control:
         loop_var: repo
         label: "{{ repo.key }}"
@@ -79,20 +81,21 @@
     - name: Expand cifmw_reproducer_repositories to pull code from ansible controller to controller-0
       when:
         - cifmw_reproducer_skip_fetch_repositories | default(false)
-        - zuul is defined
-        - zuul.items is defined
-        - zuul.projects is defined
+        - zuul_vars.zuul is defined
+        - zuul_vars.zuul.items is defined
+        - zuul_vars.zuul.projects is defined
         # check that the project is not alredy in the user defined
         # cifmw_reproducer_repositories value
         - repo.value.name not in _user_sources
       vars:
+        _zuul: "{{ zuul_vars.zuul }}"
         _user_sources: "{{ cifmw_reproducer_repositories | default([]) | map(attribute='src') }}"
         _repo_entry:
           src: "{{ ansible_user_dir }}/{{ repo.value.src_dir | regex_replace('/$', '') }}/"
           dest: "/home/zuul/{{ repo.value.src_dir }}"
       ansible.builtin.set_fact:
         _cifmw_reproducer_all_repositories: "{{ _cifmw_reproducer_all_repositories  + [_repo_entry] }}"
-      loop: "{{ zuul['projects'] | dict2items }}"
+      loop: "{{ _zuul['projects'] | dict2items }}"
       loop_control:
         loop_var: repo
         label: "{{ repo.key }}"

--- a/roles/reproducer/templates/play.yml.j2
+++ b/roles/reproducer/templates/play.yml.j2
@@ -1,10 +1,49 @@
 ---
+{% if is_molecule | default(false) %}
+- name: Prepare molecule environment
+  hosts: controller-0
+  gather_facts: true
+  tasks:
+    - name: Install required packages
+      become: true
+      ansible.builtin.package:
+        name:
+          - make
+          - podman
+          - python3
+          - python3-pip
+{% raw %}
+    - name: Check if venv exists
+      register: _venv
+      ansible.builtin.stat:
+        path: "{{ ansible_user_dir }}/test-python"
+{% endraw %}
+    - name: Install venv
+      when:
+        - not _venv.stat.exists
+      vars:
+        src_dir: "{{ zuul.zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}"
+      community.general.make:
+{%- raw %}
+        chdir: "{{ ansible_user_dir }}/{{ src_dir }}"
+        target: setup_molecule
+
+    - name: Ensure zuul-output directory exists
+      ansible.builtin.file:
+        path: "{{ ansible_user_dir }}/zuul-output/logs"
+        state: directory
+        mode: "0755"
+{% endraw %}
+{% endif %}
+
 {% for play in zuul_plays %}
 - name: "Reproducer for {{ job_id }}: {{ play }}"
   vars:
     cifmw_extras:
+{% if not is_molecule | default(false) %}
       - '@~/{{ job_id }}-params/custom-params.yml'
       - '@~/{{ job_id }}-params/install-yamls-params.yml'
+{% endif %}
       - '@~/{{ job_id }}-params/reproducer_params.yml'
 {% if (operator_content_provider | bool) or (openstack_content_provider | bool) %}
       - '@~/{{ job_id }}-params/content-provider.yml'
@@ -15,5 +54,6 @@
       - cifmw_openshift_login_skip_tls_verify=true
       - cifmw_openshift_setup_skip_internal_registry_tls_verify=true
     cifmw_zuul_target_host: controller-0
+    cifmw_reproducer_molecule_env_file: ~/ci-framework-data/artifacts/parameters/zuul-params.yml
   ansible.builtin.import_playbook: {{ play }}
 {% endfor %}


### PR DESCRIPTION
This patch enables molecule job reproducer, at least for the ones
configured in the ci-framework (not sure if molecule is running in any
other places).

This patch allows the reproducer role to detect if we're reproducing a
molecule job or a "standard" deployment; it will update the layout
accordingly (it needs #1439 for the `amount: 0` support), and create the
needed playbook/script to run the whole stack accordingly.

Several changes were needed in the reproducer role in order to ensure
we're consistent with the data we fetch from Zuul, and some tasks had to
move in dedicated files to make things easier to read, as well as
leveraging the `include_tasks` (to avoid endless list of `skipping` log
lines).

This change also needs #1440 to ensure we're able to pass a few
parameters down in the job playbook.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1440
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1439

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
