### PR TITLE
Add validation and assert before get all ip addresses

### DIFF
--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -299,6 +299,13 @@
       vars:
         this_host: "{{ _target_hosts | first }}"
 
+    - name: Assert if any EDPM node's n/w interface is missing in storage network
+      ansible.builtin.assert:
+        that:
+          - hostvars[item][all_addresses] | ansible.utils.ipaddr(cifmw_cephadm_rgw_network) | length > 0
+        fail_msg: "node {{ item }} doesn't have any interface connected to network {{ cifmw_cephadm_rgw_network }}"
+      loop: "{{ _target_hosts }}"
+
     - name: Get already assigned IP addresses
       ansible.builtin.set_fact:
         ips: "{{ ips | default([]) + [ hostvars[item][all_addresses] | ansible.utils.ipaddr(cifmw_cephadm_rgw_network) | first ] }}"


### PR DESCRIPTION
There can be a case where scale out compute nodes in HCI may not have any n/w interface configured in the storage network which may result in failures without proper info while fetching ip addresses.

This patch adds a task to validate and asset if any of the EDPM nodes doesn't have at least one n/w interface in the storage network.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
