### PR TITLE
[deploy_bmh] Allow integer values as root hints

### DIFF
--- a/docs/source/baremetal/01_baremetal_hosts_data.md
+++ b/docs/source/baremetal/01_baremetal_hosts_data.md
@@ -46,6 +46,9 @@ cifmw_baremetal_hosts:
     status: running
     # Optional: (string) The storage device to use for provisioning.
     root_device_hint: /dev/sda
+    # Optional: (string) The field to be used as rootHint. Defaults
+    #     to the cifmw_deploy_bmh_root_device_hint_field.
+    root_device_hint_field: deviceName
     # Optional: (dict) Nmstate to apply to the host when provisioned
     nmstate:
       # interfaces: # Sample nmstate state snippet

--- a/roles/deploy_bmh/README.md
+++ b/roles/deploy_bmh/README.md
@@ -24,7 +24,7 @@ The resulting CR will contain, for each node, the following objects:
 * `cifmw_deploy_bmh_node_patch_secret`: (*dict*) Dictionary with an individual BMH Secret CR patch per node. Defaults to `{}`
 * `cifmw_deploy_bmh_patch_nmstate`: (*dict*) Dictionary to combine with each of generated BMH nmstate Secret CRs. Defaults to `{}`
 * `cifmw_deploy_bmh_node_patch_nmstate`: (*dict*) Dictionary with an individual BMH nmstate Secret CR patch per node. Defaults to `{}`
-* `cifmw_deploy_bmh_root_device_hint_field`: (*string*) The field to use in the BMH `rootDeviceHints` when a node has `root_device_hint` populated. Defaults to `deviceName`
+* `cifmw_deploy_bmh_root_device_hint_field`: (*string*) The default field to use in the BMH `rootDeviceHints` when a node has `root_device_hint` populated. Defaults to `deviceName`
 
 ## Examples
 

--- a/roles/deploy_bmh/template/bmh.yml.j2
+++ b/roles/deploy_bmh/template/bmh.yml.j2
@@ -21,10 +21,15 @@ spec:
 {% endfor                                                                            %}
   bootMode: {{ node_data['boot_mode'] }}
   online: {{ 'true' if node_data['status'] | default("") == "running" else 'false' }}
-{% if 'root_device_hint' in node_data %}
+{% if 'root_device_hint' in node_data                                                                    %}
+{# Ensure integer values are rendered as integers and not as strings #}
+{% set hint_value = node_data['root_device_hint']
+  if node_data['root_device_hint'] | int != 0  else
+  '"' + node_data['root_device_hint'] + '"'                                                              %}
+{% set hint_field = node_data.root_device_hint_field | default(cifmw_deploy_bmh_root_device_hint_field)  %}
   rootDeviceHints:
-    {{ cifmw_deploy_bmh_root_device_hint_field }}: "{{ node_data['root_device_hint'] }}"
-{% endif                                                                             %}
+    {{ hint_field }}: {{ hint_value }}
+{% endif                                                                                                 %}
 {% if 'nmstate' in node_data %}
   preprovisioningNetworkDataName: {{ node_name }}-nmstate-secret
 {% endif %}


### PR DESCRIPTION
At the same time, we now allow using per host hint fields.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
