### PR TITLE
Fix(?) CRC DNS

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -71,6 +71,7 @@
       ansible.builtin.package:
         name:
           - bash-completion
+          - bind-utils
           - git-core
           - make
           - podman

--- a/roles/reproducer/tasks/configure_crc.yml
+++ b/roles/reproducer/tasks/configure_crc.yml
@@ -25,6 +25,24 @@
         never_default4: true
         state: present
 
+    - name: Ensure NetworkManager does not override /etc/resolv.conf
+      become: true
+      ansible.builtin.copy:
+        dest: "/etc/NetworkManager/conf.d/no-resolvconf.conf"
+        mode: "0644"
+        content: |
+          [main]
+          rc-manager = unmanaged
+
+    - name: Ensure we use local dnsmasq only
+      become: true
+      ansible.builtin.copy:
+        dest: "/etc/resolv.conf"
+        mode: "0644"
+        content: |
+          # Managed by ansible/cifmw
+          nameserver {{ _crc.ip_v4 }}
+
     - name: Check which dnsmasq config we must edit
       register: _dnsmasq
       ansible.builtin.stat:


### PR DESCRIPTION
In CRC, we can't really configure existing interfaces - they get
overridden by some other process, meaning we can't ensure it won't get
any public DNS.

In order to ensure we use only the local dnsmasq , the best way is
apparently to unmanage the /etc/resolv.conf from within NetworkManager,
and hardcode the content.
Even with that, the comment seems to be removed and replaced by
`# Generated by NetworkManager` - which is... weird. Since it shouldn't
do anything in there...

We use the CRC "public" IPv4 - apparently 127.0.0.1 doesn't work, at
least from the openshift-dns/dns-default pod (throws connections
refused).

In any cases, this change seems to work (for now), ensuring DNS are
properly working.

We might want to amend the DNS configuration on the controller-0 to use
the openshift-dns/dns-default service instead - but that's for a
follow-up.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
