### PR TITLE
[env_op_images] Avoid using install_yamls defaults

### DIFF
--- a/roles/env_op_images/tasks/main.yml
+++ b/roles/env_op_images/tasks/main.yml
@@ -49,7 +49,7 @@
         cmd: >-
           oc get ClusterServiceVersion
           -l operators.coreos.com/openstack-operator.openstack-operators
-          -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }}
+          --all-namespaces
           -o yaml
       register: _csvs_out
 
@@ -86,9 +86,15 @@
         label: "{{ item.name }}"
 
     - name: Get all the pods in openstack-operator namespace
+      vars:
+        csv_items: "{{ (_csvs_out.stdout | from_yaml)['items'] }}"
       kubernetes.core.k8s_info:
         kind: Pod
-        namespace: "{{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }}"
+        namespace: >-
+          {{
+            ((csv_items | first).metadata.namespace)
+            if csv_items | length > 0 else omit
+          }}
         kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
         api_key: "{{ cifmw_openshift_token | default(omit)}}"
         context: "{{ cifmw_openshift_context | default(omit)}}"


### PR DESCRIPTION
Since this role is consumed from the logs playbook, that is standalone and that should work perfectly fine without install_yamls just remove the hard dependency it has with the
cifmw_install_yamls_defaults variable.
To do so, it now queries all the namespaces searching the CSV and it uses the CSV namespace afterwards.

As a pull request owner and reviewers, I checked that:
- [] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
