### PR TITLE
Filter out and update cifmw_set_openstack_containers_registry

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -356,6 +356,7 @@
             rejectattr('key', 'equalto', 'cifmw_extras') |
             rejectattr('key', 'equalto', 'cifmw_openshift_kubeconfig') |
             rejectattr('key', 'equalto', 'cifmw_openshift_token') |
+            rejectattr('key', 'equalto', 'cifmw_set_openstack_containers_registry') |
             rejectattr('key', 'match', '^cifmw_use.*') |
             rejectattr('key', 'match', '^cifmw_reproducer.*') |
             rejectattr('key', 'match', '^cifmw_rhol.*') |

--- a/roles/reproducer/templates/content-provider.yml.j2
+++ b/roles/reproducer/templates/content-provider.yml.j2
@@ -102,7 +102,8 @@
         content: |-
           {{
             {'cifmw_operator_build_output': cifmw_operator_build_output,
-             'content_provider_registry_ip': cifmw_rp_registry_ip
+             'content_provider_registry_ip': cifmw_rp_registry_ip,
+             'cifmw_set_openstack_containers_registry:': cifmw_rp_registry_ip
             } | to_nice_yaml
           }}
 {% endraw %}


### PR DESCRIPTION
It seems we need to update `cifmw_set_openstack_containers_registry`
parameter in content-provider based job reproducer.

That parameter seems to be used in the deployment, leading to this kind
of errors:
```
image pull failed for 10.0.177.75:5001/podified-rhos18-rhel9/openstack-neutron-server:91f06f5714b27a55febb3cdb9db608ce
because the registry is unavailable: pinging container registry 10.0.177.75:5001:
Get "https://10.0.177.75:5001/v2/": dial tcp 10.0.177.75:5001: connect:
connection refused
```

The content-provider is actually on the controller-0 node, usually on
192.168.122.9 IP.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
