### PR TITLE
Fix VM base image machine-id

### DIFF
--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -178,6 +178,7 @@
       {% endif %}
       --root-password "password:{{ item.value.password | default('fooBar') }}"
       --ssh-inject {{ _admin_user }}:file:{{ ansible_user_dir }}/.ssh/authorized_keys
+      --truncate /etc/machine-id
       | tee -a {{ item.value.image_local_dir }}/{{ item.value.disk_file_name }}.log
     creates: "{{ item.value.image_local_dir }}/{{ item.value.disk_file_name }}.log"
   loop: "{{ _layout.vms | dict2items }}"


### PR DESCRIPTION
Issue, **all** VMs using the same base image had identintical machine-id in /etc/machine-id. Root cause is that virt-sysprep both removes and sets the machine-id. Logs show:

```
[   4.3] Performing "machine-id" ...
< -- SNIP -- >
[   4.6] Setting the machine ID in /etc/machine-id

```
To fix the issue, run virt-sysprep again and specify that it should only run `--operation machine-id`.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
