### PR TITLE
Replace noop molecule job parent

### DIFF
--- a/ci/playbooks/noop.yml
+++ b/ci/playbooks/noop.yml
@@ -1,8 +1,0 @@
----
-- name: Noop playbook
-  hosts: all
-  gather_facts: false
-  tasks:
-    - name: Hello world
-      ansible.builtin.debug:
-        msg: "Hello world"

--- a/zuul.d/molecule-base.yaml
+++ b/zuul.d/molecule-base.yaml
@@ -36,9 +36,12 @@
 
 - job:
     name: cifmw-molecule-noop
-    parent: base-minimal-test
-    nodeset: rdo-centos-9-stream
-    run:
-      ci/playbooks/noop.yml
+    description: |
+      NOOP job for roles without any molecule
+    parent: run-test-command
+    nodeset: centos-stream-9
+    vars:
+      test_command:
+        - "echo 'no check to run'"
     provides:
       - cifmw-molecule


### PR DESCRIPTION
Seems we don't have the label downstream - let's use a parent that seems
to be small enough, while existing in both locations

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
