### PR TITLE
[OSASINFRA] Attach a PVC to shiftstack client

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -430,6 +430,7 @@ sdk
 selinux
 sha
 shiftstack
+shiftstackclient
 sig
 skbg
 skiplist

--- a/roles/shiftstack/README.md
+++ b/roles/shiftstack/README.md
@@ -2,15 +2,17 @@
 Role for triggering Openshift on Openstack QA automation (installation and tests).
 
 ## Parameters
-* `cifmw_shiftstack_artifacts_dir`: (*string*) Directory name for the role artifacts. Defaults to `artifacts`.
+* `cifmw_shiftstack_artifacts_dir`: (*string*) Directory name for the role artifacts. Defaults to `"{{ cifmw_shiftstack_basedir }}/artifacts"`.
 * `cifmw_shiftstack_basedir`: (*string*) Base directory for the role artifacts and logs. Defaults to `{{ cifmw_basedir }}/tests/shiftstack` (which defaults to `~/ci-framework-data/tests/shiftstack`.
 * `cifmw_shiftstack_client_pod_name`: (*string*) Pod name for the pod running the Openshift installer and tests. Defaults to `shiftstackclient`.
 * `cifmw_shiftstack_client_pod_namespace`: (*string*) The namespace where the `cifmw_shiftstack_client_pod_name` will be deployed. Defaults to `openstack`.
 * `cifmw_shiftstack_client_pod_image`: (*string*) The image for the container running in the `cifmw_shiftstack_client_pod_name` pod. Defaults to `quay.io/shiftstack-qe/shiftstack-client:latest`.
-* `cifmw_shiftstack_installation_dir`: (*string*) Directory to place installation files. Defaults to `installation`.
+* `cifmw_shiftstack_installation_dir`: (*string*) Directory to place installation files. Defaults to `"{{ cifmw_shiftstack_basedir }}/installation"`.
 * `cifmw_shiftstack_qa_gerrithub_change`: (*string*) The gerrithub change to fetch from the `cifmw_shiftstack_qa_repo` repository (i.e. 'refs/changes/29/1188429/50)'. Defaults to ''.
 * `cifmw_shiftstack_qa_repo`: (*string*) The repository containing the Openshift on Openstack QA automation. Defaults to `https://review.gerrithub.io/shiftstack/shiftstack-qa`.
 * `cifmw_shiftstack_run_playbook`: (*string*) The playbook to be run from the `cifmw_shiftstack_qa_repo` repository. Defaults to `ocp_testing.yaml`.
+* `cifmw_shiftstack_sc`: (*string*) The storage class to be used for PVC for the shiftstackclient pod. Defaults to `local-storage`.
+* `cifmw_shiftstack_shiftstackclient_artifacts_dir`: (*string*) The artifacts directory path for the shiftstackclient pod. Defaults to `/home/cloud-admin/artifacts`.
 
 ## Examples
 The role is imported in the test playbook, i.e. when:

--- a/roles/shiftstack/defaults/main.yml
+++ b/roles/shiftstack/defaults/main.yml
@@ -17,12 +17,15 @@
 
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_shiftstack"
-cifmw_shiftstack_artifacts_dir: "artifacts"
+cifmw_shiftstack_artifacts_dir: "{{ cifmw_shiftstack_basedir }}/artifacts"
 cifmw_shiftstack_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}/tests/shiftstack"
 cifmw_shiftstack_client_pod_image: "quay.io/shiftstack-qe/shiftstack-client:latest"
 cifmw_shiftstack_client_pod_name: "shiftstackclient"
 cifmw_shiftstack_client_pod_namespace: "openstack"
-cifmw_shiftstack_installation_dir: "installation"
+cifmw_shiftstack_installation_dir: "{{ cifmw_shiftstack_basedir }}/installation"
 cifmw_shiftstack_qa_gerrithub_change: ""
 cifmw_shiftstack_qa_repo: "https://review.gerrithub.io/shiftstack/shiftstack-qa"
 cifmw_shiftstack_run_playbook: "ocp_testing.yaml"
+cifmw_shiftstack_sc: "local-storage"
+cifmw_shiftstack_shiftstackclient_artifacts_dir: "/home/cloud-admin/artifacts"
+cifmw_shiftstack_shiftstackclient_installation_dir: "/home/cloud-admin/installation"

--- a/roles/shiftstack/molecule/default/converge.yml
+++ b/roles/shiftstack/molecule/default/converge.yml
@@ -23,6 +23,7 @@
     cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
     cifmw_shiftstack_run_playbook: cifmw-gate.yaml
     cifmw_run_test_shiftstack_testconfig: cifmw-gate.yaml
+    cifmw_shiftstack_sc: "crc-csi-hostpath-provisioner"
   tasks:
     - name: Include the shiftstack role
       ansible.builtin.include_role:

--- a/roles/shiftstack/tasks/deploy_shiftstackclient_pod.yml
+++ b/roles/shiftstack/tasks/deploy_shiftstackclient_pod.yml
@@ -14,17 +14,28 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Render the pvc manifest
+  ansible.builtin.template:
+    src: templates/shiftstackclient_pvc.yml.j2
+    dest: "{{ (cifmw_shiftstack_basedir, cifmw_shiftstack_client_pod_name + '_pvc.yml') | path_join }}"
+
+- name: Apply the manifest for the PVC creation
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    src: "{{ (cifmw_shiftstack_basedir, cifmw_shiftstack_client_pod_name + '_pvc.yml') | path_join }}"
+
 - name: Render the pod manifest from a template
   ansible.builtin.template:
     src: "templates/shiftstackclient_pod.yml.j2"
-    dest: "{{ cifmw_shiftstack_basedir }}/{{ cifmw_shiftstack_client_pod_name }}_pod.yml"
+    dest: "{{ (cifmw_shiftstack_basedir, cifmw_shiftstack_client_pod_name + '_pod.yml') | path_join }}"
     mode: "0644"
 
 - name: Apply the manifest for the pod creation
   kubernetes.core.k8s:
     state: present
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
-    src: "{{ cifmw_shiftstack_basedir }}/{{ cifmw_shiftstack_client_pod_name }}_pod.yml"
+    src: "{{ (cifmw_shiftstack_basedir, cifmw_shiftstack_client_pod_name + '_pod.yml') | path_join }}"
     wait: true
     wait_condition:
       type: Ready

--- a/roles/shiftstack/tasks/test_shiftstack.yml
+++ b/roles/shiftstack/tasks/test_shiftstack.yml
@@ -84,12 +84,14 @@
     - name: Retrieve artifacts and installation files from the pod
       vars:
         directory_list:
-          - "{{ cifmw_shiftstack_artifacts_dir }}"
-          - "{{ cifmw_shiftstack_installation_dir }}"
+          - controller_dir: "{{ cifmw_shiftstack_artifacts_dir }}"
+            pod_dir: "{{ cifmw_shiftstack_shiftstackclient_artifacts_dir }}"
+          - controller_dir: "{{ cifmw_shiftstack_installation_dir }}"
+            pod_dir: "{{ cifmw_shiftstack_shiftstackclient_installation_dir }}"
       block:
         - name: Create the directories for the artifacts and installation files
           ansible.builtin.file:
-            path: "{{ cifmw_shiftstack_basedir }}/{{ item }}"
+            path: "{{ item.controller_dir }}"
             state: directory
             mode: "0755"
           loop: "{{ directory_list }}"
@@ -101,6 +103,6 @@
           ansible.builtin.command:
             cmd: >
               oc rsync -n {{ cifmw_shiftstack_client_pod_namespace }}
-              {{ cifmw_shiftstack_client_pod_name }}:/home/cloud-admin/{{ item }}/
-              {{ cifmw_shiftstack_basedir }}/{{ item }}/
+              {{ cifmw_shiftstack_client_pod_name }}:{{ item.pod_dir }}/
+              {{ item.controller_dir }}/
           loop: "{{ directory_list }}"

--- a/roles/shiftstack/templates/shiftstackclient_pod.yml.j2
+++ b/roles/shiftstack/templates/shiftstackclient_pod.yml.j2
@@ -28,6 +28,8 @@ spec:
     - mountPath: /home/cloud-admin/.original-config/cert/
       name: openstack-cert
       readOnly: true
+    - name: installation-volume
+      mountPath: {{ cifmw_shiftstack_installation_dir }}
   dnsPolicy: ClusterFirst
   enableServiceLinks: true
   preemptionPolicy: PreemptLowerPriority
@@ -58,3 +60,6 @@ spec:
     secret:
       defaultMode: 292
       secretName: rootca-public
+  - name: installation-volume
+    persistentVolumeClaim:
+      claimName: {{ cifmw_shiftstack_client_pod_name }}-pvc

--- a/roles/shiftstack/templates/shiftstackclient_pvc.yml.j2
+++ b/roles/shiftstack/templates/shiftstackclient_pvc.yml.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ cifmw_shiftstack_client_pod_name }}-pvc
+  namespace: openstack
+spec:
+  storageClassName: {{ cifmw_shiftstack_sc }}
+  accessModes:
+    - ReadWriteOnce
+    - ReadWriteMany
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage: 2Gi


### PR DESCRIPTION
To have a persistent storage for installation files

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
