### PR TITLE
Extend "molecule" related playbooks

### DIFF
--- a/ci/playbooks/molecule-prepare.yml
+++ b/ci/playbooks/molecule-prepare.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Run ci/playbooks/molecule-prepare.yml"
-  hosts: controller
+  hosts: "{{ cifmw_zuul_target_host | default('controller') }}"
   gather_facts: true
   tasks:
     - name: Prepare workspace
@@ -9,9 +9,13 @@
 
     - name: Create zuul-output directory
       ansible.builtin.file:
-        path: "{{ ansible_user_dir }}/zuul-output/logs"
+        path: "{{ item }}"
         state: directory
         mode: "0755"
+      loop:
+        - "{{ ansible_user_dir }}/ci-framework-data/logs"
+        - "{{ ansible_user_dir }}/zuul-output/logs"
+
     - name: Install required packages
       become: true
       ansible.builtin.package:

--- a/ci/playbooks/molecule-test.yml
+++ b/ci/playbooks/molecule-test.yml
@@ -1,8 +1,14 @@
 ---
 - name: "Run ci/playbooks/molecule-test.yml"
-  hosts: controller
+  hosts: "{{ cifmw_zuul_target_host | default('controller') }}"
   gather_facts: true
   tasks:
+    - name: Load environment var if instructed to
+      when:
+        - cifmw_reproducer_molecule_env_file is defined
+      ansible.builtin.include_vars:
+        file: "{{ cifmw_reproducer_molecule_env_file }}"
+
     - name: Run molecule
       environment:
         ANSIBLE_LOG_PATH: "{{ ansible_user_dir }}/zuul-output/logs/ansible-execution.log"
@@ -25,6 +31,9 @@
               trim(":")
             )
           }}
-      ansible.builtin.command:
+      ansible.builtin.shell:
         chdir: "{{ roles_dir }}"
-        cmd: "molecule -c {{ mol_config_dir }} test --all"
+        cmd: >-
+          set -o pipefail;
+          molecule -c {{ mol_config_dir }} test --all |
+          tee {{ ansible_user_dir }}/ci-framework-data/logs/molecule-execution.log

--- a/roles/pkg_build/templates/containerfile.buildpkg.j2
+++ b/roles/pkg_build/templates/containerfile.buildpkg.j2
@@ -12,6 +12,9 @@ RUN dnf install -y createrepo gcc redhat-rpm-config rpmdevtools httpd \
 RUN ansible-galaxy collection install --force \
   git+https://github.com/ansible-collections/ansible.posix \
   git+https://github.com/ansible-collections/community.general
+
 COPY ./build_openstack_packages /root/roles/build_openstack_packages
+# Needed for "epel" tasks file
+COPY ./ci_setup /root/roles/ci_setup
 
 WORKDIR /root


### PR DESCRIPTION
In order to allow molecule job reproducer, we must slightly extend the
existing CI playbook, to alow setting a custom `hosts` as well as
passing down environment files/parameters to ensure we're reproducing
the right job.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
