### PR TITLE
Split dataplane deployment in edpm_deploy role

### DIFF
--- a/roles/edpm_deploy/README.md
+++ b/roles/edpm_deploy/README.md
@@ -15,6 +15,7 @@ None
 * `cifmw_edpm_deploy_dryrun`: (Boolean) Do a dry run on make edpm_deploy command. Defaults to `False`.
 * `cifmw_edpm_deploy_timeout`: (Integer) Time, in minutes to wait for the deployment to be ready. Defaults to `40`.
 * `cifmw_edpm_deploy_nova_compute_extra_config`: (String) Oslo config snippet defining extra configuration for the nova-compute services. Defaults to an empty string.
+* `cifmw_edpm_deploy_step2_kind`: (String) Define the resources that should be applied only in a second step during the EDPM deployment. Defaults to `"OpenStackDataPlaneDeployment"`.
 
 ## TODO
 - Add support for deploying multiple compute node

--- a/roles/edpm_deploy/defaults/main.yml
+++ b/roles/edpm_deploy/defaults/main.yml
@@ -30,3 +30,5 @@ cifmw_edpm_deploy_timeout: 60
 cifmw_edpm_deploy_registry_url: "{{ cifmw_install_yamls_defaults['DATAPLANE_REGISTRY_URL'] }}"
 cifmw_edpm_deploy_prepare_run: true
 cifmw_edpm_deploy_nova_compute_extra_config: ""
+# Defines the kind of resources that should be applied only in step 2 of the EDPM deployment
+cifmw_edpm_deploy_step2_kind: "OpenStackDataPlaneDeployment"

--- a/roles/edpm_deploy/tasks/main.yml
+++ b/roles/edpm_deploy/tasks/main.yml
@@ -136,13 +136,15 @@
       ansible.builtin.debug:
         var: cifmw_edpm_deploy_crs_kustomize_result
 
-    - name: Apply the OpenStackDataPlaneNodeSet CR
-      when: not cifmw_edpm_deploy_dryrun
-      cifmw.general.ci_script:
-        output_dir: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
-        script: "oc apply -f {{ cifmw_edpm_deploy_crs_kustomize_result.output_path }}"
+    - name: Apply dataplane resources but ignore DataPlaneDeployment
+      kubernetes.core.k8s:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig  }}"
+        api_key: "{{ cifmw_openshift_token | default(omit) }}"
+        context: "{{ cifmw_openshift_context | default(omit) }}"
+        state: present
+        definition: "{{ lookup('file', cifmw_edpm_deploy_crs_kustomize_result.output_path) | from_yaml_all | rejectattr('kind', 'search', cifmw_edpm_deploy_step2_kind) }}"
 
-    - name: Wait for OpenStackDataPlaneNodeSet to be deployed
+    - name: Wait for OpenStackDataPlaneNodeSet become SetupReady
       when: not cifmw_edpm_deploy_dryrun
       vars:
         cr_name: >-
@@ -162,7 +164,38 @@
         cmd: >-
           oc wait OpenStackDataPlaneNodeSet {{ cr_name }}
           --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
-          --for=condition=ready
+          --for=condition=SetupReady
+          --timeout={{ cifmw_edpm_deploy_timeout }}m
+
+    - name: Apply DataPlaneDeployment resource
+      kubernetes.core.k8s:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig  }}"
+        api_key: "{{ cifmw_openshift_token | default(omit) }}"
+        context: "{{ cifmw_openshift_context | default(omit) }}"
+        state: present
+        definition: "{{ lookup('file', cifmw_edpm_deploy_crs_kustomize_result.output_path) | from_yaml_all | selectattr('kind', 'search', cifmw_edpm_deploy_step2_kind) }}"
+
+    - name: Wait for OpenStackDataPlaneDeployment become Ready
+      when: not cifmw_edpm_deploy_dryrun
+      vars:
+        cr_name: >-
+          {{
+            (
+              cifmw_edpm_deploy_crs_kustomize_result.result |
+              selectattr('kind', 'defined') |
+              selectattr('metadata.name', 'defined') |
+              selectattr('kind', 'equalto', 'OpenStackDataPlaneDeployment') |
+              first
+            ).metadata.name
+          }}
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.command:
+        cmd: >-
+          oc wait OpenStackDataPlaneDeployment {{ cr_name }}
+          --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+          --for=condition=Ready
           --timeout={{ cifmw_edpm_deploy_timeout }}m
 
 - name: Run nova-manage discover_hosts to ensure compute nodes are mapped


### PR DESCRIPTION
OpenStackDataPlaneDeployment and OpenStackDataPlaneNodeSet need to be deployed in different phases, since one depends on the other now. This PR tries to split the deployment in two steps, ignoring a specific kind of resource.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
