### PR TITLE
Correct ssh configuration cleaning

### DIFF
--- a/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/roles/libvirt_manager/tasks/clean_layout.yml
@@ -67,12 +67,25 @@
         create: true
       loop: "{{ cleanup_vms }}"
 
+    - name: "(localhost) Clean old ssh jumpers"
+      when:
+        - inventory_hostname != 'localhost'
+      delegate_to: localhost
+      vars:
+        vm: "{{ item | replace('cifmw-', '') }}"
+      ansible.builtin.blockinfile:
+        path: "{{ lookup('env', 'HOME') }}/.ssh/config"
+        marker: "## {mark} {{ vm }}"
+        state: absent
+        create: true
+      loop: "{{ cleanup_vms }}"
+
     - name: "({{ inventory_hostname }}) Clean ssh jumpers"  # noqa: name[template]
       vars:
         vm: "{{ item | replace('cifmw-', '') }}"
       ansible.builtin.blockinfile:
         path: "{{ ansible_user_dir }}/.ssh/config"
-        marker: "## {mark} {{ vm }} {{ inventory_hostname }}"
+        marker: "## {mark} {{ vm }}"
         state: absent
         create: true
       loop: "{{ cleanup_vms }}"


### PR DESCRIPTION
While the hypervisor name was added to the "mark" on the laptop, we
don't have it when we update the config on the hypervisor itself.

This patch corrects the wrong cleaning.

In order to ensure environment are in a right state, it also ensures
older configuration "marker" are removed from the laptop. This block may
be removed in a few weeks.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
