### PR TITLE
Switch from "import" to "include"

### DIFF
--- a/playbooks/02-infra.yml
+++ b/playbooks/02-infra.yml
@@ -14,14 +14,14 @@
       when:
         - cifmw_use_libvirt is defined
         - cifmw_use_libvirt | bool
-      ansible.builtin.import_role:
+      ansible.builtin.include_role:
         name: libvirt_manager
 
     - name: Perpare OpenShift provisioner node
       when:
         - cifmw_use_opn is defined
         - cifmw_use_opn | bool
-      ansible.builtin.import_role:
+      ansible.builtin.include_role:
         name: openshift_provisioner_node
 
 - name: Prepare the platform
@@ -36,21 +36,21 @@
       when:
         - cifmw_use_hive is defined
         - cifmw_use_hive | bool
-      ansible.builtin.import_role:
+      ansible.builtin.include_role:
         name: hive
 
     - name: Prepare CRC
       when:
         - cifmw_use_crc is defined
         - cifmw_use_crc | bool
-      ansible.builtin.import_role:
+      ansible.builtin.include_role:
         name: rhol_crc
 
     - name: Deploy OpenShift cluster using dev-scripts
       when:
         - cifmw_use_devscripts is defined
         - cifmw_use_devscripts | bool
-      ansible.builtin.import_role:
+      ansible.builtin.include_role:
         name: devscripts
 
     - name: Login into Openshift cluster
@@ -83,21 +83,21 @@
       when:
         - cifmw_config_certmanager is defined
         - cifmw_config_certmanager | bool
-      ansible.builtin.import_role:
+      ansible.builtin.include_role:
         name: cert_manager
 
     - name: Configure hosts networking using nmstate
       when:
         - cifmw_config_nmstate is defined
         - cifmw_config_nmstate | bool
-      ansible.builtin.import_role:
+      ansible.builtin.include_role:
         name: ci_nmstate
 
     - name: Prepare container package builder
       when:
         - cifmw_pkg_build_list is defined
         - cifmw_pkg_build_list | length > 0
-      ansible.builtin.import_role:
+      ansible.builtin.include_role:
         name: pkg_build
 
 - name: Run post_infra hooks


### PR DESCRIPTION
The tasks were using `import_role` with a `when` condition block.

In such a case, the `when` conditions are applied to all of the imported
content, and ansible will have to consider each task and apply the `when`
block, meaning:
- loss of time (it takes a few seconds for each task to consider)
- lot of useless "skipped" log entries

With `include_role`, the `when` block is considered only for this task,
and if the condition is `false`, then nothing more happens, speeding up
and cleaning the logs.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
