### PR TITLE
Add Github workflow to set [re]opened PRs into draft state

### DIFF
--- a/.github/workflows/auto-draft.yml
+++ b/.github/workflows/auto-draft.yml
@@ -1,0 +1,31 @@
+# Marks all newly opened and reopened pull requests as drafts
+# and adds a helpful comment to the PR
+
+# Run only on opened and reopened pull request events
+name: Set to draft status when PR is [re]opened
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  mark-as-draft:
+    runs-on: ubuntu-latest
+    permissions: # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+      contents: write # Required for setting draft state
+      pull-requests: write # Required for posting comment
+    steps:
+      # Use the gh cli tool to set the PR into draft state if opened without it
+      # and add a helpful comment
+      - name: Set to draft and add comment
+        continue-on-error: true # We should not block if this action fails for some reason
+        if: github.event.pull_request.draft == false
+        shell: bash
+        run: >
+          gh pr ready "$URL" --undo &&
+          printf 'Thanks for the PR! :heart:\nI am marking it as a draft,
+          once passing your happy and the PR is passing CI click the
+          \"Ready for review\" button below.' |
+          gh pr comment "$URL" -F -
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          URL: ${{ github.event.pull_request.html_url }}

--- a/docs/source/development/01_guidelines.md
+++ b/docs/source/development/01_guidelines.md
@@ -1,14 +1,18 @@
 # Contribution guidelines
 
 ## Ansible best practices
+
 We try hard to follow [Ansible Best Practices](https://docs.ansible.com/ansible/latest/tips_tricks/index.html).
 
 ### Include vs Import
+
 Usually, we should rely on `ansible.builtin.import_(tasks|role)` instead of
 `ansible.builtin.include_(tasks|role)`.
 
 While both are mostly doing the same, the time and support is different.
+
 #### Include
+
 The `include_*` directives allow to load content dynamically. This is usually
 mandatory when we want to `loop` on items, and include multiple time the same
 tasks or role. The inclusion is done mostly runtime, and makes some usages a
@@ -19,6 +23,7 @@ For instance, `tags` aren't passed along, unless we use `apply` keyword.
 The `include_*` directives may also have an impact on performances.
 
 #### Import
+
 The `import_*` directives allow to load content statically. It's usually
 "compiled" internally when the play environment is built, meaning we may get
 small performances improvements. They fully support `tags` so that we may
@@ -32,11 +37,26 @@ over the same play, I'll use `include_*` module. For the rest, I'll use
 ~~~
 
 ## Testing
+
 ### Ansible role
+
 Please take the time to ensure [molecule tests](./02_molecule.md) are present
 and cover as many corner cases as possible.
 
 ### Ansible custom plugins
+
 Please take the time to consider how to test your custom plugins. You may
 either rely on [molecule](./02_molecule.md) or, maybe,
 [ansible-test](https://github.com/openstack-k8s-operators/ci-framework/tree/main/tests/integration).
+
+## Review workflow
+
+Once your patch is passing CI and not in draft status a reviewer will review your patch.
+If you would like to bring attention to your patch before a reviewer has made it to your patch
+reached out in our [slack channel](https://redhat.enterprise.slack.com/archives/C03MD4LG22Z)
+
+### Auto Draft status
+
+When a PR is opened or reopened the Github bot will enable the draft status. Once your patch is
+passing CI and you would be happy with it merging, click the "Ready for review" button, this will
+then trigger the Review workflow mentioned above.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -39,7 +39,7 @@ In case of emergency, or if we didn't come back to you in a reasonable time (exp
 
 
 .. _`issue in Jira`: https://issues.redhat.com/
-.. _`Slack channel`: https://redhat.enterprise.slack.com/archives/C04SKQ5KSJ0
+.. _`Slack channel`: https://redhat.enterprise.slack.com/archives/C03MD4LG22Z
 
 
 .. toctree::


### PR DESCRIPTION
 Add Github workflow to set [re]opened PRs into draft state
 
 This patch:
  - Adds a workflow that runs on 'opened' and 'reopened'
 pull_request events, it will change the status to draft if not already
 and add a helpful comment.
 
 - Updates our contributor documentation to explain this behavior.
    
 JIRA: [OSPRH-6890](https://issues.redhat.com//browse/OSPRH-6890)

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
