### PR TITLE
Delete all the resources of openshift-marketplace

### DIFF
--- a/roles/openshift_setup/molecule/default/converge.yml
+++ b/roles/openshift_setup/molecule/default/converge.yml
@@ -23,6 +23,7 @@
       OPERATOR_NAMESPACE: openstack-operators
     cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
     cifmw_openshift_setup_ca_registry_to_add: test.registry.com
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
   roles:
     - role: "openshift_setup"
   tasks:

--- a/roles/openshift_setup/tasks/fix_openshift_marketplace.yml
+++ b/roles/openshift_setup/tasks/fix_openshift_marketplace.yml
@@ -7,16 +7,19 @@
   kubernetes.core.k8s:
     kind: Pod
     state: absent
+    delete_all: true
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
     namespace: openshift-marketplace
 
 - name: Wait for openshift-marketplace pods to be running
-  kubernetes.core.k8s_info:
-    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
-    kind: Pod
-    namespace: openshift-marketplace
-    wait: true
-    wait_condition:
-      type: Ready
-      status: "True"
-    wait_timeout: 300
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: >-
+      oc wait pod --all --for=condition=Ready
+      -n openshift-marketplace --timeout=1m
+  register: _pod_status
+  retries: 4
+  delay: 10
+  until: _pod_status.rc == 0


### PR DESCRIPTION
https://github.com/ansible-collections/kubernetes.core/pull/517 added delete_all: true to delete all the resources.

It needs to be added in fix openshift-marketplace task files to make sure all pods are deleted otherwise
fix_openshift_marketplace.yml taskfile does not work as expected.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

