### PR TITLE
Remove the now gone NNCP VA routes

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/network-values/values.yaml.j2
@@ -112,12 +112,6 @@ data:
           - {{ nameserver }}
 {% endfor %}
 
-  routes:
-    config:
-      - destination: {{ cifmw_networking_env_definition.networks.ctlplane.network_v4 }}
-        next-hop-address: {{ cifmw_networking_env_definition.networks.ctlplane.gw_v4 }}
-        next-hop-interface: {{ ns.interfaces['ctlplane'] }}
-
 # Hardcoding the last IP bit since we don't have support for endpoint_annotations in the networking_mapper output
   rabbitmq:
     endpoint_annotations:


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
