### PR TITLE
[libvirt_manager] Update domain.xml.j2 to support baremetal instance

### DIFF
--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -57,6 +57,7 @@ cifmw_libvirt_manager_configuration:
       password: (string, optional, defaults to fooBar. Root password for console access)
       target: (Hypervisor hostname you want to deploy the family on. Optional)
       uefi: (boolean, toggle UEFI boot. Optional, defaults to false)
+      bootmenu_enable: (string, toggle bootmenu. Optional, defaults to "no")
   networks:
     net_name: <XML definition of the network to create>
 ```
@@ -99,6 +100,15 @@ cifmw_libvirt_manager_configuration:
       nets:
         - public
         - osp_trunk
+    baremetal_instance:
+      amount: 2
+      disk_file_name: "blank"
+      disksize: 50
+      memory: 8
+      cpus: 4
+      bootmenu_enable: "yes"
+      nets:
+        - public
   networks:
     public: |-
       <network>

--- a/roles/libvirt_manager/templates/domain.xml.j2
+++ b/roles/libvirt_manager/templates/domain.xml.j2
@@ -13,7 +13,7 @@
     <type arch='x86_64' machine='q35'>hvm</type>
 {% endif %}
     <boot dev='hd'/>
-    <bootmenu enable='no'/>
+    <bootmenu enable='{{ vm_data.value.bootmenu_enable | default('no') }}'/>
   </os>
   <cpu mode='host-passthrough' check='none'/>
   <clock offset='utc'>
@@ -107,6 +107,7 @@
     </memballoon>
     <rng model='virtio'>
       <backend model='random'>/dev/urandom</backend>
+      <rate bytes="1024" period="100"/>
       <alias name='rng0'/>
       <address type='pci'/>
     </rng>


### PR DESCRIPTION
This patch:
- Adds support to enable the bootmenu
- Adds early RNG entropy[1], without this baremetal instance vms can fail with "Jitter RNG permanent health test failure" errors [2]
- Update docs with `disk_file_name: "blank"` example using `bootmenu_enable`

[1] https://libvirt.org/formatdomain.html#id109
[2] Jira: [OSPRH-1967](https://issues.redhat.com//browse/OSPRH-1967)

Jira: [OSPRH-6841](https://issues.redhat.com//browse/OSPRH-6841)

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
