### PR TITLE
Don't trigger deployment on specific files

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -49,7 +49,10 @@
       - ci/playbooks/molecule-prepare.yml
       - ci/playbooks/molecule-test.yml
       # ci-framework
+      - .ansible-lint
+      - .pre-commit-config.yaml
       - .readthedocs.yaml
+      - .spellcheck.yml
       - roles/dlrn_report
       - roles/dlrn_promote
       - roles/devscripts


### PR DESCRIPTION
There's no need to trigger a deployment when we modify ansible-lint,
pre-commit and spellcheck configurations.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
