### PR TITLE
[rhol_crc] Increase default memory

### DIFF
--- a/roles/rhol_crc/vars/main.yml
+++ b/roles/rhol_crc/vars/main.yml
@@ -31,7 +31,7 @@ cifmw_rhol_crc_sudoers_file_name: rhol_crc
 cifmw_rhol_crc_config_defaults:
   consent-telemetry: "no"
   disk-size: 32
-  memory: 9216
+  memory: 10752
   cpus: 4
   preset: "openshift"
   pull-secret-file: "{{ cifmw_rhol_crc_pullsecret_dest }}"


### PR DESCRIPTION
Recent CRC(v2.34.1) have bumped minimum memory requirement[1] to 10752 MB,
updating the same in the role defaults.

[1] https://github.com/crc-org/crc/commit/7e694ae

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
