### PR TITLE
Avoid ansibleee-operator hardcoded version

### DIFF
--- a/roles/edpm_prepare/tasks/main.yml
+++ b/roles/edpm_prepare/tasks/main.yml
@@ -133,12 +133,20 @@
   environment:
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
     PATH: "{{ cifmw_path }}"
-  ansible.builtin.command:
-    cmd: >-
-      oc patch csv -n openstack-operators openstack-ansibleee-operator.v0.0.1
-      --type='json' -p='[{
-      "op":"replace", "path":"/spec/install/spec/deployments/0/spec/template/spec/containers/1/env/0",
-      "value": {"name": "RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT", "value": "quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest"}}]'
+  block:
+    - name: Get ansibleee-operator csv name
+      ansible.builtin.shell: |
+        set -o pipefail && \
+        oc get csv -n openstack-operators -o name | grep ansibleee-operator
+      register: _ansibleee_csv_name
+
+    - name: Patch ansible runner image
+      ansible.builtin.command:
+        cmd: >-
+          oc patch -n openstack-operators "{{ _ansibleee_csv_name.stdout }}"
+          --type='json' -p='[{
+          "op":"replace", "path":"/spec/install/spec/deployments/0/spec/template/spec/containers/1/env/0",
+          "value": {"name": "RELATED_IMAGE_ANSIBLEEE_IMAGE_URL_DEFAULT", "value": "quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest"}}]'
 
 # Prepare and kustomize the OpenStackControlPlane CR
 - name: Prepare OpenStack control plane CR


### PR DESCRIPTION
When preparing to test beta operator images, version is bumped to v1.0.0
instead of v0.0.1, so the edpm_prepare roles fails to find the
ansibleee-operator, since it looks for the v0.0.1 version. Instead we
get the full name first and then use it to patch the csv.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
