### PR TITLE
Allow some retries for setup_molecule run

### DIFF
--- a/ci/playbooks/pre-commit.yml
+++ b/ci/playbooks/pre-commit.yml
@@ -10,19 +10,23 @@
           - python3
           - python3-pip
 
-    - name: Run makes target
+    - name: Run make targets
       vars:
         src_dir: >-
           {{
             zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir
           }}
       block:
-        - name: Instal dependencies
+        - name: Install dependencies
+          register: _setup
           community.general.make:
             chdir: "{{ src_dir }}"
             target: setup_molecule
             params:
               USE_VENV: "no"
+          retries: 5
+          delay: 2
+          until: _setup is success
 
         - name: Run pre-commit
           community.general.make:

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -43,6 +43,11 @@
       - docs/.*
       - contribute/.*
       - roles/.*/molecule/.*
+      - ci/playbooks/pre-commit.yml
+      - ci/playbooks/pre-doc.yml
+      - ci/playbooks/run-doc.yml
+      - ci/playbooks/molecule-prepare.yml
+      - ci/playbooks/molecule-test.yml
       # ci-framework
       - .readthedocs.yaml
       - roles/dlrn_report


### PR DESCRIPTION
#### Allow some retries for setup_molecule run

We see some unrelated failures while running the pod, during setup
stage: apparently, the DNS may fail to answer in time, and this crashes
the env setup.

With this patch, we should be in better position, since it would retry
to install the libs in case of failure, with a small delay.

Hopefully, this change will stabilize enough the job so that we may
consider it "voting" in a near future.

#### Ensure we don't run deploy jobs on unrelated modifications

A couple of files nested in ci/playbooks aren't used at all in any
deployment job.
Let's avoid useless resources usage whenever we modify them!


As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
