### PR TITLE
DNM - Check CI with image CRC 2.34.1 base on OCP 4.15.3

### DIFF
--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -78,7 +78,7 @@
 - job:
     name: podified-multinode-hci-deployment-crc-3comp
     parent: podified-multinode-edpm-deployment-crc
-    nodeset: centos-9-medium-3x-centos-9-crc-extracted-2-30-0-xxl
+    nodeset: centos-9-medium-3x-centos-9-crc-extracted-2-34-1-xxl
     vars:
       cifmw_edpm_deploy_hci: true
       crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"
@@ -247,6 +247,7 @@
 - job:
     name: podified-multinode-edpm-deployment-crc
     parent: cifmw-podified-multinode-edpm-base-crc
+    nodeset: centos-9-medium-centos-9-crc-extracted-2.34-3xl
     vars:
       cifmw_extras:
         - '@scenarios/centos-9/multinode-ci.yml'

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -111,6 +111,23 @@
           - crc
 
 - nodeset:
+    name: centos-9-medium-centos-9-crc-extracted-2.34-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: coreos-crc-extracted-2-34-1-3xl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
     name: centos-9-crc-2-30-0-3xl
     nodes:
       - name: controller
@@ -129,6 +146,29 @@
         label: cloud-centos-9-stream-tripleo
       - name: crc
         label: coreos-crc-extracted-2-30-0-xxl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+          - compute-2
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-medium-3x-centos-9-crc-extracted-2-34-1-xxl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-2
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: coreos-crc-extracted-2-34-1-xxl
     groups:
       - name: computes
         nodes:


### PR DESCRIPTION
DNM This commit is just veryfing the Zuul CI if the edpm jobs will pass on the new provided image.

