### PR TITLE
Allow to NOT deploy rhos-release on rhel-based computes

### DIFF
--- a/roles/reproducer/README.md
+++ b/roles/reproducer/README.md
@@ -8,6 +8,7 @@ None
 
 * `cifmw_reproducer_basedir`: (String) Base directory. Defaults to `cifmw_basedir`, which defaults to `~/ci-framework-data`.
 * `cifmw_reproducer_compute_repos`: (List[mapping]) List of yum repository that must be deployed on the compute nodes during their creation. Defaults to `[]`.
+* `cifmw_reproducer_compute_set_repositories`: (Bool) Deploy repositories (rhos-release) on Compute nodes. Defaults to `true`.
 * `cifmw_reproducer_play_extravars`: (List[string]) List of extra-vars you want to pass down to the EDPM deployment playbooks. Defaults to `[]`.
 * `cifmw_reproducer_kubecfg`: (String) Path to the CRC kubeconfig file. Defaults to the image_local_dir defined in the cifmw_libvirt_manager_configuration dict.
 * `cifmw_reproducer_repositories`: (List[mapping]) List of repositories you want to synchronize from your local machine to the ansible controller.

--- a/roles/reproducer/defaults/main.yml
+++ b/roles/reproducer/defaults/main.yml
@@ -29,6 +29,7 @@ cifmw_reproducer_repositories: []
 cifmw_reproducer_hp_rhos_release: false
 cifmw_reproducer_dnf_tweaks: []
 cifmw_reproducer_compute_repos: []
+cifmw_reproducer_compute_set_repositories: true
 cifmw_reproducer_repositories_path: "src"
 cifmw_reproducer_play_extravars: []
 cifmw_reproducer_supported_hypervisor_os:

--- a/roles/reproducer/tasks/configure_computes.yml
+++ b/roles/reproducer/tasks/configure_computes.yml
@@ -40,6 +40,7 @@
     - name: RHEL related tasks on computes
       become: true
       when:
+        - cifmw_reproducer_compute_set_repositories | bool
         - cifmw_repo_setup_rhos_release_rpm is defined
       block:
         - name: Get rhos-release
@@ -68,6 +69,7 @@
     - name: Ensure rhos-release is configured
       become: true
       when:
+        - cifmw_reproducer_compute_set_repositories | bool
         - _async_rhos_release.ansible_job_id is defined
       block:
         - name: Ensure async flag still exists


### PR DESCRIPTION
In RHEL, customers will usually not manually deploy repositories on the
computes, but use `edpm_bootstrap_command`[1] instead to register their
nodes.

This new parameter allows to ensure we're allowed to follow a path
closer to the customers, ensuring we're able to test it properly.

[1] https://openstack-k8s-operators.github.io/dataplane-operator/user/index.html#_initial_bootstrap_command

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
