### PR TITLE
Allow to run a layout without any CRC

### DIFF
--- a/roles/reproducer/tasks/ci_data.yml
+++ b/roles/reproducer/tasks/ci_data.yml
@@ -42,6 +42,14 @@
       ansible.builtin.set_fact:
         cacheable: true
         is_molecule: "{{ _is_molecule.status == 200 }}"
+        _use_crc: >-
+          {{
+            (updated_layout.vms.crc is defined and
+             ((updated_layout.vms.crc.amount is defined and
+              updated_layout.vms.crc.amount|int > 0) or
+             updated_layout.vms.crc.amount is undefined)) or
+             updated_layout.vms.crc is undefined
+          }}
         cifmw_libvirt_manager_configuration_gen: >-
           {{
             cifmw_libvirt_manager_configuration |

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -256,7 +256,8 @@
 
     - name: Inject kubeconfig content
       when:
-        - _devscripts_kubeconfig is defined or _crc_kubeconfig is defined
+        - _devscripts_kubeconfig.content is defined or
+          _crc_kubeconfig.content is defined
       ansible.builtin.copy:
         dest: "/home/zuul/.kube/config"
         content: >-

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -43,6 +43,17 @@
       cifmw_install_ca_url to download from a url or cifmw_install_ca_bundle_src
       to use a file present on the host.
 
+- name: Set _use_crc before layout update
+  ansible.builtin.set_fact:
+    _use_crc: >-
+      {{
+        cifmw_libvirt_manager_configuration.vms.crc is defined and
+        (
+          (cifmw_libvirt_manager_configuration.vms.crc.amount is defined and
+           cifmw_libvirt_manager_configuration.vms.crc.amount|int > 0) or
+        cifmw_libvirt_manager_configuration.vms.crc.amount is undefined)
+      }}
+
 - name: Ensure directories are present
   tags:
     - always
@@ -71,12 +82,7 @@
 
 - name: Deploy CRC if needed
   when:
-    - cifmw_libvirt_manager_configuration.vms.crc is defined
-    - (
-        cifmw_libvirt_manager_configuration.vms.crc.target is defined and
-        cifmw_libvirt_manager_configuration.vms.crc.target == inventory_hostname
-      ) or
-      cifmw_libvirt_manager_configuration.vms.crc.target is undefined
+    - _use_crc | bool
   tags:
     - bootstrap
     - bootstrap_layout


### PR DESCRIPTION
When running a molecule reproducer, we may not have any CRC. While this
case was mostly covered, it wasn't properly addressed when the user
doesn't have any pre-deployed CRC.

This patch ensures we really-really want CRC before bootstrapping it.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running

### Manual testing
- [X] va-hci could properly deploy the layout
- [X] zuul reproducer for molecule (NO CRC) is working as expected
- [X] working even if no CRC is present on node, with or without CRC in the layout (`amount: 0` set by the zuul reproducer)