### PR TITLE
Change to YAML stdout for Ansible

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -5,7 +5,8 @@ roles_path = ~/ci-framework-data/artifacts/roles:./roles:/usr/share/ansible/role
 filter_plugins = ./plugins/filter:~/plugins/filter:/usr/share/ansible/plugins/filter
 log_path = ~/ansible.log
 # We may consider ansible.builtin.junit
-callbacks_enabled = ansible.posix.profile_tasks
+callbacks_enabled = ansible.posix.profile_tasks,yaml
+stdout_callback = yaml
 display_args_to_stdout = True
 gathering = smart
 fact_caching = jsonfile


### PR DESCRIPTION
The current json output can be hard to read with large outputs from
errors.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
