### PR TITLE
Enable proper logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ CI_CTX_NAME ?= localhost/cifmw:latest
 MOLECULE_CONFIG ?= ${MOLECULE_CONFIG:-.config/molecule/config_podman.yml}
 # Run molecule against all tests
 TEST_ALL_ROLES ?= ${TEST_ALL_ROLES:-no}
+# Log output location
+LOG_DIR ?= /tmp
 
 # target vars for generic operator install info 1: target name , 2: operator name
 define vars
@@ -79,18 +81,18 @@ pre_commit_nodeps: ## Run pre-commit tests without installing dependencies
 	pushd $(BASEDIR); \
 	git config --global safe.directory '*'; \
 	if [ "x$(USE_VENV)" ==  'xyes' ]; then \
-		${HOME}/test-python/bin/pre-commit run --all-files; \
+		${HOME}/test-python/bin/pre-commit run --all-files 2>&1 | ansi2txt | tee $(LOG_DIR)/pre_commit.log; \
 	else \
-		pre-commit run --all-files; \
+		pre-commit run --all-files 2>&1 | ansi2txt | tee $(LOG_DIR)/pre_commit.log; \
 	fi
 
 .PHONY: check_zuul_files
 check_zuul_files: role_molecule ## Regenerate zuul files and check if they have not been modified manually
-	./scripts/check_zuul_files.sh
+	./scripts/check_zuul_files.sh 2>&1 | ansi2txt | tee $(LOG_DIR)/check_zuul_files.log
 
 .PHONY: check_k8s_snippets_comment
 check_k8s_snippets_comment:
-	./scripts/check_k8s_snippets_comment.sh
+	./scripts/check_k8s_snippets_comment.sh 2>&1 | ansi2txt | tee $(LOG_DIR)/check_k8s_snippets_comment.log
 
 ##@ Ansible-test testing
 .PHONY: ansible_test
@@ -98,7 +100,7 @@ ansible_test: setup_tests ansible_test_nodeps ## Runs ansible-test with dependen
 
 .PHONY: ansible_test_nodeps
 ansible_test_nodeps: ## Run ansible-test without installing dependencies
-	bash scripts/run_ansible_test
+	bash scripts/run_ansible_test 2>&1 | ansi2txt | tee $(LOG_DIR)/ansible_tests.log
 
 ##@ Container targets
 .PHONY: ci_ctx

--- a/ci/playbooks/pre-commit.yml
+++ b/ci/playbooks/pre-commit.yml
@@ -10,6 +10,12 @@
           - python3
           - python3-pip
 
+    - name: Ensure zuul-output exists
+      ansible.builtin.file:
+        path: "{{ ansible_user_dir }}/zuul-output/logs"
+        state: directory
+        mode: "0755"
+
     - name: Run make targets
       vars:
         src_dir: >-
@@ -34,3 +40,12 @@
             target: pre_commit_nodeps
             params:
               USE_VENV: "no"
+              LOG_DIR: "{{ ansible_user_dir }}/zuul-output/logs"
+      always:
+        - name: Expose pre-commit log as artifact
+          zuul_return:
+            data:
+              zuul:
+                artifacts:
+                  - name: pre-commit logfile
+                    url: pre_commit.log

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -22,3 +22,6 @@ pre-commit # MIT
 yamllint
 pyspelling
 mkdocs-pymdownx-material-extras
+
+# Common requirements
+ansi2txt


### PR DESCRIPTION
Since we're using zuul pod, we're losing some logs, masked by the
community.general.make module.

Adding the capacity to `tee` in a log file should ensure we keep track
of the potential issues.

This patch modifies all of the test targets in the Makefile to use the
new LOG_DIR parameter.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
