### PR TITLE
Allow to push secrets on controller-0

### DIFF
--- a/roles/manage_secrets/defaults/main.yml
+++ b/roles/manage_secrets/defaults/main.yml
@@ -22,6 +22,8 @@ cifmw_manage_secrets_basedir: >-
     cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data')
   }}
 
+cifmw_manage_secrets_owner: "{{ ansible_user_id }}"
+
 # pull-secret management
 cifmw_manage_secrets_pullsecret_dest: >-
   {{ (cifmw_manage_secrets_basedir,
@@ -58,3 +60,6 @@ cifmw_manage_secrets_dataplane_ssh_metaname: dataplane-ansible-ssh-private-key-s
 # osp secrets management
 cifmw_manage_secrets_ospsecrets_manifests_dest: "{{ cifmw_manifests | default(cifmw_manage_secrets_basedir ~ '/artifacts/manifests') }}/osp_secrets"
 cifmw_manage_secrets_ospsecrets_list: []
+
+# reproducer secrets
+cifmw_manage_secrets_reproducer_secrets: []

--- a/roles/manage_secrets/tasks/_push_secret.yml
+++ b/roles/manage_secrets/tasks/_push_secret.yml
@@ -14,9 +14,22 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Debug _secret_dest
+  ansible.builtin.debug:
+    var: _secret_dest
+
+- name: Debug _secret_file
+  ansible.builtin.debug:
+    var: _secret_file
+
+- name: Debug _secret_content
+  ansible.builtin.debug:
+    var: _secret_content
+
 - name: Manage file copy
   when:
     - _secret_file != None
+    - _secret_file | length > 0
   block:
     - name: Ensure parameter is an absolute path
       ansible.builtin.assert:
@@ -30,11 +43,12 @@
         dest: "{{ _secret_dest }}"
         src: "{{ _secret_file }}"
         mode: "0600"
-        owner: "{{ ansible_user_id }}"
+        owner: "{{ cifmw_manage_secrets_owner }}"
 
 - name: Manage file creation from content
   when:
     - _secret_content != None
+    - _secret_content | length > 0
   block:
     - name: Create file from content
       no_log: true
@@ -42,4 +56,4 @@
         dest: "{{ _secret_dest }}"
         content: "{{ _secret_content }}"
         mode: "0600"
-        owner: "{{ ansible_user_id }}"
+        owner: "{{ cifmw_manage_secrets_owner }}"

--- a/roles/manage_secrets/tasks/main.yml
+++ b/roles/manage_secrets/tasks/main.yml
@@ -18,5 +18,5 @@
   ansible.builtin.file:
     path: "{{ cifmw_manage_secrets_basedir }}/secrets"
     state: directory
-    owner: "{{ ansible_user_id }}"
+    owner: "{{ cifmw_manage_secrets_owner }}"
     mode: "0700"

--- a/roles/manage_secrets/tasks/reproducer.yml
+++ b/roles/manage_secrets/tasks/reproducer.yml
@@ -1,0 +1,42 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Assert we get needed data
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - cifmw_manage_secrets_reproducer_secrets is defined
+      - cifmw_manage_secrets_reproducer_secrets is iterable
+      - cifmw_manage_secrets_reproducer_secrets is not mapping
+    msg: >-
+      Provide cifmw_manage_secrets_reproducer_secrets as a list
+      of dict.
+
+- name: Push reproducer secrets
+  vars:
+    _secret_dest: >-
+      {%- if item.dest is abs -%}
+      {{ item.dest | trim}}
+      {%- else -%}
+      {{
+        (cifmw_manage_secrets_basedir, 'secrets',
+         item.dest) | path_join | trim
+      }}
+      {%- endif -%}
+    _secret_file: "{{ item.src | default('') }}"
+    _secret_content: "{{ item.content | default('') }}"
+  ansible.builtin.include_tasks: _push_secret.yml
+  loop: "{{ cifmw_manage_secrets_reproducer_secrets }}"

--- a/roles/reproducer/molecule/crc_layout/converge.yml
+++ b/roles/reproducer/molecule/crc_layout/converge.yml
@@ -19,6 +19,11 @@
   hosts: all
   gather_facts: true
   vars:
+    cifmw_manage_secrets_reproducer_secrets:
+      - content: "my-default-location-place"
+        dest: "default.txt"
+      - src: "/tmp/ipmi-things"
+        dest: "/home/zuul/ipmi-things"
     cifmw_basedir: "/opt/basedir"
     cifmw_install_yamls_repo: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
     cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
@@ -161,6 +166,20 @@
               {{ _inv.ocps.hosts['crc-0'].ansible_host }}
           ansible.builtin.command:
             cmd: "ping -c1 -w1 {{ _ip }}"
+
+        - name: Check secret files
+          block:
+            - name: Check default location secret file
+              register: _default_secret
+              ansible.builtin.stat:
+                path: "{{ ansible_user_dir }}/ci-framework-data/secrets/default.txt"
+              failed_when: not _default_secret.stat.exists
+
+            - name: Check non-default location secret
+              register: _default_secret
+              ansible.builtin.stat:
+                path: "{{ ansible_user_dir }}/ipmi-things"
+              failed_when: not _default_secret.stat.exists
 
     - name: Gather logs from nested controller-0
       vars:

--- a/roles/reproducer/molecule/crc_layout/prepare.yml
+++ b/roles/reproducer/molecule/crc_layout/prepare.yml
@@ -31,3 +31,10 @@
   roles:
     - role: "test_deps"
     - role: "ci_setup"
+  tasks:
+    - name: Create secret file
+      ansible.builtin.copy:
+        dest: "/tmp/ipmi-things"
+        mode: "0644"
+        content: |-
+          This is no secret folks

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -296,6 +296,20 @@
         state: directory
         mode: "0755"
 
+    - name: Manage secrets on controller-0
+      vars:
+        cifmw_manage_secrets_basedir: "/home/zuul/ci-framework-data"
+        cifmw_manage_secrets_owner: "zuul"
+      block:
+        - name: Initialize secret manager
+          ansible.builtin.import_role:
+            name: manage_secrets
+
+        - name: Inject secrets
+          ansible.builtin.import_role:
+            name: manage_secrets
+            tasks_from: reproducer.yml
+
     - name: Ensure packages are installed
       become: true
       block:


### PR DESCRIPTION
By leveraging `cifmw_manage_secrets_reproducer_secrets` parameter, we
are now able to push secrets from the ansible controller (your laptop,
for instance) onto controller-0.

If the destination is a relative path (just a file name for instance) it
will be pushed into cifmw_basedir/secrets - else you can pass an
absolute path. Keep in mind it's on the controller-0, meaning the user
is `zuul`.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
