### PR TITLE
[docs] Fix README links to old cookbook path

### DIFF
--- a/roles/reproducer/README.md
+++ b/roles/reproducer/README.md
@@ -37,7 +37,7 @@ None
 This role isn't intended to be called outside of the `reproducer.yml` playbook.
 
 ## Examples
-Please follow the [documentation about the overall "reproducer" feature](https://ci-framework.readthedocs.io/en/latest/cookbooks/reproducer.html).
+Please follow the [documentation about the overall "reproducer" feature](https://ci-framework.readthedocs.io/en/latest/roles/reproducer.html).
 
 ### Push repositories
 #### Local repositories on your laptop

--- a/scenarios/reproducers/README.md
+++ b/scenarios/reproducers/README.md
@@ -1,5 +1,5 @@
 # Reproducer scenarios usage
 
 These environment files should be used with the "reproducer.yml" playbook.
-Please refer to [the doc](https://ci-framework.readthedocs.io/en/latest/cookbooks/reproducer.html)
+Please refer to [the doc](https://ci-framework.readthedocs.io/en/latest/roles/reproducer.html)
 about its usage.


### PR DESCRIPTION
- [x] Appropriate documentation exists and/or is up-to-date