### PR TITLE
[libvirt_manager] Increase the number of retries for SSH configure

### DIFF
--- a/roles/libvirt_manager/tasks/start_manage_vms.yml
+++ b/roles/libvirt_manager/tasks/start_manage_vms.yml
@@ -177,7 +177,7 @@
       set -o pipefail;
       cat ~/.ssh/authorized_keys |
       ssh -v {{ _user }}@{{ vm_ip.nic.host }} "cat >> ~/.ssh/authorized_keys"
-  retries: 5
+  retries: 18
   delay: 10
   register: _ssh_access
   until: _ssh_access.rc == 0


### PR DESCRIPTION
In some environment, configure ssh access on ocp is failing with rc = 255 meaning the system is not completely booted. We also reach the maximum retries by then.

This patch increases the number of retries to allow ocp-0 to fully boot and allow remote connections.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running

