### PR TITLE
Correct regexp in generate_snippets

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -11,6 +11,7 @@ exclude_paths:
   - zuul.d/molecule.yaml  # Generated, pyYAML is bad at indentation
   - ci/
   - roles/ci_gen_kustomize_values/molecule/default/files/networking-environment-definition.yml  # Generated
+  - roles/ci_gen_kustomize_values/molecule/default/files/3-ocp-net-def.yml  # Generated
   - roles/ci_gen_kustomize_values/molecule/default/converge.yml  # invalid due to calls to "lookup('file')"
   - roles/ci_gen_kustomize_values/molecule/default/prepare.yml  # import_playbook
   - roles/reproducer/files/cifmw-bootstrap.yml  # invalid due to calls to "lookup('file')"

--- a/roles/ci_gen_kustomize_values/molecule/default/converge.yml
+++ b/roles/ci_gen_kustomize_values/molecule/default/converge.yml
@@ -56,14 +56,18 @@
         priv_key: "{{ lookup('file', '~/.ssh/id_cifw') }}"
         pub_key: "{{ lookup('file', '~/.ssh/id_cifw.pub') }}"
         authorized_keys: "{{ lookup('file', '~/.ssh/authorized_keys') }}"
-        net_env: >-
+        single_net_env: >-
           {{
-            lookup('file',
-                   '/etc/ci/env/networking-environment-definition.yml')
+            lookup('file', 'networking-environment-definition.yml')
+          }}
+        multi_ocp_net_env: >-
+          {{
+            lookup('file', '3-ocp-net-def.yml')
           }}
         _nova_priv_key: "{{ lookup('file', _nova_key.filename) }}"
       ansible.builtin.set_fact:
-        cifmw_networking_env_definition: "{{ net_env | from_yaml }}"
+        cifmw_networking_env_definition: "{{ single_net_env | from_yaml }}"
+        ocp_cluster_networking_env_definition: "{{ multi_ocp_net_env | from_yaml}}"
         cifmw_ci_gen_kustomize_values_ssh_authorizedkeys: >-
           {{ authorized_keys }}
         cifmw_ci_gen_kustomize_values_ssh_private_key: >-
@@ -76,7 +80,7 @@
           {{ _nova_priv_key }}
         cifmw_ci_gen_kustomize_values_sshd_ranges: >-
           {{
-            [(net_env | from_yaml)['networks']['ctlplane']['network_v4']]
+            [(single_net_env | from_yaml)['networks']['ctlplane']['network_v4']]
           }}
 
     - name: Generate network-values
@@ -124,7 +128,7 @@
       loop_control:
         label: "{{ item.stat.path }}"
 
-    - name: Ensure we do not case MAC anymore
+    - name: Ensure we have correct MAC
       vars:
         _val_file: "{{ artifacts }}/ci_gen_kustomize_values/edpm-nodeset-values/values.yaml"
         _edpm_val: "{{ lookup('file', _val_file) | from_yaml }}"
@@ -133,6 +137,46 @@
           - _edpm_val.data.nodeset.ansible.ansibleVars.edpm_network_config_os_net_config_mappings['edpm-compute-0'].nic2 == '52:54:00:17:05:43'
         msg: >-
           Got {{ _edpm_val.data.nodeset.ansible.ansibleVars.edpm_network_config_os_net_config_mappings['edpm-compute-0'].nic2 }}
+
+    - name: Ensure we don't have node_1 nor node_2
+      vars:
+        _val_file: "{{ artifacts }}/ci_gen_kustomize_values/network-values/values.yaml"
+        _network_val: "{{ lookup('file', _val_file) | from_yaml }}"
+      ansible.builtin.assert:
+        that:
+          - _network_val.data.node_1 is undefined
+          - _network_vak.data.node_2 is undefined
+        msg: >-
+          Got either node_1 and/or node_2 in the generated content,
+          should only get node_0
+
+    - name: Regenerate with 3-OCP cluster data
+      block:
+        - name: Update cifmw_networking_env_definition
+          ansible.builtin.set_fact:
+            cifmw_networking_env_definition: "{{ ocp_cluster_networking_env_definition }}"
+
+        - name: Regenerate network-values
+          vars:
+            cifmw_ci_gen_kustomize_values_name: "network-values"
+            cifmw_ci_gen_kustomize_values_src_file: >-
+              {{
+                [architecture_repo,
+                 "examples/va/hci/control-plane/nncp/values.yaml"] | path_join
+              }}
+          ansible.builtin.include_role:
+            name: ci_gen_kustomize_values
+
+        - name: Regenerate edpm-nodeset-values
+          vars:
+            cifmw_ci_gen_kustomize_values_name: "edpm-nodeset-values"
+            cifmw_ci_gen_kustomize_values_src_file: >-
+              {{
+                [architecture_repo,
+                 "examples/va/hci/edpm-pre-ceph/nodeset/values.yaml"] | path_join
+              }}
+          ansible.builtin.include_role:
+            name: ci_gen_kustomize_values
 
     - name: Copy generated values to correct location
       ansible.builtin.copy:

--- a/roles/ci_gen_kustomize_values/molecule/default/files/3-ocp-net-def.yml
+++ b/roles/ci_gen_kustomize_values/molecule/default/files/3-ocp-net-def.yml
@@ -1,0 +1,337 @@
+instances:
+    compute-0:
+        hostname: compute-0
+        name: compute-0
+        networks:
+            ctlplane:
+                interface_name: eth1
+                ip_v4: 192.168.122.100
+                mac_addr: '52:54:00:17:05:43'
+                mtu: 1500
+                network_name: ctlplane
+                skip_nm: false
+            internalapi:
+                interface_name: eth1.20
+                ip_v4: 172.17.0.100
+                mac_addr: '52:54:00:05:da:ef'
+                mtu: 1500
+                network_name: internalapi
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 20
+            storage:
+                interface_name: eth1.21
+                ip_v4: 172.18.0.100
+                mac_addr: '52:54:00:59:8a:4c'
+                mtu: 1500
+                network_name: storage
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 21
+            tenant:
+                interface_name: eth1.22
+                ip_v4: 172.19.0.100
+                mac_addr: '52:54:00:0b:1c:d7'
+                mtu: 1500
+                network_name: tenant
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 22
+    controller-0:
+        hostname: controller-0
+        name: controller-0
+        networks:
+            ctlplane:
+                interface_name: eth1
+                ip_v4: 192.168.122.9
+                mac_addr: '0a:02:a0:63:cb:1c'
+                mtu: 1500
+                network_name: ctlplane
+                skip_nm: false
+    ocp-master-0:
+        hostname: ocp-master-0
+        name: ocp-master-0
+        networks:
+            ctlplane:
+                interface_name: enp6s0
+                ip_v4: 192.168.122.10
+                mac_addr: '0a:02:ca:be:0b:38'
+                mtu: 1500
+                network_name: ctlplane
+                skip_nm: false
+            internalapi:
+                interface_name: enp6s0.20
+                ip_v4: 172.17.0.10
+                mac_addr: '52:54:00:1b:6e:a3'
+                mtu: 1500
+                network_name: internalapi
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 20
+            storage:
+                interface_name: enp6s0.21
+                ip_v4: 172.18.0.10
+                mac_addr: '52:54:00:56:fa:88'
+                mtu: 1500
+                network_name: storage
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 21
+            tenant:
+                interface_name: enp6s0.22
+                ip_v4: 172.19.0.10
+                mac_addr: '52:54:00:18:a0:f6'
+                mtu: 1500
+                network_name: tenant
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 22
+    ocp-master-1:
+        hostname: ocp-master-1
+        name: ocp-master-1
+        networks:
+            ctlplane:
+                interface_name: enp6s0
+                ip_v4: 192.168.122.11
+                mac_addr: '0a:02:ca:be:0b:39'
+                mtu: 1500
+                network_name: ctlplane
+                skip_nm: false
+            internalapi:
+                interface_name: enp6s0.20
+                ip_v4: 172.17.0.11
+                mac_addr: '52:54:00:1b:6e:a4'
+                mtu: 1500
+                network_name: internalapi
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 20
+            storage:
+                interface_name: enp6s0.21
+                ip_v4: 172.18.0.11
+                mac_addr: '52:54:00:56:fa:89'
+                mtu: 1500
+                network_name: storage
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 21
+            tenant:
+                interface_name: enp6s0.22
+                ip_v4: 172.19.0.11
+                mac_addr: '52:54:00:18:a0:f7'
+                mtu: 1500
+                network_name: tenant
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 22
+    ocp-master-2:
+        hostname: ocp-master-2
+        name: ocp-master-2
+        networks:
+            ctlplane:
+                interface_name: enp6s0
+                ip_v4: 192.168.122.12
+                mac_addr: '0a:02:ca:be:0b:40'
+                mtu: 1500
+                network_name: ctlplane
+                skip_nm: false
+            internalapi:
+                interface_name: enp6s0.20
+                ip_v4: 172.17.0.12
+                mac_addr: '52:54:00:1b:6e:a5'
+                mtu: 1500
+                network_name: internalapi
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 20
+            storage:
+                interface_name: enp6s0.21
+                ip_v4: 172.18.0.12
+                mac_addr: '52:54:00:56:fa:90'
+                mtu: 1500
+                network_name: storage
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 21
+            tenant:
+                interface_name: enp6s0.22
+                ip_v4: 172.19.0.12
+                mac_addr: '52:54:00:18:a0:f8'
+                mtu: 1500
+                network_name: tenant
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 22
+networks:
+    ctlplane:
+        dns_v4:
+        - 192.168.122.1
+        dns_v6: []
+        gw_v4: 192.168.122.1
+        mtu: 1500
+        network_name: ctlplane
+        network_v4: 192.168.122.0/24
+        search_domain: ctlplane.example.com
+        tools:
+            metallb:
+                ipv4_ranges:
+                -   end: 192.168.122.90
+                    end_host: 90
+                    length: 11
+                    start: 192.168.122.80
+                    start_host: 80
+                ipv6_ranges: []
+            multus:
+                ipv4_ranges:
+                -   end: 192.168.122.70
+                    end_host: 70
+                    length: 41
+                    start: 192.168.122.30
+                    start_host: 30
+                ipv6_ranges: []
+            netconfig:
+                ipv4_ranges:
+                -   end: 192.168.122.120
+                    end_host: 120
+                    length: 21
+                    start: 192.168.122.100
+                    start_host: 100
+                -   end: 192.168.122.200
+                    end_host: 200
+                    length: 51
+                    start: 192.168.122.150
+                    start_host: 150
+                ipv6_ranges: []
+    external:
+        dns_v4: []
+        dns_v6: []
+        mtu: 1500
+        network_name: external
+        network_v4: 10.0.0.0/24
+        search_domain: external.example.com
+        tools:
+            netconfig:
+                ipv4_ranges:
+                -   end: 10.0.0.250
+                    end_host: 250
+                    length: 151
+                    start: 10.0.0.100
+                    start_host: 100
+                ipv6_ranges: []
+        vlan_id: 22
+    internalapi:
+        dns_v4: []
+        dns_v6: []
+        mtu: 1496
+        network_name: internalapi
+        network_v4: 172.17.0.0/24
+        search_domain: internalapi.example.com
+        tools:
+            metallb:
+                ipv4_ranges:
+                -   end: 172.17.0.90
+                    end_host: 90
+                    length: 11
+                    start: 172.17.0.80
+                    start_host: 80
+                ipv6_ranges: []
+            multus:
+                ipv4_ranges:
+                -   end: 172.17.0.70
+                    end_host: 70
+                    length: 41
+                    start: 172.17.0.30
+                    start_host: 30
+                ipv6_ranges: []
+            netconfig:
+                ipv4_ranges:
+                -   end: 172.17.0.250
+                    end_host: 250
+                    length: 151
+                    start: 172.17.0.100
+                    start_host: 100
+                ipv6_ranges: []
+        vlan_id: 20
+    storage:
+        dns_v4: []
+        dns_v6: []
+        mtu: 1496
+        network_name: storage
+        network_v4: 172.18.0.0/24
+        search_domain: storage.example.com
+        tools:
+            metallb:
+                ipv4_ranges:
+                -   end: 172.18.0.90
+                    end_host: 90
+                    length: 11
+                    start: 172.18.0.80
+                    start_host: 80
+                ipv6_ranges: []
+            multus:
+                ipv4_ranges:
+                -   end: 172.18.0.70
+                    end_host: 70
+                    length: 41
+                    start: 172.18.0.30
+                    start_host: 30
+                ipv6_ranges: []
+            netconfig:
+                ipv4_ranges:
+                -   end: 172.18.0.250
+                    end_host: 250
+                    length: 151
+                    start: 172.18.0.100
+                    start_host: 100
+                ipv6_ranges: []
+        vlan_id: 21
+    storagemgmt:
+        dns_v4: []
+        dns_v6: []
+        mtu: 1500
+        network_name: storagemgmt
+        network_v4: 172.20.0.0/24
+        search_domain: storagemgmt.example.com
+        tools:
+            netconfig:
+                ipv4_ranges:
+                -   end: 172.20.0.250
+                    end_host: 250
+                    length: 151
+                    start: 172.20.0.100
+                    start_host: 100
+                ipv6_ranges: []
+        vlan_id: 23
+    tenant:
+        dns_v4: []
+        dns_v6: []
+        mtu: 1496
+        network_name: tenant
+        network_v4: 172.19.0.0/24
+        search_domain: tenant.example.com
+        tools:
+            metallb:
+                ipv4_ranges:
+                -   end: 172.19.0.90
+                    end_host: 90
+                    length: 11
+                    start: 172.19.0.80
+                    start_host: 80
+                ipv6_ranges: []
+            multus:
+                ipv4_ranges:
+                -   end: 172.19.0.70
+                    end_host: 70
+                    length: 41
+                    start: 172.19.0.30
+                    start_host: 30
+                ipv6_ranges: []
+            netconfig:
+                ipv4_ranges:
+                -   end: 172.19.0.250
+                    end_host: 250
+                    length: 151
+                    start: 172.19.0.100
+                    start_host: 100
+                ipv6_ranges: []
+        vlan_id: 22

--- a/roles/ci_gen_kustomize_values/molecule/default/prepare.yml
+++ b/roles/ci_gen_kustomize_values/molecule/default/prepare.yml
@@ -35,13 +35,6 @@
         state: directory
         mode: "0755"
 
-    - name: Push networking environment definition file
-      become: true
-      ansible.builtin.copy:
-        src: "networking-environment-definition.yml"
-        dest: "/etc/ci/env/networking-environment-definition.yml"
-        mode: "0644"
-
     - name: Create nova migration keypair
       register: _nova_key
       community.crypto.openssh_keypair:

--- a/roles/ci_gen_kustomize_values/tasks/generate_snippets.yml
+++ b/roles/ci_gen_kustomize_values/tasks/generate_snippets.yml
@@ -58,7 +58,7 @@
     content: >-
       {{
         original_content |
-        ansible.utils.remove_keys(target=['^nodes(_[0-9]+)?$'],
+        ansible.utils.remove_keys(target=['^nodes?(_[0-9]+)?$'],
                                   matching_parameter='regex') |
         to_nice_yaml
       }}


### PR DESCRIPTION
OCP nodes are represented with `node_[0-9]` while computes are nested
under `nodes`. The `s` is therefore not always present.

We add a specific test to ensure the key removal is working for the OCP
node filtering.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
