### PR TITLE
Switch to import_role for openshift_login

### DIFF
--- a/playbooks/02-infra.yml
+++ b/playbooks/02-infra.yml
@@ -58,7 +58,7 @@
         - always
       vars:
         cifmw_openshift_login_force_refresh: true
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: openshift_login
 
     - name: Setup Openshift cluster


### PR DESCRIPTION
Until now, the `always` tag was only affecting the `include_role`, but
none of the task was actually done if we selected a specific tag to run,
leading to issues with missing openshift_login related facts.

With this small change, we're now able to run this, for instance:
`./deploy-architecture.sh --tags edpm --skip-tags packages,storage,operators`

This command, in a VA environment, allows to re-run the deployment in a
really, really faster way: it takes about 29 seconds to get to the
Flexible Loop (i.e. execute_steps from kustomize_deploy), while it took
more than 2 minutes before, because we couldn't properly filter with the
`edpm` tag.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
