### PR TITLE
Improve gating content generation in build_openstack_packages role

### DIFF
--- a/ci/playbooks/tcib/tcib.yml
+++ b/ci/playbooks/tcib/tcib.yml
@@ -28,20 +28,12 @@
       vars:
         cifmw_bop_openstack_project_path: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/tcib"
         cifmw_bop_yum_repos_dir: "{{ cifmw_build_containers_repo_dir }}"
+        cifmw_bop_gating_repo_dest: "{{ cifmw_build_containers_repo_dir }}"
       tags:
         - container_img_build
         - build_openstack_packages
       ansible.builtin.include_role:
         name: build_openstack_packages
-
-    - name: Copy gating_repo data to repo directory
-      tags:
-        - container_img_build
-        - build_openstack_packages
-      ansible.builtin.copy:
-        src: "{{ ansible_user_dir }}/gating_repo/"
-        dest: "{{ cifmw_build_containers_repo_dir }}"
-        remote_src: true
 
     - name: Deploy local registry
       tags:

--- a/roles/build_openstack_packages/README.md
+++ b/roles/build_openstack_packages/README.md
@@ -16,7 +16,8 @@ An Ansible role for generating custom RPMSs of OpenStack Projects using DLRN
 * `cifmw_bop_openstack_release`: (String) The default release of OpenStack project. Defaults to `master`.
 * `cifmw_bop_osp_release`: (String) The downstream openstack release name.
 * `cifmw_bop_openstack_project_path`: (String) The full path of openstack cloned project to be built.
-* `cifmw_bop_gating_repo`: (String) The path of directory to store the generated rpms.
+* `cifmw_bop_gating_repo_dest`: (String) The path of directory to store gating repo file and repo metadata.
+  Defaults to `cifmw_bop_build_repo_dir` var.
 * `cifmw_bop_dlrn_cleanup`: (Boolean) Clean up the DLRN artifacts. Defaults to `False`.
 
 ### TODO
@@ -30,9 +31,6 @@ An Ansible role for generating custom RPMSs of OpenStack Projects using DLRN
 ```
 - hosts: localhost
   vars:
-    cifmw_bop_dlrn_target: centos9-stream
-    cifmw_bop_initial_dlrn_config: centos9-local
-    cifmw_bop_dlrn_baseurl: https://trunk.rdoproject.org/centos9-master
     cifmw_bop_yum_repos_dir: /tmp/repos
   pre_tasks:
     - name: Clone neutron-tempest-plugin

--- a/roles/build_openstack_packages/defaults/main.yml
+++ b/roles/build_openstack_packages/defaults/main.yml
@@ -61,7 +61,7 @@ cifmw_bop_openstack_release: master
 # cifmw_bop_osp_release: 18.0
 cifmw_bop_openstack_project_path: ''
 
-cifmw_bop_gating_repo: "{{ cifmw_bop_build_repo_dir }}/gating_repo"
+cifmw_bop_gating_repo_dest: "{{ cifmw_bop_build_repo_dir }}"
 cifmw_bop_dlrn_cleanup: false
 
 cifmw_bop_timestamper_cmd: >-

--- a/roles/build_openstack_packages/tasks/create_repo.yml
+++ b/roles/build_openstack_packages/tasks/create_repo.yml
@@ -14,24 +14,31 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Create a directory to hold the rpms
-  ansible.builtin.file:
-    path: '{{ cifmw_bop_gating_repo }}'
+- name: Create a temproary directory to hold the rpms
+  ansible.builtin.tempfile:
+    suffix: gating
     state: directory
+  register: _repodir
 
 - name: Copy the generated rpms
   ansible.builtin.shell:
     cmd: >
       set -o pipefail &&
-      rm -rf {{ cifmw_bop_gating_repo }}/*;
+      rm -rf {{ _repodir.path }}/*;
       [[ $(find {{ cifmw_bop_build_repo_dir }}/DLRN/data/repos -type f -name '*.rpm') ]] &&
-      find {{ cifmw_bop_build_repo_dir }}/DLRN/data/repos -type f -name '*.rpm' -print0 | xargs -0 cp -t {{ cifmw_bop_gating_repo }} ||
+      find {{ cifmw_bop_build_repo_dir }}/DLRN/data/repos -type f -name '*.rpm' -print0 | xargs -0 cp -t {{ _repodir.path }} ||
       echo "no DLRN builds";
 
 - name: Run createrepo on generated rpms
   ansible.builtin.command:
     cmd: createrepo .
-    chdir: '{{ cifmw_bop_gating_repo }}'
+    chdir: '{{ _repodir.path }}'
+
+- name: Copy the gating content to destination
+  ansible.builtin.copy:
+    remote_src: true
+    src: "{{ _repodir.path }}/"
+    dest: "{{ cifmw_bop_gating_repo_dest }}"
 
 - name: Add gating.repo file to install the required built packages
   ansible.builtin.copy:
@@ -42,9 +49,4 @@
       enabled=1
       gpgcheck=0
       priority=1
-    dest: "{{ cifmw_bop_gating_repo }}/gating.repo"
-
-- name: Compress the repo
-  ansible.builtin.command:  # noqa: command-instead-of-module
-    cmd: "tar czf {{ cifmw_bop_gating_repo }}.tar.gz gating_repo"
-    chdir: "{{ cifmw_bop_gating_repo | ansible.builtin.dirname }}"
+    dest: "{{ cifmw_bop_gating_repo_dest }}/gating.repo"

--- a/roles/pkg_build/templates/pkg_build_play.j2
+++ b/roles/pkg_build/templates/pkg_build_play.j2
@@ -12,7 +12,7 @@
     cifmw_bop_openstack_project_path: "{{ ansible_user_dir }}/src/{{ cifmw_project }}"
     cifmw_bop_build_repo_dir: "{{ ansible_user_dir }}/{{ cifmw_project }}"
     cifmw_bop_yum_repos_dir: "{{ ansible_user_dir }}/yum.repos.d"
-    cifmw_bop_gating_repo: "{{ ansible_user_dir }}/gating_repo"
+    cifmw_bop_gating_repo_dest: "{{ ansible_user_dir }}/gating_repo"
   tasks:
     - name: Gather parameters
       ansible.builtin.set_fact:


### PR DESCRIPTION
This pull requests improves following things:
- Renames gating repo var to cifmw_bop_gating_repo_dest to store repo file and generated repo metadata at one place.
- Use temp directory to copy all build rpms and generate repos content in temp directory
- Drops the compress repo task as it is no longer needed.
- Removes the tcib specific task from under create_repo task file

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

