### PR TITLE
Make start VM and Manage (inventory + jumper) optional

### DIFF
--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -44,7 +44,9 @@ The following structure has to be passed via the configuration parameter:
 ```YAML
 cifmw_libvirt_manager_configuration:
   vms:
-    type_name:  # (string, such as "compute", "controller")
+    type_name:  # (string, such as "compute", "controller"
+      start: (boolean, toggle if the VM should be strated or not. Optional, defaults to true)
+      manage: (boolean, toogle if the VM should be added to the inventory. Managed VM's must be on the cifmw_libvirt_manager_pub_net network. Optional, defaults to true)
       amount: (integer, optional. Optional, defaults to 1, allowed [0-9]+)
       image_url: (string, URI to the base image. Optional if disk_file_name is set to "blank")
       sha256_image_name: (string, image checksum. Optional if disk_file_name is set to "blank")

--- a/roles/libvirt_manager/defaults/main.yml
+++ b/roles/libvirt_manager/defaults/main.yml
@@ -32,6 +32,8 @@ cifmw_libvirt_manager_configuration:
     - default
   vms:
     compute:
+      start: true
+      manage: true
       amount: "{{ cifmw_libvirt_manager_compute_amount }}"
       image_url: "{{ cifmw_discovered_image_url | default('{{ cifmw_libvirt_manager_images_url }}/CentOS-Stream-GenericCloud-9-20230410.0.x86_64.qcow2') }}"
       sha256_image_name: "{{ cifmw_discovered_hash | default('8a5abbf8b0dda3e4e49b5112ffae3fff022bf97a5f53b868adbfb80c75c313fe') }}"

--- a/roles/libvirt_manager/molecule/deploy_layout/converge.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/converge.yml
@@ -37,7 +37,12 @@
       vms:
         nocompute:
           amount: 0
-          disk_file_name: "blank"
+          start: false
+          manage: false
+          image_url: "{{ cifmw_discovered_image_url }}"
+          sha256_image_name: "{{ cifmw_discovered_hash }}"
+          image_local_dir: "{{ cifmw_basedir }}/images/"
+          disk_file_name: "centos-stream-9.qcow2"
           disksize: 20
           memory: 1
           cpus: 1

--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -172,10 +172,18 @@
     index_var: index
     label: "{{ vm_type }}-{{ index }}"
 
-- name: "Assert we have public_net_nics and macs data for {{ vm_type }}"
+- name: "Assert we have macs data for {{ vm_type }}"
   ansible.builtin.assert:
     that:
       - macs | length > 0
+    msg: >-
+      Something went wrong while trying to extract interface mac addresses.
+      Please double-check your scenario!
+
+- name: "Assert we have public_net_nics {{ vm_type }}"
+  when: vm_data.value.manage | default(true) | bool
+  ansible.builtin.assert:
+    that:
       - public_net_nics | length > 0
     msg: >-
       Something went wrong while trying to extract interfaces associated to
@@ -211,9 +219,17 @@
     index_var: index
     label: "{{ vm_type }}-{{ index }}"
 
-- name: "Start and grab IP if image is not blank for {{ vm_type }}"
+- name: "Start (power-on) {{ vm_type }}"
   when:
-    - vm_data.value.disk_file_name != 'blank'
+    - vm_data.value.start | default(true) | bool
+    - "vm_data.value.disk_file_name != 'blank'"
+  ansible.builtin.include_tasks: start_vms.yml
+
+- name: "Grab IP address and manage {{ vm_type }}"
+  when:
+    - vm_data.value.manage | default(true) | bool
+    - vm_data.value.start | default(true) | bool
+    - "vm_data.value.disk_file_name != 'blank'"
   vars:
     _need_start: "{{ _create_overlays is changed }}"
-  ansible.builtin.include_tasks: start_manage_vms.yml
+  ansible.builtin.include_tasks: manage_vms.yml

--- a/roles/libvirt_manager/tasks/manage_vms.yml
+++ b/roles/libvirt_manager/tasks/manage_vms.yml
@@ -1,28 +1,4 @@
 ---
-- name: Refresh oooq_pool before starting VMs
-  when:
-    - item.value.status == 'running'
-  community.libvirt.virt_pool:
-    command: refresh
-    name: "{{ item.key }}"
-  loop: "{{ ansible_libvirt_pools | dict2items }}"
-  loop_control:
-    label: "{{ item.key }}"
-
-# Start and manage VMs, such as injecting SSH configurations,
-# inject the VMs in the live inventory for later reference, and so on.
-# In case we create a "blank" VM, without any OS, it shouldn't be known by
-# ansible, so no access should be done.
-- name: "Start VMs for type {{ vm_type }}"
-  community.libvirt.virt:
-    state: running
-    name: "cifmw-{{ vm_type }}-{{ vm_id }}"
-    uri: "qemu:///system"
-  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
-  loop_control:
-    index_var: vm_id
-    label: "{{ vm_type }}-{{ vm_id }}"
-
 - name: "Grab IPs for nodes type {{ vm_type }}"  # noqa: risky-shell-pipe
   register: vm_ips
   ansible.builtin.shell:

--- a/roles/libvirt_manager/tasks/start_vms.yml
+++ b/roles/libvirt_manager/tasks/start_vms.yml
@@ -1,0 +1,24 @@
+---
+- name: Refresh oooq_pool before starting VMs
+  when:
+    - "item.value.status == 'running'"
+  community.libvirt.virt_pool:
+    command: refresh
+    name: "{{ item.key }}"
+  loop: "{{ ansible_libvirt_pools | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+
+# Start and manage VMs, such as injecting SSH configurations,
+# inject the VMs in the live inventory for later reference, and so on.
+# In case we create a "blank" VM, without any OS, it shouldn't be known by
+# ansible, so no access should be done.
+- name: "Start VMs for type {{ vm_type }}"
+  community.libvirt.virt:
+    state: running
+    name: "cifmw-{{ vm_type }}-{{ vm_id }}"
+    uri: "qemu:///system"
+  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
+  loop_control:
+    index_var: vm_id
+    label: "{{ vm_type }}-{{ vm_id }}"


### PR DESCRIPTION
It does not make sense to add all VMs created in a lab environment to the ci-framework inventory.

Also not starting VMs can be useful even for VMs that don't use a blank image.

Add two fields to the "vms" definition: `start` and `manage`. A VM that is not started won't be managed, a VM can be started but not managed.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
