### PR TITLE
Generic nat to custom defined nets

### DIFF
--- a/roles/reproducer/README.md
+++ b/roles/reproducer/README.md
@@ -20,6 +20,7 @@ None
 * `cifmw_reproducer_dnf_tweaks`: (List) Options you want to inject in dnf.conf, both on controller-0 and hypervisor. Defaults to `[]`.
 * `cifmw_reproducer_skip_fetch_repositories`: (Bool) Skip fetching repositories from zuul var and simply copy the code from the ansible controller. Defaults to `false`.
 * `cifmw_reproducer_supported_hypervisor_os`: (List) List of supported hypervisor operating systems and their minimum version.
+* `cifmw_reproducer_nat_public_interfaces`: (Bool) All traffic allowed to masquerade out from the hypervisor via the public interface
 
 ### run_job and run_content_provider booleans and risks.
 

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -142,6 +142,33 @@
       }}
   failed_when: false
 
+- name: Ensure custom networks can be routed outside to the hypervisor
+  when:
+    - cifmw_reproducer_nat_public_interfaces | default ('false') | bool
+  become: true
+  block:
+    - name: Enable masquered over public interfaces
+      ansible.posix.firewalld:
+        masquerade: true
+        zone: public
+        permanent: true
+        immediate: true
+        state: enabled
+
+    - name: Ensure network is in libvirt zone
+      when:
+        - cifmw_ci_nmstate_instance_config is defined
+      ansible.posix.firewalld:
+        zone: libvirt
+        interface: "{{ item.name }}"
+        state: enabled
+        permanent: true
+        immediate: true
+      loop: >-
+        {{ cifmw_ci_nmstate_instance_config[inventory_hostname].interfaces | default([]) }}
+      loop_control:
+        label: "{{ item.name }}"
+
 - name: Run only on hypervisor with controller-0
   when:
     - (


### PR DESCRIPTION
In case a net defined with cifmw_ci_nmstate_instance_config
it should be allowed to be also routed to external
to the hypervisor network.
Routing only happens if has address on the hypervisor ns0 .

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
