### PR TITLE
Ensure `make` fails correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+SHELL := /bin/bash -o pipefail -e
 # Roles directory location. May point outside of this repository
 ROLE_DIR ?= roles/
 # Code base directory - used for pre-commit check


### PR DESCRIPTION
With the use of `| tee` we lost the capacity to properly catch errors in
Makefile, making the jobs irrelevant.

This change ensures we really fail on any raised error, even when
there's some pipes in the path.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
