### PR TITLE
Move generated YAML files to more appropriate location

### DIFF
--- a/roles/reproducer/tasks/configure_architecture.yml
+++ b/roles/reproducer/tasks/configure_architecture.yml
@@ -8,8 +8,8 @@
         exports:
           ANSIBLE_LOG_PATH: "~/ansible-deploy-architecture.log"
         default_extravars:
-          - "@~/reproducer-variables.yml"
-          - "@~/openshift-environment.yml"
+          - "@~/ci-framework-data/parameters/reproducer-variables.yml"
+          - "@~/ci-framework-data/parameters/openshift-environment.yml"
         extravars: "{{ cifmw_reproducer_play_extravars }}"
         playbook: "deploy-edpm.yml"
       ansible.builtin.template:

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -355,12 +355,18 @@
             items2dict
           }}
       ansible.builtin.copy:
-        dest: "/home/zuul/reproducer-variables.yml"
+        dest: "/home/zuul/ci-framework-data/parameters/reproducer-variables.yml"
         content: "{{ _filtered_vars | to_nice_yaml }}"
+
+    - name: Create reproducer-variables.yml symlink to old location
+      ansible.builtin.file:
+        dest: "/home/zuul/reproducer-variables.yml"
+        src: "/home/zuul/ci-framework-data/parameters/reproducer-variables.yml"
+        state: link
 
     - name: Inject local environment parameters
       ansible.builtin.copy:
-        dest: "/home/zuul/openshift-environment.yml"
+        dest: "/home/zuul/ci-framework-data/parameters/openshift-environment.yml"
         content: |-
           {% raw %}
           ---
@@ -381,6 +387,12 @@
               ) | ansible.builtin.path_join
             }}
           {% endraw %}
+
+    - name: Create openshift-environment.yml symlink to old location
+      ansible.builtin.file:
+        dest: "/home/zuul/openshift-environment.yml"
+        src: "/home/zuul/ci-framework-data/parameters/openshift-environment.yml"
+        state: link
 
     - name: Get interfaces-info content
       register: _nic_info

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -172,7 +172,7 @@
         chdir: "/home/zuul/src/github.com/openstack-k8s-operators/ci-framework"
         cmd: >-
           ansible-playbook -i ~/ci-framework-data/artifacts/zuul_inventory.yml
-          -e @~/reproducer-variables.yml
+          -e @~/ci-framework-data/parameters/reproducer-variables.yml
           -e @scenarios/reproducers/networking-definition.yml
           playbooks/01-bootstrap.yml
         creates: "/home/zuul/ansible-bootstrap.log"

--- a/roles/reproducer/templates/content-provider.yml.j2
+++ b/roles/reproducer/templates/content-provider.yml.j2
@@ -122,7 +122,7 @@
           -e @./scenarios/centos-9/tcib.yml
           -e cifmw_zuul_target_host=controller-0
           -e "cifmw_rp_registry_ip="{{ hostvars['localhost']['cifmw_rp_registry_ip'] }}""
-          -e "@{{ ansible_user_dir }}/reproducer-variables.yml"
+          -e "@{{ ansible_user_dir }}/ci-framework-data/parameters/reproducer-variables.yml"
           --skip-tags build_openstack_packages
 
     - name: Output needed content into consumable environment


### PR DESCRIPTION
the reproducer-variables.yml and openshift-environment.yml were in
zuul's home directory on controller-0.

This location is outside of any "ci-framework known location". It means
it won't get caught by current tools, while they provide really useful
information for debugging, or understanding of the environment.

For backward compatibility, symlinks to the old location exist

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
