### PR TITLE
Pin CentOS image used in molecule

### DIFF
--- a/.config/molecule/config_local.yml
+++ b/.config/molecule/config_local.yml
@@ -16,6 +16,15 @@ platforms:
 
 provisioner:
   name: ansible
+  # Expose configuration to all jobs by default
+  # Useful when an fix requires to provide some
+  # CIFMW parameter to many roles, such as a broken
+  # CentOS image.
+  inventory:
+    group_vars:
+      all:
+        cifmw_discover_latest_image_qcow_prefix: "CentOS-Stream-GenericCloud-9-20240401"
+
   config_options:
     defaults:
       fact_caching: jsonfile

--- a/ci/templates/molecule.yaml.j2
+++ b/ci/templates/molecule.yaml.j2
@@ -9,4 +9,5 @@
       - ^test-requirements.txt
       - ^roles/{{ role_name }}/(?!meta|README).*
       - ^ci/playbooks/molecule.*
+      - ^.config/molecule/.*
 {% endfor %}

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -4,6 +4,7 @@
     - ^test-requirements.txt
     - ^roles/artifacts/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-artifacts
     parent: cifmw-molecule-base
     vars:
@@ -14,6 +15,7 @@
     - ^test-requirements.txt
     - ^roles/build_containers/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-build_containers
     parent: cifmw-molecule-base
     vars:
@@ -24,6 +26,7 @@
     - ^test-requirements.txt
     - ^roles/build_openstack_packages/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-build_openstack_packages
     parent: cifmw-molecule-base
     vars:
@@ -34,6 +37,7 @@
     - ^test-requirements.txt
     - ^roles/cert_manager/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-cert_manager
     nodeset: centos-9-crc-2-30-0-xxl
     parent: cifmw-molecule-base
@@ -45,6 +49,7 @@
     - ^test-requirements.txt
     - ^roles/ci_gen_kustomize_values/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-ci_gen_kustomize_values
     parent: cifmw-molecule-base
     vars:
@@ -55,6 +60,7 @@
     - ^test-requirements.txt
     - ^roles/ci_local_storage/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-ci_local_storage
     nodeset: centos-9-crc-2-30-0-xl
     parent: cifmw-molecule-base
@@ -66,6 +72,7 @@
     - ^test-requirements.txt
     - ^roles/ci_metallb/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-ci_metallb
     parent: cifmw-molecule-base-crc
     vars:
@@ -76,6 +83,7 @@
     - ^test-requirements.txt
     - ^roles/ci_multus/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-ci_multus
     parent: cifmw-molecule-base-crc
     vars:
@@ -86,6 +94,7 @@
     - ^test-requirements.txt
     - ^roles/ci_netconfig/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-ci_netconfig
     parent: cifmw-molecule-base-crc
     vars:
@@ -96,6 +105,7 @@
     - ^test-requirements.txt
     - ^roles/ci_network/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-ci_network
     parent: cifmw-molecule-base
     vars:
@@ -106,6 +116,7 @@
     - ^test-requirements.txt
     - ^roles/ci_nmstate/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-ci_nmstate
     parent: cifmw-molecule-base-crc
     vars:
@@ -116,6 +127,7 @@
     - ^test-requirements.txt
     - ^roles/ci_setup/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-ci_setup
     parent: cifmw-molecule-base
     vars:
@@ -126,6 +138,7 @@
     - ^test-requirements.txt
     - ^roles/cifmw_block_device/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_block_device
     parent: cifmw-molecule-base
     vars:
@@ -136,6 +149,7 @@
     - ^test-requirements.txt
     - ^roles/cifmw_ceph_client/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_ceph_client
     parent: cifmw-molecule-base
     vars:
@@ -146,6 +160,7 @@
     - ^test-requirements.txt
     - ^roles/cifmw_ceph_spec/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_ceph_spec
     parent: cifmw-molecule-base
     vars:
@@ -156,6 +171,7 @@
     - ^test-requirements.txt
     - ^roles/cifmw_cephadm/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_cephadm
     parent: cifmw-molecule-base
     vars:
@@ -166,6 +182,7 @@
     - ^test-requirements.txt
     - ^roles/cifmw_create_admin/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_create_admin
     parent: cifmw-molecule-base
     vars:
@@ -176,6 +193,7 @@
     - ^test-requirements.txt
     - ^roles/cifmw_test_role/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_test_role
     parent: cifmw-molecule-base
     vars:
@@ -186,6 +204,7 @@
     - ^test-requirements.txt
     - ^roles/copy_container/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-copy_container
     parent: cifmw-molecule-base
     vars:
@@ -196,6 +215,7 @@
     - ^test-requirements.txt
     - ^roles/deploy_bmh/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-deploy_bmh
     parent: cifmw-molecule-base
     vars:
@@ -206,6 +226,7 @@
     - ^test-requirements.txt
     - ^roles/devscripts/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-devscripts
     parent: cifmw-molecule-base
     vars:
@@ -216,6 +237,7 @@
     - ^test-requirements.txt
     - ^roles/discover_latest_image/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-discover_latest_image
     parent: cifmw-molecule-base
     vars:
@@ -226,6 +248,7 @@
     - ^test-requirements.txt
     - ^roles/dlrn_promote/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-dlrn_promote
     parent: cifmw-molecule-base
     vars:
@@ -236,6 +259,7 @@
     - ^test-requirements.txt
     - ^roles/dlrn_report/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-dlrn_report
     parent: cifmw-molecule-base
     vars:
@@ -246,6 +270,7 @@
     - ^test-requirements.txt
     - ^roles/edpm_build_images/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-edpm_build_images
     parent: cifmw-molecule-base
     vars:
@@ -256,6 +281,7 @@
     - ^test-requirements.txt
     - ^roles/edpm_deploy/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-edpm_deploy
     parent: cifmw-molecule-base
     vars:
@@ -266,6 +292,7 @@
     - ^test-requirements.txt
     - ^roles/edpm_deploy_baremetal/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-edpm_deploy_baremetal
     parent: cifmw-molecule-base
     vars:
@@ -276,6 +303,7 @@
     - ^test-requirements.txt
     - ^roles/edpm_kustomize/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-edpm_kustomize
     parent: cifmw-molecule-base
     vars:
@@ -286,6 +314,7 @@
     - ^test-requirements.txt
     - ^roles/edpm_prepare/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-edpm_prepare
     parent: cifmw-molecule-base
     vars:
@@ -296,6 +325,7 @@
     - ^test-requirements.txt
     - ^roles/env_op_images/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-env_op_images
     nodeset: centos-9-crc-2-30-0-xl
     parent: cifmw-molecule-base
@@ -307,6 +337,7 @@
     - ^test-requirements.txt
     - ^roles/hci_prepare/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-hci_prepare
     parent: cifmw-molecule-base
     vars:
@@ -317,6 +348,7 @@
     - ^test-requirements.txt
     - ^roles/hive/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-hive
     parent: cifmw-molecule-base
     vars:
@@ -327,6 +359,7 @@
     - ^test-requirements.txt
     - ^roles/idrac_configuration/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-idrac_configuration
     parent: cifmw-molecule-base
     vars:
@@ -337,6 +370,7 @@
     - ^test-requirements.txt
     - ^roles/install_ca/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-install_ca
     parent: cifmw-molecule-base
     vars:
@@ -349,6 +383,7 @@
     - ^test-requirements.txt
     - ^roles/install_openstack_ca/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-install_openstack_ca
     nodeset: centos-9-crc-2-30-0-3xl
     parent: cifmw-molecule-base-crc
@@ -361,6 +396,7 @@
     - ^test-requirements.txt
     - ^roles/install_yamls/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-install_yamls
     parent: cifmw-molecule-base
     vars:
@@ -371,6 +407,7 @@
     - ^test-requirements.txt
     - ^roles/kustomize_deploy/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-kustomize_deploy
     parent: cifmw-molecule-base
     vars:
@@ -381,6 +418,7 @@
     - ^test-requirements.txt
     - ^roles/libvirt_manager/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-libvirt_manager
     parent: cifmw-molecule-base
     vars:
@@ -391,6 +429,7 @@
     - ^test-requirements.txt
     - ^roles/manage_secrets/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-manage_secrets
     nodeset: centos-9-crc-2-30-0-xl
     parent: cifmw-molecule-base
@@ -402,6 +441,7 @@
     - ^test-requirements.txt
     - ^roles/networking_mapper/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-networking_mapper
     nodeset: 4x-centos-9-medium
     parent: cifmw-molecule-base
@@ -413,6 +453,7 @@
     - ^test-requirements.txt
     - ^roles/openshift_login/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-openshift_login
     nodeset: centos-9-crc-2-30-0-xl
     parent: cifmw-molecule-base
@@ -424,6 +465,7 @@
     - ^test-requirements.txt
     - ^roles/openshift_provisioner_node/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-openshift_provisioner_node
     nodeset: centos-9-crc-2-30-0-xl
     parent: cifmw-molecule-base
@@ -435,6 +477,7 @@
     - ^test-requirements.txt
     - ^roles/openshift_setup/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-openshift_setup
     nodeset: centos-9-crc-2-30-0-xl
     parent: cifmw-molecule-base
@@ -446,6 +489,7 @@
     - ^test-requirements.txt
     - ^roles/operator_build/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-operator_build
     parent: cifmw-molecule-base
     vars:
@@ -456,6 +500,7 @@
     - ^test-requirements.txt
     - ^roles/operator_deploy/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-operator_deploy
     nodeset: centos-9-crc-2-30-0-xl
     parent: cifmw-molecule-base
@@ -467,6 +512,7 @@
     - ^test-requirements.txt
     - ^roles/os_must_gather/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-os_must_gather
     parent: cifmw-molecule-base-crc
     vars:
@@ -477,6 +523,7 @@
     - ^test-requirements.txt
     - ^roles/pkg_build/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-pkg_build
     parent: cifmw-molecule-base
     vars:
@@ -487,6 +534,7 @@
     - ^test-requirements.txt
     - ^roles/registry_deploy/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-registry_deploy
     parent: cifmw-molecule-base
     vars:
@@ -497,6 +545,7 @@
     - ^test-requirements.txt
     - ^roles/repo_setup/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-repo_setup
     parent: cifmw-molecule-base
     vars:
@@ -507,6 +556,7 @@
     - ^test-requirements.txt
     - ^roles/reproducer/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-reproducer
     nodeset: centos-9-crc-2-30-0-xxl
     parent: cifmw-molecule-base
@@ -519,6 +569,7 @@
     - ^test-requirements.txt
     - ^roles/rhol_crc/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-rhol_crc
     nodeset: centos-9-crc-2-30-0-xxl
     parent: cifmw-molecule-base
@@ -531,6 +582,7 @@
     - ^test-requirements.txt
     - ^roles/run_hook/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-run_hook
     parent: cifmw-molecule-base
     vars:
@@ -541,6 +593,7 @@
     - ^test-requirements.txt
     - ^roles/set_openstack_containers/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-set_openstack_containers
     parent: cifmw-molecule-base-crc
     vars:
@@ -551,6 +604,7 @@
     - ^test-requirements.txt
     - ^roles/tempest/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-tempest
     parent: cifmw-molecule-base
     vars:
@@ -561,6 +615,7 @@
     - ^test-requirements.txt
     - ^roles/test_deps/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-test_deps
     parent: cifmw-molecule-base
     vars:
@@ -571,6 +626,7 @@
     - ^test-requirements.txt
     - ^roles/test_operator/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-test_operator
     parent: cifmw-molecule-base
     vars:
@@ -581,6 +637,7 @@
     - ^test-requirements.txt
     - ^roles/tofu/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-tofu
     parent: cifmw-molecule-base
     vars:
@@ -591,6 +648,7 @@
     - ^test-requirements.txt
     - ^roles/update/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-update
     parent: cifmw-molecule-base
     vars:
@@ -601,6 +659,7 @@
     - ^test-requirements.txt
     - ^roles/virtualbmc/(?!meta|README).*
     - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
     name: cifmw-molecule-virtualbmc
     parent: cifmw-molecule-base
     vars:


### PR DESCRIPTION
It seems latest CentOS image isn't booting properly.

By passing the proper parameter via the molecule configuration, we
should be able to get a global fix, instead of having to go in each
roles to set the appropriate parameter.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
