### PR TITLE
[devscripts] Fix lookup of OpenShift api and ingress IP addresses

### DIFF
--- a/roles/devscripts/tasks/110_check_ocp.yml
+++ b/roles/devscripts/tasks/110_check_ocp.yml
@@ -68,29 +68,5 @@
     - not cifmw_devscripts_ocp_online
   ansible.builtin.include_tasks: 112_verify_golden_image.yml
 
-- name: Ensure dig is available
-  become: true
-  ansible.builtin.package:
-    name: bind-utils
-    state: present
-
-- name: Gather the IP address for OCP endpoints
-  ansible.builtin.command:
-    cmd: "dig +short {{ item }}"
-  register: _dig_info
-  loop:
-    - >-
-      {{
-        'api.' + cifmw_devscripts_config.cluster_name + '.' +
-        cifmw_devscripts_config.base_domain
-      }}
-    - >-
-      {{
-        'x.apps.' + cifmw_devscripts_config.cluster_name + '.' +
-        cifmw_devscripts_config.base_domain
-      }}
-
-- name: Gather OpenShift endpoint
-  ansible.builtin.set_fact:
-    cifmw_openshift_api_ip_address: "{{ _dig_info.results.0.stdout | trim }}"
-    cifmw_openshift_ingress_ip_address: "{{ _dig_info.results.1.stdout | trim }}"
+- name: Set the facts related to OpenShift ingress and api addresses.
+  ansible.builtin.include_tasks: get_ocp_vips.yml

--- a/roles/devscripts/tasks/133_host_network.yml
+++ b/roles/devscripts/tasks/133_host_network.yml
@@ -30,11 +30,17 @@
   ansible.builtin.include_role:
     name: ci_nmstate
 
-- name: Configure local DNS
-  when: cifmw_network_dnsmasq_config is defined
-  ansible.builtin.include_role:
-    name: ci_network
-    tasks_from: apply-dnsmasq.yml
+- name: Ensure local DNS settings are configured.
+  when:
+    - cifmw_network_dnsmasq_config is defined
+  block:
+    - name: Configure local DNS
+      ansible.builtin.include_role:
+        name: ci_network
+        tasks_from: apply-dnsmasq.yml
+
+    - name: Set the facts related to OpenShift ingress and api addresses.
+      ansible.builtin.include_tasks: get_ocp_vips.yml
 
 - name: Create and apply virtual network configuration.
   become: true

--- a/roles/devscripts/tasks/get_ocp_vips.yml
+++ b/roles/devscripts/tasks/get_ocp_vips.yml
@@ -1,0 +1,43 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Ensure dig is available
+  become: true
+  ansible.builtin.package:
+    name: bind-utils
+    state: present
+
+- name: Gather the IP address for OCP endpoints
+  ansible.builtin.command:
+    cmd: "dig +short {{ item }}"
+  register: _dig_info
+  loop:
+    - >-
+      {{
+        'api.' + cifmw_devscripts_config.cluster_name + '.' +
+        cifmw_devscripts_config.base_domain
+      }}
+    - >-
+      {{
+        'x.apps.' + cifmw_devscripts_config.cluster_name + '.' +
+        cifmw_devscripts_config.base_domain
+      }}
+
+- name: Gather OpenShift endpoint
+  ansible.builtin.set_fact:
+    cifmw_openshift_api_ip_address: "{{ _dig_info.results.0.stdout | trim }}"
+    cifmw_openshift_ingress_ip_address: "{{ _dig_info.results.1.stdout | trim }}"


### PR DESCRIPTION
In case of Hybrid deployment, the dns configuration happens late in the cycle. This could lead to skewed values being set for the facts holding OpenShift api and ingress addresses.

In this change, we are ensuring the facts hold the correct info.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

