### PR TITLE
Correct networking layout used in molecule

### DIFF
--- a/roles/kustomize_deploy/molecule/flexible_loop/files/networking-environment-definition.yml
+++ b/roles/kustomize_deploy/molecule/flexible_loop/files/networking-environment-definition.yml
@@ -6,14 +6,14 @@ instances:
             ctlplane:
                 interface_name: eth1
                 ip_v4: 192.168.122.100
-                mac_addr: 0a:02:d5:e5:d9:0b
+                mac_addr: '52:54:00:17:05:43'
                 mtu: 1500
                 network_name: ctlplane
                 skip_nm: false
             internalapi:
                 interface_name: eth1.20
                 ip_v4: 172.17.0.100
-                mac_addr: 52:54:00:05:da:ef
+                mac_addr: '52:54:00:05:da:ef'
                 mtu: 1500
                 network_name: internalapi
                 parent_interface: eth1
@@ -22,7 +22,7 @@ instances:
             storage:
                 interface_name: eth1.21
                 ip_v4: 172.18.0.100
-                mac_addr: 52:54:00:59:8a:4c
+                mac_addr: '52:54:00:59:8a:4c'
                 mtu: 1500
                 network_name: storage
                 parent_interface: eth1
@@ -31,7 +31,7 @@ instances:
             tenant:
                 interface_name: eth1.22
                 ip_v4: 172.19.0.100
-                mac_addr: 52:54:00:0b:1c:d7
+                mac_addr: '52:54:00:0b:1c:d7'
                 mtu: 1500
                 network_name: tenant
                 parent_interface: eth1
@@ -44,25 +44,25 @@ instances:
             ctlplane:
                 interface_name: eth1
                 ip_v4: 192.168.122.9
-                mac_addr: 0a:02:a0:63:cb:1c
+                mac_addr: '0a:02:a0:63:cb:1c'
                 mtu: 1500
                 network_name: ctlplane
                 skip_nm: false
-    crc-0:
-        hostname: crc-97g8f-master-0
-        name: crc-0
+    ocp-master-0:
+        hostname: ocp-master-0
+        name: ocp-master-0
         networks:
             ctlplane:
                 interface_name: enp6s0
                 ip_v4: 192.168.122.10
-                mac_addr: 0a:02:ca:be:0b:38
+                mac_addr: '0a:02:ca:be:0b:38'
                 mtu: 1500
                 network_name: ctlplane
                 skip_nm: false
             internalapi:
                 interface_name: enp6s0.20
                 ip_v4: 172.17.0.10
-                mac_addr: 52:54:00:1b:6e:a3
+                mac_addr: '52:54:00:1b:6e:a3'
                 mtu: 1500
                 network_name: internalapi
                 parent_interface: enp6s0
@@ -71,7 +71,7 @@ instances:
             storage:
                 interface_name: enp6s0.21
                 ip_v4: 172.18.0.10
-                mac_addr: 52:54:00:56:fa:88
+                mac_addr: '52:54:00:56:fa:88'
                 mtu: 1500
                 network_name: storage
                 parent_interface: enp6s0
@@ -80,7 +80,83 @@ instances:
             tenant:
                 interface_name: enp6s0.22
                 ip_v4: 172.19.0.10
-                mac_addr: 52:54:00:18:a0:f6
+                mac_addr: '52:54:00:18:a0:f6'
+                mtu: 1500
+                network_name: tenant
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 22
+    ocp-master-1:
+        hostname: ocp-master-1
+        name: ocp-master-1
+        networks:
+            ctlplane:
+                interface_name: enp6s0
+                ip_v4: 192.168.122.11
+                mac_addr: '0a:02:ca:be:0b:39'
+                mtu: 1500
+                network_name: ctlplane
+                skip_nm: false
+            internalapi:
+                interface_name: enp6s0.20
+                ip_v4: 172.17.0.11
+                mac_addr: '52:54:00:1b:6e:a4'
+                mtu: 1500
+                network_name: internalapi
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 20
+            storage:
+                interface_name: enp6s0.21
+                ip_v4: 172.18.0.11
+                mac_addr: '52:54:00:56:fa:89'
+                mtu: 1500
+                network_name: storage
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 21
+            tenant:
+                interface_name: enp6s0.22
+                ip_v4: 172.19.0.11
+                mac_addr: '52:54:00:18:a0:f7'
+                mtu: 1500
+                network_name: tenant
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 22
+    ocp-master-2:
+        hostname: ocp-master-2
+        name: ocp-master-2
+        networks:
+            ctlplane:
+                interface_name: enp6s0
+                ip_v4: 192.168.122.12
+                mac_addr: '0a:02:ca:be:0b:40'
+                mtu: 1500
+                network_name: ctlplane
+                skip_nm: false
+            internalapi:
+                interface_name: enp6s0.20
+                ip_v4: 172.17.0.12
+                mac_addr: '52:54:00:1b:6e:a5'
+                mtu: 1500
+                network_name: internalapi
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 20
+            storage:
+                interface_name: enp6s0.21
+                ip_v4: 172.18.0.12
+                mac_addr: '52:54:00:56:fa:90'
+                mtu: 1500
+                network_name: storage
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 21
+            tenant:
+                interface_name: enp6s0.22
+                ip_v4: 172.19.0.12
+                mac_addr: '52:54:00:18:a0:f8'
                 mtu: 1500
                 network_name: tenant
                 parent_interface: enp6s0


### PR DESCRIPTION
With 6c7cf1aaf71d3a2f1f628b79838adce0646a552d change,
ci_gen_kustomize_values is properly cleaning all of the OCP nodes -
meaning we have to provide the 3-nodes in the networking environment
definition.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
