### PR TITLE
Exclude main.yml from found_validations

### DIFF
--- a/roles/validations/tasks/main.yml
+++ b/roles/validations/tasks/main.yml
@@ -26,6 +26,8 @@
         paths: "{{ cifmw_validations_default_path }}"
         patterns: '*.yml'
         recurse: true
+        # We need to exclude this file from the list of found validations to avoid an infinite loop.
+        excludes: "{{ cifmw_validations_default_path }}/main.yml"
 
     - name: Run all found validations
       ansible.builtin.include_tasks:


### PR DESCRIPTION
When we run all validations, we need to avoid executing tasks/main.yml, since that would result in an infinite loop. We only want to run named validation files under the tasks/team/ directories.

Signed-off-by: Brendan Shephard <bshephar@redhat.com>

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
