### PR TITLE
[bop] Lower the priority of DLRN repo while using gating repo

### DIFF
--- a/roles/build_openstack_packages/tasks/create_repo.yml
+++ b/roles/build_openstack_packages/tasks/create_repo.yml
@@ -50,3 +50,15 @@
       gpgcheck=0
       priority=1
     dest: "{{ cifmw_bop_gating_repo_dest }}/gating.repo"
+
+- name: Check for DLRN repo at the destination
+  ansible.builtin.stat:
+    path: "{{ cifmw_bop_gating_repo_dest }}/delorean.repo"
+  register: _dlrn_repo
+
+- name: Lower the priority of DLRN repos to allow installation from gating repo
+  when: _dlrn_repo.stat.exists
+  ansible.builtin.replace:
+    path: "{{ cifmw_bop_gating_repo_dest }}/delorean.repo"
+    regexp: "priority=1"
+    replace: "priority=20"


### PR DESCRIPTION
Currently DLRN and gating repo have priority 1. In order to install packages from gating repo, we need to decrease the DLRN repos priority.

It will allow us to install packages from gating.rep Lower the priority of DLRN repo while using gating repo

It will allow us to install packages from gating.repo.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

