### PR TITLE
cifmw_target_host isn't a mandatory parameter

### DIFF
--- a/roles/reproducer/tasks/validations.yml
+++ b/roles/reproducer/tasks/validations.yml
@@ -10,7 +10,9 @@
     quiet: true
 
 - name: Verify ansible_host is defined in inventory
-  when: cifmw_target_host != 'localhost'
+  when:
+    - cifmw_target_host is defined
+    - cifmw_target_host != 'localhost'
   delegate_to: localhost
   ansible.builtin.assert:
     that: ansible_host != 'localhost'


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
