### PR TITLE
Use update_containers role to update ansibleee image

### DIFF
--- a/ci/playbooks/build_runner_image.yml
+++ b/ci/playbooks/build_runner_image.yml
@@ -42,8 +42,6 @@
       ansible.builtin.copy:
         mode: "0644"
         content: |
-          cifmw_edpm_prepare_update_os_containers: true
-          cifmw_set_openstack_containers_operator_name: openstack-ansibleee
-          cifmw_set_openstack_containers_overrides:
-            RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT: "{{ ansibleee_runner_img }}"
+          cifmw_update_containers_ansibleee_image_url: "{{ ansibleee_runner_img }}"
+          cifmw_update_containers: true
         dest: "{{ ansible_user_dir }}/ci-framework-data/artifacts/edpm-ansible.yml"

--- a/roles/edpm_prepare/tasks/main.yml
+++ b/roles/edpm_prepare/tasks/main.yml
@@ -132,32 +132,12 @@
     cacheable: true
   when: cifmw_build_images_output is defined
 
-- name: Patch baremetal CSV to override the uefi image
-  when: cifmw_update_containers_edpm_image_url is defined
+- name: Update BM CSV or Ansibleee CSV to update proper image
+  when: >-
+      (cifmw_update_containers_edpm_image_url is defined) or
+      (cifmw_update_containers_ansibleee_image_url is defined)
   ansible.builtin.include_role:
     name: update_containers
-
-- name: Patch ansible runner image temporarily
-  when:
-    - not cifmw_edpm_prepare_update_os_containers | bool
-    - not cifmw_edpm_prepare_skip_patch_ansible_runner | bool
-  environment:
-    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-    PATH: "{{ cifmw_path }}"
-  block:
-    - name: Get ansibleee-operator csv name
-      ansible.builtin.shell: |
-        set -o pipefail && \
-        oc get csv -n openstack-operators -o name | grep ansibleee-operator
-      register: _ansibleee_csv_name
-
-    - name: Patch ansible runner image
-      ansible.builtin.command:
-        cmd: >-
-          oc patch -n openstack-operators "{{ _ansibleee_csv_name.stdout }}"
-          --type='json' -p='[{
-          "op":"replace", "path":"/spec/install/spec/deployments/0/spec/template/spec/containers/1/env/0",
-          "value": {"name": "RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT", "value": "quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest"}}]'
 
 # Prepare and kustomize the OpenStackControlPlane CR
 - name: Prepare OpenStack control plane CR

--- a/roles/update_containers/tasks/main.yml
+++ b/roles/update_containers/tasks/main.yml
@@ -32,18 +32,3 @@
     PATH: "{{ cifmw_path }}"
   ansible.builtin.command:
     cmd: "oc apply -f {{ cifmw_update_containers_dest_path }}"
-
-  # Note(chkumar): It will be removed once ansiblee runner
-  # support is enabled in openstackversion interface.
-- name: Update Ansibleee Runner container
-  when: cifmw_update_containers_ansibleee_image_url is defined
-  environment:
-    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-    PATH: "{{ cifmw_path }}"
-  ansible.builtin.command:
-    cmd: >-
-      oc patch csv -n openstack-operators openstack-ansibleee-operator.v0.0.1
-      --type='json' -p='[{
-      "op":"replace", "path":"/spec/install/spec/deployments/0/spec/template/spec/containers/1/env/0",
-      "value": {"name": "RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT",
-      "value": {{ cifmw_update_containers_ansibleee_image_url }}}}]'

--- a/roles/update_containers/templates/update_containers.j2
+++ b/roles/update_containers/templates/update_containers.j2
@@ -85,3 +85,6 @@ spec:
 {% if cifmw_update_containers_edpm_image_url is defined %}
     osContainerImage: {{ cifmw_update_containers_edpm_image_url }}
 {% endif %}
+{% if cifmw_update_containers_ansibleee_image_url is defined %}
+    ansibleeeImage: {{ cifmw_update_containers_ansibleee_image_url }}
+{% endif %}


### PR DESCRIPTION
 https://github.com/openstack-k8s-operators/dataplane-operator/pull/889 adds the support of updating ansibleee runner image via openstack version interface.
    
This pr updates the update_containers role to update the same.
    
It modifies ci/playbooks/build_runner_image.yml playbook to use update_containers role to achieve the same.
    

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

