### PR TITLE
Pin golang on docs jobs

### DIFF
--- a/ci/playbooks/pre-doc.yml
+++ b/ci/playbooks/pre-doc.yml
@@ -23,5 +23,5 @@
         name:
           - make
           - python3
-          - golang
+          - golang-1.21.7-1.el9
           - ruby


### PR DESCRIPTION
controller-gen breaks with golang 1.22

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
