### PR TITLE
Allow to deploy architecture against CRC

### DIFF
--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -126,6 +126,15 @@
         name: kustomize_deploy
         tasks_from: check_requirements.yml
 
+    - name: Reduce OCP cluster size in architecture
+      when:
+        - groups['ocps'] | length == 1
+      ansible.builtin.import_role:
+        name: kustomize_deploy
+        tasks_from: reduce_ocp_cluster.yml
+      tags:
+        - edpm_bootstrap
+
     - name: Deploy OSP operators
       ansible.builtin.import_role:
         name: kustomize_deploy

--- a/roles/kustomize_deploy/tasks/reduce_ocp_cluster.yml
+++ b/roles/kustomize_deploy/tasks/reduce_ocp_cluster.yml
@@ -1,0 +1,84 @@
+---
+# NNCP: modify kustomization.yaml
+# - remove node_1 and node_2 related entries
+- name: NNCP block to reduce OCP cluster size
+  vars:
+    _nncp_lib_path: >-
+      {{
+        (cifmw_kustomize_deploy_architecture_repo_dest_dir,
+         'lib/nncp/') | path_join
+      }}
+    _nncp_kust_path: >-
+      {{
+        (_nncp_lib_path, 'kustomization.yaml') | path_join
+      }}
+    _nncp_ocp_nodes_path: >-
+      {{
+        (_nncp_lib_path, 'ocp_nodes_nncp.yaml') | path_join
+      }}
+  block:
+    - name: Load nncp kustomization.yaml
+      register: nncp_kust_raw
+      ansible.builtin.slurp:
+        path: "{{ _nncp_kust_path }}"
+
+    - name: Remove node_1 and node_2
+      vars:
+        _nncp_kust: "{{ nncp_kust_raw.content | b64decode | from_yaml }}"
+        _nncp_reduced: >-
+          {% set _out = [] -%}
+          {% for replacement in _nncp_kust.replacements -%}
+          {%   if (replacement.targets | rejectattr("select.name", "undefined") | map(attribute="select.name")) | length > 0 -%}
+          {%     set _= _out.append(replacement) if (replacement.targets | map(attribute="select.name") | first) is not match('^node-[1-9]+$') -%}
+          {%   else -%}
+          {%     set _= _out.append(replacement) -%}
+          {% endif -%}
+          {% endfor -%}
+          {{ _out }}
+        _nncp_no_replace: >-
+          {{
+            _nncp_kust |
+            dict2items |
+            rejectattr('key','equalto', 'replacements') |
+            items2dict
+          }}
+        _nncp_updated: >-
+          {{
+            _nncp_no_replace |
+            combine({'replacements': _nncp_reduced})
+          }}
+      ansible.builtin.copy:
+        backup: true
+        content: "{{ _nncp_updated | to_nice_yaml }}"
+        dest: "{{ _nncp_kust_path }}"
+        mode: "0644"
+
+    - name: Reduce NNCP ocp_nodes
+      ansible.builtin.copy:
+        backup: true
+        dest: "{{ _nncp_ocp_nodes_path }}"
+        mode: "0644"
+        content: |
+          ---
+          apiVersion: nmstate.io/v1
+          kind: NodeNetworkConfigurationPolicy
+          metadata:
+            name: node-0
+            labels:
+              osp/nncm-config-type: standard
+
+- name: Controlplane block to reduce replicas to 1
+  vars:
+    _ctlplane_path: >-
+      {{
+        (cifmw_kustomize_deploy_architecture_repo_dest_dir,
+         'lib/control-plane/openstackcontrolplane.yaml') |
+         path_join
+      }}
+  block:
+    - name: Replace replicas
+      ansible.builtin.replace:
+        backup: true
+        path: "{{ _ctlplane_path }}"
+        regexp: '^(.+) replicas: [2-9]+$'
+        replace: '\1 replicas: 1'


### PR DESCRIPTION
This patch allows to deploy at least va-hci.yml scenario against CRC.

It's not enough, crafted parameter files are also needed to ensure
proper variables are passed in the right order, but mostly: it works.

It could be used to run architecture validation jobs, at least when VMs
are enough to test things up (for now, HCI, mostly).
When it comes to "baremetal provisioning", sushy may be leveraged to act
as the IPMI/related interface for metal3, allowing to go further down
the path of architecture testing.

This capability isn't "the end" - it's just offering a light way to test
things up.

Documentation will follow to show what specific parameter files are
needed (hence the DRAFT here).

As a pull request owner and reviewers, I checked that:
- [X] For now there's no real testing for that patch. Running Architecture driven deploy isn't a thing yet.
