### PR TITLE
[libvirt_manager] Add support for static IP addressing.

### DIFF
--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -64,6 +64,10 @@ cifmw_libvirt_manager_configuration:
       target: (Hypervisor hostname you want to deploy the family on. Optional)
       uefi: (boolean, toggle UEFI boot. Optional, defaults to false)
       bootmenu_enable: (string, toggle bootmenu. Optional, defaults to "no")
+      ip_address: (dict, having static IP address information. Optional)
+        address: (string, IP address to be assigned. Example 192.168.10.20/24.)
+        gw: (string, the default gateway address.)
+        dns: (string, DNS server IP/FQDN to be configured.)
   networks:
     net_name: <XML definition of the network to create>
 ```

--- a/roles/libvirt_manager/tasks/add_static_ip_script.yml
+++ b/roles/libvirt_manager/tasks/add_static_ip_script.yml
@@ -1,0 +1,81 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Prepares the virtual machine boot image. Though the generation is
+# straight forward, we need to ensure support exists for static IP address
+# configuration.
+#
+# Multiple images are created for a single vm type in the case of static IP
+# address. Also, the index is used to determine the next usable IP address.
+
+
+- name: Generate the static address configuration script
+  vars:
+    _ip_address: >-
+      {{
+        vm_data.value.ip_address.address |
+        ansible.utils.next_nth_usable(vm_id)
+      }}
+    _ip_gw: "{{ vm_data.value.ip_address.gw | default(omit) }}"
+    _ip_dns: "{{ vm_data.value.ip_address.dns | default(omit )}}"
+    _ip_prefix: >-
+      {{
+        vm_data.value.ip_address.address | ansible.utils.ipaddr('prefix')
+      }}
+    _is_ipv6: "{{ _ip_address is ansible.utils.ipv6 }}"
+  ansible.builtin.template:
+    src: templates/static_ip.j2
+    dest: >-
+      {{
+        (
+          cifmw_libvirt_manager_ip_script_basedir,
+          'static-ip-' ~ vm_type ~ '-' ~ vm_id ~ '.sh'
+        ) | ansible.builtin.path_join
+      }}
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_id }}"
+    mode: "0755"
+  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
+  loop_control:
+    index_var: vm_id
+    label: "{{ vm_type }}-{{ vm_id }} "
+
+# Note: --ssh-inject is added to avoid login failures observed during
+#       unit testing. Initial investigation pointed to missing
+#       authorized_keys.
+- name: Insert the static addressing script.  # noqa: risky-shell-pipe
+  vars:
+    _script: >-
+      {{
+        (
+          cifmw_libvirt_manager_ip_script_basedir,
+          'static-ip-' ~ vm_type ~ '-' ~ vm_id ~ '.sh'
+        ) | ansible.builtin.path_join
+      }}
+    _vm_img: "{{ vm_type }}-{{ vm_id }}.qcow2"
+    _admin_user: "{{ item.value.admin_user | default('root') }}"
+  ansible.builtin.shell:
+    cmd: >-
+      set -o pipefail;
+      virt-sysprep -a "{{ _workload }}/{{ _vm_img }}"
+      --firstboot {{ _script }}
+      --ssh-inject {{ _admin_user }}:file:{{ ansible_user_dir }}/.ssh/authorized_keys
+      | tee -a {{ vm_data.value.image_local_dir }}/{{ _vm_img }}.log
+    creates: "{{ vm_data.value.image_local_dir }}/{{ _vm_img }}.log"
+  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
+  loop_control:
+    index_var: vm_id
+    label: "{{ vm_type }}-{{ vm_id }} "

--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -4,20 +4,22 @@
   vars:
     _base_img_name: >-
       {{
-        (vm_data.value.image_local_dir | default(ansible_user_dir),
-         vm_data.value.disk_file_name) |
-         path_join
+        (
+          vm_data.value.image_local_dir | default(ansible_user_dir),
+          vm_data.value.disk_file_name
+        ) | ansible.builtin.path_join
       }}
     _img: >-
       {{
         (vm_type is match('.*ocp.*')) |
-        ternary(_base_img_name ~ "_" ~ vm_id ~ ".qcow2",
-                _base_img_name)
+        ternary(_base_img_name ~ "_" ~ vm_id ~ ".qcow2", _base_img_name)
       }}
     _workload: "{{ cifmw_libvirt_manager_basedir }}/workload"
     _ocp_pool: "{{ ansible_libvirt_pools['oooq_pool']['path'] | default('') }}"
     _chdir: >-
-      {{ (vm_type is match('.*ocp.*')) | ternary(_ocp_pool, _workload) }}
+      {{
+        (vm_type is match('.*ocp.*')) | ternary(_ocp_pool, _workload)
+      }}
   block:
     - name: "Create VM overlay for {{ vm_type }}"
       vars:
@@ -31,13 +33,20 @@
           {% endif %}
           -f qcow2
           "{{ _vm_img }}"
-          "{{ vm_data.value.disksize|default ('40') }}G"
+          "{{ vm_data.value.disksize |default ('40') }}G"
         creates: "{{ vm_type }}-{{ vm_id }}.qcow2"
         chdir: "{{ _chdir }}"
       loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
       loop_control:
         index_var: vm_id
         label: "{{ vm_type }}-{{ vm_id }}"
+
+    - name: Include the static IP address configuration script.
+      when:
+        - vm_data.value.ip_address is defined
+        - vm_type is not match('.*ocp.*')
+      ansible.builtin.include_tasks:
+        file: add_static_ip_script.yml
 
     - name: "Ensure file ownership and rights for {{ vm_type }}"
       become: true

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -117,27 +117,6 @@
     user: "{{ ansible_user_id }}"
     key: "{{ pub_ssh_key['content'] | b64decode }}"
 
-- name: Prepare the static IP address for controller.
-  when:
-    - _cifmw_libvirt_manager_layout.vms.controller.ip_address is defined
-  vars:
-    _ip_address: >-
-      {{
-        _cifmw_libvirt_manager_layout.vms.controller.ip_address.address
-      }}
-    _ip_gw: "{{ _cifmw_libvirt_manager_layout.vms.controller.ip_address.gw }}"
-    _ip_dns: "{{ _cifmw_libvirt_manager_layout.vms.controller.ip_address.dns }}"
-  ansible.builtin.template:
-    src: templates/static_ip.j2
-    dest: >-
-      {{
-        (cifmw_libvirt_manager_ip_script_basedir, 'static-ip-controller.sh') |
-        ansible.builtin.path_join
-      }}
-    owner: "{{ ansible_user_id }}"
-    group: "{{ ansible_user_id }}"
-    mode: "0755"
-
 - name: Prepare disk image with SSH and growing volume  # noqa: risky-shell-pipe
   when:
     - item.value.disk_file_name != 'blank'
@@ -145,13 +124,6 @@
   vars:
     _admin_user: "{{ item.value.admin_user | default('root') }}"
     _root_part: "{{ item.value.root_part_id | default('1') }}"
-    _static_ip_script: >-
-      {{
-        (
-          cifmw_libvirt_manager_ip_script_basedir,
-          'static-ip-' + item.key + '.sh'
-        ) | ansible.builtin.path_join
-      }}
   ansible.builtin.shell:
     cmd: >-
       set -o pipefail;
@@ -159,9 +131,6 @@
       --selinux-relabel
       --firstboot-command "growpart /dev/sda {{ _root_part }}"
       --firstboot-command "xfs_growfs /"
-      {% if item.value.ip_address is defined %}
-      --firstboot {{ _static_ip_script }}
-      {% endif %}
       --root-password "password:{{ item.value.password | default('fooBar') }}"
       --ssh-inject {{ _admin_user }}:file:{{ ansible_user_dir }}/.ssh/authorized_keys
       --truncate /etc/machine-id

--- a/roles/libvirt_manager/templates/static_ip.j2
+++ b/roles/libvirt_manager/templates/static_ip.j2
@@ -2,9 +2,25 @@
 nmcli connection add connection.type 802-3-ethernet \
     connection.id eth0 \
     connection.interface-name eth0 \
+{% if _is_ipv6 %}
+    ipv6.method manual \
+    ipv6.addresses {{ _ip_address }}/{{ _ip_prefix }} \
+{% else %}
     ipv4.method manual \
-    ipv4.addresses {{ _ip_address }} \
+    ipv4.addresses {{ _ip_address }}/{{ _ip_prefix }} \
+{% endif %}
+{% if _ip_gw is defined             %}
+{%     if _is_ipv6                  %}
+    ipv6.gateway {{ _ip_gw }} \
+{%     else                         %}
     ipv4.gateway {{ _ip_gw }} \
+{%     endif                        %}
+{% endif                            %}
+{% if _ip_dns is defined            %}
+{%     if _is_ipv6                  %}
+    ipv6.dns {{ _ip_dns }}
+{%     else                         %}
     ipv4.dns {{ _ip_dns }}
-
+{%     endif                        %}
+{% endif                            %}
 nmcli connection up eth0


### PR DESCRIPTION
In this change set, we add support for static IP addressing for all VM types. Earlier there existed support only for controllers.

With newer requirements, we need to support for all types. Support is added by generating individual images for each VM instead of using a generic one for each type.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

*Unit testing*
25/05/ _Tasks snippets_
```
TASK [libvirt_manager : Include the static IP address configuration script. _raw_params=add_static_ip_script.yml] ****************************************************************************************************************************
Friday 24 May 2024  21:31:17 -0400 (0:00:03.616)       0:07:14.146 ************ 
included: /home/ciuser/src/ci-framework/roles/libvirt_manager/tasks/add_static_ip_script.yml for hypervisor

TASK [libvirt_manager : Generate the static address configuration script src=templates/static_ip.j2, dest={{
  (
    cifmw_libvirt_manager_ip_script_basedir,
    'static-ip-' ~ vm_type ~ '-' ~ vm_id ~ '.sh'
  ) | ansible.builtin.path_join
}}, owner={{ ansible_user_id }}, group={{ ansible_user_id }}, mode=0755] ***
Friday 24 May 2024  21:31:17 -0400 (0:00:00.053)       0:07:14.199 ************ 
changed: [hypervisor] => (item=ceph-0 )
changed: [hypervisor] => (item=ceph-1 )
changed: [hypervisor] => (item=ceph-2 )

TASK [libvirt_manager : Insert the static addressing script. creates={{ vm_data.value.image_local_dir }}/{{ _vm_img }}.log, _raw_params=set -o pipefail; virt-sysprep -a "{{ _workload }}/{{ _vm_img }}" --firstboot {{ _script }} --ssh-inject {{ _admin_user }}:file:{{ ansible_user_dir }}/.ssh/authorized_keys | tee -a {{ vm_data.value.image_local_dir }}/{{ _vm_img }}.log] ***
Friday 24 May 2024  21:31:33 -0400 (0:00:15.078)       0:07:29.277 ************ 
changed: [hypervisor] => (item=ceph-0 )
changed: [hypervisor] => (item=ceph-1 )
changed: [hypervisor] => (item=ceph-2 )
```

_ 25/5 Complete run_
```
NO MORE HOSTS LEFT ***************************************************************************************************************************************************************************************************************************

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
hypervisor                 : ok=365  changed=89   unreachable=0    failed=1    skipped=139  rescued=2    ignored=0   

Friday 24 May 2024  23:33:13 -0400 (0:48:45.383)       1:06:11.831 ************ 
=============================================================================== 
reproducer : Run deployment if instructed to --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2925.38s
reproducer : Bootstrap environment on controller-0 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 143.86s
reproducer : Install ansible dependencies -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 67.68s
reproducer : Install collections on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 39.07s
reproducer : Ensure rhos-release task is over ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 37.16s
reproducer : Ensure rhos-release task is over ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 37.01s
reproducer : Ensure rhos-release task is over ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 36.90s
networking_mapper : Gather the facts ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 32.71s
reproducer : Wait for OCP nodes to be ready ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 18.26s
reproducer : Sync local repositories to ansible controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 12.45s
networking_mapper : Save instaces refreshed facts for troubleshooting purposes ------------------------------------------------------------------------------------------------------------------------------------------------------- 12.29s
reproducer : Install dev tools from install_yamls on controller-0 -------------------------------------------------------------------------------------------------------------------------------------------------------------------- 12.10s
reproducer : Inject ProxyJump configuration for remote hypervisor VMs ---------------------------------------------------------------------------------------------------------------------------------------------------------------- 11.24s
libvirt_manager : Generate the static address configuration script -------------------------------------------------------------------------------------------------------------------------------------------------------------------- 9.59s
libvirt_manager : Grab IPs for nodes type ocp ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 9.40s
Gathering Facts ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 9.18s
openshift_adm : Ensure the nodes are in ready state. ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 9.10s
reproducer : Enable RHEL repos -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 8.00s
reproducer : Enable RHEL repos -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 7.80s
libvirt_manager : Extract UUIDs from all XMLs ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 7.73s
```

_Complete run_

```
PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
hypervisor                 : ok=465  changed=154  unreachable=0    failed=0    skipped=96   rescued=1    ignored=0   

Sunday 05 May 2024  07:22:18 -0400 (0:00:00.046)       0:22:24.006 ************ 
=============================================================================== 
reproducer : Bootstrap environment on controller-0 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 134.24s
libvirt_manager : Insert the static addressing script. ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 131.99s
reproducer : Install ansible dependencies -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 69.88s
reproducer : Check package install status -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 50.62s
reproducer : Install collections on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 39.89s
libvirt_manager : Prepare disk image with SSH and growing volume --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 39.23s
libvirt_manager : Grab IPs for nodes type ceph --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 28.81s
libvirt_manager : Insert the static addressing script. ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 27.15s
libvirt_manager : Grab IPs for nodes type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 26.34s
libvirt_manager : Wait for SSH on VMs type ocp --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 25.63s
libvirt_manager : Configure VMs type ceph -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 22.27s
devscripts : Login to the deployed OpenShift cluster. -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 19.85s
libvirt_manager : Wait for SSH on VMs type ceph -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.67s
reproducer : Wait for OCP nodes to be ready ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 17.93s
networking_mapper : Gather the facts ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.95s
libvirt_manager : Generate the static address configuration script ------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.00s
virtualbmc : Pull vbmc container image ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 11.58s
openshift_adm : Ensure the nodes are in ready state. ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 9.96s
reproducer : Inject ProxyJump configuration for remote hypervisor VMs ----------------------------------------------------------------------------------------------------------------------------------------------------------------- 9.54s
libvirt_manager : Download base image ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 9.14s
```

*HCI*
```
PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
hypervisor                 : ok=566  changed=213  unreachable=0    failed=0    skipped=122  rescued=3    ignored=0   

Wednesday 22 May 2024  08:29:47 -0400 (0:00:00.039)       0:59:45.903 ********* 
=============================================================================== 
devscripts : Deploy OpenShift cluster ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2184.24s
openshift_adm : Wait unit the OpenShift cluster is stable. -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 770.29s
openshift_adm : Wait until OCP login succeeds. --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 38.23s
libvirt_manager : Grab IPs for nodes type compute ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 35.49s
reproducer : Bootstrap environment on controller-0 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 34.80s
reproducer : Check package install status -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 31.93s
libvirt_manager : Grab IPs for nodes type ocp ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 26.78s
libvirt_manager : Grab IPs for nodes type controller --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 26.13s
reproducer : Install ansible dependencies -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 22.49s
openshift_adm : Initiate shutdown ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 18.60s
libvirt_manager : Prepare disk image with SSH and growing volume --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 17.21s
libvirt_manager : Wait for SSH on VMs type compute ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 17.01s
reproducer : Ensure rhos-release task is over ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.91s
libvirt_manager : Download base image ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 15.85s
libvirt_manager : Wait for SSH on VMs type ocp --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 15.58s
reproducer : Install collections on controller-0 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 14.00s
reproducer : Ensure rhos-release task is over ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 10.71s
reproducer : Ensure rhos-release task is over ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 10.69s
ci_setup : Install packages from EPEL ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 10.60s
reproducer : Enable RHEL repos ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 10.13s
```