### PR TITLE
pod/extend pod jobs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,24 +26,6 @@ repos:
         entry: bashate --error . --ignore=E006,E040
         verbose: false
 
-  - repo: local
-    hooks:
-      - id: make-check-zuul-files
-        name: make-check-zuul-files
-        language: system
-        entry: make
-        args: ['check_zuul_files']
-        pass_filenames: false
-
-  - repo: local
-    hooks:
-      - id: check-k8s-snippets-comment
-        name: check_k8s_snippets_comment
-        language: system
-        entry: make
-        args: ['check_k8s_snippets_comment']
-        pass_filenames: false
-
   # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.1.0

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ check_zuul_files: role_molecule ## Regenerate zuul files and check if they have 
 	./scripts/check_zuul_files.sh 2>&1 | ansi2txt | tee $(LOG_DIR)/check_zuul_files.log
 
 .PHONY: check_k8s_snippets_comment
-check_k8s_snippets_comment:
+check_k8s_snippets_comment: ## Check template snippets in ci_gen_kustomize_values to ensure proper source is set
 	./scripts/check_k8s_snippets_comment.sh 2>&1 | ansi2txt | tee $(LOG_DIR)/check_k8s_snippets_comment.log
 
 ##@ Ansible-test testing
@@ -99,8 +99,11 @@ check_k8s_snippets_comment:
 ansible_test: setup_tests ansible_test_nodeps ## Runs ansible-test with dependencies install
 
 .PHONY: ansible_test_nodeps
+ansible_test_nodeps: export HOME=/tmp
+ansible_test_nodeps: export ANSIBLE_LOCAL_TMP=/tmp
+ansible_test_nodeps: export ANSIBLE_REMOTE_TMP=/tmp
 ansible_test_nodeps: ## Run ansible-test without installing dependencies
-	bash scripts/run_ansible_test 2>&1 | ansi2txt | tee $(LOG_DIR)/ansible_tests.log
+	bash scripts/run_ansible_test 2>&1 | ansi2txt | tee $(LOG_DIR)/ansible_test.log
 
 ##@ Container targets
 .PHONY: ci_ctx

--- a/ci/playbooks/pod-jobs.yml
+++ b/ci/playbooks/pod-jobs.yml
@@ -1,5 +1,5 @@
 ---
-- name: Run pre-commit tests
+- name: Run light checks in pod
   hosts: all
   tasks:
     - name: Install packages
@@ -34,18 +34,20 @@
           delay: 2
           until: _setup is success
 
-        - name: Run pre-commit
+        - name: Run check
           community.general.make:
             chdir: "{{ src_dir }}"
-            target: pre_commit_nodeps
+            target: "{{ run_test }}"
             params:
               USE_VENV: "no"
               LOG_DIR: "{{ ansible_user_dir }}/zuul-output/logs"
       always:
-        - name: Expose pre-commit log as artifact
+        - name: Expose check log as artifact
+          vars:
+            log_name: "{{ run_test | replace('_nodeps', '') }}"
           zuul_return:
             data:
               zuul:
                 artifacts:
-                  - name: pre-commit logfile
-                    url: pre_commit.log
+                  - name: "{{ log_name }} logfile"
+                    url: "{{ log_name }}.log"

--- a/ci/templates/projects.yaml
+++ b/ci/templates/projects.yaml
@@ -2,6 +2,7 @@
 # command: ** make role_molecule **
 # If you need to add new jobs in the project, please edit
 # ** /ci/templates/project.yaml **
+---
 - project:
     name: openstack-k8s-operators/ci-framework
     templates:
@@ -10,7 +11,10 @@
     github-check:
       jobs:
         - noop
+        - cifmw-pod-ansible-test
+        - cifmw-pod-k8s-snippets-source
         - cifmw-pod-pre-commit
+        - cifmw-pod-zuul-files
         - cifmw-baremetal-nested-crc
         - cifmw-content-provider-build-images
         - cifmw-edpm-build-images

--- a/zuul.d/pods.yaml
+++ b/zuul.d/pods.yaml
@@ -1,10 +1,40 @@
 ---
 - job:
-    name: cifmw-pod-pre-commit
+    name: cifmw-pod-base
     nodeset:
       nodes:
         - name: container
           label: pod-centos-9-stream
     description: |
-      Run pre-commit against ci-framework
-    run: ci/playbooks/pre-commit.yml
+      Run lightweight jobs in pods
+    run: ci/playbooks/pod-jobs.yml
+
+- job:
+    name: cifmw-pod-pre-commit
+    parent: cifmw-pod-base
+    vars:
+      run_test: "pre_commit_nodeps"
+
+- job:
+    name: cifmw-pod-ansible-test
+    parent: cifmw-pod-base
+    vars:
+      run_test: "ansible_test_nodeps"
+
+- job:
+    name: cifmw-pod-zuul-files
+    parent: cifmw-pod-base
+    vars:
+      run_test: "check_zuul_files"
+    files:
+      - ^zuul.d/.*
+      - ^ci/templates/.*
+      - ^ci/config/.*
+
+- job:
+    name: cifmw-pod-k8s-snippets-source
+    parent: cifmw-pod-base
+    vars:
+      run_test: "check_k8s_snippets_comment"
+    files:
+      - ^roles/ci_gen_kustomize_values/templates/.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -2,7 +2,10 @@
     github-check:
       jobs:
       - noop
+      - cifmw-pod-ansible-test
+      - cifmw-pod-k8s-snippets-source
       - cifmw-pod-pre-commit
+      - cifmw-pod-zuul-files
       - cifmw-baremetal-nested-crc
       - cifmw-content-provider-build-images
       - cifmw-edpm-build-images


### PR DESCRIPTION
In order to get out of the Prow CI, we have to port some other jobs to
Zuul pods.

In order to avoid code ducplication, some changes were needed in the
`pre-commit.yml` playbook - for instance, it got renamed with a more
generic name, and it's now getting the `make` target directly from the
job definition.

In addition, two checks that were in pre-commit are now standalone:
- check_zuul_files
- check_k8s_snippets_comment

This ensures we get consistent logging and related artifacts in Zuul, as
well as ensuring we trigger them only when needed (those are small jobs,
but still - let's save resources)

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
