### PR TITLE
Do not trigger deployment on molecule related change

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -50,6 +50,7 @@
       - ci/playbooks/molecule-test.yml
       # ci-framework
       - .ansible-lint
+      - .config/molecule/.*
       - .pre-commit-config.yaml
       - .readthedocs.yaml
       - .spellcheck.yml
@@ -57,6 +58,7 @@
       - roles/dlrn_promote
       - roles/devscripts
       - roles/reproducer
+      - zuul.d/molecule.*
       # Other openstack operators
       - containers/ci
       - .ci-operator.yaml


### PR DESCRIPTION
We may modify molecule config or zuul job from time to time. Such
changes shouldn't trigger a full deployment, since it doesn't affect it
in any way.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
