### PR TITLE
Add openshift_setup role to kuttl playbook

### DIFF
--- a/ci/playbooks/kuttl/e2e-kuttl.yml
+++ b/ci/playbooks/kuttl/e2e-kuttl.yml
@@ -22,6 +22,10 @@
       ansible.builtin.include_role:
         name: openshift_login
 
+    - name: Setup Openshift cluster
+      ansible.builtin.import_role:
+        name: openshift_setup
+
     - name: Attach default network to CRC
       when:
         - kuttl_make_crc_attach_default_interface | default ('true') | bool

--- a/scenarios/centos-9/kuttl.yml
+++ b/scenarios/centos-9/kuttl.yml
@@ -3,3 +3,5 @@ cifmw_install_yamls_vars:
   OPERATOR_BASE_DIR: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators"
   BMO_SETUP: false
 cifmw_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+
+cifmw_openshift_setup_skip_internal_registry: true


### PR DESCRIPTION
When running kuttl tests, it might be necessary to run some openshit_setup tasks to properly install internal CAs to pull container images.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
