### PR TITLE
Allow rhel-9.3

### DIFF
--- a/docs/source/quickstart/02_prepare_env.md
+++ b/docs/source/quickstart/02_prepare_env.md
@@ -6,7 +6,7 @@ The following operating systems were successfully tested:
 
 - Fedora Core 38, 39 (for laptop/desktop)
 - CentOS Stream 9 (for the hypervisor, laptop/desktop)
-- Red Hat Enterprise Linux 9.4 (for the hypervisor, laptop/desktop)
+- Red Hat Enterprise Linux 9.3 (for the hypervisor, laptop/desktop)
 
 ## On your laptop/desktop
 
@@ -27,7 +27,7 @@ On the hypervisor, please ensure you have:
 - a non-root user, with passwordless SSH access (use SSH keys)
 - `sudo` configuration allowing that non-root user to run any random command, with or without password
 - at least 400G of free space in /home
-- an up-to-date CentOS Stream 9 or RHEL-9.4 system
+- an up-to-date CentOS Stream 9 or RHEL-9.3 system
 
 Note: if you chose to require a password for `sudo`, please ensure to pass the `-K` option to any
 `ansible-playbook` command running against the hypervisor.

--- a/roles/reproducer/defaults/main.yml
+++ b/roles/reproducer/defaults/main.yml
@@ -35,4 +35,4 @@ cifmw_reproducer_supported_hypervisor_os:
   CentOS:
     minimum_version: 9
   RedHat:
-    minimum_version: 9.4
+    minimum_version: 9.3


### PR DESCRIPTION
RHEL-9.4 isn't out yet, and developers might still have 9.3 on their
infrastructure.

Since the Framework has been successfully tested with that release,
let's allow it.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] Content of the docs/source is reflecting the changes
