### PR TITLE
[VA] Deploy a single SSH key for the dataplane

### DIFF
--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -84,7 +84,7 @@
               }}
           ansible.builtin.set_fact:
             cifmw_ci_gen_kustomize_values_ssh_authorizedkeys: >-
-              {{ lookup('file', '~/.ssh/authorized_keys', rstrip=False) }}
+              {{ lookup('file', '~/.ssh/id_cifw.pub', rstrip=False) }}
             cifmw_ci_gen_kustomize_values_ssh_private_key: >-
               {{ lookup('file', '~/.ssh/id_cifw', rstrip=False) }}
             cifmw_ci_gen_kustomize_values_ssh_public_key: >-


### PR DESCRIPTION
It seems that the dataplane-operator/baremetal operator is/are having issues building the authorized_keys content of the cloud-init configuration, making BM instances cloud-init to fail when booting.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
