### PR TITLE
[test-operator] Make ntp_extra_image more generic

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -142,6 +142,7 @@ envfile
 epel
 epyc
 eth
+extraImages
 ezzmy
 favorit
 fbqufbqkfbzxrja

--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -31,7 +31,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_tempest_ssh_key_secret_name`: (String) Name of a secret that contains ssh-privatekey field with a private key. The private key is mounted to `/var/lib/tempest/.ssh/id_ecdsa`
 * `cifmw_test_operator_tempest_config_overwrite`: (Dict) Dictionary where key is name of a file and value is content of the file. All files mentioned in this field are mounted to `/etc/test_operator/<filename>`
 * `cifmw_test_operator_tempest_workflow`: (List) Definition of a Tempest workflow that consists of multiple steps. Each step can contain all values from Spec section of [Tempest CR](https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource).
-* `cifmw_test_operator_tempest_ntp_extra_image`: (String) URL that points to an extra image that is used by [whitebox-neutron-tempest-plugin](https://opendev.org/x/whitebox-neutron-tempest-plugin). Default value: `''`
+* `cifmw_test_operator_tempest_extra_images`: (List) A list of images that should be uploaded to OpenStack before the tests are executed. The value is passed to extraImages parameter in the [Tempest CR](https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource). Default value: `[]`
 * `cifmw_test_operator_tempest_network_attachments`: (List) List of network attachment definitions to attach to the tempest pods spawned by test-operator. Default value: `[]`.
 * `cifmw_test_operator_tempest_config`: (Object) Definition of Tempest CRD instance that is passed to the test-operator (see [the test-operator documentation](https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource)). Default value:
 ```

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -63,6 +63,7 @@ cifmw_test_operator_tempest_config:
       concurrency: "{{ cifmw_test_operator_concurrency }}"
       externalPlugin: "{{ cifmw_test_operator_tempest_external_plugin | default([]) }}"
       neutronExtraImage: "{{ cifmw_test_operator_tempest_ntp_extra_image | default('') }}"
+      extraImages: "{{ cifmw_test_operator_tempest_extra_images | default([]) }}"
     tempestconfRun: "{{ cifmw_tempest_tempestconf_config | default(omit) }}"
     workflow: "{{ cifmw_test_operator_tempest_workflow }}"
 


### PR DESCRIPTION
The cifmw_test_operator_tempest_ntp_extra_image was designed with
neutron tempest plugin in mind. It only allows specifying an image that
should be downloaded but does not allow to define details like flavor
for this image or ID that should be assigned to the given image.
    
This patch removes the ntp_extra_image parameter and introduces a new
cifmw_test_operator_tempest_extra_images parameter that exposes the
extraImages parameter from Tempest CR that allows to specify the more
granular details.
    

- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
