### PR TITLE
Include hooks in "reproducer-vars.yml" on controller-0

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -342,7 +342,7 @@
             hostvars[inventory_hostname] | default({}) |
             dict2items |
             selectattr('key', 'match',
-                       '^cifmw_(?!install_yamls|openshift|devscripts).*') |
+                       '^(pre|post|cifmw)_(?!install_yamls|openshift|devscripts).*') |
             rejectattr('key', 'equalto', 'cifmw_target_host') |
             rejectattr('key', 'equalto', 'cifmw_basedir') |
             rejectattr('key', 'equalto', 'cifmw_path') |


### PR DESCRIPTION
There isn't any reason not to include the hooks in the generated values:
- reproducer doesn't run any hooks
- we therefore won't risk any collision

While users may leverage the `cifmw_reproducer_play_extravars` parameter
to inject additional files in the nested deployment, it would make
things easier/better/cleaner to just pass hooks down in the deployment,
in a transparent way.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
