### PR TITLE
Fix multiple IP addresses listing during collect

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -58,6 +58,8 @@ are shared among multiple roles:
 - `cifmw_fips_enabled`: (Bool) Specifies whether FIPS should be enabled in the deployment. Note that not all deployment methods support this functionality. Defaults to `false`.
 - `cifmw_baremetal_hosts`: (Dict) Baremetal nodes environment details. More details [here](../baremetal/01_baremetal_hosts_data.md)
 - `cifmw_deploy_obs` (Bool) Specifies whether to deploy Cluster Observability operator.
+- `cifmw_openshift_api_ip_address` (String) contains the OpenShift API IP address. Note: it is computed internally and should not be user defined.
+- `cifmw_openshift_ingress_ip_address` (String) contains the OpenShift Ingress IP address. Note: it is computed internally and should not be user defined.
 
 ```{admonition} Words of caution
 :class: danger

--- a/roles/devscripts/tasks/110_check_ocp.yml
+++ b/roles/devscripts/tasks/110_check_ocp.yml
@@ -67,3 +67,30 @@
     - cifmw_devscripts_ocp_exists
     - not cifmw_devscripts_ocp_online
   ansible.builtin.include_tasks: 112_verify_golden_image.yml
+
+- name: Ensure dig is available
+  become: true
+  ansible.builtin.package:
+    name: bind-utils
+    state: present
+
+- name: Gather the IP address for OCP endpoints
+  ansible.builtin.command:
+    cmd: "dig +short {{ item }}"
+  register: _dig_info
+  loop:
+    - >-
+      {{
+        'api.' + cifmw_devscripts_config.cluster_name + '.' +
+        cifmw_devscripts_config.base_domain
+      }}
+    - >-
+      {{
+        'x.apps.' + cifmw_devscripts_config.cluster_name + '.' +
+        cifmw_devscripts_config.base_domain
+      }}
+
+- name: Gather OpenShift endpoint
+  ansible.builtin.set_fact:
+    cifmw_openshift_api_ip_address: "{{ _dig_info.results.0.stdout | trim }}"
+    cifmw_openshift_ingress_ip_address: "{{ _dig_info.results.1.stdout | trim }}"

--- a/roles/libvirt_manager/tasks/start_manage_vms.yml
+++ b/roles/libvirt_manager/tasks/start_manage_vms.yml
@@ -30,6 +30,12 @@
       virsh -c qemu:///system -q
       domifaddr --source arp
       cifmw-{{ nic.host }} | grep "{{ nic.mac }}"
+      {% if cifmw_openshift_api_ip_address | default(false) %}
+      | grep -v "{{ cifmw_openshift_api_ip_address }}"
+      {% endif %}
+      {% if cifmw_openshift_ingress_ip_address | default(false) %}
+      | grep -v "{{ cifmw_openshift_ingress_ip_address }}"
+      {% endif %}
   loop: "{{ public_net_nics }}"
   loop_control:
     loop_var: nic


### PR DESCRIPTION
Primarily in the case of hybrid, we tend to see multiple IP address being listed when attempting to gather address for OCP type VMs.

The multiple lines are primarily due to api and ingress addresses being present in the arp cache.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
