### PR TITLE
[WIP] Refactor vbmc data manipulation and baremetal info generation

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -21,6 +21,7 @@ are shared among multiple roles:
 - `cifmw_use_crc`: (Bool) toggle rhol/crc usage.
 - `cifmw_use_uefi`: (Bool) toggle UEFI support in libvirt_manager provided VMs.
 - `cifmw_use_devscripts`: (Bool) toggle devscripts usage.
+- `cifmw_use_vbmc`: (Bool) toggle virtualBMC usage. Defaults to `true`.
 - `cifmw_openshift_kubeconfig`: (String) Path to the kubeconfig file if externally provided. If provided will be the kubeconfig to use and update after login.
 - `cifmw_openshift_api`: (String) Path to the kubeconfig file. If provided will be the API to authenticate against.
 - `cifmw_openshift_user`: (String) Login user. If provided, the user that logins.

--- a/roles/libvirt_manager/molecule/deploy_layout/converge.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/converge.yml
@@ -33,6 +33,10 @@
       internal-api:
         range: "172.17.0.0/24"
         vlan: 20
+    cifmw_libvirt_manager_configuration_path_more_compute:
+      vms:
+        compute:
+          amount: 2
     cifmw_libvirt_manager_configuration:
       vms:
         nocompute:
@@ -141,6 +145,14 @@
                   sort
                 }}
 
+        - name: Lewis Debug
+          ansible.builtin.debug:
+            msg:
+              - "Sorted VM: {{ sorted_vms | default('') }}"
+              - "Compared VM'{{ compare_vms | default('') }}"
+              - "Sorted net: {{ sorted_nets | default('') }}"
+              - "Compared net'{{ compare_nets | default('') }}"
+
         - name: Assert resource lists
           vars:
             sorted_nets: "{{ nets.list_nets | sort }}"
@@ -153,6 +165,7 @@
             compare_vms: >-
               {{
                 ['cifmw-compute-0',
+                 'cifmw-compute-1',
                  'cifmw-baremetal-0'] | sort
               }}
           ansible.builtin.assert:

--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -165,8 +165,11 @@
       cifmw_libvirt_manager_pub_net ({{ cifmw_libvirt_manager_pub_net }}).
       Please double-check your scenario!
 
+# TODO(lewis) here, you can inject the node in sushy_emulator.
+
 - name: Create VBMC entity
   when:
+    - cifmw_use_vbmc | default(true) | bool
     - _vbmc_available is defined
     - _vbmc_available | bool
   vars:

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -28,6 +28,7 @@
     - bootstrap
     - bootstrap_layout
   when:
+    - cifmw_use_vbmc | default(true) | bool
     - (_layout.vms.crc.target is defined and
        _layout.vms.crc.target == inventory_hostname) or
       (_layout.vms.crc is defined and
@@ -35,7 +36,8 @@
       (_layout.vms.ocp.target is defined and
        _layout.vms.ocp.target == inventory_hostname) or
       (_layout.vms.ocp is defined and
-       _layout.vms.ocp.target is undefined)
+       _layout.vms.ocp.target is undefined) or
+      (_layout.vms.crc is undefined and layout.vms.ocp is undefined)
   block:
     - name: Deploy virtualbmc
       ansible.builtin.include_role:
@@ -301,6 +303,7 @@
 
 - name: Refresh and dump vbmc hosts
   when:
+    - cifmw_use_vbmc | default(true) | bool
     - _vbmc_host is defined
     - _vbmc_host == inventory_hostname
   block:
@@ -338,6 +341,12 @@
         dest: >-
           {{ cifmw_libvirt_manager_basedir }}/artifacts/virtual-nodes.yml
         content: "{{ content | to_nice_yaml }}"
+
+# TODO(lewis) you can inject some tasks to grab sushy_emulator content
+# allowing to expose some content in the generate_bm_info.yml tasks
+
+- name: Generate baremetal-info fact
+  ansible.builtin.import_tasks: generate_bm_info.yml
 
 - name: Ensure we get proper access to CRC
   when:

--- a/roles/libvirt_manager/tasks/generate_bm_info.yml
+++ b/roles/libvirt_manager/tasks/generate_bm_info.yml
@@ -1,0 +1,57 @@
+---
+# TODO(lewis) you can manipulate sushy output in this file, to get it
+# ready for the "Generate libvirt_manager_bm_info fact" task.
+
+- name: Convert VBMC list into a dict for better usage
+  when:
+    - cifmw_use_vbmc | default(true) | bool
+    - cifmw_virtualbmc_known_hosts is defined
+  vars:
+    keys: "{{ item.keys() | difference(['Domain name']) }}"
+    vals: "{{ keys | map('extract', item) | list }}"
+    value: "{{ dict(keys | map('lower') | zip(vals)) }}"
+    _host: "{{ item['Domain name'] | regex_replace('^cifmw-', '') }}"
+  ansible.builtin.set_fact:
+    _vbmc_info_dict: >-
+      {{
+        _vbmc_info_dict | default({}) |
+        combine({_host: value}, recursive=true)
+      }}
+    cacheable: false
+  loop: "{{ cifmw_virtualbmc_known_hosts }}"
+
+# This task exposes a new fact, then consumed by the
+# reproducer/configure_controller.yml tasks in order to expose
+# the content as a file for later usage.
+- name: Generate libvirt_manager_bm_info_data fact
+  vars:
+    _host: "{{ item.key | replace('cifmw-', '') }}"
+    _uefi: >-
+      {% set _type = _host | regex_replace('-[0-9]+$', '') -%}
+      {{ _layout.vms[_type].uefi | default(false) | bool }}
+    _data: |
+      "{{ _host }}":
+        boot_mode: "{{ _uefi | ternary('UEFI', 'legacy') }}"
+        uuid: "{{ item.value }}"
+      {% if cifmw_use_vbmc | default(true) | bool %}
+        address: "{{ _vbmc_info_dict[_host].address }}"
+        connection: "ipmi://{{ _vbmc_info_dict[_host].address }}:{{ _vbmc_info_dict[_host].port }}"
+        password: "{{ _vbmc_info_dict[_host].password }}"
+        port: {{ _vbmc_info_dict[_host].port | int }}
+        username: "{{ _vbmc_info_dict[_host].username }}"
+      {% else %}
+        connection: "build-sushy-address"
+      {% endif %}
+    _with_nics: >-
+      {{
+         _data | from_yaml |
+         combine({_host: {'nics': cifmw_libvirt_manager_mac_map[_host]}},
+                 recursive=true)
+      }}
+  ansible.builtin.set_fact:
+    libvirt_manager_bm_info_data: >-
+      {{
+        libvirt_manager_bm_info_data | default({}) |
+        combine((_with_nics | from_yaml), recursive=true)
+      }}
+  loop: "{{ cifmw_libvirt_manager_uuids | dict2items }}"

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -106,53 +106,16 @@
         dest: "{{ _ctl_reproducer_basedir }}/parameters/interfaces-info.yml"
         content: "{{ cifmw_libvirt_manager_mac_map | to_nice_yaml }}"
 
-    # Here, we update the existing cifmw_virtualbmc_known_hosts fact
-    # to inject networking information such as provisioning MAC (if any),
-    # and fixed Boot mode
-    - name: Generate IPMI information
-      block:
-        - name: Convert VBMC list into a dict for better usage
-          vars:
-            keys: "{{ item.keys() | difference(['Domain name']) }}"
-            vals: "{{ keys | map('extract', item) | list }}"
-            value: "{{ dict(keys | map('lower') | zip(vals)) }}"
-            _host: "{{ item['Domain name'] | regex_replace('^cifmw-', '') }}"
-            _nics: >-
-              {{
-                cifmw_libvirt_manager_mac_map[_host]
-              }}
-            _uefi: >-
-              {% set _type = _host | regex_replace('-[0-9]+$', '') -%}
-              {{ _layout.vms[_type].uefi | default(false) | bool }}
-            _boot_mode: "{{ _uefi | ternary('UEFI', 'legacy') }}"
-            ## TODO: add sushy driver address once we get sushy in
-            ## TODO: create new parameter to allow chosing which connection
-            #        to expose in the generated file
-            _connections:
-              ipmi: "ipmi://{{ value.address }}:{{ value.port }}"
-          ansible.builtin.set_fact:
-            _ipmi_dict: >-
-              {{
-                _ipmi_dict | default({}) |
-                combine({_host: value}, recursive=true) |
-                combine({_host: {
-                                 'boot_mode': _boot_mode,
-                                 'nics': _nics,
-                                 'connection': _connections['ipmi']
-                                }
-                        }, recursive=true)
-              }}
-            cacheable: false
-          loop: "{{ cifmw_virtualbmc_known_hosts }}"
-
-        - name: Output IPMI data in a file
-          vars:
-            _content:
-              cifmw_baremetal_hosts: "{{ _ipmi_dict }}"
-          ansible.builtin.copy:
-            dest: "{{ _ctl_reproducer_basedir }}/parameters/baremetal-info.yml"
-            content: "{{ _content | to_nice_yaml }}"
-            mode: "0644"
+    # The libvirt_manager_bm_info_data fact comes from
+    # the libvirt_manager/generate_bm_info.yml tasks file.
+    - name: Output baremetal info file
+      vars:
+        _content:
+          cifmw_baremetal_hosts: "{{ libvirt_manager_bm_info_data }}"
+      ansible.builtin.copy:
+        dest: "{{ _ctl_reproducer_basedir }}/parameters/baremetal-info.yml"
+        content: "{{ _content | to_nice_yaml }}"
+        mode: "0644"
 
     - name: Inject other Hypervisor SSH keys
       when:


### PR DESCRIPTION
This patch should help integrating sushy_driver as an alternative to virtualbmc.

It exposes a new top-level parameter, `cifmw_use_vbmc`, with a default value to `true`. It also changes the "source data" of the virtual baremetal nodes, using the extracted UUID instead of virtualbmc output.

Doing so, we're now able to not rely on vbmc, allowing to switch to sushy once it's properly integrated (in a subsequent patch).

Some comments are also added to show where sushy bits might be integrated.

While refactoring, an error was detected in the code, leading to a correction in the big `when` condition allowing to deploy or not VBMC. Since it broke Molecule, while working on it, a small modification was done to ensure the "configuration patching" is working fine.

The format is mostly identical (check both outputs bellow). One data was removed from the file: `status`. It was irrevelant, since it wasn't updated "live" if we stopped a VM.

(old, original content)
```YAML
cifmw_baremetal_hosts:
    compute-0:
        address: 10.10.1.12
        boot_mode: UEFI
        connection: ipmi://10.10.1.12:6260
        nics:
        -   mac: 52:54:00:dc:b4:ec
            network: public
        -   mac: 52:54:00:51:c5:54
            network: osp_trunk
        password: password
        port: 6260
        status: running
        username: admin
        uuid: 923656ba-a992-4055-9435-c48d51a7d8f9
    controller-0:
        address: 10.10.1.12
        boot_mode: UEFI
        connection: ipmi://10.10.1.12:6250
        nics:
        -   mac: 52:54:00:8c:73:0b
            network: public
        -   mac: 52:54:00:27:bf:47
            network: osp_trunk
        password: password
        port: 6250
        status: running
        username: admin
        uuid: 493deb70-4ec8-4551-a6a3-1d0f5bb36b88
    crc-0:
        address: 10.10.1.12
        boot_mode: legacy
        connection: ipmi://10.10.1.12:6240
        nics:
        -   mac: 52:54:00:30:5a:62
            network: public
        -   mac: 52:54:00:ce:3d:91
            network: osp_trunk
        password: password
        port: 6240
        status: running
        username: admin
        uuid: a6d7698a-ce6f-42ea-84ea-aeba50843445
```

(new content)
```YAML
cifmw_baremetal_hosts:
    compute-0:
        address: 10.10.1.12
        boot_mode: UEFI
        connection: ipmi://10.10.1.12:6260
        nics:
        -   mac: 52:54:00:dc:b4:ec
            network: public
        -   mac: 52:54:00:51:c5:54
            network: osp_trunk
        password: password
        port: 6260
        username: admin
        uuid: 923656ba-a992-4055-9435-c48d51a7d8f9
    controller-0:
        address: 10.10.1.12
        boot_mode: UEFI
        connection: ipmi://10.10.1.12:6250
        nics:
        -   mac: 52:54:00:8c:73:0b
            network: public
        -   mac: 52:54:00:27:bf:47
            network: osp_trunk
        password: password
        port: 6250
        username: admin
        uuid: 493deb70-4ec8-4551-a6a3-1d0f5bb36b88
    crc-0:
        address: 10.10.1.12
        boot_mode: legacy
        connection: ipmi://10.10.1.12:6240
        nics:
        -   mac: 52:54:00:30:5a:62
            network: public
        -   mac: 52:54:00:ce:3d:91
            network: osp_trunk
        password: password
        port: 6240
        username: admin
        uuid: a6d7698a-ce6f-42ea-84ea-aeba50843445
```

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
