### PR TITLE
Toggle ansible-lint to offline

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -20,7 +20,7 @@ strict: true
 quiet: false
 verbosity: 1
 parseable: true
-offline: false
+offline: true
 var_naming_pattern: "^cifmw_[a-z_][a-z0-9_]*$"
 mock_modules:
   - zuul_return


### PR DESCRIPTION
In order to avoid seeing the dependencies installed twice, and usually
failing there, let's toggle ansible-lint to offline.

According to the doc:
```
Offline mode disables installation of requirements.yml and schema
refreshing.
```

Let's see what it means for us at this point, and if we can avoid false
flags in the pre-commit job.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
