### PR TITLE
Correct ci_gen_kustomize_values molecule

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -1,5 +1,9 @@
 ---
 - job:
+    name: cifmw-molecule-libvirt_manager
+    files:
+      - ^roles/reproducer/(?!meta|README).*
+- job:
     name: cifmw-molecule-openshift_login
     nodeset: centos-9-crc-2-30-0-xl
 - job:
@@ -21,6 +25,10 @@
 - job:
     name: cifmw-molecule-os_must_gather
     parent: cifmw-molecule-base-crc
+- job:
+    name: cifmw-molecule-ci_gen_kustomize_values
+    required-projects:
+      - openstack-k8s-operators/architecture
 - job:
     name: cifmw-molecule-ci_multus
     parent: cifmw-molecule-base-crc
@@ -44,12 +52,28 @@
     name: cifmw-molecule-reproducer
     nodeset: centos-9-crc-2-30-0-xxl
     timeout: 5400
+    files:
+      - ^roles/libvirt_manager/(?!meta|README).*
 - job:
     name: cifmw-molecule-cert_manager
     nodeset: centos-9-crc-2-30-0-xxl
 - job:
     name: cifmw-molecule-env_op_images
     nodeset: centos-9-crc-2-30-0-xl
+- job:
+    name: cifmw_molecule-pkg_build
+    files:
+      - ^roles/build_openstack_packages/(?!meta|README).*
+- job:
+    name: cifmw_molecule-build_containers
+    files:
+      - ^roles/build_openstack_packages/(?!meta|README).*
+      - ^roles/repo_setup/(?!meta|README).*
+- job:
+    name: cifmw-molecule-build_openstack_packages
+    files:
+      - ^roles/pkg_build/(?!meta|README).
+      - ^roles/repo_setup/(?!meta|README).*
 - job:
     name: cifmw-molecule-manage_secrets
     nodeset: centos-9-crc-2-30-0-xl

--- a/roles/ci_gen_kustomize_values/molecule/default/converge.yml
+++ b/roles/ci_gen_kustomize_values/molecule/default/converge.yml
@@ -31,7 +31,7 @@
       - name: 'ctlplane'
         path: 'examples/va/hci/control-plane/nncp'
       - name: 'dataplane'
-        path: 'examples/va/hci/edpm-pre-ceph'
+        path: 'examples/va/hci/edpm-pre-ceph/nodeset'
   tasks:
     - name: Ensure architecture repository is building
       ansible.builtin.shell:
@@ -90,13 +90,13 @@
       ansible.builtin.include_role:
         name: ci_gen_kustomize_values
 
-    - name: Generate edpm-values
+    - name: Generate edpm-nodeset-values
       vars:
-        cifmw_ci_gen_kustomize_values_name: "edpm-values"
+        cifmw_ci_gen_kustomize_values_name: "edpm-nodeset-values"
         cifmw_ci_gen_kustomize_values_src_file: >-
           {{
             [architecture_repo,
-             "examples/va/hci/edpm-pre-ceph/values.yaml"] | path_join
+             "examples/va/hci/edpm-pre-ceph/nodeset/values.yaml"] | path_join
           }}
       ansible.builtin.include_role:
         name: ci_gen_kustomize_values
@@ -114,7 +114,7 @@
              path_join }}
       loop:
         - network-values
-        - edpm-values
+        - edpm-nodeset-values
 
     - name: Assert generated values.yaml exists
       ansible.builtin.assert:
@@ -126,7 +126,7 @@
 
     - name: Ensure we do not case MAC anymore
       vars:
-        _val_file: "{{ artifacts }}/ci_gen_kustomize_values/edpm-values/values.yaml"
+        _val_file: "{{ artifacts }}/ci_gen_kustomize_values/edpm-nodeset-values/values.yaml"
         _edpm_val: "{{ lookup('file', _val_file) | from_yaml }}"
       ansible.builtin.assert:
         that:
@@ -142,8 +142,8 @@
       loop:
         - key: 'network-values'
           value: 'examples/va/hci/control-plane/nncp/values.yaml'
-        - key: 'edpm-values'
-          value: 'examples/va/hci/edpm-pre-ceph/values.yaml'
+        - key: 'edpm-nodeset-values'
+          value: 'examples/va/hci/edpm-pre-ceph/nodeset/values.yaml'
 
     - name: Ensure kustomize is able to build
       ansible.builtin.shell:

--- a/roles/ci_gen_kustomize_values/molecule/default/prepare.yml
+++ b/roles/ci_gen_kustomize_values/molecule/default/prepare.yml
@@ -52,11 +52,6 @@
           }}
         type: "ecdsa"
 
-    - name: Fetch architecture repository
-      ansible.builtin.git:  # noqa: latest[git]
-        repo: "https://github.com/openstack-k8s-operators/architecture"
-        dest: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/architecture"
-
 - name: Download tools for later testing and validations
   ansible.builtin.import_playbook: >-
     {{ ('/home/zuul/src/github.com/openstack-k8s-operators',

--- a/scripts/create_role_molecule.py
+++ b/scripts/create_role_molecule.py
@@ -136,7 +136,17 @@ def merge_yaml_jobs_by_name(job_list1, job_list2):
     for job1 in job_list1:
         for job2 in job_list2:
             if job1["job"]["name"] == job2["job"]["name"]:
-                job1["job"].update(job2["job"])
+                for key, val in job2["job"].items():
+                    if isinstance(val, list):
+                        if key not in job1["job"]:
+                            job1["job"][key] = []
+                        job1["job"][key] += job2["job"][key]
+                    if isinstance(val, dict):
+                        if key not in job1["job"]:
+                            job1["job"][key] = {}
+                        job1["job"][key].update(job2["job"][key])
+                    if isinstance(val, str) or isinstance(val, int):
+                        job1["job"][key] = job2["job"][key]
 
     return job_list1
 

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -27,6 +27,8 @@
     - ^roles/build_openstack_packages/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
+    - ^roles/pkg_build/(?!meta|README).
+    - ^roles/repo_setup/(?!meta|README).*
     name: cifmw-molecule-build_openstack_packages
     parent: cifmw-molecule-base
     vars:
@@ -52,6 +54,8 @@
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_gen_kustomize_values
     parent: cifmw-molecule-base
+    required-projects:
+    - openstack-k8s-operators/architecture
     vars:
       TEST_RUN: ci_gen_kustomize_values
 - job:
@@ -419,6 +423,7 @@
     - ^roles/libvirt_manager/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
+    - ^roles/reproducer/(?!meta|README).*
     name: cifmw-molecule-libvirt_manager
     parent: cifmw-molecule-base
     vars:
@@ -591,6 +596,7 @@
     - ^roles/reproducer/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
+    - ^roles/libvirt_manager/(?!meta|README).*
     name: cifmw-molecule-reproducer
     nodeset: centos-9-crc-2-30-0-xxl
     parent: cifmw-molecule-base


### PR DESCRIPTION
#### Correct ci_gen_kustomize_values molecule
Following the split dataplane, molecule was crashing. A follow-up patch
should add proper dependencies to the job, among other needed links to
ensure project consistency.

#### Better test coverage

Some roles are co-dependent, and some may require external resources in
order to ensure we get proper depends-on capability.

This change enables multiple things:
- ensure some molecule jobs are triggered cross-role
- ensure ci_gen_kustomize_values supports depends-on architecture
  repository
- modify the create_role_molecule.py script to support those new needs

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
