### PR TITLE
Create local PV directories with 0775 permissions

### DIFF
--- a/roles/ci_local_storage/molecule/default/converge.yml
+++ b/roles/ci_local_storage/molecule/default/converge.yml
@@ -51,7 +51,7 @@
                 ] | path_join
               }}
             state: directory
-            mode: "0755"
+            mode: "0775"
           loop: "{{ range(1, cifmw_cls_pv_count+1) }}"
 
         - name: Fail if we have a change  # noqa: no-handler

--- a/roles/ci_local_storage/tasks/worker_node_dirs.yml
+++ b/roles/ci_local_storage/tasks/worker_node_dirs.yml
@@ -13,6 +13,6 @@
       {{
         'directory' if cifmw_cls_action == 'create' else 'absent'
       }}
-    mode: "0755"
+    mode: "0775"
   delegate_to: "{{ host }}"
   loop: "{{ range(1, cifmw_cls_pv_count+1) }}"


### PR DESCRIPTION
k8s changes permissions of the PV directories when starting eg. an StatefulSet. However, if the playbook is rerun after starting a deployment, the group permissions will be reset to read-only and services can't create new subdirectories.

Changing the group permissions to writeable should be ok for new directories, as the default group is root until the PV gets mounted and prevents service errors if the playbook is re-run.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running