### PR TITLE
Add a cifmw_cephadm_min_compat_client default value

### DIFF
--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -51,7 +51,7 @@ cifmw_cephadm_fqdn: false
 cifmw_cephadm_internal_tls_enabled: false
 cifmw_cephadm_certs: /etc/pki/tls
 cifmw_cephadm_debug: false
-cifmw_cephadm_min_compat_client: ''
+cifmw_cephadm_min_compat_client: "mimic"
 cifmw_cephadm_deployed_ceph: false
 cifmw_cephadm_backend: ''
 cifmw_cephadm_action: disable


### PR DESCRIPTION
This patch adds a default for the min-compat-client so we don't have to define it in the job definitions.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
- [x] README in the role
- [x] Content of the docs/source is reflecting the changes
