### PR TITLE
Integrate update_containers in validated architecture role

### DIFF
--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -143,6 +143,13 @@
         - operator
         - edpm_bootstrap
 
+    - name: Update containers in deployed OSP operators
+      ansible.builtin.include_role:
+        name: update_containers
+      tags:
+        - update_containers
+        - edpm_bootstrap
+
     - name: Configure Storage Class
       ansible.builtin.import_role:
         name: ci_local_storage


### PR DESCRIPTION
update_containers role is used to update container images
using openstack version interface. Let's use the same to
update the containers in va.

It will be used in downstream VA jobs to use RHEL openstack
services container. 
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
