### PR TITLE
Move ansi2txt from molecule requirements to common

### DIFF
--- a/common-requirements.txt
+++ b/common-requirements.txt
@@ -4,6 +4,7 @@ kubernetes
 kubernetes-validate
 openstacksdk
 jsonschema>=4.20.0
+ansi2txt
 
 # Allows to unpin cryptography
 pyOpenSSL>=22.1.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -22,6 +22,3 @@ pre-commit # MIT
 yamllint
 pyspelling
 mkdocs-pymdownx-material-extras
-
-# Common requirements
-ansi2txt


### PR DESCRIPTION
`ansi2txt` is required as of #1570 however the requirement was added to `test-requirements.txt` which only gets called for Molecule jobs. This patch adds the requirement to `common-requirements.txt` which is called in both scenarios.

This has broken `make run_ctx_pre_commit` for example.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running