### PR TITLE
[bop]Move dlrn-venv to a proper ansible var

### DIFF
--- a/roles/build_openstack_packages/README.md
+++ b/roles/build_openstack_packages/README.md
@@ -7,6 +7,7 @@ An Ansible role for generating custom RPMSs of OpenStack Projects using DLRN
 * `cifmw_bop_build_repo_dir`: (String) The directory where the DLRN repo is built. Defaults to `{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}/logs`.
 * `cifmw_bop_dlrn_repo_url`: (String) The URL of the DLRN repository.
 * `cifmw_bop_dlrn_from_source`: (String) Install DLRN from git. Defaults to `False`.
+* `cifmw_bop_dlrn_venv: (String) DLRN Virtualenv directory Default to `{{ ansible_user_dir }}/dlrn_venv`.
 * `cifmw_bop_rdoinfo_repo_url`: (String) The URL of the rdoinfo repository that contains the project definitions for DLRN.
 * `cifmw_bop_rdoinfo_repo_name`: (String) Name of the rdoinfo repository.
 * `cifmw_bop_initial_dlrn_config`: (String) Name of the initial DLRN config. Defaults to `centos9-stream`.

--- a/roles/build_openstack_packages/defaults/main.yml
+++ b/roles/build_openstack_packages/defaults/main.yml
@@ -34,6 +34,7 @@ cifmw_bop_dlrn_deps:
 cifmw_bop_build_repo_dir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}/logs"
 cifmw_bop_dlrn_repo_url: "https://github.com/openstack-packages/DLRN.git"
 cifmw_bop_dlrn_from_source: false
+cifmw_bop_dlrn_venv: "{{ ansible_user_dir }}/dlrn_venv"
 
 cifmw_bop_rdoinfo_repo_url: https://github.com/redhat-openstack/rdoinfo
 cifmw_bop_rdoinfo_repo_name: rdoinfo

--- a/roles/build_openstack_packages/tasks/cleanup_dlrn.yml
+++ b/roles/build_openstack_packages/tasks/cleanup_dlrn.yml
@@ -19,7 +19,7 @@
     path: '{{ item }}'
     state: absent
   with_items:
-    - '{{ cifmw_bop_build_repo_dir }}/dlrn-venv'
+    - '{{ cifmw_bop_dlrn_venv }}'
     - '{{ cifmw_bop_build_repo_dir }}/gating_repo'
   when: cifmw_bop_dlrn_cleanup|bool
 

--- a/roles/build_openstack_packages/tasks/install_dlrn.yml
+++ b/roles/build_openstack_packages/tasks/install_dlrn.yml
@@ -74,7 +74,7 @@
 - name: Create dlrn-venv
   ansible.builtin.pip:  # noqa: package-latest
     name: pip
-    virtualenv: "{{ cifmw_bop_build_repo_dir }}/dlrn-venv"
+    virtualenv: "{{ cifmw_bop_dlrn_venv }}"
     virtualenv_command: "/usr/bin/python3 -m venv"
     state: latest
     extra_args: --upgrade
@@ -93,30 +93,25 @@
       retries: 3
       delay: 5
 
-    - name: Install DLRN
-      ansible.builtin.shell: >
-        source {{ cifmw_bop_build_repo_dir }}/dlrn-venv/bin/activate;
-        pip install -r requirements.txt;
-        python3 setup.py install;
-      args:
-        chdir: '{{ cifmw_bop_build_repo_dir }}/DLRN'
+    - name: Install DLRN requirements
+      ansible.builtin.pip:
+        virtualenv: "{{ cifmw_bop_dlrn_venv }}"
+        requirements: "{{ cifmw_bop_build_repo_dir }}/DLRN/requirements.txt"
 
-- name: Install DLRN from pip
+    - name: Install DLRN from source
+      ansible.builtin.command:
+        cmd: "{{ cifmw_bop_dlrn_venv }}/bin/python setup.py install"
+        chdir: "{{ cifmw_bop_build_repo_dir }}/DLRN"
+        creates: "{{ cifmw_bop_dlrn_venv }}/bin/dlrn"
+
+- name: Install DLRN and rdopkg from pip
   when: not cifmw_bop_dlrn_from_source|bool
-  block:
-    - name: Pip install rdopkg
-      ansible.builtin.pip:  # noqa: package-latest
-        name: rdopkg
-        virtualenv: "{{ cifmw_bop_build_repo_dir }}/dlrn-venv"
-        virtualenv_command: "/usr/bin/python3 -m venv"
-        state: latest
-
-    - name: Pip install DLRN
-      ansible.builtin.pip:  # noqa: package-latest
-        name: dlrn
-        virtualenv: "{{ cifmw_bop_build_repo_dir }}/dlrn-venv"
-        virtualenv_command: "/usr/bin/python3 -m venv"
-        state: latest
+  ansible.builtin.pip:  # noqa: package-latest
+    name:
+      - rdopkg
+      - dlrn
+    virtualenv: "{{ cifmw_bop_dlrn_venv }}"
+    state: latest
 
 - name: Drop in the templated version of projects.ini
   ansible.builtin.template:
@@ -125,7 +120,7 @@
 
 - name: Copy the DLRN scripts in the virtualenv to the scripts dir
   ansible.posix.synchronize:
-    src: "{{ cifmw_bop_build_repo_dir }}/dlrn-venv/share/dlrn/scripts"
+    src: "{{ cifmw_bop_dlrn_venv }}/share/dlrn/scripts"
     dest: "{{ cifmw_bop_build_repo_dir }}/DLRN"
   delegate_to: "{{ inventory_hostname }}"
 

--- a/roles/build_openstack_packages/tasks/run_dlrn.yml
+++ b/roles/build_openstack_packages/tasks/run_dlrn.yml
@@ -68,7 +68,7 @@
       ansible.builtin.shell:
         chdir: '{{ cifmw_bop_build_repo_dir }}/DLRN'
         cmd: |
-          source '{{ cifmw_bop_build_repo_dir }}/dlrn-venv/bin/activate'
+          source '{{ cifmw_bop_dlrn_venv }}/bin/activate'
           set -xeo pipefail
           # {{ cifmw_bop_rdoinfo_repo_name }}/{{ cifmw_bop_rdoinfo_repo_name.split('info')[0] }}-full.yml will
           # return rdo-full.yml and for downstream is osp-full.yml.

--- a/roles/build_openstack_packages/templates/run_dlrn.sh.j2
+++ b/roles/build_openstack_packages/templates/run_dlrn.sh.j2
@@ -1,7 +1,7 @@
 set +e
 
 cd {{ cifmw_bop_build_repo_dir }}/DLRN
-source {{ cifmw_bop_build_repo_dir }}/dlrn-venv/bin/activate;
+source {{ cifmw_bop_dlrn_venv }}/bin/activate;
 export PKG={{ project_name_mapped.stdout }}
 {% if ansible_distribution|lower  == "redhat" %}
 export REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt


### PR DESCRIPTION
This pull request moves the hardcoded dlrn venv path to a proper ansible var. It also modified the DLRN installation shell related tasks to ansible pip
tasks.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

