### PR TITLE
Add default for cifmw_validations_edpm_check_node

### DIFF
--- a/roles/validations/defaults/main.yml
+++ b/roles/validations/defaults/main.yml
@@ -32,3 +32,8 @@ cifmw_validations_list: []
 cifmw_validations_run_all: false
 
 cifmw_validations_default_path: "{{ role_path }}/tasks"
+
+# cifmw_validations_edpm_check_node is the node that we will validate for edpm jobs. We
+# achieve this by delegating_to the check node and executing the required commands to
+# validate that our desired state change has been achieved.
+cifmw_validations_edpm_check_node: 192.168.122.100


### PR DESCRIPTION
This change sets the default value for cifmw_validations_edpm_check_node.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
