### PR TITLE
Bumping flake8 and typing-imports to more recent version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,10 +13,10 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.0
+    rev: 7.0.0
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-typing-imports==1.6.0]
+        additional_dependencies: [flake8-typing-imports==1.15.0]
         # List of ignored checks overrides the flake8 defaults.
         # Changes to the list, especially extensions should be
         # justified with relation to defaults.

--- a/plugins/module_utils/net_map/networking_definition.py
+++ b/plugins/module_utils/net_map/networking_definition.py
@@ -105,7 +105,7 @@ def _validate_parse_netadrr(
 def _validate_parse_field_type(
     field_name: str,
     raw_definition: typing.Dict[str, typing.Any],
-    expected_type: typing.Type,
+    expected_type: "typing.Type",
     parent_name: str = None,
     parent_type: str = None,
     mandatory: bool = False,

--- a/plugins/module_utils/net_map/networking_mapper.py
+++ b/plugins/module_utils/net_map/networking_mapper.py
@@ -600,7 +600,7 @@ class NetworkingNetworksMapper:
     @staticmethod
     def __build_network_tool_common(
         tool_net_def: networking_definition.SubnetBasedNetworkToolDefinition,
-        tool_type: typing.Type,
+        tool_type: "typing.Type",
     ) -> typing.Union[
         networking_env_definitions.MappedMetallbNetworkConfig,
         networking_env_definitions.MappedMultusNetworkConfig,


### PR DESCRIPTION
Right now we are using version of flake8 that's bit over 3 years old, similarly we are using rather outdated version of the `flake8-typing-imports` plugin. This is still workable in the short term, but there is one incoming issue.

Version 3.9.0 won't work with python>=3.12. Since many devs are working on stream distros, or frequently update their OS, we are going to run into some issues.  

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
