### PR TITLE
Prepare for job dependency

### DIFF
--- a/ci/playbooks/noop.yml
+++ b/ci/playbooks/noop.yml
@@ -1,0 +1,8 @@
+---
+- name: Noop playbook
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Hello world
+      ansible.builtin.debug:
+        msg: "Hello world"

--- a/ci/templates/noop-molecule.yaml.j2
+++ b/ci/templates/noop-molecule.yaml.j2
@@ -1,0 +1,11 @@
+{% for role_name in role_names | sort %}
+- job:
+    name: cifmw-molecule-{{ role_name }}
+    parent: cifmw-molecule-noop
+    files:
+      - ^common-requirements.txt
+      - ^test-requirements.txt
+      - ^roles/{{ role_name }}/(?!meta|README).*
+      - ^ci/playbooks/molecule.*
+      - ^.config/molecule/.*
+{% endfor %}

--- a/ci/templates/projects.yaml
+++ b/ci/templates/projects.yaml
@@ -6,8 +6,8 @@
 - project:
     name: openstack-k8s-operators/ci-framework
     templates:
-      - podified-multinode-edpm-pipeline
-      - data-plane-adoption-pipeline
+      - podified-multinode-edpm-ci-framework-pipeline
+      - data-plane-adoption-ci-framework-pipeline
     github-check:
       jobs:
         - noop

--- a/zuul.d/molecule-base.yaml
+++ b/zuul.d/molecule-base.yaml
@@ -4,6 +4,8 @@
     name: cifmw-molecule-base
     nodeset: centos-stream-9
     parent: base-ci-framework
+    provides:
+      - cifmw-molecule
     pre-run:
       - ci/playbooks/dump_zuul_data.yml
       - ci/playbooks/molecule-prepare.yml
@@ -19,6 +21,8 @@
     name: cifmw-molecule-base-crc
     nodeset: centos-9-crc-2-30-0-xxl
     parent: base-simple-crc
+    provides:
+      - cifmw-molecule
     pre-run:
       - ci/playbooks/dump_zuul_data.yml
       - ci/playbooks/molecule-prepare.yml
@@ -29,3 +33,12 @@
     vars:
       roles_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/roles/{{ TEST_RUN }}"
       mol_config_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/.config/molecule/config_local.yml"
+
+- job:
+    name: cifmw-molecule-noop
+    parent: base-minimal-test
+    nodeset: rdo-centos-9-stream
+    run:
+      ci/playbooks/noop.yml
+    provides:
+      - cifmw-molecule

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -750,3 +750,48 @@
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: virtualbmc
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
+    - ^roles/openshift_adm/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-openshift_adm
+    parent: cifmw-molecule-noop
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
+    - ^roles/os_net_setup/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-os_net_setup
+    parent: cifmw-molecule-noop
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
+    - ^roles/ovirt/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-ovirt
+    parent: cifmw-molecule-noop
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
+    - ^roles/polarion/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-polarion
+    parent: cifmw-molecule-noop
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
+    - ^roles/switch_config/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-switch_config
+    parent: cifmw-molecule-noop

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -20,10 +20,8 @@
     github-check:
       jobs:
         - openstack-k8s-operators-content-provider
-        - podified-multinode-edpm-deployment-crc: &content_provider_edpm
-            dependencies:
-              - openstack-k8s-operators-content-provider
-        - podified-multinode-hci-deployment-crc: *content_provider_edpm
+        - podified-multinode-edpm-deployment-crc: *content_provider
+        - podified-multinode-hci-deployment-crc: *content_provider
 
 - project-template:
     name: data-plane-adoption-pipeline
@@ -45,5 +43,34 @@
         - noop
         - openstack-k8s-operators-content-provider
         - podified-multinode-ironic-deployment:
+            dependencies:
+              - openstack-k8s-operators-content-provider
+
+- project-template:
+    name: podified-multinode-edpm-ci-framework-pipeline
+    description: |
+      Project template to run content provider for EDPM jobs,
+      with dependency on smaller jobs.
+    github-check:
+      jobs:
+        - openstack-k8s-operators-content-provider:
+            requires:
+              - cifmw-pod-pre-commit
+              - cifmw-molecule
+        - podified-multinode-edpm-deployment-crc: *content_provider
+        - cifmw-crc-podified-edpm-baremetal: *content_provider
+
+- project-template:
+    name: data-plane-adoption-ci-framework-pipeline
+    description: |
+      Project template to run content provider with data-plane adoption job,
+      with dependency on smaller jobs.
+    github-check:
+      jobs:
+        - openstack-k8s-operators-content-provider:
+            requires:
+              - cifmw-pod-pre-commit
+              - cifmw-molecule
+        - cifmw-data-plane-adoption-osp-17-to-extracted-crc:
             dependencies:
               - openstack-k8s-operators-content-provider

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -52,6 +52,7 @@
       - cifmw-molecule-manage_secrets
       - cifmw-molecule-nat64_appliance
       - cifmw-molecule-networking_mapper
+      - cifmw-molecule-openshift_adm
       - cifmw-molecule-openshift_login
       - cifmw-molecule-openshift_obs
       - cifmw-molecule-openshift_provisioner_node
@@ -59,8 +60,11 @@
       - cifmw-molecule-operator_build
       - cifmw-molecule-operator_deploy
       - cifmw-molecule-os_must_gather
+      - cifmw-molecule-os_net_setup
+      - cifmw-molecule-ovirt
       - cifmw-molecule-pkg_build
       - cifmw-molecule-podman
+      - cifmw-molecule-polarion
       - cifmw-molecule-registry_deploy
       - cifmw-molecule-repo_setup
       - cifmw-molecule-reproducer
@@ -69,6 +73,7 @@
       - cifmw-molecule-set_openstack_containers
       - cifmw-molecule-shiftstack
       - cifmw-molecule-sushy_emulator
+      - cifmw-molecule-switch_config
       - cifmw-molecule-tempest
       - cifmw-molecule-test_deps
       - cifmw-molecule-test_operator
@@ -79,5 +84,5 @@
       - cifmw-molecule-virtualbmc
     name: openstack-k8s-operators/ci-framework
     templates:
-    - podified-multinode-edpm-pipeline
-    - data-plane-adoption-pipeline
+    - podified-multinode-edpm-ci-framework-pipeline
+    - data-plane-adoption-ci-framework-pipeline


### PR DESCRIPTION
In order to save resources and time, we want to make jobs dependent.
Since a patch won't merge if molecule (or pre-commit, or ansible-test)
don't pass, let's not run the full deploy if those smaller, faster tests
fail.

To get that dependency, we leverage the `provides` parameter for zuul
job definition. The next step is to modify the "big jobs" to `requires`
the listed job(s).

For now, we can depend on molecule and pre-commit
- ansible-test is still in Prow

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
