### PR TITLE
Delete/Recreate openshift marketplace pods

### DIFF
--- a/roles/openshift_setup/tasks/fix_openshift_marketplace.yml
+++ b/roles/openshift_setup/tasks/fix_openshift_marketplace.yml
@@ -1,0 +1,22 @@
+---
+# Note(Chandan): This workaround is taken from
+# https://github.com/crc-org/crc/issues/4109#issuecomment-2042497411.
+# It will be removed once https://github.com/crc-org/crc/issues/4109
+# closed.
+- name: Delete the pods from openshift-marketplace namespace
+  kubernetes.core.k8s:
+    kind: Pod
+    state: absent
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    namespace: openshift-marketplace
+
+- name: Wait for openshift-marketplace pods to be running
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    kind: Pod
+    namespace: openshift-marketplace
+    wait: true
+    wait_condition:
+      type: Ready
+      status: "True"
+    wait_timeout: 300

--- a/roles/openshift_setup/tasks/main.yml
+++ b/roles/openshift_setup/tasks/main.yml
@@ -166,3 +166,6 @@
           spec:
             additionalTrustedCA:
               name: "registry-cas"
+
+- name: Fix openshift-marketplace pods
+  ansible.builtin.import_tasks: fix_openshift_marketplace.yml


### PR DESCRIPTION
On crc Zuul reproducer job, cert-manager operator installation is failing with following error.
```
the cert-manager CRDs are not yet installed on the Kubernetes API server
```

The cert-manager operator get installed from openshift marketplace. After digging deep, we found that pods under openshift-marketplace namespace are hitting CrashLoopBackOff due to following error.
```
failed to populate resolver cache from source redhat-operators/openshift-marketplace:
failed to list bundles: rpc error: code = Unavailable desc = connection error: desc =
```

Based on https://github.com/crc-org/crc/issues/4109#issuecomment-2042497411, Delete and recreating openshift-marketplace pods fixes the issue.
    
Since OCP is deployed after pre_infra hook and cert_manager role iscalled before post_infra. There is no way to run this workaround as a hook.
    
It would be best to include under openshift_setup role.



As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

