### PR TITLE
Enable PR auto cleaning

### DIFF
--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -1,0 +1,16 @@
+---
+name: Manage stale PRs
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntun-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          start-date: '2024-04-25T00:00:00Z'
+          stale-pr-message: |
+            This PR is stale because it has been for over 60 days with no activity.
+            Remove stale label or comment or this will be closed in 7 days.


### PR DESCRIPTION
If a PR is open for more than 60 days without any activity, the bot will
send a gentle reminder.

If nothing moves during the next 7 days, the bot will close the PR.

We might consider removing the `start-date` parameter (discussion is
needed): with that parameter, and the set value, the current stale PR
will be ignored by the bot, only newer content will start seeing its
action.

Link to the action: https://github.com/actions/stale

As a pull request owner and reviewers, I checked that:
- [X] This is an action. No need for test.
