### PR TITLE
Drop cifmw_repo_setup_component var

### DIFF
--- a/roles/repo_setup/defaults/main.yml
+++ b/roles/repo_setup/defaults/main.yml
@@ -19,7 +19,6 @@
 # All variables within this role should have a prefix of "cifmw_setup_repos"
 # To get dlrn md5 hash for components [baremetal,cinder,clients,cloudops,common,
 # compute,glance,manila,network,octavia,security,swift,tempest,podified,ui,validation]
-# cifmw_repo_setup_component: <component name>
 cifmw_repo_setup_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_repo_setup_promotion: "current-podified"
 cifmw_repo_setup_branch: "antelope"

--- a/roles/repo_setup/tasks/artifacts.yml
+++ b/roles/repo_setup/tasks/artifacts.yml
@@ -6,8 +6,8 @@
       --dlrn-url {{ cifmw_repo_setup_dlrn_uri[:-1] }}
       --os-version {{ cifmw_repo_setup_os_release }}{{ cifmw_repo_setup_dist_major_version }}
       --release {{ cifmw_repo_setup_branch }}
-      {% if cifmw_repo_setup_component is defined -%}
-      --component {{ cifmw_repo_setup_component }}
+      {% if cifmw_repo_setup_component_name | length > 0 -%}
+      --component {{ cifmw_repo_setup_component_name }}
       --tag {{ cifmw_repo_setup_component_promotion_tag }}
       {% else -%}
       --tag {{cifmw_repo_setup_promotion }}


### PR DESCRIPTION
Remove cifmw_repo_setup_component var in favor of
cifmw_repo_setup_component_name var. The correct var for specifying the component name is cifmw_repo_setup_component_name.

It is causing issue while running dlrn reporting in the component line. Let's drop cifmw_repo_setup_component var and use cifmw_repo_setup_component_name in artifacts to get the proper hashes.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

