### PR TITLE
Ensure we run custom, injected hooks in all cases

### DIFF
--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -104,9 +104,8 @@
     - name: "Executing pre_stage hooks for {{ stage.path }}"
       when:
         - not cifmw_kustomize_deploy_generate_crs_only | bool
-        - stage.pre_stage_run is defined
       vars:
-        hooks: "{{ stage.pre_stage_run }}"
+        hooks: "{{ stage.pre_stage_run | default([]) }}"
         step: "pre_{{ _stage_name_id }}_run"
       ansible.builtin.include_role:
         name: run_hook
@@ -282,9 +281,8 @@
     - name: "Executing post_stage hooks for {{ stage.path }}"
       when:
         - not cifmw_kustomize_deploy_generate_crs_only | bool
-        - stage.post_stage_run is defined
       vars:
-        hooks: "{{ stage.post_stage_run }}"
+        hooks: "{{ stage.post_stage_run | default([]) }}"
         step: "post_{{ _stage_name_id }}_run"
       ansible.builtin.include_role:
         name: run_hook


### PR DESCRIPTION
Until now we had to get at least one hook in the automation file to run
custom, injected hooks.
This is leading to issues when a user wants to inject a hook on their
own, without any pre-existing hooks from the automation.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
