### PR TITLE
Use update_containers role to update EDPM BM OS image

### DIFF
--- a/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -62,22 +62,6 @@
       }}
     cifmw_edpm_deploy_baremetal_operators_build_output: "{{ operators_build_output }}"
 
-- name: Set facts for baremetal UEFI image url
-  ansible.builtin.set_fact:
-    cifmw_set_openstack_containers_overrides:
-      RELATED_IMAGE_OS_CONTAINER_IMAGE_URL_DEFAULT: "{{ cifmw_build_images_output['images']['edpm-hardened-uefi']['image'] }}"
-    cacheable: true
-  when: cifmw_build_images_output is defined
-
-- name: Patch baremetal CSV to override the uefi image
-  when:
-    - not cifmw_edpm_deploy_baremetal_dry_run
-    - (cifmw_edpm_deploy_baremetal_update_os_containers|bool) or (cifmw_build_images_output is defined)
-  vars:
-    cifmw_set_openstack_containers_operator_name: openstack-baremetal
-  ansible.builtin.include_role:
-    name: set_openstack_containers
-
 - name: Create virtual baremetal
   when: cifmw_edpm_deploy_baremetal_create_vms | bool
   vars:

--- a/roles/edpm_prepare/tasks/main.yml
+++ b/roles/edpm_prepare/tasks/main.yml
@@ -126,6 +126,17 @@
   ansible.builtin.include_role:
     name: set_openstack_containers
 
+- name: Set facts for baremetal UEFI image url
+  ansible.builtin.set_fact:
+    cifmw_update_containers_edpm_image_url: "{{ cifmw_build_images_output['images']['edpm-hardened-uefi']['image'] }}"
+    cacheable: true
+  when: cifmw_build_images_output is defined
+
+- name: Patch baremetal CSV to override the uefi image
+  when: cifmw_update_containers_edpm_image_url is defined
+  ansible.builtin.include_role:
+    name: update_containers
+
 - name: Patch ansible runner image temporarily
   when:
     - not cifmw_edpm_prepare_update_os_containers | bool

--- a/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
+++ b/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
@@ -19,6 +19,9 @@ pre_infra:
 cifmw_operator_build_meta_name: "openstack-operator"
 cifmw_edpm_prepare_skip_crc_storage_creation: true
 
+# update containers vars
+cifmw_update_containers: true
+cifmw_update_containers_metadata: openstack-galera-network-isolation
 
 # edpm_deploy role vars
 cifmw_deploy_edpm: true

--- a/scenarios/centos-9/edpm_periodic.yml
+++ b/scenarios/centos-9/edpm_periodic.yml
@@ -6,9 +6,9 @@ cifmw_set_openstack_containers_tag_from_md5: true
 cifmw_set_openstack_containers_dlrn_md5_path: "{{ cifmw_basedir }}/artifacts/repositories/delorean.repo.md5"
 cifmw_edpm_prepare_update_os_containers: true
 cifmw_set_openstack_containers_namespace: "podified-master-centos9"
-cifmw_edpm_deploy_baremetal_update_os_containers: true
 cifmw_run_tests: true
 cifmw_edpm_deploy_registry_url: "{{ cifmw_set_openstack_containers_registry }}/{{ cifmw_set_openstack_containers_namespace }}"
 cifmw_test_operator_tempest_registry: "{{ cifmw_set_openstack_containers_registry }}"
 cifmw_test_operator_tempest_namespace: "{{ cifmw_set_openstack_containers_namespace }}"
 cifmw_test_operator_tempest_image_tag: "{{ cifmw_repo_setup_full_hash }}"
+cifmw_update_containers_edpm_image_url: "quay.rdoproject.org/podified-{{cifmw_repo_setup_branch}}-centos9/edpm-hardened-uefi:{{ cifmw_repo_setup_full_hash }}"


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/ci-framework/pull/1574 adds update_containers role to update the EDPM BM OS image.
    
It removes the set_openstack_containers role and replaces it with update_containers role to update the EDPM BM OS image by moving the required tasks in edpm_prepare role after operator deployment.
    
It also update the periodic vars based on update_containers role and drop set_openstack_containers role.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
