### PR TITLE
Add creation of the default subnet pools for tenant networks

### DIFF
--- a/roles/os_net_setup/defaults/main.yml
+++ b/roles/os_net_setup/defaults/main.yml
@@ -16,3 +16,15 @@ cifmw_os_net_setup_config:
         gateway_ip: 192.168.122.1
         enable_dhcp: false
 cifmw_os_net_setup_verify_tls: true
+
+cifmw_os_net_subnetpool_config:
+  - name: shared-pool-ipv4
+    default_prefix_length: 26
+    prefixes: '10.1.0.0/20'
+    is_default: true
+    is_shared: true
+  - name: shared-pool-ipv6
+    default_prefix_length: 64
+    prefixes: 'fdfe:381f:8400::/56'
+    is_default: true
+    is_shared: true

--- a/roles/os_net_setup/tasks/subtask_net.yml
+++ b/roles/os_net_setup/tasks/subtask_net.yml
@@ -55,3 +55,22 @@
   until: cifmw_os_net_setup_subnet_fetch_out is not failed
   retries: "{{ cifmw_os_net_setup_osp_calls_retries }}"
   delay: "{{ cifmw_os_net_setup_osp_calls_delay }}"
+
+- name: Process subnet pool list elements
+  openstack.cloud.subnet_pool:
+    name: '{{ subnet_pool_item.name }}'
+    default_prefix_length: '{{ subnet_pool_item.default_prefix_length }}'
+    prefixes: '{{ subnet_pool_item.prefixes }}'
+    is_default: '{{ subnet_pool_item.is_default | default(omit) }}'
+    is_shared: '{{ subnet_pool_item.is_shared | default(omit) }}'
+    region_name: '{{ region_name }}'
+    state: present
+    auth: "{{ openstack_auth }}"
+    validate_certs: "{{ cifmw_os_net_setup_verify_tls }}"
+  loop: "{{ cifmw_os_net_subnetpool_config|flatten(levels=1) }}"
+  loop_control:
+    loop_var: subnet_pool_item
+  register: cifmw_os_net_setup_subnet_fetch_out
+  until: cifmw_os_net_setup_subnet_fetch_out is not failed
+  retries: "{{ cifmw_os_net_setup_osp_calls_retries }}"
+  delay: "{{ cifmw_os_net_setup_osp_calls_delay }}"


### PR DESCRIPTION
Default subnet pool is required to run tests for the auto allocate network functionality. This patch adds creation of such default and shared pools for IPv4 and IPv6.

This patch is not enough to make auto allocate network tests running fine as it also require external network to be marked as "default" for projects and that can't be done using ansible openstack module yet. It will require patch [1] and then additional change in the os_net_setup module.

[1] https://review.opendev.org/c/openstack/ansible-collections-openstack/+/917690

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes

Related: #OSPRH-6541