### PR TITLE
[run_hook] Fix default value of state key in CR type

### DIFF
--- a/roles/run_hook/tasks/cr.yml
+++ b/roles/run_hook/tasks/cr.yml
@@ -34,12 +34,13 @@
 
 - name: "Manage the k8s object"
   kubernetes.core.k8s:
+    api_version: "{{ hook.api_version | default(omit) }}"
     definition: "{{ hook.definition | default(omit) }}"
     kind: "{{ hook.kind | default(omit) }}"
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
     name: "{{ hook.resource_name | default(omit) }}"
     src: "{{ crd_path | default(omit) }}"
-    state: "{{ hook.state | default(present) }}"
+    state: "{{ hook.state | default('present') }}"
     validate:
       fail_on_error: true
     wait: true


### PR DESCRIPTION
Fixes syntax error being thrown when no state key is provided. This ensures `present` is set as string instead of variable.

*Error*
```
2024-05-02 05:01:04.004317 | controller | TASK [run_hook : Manage the k8s object definition={{ hook.definition | default(omit) }}, kind={{ hook.kind | default(omit) }}, kubeconfig={{ cifmw_openshift_kubeconfig }}, name={{ hook.resource_name | default(omit) }}, src={{ crd_path | default(omit) }}, state={{ hook.state | default(present) }}, validate={'fail_on_error': True}, wait=True, wait_condition={{ hook.wait_condition | default(omit) }}, validate_certs={{ hook.validate_certs | default(false) }}] ***
2024-05-02 05:01:04.004324 | controller | Thursday 02 May 2024  05:01:04 -0400 (0:00:00.026)       0:05:37.175 **********
2024-05-02 05:01:04.026225 | controller | fatal: [localhost]: FAILED! =>
2024-05-02 05:01:04.026258 | controller |   msg: |-
2024-05-02 05:01:04.026264 | controller |     The task includes an option with an undefined variable. The error was: 'present' is undefined. 'present' is undefined
2024-05-02 05:01:04.026269 | controller |
2024-05-02 05:01:04.026274 | controller |     The error appears to be in '/home/zuul/src/github.com/openstack-k8s-operators/ci-framework/roles/run_hook/tasks/cr.yml': line 35, column 3, but may
2024-05-02 05:01:04.026279 | controller |     be elsewhere in the file depending on the exact syntax problem.
2024-05-02 05:01:04.026284 | controller |
2024-05-02 05:01:04.026289 | controller |     The offending line appears to be:
2024-05-02 05:01:04.026293 | controller |
2024-05-02 05:01:04.026298 | controller |
2024-05-02 05:01:04.026302 | controller |     - name: "Manage the k8s object"
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

