### PR TITLE
Ensure we keep track of the kustomize builds

### DIFF
--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -128,7 +128,7 @@
       ansible.builtin.fail:
         msg: "Failing on demand {{ cifmw_deploy_architecture_stopper }}"
 
-    - name: "Build kustomized content for {{ stage.path }}"
+    - name: "Build and store kustomized content for {{ stage.path }}"
       vars:
         _output: >-
           {{
@@ -142,16 +142,29 @@
              stage['path']) |
              path_join | realpath
           }}
-      ansible.builtin.copy:
-        dest: "{{ _output }}"
-        mode: "0644"
-        content: >-
-          {{
-            lookup(
-              'kubernetes.core.kustomize',
-              dir=_chdir
-            )
-          }}
+      block:
+        - name: "Build kustomized content for {{ stage.path }}"
+          ansible.builtin.copy:
+            dest: "{{ _output }}"
+            mode: "0644"
+            content: >-
+              {{
+                lookup(
+                  'kubernetes.core.kustomize',
+                  dir=_chdir
+                )
+              }}
+
+        - name: "Store kustomized content in artifacts for {{ stage.path }}"
+          ansible.builtin.copy:
+            remote_src: true
+            src: "{{ _output }}"
+            dest: >-
+              {{
+                (cifmw_kustomize_deploy_kustomizations_dest_dir,
+                 stage['build_output'] | basename) | path_join
+              }}
+            mode: "0644"
 
     - name: Stop after building kustomization if requested
       when:


### PR DESCRIPTION
We were missing artifacts in the flexible loop. This patch ensures we're
using the same location as the `install_operators.yml` tasks to keep the
various outputs of the `execute_steps.yml` kustomize calls.

Depends-On: https://github.com/openstack-k8s-operators/architecture/pull/173

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
