### PR TITLE
Fix allowedlist and skiplist

### DIFF
--- a/roles/test_operator/tasks/tempest-tests.yml
+++ b/roles/test_operator/tasks/tempest-tests.yml
@@ -38,7 +38,7 @@
           {{
               test_operator_cr |
               combine({'spec': {'tempestRun': { 'includeList':
-                      list_allowed.allowed_tests | join('\n')
+                      list_allowed.allowed_tests | join(" ") | to_nice_yaml
                       }}}, recursive=true)
           }}
 
@@ -65,7 +65,7 @@
           {{
               test_operator_cr |
               combine({'spec': {'tempestRun': { 'excludeList':
-                      list_skipped.skipped_tests | join('\n')
+                      list_skipped.skipped_tests | join(" ") | to_nice_yaml
                       }}}, recursive=true)
           }}
 


### PR DESCRIPTION
The test names are not separated correctly by the new line when there is more than one test in the list generated using the skiplist and allowedlist module in the test-operator role.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running

