### PR TITLE
Dump dlrn md5 hash from current-podified while using component repo

### DIFF
--- a/roles/repo_setup/tasks/artifacts.yml
+++ b/roles/repo_setup/tasks/artifacts.yml
@@ -12,7 +12,7 @@
       {% else -%}
       --tag {{cifmw_repo_setup_promotion }}
       {% endif -%}
-      {% if cifmw_repo_setup_dlrn_hash_tag | length > 0 -%}
+      {% if (cifmw_repo_setup_dlrn_hash_tag | length > 0) and (cifmw_repo_setup_component_name | length <= 0) -%}
       --dlrn-hash-tag {{ cifmw_repo_setup_dlrn_hash_tag }}
       {% endif -%}
       --json
@@ -24,9 +24,16 @@
     _repo_setup_json: "{{ _get_hash.stdout | from_json }}"
   block:
     - name: Dump full hash in delorean.repo.md5 file
+      when: cifmw_repo_setup_component_promotion_tag is not defined
       ansible.builtin.copy:
         content: |
           {{ _repo_setup_json['full_hash'] }}
+        dest: "{{ cifmw_repo_setup_basedir }}/artifacts/repositories/delorean.repo.md5"
+
+    - name: Dump current-podified hash when using with component repo
+      when: cifmw_repo_setup_component_promotion_tag is defined
+      ansible.builtin.get_url:
+        url: "{{ cifmw_repo_setup_dlrn_uri }}/{{ cifmw_repo_setup_os_release }}{{ cifmw_repo_setup_dist_major_version }}-{{ cifmw_repo_setup_branch }}/current-podified/delorean.repo.md5"
         dest: "{{ cifmw_repo_setup_basedir }}/artifacts/repositories/delorean.repo.md5"
 
     - name: Export hashes facts for further use


### PR DESCRIPTION
DLRN md5 hash files are generated when we promote all components in promoted-components, podified-ci-testing and current-podified.

in repo_setup role, we generate the dlrn_md5 hash file based on full_hash. full_hash is returned by all dlrn tags.

In component repo, there is no dlrn md5 hash and repo_setup role is generating wrong dlrn_md5 hash file.

In component pipeline, tcib job as a parent job generating the wrong dlrn md5 hash file and passed it child edpm/podified job.

The child job repo-setup will receive wrong dlrn md5 hash tag and the repo-setup tool will fail.

In component pipeline, we generate current-podified repos then populate the component repos. So, we need to write dlrn_md5 hash from current-podified in the component jobs.

This pull request fixes the same.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
