### PR TITLE
Fix push_code and zuul_vars vs zuul

### DIFF
--- a/roles/reproducer/tasks/push_code.yml
+++ b/roles/reproducer/tasks/push_code.yml
@@ -1,14 +1,14 @@
 ---
 - name: Sync zuul content if available
   when:
-    - zuul_vars.zuul is defined
-    - zuul_vars.zuul.items is defined
-    - zuul_vars.zuul.projects is defined
+    - (zuul is defined) or (zuul_vars.zuul is defined)
+    - (zuul is defined) or (zuul_vars.zuul.items is defined)
+    - (zuul is defined) or (zuul_vars.zuul.projects is defined)
     - not cifmw_reproducer_skip_fetch_repositories | default(false)
   delegate_to: controller-0
   delegate_facts: true
   vars:
-    _zuul: "{{ zuul_vars.zuul }}"
+    _zuul: "{{ zuul_vars.zuul | default(zuul) }}"
   block:
     - name: Check if repository directories already exist
       when: job_id is defined
@@ -81,14 +81,14 @@
     - name: Expand cifmw_reproducer_repositories to pull code from ansible controller to controller-0
       when:
         - cifmw_reproducer_skip_fetch_repositories | default(false)
-        - zuul_vars.zuul is defined
-        - zuul_vars.zuul.items is defined
-        - zuul_vars.zuul.projects is defined
+        - (zuul is defined) or (zuul_vars.zuul is defined)
+        - (zuul is defined) or (zuul_vars.zuul.items is defined)
+        - (zuul is defined) or (zuul_vars.zuul.projects is defined)
         # check that the project is not alredy in the user defined
         # cifmw_reproducer_repositories value
         - repo.value.name not in _user_sources
       vars:
-        _zuul: "{{ zuul_vars.zuul }}"
+        _zuul: "{{ zuul_vars.zuul | default(zuul) }}"
         _user_sources: "{{ cifmw_reproducer_repositories | default([]) | map(attribute='src') }}"
         _repo_entry:
           src: "{{ ansible_user_dir }}/{{ repo.value.src_dir | regex_replace('/$', '') }}/"


### PR DESCRIPTION
With the addition of the molecule job reproducer, we had to take
parameters one level up in the environment. Those parameters were at the
same level as `zuul` - so we created a new `zuul_vars`, containing `zuul` itself.

This patch now checks for both `zuul` and `zuul_vars`, so that we can
match in CI runtime and in a job reproducer.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [X] Working outside of zuul (@cjeanner)
- [x] Working with a molecule job reproducer (@cjeanner)
- [x] Working with a deploy job reproducer (@cjeanner)
- [x] Downstream testproject (@cescgina)
- [x] Downstream VA job (@cescgina)
