### PR TITLE
Fix ansible lint issue raised in pod job

### DIFF
--- a/roles/shiftstack/molecule/default/cleanup.yml
+++ b/roles/shiftstack/molecule/default/cleanup.yml
@@ -28,7 +28,7 @@
         tasks_from: cleanup.yml
 
     - name: Delete the openstack namespace
-      k8s:
+      kubernetes.core.k8s:
         state: absent
         kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
         definition:


### PR DESCRIPTION
```
WARNING  Listing 1 violation(s) that are fatal
roles/shiftstack/molecule/default/cleanup.yml:30: fqcn[action]: Use FQCN for module actions, such `kubernetes.core.k8s`.
```

It seems the linter running in Zuul is stricter than the one in prow.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
