### PR TITLE
Fix podified-multinode-edpm-e2e-nobuild-tagged-crc

### DIFF
--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -296,7 +296,7 @@
       cifmw_extras:
         - '@scenarios/centos-9/ci.yml'
         - '@scenarios/centos-9/multinode-ci.yml'
-        - '@scenarios/centos-9/ceph_backends.yml'
+        - '@scenarios/centos-9/hci_ceph_backends.yml'
     run:
       - ci/playbooks/e2e-run.yml
     irrelevant-files:


### PR DESCRIPTION
podified-multinode-edpm-e2e-nobuild-tagged-crc fails with Could not find or access
'/home/zuul/ci-framework-data/artifacts/pre_deploy_ceph_deploy.yml' 

Testing the job with hci_ceph_backends.yml

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
