### PR TITLE
[bootstrap] Add the packages tag to import_role/setup_ci

### DIFF
--- a/playbooks/01-bootstrap.yml
+++ b/playbooks/01-bootstrap.yml
@@ -40,6 +40,7 @@
     - name: Run ci_setup role
       tags:
         - bootstrap
+        - packages
       ansible.builtin.import_role:
         role: ci_setup
 


### PR DESCRIPTION
The oc client (and other packages) are installed set up in the ci_setup role. Intuitively, the task in 01-bootstrap.yml should have the `packages` tag

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
