### PR TITLE
Extract podman related bits in its own role

### DIFF
--- a/roles/podman/README.md
+++ b/roles/podman/README.md
@@ -1,0 +1,25 @@
+# podman
+
+Install podman and enable sessions without login (linger).
+
+## Privilege escalation
+
+Requested to install packages.
+
+## Parameters
+
+* `cifmw_podman_packages`: (List) list of packages to install for Podman. Defaults to `[podman]`.
+* `cifmw_podman_enable_linger`: (Bool) toggle session linger. Defaults to `true`.
+
+## Examples
+
+```YAML
+- name: Configure podman
+  vars:
+    cifmw_podman_enable_linger: false
+    cifmw_podman_packages:
+      - podman
+      - skopeo
+  ansible.builtin.import_role:
+    name: podman
+```

--- a/roles/podman/defaults/main.yml
+++ b/roles/podman/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# All variables within this role should have a prefix of "cifmw_podman"
+cifmw_podman_packages:
+  - podman
+cifmw_podman_enable_linger: true

--- a/roles/podman/meta/main.yml
+++ b/roles/podman/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- podman
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: cifmw
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - cifmw
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/podman/molecule/default/converge.yml
+++ b/roles/podman/molecule/default/converge.yml
@@ -1,0 +1,21 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  roles:
+    - role: "podman"

--- a/roles/podman/molecule/default/molecule.yml
+++ b/roles/podman/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/roles/podman/molecule/default/prepare.yml
+++ b/roles/podman/molecule/default/prepare.yml
@@ -1,0 +1,21 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  roles:
+    - role: test_deps

--- a/roles/podman/tasks/main.yml
+++ b/roles/podman/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure podman is installed
+  become: true
+  ansible.builtin.package:
+    name: "{{ cifmw_podman_packages }}"
+    state: present
+
+- name: Enable loginctl linger for ansible_user_id
+  when:
+    - cifmw_podman_enable_linger | bool
+  ansible.builtin.command:
+    cmd: "loginctl enable-linger {{ ansible_user_id }}"

--- a/roles/podman/vars/main.yml
+++ b/roles/podman/vars/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# While options found within the vars/ path can be overridden using extra
+# vars, items within this path are considered part of the role and not
+# intended to be modified.
+
+# All variables within this role should have a prefix of "cifmw_podman"

--- a/roles/virtualbmc/tasks/main.yml
+++ b/roles/virtualbmc/tasks/main.yml
@@ -23,14 +23,9 @@
     - key: "{{ cifmw_virtualbmc_sshkey_path | dirname }}"
       mode: "0700"
 
-- name: Ensure podman is installed
-  become: true
-  ansible.builtin.package:
+- name: Install podman and configure session linger
+  ansible.builtin.import_role:
     name: podman
-    state: present
-
-- name: Fix podman issue related mkdir /run/user/1000 permission denied
-  ansible.builtin.command: "loginctl enable-linger {{ ansible_user_id }}"
 
 - name: Check if container already exists
   register: _vbmc_container_info

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -544,6 +544,17 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/podman/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-podman
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: podman
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/registry_deploy/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -56,6 +56,7 @@
       - cifmw-molecule-operator_deploy
       - cifmw-molecule-os_must_gather
       - cifmw-molecule-pkg_build
+      - cifmw-molecule-podman
       - cifmw-molecule-registry_deploy
       - cifmw-molecule-repo_setup
       - cifmw-molecule-reproducer


### PR DESCRIPTION
Since we'll see more podman containers in the near future, let's get a
deidcated role to group the needed actions.

This new `podman` role installs the package, and enable session
lingering if requestes (defaults `true`).

We can also override the package list to install in case we want more of
podman-related content, such as buildah, skopeo and so on.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
