### PR TITLE
Ensure we know what template has been used

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,15 @@ repos:
         args: ['check_zuul_files']
         pass_filenames: false
 
+  - repo: local
+    hooks:
+      - id: check-k8s-snippets-comment
+        name: check_k8s_snippets_comment
+        language: system
+        entry: make
+        args: ['check_k8s_snippets_comment']
+        pass_filenames: false
+
   # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.1.0

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,10 @@ pre_commit_nodeps: ## Run pre-commit tests without installing dependencies
 check_zuul_files: role_molecule ## Regenerate zuul files and check if they have not been modified manually
 	./scripts/check_zuul_files.sh
 
+.PHONY: check_k8s_snippets_comment
+check_k8s_snippets_comment:
+	./scripts/check_k8s_snippets_comment.sh
+
 ##@ Ansible-test testing
 .PHONY: ansible_test
 ansible_test: setup_tests ansible_test_nodeps ## Runs ansible-test with dependencies install

--- a/roles/ci_gen_kustomize_values/README.md
+++ b/roles/ci_gen_kustomize_values/README.md
@@ -44,6 +44,19 @@ Note that all of the SSH keys should be in `ecdsa` format to comply with FIPS di
 ### Required parameters only when baremetal compute nodes are used.
 * `cifmw_ci_gen_kustomize_values_ctlplane_interface`: (String) Used to override default controlplane interface for OSP compute nodes.
 
+## Adding a new template
+
+The template must have a leading comment staging its source. For example, if your template is located in
+`templates/foo/edpm-values/values.yaml.j2` it must have the following header:
+
+```YAML
+---
+# source: foo/edpm-values/values.yaml.j2
+```
+
+The `source` must be relative to the `templates` directory. This will help during debugging sessions, since it will show the used template
+directly in `ci-framework-data/ci_k8s_snippets/TYPE/02_ci_data.yaml`.
+
 ## Examples
 
 ### Generate controlplane values.yaml for `nfv/sriov` VA

--- a/roles/ci_gen_kustomize_values/templates/common/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/common/network-values/values.yaml.j2
@@ -1,4 +1,5 @@
 ---
+# source: common/network-values/values.yaml.j2
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
                       lb_tools={}) %}

--- a/roles/ci_gen_kustomize_values/templates/common/olm/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/common/olm/values.yaml.j2
@@ -1,2 +1,3 @@
+# source: common/olm/values.yaml.j2
 data:
     openstack-operator-image: {{ cifmw_ci_gen_kustomize_values_ooi_image | default('quay.io/openstack-k8s-operators/openstack-operator-index:latest', true) }}

--- a/roles/ci_gen_kustomize_values/templates/hci/edpm-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/hci/edpm-values/values.yaml.j2
@@ -1,3 +1,5 @@
+---
+# source: hci/edpm-values/values.yaml.j2
 {% set instances_names = []                                                            %}
 {% set _original_nodeset = (original_content.data | default({})).nodeset | default({}) %}
 {% set _original_nodes = _original_nodeset.nodes | default({})                         %}

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/edpm-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/edpm-values/values.yaml.j2
@@ -1,3 +1,5 @@
+---
+# source: ovs-dpdk-sriov/edpm-values/values.yaml.j2
 {% set instances_names = []                                                            %}
 {% set _original_nodeset = (original_content.data | default({})).nodeset | default({}) %}
 {% set _original_nodes = _original_nodeset.nodes | default({})                         %}

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/network-values/values.yaml.j2
@@ -1,4 +1,5 @@
 ---
+# source: ovs-dpdk-sriov/network-values/values.yaml.j2
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
                       lb_tools={}) %}

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk/edpm-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk/edpm-values/values.yaml.j2
@@ -1,3 +1,5 @@
+---
+# source: ovs-dpdk/edpm-values/values.yaml.j2
 {% set instances_names = []                                                            %}
 {% set _original_nodeset = (original_content.data | default({})).nodeset | default({}) %}
 {% set _original_nodes = _original_nodeset.nodes | default({})                         %}

--- a/roles/ci_gen_kustomize_values/templates/sriov/edpm-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/sriov/edpm-values/values.yaml.j2
@@ -1,3 +1,5 @@
+---
+# source:  sriov/edpm-values/values.yaml.j2
 {% set instances_names = []                                                            %}
 {% set _original_nodeset = (original_content.data | default({})).nodeset | default({}) %}
 {% set _original_nodes = _original_nodeset.nodes | default({})                         %}

--- a/roles/ci_gen_kustomize_values/templates/uni01alpha/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni01alpha/network-values/values.yaml.j2
@@ -1,4 +1,5 @@
 ---
+# source: uni01alpha/network-values/values.yaml.j2
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
                       lb_tools={}) %}

--- a/scripts/check_k8s_snippets_comment.sh
+++ b/scripts/check_k8s_snippets_comment.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -o pipefail
+
+exit_code=0
+
+missing_comment=$(grep -rL '^# source: ' roles/ci_gen_kustomize_values/templates)
+if [[ $missing_comment != '' ]]; then
+    echo "!! Following templates are missing the needed '# source: path/to/template' comment."
+    echo "   Path must be relative to 'templates'"
+    echo
+    echo "${missing_comment}"
+    echo
+    let "exit_code+=1"
+fi
+
+set_path=$(grep -r '^# source: ' roles/ci_gen_kustomize_values/templates | sed 's!roles/ci_gen_kustomize_values/templates/!!')
+while read match; do
+    tmpl=$(echo -n "${match}" | cut -d ':' -f 1)
+    comment=$(echo -n "${match}" | cut -d ':' -f 3 | tr -d '[:space:]')
+    if [[ "${tmpl}" != "${comment}" ]]; then
+        let "exit_code+=1"
+        echo "${tmpl} doesn't have correct 'source': ${comment}"
+    fi
+done <<< ${set_path}
+exit $exit_code


### PR DESCRIPTION
In ci_gen_kustomize_values, we have a growing number of templates. It
might be hard to know what template was used to generated the
02_ci_data.yaml snippet, unless we add a small comment in the templates
directly, pointing to its origin.

This patch adds such comment to the existing files, and also adds a
small "linter" ensuring we match the comment in those templates.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
