### PR TITLE
Pinning golang version for doc builds to 1.21.7

### DIFF
--- a/ci/playbooks/pre-doc.yml
+++ b/ci/playbooks/pre-doc.yml
@@ -17,11 +17,12 @@
         state: directory
         mode: "0755"
 
+    # TODO(jpodivin) unpin the go version when dataplane-operator reaches go 1.22
     - name: Install required packages
       become: true
       ansible.builtin.package:
         name:
           - make
           - python3
-          - golang
+          - golang-1.21.7-1.el9
           - ruby


### PR DESCRIPTION
Fixing the argument

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
