### PR TITLE
Remove cifmw_discover_latest_image_qcow_prefix from molecule config

### DIFF
--- a/.config/molecule/config_local.yml
+++ b/.config/molecule/config_local.yml
@@ -20,10 +20,10 @@ provisioner:
   # Useful when an fix requires to provide some
   # CIFMW parameter to many roles, such as a broken
   # CentOS image.
-  inventory:
-    group_vars:
-      all:
-        cifmw_discover_latest_image_qcow_prefix: "CentOS-Stream-GenericCloud-9-20240401"
+  # inventory:
+  #   group_vars:
+  #     all:
+  #       cifmw_discover_latest_image_qcow_prefix: "CentOS-Stream-GenericCloud-9-20240506"
 
   config_options:
     defaults:


### PR DESCRIPTION
Previous value CentOS-Stream-GenericCloud-9-20240401 is not available
anymore.
This patch comments it out from the molecule config, because the default
upstream image can be used instead.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
