### PR TITLE
Group common parameters for Architecture deployment

### DIFF
--- a/reproducer.yml
+++ b/reproducer.yml
@@ -4,6 +4,13 @@
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: true
   pre_tasks:
+    - name: Include common architecture parameter file
+      when:
+        - cifmw_architecture_scenario is defined
+        - cifmw_architecture_scenario | length > 0
+      ansible.builtin.include_vars:
+        file: "scenarios/reproducers/va-common.yml"
+
     - name: Run reproducer validations
       ansible.builtin.import_role:
         name: reproducer

--- a/scenarios/reproducers/va-common.yml
+++ b/scenarios/reproducers/va-common.yml
@@ -1,0 +1,67 @@
+---
+# This file groups common parameters for Architecture based deployment.
+# It is *automatically* included in any run having cifmw_architecture_scenario
+# parameter set.
+# You can of course manually pass it, it won't make any difference.
+#
+# Any of those parameter might be overridden from your own parameter file!
+#
+# This file should NOT be used for the CRC based deployment (3-nodes.yml).
+
+
+# Ensure some basic directories and parameter are set
+cifmw_install_yamls_repo: >-
+  {{
+    (ansible_user_dir,
+     'src/github.com/openstack-k8s-operators/install_yamls') |
+     path_join
+  }}
+cifmw_basedir: "{{ ansible_user_dir }}/ci-framework-data"
+cifmw_path: "{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+
+# Ensure our vbmcd isn't conflicting with devscripts managed instance
+cifmw_virtualbmc_daemon_port: 50881
+
+# Ensure we pass libvirt backend
+cifmw_use_libvirt: true
+
+# Dependencies for devscripts
+cifmw_reproducer_epel_pkgs:
+  - python3-bcrypt
+  - python3-passlib
+
+# Public network
+cifmw_libvirt_manager_pub_net: ocpbm
+
+# Run tests
+cifmw_run_tests: true
+cifmw_run_tempest: true
+cifmw_run_test_role: test_operator
+cifmw_test_operator_timeout: 7200
+cifmw_test_operator_tempest_include_list: |
+  tempest.scenario.test_network_basic_ops.TestNetworkBasicOps
+
+# Set VM partitions and boot mode
+cifmw_use_uefi: >-
+  {{ (cifmw_repo_setup_os_release is defined
+      and cifmw_repo_setup_os_release == 'rhel') | bool }}
+cifmw_root_partition_id: >-
+  {{
+    (cifmw_repo_setup_os_release is defined and
+     cifmw_repo_setup_os_release == 'rhel') |
+    ternary(4, 1)
+  }}
+
+cifmw_libvirt_manager_compute_amount: 3
+cifmw_libvirt_manager_compute_disksize: 20
+cifmw_libvirt_manager_compute_memory: 4
+cifmw_libvirt_manager_compute_cpus: 1
+
+# devscript support for OCP deploy
+cifmw_use_devscripts: true
+# Required for egress traffic from pods to the osp_trunk network
+cifmw_devscripts_enable_ocp_nodes_host_routing: true
+
+# type and size of ssh keys injected into the OCP workers and compute nodes
+cifmw_ssh_keytype: ecdsa
+cifmw_ssh_keysize: 521

--- a/scenarios/reproducers/va-hci.yml
+++ b/scenarios/reproducers/va-hci.yml
@@ -1,24 +1,11 @@
 ---
-# This is local to your desktop/laptop.
-# We can't use ansible_user_dir here, unless you have the same user on the
-# hypervisor and locally.
-cifmw_install_yamls_repo: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
-# This will be created on the hypervisor.
-cifmw_basedir: "{{ ansible_user_dir }}/ci-framework-data"
-cifmw_path: "{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
-
-cifmw_reproducer_epel_pkgs:
-  - python3-bcrypt
-  - python3-passlib
-
-cifmw_libvirt_manager_pub_net: ocpbm
+cifmw_architecture_scenario: hci
 
 # Automation section. Most of those parameters will be passed to the
 # controller-0 as-is and be consumed by the `deploy-va.sh` script.
 # Please note, all paths are on the controller-0, meaning managed by the
 # Framework. Please do not edit them!
 _arch_repo: "/home/zuul/src/github.com/openstack-k8s-operators/architecture"
-cifmw_architecture_scenario: hci
 cifmw_ceph_client_vars: /tmp/ceph_client.yml
 cifmw_ceph_client_values_post_ceph_path_src: >-
   {{ _arch_repo }}/examples/va/hci/values.yaml
@@ -46,37 +33,6 @@ cifmw_ceph_client_service_values_post_ceph_path_dst: >-
 #
 # cifmw_deploy_architecture_stopper:
 
-# What about some tempest?
-cifmw_run_tests: true
-cifmw_run_tempest: true
-cifmw_run_test_role: test_operator
-cifmw_test_operator_timeout: 7200
-cifmw_test_operator_tempest_include_list: |
-  tempest.scenario.test_network_basic_ops.TestNetworkBasicOps
-
-# This will instruct libvirt_manager to create 3 compute and
-# the ansible-controller, consuming the networks created and
-# managed by devscripts.
-# Note that the "osp_trunk" network is the equivalent of the
-# "private_net" in the CI layout, and will hold the VLAN for
-# network isolation.
-# The "ocpbm" network is managed by devscripts as well, and
-# provides access to Internet. This will be the equivalent of the
-# "public network" as seen in CI.
-cifmw_use_libvirt: true
-cifmw_virtualbmc_daemon_port: 50881
-cifmw_use_uefi: >-
-  {{ (cifmw_repo_setup_os_release is defined
-      and cifmw_repo_setup_os_release == 'rhel') | bool }}
-cifmw_root_partition_id: >-
-  {{
-    (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
-    ternary(4, 1)
-  }}
-cifmw_libvirt_manager_compute_amount: 3
-cifmw_libvirt_manager_compute_disksize: 20
-cifmw_libvirt_manager_compute_memory: 4
-cifmw_libvirt_manager_compute_cpus: 1
 cifmw_libvirt_manager_configuration:
   networks:
     osp_trunk: |
@@ -134,15 +90,12 @@ cifmw_libvirt_manager_configuration:
 
 
 ## devscript support for OCP deploy
-cifmw_use_devscripts: true
 cifmw_devscripts_config_overrides:
   worker_memory: 16384
   worker_disk: 100
   worker_vcpu: 10
   num_extra_workers: 0
   fips_mode: "{{ cifmw_fips_enabled | default(false) | bool }}"
-# Required for egress traffic from pods to the osp_trunk network
-cifmw_devscripts_enable_ocp_nodes_host_routing: true
 
 # Note: with that extra_network_names "osp_trunk", we instruct
 # devscripts role to create a new network, and associate it to
@@ -152,10 +105,6 @@ cifmw_devscripts_enable_ocp_nodes_host_routing: true
 # Please create a custom env file to provide:
 # cifmw_devscripts_ci_token:
 # cifmw_devscripts_pull_secret:
-
-# type and size of ssh keys injected into the OCP workers and compute nodes
-cifmw_ssh_keytype: ecdsa
-cifmw_ssh_keysize: 521
 
 # Test Ceph file and object storage (block is enabled by default)
 cifmw_ceph_daemons_layout:

--- a/scenarios/reproducers/va-nfv-ovs-dpdk-sriov.yml
+++ b/scenarios/reproducers/va-nfv-ovs-dpdk-sriov.yml
@@ -1,24 +1,11 @@
 ---
-# This is local to your desktop/laptop.
-# We can only use ansible_user_dir if you have the same user on the hypervisor
-# and locally - otherwise edit this
-cifmw_install_yamls_repo: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
-# This will be created on the hypervisor.
-cifmw_basedir: "{{ ansible_user_dir }}/ci-framework-data"
-cifmw_path: "{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
-
-cifmw_reproducer_epel_pkgs:
-  - python3-bcrypt
-  - python3-passlib
-
-cifmw_libvirt_manager_pub_net: ocpbm
+cifmw_architecture_scenario: "ovs-dpdk-sriov"
 
 # Automation section. Most of those parameters will be passed to the
 # controller-0 as-is and be consumed by the `deploy-va.sh` script.
 # Please note, all paths are on the controller-0, meaning managed by the
 # Framework. Please do not edit them!
 _arch_repo: "/home/zuul/src/github.com/openstack-k8s-operators/architecture"
-cifmw_architecture_scenario: "ovs-dpdk-sriov"
 
 # HERE if you want to overload kustomization, you can uncomment this parameter
 # and push the data structure you want to apply.
@@ -37,39 +24,13 @@ cifmw_architecture_scenario: "ovs-dpdk-sriov"
 #
 # cifmw_deploy_architecture_stopper:
 
-# What about some tempest?
-cifmw_run_tests: true
-cifmw_run_tempest: true
-cifmw_run_test_role: test_operator
-cifmw_test_operator_timeout: 7200
-cifmw_test_operator_tempest_include_list: |
-  tempest.scenario.test_network_basic_ops.TestNetworkBasicOps
-
-# This will instruct libvirt_manager to create
-# the ansible-controller, consuming the networks created and
-# managed by devscripts.
-# Note that the "osp_trunk" network is the equivalent of the
-# "private_net" in the CI layout, and will hold the VLAN for
-# network isolation.
-# The "ocpbm" network is managed by devscripts as well, and
-# provides access to Internet. This will be the equivalent of the
-# "public network" as seen in CI.
-cifmw_use_libvirt: true
-cifmw_virtualbmc_daemon_port: 50881
-cifmw_use_uefi: >-
-  {{ (cifmw_repo_setup_os_release is defined
-      and cifmw_repo_setup_os_release == 'rhel') | bool }}
-cifmw_root_partition_id: >-
-  {{
-    (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
-    ternary(4, 1)
-  }}
 cifmw_libvirt_manager_net_prefix_add: false
 cifmw_libvirt_manager_fixed_networks:
   - ocpbm
   - ocppr
   - osp_external
   - osp_trunk
+
 cifmw_libvirt_manager_configuration:
   networks:
     ocpbm: |
@@ -124,11 +85,6 @@ cifmw_libvirt_manager_configuration:
         - osp_trunk
         - osp_external
 
-## devscript support for OCP deploy
-cifmw_use_devscripts: true
-# Required for egress traffic from pods to the osp_trunk network
-cifmw_devscripts_enable_ocp_nodes_host_routing: true
-
 # Note: with that extra_network_names "osp_trunk", we instruct
 # devscripts role to create a new network, and associate it to
 # the OCP nodes. This one is a "private network", and will hold
@@ -137,10 +93,6 @@ cifmw_devscripts_enable_ocp_nodes_host_routing: true
 # Please create a custom env file to provide:
 # cifmw_devscripts_ci_token:
 # cifmw_devscripts_pull_secret:
-
-# type and size of ssh keys injected into the OCP workers and compute nodes
-cifmw_ssh_keytype: ecdsa
-cifmw_ssh_keysize: 521
 
 # Baremetal host configuration
 cifmw_config_bmh: true


### PR DESCRIPTION
A series of parameters are mandatory in all cases. Let's avoid
duplication and group them in a single file.

That single file is then loaded if and only if we set the
`cifmw_architecture_scenario` parameter to a non-empty string.

As noted in the va-common.yml file, ANY parameter there can be
overridden by a parameter file, or even using `-e foo=bar` directly.

This should make "creating new VA or DT" process slightly easier for
everyone, while providing a unified way to fix all the scenarios in case
of new parameter/feature/others.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
