### PR TITLE
Drop cifmw_test_operator_tempest_tests_exclude_override_scenario from  scenario file

### DIFF
--- a/scenarios/centos-9/multinode-ci.yml
+++ b/scenarios/centos-9/multinode-ci.yml
@@ -26,6 +26,5 @@ cifmw_deploy_edpm: true
 
 # Tempest vars
 cifmw_run_test_role: test_operator
-cifmw_test_operator_tempest_tests_exclude_override_scenario: true
 cifmw_test_operator_tempest_include_list: |
   tempest.scenario.test_network_basic_ops.TestNetworkBasicOps

--- a/scenarios/reproducers/va-hci.yml
+++ b/scenarios/reproducers/va-hci.yml
@@ -51,7 +51,6 @@ cifmw_run_tests: true
 cifmw_run_tempest: true
 cifmw_run_test_role: test_operator
 cifmw_test_operator_timeout: 7200
-cifmw_test_operator_tempest_tests_exclude_override_scenario: true
 cifmw_test_operator_tempest_include_list: |
   tempest.scenario.test_network_basic_ops.TestNetworkBasicOps
 


### PR DESCRIPTION
cifmw_test_operator_tempest_tests_exclude_override_scenario var is used to override the cifmw_test_operator_tempest_exclude_list and use the default test_operator skip list.

Since it is set to false by default and cifmw_test_operator_tempest_exclude_list is not defined in default role var. The role is always going to use the default test_operator skip list. So we donot need to re-run the same vars.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

