### PR TITLE
[edpm_prepare] Ensure the ctrlplane CR has latest content

### DIFF
--- a/plugins/action/ci_kustomize.py
+++ b/plugins/action/ci_kustomize.py
@@ -434,7 +434,6 @@ class CifmwKustomizeWrapper:
         if self.target_path.is_dir():
             manifests_contents = self.__get_manifests_paths_from_dir_candidates(
                 self.target_path,
-                skip_paths=[self.output_path],
                 skip_regexes=self.__skip_regexes,
                 include_regexes=self.__include_regexes,
             )

--- a/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
+++ b/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
@@ -27,6 +27,13 @@
       }}
   ci_kustomize:
     target_path: "{{ cifmw_edpm_prepare_openstack_crs_path }}"
+    output_path: >-
+      {{
+        [
+          cifmw_edpm_prepare_openstack_crs_path,
+          (cifmw_install_yamls_defaults['OPENSTACK_CTLPLANE'] | basename)
+        ] | ansible.builtin.path_join
+      }}
     sort_ascending: false
     kustomizations: "{{ cifmw_edpm_prepare_kustomizations }}"
     kustomizations_paths: >-


### PR DESCRIPTION
Initially the edpm_prepare role apply logic wasn't designed to be called more than once, but now it's possible, leading to the unexpected situation of ci_kustomize picking always the initial install_yamls CR as the input instead of the last applied content. Forcing the ci_kustomize output to the same file always will ensure we consume always the same CR instead of creating the ci_kustomize default one.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
