### PR TITLE
Drop task to install dataplane services

### DIFF
--- a/roles/edpm_deploy/tasks/main.yml
+++ b/roles/edpm_deploy/tasks/main.yml
@@ -77,24 +77,6 @@
     name: 'install_yamls_makes'
     tasks_from: 'make_edpm_deploy_prep'
 
-- name: Install Dataplane services
-  vars:
-    _cifmw_edpm_deploy_service_path: >-
-      {{
-        [
-          cifmw_edpm_deploy_manifests_dir,
-          'operator/dataplane-operator',
-          'config/services'
-        ] | ansible.builtin.path_join
-      }}
-  when: not cifmw_edpm_deploy_dryrun
-  environment:
-    PATH: "{{ cifmw_path }}"
-    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-  cifmw.general.ci_script:
-    output_dir: "{{ cifmw_edpm_deploy_basedir }}/artifacts"
-    script: "oc apply -f {{ _cifmw_edpm_deploy_service_path }}"
-
 - name: Kustomize and deploy OpenStackDataPlaneNodeSet
   when:
     - not cifmw_edpm_deploy_dryrun | bool


### PR DESCRIPTION
Installing the dataplane services that come bundled with the
dataplane-operator under config/services is not necessary, they are are
created automatically by the NodeSet controller.

There was a similar change committed to install_yamls in
commit cb9e41ef12c79629a92cea1fd0a307a6b1d8f9a1.

Signed-off-by: James Slagle <jslagle@redhat.com>

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
