### PR TITLE
Use base.yaml irrelevant file list

### DIFF
--- a/zuul.d/podified_multinode.yaml
+++ b/zuul.d/podified_multinode.yaml
@@ -15,15 +15,6 @@
     nodeset: centos-9-medium-crc-extracted-2-30-0-3xl
     run:
       - ci/playbooks/edpm/run.yml
-    irrelevant-files:
-      - ^roles/.*_build
-      - ^roles/build.*
-      - ^roles/local_env_vm
-      - ^ci/templates
-      - ^docs
-      - ^.*/*.md
-      - ^OWNERS
-      - ^.github
     extra-vars:
       crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"
       crc_ci_bootstrap_networking:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -42,6 +42,7 @@
       Project template to run content provider with ironic podified job.
     github-check:
       jobs:
+        - noop
         - openstack-k8s-operators-content-provider
         - podified-multinode-ironic-deployment:
             dependencies:


### PR DESCRIPTION
It will help to avoid zuul job freeze issue[1]. where[1] child jobs gets triggering without running content provider.

Podified base job is parented from cifmw-podified-multinode-edpm-base-crc and is defined in base.yaml. Let's use the irrelevant file list from cifmw-podified-multinode-edpm-base-crc instead of overidding it.

Links:
[1]. https://github.com/openstack-k8s-operators/ironic-operator/pull/421#issuecomment-2069087141

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

