### PR TITLE
[networking-values] Remove missleading unused fields

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/common/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/common/network-values/values.yaml.j2
@@ -115,7 +115,6 @@ data:
     config:
       - destination: 0.0.0.0/0
         next-hop-address: {{ cifmw_networking_env_definition.networks.ctlplane.gw_v4 }}
-        next-hop-interface: {{ ns.interfaces['ctlplane'] }}
 
 # Hardcoding the last IP bit since we don't have support for endpoint_annotations in the networking_mapper output
   rabbitmq:

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/network-values/values.yaml.j2
@@ -115,7 +115,6 @@ data:
     config:
       - destination: {{ cifmw_networking_env_definition.networks.ctlplane.network_v4 }}
         next-hop-address: {{ cifmw_networking_env_definition.networks.ctlplane.gw_v4 }}
-        next-hop-interface: {{ ns.interfaces['ctlplane'] }}
 
 # Hardcoding the last IP bit since we don't have support for endpoint_annotations in the networking_mapper output
   rabbitmq:


### PR DESCRIPTION
The architecture repo kustomizations are not using the next-hop-interface field of the routes as that value is directly picked from the name of the bridge.
To avoid confusion among users let's remove it.

Related to: https://github.com/openstack-k8s-operators/architecture/pull/185

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
