### PR TITLE
Ensure the configuration patch works

### DIFF
--- a/roles/libvirt_manager/molecule/deploy_layout/converge.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/converge.yml
@@ -153,6 +153,7 @@
             compare_vms: >-
               {{
                 ['cifmw-compute-0',
+                 'cifmw-compute-1',
                  'cifmw-baremetal-0'] | sort
               }}
           ansible.builtin.assert:
@@ -213,8 +214,8 @@
           vars:
             expect_vol_num: >-
               {{
-                (cifmw_libvirt_manager_configuration.vms.compute.amount | int) *
-                (cifmw_libvirt_manager_configuration.vms.compute.extra_disks_num | int)
+                (_layout.vms.compute.amount | int) *
+                (_layout.vms.compute.extra_disks_num | int)
               }}
             found_vol_num: "{{ vol_count.stdout | int }}"
           ansible.builtin.assert:

--- a/roles/libvirt_manager/molecule/deploy_layout/molecule.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/molecule.yml
@@ -4,3 +4,10 @@ log: true
 provisioner:
   name: ansible
   log: true
+  inventory:
+    host_vars:
+      instance:
+        cifmw_libvirt_manager_configuration_patch_01_more_computes:
+          vms:
+            compute:
+              amount: 2


### PR DESCRIPTION
Modifying molecule to ensure the libvirt_manager_configuration patch is
properly working.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1507

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
