### PR TITLE
[openshift_login] Only slurp install-yamls-params when update is needed

### DIFF
--- a/roles/openshift_login/tasks/main.yml
+++ b/roles/openshift_login/tasks/main.yml
@@ -98,22 +98,24 @@
     dest: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts/parameters/openshift-login-params.yml"
     content: "{{ cifmw_openshift_login_params_content | from_yaml | to_nice_yaml }}"
 
-- name: Read the install yamls parameters file
-  ansible.builtin.slurp:
-    path: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts/parameters/install-yamls-params.yml"
-  register: cifmw_openshift_login_install_yamls_artifacts_slurp
-
-- name: Append the KUBECONFIG to the install yamls parameters
+- name: Update the install-yamls-params with KUBECONFIG
   when: cifmw_install_yamls_environment is defined
-  ansible.builtin.copy:
-    content: >-
-      {{
-        cifmw_openshift_login_install_yamls_artifacts_slurp['content'] | b64decode | from_yaml |
-        combine(
-          {
-            'cifmw_install_yamls_environment': {
-              'KUBECONFIG': cifmw_openshift_login_kubeconfig
-            }
-          }, recursive=true) | to_nice_yaml
-      }}
-    dest: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts/parameters/install-yamls-params.yml"
+  block:
+    - name: Read the install yamls parameters file
+      ansible.builtin.slurp:
+        path: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts/parameters/install-yamls-params.yml"
+      register: cifmw_openshift_login_install_yamls_artifacts_slurp
+
+    - name: Append the KUBECONFIG to the install yamls parameters
+      ansible.builtin.copy:
+        content: >-
+          {{
+            cifmw_openshift_login_install_yamls_artifacts_slurp['content'] | b64decode | from_yaml |
+            combine(
+              {
+                'cifmw_install_yamls_environment': {
+                  'KUBECONFIG': cifmw_openshift_login_kubeconfig
+                }
+              }, recursive=true) | to_nice_yaml
+          }}
+        dest: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts/parameters/install-yamls-params.yml"


### PR DESCRIPTION
The install-yamls-params.yml param file is always slurped. The task that uses this slurped file is only run conditionally. Add the slurp to a conditional block with the file-update task.

The bootstrap playbook, which runs install_yamls and creates the file can skip running install_yamls when the bootstrap tag is skipped. This causes errors when the infra playbook is run and expects the params file to exist so it can be read.

This issue was discovered when trying to debug stf jobs failures.
The job failures are here:  https://review.rdoproject.org/zuul/build/043eab3a41c04c79ae46392100bc6607
The current workaround/fix is in progress here: https://github.com/infrawatch/service-telemetry-operator/pull/590

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
