### PR TITLE
Replace use of domifaddr with ip neighbour - v2

### DIFF
--- a/roles/libvirt_manager/molecule/deploy_ipv6_layout/cleanup.yml
+++ b/roles/libvirt_manager/molecule/deploy_ipv6_layout/cleanup.yml
@@ -1,0 +1,116 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Cleanup
+  hosts: instance
+  gather_facts: true
+  vars:
+    log_dir: "{{ ansible_user_dir }}/ci-framework-data/logs"
+    cifmw_basedir: "/opt/basedir"
+    bridges:
+      ocpbm:
+        address: "fd00:abcd:aaaa::1"
+        prefix: "64"
+        dhcp_start: "fd00:abcd:aaaa::000a"
+        dhcp_end: "fd00:abcd:aaaa::aaaa"
+      osp_trunk:
+        address: "fd00:abcd:bbbb::1"
+        prefix: "64"
+        dhcp_start: "fd00:abcd:bbbb::000a"
+        dhcp_end: "fd00:abcd:bbbb::aaaa"
+  tasks:
+    - name: Get logs
+      block:
+        - name: Ensure directories
+          ansible.builtin.file:
+            path: "{{ log_dir }}"
+            state: directory
+            owner: zuul
+            group: zuul
+            mode: "0755"
+        - name: Get dnsmasq logs
+          become: true
+          register: dnsmasq_logs
+          ansible.builtin.command: "journalctl -u {{ item.key }}-dnsmasq.service --no-pager"
+          loop: "{{ bridges | dict2items }}"
+        - name: Write dnsmasq_logs to file
+          ansible.builtin.copy:
+            dest: "{{ log_dir }}/{{ item.item.key }}-dnsmasq.service.log"
+            content: "{{ item.stdout }}"
+            owner: zuul
+            group: zuul
+            mode: '0644'
+          loop: "{{ dnsmasq_logs.results }}"
+        - name: Stat /var/log/libvirt/qemu
+          become: true
+          register: stat_var_log_libvirt_qemu
+          ansible.builtin.stat:
+            path: /var/log/libvirt/qemu
+        - name: Get VM console and serial logs /var/log/libvirt/qemu
+          when: stat_var_log_libvirt_qemu.stat.isdir is defined and stat_var_log_libvirt_qemu.stat.isdir
+          become: true
+          ansible.builtin.copy:
+            src: /var/log/libvirt/qemu
+            dest: "{{ log_dir }}/"
+            owner: zuul
+            group: zuul
+            mode: '0644'
+        - name: Change ownership
+          become: true
+          ansible.builtin.file:
+            path: "{{ log_dir }}"
+            state: directory
+            recurse: true
+            owner: zuul
+            group: zuul
+
+    - name: Clean layout
+      ansible.builtin.import_role:
+        name: libvirt_manager
+        tasks_from: clean_layout.yml
+
+    - name: Stop dnsmasq services
+      become: true
+      ansible.builtin.systemd_service:
+        state: stopped
+        name: "{{ item.key }}-dnsmasq.service"
+      loop: "{{ bridges | dict2items }}"
+
+    - name: Delete dnsmasq systemd unit files
+      become: true
+      ansible.builtin.file:
+        path: "/etc/systemd/system/{{ item.key }}-dnsmasq.service"
+        state: absent
+      loop: "{{ bridges | dict2items }}"
+
+    - name: Reload systemd daemon
+      become: true
+      ansible.builtin.systemd_service:
+        daemon_reload: true
+
+    - name: Bring down bridges
+      become: true
+      ansible.builtin.shell: |
+        nmcli con down {{ item.key }}
+        nmcli con delete {{ item.key }}
+      loop: "{{ bridges | dict2items }}"
+
+    - name: Delete bridge nmconnection files
+      become: true
+      ansible.builtin.file:
+        path: "/etc/NetworkManager/system-connections/{{ item.key }}.nmconnection"
+        state: absent
+      loop: "{{ bridges | dict2items }}"

--- a/roles/libvirt_manager/molecule/deploy_ipv6_layout/converge.yml
+++ b/roles/libvirt_manager/molecule/deploy_ipv6_layout/converge.yml
@@ -1,0 +1,134 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: "One hypervisor - hybrid, pre-created bridges"
+  hosts: instance
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_basedir: "/opt/basedir"
+    cifmw_libvirt_manager_fixed_networks:
+      - osp_trunk
+    cifmw_libvirt_manager_pub_net: ocpbm
+    cifmw_libvirt_manager_configuration:
+      vms:
+        compute:
+          amount: 2
+          image_url: "{{ cifmw_discovered_image_url }}"
+          sha256_image_name: "{{ cifmw_discovered_hash }}"
+          image_local_dir: "{{ cifmw_basedir }}/images/"
+          disk_file_name: "centos-stream-9.qcow2"
+          disksize: 20
+          memory: 1
+          cpus: 1
+          nets:
+            - ocpbm
+            - osp_trunk
+      networks:
+        ocpbm: |
+          <network>
+            <name>ocpbm</name>
+            <forward mode='bridge' />
+            <bridge name='ocpbm' />
+          </network>
+        osp_trunk: |
+          <network>
+            <name>osp_trunk</name>
+            <forward mode='bridge' />
+            <bridge name='osp_trunk' />
+          </network>
+    bridges:
+      ocpbm:
+        address: "fd00:abcd:aaaa::1"
+        prefix: "64"
+        dhcp_start: "fd00:abcd:aaaa::000a"
+        dhcp_end: "fd00:abcd:aaaa::aaaa"
+      osp_trunk:
+        address: "fd00:abcd:bbbb::1"
+        prefix: "64"
+        dhcp_start: "fd00:abcd:bbbb::000a"
+        dhcp_end: "fd00:abcd:bbbb::aaaa"
+  pre_tasks:
+    - name: Create NetworkManager connection files
+      become: true
+      ansible.builtin.copy:
+        dest: "/etc/NetworkManager/system-connections/{{ item.key }}.nmconnection"
+        content: |
+          [connection]
+          id={{ item.key }}
+          type=bridge
+          interface-name={{ item.key }}
+          autoconnect=true
+
+          [bridge]
+          stp=false
+
+          [ipv4]
+          method=disabled
+
+          [ipv6]
+          addr-gen-mode=stable-privacy
+          method=manual
+          address1={{ item.value.address }}/{{ item.value.prefix }}
+        owner: root
+        group: root
+        mode: '0600'
+      loop: "{{ bridges | dict2items }}"
+
+    - name: Load and bring up NetworkManager connections
+      become: true
+      ansible.builtin.shell: |
+        nmcli con load /etc/NetworkManager/system-connections/{{ item.key }}.nmconnection
+        nmcli con up {{ item.key }}
+      loop: "{{ bridges | dict2items }}"
+
+    - name: Create dnsmasq services for bridges
+      become: true
+      ansible.builtin.copy:
+        dest: "/etc/systemd/system/{{ item.key }}-dnsmasq.service"
+        content: |
+           [Unit]
+           Description=DHCP service for {{ item.key }} bridge
+           Documentation=man:dnsmasq(8)
+           Wants=network-online.target
+           After=network-online.target
+
+           [Service]
+           Type=simple
+           ExecStart=/usr/sbin/dnsmasq --keep-in-foreground --pid-file=/run/{{ item.key }}-dnsmasq.pid --except-interface=lo --interface={{ item.key }} --enable-ra --dhcp-range={{ item.value.dhcp_start}},{{ item.value.dhcp_end}},64,2m
+           StandardError=null
+           PIDFile=/run/{{ item.key }}-dnsmasq.pid
+
+           [Install]
+           WantedBy=multi-user.target
+        owner: root
+        group: root
+        mode: '0644'
+      loop: "{{ bridges | dict2items }}"
+
+    - name: Reload systemd daemon and start dnsmasq DHCP services
+      become: true
+      ansible.builtin.systemd_service:
+        daemon_reload: true
+        state: started
+        name: "{{ item.key }}-dnsmasq.service"
+      loop: "{{ bridges | dict2items }}"
+  roles:
+    - role: "discover_latest_image"
+  tasks:
+    - name: Deploy layout
+      ansible.builtin.import_role:
+        name: libvirt_manager
+        tasks_from: deploy_layout

--- a/roles/libvirt_manager/molecule/deploy_ipv6_layout/molecule.yml
+++ b/roles/libvirt_manager/molecule/deploy_ipv6_layout/molecule.yml
@@ -1,0 +1,6 @@
+---
+log: true
+
+provisioner:
+  name: ansible
+  log: true

--- a/roles/libvirt_manager/molecule/deploy_ipv6_layout/prepare.yml
+++ b/roles/libvirt_manager/molecule/deploy_ipv6_layout/prepare.yml
@@ -1,0 +1,34 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: instance
+  vars:
+    cifmw_basedir: "/opt/basedir"
+  pre_tasks:
+    - name: Create custom basedir
+      become: true
+      ansible.builtin.file:
+        path: "{{ cifmw_basedir }}"
+        state: directory
+        owner: zuul
+        group: zuul
+        mode: "0755"
+  roles:
+    - role: "test_deps"
+    - role: "ci_setup"
+    - role: "libvirt_manager"

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -195,6 +195,38 @@
   community.libvirt.virt_net:
     command: "list_nets"
 
+- name: Get libvirt networks facts
+  community.libvirt.virt_net:
+    command: "facts"
+
+- name: Get libvirt networks ip addr show
+  when: 'item.value.state == "active"'
+  register: _virt_nets_ip_addr_show
+  ansible.builtin.command: ip -json addr show {{ item.value.bridge }}
+  loop: "{{ ansible_libvirt_networks | dict2items }}"
+
+- name: Format the libvirt networks ip addr show
+  ansible.builtin.set_fact:
+    virt_nets_addr_info: >-
+      {{
+        virt_nets_addr_info | default({}) |
+        combine(
+          {
+            net.item.key: (net.stdout | from_json | first).addr_info
+            | community.general.json_query(
+                "[?scope=='global'].{
+                    address: local,
+                    prefixlen: prefixlen,
+                    family: family
+                  }"
+              )
+          }
+        )
+      }}
+  loop: "{{ _virt_nets_ip_addr_show.results }}"
+  loop_control:
+    loop_var: net
+
 - name: Gather pool fact
   when:
     - ansible_libvirt_pools is undefined

--- a/roles/libvirt_manager/tasks/start_manage_vms.yml
+++ b/roles/libvirt_manager/tasks/start_manage_vms.yml
@@ -25,23 +25,28 @@
 
 - name: "Grab IPs for nodes type {{ vm_type }}"  # noqa: risky-shell-pipe
   register: vm_ips
-  ansible.builtin.shell:
-    cmd: >-
-      virsh -c qemu:///system -q
-      domifaddr --source arp
-      cifmw-{{ nic.host }} | grep "{{ nic.mac }}"
+  vars:
+    jq_filter: >-
+      '.[]
+      | select(has("lladdr") and has("dst") and .lladdr == "{{ nic.mac }}")
       {% if cifmw_openshift_api_ip_address | default(false) %}
-      | grep -v "{{ cifmw_openshift_api_ip_address }}/"
+      | select(.dst != "{{ cifmw_openshift_api_ip_address }}")
       {% endif %}
       {% if cifmw_openshift_ingress_ip_address | default(false) %}
-      | grep -v "{{ cifmw_openshift_ingress_ip_address }}/"
+      | select(.dst != "{{ cifmw_openshift_ingress_ip_address }}")
       {% endif %}
+      | .dst'
+    net_ip_addr: >-
+      {{ virt_nets_addr_info[nic.network][0]["address"] }}/{{ virt_nets_addr_info[nic.network][0]["prefixlen"] }}
+  ansible.builtin.shell:
+    cmd: >-
+      ip -json neighbour show dev {{ nic.network }} to {{ net_ip_addr }} | jq -r {{ jq_filter }}
   loop: "{{ public_net_nics }}"
   loop_control:
     loop_var: nic
     label: "{{ nic.host }}"
   retries: 20
-  delay: 5
+  delay: 10
   until:
     - vm_ips.rc == 0
     - vm_ips.stdout != ''
@@ -56,7 +61,7 @@
 
 - name: "Add the IP to the libvirt host port details fact for {{ vm_type }}"
   vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
+    extracted_ip: "{{ vm_ip.stdout | ansible.utils.ipaddr('address') }}"
   ansible.builtin.set_fact:
     cifmw_hosts_ports: >-
       {{
@@ -80,7 +85,7 @@
     - _need_start | bool
   delegate_to: localhost
   vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
+    extracted_ip: "{{ vm_ip.stdout | ansible.utils.ipaddr('address') }}"
     proxy_hostname: "{{ ansible_host | default(inventory_hostname) }}"
   ansible.builtin.blockinfile:
     create: true
@@ -103,7 +108,7 @@
   when:
     - _need_start | bool
   vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
+    extracted_ip: "{{ vm_ip.stdout | ansible.utils.ipaddr('address') }}"
     identity_file: >-
       {{
         cifmw_libvirt_manager_basedir ~ '/artifacts/cifmw_ocp_access_key' if vm_type == 'ocp' else
@@ -130,7 +135,7 @@
 - name: Inject nodes in the ansible inventory
   delegate_to: localhost
   vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
+    extracted_ip: "{{ vm_ip.stdout | ansible.utils.ipaddr('address') }}"
   ansible.builtin.add_host:
     name: "{{ vm_ip.nic.host }}"
     groups: "{{ (vm_type == 'crc') | ternary('ocp', vm_type) }}s"
@@ -153,7 +158,7 @@
   when:
     - _need_start | bool
   vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
+    extracted_ip: "{{ vm_ip.stdout | ansible.utils.ipaddr('address') }}"
   ansible.builtin.wait_for:
     host: "{{ extracted_ip }}"
     port: 22
@@ -246,7 +251,7 @@
 - name: Update inventory to consume correct user
   delegate_to: localhost
   vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
+    extracted_ip: "{{ vm_ip.stdout | ansible.utils.ipaddr('address') }}"
   ansible.builtin.add_host:
     name: "{{ vm_ip.nic.host }}"
     groups: "{{ (vm_type == 'crc') | ternary('ocp', vm_type) }}s"

--- a/roles/libvirt_manager/templates/inventory.yml.j2
+++ b/roles/libvirt_manager/templates/inventory.yml.j2
@@ -2,7 +2,7 @@
   hosts:
 {% for host in hosts %}
     {{ host.nic.host }}:
-      ansible_host: {{ (host.stdout.split())[3] | ansible.utils.ipaddr('address') }}
+      ansible_host: {{ host.stdout | ansible.utils.ipaddr('address') }}
       ansible_user: {{ admin_user }}
 {% if vm_type is match('^crc.*') %}
       ansible_ssh_private_key_file: ~/.ssh/crc_key


### PR DESCRIPTION
virsh domifaddr does not work with IPv6, replace the usage and instead use the ip neighbour command to get VM ip's.

This change s roles/libvirt_manager/tasks/start_manage_vms.yml only, there is also use of domifaddr in
roles/libvirt_manager/tasks/deploy_edpm_compute.yml.

Let's look at that in a follow up.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
