### PR TITLE
[test-operator] Add option to set networkAttachments

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -32,6 +32,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_tempest_config_overwrite`: (Dict) Dictionary where key is name of a file and value is content of the file. All files mentioned in this field are mounted to `/etc/test_operator/<filename>`
 * `cifmw_test_operator_tempest_workflow`: (List) Definition of a Tempest workflow that consists of multiple steps. Each step can contain all values from Spec section of [Tempest CR](https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource).
 * `cifmw_test_operator_tempest_ntp_extra_image`: (String) URL that points to an extra image that is used by [whitebox-neutron-tempest-plugin](https://opendev.org/x/whitebox-neutron-tempest-plugin). Default value: `''`
+* `cifmw_test_operator_tempest_network_attachments`: (List) List of network attachment definitions to attach to the tempest pods spawned by test-operator. Default value: `[]`.
 * `cifmw_test_operator_tempest_config`: (Object) Definition of Tempest CRD instance that is passed to the test-operator (see [the test-operator documentation](https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource)). Default value:
 ```
   apiVersion: test.openstack.org/v1beta1

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -39,6 +39,7 @@ cifmw_test_operator_tempest_namespace: podified-antelope-centos9
 cifmw_test_operator_tempest_container: openstack-tempest-all
 cifmw_test_operator_tempest_image: "{{ cifmw_test_operator_tempest_registry }}/{{ cifmw_test_operator_tempest_namespace }}/{{ cifmw_test_operator_tempest_container }}"
 cifmw_test_operator_tempest_image_tag: current-podified
+cifmw_test_operator_tempest_network_attachments: []
 cifmw_test_operator_tempest_tests_include_override_scenario: false
 cifmw_test_operator_tempest_tests_exclude_override_scenario: false
 cifmw_test_operator_tempest_workflow: []
@@ -53,6 +54,7 @@ cifmw_test_operator_tempest_config:
     containerImage: "{{ cifmw_test_operator_tempest_image }}:{{ cifmw_test_operator_tempest_image_tag }}"
     SSHKeySecretName: "{{ cifmw_test_operator_tempest_ssh_key_secret_name | default(omit) }}"
     configOverwrite: "{{ cifmw_test_operator_tempest_config_overwrite | default(omit) }}"
+    networkAttachments: "{{ cifmw_test_operator_tempest_network_attachments }}"
     tempestRun:
       includeList: |
         {{ cifmw_test_operator_tempest_include_list | default('') }}


### PR DESCRIPTION
This will allow attaching secondary nics to the tempest pods and use that for the egress traffic to the respective network.
Without this all egress traffic flows through the default OCP cluster network and can trigger mtu specific
issues for non cluster n/w traffic as cluster n/w force lower MTU based on network backend used.

Default is empty list so no secondary interfaces will be attached by default.

Related-Issue: [OSPRH-6546](https://issues.redhat.com//browse/OSPRH-6546)

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
