### PR TITLE
Fix allow/skip list generation in test-operator

### DIFF
--- a/roles/test_operator/tasks/tempest-tests.yml
+++ b/roles/test_operator/tasks/tempest-tests.yml
@@ -33,12 +33,17 @@
         list_allowed
 
     - name: Set variable
+      vars:
+        allowed_tests: |
+          {% for item in list_allowed.allowed_tests %}
+          {{ item }}
+          {% endfor %}
       ansible.builtin.set_fact:
         test_operator_cr: >-
           {{
               test_operator_cr |
               combine({'spec': {'tempestRun': { 'includeList':
-                      list_allowed.allowed_tests | join('\n')
+                      allowed_tests
                       }}}, recursive=true)
           }}
 
@@ -60,12 +65,17 @@
         list_skipped
 
     - name: Set variable
+      vars:
+        skipped_tests: |
+          {% for item in list_skipped.skipped_tests %}
+          {{ item }}
+          {% endfor %}
       ansible.builtin.set_fact:
         test_operator_cr: >-
           {{
               test_operator_cr |
               combine({'spec': {'tempestRun': { 'excludeList':
-                      list_skipped.skipped_tests | join('\n')
+                      skipped_tests
                       }}}, recursive=true)
           }}
 


### PR DESCRIPTION
There was an issue with the allow/skip list generation in the test-operator role. The generated lists of tests contained the literal interpretation of \n.

We want to get from:

```
excludeList: test1\ntest2
```
to:

```
excludeList: |
  test1
  test2
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
