### PR TITLE
Restart dnsmasq if available

### DIFF
--- a/ci/playbooks/multinode-customizations.yml
+++ b/ci/playbooks/multinode-customizations.yml
@@ -100,13 +100,13 @@
                 replace: >-
                   {{ _crc_default_net_ip | ansible.utils.ipaddr('address') }}
 
-    - name: Reload dnsmasq service if used
+    - name: Restart dnsmasq service if used
       become: true
       when:
         - not _dnsmasq.stat.exists
       ansible.builtin.service:
         name: dnsmasq
-        state: reloaded
+        state: restarted
 
     - name: Manage old dnsmasq container
       when:


### PR DESCRIPTION
The dnsmasq service can not be reloaded, as it was provided, because it will raise an error:

     TASK [Reload dnsmasq service if used]
     crc | ERROR
     crc | {
     crc |   "msg": "Unable to reload service dnsmasq: Failed to reload dnsmasq.service: Job type reload is not applicable for unit dnsmasq.service.\n"
     crc | }

This commit is changing service state to restarted.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running