### PR TITLE
[NFV] Remove hardcoded zuul edpm user

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/edpm-nodeset-values/values.yaml.j2
@@ -20,7 +20,6 @@ data:
         public: {{ cifmw_ci_gen_kustomize_values_migration_pub_key | b64encode }}
   nodeset:
     ansible:
-      ansibleUser: "zuul"
       ansibleVars:
         edpm_fips_mode: "{{ 'enabled' if cifmw_fips_enabled|default(false)|bool else 'check' }}"
         timesync_ntp_servers:

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk/edpm-nodeset-values/values.yaml.j2
@@ -20,7 +20,6 @@ data:
         public: {{ cifmw_ci_gen_kustomize_values_migration_pub_key | b64encode }}
   nodeset:
     ansible:
-      ansibleUser: "zuul"
       ansibleVars:
         edpm_fips_mode: "{{ 'enabled' if cifmw_fips_enabled|default(false)|bool else 'check' }}"
         timesync_ntp_servers:

--- a/roles/ci_gen_kustomize_values/templates/sriov/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/sriov/edpm-nodeset-values/values.yaml.j2
@@ -20,7 +20,6 @@ data:
         public: {{ cifmw_ci_gen_kustomize_values_migration_pub_key | b64encode }}
   nodeset:
     ansible:
-      ansibleUser: "zuul"
       ansibleVars:
         edpm_fips_mode: "{{ 'enabled' if cifmw_fips_enabled|default(false)|bool else 'check' }}"
         timesync_ntp_servers:


### PR DESCRIPTION
In NFV deployments, where BM nodes are used, we do not handle the deployed image, so we cannot warranty the user to be used. To avoid handling what we don't know, let the VA set the value and let the user modify it if he/she changes the deployed image.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
