### PR TITLE
[ci_gen_kustomize_values] renamed olm template folder

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/common/olm-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/common/olm-values/values.yaml.j2
@@ -1,3 +1,3 @@
-# source: common/olm/values.yaml.j2
+# source: common/olm-values/values.yaml.j2
 data:
     openstack-operator-image: {{ cifmw_ci_gen_kustomize_values_ooi_image | default('quay.io/openstack-k8s-operators/openstack-operator-index:latest', true) }}


### PR DESCRIPTION
This patch is a followup of #1248 [1]. Since the role code was searching for `values.yaml` file inside `{{ _datatype }}-values` the customization wasn't applied so even if the `cifmw_ci_gen_kustomize_values_ooi_image` was provided.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/1248

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
