### PR TITLE
Extend ip ranges and regexes to allow deploying additional ocp workers

### DIFF
--- a/roles/libvirt_manager/tasks/start_manage_vms.yml
+++ b/roles/libvirt_manager/tasks/start_manage_vms.yml
@@ -106,7 +106,7 @@
     extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
     identity_file: >-
       {{
-        cifmw_libvirt_manager_basedir ~ '/artifacts/cifmw_ocp_access_key' if vm_type == 'ocp' else
+        cifmw_libvirt_manager_basedir ~ '/artifacts/cifmw_ocp_access_key' if vm_type is match('^ocp.*') else
         ansible_user_dir ~ '/.crc/machines/crc/id_ecdsa' if vm_type == 'crc' else
         ansible_user_dir ~ '/.ssh/cifmw_reproducer_key'
       }}

--- a/scenarios/reproducers/networking-definition.yml
+++ b/scenarios/reproducers/networking-definition.yml
@@ -97,7 +97,7 @@ cifmw_networking_definition:
       network-template:
         range:
           start: 10
-          length: 5
+          length: 10
       networks:
         ctlplane: {}
         internalapi: {}


### PR DESCRIPTION
Without the additional ips we would have errors like:

  fatal: [hypervisor-1 -> controller-0(192.168.111.50)]: FAILED! => changed=false
  message: IP Pool for 192.168.122.10-192.168.122.14 exhausted

Similarly, we need to expand the regex to allow ssh to get the right key for ssh'ing to ocp_worker nodes.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
