### PR TITLE
Collect openshift-marketplace related logs and resources in CI

### DIFF
--- a/roles/os_must_gather/defaults/main.yml
+++ b/roles/os_must_gather/defaults/main.yml
@@ -31,5 +31,6 @@ cifmw_os_must_gather_namespaces:
   - openshift-machine-api
   - cert-manager
   - openshift-nmstate
+  - openshift-marketplace
   - metallb-system
 cifmw_os_must_gather_host_network: false


### PR DESCRIPTION
Many times certmanager operator installation fails in CI. certmanager-operator comes from openshift-marketplace namespace. os-must-gather does not collects logs related to openshift-marketplace namespace by default, but we need that kind of info in CI. This patch adds openshift-marketplace among the additional_namespaces collected by must-gather in CI.

Related: [OSPCIX-26](https://issues.redhat.com/browse/OSPCIX-261)

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
- [x] README in the role
- [x] Content of the docs/source is reflecting the changes
