### PR TITLE
Use ad-hoc reboot play

### DIFF
--- a/roles/validations/tasks/edpm/hugepages_and_reboot.yml
+++ b/roles/validations/tasks/edpm/hugepages_and_reboot.yml
@@ -45,9 +45,8 @@
     script: >-
       oc patch -n {{ cifmw_validations_namespace }} osdpns/"{{ deployed_nodeset_name.stdout | trim }}" --type=merge -p '{"spec": {"nodeTemplate": {"ansible": {"ansibleVars": {"edpm_kernel_args": "default_hugepagesz=1gb hugepagesz=1g hugepages=64 iommu=pt intel_iommu=on tsx=off isolcpus=2-11,14-23"}}}}}'
 
-# The reboot-os service doesn't exist by default. So we need to create this service in
-# order to reboot the nodes.
-- name: Create reboot service
+# Define an ad-hoc reboot service for our node reboot
+- name: Create ad-hoc reboot service
   environment:
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
     PATH: "{{ cifmw_path }}"
@@ -58,9 +57,15 @@
       apiVersion: dataplane.openstack.org/v1beta1
       kind: OpenStackDataPlaneService
       metadata:
-        name: reboot-os
+        name: reboot-adhoc
       spec:
-        playbook: osp.edpm.reboot
+        play: |
+          - hosts: all
+            become: true
+            tasks:
+              - name: Reboot nodes
+                ansible.builtin.reboot:
+                  msg: "Node will be rebooted now!"
       EOF
 
 # Create a new OpenStackDataPlaneDeployment to set the reboot variable. We also only need to execute
@@ -81,11 +86,9 @@
       spec:
         nodeSets:
           - "{{ deployed_nodeset_name.stdout | trim }}"
-        ansibleExtraVars:
-          edpm_reboot_force_reboot: "true"
         servicesOverride:
           - bootstrap
-          - reboot-os
+          - reboot-adhoc
       EOF
 
 # loop check the status of the openstackdataplanedeployment until it is either completed,


### PR DESCRIPTION
This change implements the supported user interface for initiating reboots. We were using the reboot-os service, but it's expected that this wouldn't work consistently for day 2 operations. Nothing in the edpm_kernel role creates a reboot_required file and therefore the default reboot-os service could potentially skip rebooting for changes to kernel args. This instead implements a custom reboot service that will ensure the reboot is executed against the defined set of nodes.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
