### PR TITLE
[devscripts] Modifying the OpenShift version to 4.15

### DIFF
--- a/roles/devscripts/vars/main.yml
+++ b/roles/devscripts/vars/main.yml
@@ -33,7 +33,7 @@ cifmw_devscripts_config_defaults:
   working_dir: "/home/dev-scripts"
   assets_extra_folder: "/home/dev-scripts/assets"
   openshift_release_type: "ga"
-  openshift_version: "4.14.12"
+  openshift_version: "4.15.15"
   cluster_name: "ocp"
   base_domain: "openstack.lab"
   ntp_servers: "clock.corp.redhat.com"


### PR DESCRIPTION
Most of the unified jobs have moved to 4.15.10 version. This has been found to be stable. Also, it would bring us closer to the intended version of OCP with OSP

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

*Overrides*
```
# devscripts override
cifmw_devscripts_config_overrides:
  openshift_version: "4.14.12"
```