### PR TITLE
Architecture repository test playbook

### DIFF
--- a/ci/playbooks/files/networking-env-definition.yml
+++ b/ci/playbooks/files/networking-env-definition.yml
@@ -1,0 +1,337 @@
+instances:
+    compute-0:
+        hostname: compute-0
+        name: compute-0
+        networks:
+            ctlplane:
+                interface_name: eth1
+                ip_v4: 192.168.122.100
+                mac_addr: '52:54:00:17:05:43'
+                mtu: 1500
+                network_name: ctlplane
+                skip_nm: false
+            internalapi:
+                interface_name: eth1.20
+                ip_v4: 172.17.0.100
+                mac_addr: '52:54:00:05:da:ef'
+                mtu: 1500
+                network_name: internalapi
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 20
+            storage:
+                interface_name: eth1.21
+                ip_v4: 172.18.0.100
+                mac_addr: '52:54:00:59:8a:4c'
+                mtu: 1500
+                network_name: storage
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 21
+            tenant:
+                interface_name: eth1.22
+                ip_v4: 172.19.0.100
+                mac_addr: '52:54:00:0b:1c:d7'
+                mtu: 1500
+                network_name: tenant
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 22
+    controller-0:
+        hostname: controller-0
+        name: controller-0
+        networks:
+            ctlplane:
+                interface_name: eth1
+                ip_v4: 192.168.122.9
+                mac_addr: '0a:02:a0:63:cb:1c'
+                mtu: 1500
+                network_name: ctlplane
+                skip_nm: false
+    ocp-master-0:
+        hostname: ocp-master-0
+        name: ocp-master-0
+        networks:
+            ctlplane:
+                interface_name: enp6s0
+                ip_v4: 192.168.122.10
+                mac_addr: '0a:02:ca:be:0b:38'
+                mtu: 1500
+                network_name: ctlplane
+                skip_nm: false
+            internalapi:
+                interface_name: enp6s0.20
+                ip_v4: 172.17.0.10
+                mac_addr: '52:54:00:1b:6e:a3'
+                mtu: 1500
+                network_name: internalapi
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 20
+            storage:
+                interface_name: enp6s0.21
+                ip_v4: 172.18.0.10
+                mac_addr: '52:54:00:56:fa:88'
+                mtu: 1500
+                network_name: storage
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 21
+            tenant:
+                interface_name: enp6s0.22
+                ip_v4: 172.19.0.10
+                mac_addr: '52:54:00:18:a0:f6'
+                mtu: 1500
+                network_name: tenant
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 22
+    ocp-master-1:
+        hostname: ocp-master-1
+        name: ocp-master-1
+        networks:
+            ctlplane:
+                interface_name: enp6s0
+                ip_v4: 192.168.122.11
+                mac_addr: '0a:02:ca:be:0b:39'
+                mtu: 1500
+                network_name: ctlplane
+                skip_nm: false
+            internalapi:
+                interface_name: enp6s0.20
+                ip_v4: 172.17.0.11
+                mac_addr: '52:54:00:1b:6e:a4'
+                mtu: 1500
+                network_name: internalapi
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 20
+            storage:
+                interface_name: enp6s0.21
+                ip_v4: 172.18.0.11
+                mac_addr: '52:54:00:56:fa:89'
+                mtu: 1500
+                network_name: storage
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 21
+            tenant:
+                interface_name: enp6s0.22
+                ip_v4: 172.19.0.11
+                mac_addr: '52:54:00:18:a0:f7'
+                mtu: 1500
+                network_name: tenant
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 22
+    ocp-master-2:
+        hostname: ocp-master-2
+        name: ocp-master-2
+        networks:
+            ctlplane:
+                interface_name: enp6s0
+                ip_v4: 192.168.122.12
+                mac_addr: '0a:02:ca:be:0b:40'
+                mtu: 1500
+                network_name: ctlplane
+                skip_nm: false
+            internalapi:
+                interface_name: enp6s0.20
+                ip_v4: 172.17.0.12
+                mac_addr: '52:54:00:1b:6e:a5'
+                mtu: 1500
+                network_name: internalapi
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 20
+            storage:
+                interface_name: enp6s0.21
+                ip_v4: 172.18.0.12
+                mac_addr: '52:54:00:56:fa:90'
+                mtu: 1500
+                network_name: storage
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 21
+            tenant:
+                interface_name: enp6s0.22
+                ip_v4: 172.19.0.12
+                mac_addr: '52:54:00:18:a0:f8'
+                mtu: 1500
+                network_name: tenant
+                parent_interface: enp6s0
+                skip_nm: false
+                vlan_id: 22
+networks:
+    ctlplane:
+        dns_v4:
+        - 192.168.122.1
+        dns_v6: []
+        gw_v4: 192.168.122.1
+        mtu: 1500
+        network_name: ctlplane
+        network_v4: 192.168.122.0/24
+        search_domain: ctlplane.example.com
+        tools:
+            metallb:
+                ipv4_ranges:
+                -   end: 192.168.122.90
+                    end_host: 90
+                    length: 11
+                    start: 192.168.122.80
+                    start_host: 80
+                ipv6_ranges: []
+            multus:
+                ipv4_ranges:
+                -   end: 192.168.122.70
+                    end_host: 70
+                    length: 41
+                    start: 192.168.122.30
+                    start_host: 30
+                ipv6_ranges: []
+            netconfig:
+                ipv4_ranges:
+                -   end: 192.168.122.120
+                    end_host: 120
+                    length: 21
+                    start: 192.168.122.100
+                    start_host: 100
+                -   end: 192.168.122.200
+                    end_host: 200
+                    length: 51
+                    start: 192.168.122.150
+                    start_host: 150
+                ipv6_ranges: []
+    external:
+        dns_v4: []
+        dns_v6: []
+        mtu: 1500
+        network_name: external
+        network_v4: 10.0.0.0/24
+        search_domain: external.example.com
+        tools:
+            netconfig:
+                ipv4_ranges:
+                -   end: 10.0.0.250
+                    end_host: 250
+                    length: 151
+                    start: 10.0.0.100
+                    start_host: 100
+                ipv6_ranges: []
+        vlan_id: 22
+    internalapi:
+        dns_v4: []
+        dns_v6: []
+        mtu: 1496
+        network_name: internalapi
+        network_v4: 172.17.0.0/24
+        search_domain: internalapi.example.com
+        tools:
+            metallb:
+                ipv4_ranges:
+                -   end: 172.17.0.90
+                    end_host: 90
+                    length: 11
+                    start: 172.17.0.80
+                    start_host: 80
+                ipv6_ranges: []
+            multus:
+                ipv4_ranges:
+                -   end: 172.17.0.70
+                    end_host: 70
+                    length: 41
+                    start: 172.17.0.30
+                    start_host: 30
+                ipv6_ranges: []
+            netconfig:
+                ipv4_ranges:
+                -   end: 172.17.0.250
+                    end_host: 250
+                    length: 151
+                    start: 172.17.0.100
+                    start_host: 100
+                ipv6_ranges: []
+        vlan_id: 20
+    storage:
+        dns_v4: []
+        dns_v6: []
+        mtu: 1496
+        network_name: storage
+        network_v4: 172.18.0.0/24
+        search_domain: storage.example.com
+        tools:
+            metallb:
+                ipv4_ranges:
+                -   end: 172.18.0.90
+                    end_host: 90
+                    length: 11
+                    start: 172.18.0.80
+                    start_host: 80
+                ipv6_ranges: []
+            multus:
+                ipv4_ranges:
+                -   end: 172.18.0.70
+                    end_host: 70
+                    length: 41
+                    start: 172.18.0.30
+                    start_host: 30
+                ipv6_ranges: []
+            netconfig:
+                ipv4_ranges:
+                -   end: 172.18.0.250
+                    end_host: 250
+                    length: 151
+                    start: 172.18.0.100
+                    start_host: 100
+                ipv6_ranges: []
+        vlan_id: 21
+    storagemgmt:
+        dns_v4: []
+        dns_v6: []
+        mtu: 1500
+        network_name: storagemgmt
+        network_v4: 172.20.0.0/24
+        search_domain: storagemgmt.example.com
+        tools:
+            netconfig:
+                ipv4_ranges:
+                -   end: 172.20.0.250
+                    end_host: 250
+                    length: 151
+                    start: 172.20.0.100
+                    start_host: 100
+                ipv6_ranges: []
+        vlan_id: 23
+    tenant:
+        dns_v4: []
+        dns_v6: []
+        mtu: 1496
+        network_name: tenant
+        network_v4: 172.19.0.0/24
+        search_domain: tenant.example.com
+        tools:
+            metallb:
+                ipv4_ranges:
+                -   end: 172.19.0.90
+                    end_host: 90
+                    length: 11
+                    start: 172.19.0.80
+                    start_host: 80
+                ipv6_ranges: []
+            multus:
+                ipv4_ranges:
+                -   end: 172.19.0.70
+                    end_host: 70
+                    length: 41
+                    start: 172.19.0.30
+                    start_host: 30
+                ipv6_ranges: []
+            netconfig:
+                ipv4_ranges:
+                -   end: 172.19.0.250
+                    end_host: 250
+                    length: 151
+                    start: 172.19.0.100
+                    start_host: 100
+                ipv6_ranges: []
+        vlan_id: 22

--- a/ci/playbooks/validate-architecture.yml
+++ b/ci/playbooks/validate-architecture.yml
@@ -1,0 +1,194 @@
+---
+# Usage and expected parameters
+# $ ansible-playbook -i localhost, -c local \
+#     validate-architecture.yml \
+#     -e cifmw_architecture_repo=$HOME/architecture \
+#     -e cifmw_architecture_scenario=hci \
+#     -e cifmw_networking_mapper_networking_env_def_path=$HOME/net-env.yml
+#     [any other parameter/files your VA/DT might need]
+#
+# cifmw_architecture_repo: location of the architecture repository.
+# cifmw_architecture_scenario: the scenario you want to test.
+# cifmw_networking_mapper_networking_env_def_path: path to the
+#        networking-mapper environment definition file.
+#
+# Special parameters set in the playbook (you can override them)
+# cifmw_basedir: defaults to ~/ci-framework-data
+# cifmw_zuul_target_host: target host. Defaults to localhost
+
+- name: Test architecture automations
+  hosts: "{{ cifmw_zuul_target_host | default('controller') }}"
+  gather_facts: true
+  vars:
+    cifmw_kustomize_deploy_generate_crs_only: true
+    ci_gen_kustomize_fetch_ocp_state: false
+    _homedir: "{{ ansible_user_dir | default(lookup('env', 'HOME')) }}"
+    cifmw_basedir: >-
+      {{
+        (_homedir,
+         'ci-framework-data') |
+        path_join
+      }}
+    _automation_relative: "automation/vars/"
+    cifmw_path: >-
+      {{
+        ['~/bin',
+         ansible_env.PATH] | join(':')
+      }}
+  pre_tasks:
+    - name: Assert we have the bare minimum to run
+      ansible.builtin.assert:
+        quiet: true
+        that:
+          - cifmw_architecture_repo is defined
+          - cifmw_architecture_scenario is defined
+          - cifmw_networking_mapper_networking_env_def_path is defined
+
+    - name: Deploy basic dependencies
+      ansible.builtin.import_role:
+        name: 'ci_setup'
+
+    - name: Install kustomize
+      when:
+        - zuul.projects is defined
+        - zuul.projects['github.com/openstack-k8s-operators/install_yamls'] is defined
+      vars:
+        _chdir: >-
+          {{
+            [zuul.projects['github.com/openstack-k8s-operators/install_yamls'].src_dir,
+             'devsetup'] | path_join
+          }}
+      ansible.builtin.command:
+        chdir: "{{ _chdir }}"
+        cmd: >-
+          ansible-playbook -i localhost, -c local
+          download_tools.yaml --tags kustomize
+
+    - name: Create needed directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0755"
+      loop:
+        - "{{ cifmw_basedir }}/logs"
+        - "{{ cifmw_basedir }}/artifacts"
+
+    - name: Ensure kustomize_deploy is bootstraped
+      ansible.builtin.import_role:
+        name: "kustomize_deploy"
+        tasks_from: "check_requirements.yml"
+  tasks:
+    - name: Output kubectl data
+      ansible.builtin.shell:
+        cmd: |
+          which kubectl
+          kubectl version --client=true
+          kubectl kustomize --help
+
+    - name: Load networking mapper environment
+      ansible.builtin.import_role:
+        name: "networking_mapper"
+        tasks_from: "load_env_definition.yml"
+
+    - name: Discover automation files
+      register: _automation_files
+      ansible.builtin.find:
+        paths: >-
+          {{
+            [cifmw_architecture_repo, _automation_relative] |
+            path_join
+          }}
+        patterns: "*.yaml"
+
+    - name: Get automation contents
+      register: _automation_contents
+      ansible.builtin.slurp:
+        path: "{{ item.path }}"
+      loop: "{{ _automation_files.files }}"
+      loop_control:
+        label: "{{ item.path | basename }}"
+
+    - name: Load automation files as fact
+      ansible.builtin.set_fact:
+        vas: >-
+          {{
+            vas | default({}) |
+            combine(item.content | b64decode | from_yaml, recursive=true)
+          }}
+      loop: "{{ _automation_contents.results }}"
+      loop_control:
+        label: "{{ item.source | basename }}"
+
+    - name: Prepare automation data
+      ansible.builtin.set_fact:
+        cifmw_deploy_architecture_steps: >-
+          {{ vas['vas'][cifmw_architecture_scenario] }}
+
+    - name: Create needed SSH keypairs
+      community.crypto.openssh_keypair:
+        comment: "{{ item.comment }}"
+        path: "{{ item.path }}"
+        type: "ecdsa"
+        size: "521"
+      loop:
+        - comment: "Nova migration"
+          path: "{{ cifmw_basedir }}/artifacts/ecdsa_nova_migration"
+        - comment: "EDPM deploy key"
+          path: "{{ cifmw_basedir }}/artifacts/ecdsa_deploy"
+
+    - name: Load public SSH keys
+      register: _pub_keys
+      ansible.builtin.slurp:
+        path: "{{ item }}"
+      loop:
+        - "{{ cifmw_basedir }}/artifacts/ecdsa_nova_migration.pub"
+        - "{{ cifmw_basedir }}/artifacts/ecdsa_deploy.pub"
+
+    - name: Load private SSH keys
+      register: _priv_keys
+      ansible.builtin.slurp:
+        path: "{{ item }}"
+      loop:
+        - "{{ cifmw_basedir }}/artifacts/ecdsa_nova_migration"
+        - "{{ cifmw_basedir }}/artifacts/ecdsa_deploy"
+
+    - name: Generate needed facts out of local files
+      vars:
+      ansible.builtin.set_fact:
+        cifmw_ci_gen_kustomize_values_ssh_authorizedkeys: >-
+          {{
+            _pub_keys.results[1].content | b64decode
+          }}
+        cifmw_ci_gen_kustomize_values_ssh_private_key: >-
+          {{
+            _priv_keys.results[1].content | b64decode
+          }}
+        cifmw_ci_gen_kustomize_values_ssh_public_key: >-
+          {{
+            _pub_keys.results[1].content | b64decode
+          }}
+        cifmw_ci_gen_kustomize_values_migration_pub_key: >-
+          {{
+            _pub_keys.results[0].content | b64decode
+          }}
+        cifmw_ci_gen_kustomize_values_migration_priv_key: >-
+          {{
+            _priv_keys.results[0].content | b64decode
+          }}
+        cifmw_ci_gen_kustomize_values_sshd_ranges: >-
+          {{
+            [cifmw_networking_env_definition.networks.ctlplane.network_v4]
+          }}
+
+    - name: Execute deployment steps
+      ansible.builtin.include_role:
+        name: kustomize_deploy
+        tasks_from: execute_step.yml
+        apply:
+          tags:
+            - edpm_deploy
+      loop: "{{ cifmw_deploy_architecture_steps.stages }}"
+      loop_control:
+        label: "{{ stage.path }}"
+        loop_var: stage
+        index_var: stage_id

--- a/ci/templates/projects.yaml
+++ b/ci/templates/projects.yaml
@@ -20,4 +20,5 @@
         - cifmw-edpm-build-images
         - cifmw-multinode-kuttl
         - cifmw-tcib
+        - cifmw-architecture-validate-hci
 # Start generated content

--- a/roles/ci_setup/tasks/packages.yml
+++ b/roles/ci_setup/tasks/packages.yml
@@ -76,6 +76,8 @@
 
     - name: Source completion from within .bashrc
       ansible.builtin.blockinfile:
+        create: true
+        mode: "0644"
         path: "{{ ansible_user_dir }}/.bashrc"
         block: |-
           if [ -f ~/.oc_completion ]; then

--- a/zuul.d/architecture-jobs.yaml
+++ b/zuul.d/architecture-jobs.yaml
@@ -1,0 +1,38 @@
+---
+# Base job defined for the architecture related jobs.
+# Mostly, they are "linters", ensuring we're able to read
+# and build content based on the automation file.
+# You can refer to the ci/playbooks/validate-architecture.yml
+# playbook for more information about the playbook capabilities.
+
+- job:
+    name: cifmw-architecture-validate-base
+    parent: cifmw-base-minimal
+    vars:
+      cifmw_networking_mapper_networking_env_def_path: >-
+        {{
+          [ansible_user_dir,
+           zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
+           'ci/playbooks/files/networking-env-definition.yml']
+           | path_join
+        }}
+      cifmw_architecture_repo: >-
+        {{
+          [ansible_user_dir,
+           zuul.projects['github.com/openstack-k8s-operators/architecture'].src_dir]
+           | path_join
+        }}
+    run:
+      - ci/playbooks/validate-architecture.yml
+    required-projects:
+      - openstack-k8s-operators/architecture
+
+- job:
+    name: cifmw-architecture-validate-hci
+    parent: cifmw-architecture-validate-base
+    vars:
+      cifmw_architecture_scenario: hci
+    files:
+      - zuul.d/architecture-jobs.yaml
+      - ^roles/ci_gen_kustomize_values/(?!meta|README).*
+      - ^roles/kustomize_deploy/(?!meta|README).*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -11,6 +11,7 @@
       - cifmw-edpm-build-images
       - cifmw-multinode-kuttl
       - cifmw-tcib
+      - cifmw-architecture-validate-hci
       - cifmw-molecule-artifacts
       - cifmw-molecule-build_containers
       - cifmw-molecule-build_openstack_packages


### PR DESCRIPTION
The architecture repository needs some more testing. This playbook
allows to use the ci-framework "flexible loop" in order to ensure we
can:
- load the files (all of them)
- loop on the automation steps
- generate all the needed content (via ci_gen_kustomize_values)
- build final CRs with all the data

This is mostly a "read-only", "linting-like" check, and does NOT apply
the CRs.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
