### PR TITLE
Correct import vs include, apply tags

### DIFF
--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -11,16 +11,22 @@
   tasks:
     # end_play will end only current play, not the main edpm-deploy.yml
     - name: Early end if not architecture deploy
+      tags:
+        - always
       when:
         - cifmw_architecture_scenario is not defined
       ansible.builtin.meta: end_play
 
     - name: Load Networking Environment Definition
+      tags:
+        - always
       ansible.builtin.include_role:
         name: networking_mapper
         tasks_from: load_env_definition.yml
 
     - name: Fetch network facts
+      tags:
+        - always
       when:
         - "not item.startswith('ocp-')"
       ansible.builtin.setup:
@@ -32,11 +38,15 @@
         label: "{{ item }}"
 
     - name: Look for nova migration keypair file
+      tags:
+        - edpm_bootstrap
       register: _nova_key_file
       ansible.builtin.stat:
         path: "{{ cifmw_basedir }}/artifacts/nova_migration_key"
 
     - name: Ensure nova migration keypair details are propagated
+      tags:
+        - always
       vars:
         _ssh_file: >-
           {{
@@ -94,11 +104,15 @@
               }}
 
     - name: Load architecture automation file
+      tags:
+        - edpm_deploy
       register: _automation
       ansible.builtin.slurp:
         path: "{{ cifmw_architecture_automation_file }}"
 
     - name: Prepare automation data
+      tags:
+        - edpm_deploy
       vars:
         _parsed: "{{ _automation.content | b64decode | from_yaml }}"
       ansible.builtin.set_fact:
@@ -106,6 +120,8 @@
           {{ _parsed['vas'][cifmw_architecture_scenario] }}
 
     - name: Check requirements
+      tags:
+        - edpm_bootstrap
       ansible.builtin.import_role:
         name: kustomize_deploy
         tasks_from: check_requirements.yml
@@ -116,32 +132,40 @@
         tasks_from: install_operators.yml
       tags:
         - operator
+        - edpm_bootstrap
 
     - name: Configure Storage Class
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: ci_local_storage
       tags:
         - storage
+        - edpm_bootstrap
 
     - name: Execute deployment steps
+      tags:
+        - edpm_deploy
       ansible.builtin.include_role:
         name: kustomize_deploy
         tasks_from: execute_step.yml
+        apply:
+          tags:
+            - edpm_deploy
       loop: "{{ cifmw_deploy_architecture_steps.stages }}"
       loop_control:
         label: "{{ stage.path }}"
         loop_var: stage
         index_var: stage_id
-      tags:
-        - edpm_deploy
 
     - name: Extract and install OpenStackControlplane CA
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         role: install_openstack_ca
       tags:
         - openstack_ca
+        - edpm_post
 
     - name: Run nova host discover process
+      tags:
+        - edpm_post
       environment:
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"


### PR DESCRIPTION
The 06-deploy-architecture.yml playbook exposes a series of useful tags,
but due to the differences between import and include, some tasks
weren't running when we "select" them with a tag.

There were also issues with import vs include in the play:
- include will dynamically load the content when the play hits that
  task; any tag you set there will be applied only to that "include"
  action, and not reported to the included content.

- import, on the contrary, load all the content during the catalog
  build, and any tag (or `when` condition) set on that import task will
  be applied down to any of the imported content.

In short, when there is no condition on the import, let's use
`import_*`.
If we want to apply the tags down included content, we have to use
`apply` directive.

In order to target precisely the "deploy rhoso" part, new tags were
needed:
- edpm_bootstrap
- edpm_post

With those new tags, in case you want to iterate only on the "generate
CRs" for instance, you can call this:
```Bash
[controller-0]$ ./deploy-architecture.sh --tags edpm \
        --skip-tags edpm_bootstrap,edpm_post \
        -e cifmw_kustomize_deploy_generate_crs_only=true
```
This will target only the necessary tasks to start generating the CRs.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
