### PR TITLE
Correct IP detection

### DIFF
--- a/roles/libvirt_manager/tasks/start_manage_vms.yml
+++ b/roles/libvirt_manager/tasks/start_manage_vms.yml
@@ -31,10 +31,10 @@
       domifaddr --source arp
       cifmw-{{ nic.host }} | grep "{{ nic.mac }}"
       {% if cifmw_openshift_api_ip_address | default(false) %}
-      | grep -v "{{ cifmw_openshift_api_ip_address }}"
+      | grep -v "{{ cifmw_openshift_api_ip_address }}/"
       {% endif %}
       {% if cifmw_openshift_ingress_ip_address | default(false) %}
-      | grep -v "{{ cifmw_openshift_ingress_ip_address }}"
+      | grep -v "{{ cifmw_openshift_ingress_ip_address }}/"
       {% endif %}
   loop: "{{ public_net_nics }}"
   loop_control:


### PR DESCRIPTION
The `grep` needs to be stricter in order to properly match the IP.

Before this patch, this didn't work:

```Bash
virsh -c qemu:///system -q domifaddr --source arp cifmw-controller-0 |
  grep 52:54:00:6b:f2:78 | grep -v 192.168.111.5 | grep -v 192.168.111.4
```

if the IP is `192.168.111.53/0`

This patch adds a separator (`/`) to ensure we're matching the whole IP.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running