### PR TITLE
[reproducer] Fix undefined devscripts_kubeadm

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -272,13 +272,13 @@
     - name: Inject kubeadmin-password if exists
       when:
         - _devscripts_kubeadm.content is defined or
-          _crc_kubeconfig.content is defined
+          _crc_kubeadm.content is defined
       ansible.builtin.copy:
         dest: "/home/zuul/.kube/kubeadmin-password"
         content: >-
           {{
             (_devscripts_kubeadm.content is defined) |
-            ternary(devscripts_kubeadm.content, _crc_kubeadm.content) |
+            ternary(_devscripts_kubeadm.content, _crc_kubeadm.content) |
             b64decode
           }}
         owner: zuul


### PR DESCRIPTION
Missing `_` hence the undefined error. This change fixes the issue

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

