### PR TITLE
[shiftstack] Add shifstack-qa gerrithub repo change support

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -161,6 +161,7 @@ gapped
 genericcloud
 genindex
 gerrit
+gerrithub
 gib
 githooks
 golang

--- a/roles/shiftstack/README.md
+++ b/roles/shiftstack/README.md
@@ -7,6 +7,8 @@ Role for triggering Openshift on Openstack QA automation (installation and tests
 * `cifmw_shiftstack_client_pod_name`: (*string*) Pod name for the pod running the Openshift installer and tests. Defaults to `shiftstackclient`.
 * `cifmw_shiftstack_client_pod_namespace`: (*string*) The namespace where the `cifmw_shiftstack_client_pod_name` will be deployed. Defaults to `openstack`.
 * `cifmw_shiftstack_client_pod_image`: (*string*) The image for the container running in the `cifmw_shiftstack_client_pod_name` pod. Defaults to `quay.io/shiftstack-qe/shiftstack-client:latest`.
+* `cifmw_shiftstack_installation_dir`: (*string*) Directory to place installation files. Defaults to `installation`.
+* `cifmw_shiftstack_qa_gerrithub_change`: (*string*) The gerrithub change to fetch from the `cifmw_shiftstack_qa_repo` repository (i.e. 'refs/changes/29/1188429/50)'. Defaults to ''.
 * `cifmw_shiftstack_qa_repo`: (*string*) The repository containing the Openshift on Openstack QA automation. Defaults to `https://review.gerrithub.io/shiftstack/shiftstack-qa`.
 * `cifmw_shiftstack_run_playbook`: (*string*) The playbook to be run from the `cifmw_shiftstack_qa_repo` repository. Defaults to `ocp_testing.yaml`.
 
@@ -17,6 +19,7 @@ cifmw_run_tests: true
 cifmw_run_tempest: false
 cifmw_run_test_role: shiftstack
 cifmw_run_test_shiftstack_testconfig: 4.15_ovnkubernetes_ipi_va1.yaml
+cifmw_shiftstack_qa_gerrithub_change: refs/changes/29/1188429/50 #optional
 
-$ ansible-playbook deploy-edpm.yml --extra-vars "cifmw_run_tests=true cifmw_run_tempest=false cifmw_run_test_role=shiftstack cifmw_openshift_kubeconfig={{ ansible_user_dir }}/.kube/config cifmw_run_test_shiftstack_testconfig=4.15_ovnkubernetes_ipi_va1.yaml"
+$ ansible-playbook deploy-edpm.yml --extra-vars "cifmw_run_tests=true cifmw_run_tempest=false cifmw_run_test_role=shiftstack cifmw_openshift_kubeconfig={{ ansible_user_dir }}/.kube/config cifmw_run_test_shiftstack_testconfig=4.15_ovnkubernetes_ipi_va1.yaml cifmw_shiftstack_qa_gerrithub_change=refs/changes/29/1188429/50"
 ```

--- a/roles/shiftstack/defaults/main.yml
+++ b/roles/shiftstack/defaults/main.yml
@@ -22,5 +22,7 @@ cifmw_shiftstack_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-fr
 cifmw_shiftstack_client_pod_image: "quay.io/shiftstack-qe/shiftstack-client:latest"
 cifmw_shiftstack_client_pod_name: "shiftstackclient"
 cifmw_shiftstack_client_pod_namespace: "openstack"
+cifmw_shiftstack_installation_dir: "installation"
+cifmw_shiftstack_qa_gerrithub_change: ""
 cifmw_shiftstack_qa_repo: "https://review.gerrithub.io/shiftstack/shiftstack-qa"
 cifmw_shiftstack_run_playbook: "ocp_testing.yaml"

--- a/roles/shiftstack/tasks/test_shiftstack.yml
+++ b/roles/shiftstack/tasks/test_shiftstack.yml
@@ -15,51 +15,65 @@
 # under the License.
 
 - name: Clone the repository '{{ cifmw_shiftstack_qa_repo }}'
-  ansible.builtin.include_tasks: exec_command_in_pod.yml
   vars:
     namespace: "{{ cifmw_shiftstack_client_pod_namespace }}"
     pod: "{{ cifmw_shiftstack_client_pod_name }}"
-    command: >
+    command: >-
       git clone {{ cifmw_shiftstack_qa_repo }}
     log_file_name: "clone_shiftstack_qa_repo.log"
+  ansible.builtin.include_tasks: exec_command_in_pod.yml
+
+- name: Fetch the gerrithub change '{{ cifmw_shiftstack_qa_gerrithub_change }}'
+  vars:
+    namespace: "{{ cifmw_shiftstack_client_pod_namespace }}"
+    pod: "{{ cifmw_shiftstack_client_pod_name }}"
+    command: >-
+      cd shiftstack-qa &&
+      git fetch {{ cifmw_shiftstack_qa_repo }} {{ cifmw_shiftstack_qa_gerrithub_change }} &&
+      git checkout FETCH_HEAD
+    log_file_name: "fetch_shiftstack_qa_gerrithub_change.log"
+  when:
+    - cifmw_shiftstack_qa_gerrithub_change is defined
+    - cifmw_shiftstack_qa_gerrithub_change != ''
+  ansible.builtin.include_tasks: exec_command_in_pod.yml
 
 - name: Install the ansible collections
-  ansible.builtin.include_tasks: exec_command_in_pod.yml
   vars:
     namespace: "{{ cifmw_shiftstack_client_pod_namespace }}"
     pod: "{{ cifmw_shiftstack_client_pod_name }}"
-    command: >
+    command: >-
       cd shiftstack-qa && ansible-galaxy collection install -f -r requirements.yaml
     log_file_name: "install_collections.log"
+  ansible.builtin.include_tasks: exec_command_in_pod.yml
 
 - name: Check the playbook to be run exists in the repository
-  ansible.builtin.include_tasks: exec_command_in_pod.yml
   vars:
     namespace: "{{ cifmw_shiftstack_client_pod_namespace }}"
     pod: "{{ cifmw_shiftstack_client_pod_name }}"
-    command: >
+    command: >-
       test -f shiftstack-qa/playbooks/{{ cifmw_shiftstack_run_playbook }}
     log_file_name: "find_playbook.log"
+  ansible.builtin.include_tasks: exec_command_in_pod.yml
 
 - name: Check the test configuration file exists in the repository
-  ansible.builtin.include_tasks: exec_command_in_pod.yml
   vars:
     namespace: "{{ cifmw_shiftstack_client_pod_namespace }}"
     pod: "{{ cifmw_shiftstack_client_pod_name }}"
-    command: >
+    command: >-
       test -f shiftstack-qa/jobs_definitions/{{ cifmw_run_test_shiftstack_testconfig }}
     log_file_name: "find_test_config.log"
+  ansible.builtin.include_tasks: exec_command_in_pod.yml
 
 - name: OCP install and test block
   block:
     - name: Test Openshift on Openstack with the test configuration '{{ cifmw_run_test_shiftstack_testconfig }}'
-      ansible.builtin.include_tasks: exec_command_in_pod.yml
       vars:
         namespace: "{{ cifmw_shiftstack_client_pod_namespace }}"
         pod: "{{ cifmw_shiftstack_client_pod_name }}"
         command: >-
-          cd shiftstack-qa && ANSIBLE_LOG_PATH=~/artifacts/ansible-log.txt
+          cd shiftstack-qa &&
           ansible-navigator run playbooks/{{ cifmw_shiftstack_run_playbook }} -e @jobs_definitions/{{ cifmw_run_test_shiftstack_testconfig }}
+      ansible.builtin.include_tasks: exec_command_in_pod.yml
 
   rescue:
     - name: Fail task when OCP installation/test fails
@@ -67,18 +81,26 @@
         msg: "OCP install/test block failed, see logs for more information."
 
   always:
-    - name: Create the directory for the artifacts
-      ansible.builtin.file:
-        path: "{{ cifmw_shiftstack_basedir }}/{{ cifmw_shiftstack_artifacts_dir }}"
-        state: directory
-        mode: "0755"
+    - name: Retrieve artifacts and installation files from the pod
+      vars:
+        directory_list:
+          - "{{ cifmw_shiftstack_artifacts_dir }}"
+          - "{{ cifmw_shiftstack_installation_dir }}"
+      block:
+        - name: Create the directories for the artifacts and installation files
+          ansible.builtin.file:
+            path: "{{ cifmw_shiftstack_basedir }}/{{ item }}"
+            state: directory
+            mode: "0755"
+          loop: "{{ directory_list }}"
 
-    - name: Copy the artifacts from the pod '{{ cifmw_shiftstack_client_pod_name }}'
-      environment:
-        PATH: "{{ cifmw_path }}"
-        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-      ansible.builtin.command:
-        cmd: >
-          oc rsync -n {{ cifmw_shiftstack_client_pod_namespace }}
-          {{ cifmw_shiftstack_client_pod_name }}:/home/cloud-admin/{{ cifmw_shiftstack_artifacts_dir }}/
-          {{ cifmw_shiftstack_basedir }}/{{ cifmw_shiftstack_artifacts_dir }}/
+        - name: Copy the artifacts and installation files from the pod '{{ cifmw_shiftstack_client_pod_name }}'
+          environment:
+            PATH: "{{ cifmw_path }}"
+            KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+          ansible.builtin.command:
+            cmd: >
+              oc rsync -n {{ cifmw_shiftstack_client_pod_namespace }}
+              {{ cifmw_shiftstack_client_pod_name }}:/home/cloud-admin/{{ item }}/
+              {{ cifmw_shiftstack_basedir }}/{{ item }}/
+          loop: "{{ directory_list }}"


### PR DESCRIPTION
This commit adds a new parameter `cifmw_shiftstack_qa_gerrithub_change` and adds support for fetching a gerrithub change from the shiftstack-qa repository (i.e. 'refs/changes/29/1188429/50').

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
