### PR TITLE
[test-operator] Fix tempest workflows

### DIFF
--- a/roles/test_operator/tasks/main.yml
+++ b/roles/test_operator/tasks/main.yml
@@ -133,7 +133,7 @@
     test_operator_job_name: "{{ cifmw_test_operator_tempest_name }}"
     test_operator_kind_name: "{{ cifmw_test_operator_tempest_kind_name }}"
     test_operator_crd_name: "{{ cifmw_test_operator_tempest_crd_name }}"
-    test_operator_workflow: []
+    test_operator_workflow: "{{ cifmw_test_operator_tempest_workflow }}"
     test_operator_config_playbook: tempest-tests.yml
   ansible.builtin.include_tasks: run-test-operator-job.yml
   when: run_tempest


### PR DESCRIPTION
Currently, the tempest_workflow var is not passed to the run-test-operator-job.yml thanks to this the role does not wait for the last test pod and finishes prematurely.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
