### PR TITLE
[reproducer] Fix undefined variable error during deploy architecture

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -383,7 +383,7 @@
                 ansible_user_dir,
                 'src/github.com/openstack-k8s-operators',
                 'architecture/automation/vars',
-                cifmw_arch_automation_file | default('default.yaml')
+                (cifmw_arch_automation_file | default('default.yaml'))
               ) | ansible.builtin.path_join
             }}
           {% endraw %}


### PR DESCRIPTION
When cifmw_arch_automation_file is not defined, there is a high chance that an executer would hit undefined error during execution of deploy-architecture script.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
