### PR TITLE
Remove yq dependency from validation

### DIFF
--- a/roles/validations/tasks/edpm/hugepages_and_reboot.yml
+++ b/roles/validations/tasks/edpm/hugepages_and_reboot.yml
@@ -33,7 +33,7 @@
   cifmw.general.ci_script:
     output_dir: "{{ cifmw_validations_basedir }}/artifacts"
     script: >-
-      set -o pipefail && oc get -n {{ cifmw_validations_namespace }} osdpns "{{ deployed_nodeset_name.stdout }}" -o yaml | yq .status.configHash
+      set -o pipefail && oc get -n {{ cifmw_validations_namespace }} osdpns "{{ deployed_nodeset_name.stdout | trim }}" -o jsonpath='{.status.configHash}'
   register: initial_config_hash
 
 - name: Update hugepages value
@@ -43,7 +43,7 @@
   cifmw.general.ci_script:
     output_dir: "{{ cifmw_validations_basedir }}/artifacts"
     script: >-
-      oc patch -n {{ cifmw_validations_namespace }} osdpns/"{{ deployed_nodeset_name.stdout }}" --type=merge -p '{"spec": {"nodeTemplate": {"ansible": {"ansibleVars": {"edpm_kernel_args": "default_hugepagesz=1gb hugepagesz=1g hugepages=64 iommu=pt intel_iommu=on tsx=off isolcpus=2-11,14-23"}}}}}'
+      oc patch -n {{ cifmw_validations_namespace }} osdpns/"{{ deployed_nodeset_name.stdout | trim }}" --type=merge -p '{"spec": {"nodeTemplate": {"ansible": {"ansibleVars": {"edpm_kernel_args": "default_hugepagesz=1gb hugepagesz=1g hugepages=64 iommu=pt intel_iommu=on tsx=off isolcpus=2-11,14-23"}}}}}'
 
 # The reboot-os service doesn't exist by default. So we need to create this service in
 # order to reboot the nodes.
@@ -80,7 +80,7 @@
         namespace: {{ cifmw_validations_namespace }}
       spec:
         nodeSets:
-          - "{{ deployed_nodeset_name.stdout }}"
+          - "{{ deployed_nodeset_name.stdout | trim }}"
         ansibleExtraVars:
           edpm_reboot_force_reboot: "true"
         servicesOverride:
@@ -110,7 +110,7 @@
   cifmw.general.ci_script:
     output_dir: "{{ cifmw_validations_basedir }}/artifacts"
     script: >-
-      set -o pipefail && oc get -n {{ cifmw_validations_namespace }} osdpns "{{ deployed_nodeset_name.stdout }}" -o yaml | yq .status.configHash
+      set -o pipefail && oc get -n {{ cifmw_validations_namespace }} osdpns "{{ deployed_nodeset_name.stdout | trim }}" -o jsonpath='{.status.configHash}'
   register: post_change_config_hash
 
 # gather facts again to compare against the initial state.

--- a/roles/validations/tasks/main.yml
+++ b/roles/validations/tasks/main.yml
@@ -50,7 +50,7 @@
   block:
     - name: Assert all listed validations exist
       ansible.builtin.stat:
-        path: "{{ cifmw_validations_default_path }}{{ item }}"
+        path: "{{ cifmw_validations_default_path }}/{{ item }}"
       loop: "{{ cifmw_validations_list }}"
       register: validation_exists
       failed_when: not validation_exists.stat.exists


### PR DESCRIPTION
This change removes the dependency on `yq` and replaces it with the `jsonpath` output option for `oc`.

It also fixes the missing `/` in the validations path address.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
