### PR TITLE
Allow defined VM with amount=0

### DIFF
--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -42,7 +42,7 @@ The following structure has to be passed via the configuration parameter:
 cifmw_libvirt_manager_configuration:
   vms:
     type_name:  # (string, such as "compute", "controller")
-      amount: (integer, optional. Optional, defaults to 1)
+      amount: (integer, optional. Optional, defaults to 1, allowed [0-9]+)
       image_url: (string, URI to the base image. Optional if disk_file_name is set to "blank")
       sha256_image_name: (string, image checksum. Optional if disk_file_name is set to "blank")
       image_local_dir: (string, image destination for download. Optional if disk_file_name is set to "blank")
@@ -55,6 +55,7 @@ cifmw_libvirt_manager_configuration:
       extra_disks_size: (string, optional. Storage capacity to be allocated. Example 1G, 512M)
       password: (string, optional, defaults to fooBar. Root password for console access)
       target: (Hypervisor hostname you want to deploy the family on. Optional)
+      uefi: (boolean, toggle UEFI boot. Optional, defaults to false)
   networks:
     net_name: <XML definition of the network to create>
 ```

--- a/roles/libvirt_manager/molecule/deploy_layout/converge.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/converge.yml
@@ -35,6 +35,17 @@
         vlan: 20
     cifmw_libvirt_manager_configuration:
       vms:
+        nocompute:
+          amount: 0
+          disk_file_name: "blank"
+          disksize: 20
+          memory: 1
+          cpus: 1
+          nets:
+            - public
+            - osp_trunk
+          extra_disks_num: 1
+          extra_disks_size: 1G
         compute:
           amount: 2
           image_url: "{{ cifmw_discovered_image_url }}"

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -192,6 +192,9 @@
         vm_data.value.target == inventory_hostname
       ) or
       vm_data.value.target is undefined
+    - (vm_data.value.amount is defined and
+       (vm_data.value.amount | int) > 0) or
+      vm_data.value.amount is undefined
   vars:
     vm_type: "{{ vm_data.key }}"
     pub_key: "{{ pub_ssh_key.content | b64decode }}"
@@ -324,6 +327,9 @@
 - name: Ensure we get proper access to CRC
   when:
     - _layout.vms.crc is defined
+    - (_layout.vms.crc.amount is defined and
+       (_layout.vms.crc.amount | int) > 0) or
+      _layout.vms.crc.amount is undefined
     - (
         _layout.vms.crc.target is defined and
         _layout.vms.crc.target == inventory_hostname


### PR DESCRIPTION
In some cases, we may get a layout with defined VM with a amount set to
0.

This is interesting in certain conditions, for instance if we we're
running a zuul reproducer setting 0 computes, or 0 CRC node.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
