### PR TITLE
Change default for cifmw_virtualbmc_daemon_port

### DIFF
--- a/roles/virtualbmc/README.md
+++ b/roles/virtualbmc/README.md
@@ -12,7 +12,7 @@ None
 * `cifmw_virtualbmc_image`: (String) VirtualBMC container image. Defaults to `quay.io/metal3-io/vbmc:latest`.
 * `cifmw_virtualbmc_container_name`: (String) VirtualBMC container name. Defaults to `cifmw-vbmc`.
 * `cifmw_virtualbmc_listen_address`: (String) VirtualBMC listen address. Defaults to `127.0.0.1`.
-* `cifmw_virtualbmc_daemon_port`: (Integer) VirtualBMC daemon listen port. Default to `50891`.
+* `cifmw_virtualbmc_daemon_port`: (Integer) VirtualBMC daemon listen port. Default to `50881`.
 * `cifmw_virtualbmc_machine`: (String) Virtual machine to manage in VirtualBMC. Mandatory. Defaults to `null`.
 * `cifmw_virtualbmc_action`: (String) VirtualBMC action. Must be either `add` or `delete`. Mandatory. Defaults to `null`.
 * `cifmw_virtualbmc_sshkey_path`: (String) SSH keypair path for VirtualBMC. Defaults to `{{ ansible_user_dir }}/.ssh/vbmc-key`.

--- a/roles/virtualbmc/defaults/main.yml
+++ b/roles/virtualbmc/defaults/main.yml
@@ -20,7 +20,7 @@
 cifmw_virtualbmc_image: "quay.io/metal3-io/vbmc:latest"
 cifmw_virtualbmc_container_name: "cifmw-vbmc"
 cifmw_virtualbmc_listen_address: "127.0.0.1"
-cifmw_virtualbmc_daemon_port: 50891
+cifmw_virtualbmc_daemon_port: 50881
 
 cifmw_virtualbmc_machine: null
 cifmw_virtualbmc_action: null

--- a/scenarios/reproducers/va-hci.yml
+++ b/scenarios/reproducers/va-hci.yml
@@ -64,7 +64,6 @@ cifmw_test_operator_tempest_include_list: |
 # provides access to Internet. This will be the equivalent of the
 # "public network" as seen in CI.
 cifmw_use_libvirt: true
-cifmw_virtualbmc_daemon_port: 50881
 cifmw_use_uefi: >-
   {{ (cifmw_repo_setup_os_release is defined
       and cifmw_repo_setup_os_release == 'rhel') | bool }}

--- a/scenarios/reproducers/va-nfv-ovs-dpdk-sriov.yml
+++ b/scenarios/reproducers/va-nfv-ovs-dpdk-sriov.yml
@@ -55,7 +55,6 @@ cifmw_test_operator_tempest_include_list: |
 # provides access to Internet. This will be the equivalent of the
 # "public network" as seen in CI.
 cifmw_use_libvirt: true
-cifmw_virtualbmc_daemon_port: 50881
 cifmw_use_uefi: >-
   {{ (cifmw_repo_setup_os_release is defined
       and cifmw_repo_setup_os_release == 'rhel') | bool }}


### PR DESCRIPTION
vbmcd is also setup by dev-scripts with default
server_port i.e 50891 and that conflicts with vbmc setup from cifmw.
This patch changes default for cifmw_virtualbmc_daemon_port to 50881 to avoid the conflict, since changed default dropped the overrides from scenario files.

Related-Issue: OSPRH-6324

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
