### PR TITLE
Fix dlrn_reporting role for component promotion

### DIFF
--- a/roles/dlrn_report/tasks/dlrn_report_results.yml
+++ b/roles/dlrn_report/tasks/dlrn_report_results.yml
@@ -30,11 +30,7 @@
       --server-principal {{ cifmw_dlrn_report_dlrnapi_host_principal }} --auth-method kerberosAuth
       {% endif -%}
       report-result
-      {% if (cifmw_repo_setup_dlrn_hash_tag is defined) and (cifmw_repo_setup_dlrn_hash_tag | length > 0) -%}
-      --agg-hash {{ cifmw_repo_setup_dlrn_hash_tag }}
-      {% elif (cifmw_repo_setup_full_hash is defined) and (cifmw_repo_setup_full_hash | length > 0) -%}
-      --agg-hash {{ cifmw_repo_setup_full_hash }}
-      {% endif -%}
+      {% if cifmw_repo_setup_component_name | length > 0%}
       {% if (cifmw_repo_setup_extended_hash is defined) and (cifmw_repo_setup_extended_hash | length > 0) -%}
       --extended_hash {{ cifmw_repo_setup_extended_hash }}
       {% endif -%}
@@ -44,6 +40,13 @@
       {% if (cifmw_repo_setup_distro_hash is defined) and (cifmw_repo_setup_distro_hash | length > 0) -%}
       --distro_hash {{ cifmw_repo_setup_distro_hash }}
       {% endif -%}
+      {% else %}
+      {% if (cifmw_repo_setup_dlrn_hash_tag is defined) and (cifmw_repo_setup_dlrn_hash_tag | length > 0) -%}
+      --agg-hash {{ cifmw_repo_setup_dlrn_hash_tag }}
+      {% elif (cifmw_repo_setup_full_hash is defined) and (cifmw_repo_setup_full_hash | length > 0) -%}
+      --agg-hash {{ cifmw_repo_setup_full_hash }}
+      {% endif -%}
+      {% endif %}
       --job-id {{ zuul.job }}
       --info-url "{{ cifmw_dlrn_report_zuul_log_path }}/{{ zuul_log_path }}"
       --timestamp $(date +%s)


### PR DESCRIPTION
For integration promotion, Only aggregate dlrn hash is needed but for component promotion, we need to commit, distro and extended hash.

This pr fixes the same by adding proper conditions for components.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
