### PR TITLE
Do not initialize install_yamls in architecture scenario

### DIFF
--- a/playbooks/01-bootstrap.yml
+++ b/playbooks/01-bootstrap.yml
@@ -44,10 +44,15 @@
         role: ci_setup
 
     - name: Prepare install_yamls make targets
+      when:
+        - cifmw_architecture_scenario is undefined
       tags:
         - bootstrap
-      ansible.builtin.import_role:
+      ansible.builtin.include_role:
         name: install_yamls
+        apply:
+          tags:
+            - bootstrap
 
     - name: Get latest image for future reference
       tags:


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
  - [X] @cjeanner tested with HCI deployment locally
  - [X] downstream job essentially passed (failure hit, but on non-related step)
