### PR TITLE
Add support for Sushy Emulator backed virtual baremetal

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -32,6 +32,9 @@ are shared among multiple roles:
 - `cifmw_use_devscripts`: (Bool) toggle OpenShift deploying using devscripts role.
 - `cifmw_openshift_crio_stats`: (Bool) toggle collecting cri-o stats in CRC deployment.
 - `cifmw_deploy_edpm`: (Bool) toggle deploying EDPM. Default to false.
+- `cifmw_use_vbmc`: (Bool) Toggle VirtualBMC usage. Defaults to `false`.
+- `cifmw_use_sushy_emulator`: (Bool) Toggle Sushy Emulator usage. Defaults to `true`.
+- `cifmw_sushy_redfish_bmc_protocol`: (String) The RedFish BMC protocol you would like to use with Sushy Emulator, options are `redfish` or `redfish-virtualmedia`. Defaults to `redfish-virtualmedia`
 - `cifmw_config_nmstate`: (Bool) toggle NMstate networking deployment. Default to false.
 - `cifmw_config_bmh`: (Bool) toggle Metal3 BareMetalHost CRs deployment. Default to false.
 - `cifmw_config_certmanager`: (Bool) toggle cert-manager deployment. Default to false.

--- a/roles/libvirt_manager/tasks/create_networks.yml
+++ b/roles/libvirt_manager/tasks/create_networks.yml
@@ -100,3 +100,16 @@
   loop: "{{ networks }}"
   loop_control:
     label: "{{ item.name }}"
+
+- name: Extract public IP address from network bridge
+  block:
+    - name: Extract IP address from network bridges
+      ansible.builtin.include_tasks:
+        file: network_bridge_info_gen.yml
+      loop: "{{ networks }}"
+      loop_control:
+        label: "{{ item.name }}"
+  rescue:
+    - name: Clear error if IP address isn't defined
+      ansible.builtin.meta: clear_host_errors
+      when: networkxml.msg == 'Xpath /network/ip does not reference a node!'

--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -192,6 +192,7 @@
 
 - name: Create VBMC entity
   when:
+    - cifmw_use_vbmc | default(false) | bool
     - _vbmc_available is defined
     - _vbmc_available | bool
   vars:

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -4,6 +4,7 @@
     - _cifmw_libvirt_manager_layout is not defined
   ansible.builtin.include_tasks: generate_layout.yml
 
+# todo(Lewis): We need to deploy VirtualBMC on the controller rather than hypervisor
 # Deploy VBMC only on the hypervisor running OpenShift services,
 # being OCP cluster or single CRC.
 - name: Deploy VirtualBMC service container
@@ -11,6 +12,7 @@
     - bootstrap
     - bootstrap_layout
   when:
+    - cifmw_use_vbmc | default(false) | bool
     - (_cifmw_libvirt_manager_layout.vms.crc.target is defined and
        _cifmw_libvirt_manager_layout.vms.crc.target == inventory_hostname) or
       (_cifmw_libvirt_manager_layout.vms.crc is defined and
@@ -18,7 +20,8 @@
       (_cifmw_libvirt_manager_layout.vms.ocp.target is defined and
        _cifmw_libvirt_manager_layout.vms.ocp.target == inventory_hostname) or
       (_cifmw_libvirt_manager_layout.vms.ocp is defined and
-       _cifmw_libvirt_manager_layout.vms.ocp.target is undefined)
+       _cifmw_libvirt_manager_layout.vms.ocp.target is undefined) or
+      (_cifmw_libvirt_manager_layout.vms.crc is undefined and _cifmw_libvirt_manager_layout.vms.ocp is undefined)
   block:
     - name: Deploy virtualbmc
       ansible.builtin.include_role:
@@ -285,6 +288,7 @@
 
 - name: Refresh and dump vbmc hosts
   when:
+    - cifmw_use_vbmc | default(false) | bool
     - _vbmc_host is defined
     - _vbmc_host == inventory_hostname
   block:

--- a/roles/libvirt_manager/tasks/network_bridge_info_gen.yml
+++ b/roles/libvirt_manager/tasks/network_bridge_info_gen.yml
@@ -1,0 +1,10 @@
+- name: Extract IP address from network bridges
+  community.general.xml:
+    xmlstring: "{{ item.xml }}"
+    xpath: /network/ip
+    content: attribute
+  register: networkxml
+
+- name: Set network_bridge_info fact with network and address
+  ansible.builtin.set_fact:
+    network_bridge_info: "{{ network_bridge_info | default({}) | combine( {item.name: networkxml.matches[0].ip.address} ) }}"

--- a/roles/reproducer/defaults/main.yml
+++ b/roles/reproducer/defaults/main.yml
@@ -37,3 +37,10 @@ cifmw_reproducer_supported_hypervisor_os:
     minimum_version: 9
   RedHat:
     minimum_version: 9.3
+cifmw_reproducer_controller_basedir: >-
+  {{
+    (
+      '/home/zuul',
+      'ci-framework-data',
+      ) | path_join
+  }}

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -29,6 +29,7 @@
       loop:
         - parameters
         - artifacts
+
     - name: Install custom CA if needed
       ansible.builtin.import_role:
         name: install_ca
@@ -107,56 +108,33 @@
         dest: "{{ _ctl_reproducer_basedir }}/parameters/interfaces-info.yml"
         content: "{{ cifmw_libvirt_manager_mac_map | to_nice_yaml }}"
 
-    # Here, we update the existing cifmw_virtualbmc_known_hosts fact
-    # to inject networking information such as provisioning MAC (if any),
-    # and fixed Boot mode
-    - name: Generate IPMI information
+    # Deploy Sushy Emulator on the Ansible controller,
+    - name: Deploy Sushy Emulator service container
+      tags:
+        - bootstrap
+        - bootstrap_layout
+      when: cifmw_use_sushy_emulator | default(true) | bool
       block:
-        - name: Convert VBMC list into a dict for better usage
+        - name: Deploy Sushy Emulator
           vars:
-            keys: "{{ item.keys() | difference(['Domain name']) }}"
-            vals: "{{ keys | map('extract', item) | list }}"
-            value: "{{ dict(keys | map('lower') | zip(vals)) }}"
-            _host: "{{ item['Domain name'] | regex_replace('^cifmw-', '') }}"
-            _nics: >-
-              {{
-                cifmw_libvirt_manager_mac_map[_host]
-              }}
-            _uefi: >-
-              {% set _type = _host | regex_replace('-[0-9]+$', '') -%}
-              {{
-                _cifmw_libvirt_manager_layout.vms[_type].uefi |
-                default(false) | bool
-              }}
-            _boot_mode: "{{ _uefi | ternary('UEFI', 'legacy') }}"
-            ## TODO: add sushy driver address once we get sushy in
-            ## TODO: create new parameter to allow chosing which connection
-            #        to expose in the generated file
-            _connections:
-              ipmi: "ipmi://{{ value.address }}:{{ value.port }}"
-          ansible.builtin.set_fact:
-            _ipmi_dict: >-
-              {{
-                _ipmi_dict | default({}) |
-                combine({_host: value}, recursive=true) |
-                combine({_host: {
-                                 'boot_mode': _boot_mode,
-                                 'nics': _nics,
-                                 'connection': _connections['ipmi']
-                                }
-                        }, recursive=true)
-              }}
-            cacheable: false
-          loop: "{{ cifmw_virtualbmc_known_hosts }}"
+            cifmw_sushy_emulator_hypervisor_target: "{{ cifmw_target_host | default('localhost') }}"
+            cifmw_sushy_emulator_install_type: podman
+            cifmw_sushy_emulator_hypervisor_target_connection_ip: "{{ network_bridge_info['cifmw-public'] }}"
+          ansible.builtin.include_role:
+            name: sushy_emulator
 
-        - name: Output IPMI data in a file
-          vars:
-            _content:
-              cifmw_baremetal_hosts: "{{ _ipmi_dict }}"
-          ansible.builtin.copy:
-            dest: "{{ _ctl_reproducer_basedir }}/parameters/baremetal-info.yml"
-            content: "{{ _content | to_nice_yaml }}"
-            mode: "0644"
+        - name: Let the project know we have Sushy Emulator available
+          ansible.builtin.set_fact:
+            _sushy_emulator_available: true
+
+    - name: Generate baremetal-info fact
+      ansible.builtin.import_tasks: generate_bm_info.yml
+
+    - name: Verify connection to baremetal VMs via Sushy Emulator
+      when: _sushy_emulator_available
+      ansible.builtin.include_role:
+        name: sushy_emulator
+        tasks_from: verify.yml
 
     - name: Inject other Hypervisor SSH keys
       when:

--- a/roles/reproducer/tasks/generate_bm_info.yml
+++ b/roles/reproducer/tasks/generate_bm_info.yml
@@ -1,0 +1,118 @@
+---
+- name: Ensure directories exist
+  ansible.builtin.file:
+    path: "{{ cifmw_reproducer_controller_basedir }}/{{ item }}"
+    state: directory
+    mode: "0755"
+  loop:
+    - parameters
+    - artifacts
+
+- name: Convert VBMC list into a dict for better usage
+  when:
+    - cifmw_use_vbmc | default(false) | bool
+    - cifmw_virtualbmc_known_hosts is defined
+  vars:
+    keys: "{{ item.keys() | difference(['Domain name']) }}"
+    vals: "{{ keys | map('extract', item) | list }}"
+    value: "{{ dict(keys | map('lower') | zip(vals)) }}"
+    _host: "{{ item['Domain name'] | regex_replace('^cifmw-', '') }}"
+  ansible.builtin.set_fact:
+    _vbmc_info_dict: >-
+      {{
+        _vbmc_info_dict | default({}) |
+        combine({_host: value}, recursive=true)
+      }}
+    cacheable: false
+  loop: "{{ cifmw_virtualbmc_known_hosts }}"
+
+- name: Check if baremetal-info.yml exists
+  register: _stat_baremetal_info_file
+  ansible.builtin.stat:
+    path: "{{ cifmw_reproducer_controller_basedir }}/parameters/baremetal-info.yml"
+
+- name: Slurp current baremetal-info file into _oringal_cifmw_baremetal_hosts var
+  when: _stat_baremetal_info_file.stat.exists
+  block:
+    - name: Get content of baremetal-info file
+      ansible.builtin.slurp:
+        src: "{{ cifmw_reproducer_controller_basedir }}/parameters/baremetal-info.yml"
+      register: _baremetal_info_file
+
+    - name: Interpret remote file content as yaml
+      vars:
+        _yaml: "{{ _baremetal_info_file.content | b64decode | from_yaml }}"
+      ansible.builtin.set_fact:
+        _oringal_cifmw_baremetal_hosts: "{{ _yaml.cifmw_baremetal_hosts }}"
+
+- name: Load cifmw_libvirt_manager_mac_map fact from file
+  vars:
+    _file: "{{ cifmw_reproducer_controller_basedir }}/artifacts/interfaces-info.yml"
+  when:
+    - cifmw_libvirt_manager_mac_map is not defined
+  block:
+    - name: "Slurp content of: {{ _file }}"
+      ansible.builtin.slurp:
+        src: "{{ _file }}"
+      register: _slurped_file
+
+    - name: "Set cifmw_libvirt_manager_mac_map fact from {{ _file }}"
+      vars:
+        _yaml: "{{ _slurped_file.content | b64decode | from_yaml }}"
+      ansible.builtin.set_fact:
+        cifmw_libvirt_manager_mac_map: "{{ _yaml }}"
+
+
+# In this task we combine information from _cifmw_libvirt_manager_layout, cifmw_libvirt_manager_mac_map
+# and cifmw_libvirt_manager_uuids to create the libvirt_manager_bm_info_data fact.
+# to create the `baremetal-info.yml` file which is used as a source of truth for
+# for baremetal nodes. If `baremetal-info.yml` already exists we combine
+# `_oringal_cifmw_baremetal_hosts` with the updated hosts and override
+# `baremetal-info.yml`
+- name: Generate libvirt_manager_bm_info_data fact
+  when: item.key is match('cifmw-')
+  vars:
+    _host: "{{ item.key | replace('cifmw-', '') }}"
+    _uefi: >-
+      {% set _type = _host | regex_replace('-[0-9]+$', '') -%}
+      {{ _cifmw_libvirt_manager_layout.vms[_type].uefi | default(false) | bool }}
+    _data: |
+      "{{ _host }}":
+        boot_mode: "{{ _uefi | ternary('UEFI', 'legacy') }}"
+        uuid: "{{ item.value }}"
+      {% if cifmw_use_vbmc | default(false) | bool %}
+        address: "{{ _vbmc_info_dict[_host].address }}"
+        connection: "ipmi://{{ _vbmc_info_dict[_host].address }}:{{ _vbmc_info_dict[_host].port }}"
+        password: "{{ _vbmc_info_dict[_host].password }}"
+        port: {{ _vbmc_info_dict[_host].port | int }}
+        username: "{{ _vbmc_info_dict[_host].username }}"
+      {% elif cifmw_use_sushy_emulator | default(true) | bool %}
+      {% if item.value in _cifmw_sushy_emulator_instances | default([]) %}
+        connection: "{{ cifmw_sushy_redfish_bmc_protocol | default('redfish-virtualmedia') ~ '+' ~ _sushy_url }}/redfish/v1/Systems/{{ item.value }}"
+        username: "{{ cifmw_redfish_username | default('admin') }}"
+        password: "{{ cifmw_redfish_password | default('password') }}"
+      {% endif %}
+      {% endif %}
+    _with_nics: >-
+      {{
+        _data | from_yaml |
+        combine({_host: {'nics': cifmw_libvirt_manager_mac_map[_host]}},
+                recursive=true)
+      }}
+  ansible.builtin.set_fact:
+    libvirt_manager_bm_info_data: >-
+      {{
+        libvirt_manager_bm_info_data | default({}) |
+        combine((_with_nics | from_yaml), recursive=true) |
+        combine((_oringal_cifmw_baremetal_hosts | default({}) | from_yaml), recursive=true)
+      }}
+  loop: "{{ cifmw_libvirt_manager_uuids | dict2items }}"
+
+- name: Output baremetal info file
+  vars:
+    _content:
+      cifmw_baremetal_hosts: "{{ libvirt_manager_bm_info_data }}"
+  ansible.builtin.copy:
+    dest: "{{ cifmw_reproducer_controller_basedir }}/parameters/baremetal-info.yml"
+    content: "{{ _content | to_nice_yaml }}"
+    mode: "0644"

--- a/roles/sushy_emulator/README.md
+++ b/roles/sushy_emulator/README.md
@@ -6,33 +6,45 @@ Sushi Emulator is a virtual Redfish BMC, this role supports both the OpenStack a
 
 Baremetal instances must be configured prior to running this role, for the Libvirt driver, the `libvirt_manager` role can be used.
 
+This role supports installing via a Podman pod onto the controller node or a pod in OCP or CRC.
+
 ## Privilege escalation
 
 Required to installed required packages.
 
 ## Parameters
 
+* `cifmw_sushy_emulator_basedir`: (String) Base directory. Defaults to `{{ ansible_user_dir ~ '/ci-framework-data' }}`
+* `cifmw_sushy_emulator_container_name`: (String) Name of Podman container created. Defaults to `cifmw-sushy_emulator`
 * `cifmw_sushy_emulator_driver`: (String) Select between `openstack` and `libvirt` sushy emulator driver. Defaults to `libvirt`
-* `cifmw_sushy_emulator_sshkey_path`: (String) Path of SSH key used by sushy emulator to talk to libvirt socket. Defaults to `"{{ ansible_user_dir }}/.ssh/id_cifw"`
-* `cifmw_sushy_emulator_libvirt_user`: (String) Username used by Sushi Emulator to connect to Libvirt socket. Defaults to `zuul`
-* `cifmw_sushy_emulator_listen_ip`: (String) IP Sushi Emulator service listens on. Defaults to `0.0.0.0`
 * `cifmw_sushy_emulator_driver_openstack_client_config_file`: (String) Path to OpenStack config file, used by OpenStack Sushi Emulator driver. Defaults to `/etc/openstack/clouds.yaml`
 * `cifmw_sushy_emulator_driver_openstack_cloud`: (String) Cloud key reference in OpenStack config file. Defaults to `None`
-* `cifmw_sushy_emulator_namespace`: (String) Namespace Sushi Emulator is deployed into when using the `ocp` install method. Defaults to `sushy-emulator`
-* `cifmw_sushy_emulator_redfish_username`: (String) Redfish username. Defaults to `admin`
-* `cifmw_sushy_emulator_redfish_password`: (String) Redfish password. Defaults to `password`
-* `cifmw_sushy_emulator_resource_directory`: (String) Path where resource files will be written. Defaults to `"{{ (ansible_user_dir, 'ci-framework-data', 'artifacts', 'sushy_emulator') | path_join }}"`
-* `cifmw_sushy_emulator_image`: (String) Container image used when deploying Sushi Emulator container and pod. Defaults to `quay.io/metal3-io/sushy-tools:latest`
-* `cifmw_sushy_emulator_instance_node_name_prefix`: (String) String used to find instances created for baremetal use. Defaults to `cifmw-`
-* `cifmw_sushy_emulator_container_name`: (String) Name of Podman container created. Defaults to `cifmw-sushy_emulator`
+* `cifmw_sushy_emulator_hypervisor_target` (String) Hostname of the Libvirt hypervisor to connect to.
+* `cifmw_sushy_emulator_hypervisor_target_connection_ip` (String) IP Address used to connect to hypervisor, optional override for `cifmw_sushy_emulator_hypervisor_target` when specific address is required.
 * `cifmw_sushy_emulator_install_type`: (String) Install type can either be `ocp` or `podman` and dictates where Sushi Emulator will be installed. Defaults to `ocp`
+* `cifmw_sushy_emulator_image`: (String) Container image used when deploying Sushi Emulator container and pod. Defaults to `quay.io/metal3-io/sushy-tools:latest`
+* `cifmw_sushy_emulator_libvirt_uri`: (String) Internal URI to access qemu daemon. Defaults to `qemu+ssh://{{ cifmw_sushy_emulator_libvirt_user }}@{{ cifmw_sushy_emulator_hypervisor_target_connection_ip | default(cifmw_sushy_emulator_hypervisor_target) }}/system?no_tty=1`
+* `cifmw_sushy_emulator_libvirt_user`: (String) Username used by Sushi Emulator to connect to Libvirt socket. Defaults to `zuul`
+* `cifmw_sushy_emulator_listen_ip`: (String) IP address Sushy Emulator listens on. Defaults to `0.0.0.0`
+* `cifmw_sushy_emulator_namespace`: (String) Namespace Sushi Emulator is deployed into when using the `ocp` install method. Defaults to `sushy-emulator`
+* `cifmw_sushy_emulator_parameters_file`:  (string) Path of the file which contains (v)bmc parameters. Defaults to `cifmw_sushy_emulator_basedir + parameters + baremetal-info.yml`
+* `cifmw_sushy_emulator_redfish_username`: (String) Redfish username. Defaults to `{{ cifmw_redfish_username | default('admin') }}`
+* `cifmw_sushy_emulator_redfish_password`: (String) Redfish password. Defaults to `{{ cifmw_redfish_password | default('password') }}`
+* `cifmw_sushy_emulator_resource_directory`: (String) Path where resource files will be written. Defaults to `"{{ (ansible_user_dir, 'ci-framework-data', 'artifacts', 'sushy_emulator') | path_join }}"`
+* `cifmw_sushy_emulator_sshkey_path`: (String) Path of SSH key used by sushy emulator to talk to libvirt socket. Defaults to `"{{ ansible_user_dir }}/.ssh/sushy_emulator-key"`
+* `cifmw_sushy_emulator_sshkey_type`: (String) Type of SSH keypair. Defaults to `{{ cifmw_ssh_keytype | default('ecdsa') }}`.
+* `cifmw_sushy_emulator_sshkey_size`: (Integer) Size of the SSH keypair. Defaults to `{{ cifmw_ssh_keysize | default(521) }}`.
+* `cifmw_sushy_emulator_vm_prefix_filter`: (String) Prefix string used to filter instances created for baremetal use. Defaults to `.*`
 
 ## Examples
 
 ```yaml
 - hosts: all
   vars:
-    cifmw_baremetal_hypervisor_target: baremetal-hypervisor
+    cifmw_sushy_emulator_hypervisor_target: "{{ cifmw_target_host | default('localhost') }}"
+    cifmw_sushy_emulator_install_type: podman
+    cifmw_sushy_emulator_hypervisor_target_connection_ip: "{{ network_bridge_info['cifmw-public'] }}"
+    cifmw_sushy_emulator_vm_prefix_filter: cifmw-compute
   tasks:
     - name: Deploy and configure sushy-emulator
       ansible.builtin.import_role:

--- a/roles/sushy_emulator/defaults/main.yml
+++ b/roles/sushy_emulator/defaults/main.yml
@@ -18,17 +18,33 @@
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_sushy_emulator"
 
+cifmw_sushy_emulator_basedir: "{{ ansible_user_dir ~ '/ci-framework-data' }}"
+cifmw_sushy_emulator_container_name: "cifmw-sushy_emulator"
 cifmw_sushy_emulator_driver: libvirt
-cifmw_sushy_emulator_sshkey_path: "{{ ansible_user_dir }}/.ssh/id_cifw"
-cifmw_sushy_emulator_libvirt_user: zuul
-cifmw_sushy_emulator_listen_ip: 0.0.0.0
 cifmw_sushy_emulator_driver_openstack_client_config_file: /etc/openstack/clouds.yaml
 cifmw_sushy_emulator_driver_openstack_cloud: None
-cifmw_sushy_emulator_namespace: sushy-emulator
-cifmw_sushy_emulator_redfish_username: admin
-cifmw_sushy_emulator_redfish_password: password
-cifmw_sushy_emulator_resource_directory: "{{ (ansible_user_dir, 'ci-framework-data', 'artifacts', 'sushy_emulator') | path_join }}"
-cifmw_sushy_emulator_image: quay.io/metal3-io/sushy-tools:latest
-cifmw_sushy_emulator_instance_node_name_prefix: cifmw-
-cifmw_sushy_emulator_container_name: "cifmw-sushy_emulator"
 cifmw_sushy_emulator_install_type: 'ocp'
+cifmw_sushy_emulator_image: quay.io/metal3-io/sushy-tools:latest
+cifmw_sushy_emulator_libvirt_uri: >-
+  qemu+ssh://
+  {{- cifmw_sushy_emulator_libvirt_user -}}
+  @
+  {{- cifmw_sushy_emulator_hypervisor_target_connection_ip | default(hostvars[cifmw_sushy_emulator_hypervisor_target].ansible_host) -}}
+  /system?no_tty=1
+cifmw_sushy_emulator_libvirt_user: zuul
+cifmw_sushy_emulator_listen_ip: 0.0.0.0
+cifmw_sushy_emulator_namespace: sushy-emulator
+cifmw_sushy_emulator_parameters_file: >-
+  {{
+    [
+      cifmw_sushy_emulator_basedir,
+      'parameters',
+      'baremetal-info.yml'
+    ] | path_join
+  }}
+cifmw_sushy_emulator_redfish_username: "{{ cifmw_redfish_username | default('admin') }}"
+cifmw_sushy_emulator_redfish_password: "{{ cifmw_redfish_password | default('password') }}"
+cifmw_sushy_emulator_resource_directory: "{{ (cifmw_sushy_emulator_basedir, 'artifacts', 'sushy_emulator') | path_join }}"
+cifmw_sushy_emulator_sshkey_path: "{{ ansible_user_dir }}/.ssh/sushy_emulator-key"
+cifmw_sushy_emulator_sshkey_type: "{{ cifmw_ssh_keytype | default('ecdsa') }}"
+cifmw_sushy_emulator_sshkey_size: "{{ cifmw_ssh_keysize | default(521) }}"

--- a/roles/sushy_emulator/molecule/default/converge.yml
+++ b/roles/sushy_emulator/molecule/default/converge.yml
@@ -20,20 +20,68 @@
   vars:
     cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
     cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
-    cifmw_baremetal_hypervisor_target: instance
-    cifmw_sushy_emulator_sshkey_path: "{{ ansible_user_dir }}/.ssh/id_rsa"
+    cifmw_sushy_emulator_hypervisor_target: controller-0
+    cifmw_sushy_emulator_hypervisor_target_connection_ip: "{{ hostvars[cifmw_sushy_emulator_hypervisor_target].ansible_host }}"
+    cifmw_libvirt_manager_configuration:
+      vms:
+        compute:
+          amount: 2
+          disk_file_name: "blank"
+          disksize: 50
+          memory: 8
+          cpus: 4
+          nets:
+            - public
+            - default
+
   tasks:
-    - name: Add instance anisble_host
+    - name: Add the crc host dynamically
       ansible.builtin.add_host:
-        name: "{{ cifmw_baremetal_hypervisor_target }}"
-        ansible_host: "{{ hostvars[cifmw_baremetal_hypervisor_target]['ansible_default_ipv4']['address'] }}"
+        name: crc
+        ansible_ssh_private_key_file: "{{ ansible_user_dir }}/.crc/machines/crc/id_ecdsa"
+        ansible_ssh_user: core
+
+    - name: Add ansible_host entry to "{{ cifmw_sushy_emulator_hypervisor_target }}"
+      ansible.builtin.add_host:
+        name: "{{ cifmw_sushy_emulator_hypervisor_target }}"
+        ansible_host: "{{ hostvars['instance']['ansible_default_ipv4']['address'] }}"
+
+    - name: "Add host key to {{ cifmw_sushy_emulator_hypervisor_target }}"
+      ansible.builtin.shell:
+        cmd: ssh-keyscan {{ hostvars[cifmw_sushy_emulator_hypervisor_target].ansible_host }} >> ~/.ssh/known_hosts
+
+    - name: Setup and create virtual baremetal
+      block:
+        - name: Ensure libvirt is present/configured
+          ansible.builtin.import_role:
+            name: libvirt_manager
+
+        - name: Create virtual baremetal VMs
+          ansible.builtin.include_role:
+            name: libvirt_manager
+            tasks_from: deploy_layout
+
+        - name: Generate baremetal-info fact
+          ansible.builtin.include_role:
+            name: reproducer
+            tasks_from: generate_bm_info.yml
 
     - name: Run Sushy Emulator role against OCP
       ansible.builtin.include_role:
         name: sushy_emulator
+
+    - name: Verify connection to baremetal VMs via Sushy Emulator
+      ansible.builtin.include_role:
+        name: sushy_emulator
+        tasks_from: verify.yml
 
     - name: Run Sushy Emulator role against podman
       vars:
         cifmw_sushy_emulator_install_type: "podman"
       ansible.builtin.include_role:
         name: sushy_emulator
+
+    - name: Verify connection to baremetal VMs via Sushy Emulator
+      ansible.builtin.include_role:
+        name: sushy_emulator
+        tasks_from: verify.yml

--- a/roles/sushy_emulator/molecule/default/prepare.yml
+++ b/roles/sushy_emulator/molecule/default/prepare.yml
@@ -17,19 +17,6 @@
 
 - name: Prepare
   hosts: all
-  vars:
-    cifmw_baremetal_hypervisor_target: instance
-    cifmw_libvirt_manager_configuration:
-      vms:
-        compute:
-          amount: 2
-          disk_file_name: "blank"
-          disksize: 50
-          memory: 8
-          cpus: 4
-          nets:
-            - public
-            - default
   roles:
     - role: test_deps
   tasks:
@@ -42,33 +29,3 @@
       ansible.builtin.lineinfile:
         path: /etc/hosts
         line: "192.168.130.11 crc"
-
-    - name: Add the crc host dynamically
-      ansible.builtin.add_host:
-        name: crc
-        ansible_ssh_private_key_file: "{{ ansible_user_dir }}/.crc/machines/crc/id_ecdsa"
-        ansible_ssh_user: core
-
-    - name: Add instance anisble_host
-      ansible.builtin.add_host:
-        name: instance
-        ansible_host: "{{ hostvars[cifmw_baremetal_hypervisor_target]['ansible_default_ipv4']['address'] }}"
-
-    - name: "Add host key to {{ cifmw_baremetal_hypervisor_target }}"
-      ansible.builtin.shell:
-        cmd: ssh-keyscan {{ hostvars[cifmw_baremetal_hypervisor_target].ansible_host }} >> ~/.ssh/known_hosts
-
-    - name: "Add SSH key to authorized_keys"
-      ansible.builtin.shell:
-        cmd: 'cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys'
-
-    - name: Setup and create virtual baremetal
-      block:
-        - name: Ensure libvirt is present/configured
-          ansible.builtin.import_role:
-            name: libvirt_manager
-
-        - name: Create virtual baremetal VMs
-          ansible.builtin.include_role:
-            name: libvirt_manager
-            tasks_from: deploy_layout

--- a/roles/sushy_emulator/tasks/collect_details.yml
+++ b/roles/sushy_emulator/tasks/collect_details.yml
@@ -25,26 +25,34 @@
 
 - name: Set sushy url for ocp installation
   ansible.builtin.set_fact:
-    sushy_url: "http://sushy-emulator.{{ _ingress_domain.stdout }}"
+    _sushy_url: "http://sushy-emulator.{{ _ingress_domain.stdout }}"
   when: cifmw_sushy_emulator_install_type == 'ocp'
 
-- name: Base64 encode ssh private key
+- name: Create ssh key for Sushy Emulator
+  register: _sushy_emulator_key
+  community.crypto.openssh_keypair:
+    path: "{{ cifmw_sushy_emulator_sshkey_path }}"
+    type: "{{ cifmw_sushy_emulator_sshkey_type }}"
+    size: "{{ cifmw_sushy_emulator_sshkey_size }}"
+    regenerate: full_idempotence
+
+- name: Slurp private ssh key for later use
   ansible.builtin.slurp:
     src: "{{ cifmw_sushy_emulator_sshkey_path }}"
-  register: _cifmw_sushy_emulator_private_key_b64
-  no_log: true
+  register: _sushy_emulator_private_key
 
-- name: Base64 encode ssh public key
-  ansible.builtin.slurp:
-    src: "{{ cifmw_sushy_emulator_sshkey_path }}.pub"
-  register: _cifmw_sushy_emulator_public_key_b64
-  no_log: true
+- name: Allow Sushy Emulator key
+  ansible.posix.authorized_key:
+    user: "{{ cifmw_sushy_emulator_libvirt_user }}"
+    key: "{{ _sushy_emulator_key.public_key }}"
+    state: present
+  delegate_to: "{{ cifmw_sushy_emulator_hypervisor_target }}"
 
 - name: Run ssh-keyscan
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      ssh-keyscan -H {{ hostvars[cifmw_baremetal_hypervisor_target].ansible_host }} 2>/dev/null | base64 -w 0
+      ssh-keyscan -H {{ cifmw_sushy_emulator_hypervisor_target_connection_ip | default(hostvars[cifmw_sushy_emulator_hypervisor_target].ansible_host) }} 2>/dev/null | base64 -w 0
   register: _cifmw_sushy_emulator_ssh_known_hosts_b64
 
 - name: Write known hosts for later use
@@ -53,24 +61,41 @@
     dest: "{{ cifmw_sushy_emulator_resource_directory }}/known_hosts"
     mode: '0644'
 
-- name: Get details for Libvirt driver
-  when: cifmw_sushy_emulator_driver == 'libvirt'
+- name: Load cifmw_libvirt_manager_uuids fact from file
+  vars:
+    _uuid_file: "{{ cifmw_sushy_emulator_basedir }}/artifacts/libvirt-uuids.yml"
+  when:
+    - cifmw_libvirt_manager_uuids is not defined
   block:
-    - name: Set vars
-      ansible.builtin.set_fact:
-        _libvirt_uri: "qemu+ssh://{{ cifmw_sushy_emulator_libvirt_user }}@{{ hostvars[cifmw_baremetal_hypervisor_target].ansible_host }}/system"
+    - name: "Slurp content of: {{ _uuid_file }}"
+      ansible.builtin.slurp:
+        src: "{{ _uuid_file }}"
+      register: _libvirt_uuids_file
 
-    # todo(Lewis): Once changes are made to the libvirt_manager role, the baremetal-info.yml can be consumed to gather required info
-    - name: Get Libvirt instance UUIDs
-      ansible.builtin.shell:
-        cmd: |
-          set -o pipefail
-          virsh --connect={{ _libvirt_uri }} list --all --uuid --name | grep {{ cifmw_sushy_emulator_instance_node_name_prefix }} | cut -d' ' -f1
-      register: _virsh_list_uuid
-
-    - name: Set instance_uuid variable
+    - name: "Set cifmw_libvirt_manager_uuids fact from {{ _uuid_file }}"
+      vars:
+        _yaml: "{{ _libvirt_uuids_file.content | b64decode | from_yaml }}"
       ansible.builtin.set_fact:
-        _cifmw_sushy_emulator_instances: "{{ _virsh_list_uuid.stdout_lines | regex_replace('\n(?!.*\n)', ', ')}}"
+        cifmw_libvirt_manager_uuids: "{{ _yaml.libvirt_uuid }}"
+
+- name: Set fact related to Libvirt driver
+  when:
+    - cifmw_sushy_emulator_driver == 'libvirt'
+  block:
+    - name: Generate list of filtered VMs
+      vars:
+        _matching_vms: >-
+          {% set matching_vms = [] -%}
+          {% for host, uuid in cifmw_libvirt_manager_uuids.items() -%}
+          {%   if host | regex_search(cifmw_sushy_emulator_vm_prefix_filter | default('') + '.*') -%}
+          {%     set _ = matching_vms.append(uuid) -%}
+          {%   endif -%}
+          {% endfor -%}
+          {{ matching_vms }}
+      ansible.builtin.set_fact:
+        _cifmw_sushy_emulator_instances: "{{ _matching_vms | regex_replace('\n(?!.*\n)', ', ')}}"
+      when:
+        - _matching_vms | length > 0
 
 # todo(Lewis): The OpenStack driver is currently untested waiting for changes being implemented upstream by sbaker.
 - name: Gather details for Openstack driver
@@ -79,13 +104,12 @@
   block:
     - name: Get Openstack instance UUIDs
       ansible.builtin.command:
-        cmd: "openstack --os-cloud={{ cifmw_sushy_emulator_driver_openstack_cloud }} server list --name {{ cifmw_sushy_emulator_instance_node_name_prefix }}.* -f json -c ID | jq -c [.[].ID])"
+        cmd: "openstack --os-cloud={{ cifmw_sushy_emulator_driver_openstack_cloud }} server list --name {{ cifmw_sushy_emulator_vm_prefix_filter }}.* -f json -c ID | jq -c [.[].ID])"
       register: _openstack_server_list_uuid
 
     - name: Set instance_uuid variable for openstack driver
       ansible.builtin.set_fact:
         _cifmw_sushy_emulator_instances: "{{ _openstack_server_list_uuid }}"
-        _libvirt_uri: None
 
     - name: Base64 encode openstack clouds.yaml file
       ansible.builtin.slurp:

--- a/roles/sushy_emulator/tasks/create_container.yml
+++ b/roles/sushy_emulator/tasks/create_container.yml
@@ -14,6 +14,10 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Install podman and configure session linger
+  ansible.builtin.import_role:
+    name: podman
+
 - name: Pull Sushy Emulator container image
   containers.podman.podman_image:
     name: "{{ cifmw_sushy_emulator_image }}"
@@ -27,15 +31,19 @@
     name: "{{ cifmw_sushy_emulator_container_name }}"
     network: host
     state: started
+    force_restart: true
     env:
       SUSHY_TOOLS_CONFIG: '/etc/sushy-emulator/config.conf'
     volumes:
+      - "{{ dest_dir }}/config.conf:/etc/sushy-emulator/config.conf:ro,Z"
+      - "{{ dest_dir }}/.htpasswd:/etc/sushy-emulator/.htpasswd:ro,Z"
       - "{{ dest_dir }}/known_hosts:/root/.ssh/known_hosts:ro,Z"
       - "{{ cifmw_sushy_emulator_sshkey_path }}:/root/.ssh/id_rsa:ro,Z"
       - "{{ cifmw_sushy_emulator_sshkey_path }}.pub:/root/.ssh/id_rsa.pub:ro,Z"
-      - "{{ dest_dir }}/config.conf:/etc/sushy-emulator/config.conf:ro,Z"
-      - "{{ dest_dir }}/.htpasswd:/etc/sushy-emulator/.htpasswd:ro,Z"
 
-- name: Set sushy url for podman installation
+# We only support deploying Sushy Emulator Podman container on controller-0
+- name: Set Sushy Emulator URL for Podman installation
+  vars:
+    _ip_address: "{{ hostvars['controller-0']['ansible_host'] }}"
   ansible.builtin.set_fact:
-    sushy_url: "http://localhost:8000"
+    _sushy_url: "http://{{ _ip_address }}:8000"

--- a/roles/sushy_emulator/tasks/main.yml
+++ b/roles/sushy_emulator/tasks/main.yml
@@ -22,11 +22,8 @@
 - name: Install required packages
   become: true
   ansible.builtin.package:
-    name: "{{ item }}"
+    name: httpd-tools
     state: present
-  with_items:
-    - httpd-tools
-    - libvirt-client
 
 - name: Collect details for Sushy Emulator config
   ansible.builtin.import_tasks: collect_details.yml
@@ -41,14 +38,3 @@
 - name: Deploy Sushy Emulator into Podman container
   ansible.builtin.import_tasks: create_container.yml
   when: cifmw_sushy_emulator_install_type == 'podman'
-
-# todo(Lewis): Once vms deployed by libvirt_manager are working we should
-# add one more basic fuctional test like checking power status
-- name: Test sushy Emulator and connection to hypervisor libvirt socket
-  ansible.builtin.uri:
-    url: "{{ sushy_url}}/redfish/v1/Managers"
-    return_content: true
-    user: admin
-    password: password
-  retries: 5
-  delay: 5

--- a/roles/sushy_emulator/tasks/verify.yml
+++ b/roles/sushy_emulator/tasks/verify.yml
@@ -1,0 +1,67 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Load baremetal hosts from libvirt_manager_bm_info_data fact
+  when: libvirt_manager_bm_info_data is defined
+  ansible.builtin.set_fact:
+    cifmw_baremetal_hosts: "{{ libvirt_manager_bm_info_data }}"
+
+- name: Load cifmw_baremetal_hosts fact from file
+  vars:
+    cifmw_parameters_file: "{{ cifmw_sushy_emulator_basedir }}/parameters/baremetal-info.yml"
+  when:
+    - libvirt_manager_bm_info_data is not defined
+  block:
+    - name: "Slurp content of: {{ cifmw_parameters_file }}"
+      ansible.builtin.slurp:
+        src: "{{ cifmw_parameters_file }}"
+      register: cifmw_baremetal_hosts_file
+
+    - name: "Set cifmw_baremetal_hosts fact from {{ cifmw_parameters_file }}"
+      vars:
+        _yaml: "{{ cifmw_baremetal_hosts_file.content | b64decode | from_yaml }}"
+      ansible.builtin.set_fact:
+        cifmw_baremetal_hosts: "{{ _yaml.cifmw_baremetal_hosts }}"
+
+- name: Test Sushy Emulator and connection to hypervisor libvirt socket
+  ansible.builtin.uri:
+    url: "{{ _sushy_url}}/redfish/v1/Managers"
+    return_content: true
+    user: "{{ cifmw_sushy_emulator_redfish_username }}"
+    password: "{{ cifmw_sushy_emulator_redfish_password }}"
+  retries: 5
+  delay: 5
+  register: _sushy_emulator_content
+
+- name: Verify connection to baremetal VMs via Sushy Emulator
+  when:
+    - _cifmw_sushy_emulator_instances | length > 0
+  ansible.builtin.uri:
+    url: "{{ _sushy_url}}/redfish/v1/Systems/{{item}}"
+    return_content: true
+    user: "{{ cifmw_sushy_emulator_redfish_username }}"
+    password: "{{ cifmw_sushy_emulator_redfish_password }}"
+  retries: 5
+  delay: 5
+  register: _sushy_emulator_content_system
+  loop: "{{ _cifmw_sushy_emulator_instances }}"
+
+- name: Verify baremetal VM power status
+  when: _sushy_emulator_content_system != 'All items skipped'
+  ansible.builtin.assert:
+    that:
+      - item.json.PowerState is defined
+  loop: "{{ _sushy_emulator_content_system.results }}"

--- a/roles/sushy_emulator/templates/config_conf.j2
+++ b/roles/sushy_emulator/templates/config_conf.j2
@@ -17,7 +17,11 @@ SUSHY_EMULATOR_AUTH_FILE = '/etc/sushy-emulator/.htpasswd'
 SUSHY_EMULATOR_OS_CLOUD = {{ cifmw_sushy_emulator_driver_openstack_cloud }}
 
 # The libvirt URI to use. This option enables libvirt driver.
-SUSHY_EMULATOR_LIBVIRT_URI = '{{ _libvirt_uri }}'
+{% if cifmw_sushy_emulator_driver == 'libvirt' %}
+SUSHY_EMULATOR_LIBVIRT_URI = '{{ cifmw_sushy_emulator_libvirt_uri }}'
+{% else %}
+SUSHY_EMULATOR_LIBVIRT_URI = None
+{% endif %}
 
 # Instruct the libvirt driver to ignore any instructions to
 # set the boot device. Allowing the UEFI firmware to instead
@@ -27,7 +31,9 @@ SUSHY_EMULATOR_LIBVIRT_URI = '{{ _libvirt_uri }}'
 # your VM has a floppy drive.
 SUSHY_EMULATOR_IGNORE_BOOT_DEVICE = False
 
+{% if _cifmw_sushy_emulator_instances is defined %}
 # This list contains the identities of instances that the driver will filter by.
 # It is useful in a tenant environment where only some instances represent
 # virtual baremetal.
 SUSHY_EMULATOR_ALLOWED_INSTANCES = {{ _cifmw_sushy_emulator_instances }}
+{% endif %}

--- a/roles/sushy_emulator/templates/secret_yaml.j2
+++ b/roles/sushy_emulator/templates/secret_yaml.j2
@@ -5,9 +5,9 @@ metadata:
     namespace: {{ cifmw_sushy_emulator_namespace }}
 data:
     ssh-publickey: |
-        {{ _cifmw_sushy_emulator_public_key_b64.content | default('""') | trim }}
+        {{ _sushy_emulator_key.public_key | b64encode | default('""') | trim }}
     ssh-privatekey: |
-        {{ _cifmw_sushy_emulator_private_key_b64.content | default('""') | trim }}
+        {{ _sushy_emulator_private_key.content | default('""') | trim }}
     ssh-known-hosts: |
         {{ _cifmw_sushy_emulator_ssh_known_hosts_b64.stdout | default('""') | trim }}
 {% if cifmw_sushy_emulator_driver == 'openstack' %}


### PR DESCRIPTION
This patch enables Redfish BMC control of VMs deployed via the reproducer
layout.

Sushy Emulator is deployed onto the Ansible controller as a Podman Pod
and access' the hypervisor's libvirt socket via SSH.

- `cifmw_use_sushy_emulator` parameter is added to control the
deployment of Sushy Emulator in the reproducer and set to true.
- `cifmw_use_vbmc` parameter is added to control the
deployment of Virtual BMC in the reproducer and behavoir changed to
default to false.
- sushy_emulator role now creates and uses it's own ssh keypair to
to communicate with the hypervisor
- `baremetal-info.yml` creation has now been extracted into it's own
task file and enhanced to support adding new baremetal hosts entries
resulting from scaling or additional hosts for baremetal instances.
- Sushy Emulator verification has now moved to it's own task file and
tests both Sushy Emulator connection and connection to each host.
- sushy_emulator role now uses the `cifmw_libvirt_manager_uuids` fact
to filter vms rather than using an additional `virsh` call. This means
`libvirt-client` can be removed from the packages list to install.
- Add `cifmw_sushy_redfish_bmc_protocol` param to control the bmc protocol Sushy Emulator uses. [1][2][3]

[1] https://github.com/openstack-k8s-operators/install_yamls/blob/6f43dd716e8d1ab7b38926ca29c45699a874e164/devsetup/scripts/edpm-compute-baremetal.sh#L76C14-L76C35
[2] https://github.com/metal3-io/baremetal-operator/blob/b87793e1e394bbc4e4b93fda967e2ff9f1bbbe79/docs/api.md?plain=1#L37-L38
[3] https://book.metal3.io/quick-start.html?highlight=redfish-virtualmedia#create-baremetalhosts

Jira: [OSPRH-6497](https://issues.redhat.com//browse/OSPRH-6497)

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
