### PR TITLE
Update HCI scenario for test_operator

### DIFF
--- a/scenarios/centos-9/hci_ceph_backends.yml
+++ b/scenarios/centos-9/hci_ceph_backends.yml
@@ -24,26 +24,18 @@ cifmw_block_device_size: 20G
 
 cifmw_services_manila_enabled: true
 
-pre_tempest:
-  - name: Create manila resources
+pre_tests:
+  - name: 90 Create manila resources
     type: playbook
     source: manila_create_default_resources.yml
 
 cifmw_run_tests: true
 cifmw_tempest_container: openstack-tempest-all
-cifmw_tempest_default_groups: &test_operator_list
-  - cinder-operator
-  - manila-operator
-cifmw_tempest_default_jobs: *test_operator_list
-
 cifmw_tempest_tests_allowed_override_scenario: true
 
-cifmw_tempest_tempestconf_profile:
-  create: true
-  debug: true
-  os_cloud: default
-  overrides:
-    identity.v3_endpoint_type: public
-    share.run_share_group_tests: "False"
-    share.capability_storage_protocol: CEPHFS
-    share.suppress_errors_in_cleanup: "True"
+cifmw_tempest_tempestconf_config:
+  overrides: |
+    identity.v3_endpoint_type public
+    share.run_share_group_tests false
+    share.capability_storage_protocol cephfs
+    share.suppress_errors_in_cleanup true

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -284,6 +284,8 @@
       - ^roles/cifmw_ceph.*/(?!meta|README).*
       - ^roles/cifmw_block_device/(?!meta|README).*
       - ^roles/cifmw_create_admin/(?!meta|README).*
+      - ^scenarios/centos-9/hci_ceph_backends.yml
+      - ^scenarios/centos-9/multinode-ci.yml
 
 - job:
     name: podified-multinode-edpm-e2e-nobuild-tagged-crc


### PR DESCRIPTION
Selecting tests by operator is still not working, so each child job will need to provide a list of include/exclude tests. Move from pre_tempest to pre_test hook.
Override tempestconf to add manila configuration.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [X] Content of the docs/source is reflecting the changes
