### PR TITLE
[ci_gen_kustomize_values] Add support to va2 NFV related values.yml

### DIFF
--- a/roles/ci_gen_kustomize_values/README.md
+++ b/roles/ci_gen_kustomize_values/README.md
@@ -39,8 +39,10 @@ This configMap needs some more parameters in order to properly override the `arc
 * `cifmw_ci_gen_kustomize_values_ssh_public_key`: (String) SSH public key associated to `cifmw_ci_gen_kustomize_values_ssh_private_key`.
 * `cifmw_ci_gen_kustomize_values_migration_priv_key`: (String) SSH private key dedicated for the nova-migration services.
 * `cifmw_ci_gen_kustomize_values_migration_pub_key`: (String) SSH public key associated to `cifmw_ci_gen_kustomize_values_migration_priv_key`.
-
 Note that all of the SSH keys should be in `ecdsa` format to comply with FIPS directives.
+
+### Required parameters only when baremetal compute nodes are used.
+* `cifmw_ci_gen_kustomize_values_ctlplane_interface`: (String) Used to override default controlplane interface for OSP compute nodes.
 
 ## Examples
 

--- a/roles/ci_gen_kustomize_values/defaults/main.yml
+++ b/roles/ci_gen_kustomize_values/defaults/main.yml
@@ -72,3 +72,4 @@ cifmw_ci_gen_kustomize_values_userdata: {}
 # cifmw_ci_gen_kustomize_values_ssh_public_key
 # cifmw_ci_gen_kustomize_values_migration_priv_key
 # cifmw_ci_gen_kustomize_values_migration_pub_key
+# cifmw_ci_gen_kustomize_values_ctlplane_interface

--- a/roles/ci_gen_kustomize_values/tasks/edpm_core_asserts.yml
+++ b/roles/ci_gen_kustomize_values/tasks/edpm_core_asserts.yml
@@ -25,3 +25,11 @@
       - cifmw_ci_gen_kustomize_values_ssh_private_key != ''
       - cifmw_ci_gen_kustomize_values_ssh_public_key is defined
       - cifmw_ci_gen_kustomize_values_ssh_public_key != ''
+
+- name: Ensure the required baremetal host parameters are configured.
+  when:
+    - cifmw_baremetal_hosts is defined
+  ansible.builtin.assert:
+    that:
+      - cifmw_ci_gen_kustomize_values_ctlplane_interface is defined
+      - cifmw_ci_gen_kustomize_values_ctlplane_interface != ''

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/edpm-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/edpm-values/values.yaml.j2
@@ -1,0 +1,36 @@
+{% set instances_names = []                                                            %}
+{% set _original_nodeset = (original_content.data | default({})).nodeset | default({}) %}
+{% set _original_nodes = _original_nodeset.nodes | default({})                         %}
+{% for _inst in cifmw_baremetal_hosts.keys()                                           %}
+{%   set _ = instances_names.append(_inst)                                             %}
+{% endfor                                                                              %}
+data:
+  baremetalSetTemplate:
+    ctlplaneInterface: {{ cifmw_ci_gen_kustomize_values_ctlplane_interface }}
+  ssh_keys:
+    authorized: {{ cifmw_ci_gen_kustomize_values_ssh_authorizedkeys | b64encode }}
+    private: {{ cifmw_ci_gen_kustomize_values_ssh_private_key | b64encode }}
+    public: {{ cifmw_ci_gen_kustomize_values_ssh_public_key | b64encode }}
+  nova:
+    migration:
+      ssh_keys:
+        private: {{ cifmw_ci_gen_kustomize_values_migration_priv_key | b64encode }}
+        public: {{ cifmw_ci_gen_kustomize_values_migration_pub_key | b64encode }}
+  nodeset:
+    ansible:
+      ansibleUser: "zuul"
+      ansibleVars:
+        edpm_fips_mode: "{{ 'enabled' if cifmw_fips_enabled|default(false)|bool else 'check' }}"
+        timesync_ntp_servers:
+          - hostname: "{{ cifmw_ci_gen_kustomize_values_ntp_srv | default('pool.ntp.org') }}"
+{% if cifmw_ci_gen_kustomize_values_sshd_ranges | default([]) | length > 0             %}
+        edpm_sshd_allowed_ranges:
+{%   for range in cifmw_ci_gen_kustomize_values_sshd_ranges                            %}
+          - "{{ range }}"
+{%   endfor                                                                            %}
+{% endif                                                                               %}
+    nodes:
+{% for instance in instances_names                                                     %}
+      edpm-{{ instance }}:
+        hostName: {{ instance }}
+{% endfor                                                                              %}

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk/edpm-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk/edpm-values/values.yaml.j2
@@ -1,0 +1,36 @@
+{% set instances_names = []                                                            %}
+{% set _original_nodeset = (original_content.data | default({})).nodeset | default({}) %}
+{% set _original_nodes = _original_nodeset.nodes | default({})                         %}
+{% for _inst in cifmw_baremetal_hosts.keys()                                           %}
+{%   set _ = instances_names.append(_inst)                                             %}
+{% endfor                                                                              %}
+data:
+  baremetalSetTemplate:
+    ctlplaneInterface: {{ cifmw_ci_gen_kustomize_values_ctlplane_interface }}
+  ssh_keys:
+    authorized: {{ cifmw_ci_gen_kustomize_values_ssh_authorizedkeys | b64encode }}
+    private: {{ cifmw_ci_gen_kustomize_values_ssh_private_key | b64encode }}
+    public: {{ cifmw_ci_gen_kustomize_values_ssh_public_key | b64encode }}
+  nova:
+    migration:
+      ssh_keys:
+        private: {{ cifmw_ci_gen_kustomize_values_migration_priv_key | b64encode }}
+        public: {{ cifmw_ci_gen_kustomize_values_migration_pub_key | b64encode }}
+  nodeset:
+    ansible:
+      ansibleUser: "zuul"
+      ansibleVars:
+        edpm_fips_mode: "{{ 'enabled' if cifmw_fips_enabled|default(false)|bool else 'check' }}"
+        timesync_ntp_servers:
+          - hostname: "{{ cifmw_ci_gen_kustomize_values_ntp_srv | default('pool.ntp.org') }}"
+{% if cifmw_ci_gen_kustomize_values_sshd_ranges | default([]) | length > 0             %}
+        edpm_sshd_allowed_ranges:
+{%   for range in cifmw_ci_gen_kustomize_values_sshd_ranges                            %}
+          - "{{ range }}"
+{%   endfor                                                                            %}
+{% endif                                                                               %}
+    nodes:
+{% for instance in instances_names                                                     %}
+      edpm-{{ instance }}:
+        hostName: {{ instance }}
+{% endfor                                                                              %}

--- a/roles/ci_gen_kustomize_values/templates/sriov/edpm-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/sriov/edpm-values/values.yaml.j2
@@ -1,0 +1,36 @@
+{% set instances_names = []                                                            %}
+{% set _original_nodeset = (original_content.data | default({})).nodeset | default({}) %}
+{% set _original_nodes = _original_nodeset.nodes | default({})                         %}
+{% for _inst in cifmw_baremetal_hosts.keys()                                           %}
+{%   set _ = instances_names.append(_inst)                                             %}
+{% endfor                                                                              %}
+data:
+  baremetalSetTemplate:
+    ctlplaneInterface: {{ cifmw_ci_gen_kustomize_values_ctlplane_interface }}
+  ssh_keys:
+    authorized: {{ cifmw_ci_gen_kustomize_values_ssh_authorizedkeys | b64encode }}
+    private: {{ cifmw_ci_gen_kustomize_values_ssh_private_key | b64encode }}
+    public: {{ cifmw_ci_gen_kustomize_values_ssh_public_key | b64encode }}
+  nova:
+    migration:
+      ssh_keys:
+        private: {{ cifmw_ci_gen_kustomize_values_migration_priv_key | b64encode }}
+        public: {{ cifmw_ci_gen_kustomize_values_migration_pub_key | b64encode }}
+  nodeset:
+    ansible:
+      ansibleUser: "zuul"
+      ansibleVars:
+        edpm_fips_mode: "{{ 'enabled' if cifmw_fips_enabled|default(false)|bool else 'check' }}"
+        timesync_ntp_servers:
+          - hostname: "{{ cifmw_ci_gen_kustomize_values_ntp_srv | default('pool.ntp.org') }}"
+{% if cifmw_ci_gen_kustomize_values_sshd_ranges | default([]) | length > 0             %}
+        edpm_sshd_allowed_ranges:
+{%   for range in cifmw_ci_gen_kustomize_values_sshd_ranges                            %}
+          - "{{ range }}"
+{%   endfor                                                                            %}
+{% endif                                                                               %}
+    nodes:
+{% for instance in instances_names                                                     %}
+      edpm-{{ instance }}:
+        hostName: {{ instance }}
+{% endfor                                                                              %}


### PR DESCRIPTION
This changes to provide a support to configure VA2 NFV EDPM values via CIFW (ci_gen_kustomize_values).
Based on existing PR#1369.

As a pull request owner and reviewers, I checked that:
  - [x] Appropriate testing is done and actually running
  - [x] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [x] Content of the docs/source is reflecting the changes
