### PR TITLE
Tweak to cifmw_job_uri regex for downstream

### DIFF
--- a/roles/reproducer/molecule/job_uri/converge.yml
+++ b/roles/reproducer/molecule/job_uri/converge.yml
@@ -24,6 +24,10 @@
         string: https://logserver.rdoproject.org/94/1494/1f72e2797961e0fb0192e3280c3027a8d70b4e45/github-check/cifmw-molecule-libvirt_manager/d0304e7/anything/////
       - pass: true
         string: https://logserver.rdoproject.org/94/1494/1f72e2797961e0fb0192e3280c3027a8d70b4e45/github-check/cifmw-molecule-libvirt_manager/d0304e7
+      - pass: true
+        string: https://logserver.rdoproject.abc2.org/94/1494/1f72e2797961e0fb0192e3280c3027a8d70b4e45/github-check/cifmw-molecule-libvirt_manager/d0304e7
+      - pass: true
+        string: https://sf.hosted.hostanme.abc2.host.com/logs/pipeline-name-version2/repo.source.com/tripleo-ci/master/job-name-edpm-deployment-rhel9-osp18-crc-job-reproducer/f697f35
       - pass: false
         string: https://logserver.rdoproject.org/94/1494/1f72e2797961e0fb0192e3280c3027a8d70b4e45/github-check/cifmw-molecule-libvirt_manager/d030
       - pass: false

--- a/roles/reproducer/tasks/parse_cifmw_job_uri.yml
+++ b/roles/reproducer/tasks/parse_cifmw_job_uri.yml
@@ -1,7 +1,7 @@
 ---
 - name: Parse cifmw_job_uri
   vars:
-    regex_pattern: "^https://[a-zA-Z\\.]+(?=\\w{3}(?:/|$))\\w{3}/.*/.*/.*/.*[a-f0-9]{7}"
+    regex_pattern: "^https://[a-zA-Z0-9\\.]+(?=\\w{3}(?:/|$))\\w{3}/.*/.*/.*/.*[a-f0-9]{7}"
   block:
     - name: Apply regex match filter
       ansible.builtin.set_fact:


### PR DESCRIPTION
Downstream logserver contains a digit in the hostname, which fails the
current regex validation. This change adds a small tweak so d/s uris are
valid and adds two test cases to avoid regressions.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Tested downstream 
