### PR TITLE
Remove cacheable: true from ci_data.yml

### DIFF
--- a/roles/reproducer/tasks/ci_data.yml
+++ b/roles/reproducer/tasks/ci_data.yml
@@ -40,7 +40,6 @@
 
     - name: Update layout
       ansible.builtin.set_fact:
-        cacheable: true
         is_molecule: "{{ _is_molecule.status == 200 }}"
         cifmw_libvirt_manager_configuration_gen: >-
           {{


### PR DESCRIPTION
Follow up from https://github.com/openstack-k8s-operators/ci-framework/pull/1499#discussion_r1584333119

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running