### PR TITLE
[test-operator] Add Vif tests to skiplist

### DIFF
--- a/roles/test_operator/files/list_skipped.yml
+++ b/roles/test_operator/files/list_skipped.yml
@@ -1427,3 +1427,21 @@ known_failures:
         lp: https://bugs.launchpad.net/ironic/+bug/2054722
     jobs:
       - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodesVif.test_vif_attach_node_doesnt_exist
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: The test is not adjusted for the podified env.
+        lp: https://bugs.launchpad.net/ironic/+bug/2065378
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodesVif.test_vif_detach_no_args
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: The test is not adjusted for the podified env.
+        lp: https://bugs.launchpad.net/ironic/+bug/2065378
+    jobs:
+      - ironic-operator


### PR DESCRIPTION
The following two tests are failing when shared_physical_network is set to true in the podified environment. Let's skip them until the issue is resolved.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
