### PR TITLE
[run_hook] Allow passing namespace if needed in CR hooks

### DIFF
--- a/roles/run_hook/tasks/cr.yml
+++ b/roles/run_hook/tasks/cr.yml
@@ -41,6 +41,7 @@
     name: "{{ hook.resource_name | default(omit) }}"
     src: "{{ crd_path | default(omit) }}"
     state: "{{ hook.state | default('present') }}"
+    namespace: "{{ hook.namespace | default(omit) }}"
     validate:
       fail_on_error: true
     wait: true


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
