### PR TITLE
add missing ssh-known-hosts service to hci_prepare

### DIFF
--- a/roles/hci_prepare/tasks/phase1.yml
+++ b/roles/hci_prepare/tasks/phase1.yml
@@ -69,6 +69,7 @@
               - install-os
               - ceph-hci-pre
               - configure-os
+              - ssh-known-hosts
               - run-os
               - reboot-os
 

--- a/roles/hci_prepare/tasks/phase2.yml
+++ b/roles/hci_prepare/tasks/phase2.yml
@@ -102,6 +102,7 @@
               - install-os
               - ceph-hci-pre
               - configure-os
+              - ssh-known-hosts
               - run-os
               - reboot-os
               - install-certs


### PR DESCRIPTION
nova requires that a ssh known hosts file is created on
all hosts however this service was missing from the
nodeset created in the hci_prepare role.

The hci_prepare role replaces the default set of services
used by the nodeset with a custom set, this change adds
ssh-known-hosts to that list in the same location as the
default nodeset sample.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

