### PR TITLE
Toggle nolog to true for architecture deploy

### DIFF
--- a/roles/reproducer/tasks/configure_architecture.yml
+++ b/roles/reproducer/tasks/configure_architecture.yml
@@ -29,7 +29,7 @@
     - name: Run deployment if instructed to
       when:
         - cifmw_deploy_architecture | default(false) | bool
-      no_log: false
+      no_log: true
       async: 7200  # 2h should be enough to deploy EDPM.
       poll: 20
       ansible.builtin.command:


### PR DESCRIPTION
It was set to `false` for debugging purpose, and never got back to `true`

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
