### PR TITLE
[deploy_bmh] Pass host credentials through a file

### DIFF
--- a/docs/source/baremetal/01_baremetal_hosts_data.md
+++ b/docs/source/baremetal/01_baremetal_hosts_data.md
@@ -19,10 +19,16 @@ The structure of that variable is the following:
 ```yaml
 cifmw_baremetal_hosts:
   compute-0:
-    # Mandatory: (string) The BMC password of the host
+    # Mandatory if credentials_file is missing:
+    #   (string) The BMC password of the host
     password: password
-    # Mandatory: (string) The BMC username of the host
+    # Mandatory if credentials_file is missing:
+    #   (string) The BMC username of the host
     username: user
+    # Mandatory if user/password are missing
+    #   (string) A path to a yaml file containing the
+    #     the username and password fields
+    credentials_file: /path/to/credentials.yaml
     # Mandatory: (string) The BMC connection URL
     #   The format should be: <proto>://host:port
     connection: idrac://host-bmc.example.local

--- a/roles/deploy_bmh/tasks/main.yml
+++ b/roles/deploy_bmh/tasks/main.yml
@@ -44,6 +44,19 @@
       vars:
         node_name: "{{ item.key }}"
         node_data: "{{ item.value }}"
+        _credentials_content: >-
+          {{
+            lookup('file', item.value['credentials_file']) | from_yaml
+            if 'credentials_file' in item.value else {}
+          }}
+        node_user: >-
+          {{
+            item.value['username'] if 'username' in item.value else _credentials_content['username']
+          }}
+        node_password: >-
+          {{
+            item.value['password'] if 'password' in item.value else _credentials_content['password']
+          }}
         template_name: "bmh-secret"
         manifest_patch: >-
           {{

--- a/roles/deploy_bmh/template/bmh-secret.yml.j2
+++ b/roles/deploy_bmh/template/bmh-secret.yml.j2
@@ -6,5 +6,5 @@ metadata:
   namespace: {{ cimfw_deploy_bmh_namespace }}
 type: Opaque
 stringData:
-  username: {{ node_data['username'] }}
-  password: {{ node_data['password'] }}
+  username: {{ node_user }}
+  password: {{ node_password }}


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
