### PR TITLE
[deploy_bmh] Fix the molecule input file path

### DIFF
--- a/roles/deploy_bmh/molecule/default/converge.yml
+++ b/roles/deploy_bmh/molecule/default/converge.yml
@@ -22,5 +22,5 @@
       ansible.builtin.include_role:
         name: "deploy_bmh"
       vars:
-        cimfw_deploy_bmh_parameters_dir: /tmp/deploy_bmh
+        cimfw_deploy_bmh_parameters_file: /tmp/baremetal-info.yml
         cimfw_deploy_bmh_apply_cr: false

--- a/roles/deploy_bmh/tasks/cleanup.yml
+++ b/roles/deploy_bmh/tasks/cleanup.yml
@@ -34,6 +34,6 @@
 
 - name: Delete CR files
   ansible.builtin.file:
-    path: "{{ cimfw_deploy_bmh_dest_file }}"
+    path: "{{ item.path }}"
     state: absent
   loop: "{{ _bmh_manifests_find.files | default([]) }}"


### PR DESCRIPTION
This commit contains the needed fixed to make the molecule pass after fixing it.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
