### PR TITLE
[kustomize_deploy] Combine multiple user kustomizations as one

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -44,7 +44,7 @@ are shared among multiple roles:
   in the architecture repository. Defaults to `default.yaml`
 - `cifmw_architecture_scenario`: (String) The selected VA scenario to deploy.
 - `cifmw_architecture_wait_condition`: (Dict) Structure defining custom wait_conditions for the automation.
-- `cifmw_architecture_user_kustomize`: (Dict) Structure defining user provided kustomization for automation.
+- `cifmw_architecture_user_kustomize.*`: (Dict) Structures defining user provided kustomization for automation. All these variables are combined together.
 - `cifmw_ceph_target`: (String) The Ansible inventory group where ceph is deployed. Defaults to `computes`.
 - `cifmw_run_tests`: (Bool) Specifies whether tests should be executed.
   Defaults to false.

--- a/roles/kustomize_deploy/molecule/flexible_loop/converge.yml
+++ b/roles/kustomize_deploy/molecule/flexible_loop/converge.yml
@@ -25,6 +25,11 @@
         name: networking_mapper
         tasks_from: load_env_definition.yml
 
+    - name: Check requirements
+      ansible.builtin.import_role:
+        role: kustomize_deploy
+        tasks_from: check_requirements.yml
+
     - name: Load architecture automation
       vars:
         _automation: >-
@@ -50,7 +55,6 @@
           {{ lookup('file', _nova_key ~ '.pub', rstrip=False)}}
         cifmw_ci_gen_kustomize_values_migration_priv_key: >-
           {{ lookup('file', _nova_key, rstrip=False) }}
-
 
     - name: Loop the deploy
       ansible.builtin.include_role:

--- a/roles/kustomize_deploy/molecule/flexible_loop/prepare.yml
+++ b/roles/kustomize_deploy/molecule/flexible_loop/prepare.yml
@@ -20,11 +20,6 @@
     - ../../defaults/main.yml
     - ./resources/vars.yml
   tasks:
-    - name: Check requirements
-      ansible.builtin.import_role:
-        role: kustomize_deploy
-        tasks_from: check_requirements.yml
-
     - name: Ensure we have networking mapper definition
       become: true
       block:

--- a/roles/kustomize_deploy/molecule/flexible_loop/resources/vars.yml
+++ b/roles/kustomize_deploy/molecule/flexible_loop/resources/vars.yml
@@ -8,6 +8,7 @@ cifmw_path: >-
                ansible_env.PATH])
   }}
 cifmw_kustomize_deploy_generate_crs_only: true
+ci_gen_kustomize_fetch_ocp_state: false
 _nova_key: >-
   {{
     (ansible_user_dir, 'ci-framework-data',

--- a/roles/kustomize_deploy/tasks/_compute_user_kustomize.yml
+++ b/roles/kustomize_deploy/tasks/_compute_user_kustomize.yml
@@ -1,0 +1,29 @@
+---
+- name: Set the final cifmw_architecture_user_kustomize based on its patches
+  vars:
+    _kustomize_user_patches: >-
+      {{
+        hostvars[inventory_hostname] |
+        dict2items |
+        selectattr("key", "match", "^cifmw_architecture_user_kustomize.+") |
+        sort(attribute='key')
+      }}
+  ansible.builtin.set_fact:
+    _cifmw_kustomize_deploy_user_kustomize: >-
+      {{
+        _cifmw_kustomize_deploy_user_kustomize |
+        default({}) |
+        combine(item.value, recursive=True)
+      }}
+  loop: >-
+    {{
+      _kustomize_user_patches +
+      [
+        {
+          'key': 'cifmw_architecture_user_kustomize',
+          'value': (cifmw_architecture_user_kustomize | default({}))
+        }
+      ]
+    }}
+  loop_control:
+    label: "{{ item.key }}"

--- a/roles/kustomize_deploy/tasks/check_requirements.yml
+++ b/roles/kustomize_deploy/tasks/check_requirements.yml
@@ -53,3 +53,6 @@
     path: "{{ cifmw_kustomize_deploy_kustomizations_dest_dir }}"
     mode: "0755"
     state: "directory"
+
+- name: Compute the user kustomize dict
+  ansible.builtin.import_tasks: _compute_user_kustomize.yml

--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -125,17 +125,13 @@
            }}
         cifmw_ci_gen_kustomize_values_userdata: >-
           {{
-            (cifmw_architecture_user_kustomize is defined and
-             cifmw_architecture_user_kustomize[_stage_name_id][_name] is defined
+            (
+              _cifmw_kustomize_deploy_user_kustomize[_stage_name_id][_name] is defined |
+              ternary(_cifmw_kustomize_deploy_user_kustomize[_stage_name_id][_name], {})
             ) |
-            ternary(cifmw_architecture_user_kustomize[_stage_name_id][_name],
-                    {}) |
             combine(
-            (cifmw_architecture_user_kustomize is defined and
-             cifmw_architecture_user_kustomize[_stage_name][_name] is defined
-            ) |
-            ternary(cifmw_architecture_user_kustomize[_stage_name][_name],
-                    {})
+              _cifmw_kustomize_deploy_user_kustomize[_stage_name][_name] is defined |
+              ternary(_cifmw_kustomize_deploy_user_kustomize[_stage_name][_name], {})
             )
           }}
       ansible.builtin.include_role:

--- a/roles/kustomize_deploy/tasks/install_operators.yml
+++ b/roles/kustomize_deploy/tasks/install_operators.yml
@@ -26,10 +26,10 @@
     cifmw_ci_gen_kustomize_values_userdata: >-
       {{
         (
-          cifmw_architecture_user_kustomize is defined and
-          cifmw_architecture_user_kustomize['common']['olm-values'] is defined
+          _cifmw_kustomize_deploy_user_kustomize is defined and
+          _cifmw_kustomize_deploy_user_kustomize['common']['olm-values'] is defined
         ) |
-        ternary( cifmw_architecture_user_kustomize['common']['olm-values'], {} )
+        ternary(_cifmw_kustomize_deploy_user_kustomize['common']['olm-values'], {} )
       }}
   ansible.builtin.include_role:
     name: ci_gen_kustomize_values


### PR DESCRIPTION
In automation it may happen that the jobs have already defined a cifmw_architecture_user_kustomize but the user wants to add his own kutomization or just concat multiple ones as part of his job parenting strategy. With the previous approach only one cifmw_architecture_user_kustomize may survive, forcing the user to be aware of the already defined kustomization and making him duplicate all the content.
With this approach we can consume multiple kustomization dicts that will be combined all together before consuming them as a single one.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
