### PR TITLE
Set dlrn proper tag for components

### DIFF
--- a/roles/repo_setup/tasks/artifacts.yml
+++ b/roles/repo_setup/tasks/artifacts.yml
@@ -5,10 +5,12 @@
       {{ cifmw_repo_setup_basedir }}/venv/bin/repo-setup-get-hash
       --dlrn-url {{ cifmw_repo_setup_dlrn_uri[:-1] }}
       --os-version {{ cifmw_repo_setup_os_release }}{{ cifmw_repo_setup_dist_major_version }}
-      --tag {{cifmw_repo_setup_promotion }}
       --release {{ cifmw_repo_setup_branch }}
       {% if cifmw_repo_setup_component is defined -%}
       --component {{ cifmw_repo_setup_component }}
+      --tag {{ cifmw_repo_setup_component_promotion_tag }}
+      {% else -%}
+      --tag {{cifmw_repo_setup_promotion }}
       {% endif -%}
       {% if cifmw_repo_setup_dlrn_hash_tag | length > 0 -%}
       --dlrn-hash-tag {{ cifmw_repo_setup_dlrn_hash_tag }}


### PR DESCRIPTION
We need to pass component-ci-testing or promoted-component tag to repo-setup-get-hash to return proper hashes for downstream otherwise it will return distro and commit empty hash.

This pr fixes the same.
```
❯ repo-setup-get-hash --component baremetal --dlrn-url https://x.x.x.x --os-version rhel9 --release osp18 --tag component-ci-testing
os_version: rhel9,
release: osp18,
component: baremetal,
tag: component-ci-testing,
dlrn_hash_tag: None,
dlrn_url: x.x.x.x/rhel9-osp18/component/baremetal/component-ci-testing/commit.yaml,
dlrn_api_url: x.x.x.x/api-rhel9-osp18,
full_hash: 4e51aefa3ee32417a2b5b6ae801710a365818586_48e5ac78,
commit_hash: 4e51aefa3ee32417a2b5b6ae801710a365818586,
distro_hash: 48e5ac78483bfb7b327084386aa22dd88a214b60,
extended_hash: 252b6b5fa34585d47af0954ee5d84c4f4dec0d52_4ee8dca8786a024cd470bbe8cab14bf586e63abf
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

