### PR TITLE
Improve parsing of cifmw_job_uri

### DIFF
--- a/docs/source/reproducers/03-zuul.md
+++ b/docs/source/reproducers/03-zuul.md
@@ -75,9 +75,6 @@ looks like this:
 
 https://logserver.rdoproject.org/74/574/LONG_HASH/github-check/podified-multinode-edpm-e2e-nobuild-tagged-crc/SHORT_HASH/
 
-Please take extra care to ensure it's NOT pointing to any sub-directory of that page, such
-as "/controller" - else, it will fail to fetch the needed pieces.
-
 
 ### Inject your custom code
 As an option, you're able to inject your custom code by leveraging the

--- a/roles/reproducer/molecule/job_uri/converge.yml
+++ b/roles/reproducer/molecule/job_uri/converge.yml
@@ -1,0 +1,50 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  vars:
+    regex_tests:
+      - pass: true
+        string: https://logserver.rdoproject.org/94/1494/1f72e2797961e0fb0192e3280c3027a8d70b4e45/github-check/cifmw-molecule-libvirt_manager/d0304e7/anything/////
+      - pass: true
+        string: https://logserver.rdoproject.org/94/1494/1f72e2797961e0fb0192e3280c3027a8d70b4e45/github-check/cifmw-molecule-libvirt_manager/d0304e7
+      - pass: false
+        string: https://logserver.rdoproject.org/94/1494/1f72e2797961e0fb0192e3280c3027a8d70b4e45/github-check/cifmw-molecule-libvirt_manager/d030
+      - pass: false
+        string: httdoproject.org/94/1494/1f72e2797961e0fb0192e3280c3027a8d70b4e45/github-check/cifmw-molecule-libvirt_manager/d030
+      - pass: true
+        string: https://internalhostname.com/logs/internal_pipeline_name/internalhostname.com/tripleo-ci/master/internal_job_name/d0f4a7a/installed-pkgs.log
+      - pass: true
+        string: https://internalhostname.com/logs/internal_pipeline_name/internalhostname.com/tripleo-ci/master/internal_job_name/d0f4a7a/
+      - pass: false
+        string: https://internalhostname.com/logs/internal_pipeline_name/internalhostname.com/tripleo-ci/master/internal_job_name/d0f4
+      - pass: false
+        string: /logs/internal_pipeline_name/internalhostname.com/tripleo-ci/master/internal_job_name/d0f4a7a
+  tasks:
+    - name: Call task file in loop
+      ansible.builtin.include_tasks: tasks/test_regex.yml
+      loop: "{{ regex_tests }}"
+      loop_control:
+        index_var: index
+        loop_var: regex_test
+      register: results
+
+    - name: Print success message
+      ansible.builtin.debug:
+        msg: "All strings passed!"

--- a/roles/reproducer/molecule/job_uri/molecule.yml
+++ b/roles/reproducer/molecule/job_uri/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+
+prerun: false

--- a/roles/reproducer/molecule/job_uri/tasks/test_regex.yml
+++ b/roles/reproducer/molecule/job_uri/tasks/test_regex.yml
@@ -1,0 +1,43 @@
+---
+# This block is called in a loop, the loop iterates over a list of `regex_tests`
+# It will test the following scenario:
+# 1. (Success) The string passes regex and we expext it: pass = true
+# 2. (Success) The string fails regex and we expext it: pass = false
+# 3. (Failure) The string passes regex but the return value doesn't match expected.
+# 4. (Failure) The string passes regex but we don't expect it: pass = false
+# 5. (Failure) The string fails regex but we don't expect it: pass = true
+
+- name: Test regex
+  block:
+    - name: "Call task file with {{ regex_test.string }}"
+      vars:
+        cifmw_job_uri: "{{ regex_test.string }}"
+      ansible.builtin.include_role:
+        name: reproducer
+        tasks_from: parse_cifmw_job_uri.yml
+
+    - name: Fail if return string doesn't match expected value
+      when:
+        - regex_test.return is defined
+        - regex_test.return != _matched_url
+      ansible.builtin.fail:
+        msg: "The return string doesn't match the expected value {{ regex_test.return }} vs {{ _matched_url }}"
+
+    - name: Fail if string incorrectly passed when defined not to pass
+      ansible.builtin.assert:
+        that: regex_test.pass | bool
+      register: _string_incorrecly_passed
+
+  rescue:
+    - name: Clear errors to manually handle them
+      ansible.builtin.meta: clear_host_errors
+
+    - name: Really fail if string passed but should have failed
+      when: _string_incorrecly_passed.failed | default(false) | bool
+      ansible.builtin.fail:
+        msg: "The following string passed and it shouldn't have {{ regex_test.string }} at index {{ index }}"
+
+    - name: Really fail if string failed but should have passed
+      when: regex_test.pass | bool
+      ansible.builtin.fail:
+        msg: "The following string failed but it shouldn't have: {{ regex_test.string }} at index: {{ index }}"

--- a/roles/reproducer/tasks/ci_data.yml
+++ b/roles/reproducer/tasks/ci_data.yml
@@ -4,16 +4,9 @@
     - cifmw_job_uri is defined
   delegate_to: localhost
   block:
-    - name: Extract job id for later reference
-      vars:
-        user_dir: "{{ lookup('env', 'HOME') }}"
-        basedir: "{{ user_dir ~ '/ci-framework-data' }}"
-        job_id: "{{ cifmw_job_uri | regex_replace('/$', '') | basename }}"
-      ansible.builtin.set_fact:
-        cacheable: true
-        _reproducer_basedir: "{{ basedir }}/ci-reproducer/{{ job_id }}"
-        data_baseurl: "{{ cifmw_job_uri }}/controller/ci-framework-data/artifacts/"
-        job_id: "{{ job_id }}"
+    - name: Parse cifmw_job_uri
+      ansible.builtin.include_tasks:
+        file: parse_cifmw_job_uri.yml
 
     - name: Create local directory for parameters
       ansible.builtin.file:
@@ -23,7 +16,7 @@
     - name: Check if we're facing molecule job
       register: _is_molecule
       ansible.builtin.uri:
-        url: "{{ cifmw_job_uri }}/report.html"
+        url: "{{ _matched_url }}/report.html"
         method: HEAD
         status_code:
           - 200
@@ -32,7 +25,7 @@
     - name: Fetch zuul inventory
       ansible.builtin.get_url:
         dest: "{{ _reproducer_basedir }}/zuul_inventory.yml"
-        url: "{{ cifmw_job_uri }}/zuul-info/inventory.yaml"
+        url: "{{ _matched_url }}/zuul-info/inventory.yaml"
         force: true
 
     - name: Facing non-molecule job

--- a/roles/reproducer/tasks/parse_cifmw_job_uri.yml
+++ b/roles/reproducer/tasks/parse_cifmw_job_uri.yml
@@ -1,0 +1,27 @@
+---
+- name: Parse cifmw_job_uri
+  vars:
+    regex_pattern: "^https://[a-zA-Z\\.]+(?=\\w{3}(?:/|$))\\w{3}/.*/.*/.*/.*[a-f0-9]{7}"
+  block:
+    - name: Apply regex match filter
+      ansible.builtin.set_fact:
+        _matched_url: "{{ cifmw_job_uri | regex_search(regex_pattern) }}"
+
+    - name: Verify URL is valid
+      ansible.builtin.assert:
+        that: _matched_url | default('') | length > 0
+        quiet: true
+        msg: >-
+          The cifmw_job_uri value provided is not valid: {{ cifmw_job_uri }} More details here:
+          https://ci-framework.readthedocs.io/en/latest/reproducers/03-zuul.html#create-a-custom-environment-file-to-feed-your-job
+
+    - name: Extract job id for later reference
+      vars:
+        user_dir: "{{ lookup('env', 'HOME') }}"
+        basedir: "{{ user_dir ~ '/ci-framework-data' }}"
+        job_id: "{{ _matched_url| basename }}"
+      ansible.builtin.set_fact:
+        cacheable: true
+        _reproducer_basedir: "{{ basedir }}/ci-reproducer/{{ job_id }}"
+        data_baseurl: "{{ _matched_url }}/controller/ci-framework-data/artifacts/"
+        job_id: "{{ job_id }}"


### PR DESCRIPTION
`cifmw_job_uri` is the entry point into reproducing a zuul job, as this
variable is user provided this patch makes the input more flexible as
well as adding some validation and useful error message.

This patch also adds molecule testing for the regex used in parsing
`cifmw_job_uri`

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] Content of the docs/source is reflecting the changes
