### PR TITLE
Install cert_manager from release manifest

### DIFF
--- a/roles/cert_manager/defaults/main.yml
+++ b/roles/cert_manager/defaults/main.yml
@@ -23,6 +23,9 @@ cifmw_cert_manager_manifests_dir: "{{ cifmw_manifests | default(cifmw_cert_manag
 cifmw_cert_manager_operator_namespace: cert-manager-operator
 cifmw_cert_manager_openshift_version: stable-v1
 
+cifmw_cert_manager_release_manifest: "https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml"
+cifmw_cert_manager_install_from_release_manifest: true
+
 cifmw_cert_manager_olm_operator_group:
   apiVersion: operators.coreos.com/v1
   kind: OperatorGroup

--- a/roles/cert_manager/tasks/main.yml
+++ b/roles/cert_manager/tasks/main.yml
@@ -28,65 +28,13 @@
     kind: Namespace
     state: present
 
-- name: Save k8s cert-manager OLM manifests as artifacts
-  ansible.builtin.copy:
-    dest: "{{ cifmw_cert_manager_manifests_dir }}/cert-manager-{{ item.kind | lower }}-olm.yaml"
-    content: "{{ item | to_nice_yaml }}"
-  loop:
-    - "{{ cifmw_cert_manager_olm_operator_group }}"
-    - "{{ cifmw_cert_manager_olm_subscription }}"
-  loop_control:
-    label: "{{ item.metadata.name }}"
+- name: Install from Release Manifest
+  when: cifmw_cert_manager_install_from_release_manifest | bool
+  ansible.builtin.include_tasks: release_manifest.yml
 
-- name: Create the cert-manager OLM subscription resources
-  kubernetes.core.k8s:
-    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
-    api_key: "{{ cifmw_openshift_token | default(omit)}}"
-    context: "{{ cifmw_openshift_context | default(omit) }}"
-    definition: "{{ item }}"
-    state: present
-  loop:
-    - "{{ cifmw_cert_manager_olm_operator_group }}"
-    - "{{ cifmw_cert_manager_olm_subscription }}"
-  loop_control:
-    label: "{{ item.metadata.name }}"
-
-- name: Get the operator name
-  ansible.builtin.set_fact:
-    _operator_name: "{{ cifmw_cert_manager_olm_subscription.metadata.name }}"
-
-- name: Wait for the cert-manager operator deployment to be Ready
-  kubernetes.core.k8s_info:
-    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
-    api_key: "{{ cifmw_openshift_token | default(omit)}}"
-    context: "{{ cifmw_openshift_context | default(omit) }}"
-    namespace: "{{ cifmw_cert_manager_operator_namespace }}"
-    kind: Deployment
-    name: "{{ _operator_name }}"
-    wait_sleep: 10
-    wait_timeout: 360
-    wait_condition:
-      type: Ready
-      status: "True"
-
-- name: Wait for the cert-manager operator csv to be installed
-  environment:
-    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-    PATH: "{{ cifmw_path }}"
-  ansible.builtin.command:
-    cmd: >-
-      oc get ClusterServiceVersion
-      -n "{{ cifmw_cert_manager_operator_namespace }}"
-      -o jsonpath='{.items[*].status.phase}'
-  changed_when: false
-  register: _certmanager_csv_out
-  retries: 12
-  delay: 10
-  until:
-    - _certmanager_csv_out is defined
-    - _certmanager_csv_out.failed is false
-    - _certmanager_csv_out.stdout_lines | length > 0
-    - "(_certmanager_csv_out.stdout_lines[0] | lower) == 'succeeded'"
+- name: Install from OLM Manifest
+  when: not cifmw_cert_manager_install_from_release_manifest | bool
+  ansible.builtin.include_tasks: olm_manifest.yml
 
 - name: Check for cert-manager namspeace existance
   kubernetes.core.k8s_info:

--- a/roles/cert_manager/tasks/olm_manifest.yml
+++ b/roles/cert_manager/tasks/olm_manifest.yml
@@ -1,0 +1,60 @@
+---
+- name: Save k8s cert-manager OLM manifests as artifacts
+  ansible.builtin.copy:
+    dest: "{{ cifmw_cert_manager_manifests_dir }}/cert-manager-{{ item.kind | lower }}-olm.yaml"
+    content: "{{ item | to_nice_yaml }}"
+  loop:
+    - "{{ cifmw_cert_manager_olm_operator_group }}"
+    - "{{ cifmw_cert_manager_olm_subscription }}"
+  loop_control:
+    label: "{{ item.metadata.name }}"
+
+- name: Create the cert-manager OLM subscription resources
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    definition: "{{ item }}"
+    state: present
+  loop:
+    - "{{ cifmw_cert_manager_olm_operator_group }}"
+    - "{{ cifmw_cert_manager_olm_subscription }}"
+  loop_control:
+    label: "{{ item.metadata.name }}"
+
+- name: Get the operator name
+  ansible.builtin.set_fact:
+    _operator_name: "{{ cifmw_cert_manager_olm_subscription.metadata.name }}"
+
+- name: Wait for the cert-manager operator deployment to be Ready
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    namespace: "{{ cifmw_cert_manager_operator_namespace }}"
+    kind: Deployment
+    name: "{{ _operator_name }}"
+    wait_sleep: 10
+    wait_timeout: 360
+    wait_condition:
+      type: Ready
+      status: "True"
+
+- name: Wait for the cert-manager operator csv to be installed
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: >-
+      oc get ClusterServiceVersion
+      -n "{{ cifmw_cert_manager_operator_namespace }}"
+      -o jsonpath='{.items[*].status.phase}'
+  changed_when: false
+  register: _certmanager_csv_out
+  retries: 12
+  delay: 10
+  until:
+    - _certmanager_csv_out is defined
+    - _certmanager_csv_out.failed is false
+    - _certmanager_csv_out.stdout_lines | length > 0
+    - "(_certmanager_csv_out.stdout_lines[0] | lower) == 'succeeded'"

--- a/roles/cert_manager/tasks/release_manifest.yml
+++ b/roles/cert_manager/tasks/release_manifest.yml
@@ -1,0 +1,14 @@
+---
+- name: Download release manifests
+  ansible.builtin.get_url:
+    url: "{{ cifmw_cert_manager_release_manifest }}"
+    dest: "{{ cifmw_cert_manager_manifests_dir }}/cert_manager_manifest.yml"
+    mode: '0664'
+
+- name: Install cert-manager from release manifest
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    state: present
+    src: "{{ cifmw_cert_manager_manifests_dir }}/cert_manager_manifest.yml"

--- a/scenarios/centos-9/multinode-ci.yml
+++ b/scenarios/centos-9/multinode-ci.yml
@@ -20,6 +20,7 @@ cifmw_run_tests: true
 
 cifmw_install_yamls_vars:
   BMO_SETUP: false
+  INSTALL_CERT_MANAGER: false
 
 # Deploy EDPM in multinode scenario
 cifmw_deploy_edpm: true


### PR DESCRIPTION
This pr add the support of installing cert-manager fromrelease manifest. It will be useful when we saw issue with
 OLm resources.

Note: It also add "INSTALL_CERT_MANAGER: false" in multinode-ci.yml scenario as it has higher prefernce otherwise
It will call install_yaml certmanager scripts.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

