### PR TITLE
Lock wait_conditions to `oc|kubectl wait` pattern

### DIFF
--- a/roles/kustomize_deploy/molecule/flexible_loop/converge.yml
+++ b/roles/kustomize_deploy/molecule/flexible_loop/converge.yml
@@ -61,3 +61,32 @@
         label: "{{ stage.path }}"
         loop_var: "stage"
         index_var: "stage_id"
+
+    - name: Check failure with faulty wait_condition injection
+      vars:
+        cifmw_architecture_wait_condition:
+          stage_0:
+            - sudo cat /etc/passwd
+            - oc rsh exec blah
+            - kubectl rsh exec bar
+      block:
+        - name: Run loop deployment again
+          ansible.builtin.include_role:
+            name: "kustomize_deploy"
+            tasks_from: execute_step.yml
+          loop: "{{ cifmw_deploy_architecture_steps.vas.hci.stages }}"
+          loop_control:
+            label: "{{ stage.path }}"
+            loop_var: "stage"
+            index_var: "stage_id"
+      rescue:
+        - name: Clear expected errors
+          ansible.builtin.meta: clear_host_errors
+
+        - name: Ensure a successful end
+          ansible.builtin.meta: end_play
+
+    - name: Wait conditions validation failed
+      ansible.builtin.fail:
+        msg: >-
+          Wait condition validation failed!

--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -5,13 +5,46 @@
       - stage is defined
       - stage_id is defined
       - stage['path'] is defined
-      ## TODO: remove "validations" once architecture repo is up-to-date
-      - (stage.validations is defined and
-         stage.validations | length > 0) or
-        (stage.wait_conditions is defined and
+      - (stage.wait_conditions is defined and
          stage.wait_conditions | length > 0)
       - stage['values'] is defined
       - stage['values'] | length > 0
+
+- name: Assert all wait conditions are valid
+  vars:
+    _stage_name: "stage_{{ stage_id }}"
+    _custom_conditions: >-
+      {{
+        cifmw_architecture_wait_condition[_stage_name] |
+        default([])
+      }}
+    _pattern: '^(oc|kubectl).*wait.*$'
+  block:
+    - name: Check custom wait conditions
+      ansible.builtin.assert:
+        that: item is match(_pattern)
+        msg: "The following custom condition is invalid: {{ item }}"
+        quiet: true
+      ignore_errors: true  # noqa: ignore-errors
+      register: _custom_wait_cond_result
+      loop: "{{ _custom_conditions }}"
+
+    - name: Check builtin wait conditions
+      ansible.builtin.assert:
+        that: item is match(_pattern)
+        msg: "The following builtin condition is invalid: {{ item }}"
+        quiet: true
+      ignore_errors: true  # noqa: ignore-errors
+      register: _builtin_wait_cond_result
+      loop: "{{ stage.wait_conditions }}"
+
+    - name: Check wait_conditions validation result
+      when:
+        - _custom_wait_cond_result is failed or
+          _builtin_wait_cond_result is failed
+      ansible.builtin.fail:
+        msg: >-
+          Review and correct the faulty wait_conditions listed above.
 
 - name: Group tasks under the same tag
   vars:
@@ -208,11 +241,9 @@
             cifmw_architecture_wait_condition[_stage_name] |
             default([])
           }}
-        ## TODO: remove "validations" once architecture is up-to-date
         _commands: >-
           {{
-            (stage['wait_conditions'] |
-             default(stage['validations'])) + _custom_conditions
+            stage['wait_conditions'] + _custom_conditions
            }}
       environment:
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"


### PR DESCRIPTION
In order to avoid any misusage of the wait_conditions, and the
user-provided extension of those conditions, this patch ensures any
command passed for "wait condition" is a real "wait"

For instance, if anyone passes `cat /etc/passwd`, or `oc rsh` and
related, the assertion will fail, ensuring we don't have something that
should be either in a new stage, or in a post_stage_run hook.

An equivalent check is also existing in the architecture repository via
https://github.com/openstack-k8s-operators/architecture/pull/183

#### WARNING
This patch also remove the deprecated "validations" entry, since it has
been replaced by "wait_conditions", and architecture repository has a
check on the YAML structure

Co-Authored-By: @lewisdenny 

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
(tested both situation, with a valid and an invalid pattern)
