### PR TITLE
[nfv] Fix wrong route interface name

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/network-values/values.yaml.j2
@@ -115,7 +115,6 @@ data:
     config:
       - destination: {{ cifmw_networking_env_definition.networks.ctlplane.network_v4 }}
         next-hop-address: {{ cifmw_networking_env_definition.networks.ctlplane.gw_v4 }}
-        next-hop-interface: {{ ns.interfaces['ctlplane'] }}
 
 # Hardcoding the last IP bit since we don't have support for endpoint_annotations in the networking_mapper output
   rabbitmq:


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
