### PR TITLE
ironic-operatpr -  Disable TestNodesVif tempest

### DIFF
--- a/roles/test_operator/files/list_skipped.yml
+++ b/roles/test_operator/files/list_skipped.yml
@@ -1283,6 +1283,78 @@ known_failures:
         lp: http://no.bug
     jobs:
       - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodesVif.test_vif_already_attached_on_internal_info
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodesVif.test_vif_already_attached_with_portgroups
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodesVif.test_vif_attach_no_args
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodesVif.test_vif_attach_no_free_port
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodesVif.test_vif_attach_no_port
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodesVif.test_vif_attach_port_not_in_portgroup
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodesVif.test_vif_attach_with_empty_portgroup
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodesVif.test_vif_detach_not_existing
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Not supported
+        lp: http://no.bug
+    jobs:
+      - ironic-operator
   - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestHardwareInterfaces.test_reset_interfaces
     deployment:
       - overcloud


### PR DESCRIPTION
These tests are blocking CI, the tests are failinb becuase the tests attempts to run with the wrong interface type.

The tests require fixing in upstream ironic. For now we can disable the tests in ironic-operator.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
