### PR TITLE
Rework imported vars in the reproducer

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -348,16 +348,19 @@
             hostvars[inventory_hostname] | default({}) |
             dict2items |
             selectattr('key', 'match',
-                       '^(pre|post|cifmw)_(?!install_yamls|openshift|devscripts).*') |
+                       '^(pre|post|cifmw)_(?!install_yamls|devscripts).*') |
             rejectattr('key', 'equalto', 'cifmw_target_host') |
             rejectattr('key', 'equalto', 'cifmw_basedir') |
             rejectattr('key', 'equalto', 'cifmw_path') |
             rejectattr('key', 'equalto', 'cifmw_extras') |
+            rejectattr('key', 'equalto', 'cifmw_openshift_kubeconfig') |
+            rejectattr('key', 'equalto', 'cifmw_openshift_token') |
             rejectattr('key', 'match', '^cifmw_use.*') |
             rejectattr('key', 'match', '^cifmw_reproducer.*') |
             rejectattr('key', 'match', '^cifmw_rhol.*') |
             rejectattr('key', 'match', '^cifmw_discover.*') |
             rejectattr('key', 'match', '^cifmw_libvirt_manager.*') |
+            rejectattr('key', 'match', '^cifmw_manage_secrets_(pullsecret|citoken).*') |
             items2dict
           }}
       ansible.builtin.copy:
@@ -381,8 +384,6 @@
             {{ ansible_user_dir }}/.kube/kubeadmin-password
           cifmw_openshift_login_kubeconfig: >-
             {{ ansible_user_dir }}/.kube/config
-          cifmw_openshift_user: "kubeadmin"
-          cifmw_openshift_skip_tls_verify: true
           cifmw_architecture_automation_file: >-
             {{
               (


### PR DESCRIPTION
Until now, we were filtering out anything `cifmw_openshift*` related.
This leads to issues, for instance when we want to pass
`cifmw_openshift_setup_ca_registry_to_add` down in the environment.

In order to ensure we're not filtering too many parameter, this change
modifies a bit how things are handled:
- we allow all of `cifmw_openshift*` parameter
- but we filter out some that may be problematic: kubeconfig (due to
  potential user HOME mismatch), and openshift_token.

We also take the opportunity to reject the pull-secret and ci-token
keys, to ensure they don't leak in the env (they are mostly useless on
controller-0).

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

#### Manual tests
With CRC, we end with this:
```
[zuul@controller-0 ~]$ grep openshift openshift-environment.yml 
cifmw_openshift_login_password_file: >-
cifmw_openshift_login_kubeconfig: >-

[zuul@controller-0 ~]$ grep openshift reproducer-variables.yml 
cifmw_openshift_api: https://api.crc.testing:6443
cifmw_openshift_password: '12345678'
cifmw_openshift_user: kubeadmin
```
It really looks like what we need.
