### PR TITLE
[bop]Build DLRN packages from downstream changes

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -403,6 +403,7 @@ rdoproject
 readme
 readmes
 readthedocs
+rebaser
 redfish
 redhat
 refspec

--- a/roles/build_openstack_packages/README.md
+++ b/roles/build_openstack_packages/README.md
@@ -8,6 +8,7 @@ An Ansible role for generating custom RPMSs of OpenStack Projects using DLRN
 * `cifmw_bop_dlrn_repo_url`: (String) The URL of the DLRN repository.
 * `cifmw_bop_dlrn_from_source`: (String) Install DLRN from git. Defaults to `False`.
 * `cifmw_bop_dlrn_venv: (String) DLRN Virtualenv directory Default to `{{ ansible_user_dir }}/dlrn_venv`.
+* `cifmw_bop_patch_rebaser_repo_url`: (String) The URL of patch rebaser repository.
 * `cifmw_bop_rdoinfo_repo_url`: (String) The URL of the rdoinfo repository that contains the project definitions for DLRN.
 * `cifmw_bop_rdoinfo_repo_name`: (String) Name of the rdoinfo repository.
 * `cifmw_bop_initial_dlrn_config`: (String) Name of the initial DLRN config. Defaults to `centos9-stream`.

--- a/roles/build_openstack_packages/defaults/main.yml
+++ b/roles/build_openstack_packages/defaults/main.yml
@@ -38,20 +38,12 @@ cifmw_bop_dlrn_venv: "{{ ansible_user_dir }}/dlrn_venv"
 
 cifmw_bop_rdoinfo_repo_url: https://github.com/redhat-openstack/rdoinfo
 cifmw_bop_rdoinfo_repo_name: rdoinfo
+# cifmw_bop_rhospkg_repo_url:
+cifmw_bop_patch_rebaser_repo_url: "https://github.com/release-depot/patch_rebaser.git"
 
-cifmw_bop_initial_dlrn_config: >-
-  {%- if ansible_distribution == "RedHat" -%}
-  redhat
-  {%- elif ansible_distribution == "CentOS" -%}
-  centos9-stream
-  {%- endif -%}
+cifmw_bop_initial_dlrn_config: centos9-stream
 
-cifmw_bop_dlrn_target: >-
-  {%- if ansible_distribution == "RedHat" -%}
-  redhat-local
-  {%- elif ansible_distribution == "CentOS" -%}
-  centos9-stream
-  {%- endif -%}
+cifmw_bop_dlrn_target: centos9-stream
 
 cifmw_bop_dlrn_baseurl: "https://trunk.rdoproject.org/centos9-antelope"
 cifmw_bop_use_components: 1

--- a/roles/build_openstack_packages/tasks/append_repos.yml
+++ b/roles/build_openstack_packages/tasks/append_repos.yml
@@ -4,7 +4,9 @@
     src: "{{ _repo_path }}"
   register: _repo_data
 
-- name: Append the content in mock config
-  ansible.builtin.lineinfile:
-    path: "{{ cifmw_bop_build_repo_dir }}/DLRN/scripts/{{ cifmw_bop_initial_dlrn_config }}-local.cfg"
-    line: "{{ _repo_data['content'] | b64decode }}"
+- name: Store the all repo data in a single list
+  ansible.builtin.set_fact:
+    _repo_contents:
+      "{{ _repo_contents|default([]) +
+        [ _repo_data['content'] | b64decode ]
+       }}"

--- a/roles/build_openstack_packages/tasks/downstream.yml
+++ b/roles/build_openstack_packages/tasks/downstream.yml
@@ -1,0 +1,65 @@
+---
+- name: Fetch patch rebaser source
+  ansible.builtin.git:
+    repo: '{{ cifmw_bop_patch_rebaser_repo_url }}'
+    dest: '{{ cifmw_bop_build_repo_dir }}/patch_rebaser'
+    version: 'master'
+  register: _git_clone
+  until: _git_clone is success
+  retries: 3
+  delay: 5
+
+- name: Install patch rebaser requirements
+  ansible.builtin.pip:
+    virtualenv: "{{ cifmw_bop_dlrn_venv }}"
+    requirements: "{{ cifmw_bop_build_repo_dir }}/patch_rebaser/requirements.txt"
+
+- name: Install patch rebaser and rhospkg
+  ansible.builtin.pip:
+    name:
+      - "{{ cifmw_bop_build_repo_dir }}/patch_rebaser"
+      - "{{ cifmw_bop_rhospkg_repo_url }}"
+    virtualenv: "{{ cifmw_bop_dlrn_venv }}"
+
+- name: Copy Downstream mock config to DLRN repo
+  ansible.builtin.copy:
+    remote_src: true
+    src: "{{ ansible_user_dir }}/{{ cifmw_bop_initial_dlrn_config }}.cfg"
+    dest: "{{ cifmw_bop_build_repo_dir }}/DLRN/scripts/{{ cifmw_bop_initial_dlrn_config }}.cfg"
+
+- name: Copy patch_rebaser.ini to patch_rebaser repo
+  ansible.builtin.copy:
+    remote_src: true
+    src: "{{ ansible_user_dir }}/patch_rebaser.ini"
+    dest: "{{ cifmw_bop_build_repo_dir }}/patch_rebaser/patch_rebaser/patch_rebaser.ini"
+
+- name: Copy Downstream scripts to DLRN repo
+  ansible.builtin.copy:
+    remote_src: true
+    src: "{{ ansible_user_dir }}/{{ item.key }}"
+    dest: "{{ cifmw_bop_build_repo_dir }}/DLRN/scripts/{{ item.key }}"
+    mode: "{{ item.value }}"
+  with_dict:
+    - "patch_rebaser.sh": "0755"
+    - "set_nvr.sh": "0755"
+
+- name: Configure git on the system
+  ansible.builtin.command: "{{ item }}"
+  loop:
+    - 'git config --global user.email "you@example.com"'
+    - 'git config --global user.name "Your Name"'
+
+- name: Fix packages.yml for buidling packages
+  vars:
+    _ospinfo_path: "{{ cifmw_bop_build_repo_dir }}/DLRN/{{ cifmw_bop_rdoinfo_repo_name }}"
+  block:
+    - name: Replace git ssh reference with https # noqa: command-instead-of-module
+      ansible.builtin.command:
+        cmd: "sed -i -e 's|osp-distgit: git+ssh|osp-distgit: https|g' packages.yml"
+        chdir: "{{ _ospinfo_path }}"
+
+    - name: Replace append git before rpms in package url
+      ansible.builtin.replace:
+        path: "{{ _ospinfo_path }}/packages.yml"
+        regexp: ".com/rpms"
+        replace: ".com/git/rpms"

--- a/roles/build_openstack_packages/tasks/install_dlrn.yml
+++ b/roles/build_openstack_packages/tasks/install_dlrn.yml
@@ -72,10 +72,18 @@
   changed_when: result.stdout or result.stderr
 
 - name: Create dlrn-venv
+  vars:
+    _upstream_command: "/usr/bin/python3 -m venv"
+    _command: >-
+      {%- if cifmw_bop_osp_release is defined -%}
+      {{ _upstream_command }} --system-site-packages
+      {%- else -%}
+      {{ _upstream_command }}
+      {%- endif -%}
   ansible.builtin.pip:  # noqa: package-latest
     name: pip
     virtualenv: "{{ cifmw_bop_dlrn_venv }}"
-    virtualenv_command: "/usr/bin/python3 -m venv"
+    virtualenv_command: "{{ _command }}"
     state: latest
     extra_args: --upgrade
 
@@ -134,15 +142,13 @@
   retries: 3
   delay: 5
 
-- name: Remove ssh reference from dist-git url  # noqa: command-instead-of-module
-  ansible.builtin.command:
-    cmd: "sed -i -e 's|osp-distgit: git+ssh|osp-distgit: git|g' packages.yml"
-    chdir: "{{ cifmw_bop_build_repo_dir }}/DLRN/{{ cifmw_bop_rdoinfo_repo_name }}"
-  when: ansible_distribution in ['RedHat']
+- name: Downstream related tasks
+  when: cifmw_bop_osp_release is defined
+  ansible.builtin.include_tasks: downstream.yml
 
 - name: Find all the repos files
   ansible.builtin.find:
-    paths: "{{ cifmw_bop_build_repo_dir }}"
+    paths: "{{ cifmw_bop_yum_repos_dir }}"
     patterns: "*.repo"
     recurse: false
   register: _yum_repos
@@ -165,10 +171,13 @@
   loop_control:
     loop_var: "_repo_path"
 
-- name: Append the """ content in mock local config at last
+- name: Append repo_content ending with """ in mock local config at last # noqa: jinja[invalid]
+  vars:
+    _repo_contents: '{{ _repo_contents  }}'
+    _end_content: '"""'
   ansible.builtin.lineinfile:
     path: "{{ cifmw_bop_build_repo_dir }}/DLRN/scripts/{{ cifmw_bop_initial_dlrn_config }}-local.cfg"
-    line: '"""'
+    line: "{{ _repo_contents | join('\n') + _end_content }}"
     insertafter: EOF
     state: present
 

--- a/roles/build_openstack_packages/tasks/run_dlrn.yml
+++ b/roles/build_openstack_packages/tasks/run_dlrn.yml
@@ -137,11 +137,51 @@
         refspec: "{{ _change.refspec }}"
         version: 'FETCH_HEAD'
 
+    - name: "Clone downstream Openstack {{ project_name_mapped.stdout }}" # noqa: name[template]
+      when:
+        - cifmw_bop_openstack_project_path | length == 0
+        - not repo_status.stat.exists
+        - "'host' in _change"
+        - "'redhat.com' in _change.host"
+      block:
+        - name: Clone the downstream project
+          ansible.builtin.git:
+            repo: '{{ _change.host }}/gerrit/{{ _change.project }}'
+            dest: '{{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}-tested'
+            refspec: "{{ _change.refspec }}"
+            version: 'FETCH_HEAD'
+
+        - name: Update the branch name for local DLRN clone # noqa: command-instead-of-module
+          ansible.builtin.command:
+            cmd: "git checkout -b {{ item }}"
+          args:
+            chdir: "{{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}-tested"
+          loop:
+            - "{{ cifmw_bop_osp_release }}-rhel-9-trunk"
+            - "{{ cifmw_bop_osp_release }}-trunk-patches"
+
+        - name: Update the project reference in packages.yml # noqa: command-instead-of-module
+          vars:
+            _old_content: 'osp-patches: ssh://{{ _change.host | split("//") | last }}:22/{{ _change.project }}'
+            _new_content: 'osp-patches: file://{{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}-tested'
+          ansible.builtin.command:
+            cmd: >-
+              sed -i -e 's|{{ _old_content }}|{{ _new_content }}|g' packages.yml
+          args:
+            chdir: "{{ cifmw_bop_build_repo_dir }}/DLRN/{{ cifmw_bop_rdoinfo_repo_name }}"
+
     - name: Find the last commit from the clonned repo
       register: _commit
+      vars:
+        _project_path: >-
+          {%- if cifmw_bop_osp_release is defined -%}
+          {{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}-tested
+          {%- else -%}
+          {{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}
+          {%- endif -%}
       ansible.builtin.command:
         cmd: git show-ref --head --hash head # noqa: command-instead-of-module
-        chdir: "{{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}"
+        chdir: "{{ _project_path }}"
 
     - name: Print the last commit of the git repo
       ansible.builtin.debug:

--- a/roles/build_openstack_packages/templates/projects.ini.j2
+++ b/roles/build_openstack_packages/templates/projects.ini.j2
@@ -1,6 +1,6 @@
 [DEFAULT]
-datadir=./data
-scriptsdir=./scripts
+datadir={{ cifmw_bop_build_repo_dir }}/DLRN/data
+scriptsdir={{ cifmw_bop_build_repo_dir }}/DLRN/scripts
 baseurl={{ cifmw_bop_dlrn_baseurl }}
 distro=rpm-master
 source=master
@@ -29,16 +29,20 @@ use_components={{ cifmw_bop_use_components }}
 # We are only setting these for downstream case when cifmw_bop_osp_release
 # is defined. For downstream case, we are hardcoding release_numbering=minor.date.hash
 # and then just set the release_minor value based on the OSP version
-# (e.g. 0 for 16/16.0, 1 for 16.1, 2 for 16.2 etc).
+# (e.g. 0 for 18/18.0, 1 for 18.1, 2 for 18.2 etc).
 release_numbering=minor.date.hash
 release_minor={{ '0' if '.' not in cifmw_bop_osp_release.split('-')[1] else cifmw_bop_osp_release.split('-')[1].split('.')[1] }}
+nonfallback_branches=^master$,^rpm-master$,^rhos-
+custom_preprocess={{ cifmw_bop_build_repo_dir }}/DLRN/scripts/set_nvr.sh,{{ cifmw_bop_build_repo_dir }}/DLRN/scripts/patch_rebaser.sh
 
 [downstream_driver]
 info_files=osp.yml
-versions_url=https://trunk.rdoproject.org/centos9-{{ cifmw_bop_openstack_release }}/current/versions.csv
-downstream_distro_branch={{ cifmw_bop_osp_release }}{{ '.0' if '.' not in cifmw_bop_osp_release else '' }}-rhel-8-trunk
+versions_url=https://trunk.rdoproject.org/centos9-{{ cifmw_bop_openstack_release }}/current-podified/versions.csv
+downstream_source_git_branch={{ cifmw_bop_osp_release }}-trunk-patches
+downstream_distro_branch={{ cifmw_bop_osp_release }}{{ '.0' if '.' not in cifmw_bop_osp_release else '' }}-rhel-9-trunk
 downstream_tag=osp-{{ cifmw_bop_osp_release.split('-')[1] }}{{ '.0' if '.' not in cifmw_bop_osp_release else '' }}
 downstream_distgit_key=osp-distgit
+downstream_source_git_key=osp-patches
 use_upstream_spec=true
 downstream_spec_replace_list=^%global with_doc.+/%global with_doc 0,^%global rhosp.*/%global rhosp 1
 {% endif %}

--- a/roles/build_openstack_packages/templates/run_dlrn.sh.j2
+++ b/roles/build_openstack_packages/templates/run_dlrn.sh.j2
@@ -9,7 +9,8 @@ export REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.cr
 
 while true; do
     dlrn --config-file projects.ini --head-only --package-name $PKG --local \
-        --info-repo {{ cifmw_bop_rdoinfo_repo_name }} --dev;
+        --info-repo {{ cifmw_bop_build_repo_dir }}/DLRN/{{ cifmw_bop_rdoinfo_repo_name }} \
+	--dev;
     if [ $? -eq 0 ]; then
         # SUCCESS
         break;

--- a/roles/pkg_build/vars/main.yml
+++ b/roles/pkg_build/vars/main.yml
@@ -22,5 +22,5 @@
 # All variables within this role should have a prefix of "cifmw_pkg_build"
 cifmw_pkg_build_bop_env_defaults:
   cifmw_bop_dlrn_target: "centos9-stream"
-  cifmw_bop_initial_dlrn_config: "centos9-local"
+  cifmw_bop_initial_dlrn_config: "centos9-stream"
   cifmw_bop_dlrn_baseurl: "https://trunk.rdoproject.org/centos9-master"


### PR DESCRIPTION
This pull request adds the support for building DLRN packages from downstream changes:
    
 This pull request does the following things:
-  Creates the venv with system-site-packages enabled to access python-rpm library.
- Clone and install patch rebaser repo.
- Install rhospkg
- Copy downstream mock and patch rebaser config to specific location
- Copy downstream DLRN scripts to dlrn script directory
- Configure git needed by DLRN scripts while creating patch file in specs.
- Update packages.yml to allow clone without using ssh keys
- Update project.ini setting
      * for downstream driver
      * Update scripts and data directory full path
- Added tasks to clone downstream repo and update packages.yml to use the cloned repo as source
- Create respective branches on clonned repo needed by dlrn.
- Update DLRN script to pass full rdoinfo repo url
    
With this changes, we can build packages from multiple downstream changes.


As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running.

