### PR TITLE
Drop nncp ctlplane routes

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/common/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/common/network-values/values.yaml.j2
@@ -113,10 +113,7 @@ data:
 {% endfor %}
 
   routes:
-    config:
-      - destination: 0.0.0.0/0
-        next-hop-address: {{ cifmw_networking_env_definition.networks.ctlplane.gw_v4 }}
-        next-hop-interface: {{ ns.interfaces['ctlplane'] }}
+    config: []
 
 # Hardcoding the last IP bit since we don't have support for endpoint_annotations in the networking_mapper output
   rabbitmq:

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/network-values/values.yaml.j2
@@ -113,10 +113,7 @@ data:
 {% endfor %}
 
   routes:
-    config:
-      - destination: {{ cifmw_networking_env_definition.networks.ctlplane.network_v4 }}
-        next-hop-address: {{ cifmw_networking_env_definition.networks.ctlplane.gw_v4 }}
-        next-hop-interface: {{ ns.interfaces['ctlplane'] }}
+    config: []
 
 # Hardcoding the last IP bit since we don't have support for endpoint_annotations in the networking_mapper output
   rabbitmq:


### PR DESCRIPTION
These ctlplane routes were originally added as part of [1], and since then they required various adjustment due to one or the other issues. It was pointed out these routes shouldn't be needed for the use case it was originally added for, so let's drop these ctlplane routes. It would still be possible to add some custom host routes by passing config like in values.yaml:-

routes:
  config:
    - destination: <destination>
      next-hop-address: <gateway>
      next-hop-interface: <interface/bridge>

[1] openstack-k8s-operators/install_yamls#481

Related-Issue: [OSPRH-6307](https://issues.redhat.com//browse/OSPRH-6307)
Depends-On: https://github.com/openstack-k8s-operators/architecture/pull/208

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
