### PR TITLE
Replace use of domifaddr with `ip neighbour`

### DIFF
--- a/common-requirements.txt
+++ b/common-requirements.txt
@@ -5,5 +5,8 @@ kubernetes-validate
 openstacksdk
 jsonschema>=4.20.0
 
+# Requiered to use ansible.utils.from_xml / ansible.utils.to_xml
+xmltodict
+
 # Allows to unpin cryptography
 pyOpenSSL>=22.1.0

--- a/roles/libvirt_manager/tasks/start_manage_vms.yml
+++ b/roles/libvirt_manager/tasks/start_manage_vms.yml
@@ -23,19 +23,22 @@
     index_var: vm_id
     label: "{{ vm_type }}-{{ vm_id }}"
 
+- name: "Get public network XML"
+  register: public_net_xml
+  community.libvirt.virt_net:
+    command: get_xml
+    name: "{{ public_net_nics[0].network }}"
+
 - name: "Grab IPs for nodes type {{ vm_type }}"  # noqa: risky-shell-pipe
   register: vm_ips
+  vars:
+    public_net_dict: "{{ public_net_xml.get_xml | ansible.utils.from_xml }}"
   ansible.builtin.shell:
     cmd: >-
-      virsh -c qemu:///system -q
-      domifaddr --source arp
-      cifmw-{{ nic.host }} | grep "{{ nic.mac }}"
-      {% if cifmw_openshift_api_ip_address | default(false) %}
-      | grep -v "{{ cifmw_openshift_api_ip_address }}/"
-      {% endif %}
-      {% if cifmw_openshift_ingress_ip_address | default(false) %}
-      | grep -v "{{ cifmw_openshift_ingress_ip_address }}/"
-      {% endif %}
+      ip -json neighbour show \
+        dev {{ nic.network }} \
+        to {{ public_net_dict.network.ip['@address'] }}/{{ public_net_dict.network.ip['@prefix'] }} \
+        | jq -r '.[] | select(has("lladdr")) | select(.["lladdr"] | contains ("{{ nic.mac }}")) | .dst'
   loop: "{{ public_net_nics }}"
   loop_control:
     loop_var: nic
@@ -56,7 +59,7 @@
 
 - name: "Add the IP to the libvirt host port details fact for {{ vm_type }}"
   vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
+    extracted_ip: "{{ vm_ip.stdout | ansible.utils.ipaddr('address') }}"
   ansible.builtin.set_fact:
     cifmw_hosts_ports: >-
       {{
@@ -80,7 +83,7 @@
     - _need_start | bool
   delegate_to: localhost
   vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
+    extracted_ip: "{{ vm_ip.stdout | ansible.utils.ipaddr('address') }}"
     proxy_hostname: "{{ ansible_host | default(inventory_hostname) }}"
   ansible.builtin.blockinfile:
     create: true
@@ -103,7 +106,7 @@
   when:
     - _need_start | bool
   vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
+    extracted_ip: "{{ vm_ip.stdout | ansible.utils.ipaddr('address') }}"
     identity_file: >-
       {{
         cifmw_libvirt_manager_basedir ~ '/artifacts/cifmw_ocp_access_key' if vm_type == 'ocp' else
@@ -130,7 +133,7 @@
 - name: Inject nodes in the ansible inventory
   delegate_to: localhost
   vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
+    extracted_ip: "{{ vm_ip.stdout | ansible.utils.ipaddr('address') }}"
   ansible.builtin.add_host:
     name: "{{ vm_ip.nic.host }}"
     groups: "{{ (vm_type == 'crc') | ternary('ocp', vm_type) }}s"
@@ -153,7 +156,7 @@
   when:
     - _need_start | bool
   vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
+    extracted_ip: "{{ vm_ip.stdout | ansible.utils.ipaddr('address') }}"
   ansible.builtin.wait_for:
     host: "{{ extracted_ip }}"
     port: 22
@@ -246,7 +249,7 @@
 - name: Update inventory to consume correct user
   delegate_to: localhost
   vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
+    extracted_ip: "{{ vm_ip.stdout | ansible.utils.ipaddr('address') }}"
   ansible.builtin.add_host:
     name: "{{ vm_ip.nic.host }}"
     groups: "{{ (vm_type == 'crc') | ternary('ocp', vm_type) }}s"

--- a/roles/libvirt_manager/templates/inventory.yml.j2
+++ b/roles/libvirt_manager/templates/inventory.yml.j2
@@ -2,7 +2,7 @@
   hosts:
 {% for host in hosts %}
     {{ host.nic.host }}:
-      ansible_host: {{ (host.stdout.split())[3] | ansible.utils.ipaddr('address') }}
+      ansible_host: {{ host.stdout | ansible.utils.ipaddr('address') }}
       ansible_user: {{ admin_user }}
 {% if vm_type is match('^crc.*') %}
       ansible_ssh_private_key_file: ~/.ssh/crc_key

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,6 +8,7 @@ ansi2html
 dogpile.cache>=0.9.2
 jmespath # required by devscripts role
 netaddr # required by libvirt_manager role
+xmltodict # Requiered to use ansible.utils.from_xml / ansible.utils.to_xml
 
 # UT Deps
 pytest


### PR DESCRIPTION
virsh domifaddr does not work with IPv6, replace the usage and instead use the `ip neighbour` command to get VM ip's.

This change s roles/libvirt_manager/tasks/start_manage_vms.yml only, there is also use of domifaddr in
roles/libvirt_manager/tasks/deploy_edpm_compute.yml. Let's look at that in a follow up.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
