### PR TITLE
Correct import vs include

### DIFF
--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -20,7 +20,7 @@
     - name: Load Networking Environment Definition
       tags:
         - always
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: networking_mapper
         tasks_from: load_env_definition.yml
 

--- a/playbooks/06-deploy-edpm.yml
+++ b/playbooks/06-deploy-edpm.yml
@@ -28,7 +28,7 @@
         name: ci_local_storage
 
     - name: Run edpm_prepare
-      ansible.builtin.import_role:
+      ansible.builtin.include_role:
         name: edpm_prepare
 
 - name: Run post_ctlplane_deploy hooks


### PR DESCRIPTION
The `import_role` in 06-deploy-edpm.yml play was leading to an uncaught
issue in architecture driven deployment: with `import`, the content of
the role was directly in the playbook and, while we exit it early via
the ansible.builtin.meta, it was still "too late" for some undefined
variable hit (install_yamls related).

The `include_role` in 06-deploy-architecture.yml play was leading to an
error when we were trying to iterate on `edpm_deploy` tag: the `always`
tag wasn't applied to the subsequent list of tasks, leading to an error
with undefined variable. Switchint to `import` allows to get all the
tasks tagged with `always`.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
