### PR TITLE
Correct reproducer following the zuul -> zuul_vars renaming

### DIFF
--- a/roles/reproducer/tasks/ci_job.yml
+++ b/roles/reproducer/tasks/ci_job.yml
@@ -84,14 +84,14 @@
           vars:
             zuul_params_filtered: >-
               {{
-                zuul | dict2items |
+                zuul_vars.zuul | dict2items |
                 rejectattr('key', 'equalto', 'cifmw_operator_build_output') |
                 rejectattr('key', 'equalto', 'content_provider_registry_ip') |
                 items2dict
               }}
           ansible.builtin.copy:
             dest: "/home/zuul/ci-framework-data/artifacts/parameters/zuul-params.yml"
-            content: "{{ zuul_params_filtered | to_nice_yaml }}"
+            content: "{{ {'zuul': zuul_params_filtered} | to_nice_yaml }}"
 
     - name: Check for ansible logs file and rotate it
       tags:

--- a/roles/reproducer/tasks/ci_molecule_data.yml
+++ b/roles/reproducer/tasks/ci_molecule_data.yml
@@ -26,7 +26,3 @@
           amount: "{{ compute_amount | int }}"
         crc:
           amount: "{{ crc_amount | int }}"
-
-- name: Debug
-  ansible.builtin.debug:
-    var: updated_layout

--- a/roles/reproducer/templates/play.yml.j2
+++ b/roles/reproducer/templates/play.yml.j2
@@ -22,7 +22,7 @@
       when:
         - not _venv.stat.exists
       vars:
-        src_dir: "{{ zuul.zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}"
+        src_dir: "{{ zuul_vars.zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}"
       community.general.make:
 {%- raw %}
         chdir: "{{ ansible_user_dir }}/{{ src_dir }}"
@@ -53,6 +53,11 @@
       - cifmw_openshift_kubeconfig=/home/zuul/.kube/config
       - cifmw_openshift_login_skip_tls_verify=true
       - cifmw_openshift_setup_skip_internal_registry_tls_verify=true
+{% if is_molecule | default(false) %}
+    TEST_RUN: "{{ zuul_vars.TEST_RUN }}"
+    roles_dir: "{{ zuul_vars.roles_dir }}"
+    mol_config_dir: "{{ zuul_vars.mol_config_dir }}"
+{% endif %}
     cifmw_zuul_target_host: controller-0
     cifmw_reproducer_molecule_env_file: ~/ci-framework-data/artifacts/parameters/zuul-params.yml
   ansible.builtin.import_playbook: {{ play }}


### PR DESCRIPTION
There were some missing renames, and also some issues with the "level"
of the zuul var in some cases.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
    - [X] @cjeanner to test molecule reproducer
    - [X] @cjeanner to test deployment reproducer
    - [X] @cescgina/@cjeanner to test downstream

Note: DS is red due to an unrelated issue with the market place. The job got correctly configured and started.
