### PR TITLE
Dropping flak8 as it is covering same ground as black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,20 +12,6 @@ repos:
       - id: check-symlinks
       - id: debug-statements
 
-  - repo: https://github.com/pycqa/flake8
-    rev: 3.9.0
-    hooks:
-      - id: flake8
-        additional_dependencies: [flake8-typing-imports==1.6.0]
-        # List of ignored checks overrides the flake8 defaults.
-        # Changes to the list, especially extensions should be
-        # justified with relation to defaults.
-        # W503 - line break before binary operator, ignored by default
-        # E402 - Module level import not at top of file
-        # E203 - As per black doc to match PEP8
-        # max-line-length increased to 88 as per blacks recommendation
-        entry: flake8 --ignore=W503,E203,E402 --max-line-length=88
-
   - repo: https://github.com/openstack-dev/bashate.git
     rev: 2.1.1
     hooks:


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
