### PR TITLE
Fix relative path for custom CR hook type

### DIFF
--- a/roles/run_hook/tasks/cr.yml
+++ b/roles/run_hook/tasks/cr.yml
@@ -24,8 +24,8 @@
       {{
         (
           ansible.builtin.role_path,
-          '../../hooks/crds',
-          hook.src
+          '../../hooks/crs',
+          hook.source
         ) | ansible.builtin.path_join | ansible.builtin.realpath
       }}
       {%- else -%}


### PR DESCRIPTION
With last change renaming hook type from 'crd' to 'cr', there are two typos:
- path to builtin hook CR directory changed from `/hooks/crds` to `/hooks/crs`
- and typo which was there already before `hook.src` should be `hook.source`

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
