### PR TITLE
[NFV] Move root hint selector to DS

### DIFF
--- a/scenarios/reproducers/va-nfv-ovs-dpdk-sriov.yml
+++ b/scenarios/reproducers/va-nfv-ovs-dpdk-sriov.yml
@@ -96,4 +96,3 @@ cifmw_libvirt_manager_configuration:
 
 # Baremetal host configuration
 cifmw_config_bmh: true
-cifmw_deploy_bmh_root_device_hint_field: "wwnWithExtension"


### PR DESCRIPTION
As that variable is tightly coupled to cifmw_baremetal_hosts we move cifmw_ci_gen_kustomize_values_ctlplane_interface there as the root_device_hint value depends on that selector.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
