### PR TITLE
Pass reproducer Job zuul-params.yml in tcib content provider

### DIFF
--- a/roles/reproducer/templates/content-provider.yml.j2
+++ b/roles/reproducer/templates/content-provider.yml.j2
@@ -108,7 +108,6 @@
           }}
 {% endraw %}
 {% endif %}
-
 {% if openstack_content_provider | default('false') | bool %}
 {% raw %}
     - name: Run tcib playbook
@@ -124,6 +123,7 @@
           -e cifmw_zuul_target_host=controller-0
           -e "cifmw_rp_registry_ip="{{ hostvars['localhost']['cifmw_rp_registry_ip'] }}""
           -e "@{{ ansible_user_dir }}/ci-framework-data/parameters/reproducer-variables.yml"
+          -e "@~/{{ job_id }}-params/zuul-params.yml"
           --skip-tags build_openstack_packages
 
     - name: Output needed content into consumable environment


### PR DESCRIPTION
ci/playbooks/tcib/tcib.yml depends on zuul vars to find out the ci-framework 01-bootstrap.yml path.

Otherwise the tcib reproducer content provider playbook fails with following error
```
2024-05-09 03:30:52,939 p=25285 u=zuul n=ansible | ERROR! Unable to look up a name or access an attribute in template string ({{
    [
      ansible_user_dir,
      zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
      'playbooks',
      '01-bootstrap.yml'
    ] | ansible.builtin.path_join

}}).
Make sure your variable name does not contain invalid characters like '-': join() argument must be str, bytes, or os.PathLike object, not 'AnsibleUndefined'. join() argument must be str, bytes, or os.PathLike object, not 'AnsibleUndefined'.
```
Passing reproducer Job zuul-params.yml fixes the issue.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

