### PR TITLE
 Use cifmw_rhol_crc_version to 2.30.0 for crc reproducer

### DIFF
--- a/roles/rhol_crc/defaults/main.yml
+++ b/roles/rhol_crc/defaults/main.yml
@@ -28,7 +28,7 @@ cifmw_rhol_crc_kubeadmin_pwd: 12345678
 cifmw_rhol_crc_dryrun: false
 
 # Binary variables:
-cifmw_rhol_crc_version: latest
+cifmw_rhol_crc_version: 2.30.0
 cifmw_rhol_crc_tarball_name: crc-linux-amd64.tar.xz
 cifmw_rhol_crc_tarball_checksum_name: crc-linux-amd64.tar.xz.sha256
 cifmw_rhol_crc_base_url: https://mirror.openshift.com/pub/openshift-v4/clients/crc/{{ cifmw_rhol_crc_version }}


### PR DESCRIPTION
In CI, we are using crc version 2.30.0. By default the crc reproducer
job deploys latest crc which breaks while reproducing the job locally and in crc ci-reproducer job.
    
This pr sets the cifmw_rhol_crc_version to 2.30.0 so that crc ci-reproducer reproduces the job without any issue.


As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

