### PR TITLE
Introduce scenario inheritance in reproducer.yml play

### DIFF
--- a/ci/playbooks/tasks/inherit_parent_scenario.yml
+++ b/ci/playbooks/tasks/inherit_parent_scenario.yml
@@ -1,0 +1,30 @@
+# This allows to create a custom scenario file that would
+# just override some parts of an existing one.
+# For example, you create a DT based on the va-hci.yml.
+# You will then just add
+# `cifmw_parent_scenario: scenarios/reproducers/va-hci.yml`
+# in the file, and override/extend the scenario to match your
+# needs.
+# The parameter also supports a list of files if needed.
+#
+# File path are relative to the root of the ci-framework repository.
+- name: Inherit from parent parameter file if instructed
+  vars:
+    _file_list: >-
+      {% if cifmw_parent_scenario is defined and
+         cifmw_parent_scenario is string -%}
+         {{ [cifmw_parent_scenario] }}
+      {% elif cifmw_parent_scenario is defined and
+         cifmw_parent_scenario is not string and
+         cifmw_parent_scenario is not mapping and
+         cifmw_parent_scenario is iterable -%}
+         {{ cifmw_parent_scenario }}
+      {%- else -%}
+      {{ [] }}
+      {%- endif -%}
+  when:
+    - cifmw_parent_scenario is defined
+    - item is exists
+  ansible.builtin.include_vars:
+    file: "{{ item }}"
+  loop: "{{ _file_list }}"

--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -14,6 +14,10 @@
         path: "{{ ansible_user_dir }}/cifmw-success"
         state: absent
 
+    - name: Inherit from parent scenarios if needed
+      ansible.builtin.include_tasks:
+        file: "ci/playbooks/tasks/inherit_parent_scenario.yml"
+
 - name: Bootstrap step
   ansible.builtin.import_playbook: playbooks/01-bootstrap.yml
 

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -66,6 +66,7 @@ are shared among multiple roles:
 - `cifmw_openshift_api_ip_address` (String) contains the OpenShift API IP address. Note: it is computed internally and should not be user defined.
 - `cifmw_openshift_ingress_ip_address` (String) contains the OpenShift Ingress IP address. Note: it is computed internally and should not be user defined.
 - `cifmw_nolog`: (Bool) Toggle `no_log` value for selected tasks. Defaults to `true` (hiding those logs by default).
+- `cifmw_parent_scenario`: (String or List(String)) path to existing scenario/parameter file to inherit from.
 
 ```{admonition} Words of caution
 :class: danger

--- a/reproducer.yml
+++ b/reproducer.yml
@@ -11,6 +11,35 @@
       ansible.builtin.include_vars:
         file: "scenarios/reproducers/va-common.yml"
 
+    # This allows to create a custom scenario file that would
+    # just override some parts of an existing one.
+    # For example, you create a DT based on the va-hci.yml.
+    # You will then just add
+    # `cifmw_parent_scenario: scenarios/reproducers/va-hci.yml`
+    # in the file, and override/extend the scenario to match your
+    # needs.
+    # The parameter also supports a list of files if needed.
+    #
+    # File path are relative to the root of the ci-framework repository.
+    - name: Inherit from parent parameter file if instructed
+      vars:
+        _file_list: >-
+          {% if cifmw_parent_scenario is defined and
+             cifmw_parent_scenario is string -%}
+             {{ [cifmw_parent_scenario] }}
+          {% elif cifmw_parent_scenario is defined and
+             cifmw_parent_scenario is not string and
+             cifmw_parent_scenario is iterable -%}
+             {{ cifmw_parent_scenario }}
+          {% else %}
+          {{ [] }}
+          {% endif %}
+      when:
+        - item is exists
+      ansible.builtin.include_vars:
+        file: "{{ item }}"
+      loop: "{{ _file_list }}"
+
     - name: Run reproducer validations
       ansible.builtin.import_role:
         name: reproducer

--- a/reproducer.yml
+++ b/reproducer.yml
@@ -4,41 +4,16 @@
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: true
   pre_tasks:
+    - name: Inherit from parent scenarios if needed
+      ansible.builtin.include_tasks:
+        file: "ci/playbooks/tasks/inherit_parent_scenario.yml"
+
     - name: Include common architecture parameter file
       when:
         - cifmw_architecture_scenario is defined
         - cifmw_architecture_scenario | length > 0
       ansible.builtin.include_vars:
         file: "scenarios/reproducers/va-common.yml"
-
-    # This allows to create a custom scenario file that would
-    # just override some parts of an existing one.
-    # For example, you create a DT based on the va-hci.yml.
-    # You will then just add
-    # `cifmw_parent_scenario: scenarios/reproducers/va-hci.yml`
-    # in the file, and override/extend the scenario to match your
-    # needs.
-    # The parameter also supports a list of files if needed.
-    #
-    # File path are relative to the root of the ci-framework repository.
-    - name: Inherit from parent parameter file if instructed
-      vars:
-        _file_list: >-
-          {% if cifmw_parent_scenario is defined and
-             cifmw_parent_scenario is string -%}
-             {{ [cifmw_parent_scenario] }}
-          {% elif cifmw_parent_scenario is defined and
-             cifmw_parent_scenario is not string and
-             cifmw_parent_scenario is iterable -%}
-             {{ cifmw_parent_scenario }}
-          {% else %}
-          {{ [] }}
-          {% endif %}
-      when:
-        - item is exists
-      ansible.builtin.include_vars:
-        file: "{{ item }}"
-      loop: "{{ _file_list }}"
 
     - name: Run reproducer validations
       ansible.builtin.import_role:

--- a/scenarios/reproducers/va-hci-base.yml
+++ b/scenarios/reproducers/va-hci-base.yml
@@ -1,0 +1,17 @@
+---
+cifmw_architecture_scenario: hci
+
+# Automation section. Most of those parameters will be passed to the
+# controller-0 as-is and be consumed by the `deploy-va.sh` script.
+# Please note, all paths are on the controller-0, meaning managed by the
+# Framework. Please do not edit them!
+_arch_repo: "/home/zuul/src/github.com/openstack-k8s-operators/architecture"
+cifmw_ceph_client_vars: /tmp/ceph_client.yml
+cifmw_ceph_client_values_post_ceph_path_src: >-
+  {{ _arch_repo }}/examples/va/hci/values.yaml
+cifmw_ceph_client_values_post_ceph_path_dst: >-
+  {{ cifmw_ceph_client_values_post_ceph_path_src }}
+cifmw_ceph_client_service_values_post_ceph_path_src: >-
+  {{ _arch_repo }}/examples/va/hci/service-values.yaml
+cifmw_ceph_client_service_values_post_ceph_path_dst: >-
+  {{ cifmw_ceph_client_service_values_post_ceph_path_src }}

--- a/scenarios/reproducers/va-hci-reduced.yml
+++ b/scenarios/reproducers/va-hci-reduced.yml
@@ -1,0 +1,8 @@
+---
+cifmw_parent_scenario: "scenarios/reproducers/va-hci-base.yml"
+
+# Test Ceph file and object storage (block is enabled by default)
+cifmw_ceph_daemons_layout:
+  rgw_enabled: true
+  dashboard_enabled: false
+  cephfs_enabled: true

--- a/scenarios/reproducers/va-hci.yml
+++ b/scenarios/reproducers/va-hci.yml
@@ -1,20 +1,5 @@
 ---
-cifmw_architecture_scenario: hci
-
-# Automation section. Most of those parameters will be passed to the
-# controller-0 as-is and be consumed by the `deploy-va.sh` script.
-# Please note, all paths are on the controller-0, meaning managed by the
-# Framework. Please do not edit them!
-_arch_repo: "/home/zuul/src/github.com/openstack-k8s-operators/architecture"
-cifmw_ceph_client_vars: /tmp/ceph_client.yml
-cifmw_ceph_client_values_post_ceph_path_src: >-
-  {{ _arch_repo }}/examples/va/hci/values.yaml
-cifmw_ceph_client_values_post_ceph_path_dst: >-
-  {{ cifmw_ceph_client_values_post_ceph_path_src }}
-cifmw_ceph_client_service_values_post_ceph_path_src: >-
-  {{ _arch_repo }}/examples/va/hci/service-values.yaml
-cifmw_ceph_client_service_values_post_ceph_path_dst: >-
-  {{ cifmw_ceph_client_service_values_post_ceph_path_src }}
+cifmw_parent_scenario: "scenarios/reproducers/va-hci-base.yml"
 
 # HERE if you want to override kustomization, you can uncomment this parameter
 # and push the data structure you want to apply.


### PR DESCRIPTION
### Proof of work
`test.yml` playbook:
```YAML
---
- hosts: localhost
  gather_facts: false
  pre_tasks:
    - name: Load master parameter file
      when:
        - var_file is defined
        - var_file is exists
      ansible.builtin.include_vars:
        file: "{{ var_file }}"

  tasks:
    - name: Output va_parameter if available
      when:
        - va_parameter is defined
      ansible.builtin.debug:
        var: va_parameter

    - name: Output dt_parameter if available
      when:
        - dt_parameter is defined
      ansible.builtin.debug:
        var: dt_parameter

    - name: Output overridden parameter if available
      when:
        - my_parameter is defined
      ansible.builtin.debug:
        var: my_parameter
```
`va.yml` parameter file:
```YAML
---
my_parameter: starwars
va_parameter: foo
```

`dt.yml` parameter file:
```YAML
---
var_file: va.yml
my_parameter: foo_bar
dt_parameter: bar
```

Output:
```
PLAY
[localhost] ************************************************************************

TASK
[Load master parameter file] *********************************************************
ok: [localhost]

TASK [Output va_parameter if available] ****************************************************
ok:
[localhost] => {
    "va_parameter": "foo"
}

TASK [Output
dt_parameter if available] *****************************************************
ok: [localhost] => {
    "dt_parameter": "bar"
}

TASK [Output
overridden parameter if available] **********************************************
ok: [localhost] => {
    "my_parameter": "foo_bar"
}

PLAY RECAP
*****************************************************************************
localhost                   : ok=4    changed=0    unreachable=0    failed=0    skipped=0   rescued=0    ignored=0
```
As you can see, `my_param` has the
override from the `dt.yml` instead of the `va.yml` content!

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] Content of the docs/source is reflecting the changes

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2084