### PR TITLE
Pinning golang version for doc builds to 1.21.7

### DIFF
--- a/ci/playbooks/pre-doc.yml
+++ b/ci/playbooks/pre-doc.yml
@@ -23,5 +23,22 @@
         name:
           - make
           - python3
-          - golang
           - ruby
+
+    - name: Download golang version 1.21.7
+      ansible.builtin.get_url:
+        source: https://go.dev/dl/go1.21.7.linux-amd64.tar.gz
+        dest: go1.21.7.linux-amd64.tar.gz
+        checksum: ffeabdfe10a7e84197ac7d28fda7484d0f855a92
+
+    - name: Install golang
+      become: true
+      ansible.builtin.unarchive:
+        src: go1.27.linux-amd64.tar.gz
+        dest: ~/bin
+        include:
+          - bin/go
+          - bin/gofmt
+        extra_opts:
+          - --strip-components=2
+        creates: ~/bin/go


### PR DESCRIPTION
There is an ongoing issue with doc builds under dataplane-operator-docs-preview https://review.rdoproject.org/zuul/builds?job_name=dataplane-operator-docs-preview The new version of go `1.22` is not compatible with some of the source, due to several modules moving from experimental to builtins.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes

