### PR TITLE
Check for cifmw_repo_setup_component_name definition

### DIFF
--- a/roles/dlrn_report/tasks/dlrn_report_results.yml
+++ b/roles/dlrn_report/tasks/dlrn_report_results.yml
@@ -30,7 +30,7 @@
       --server-principal {{ cifmw_dlrn_report_dlrnapi_host_principal }} --auth-method kerberosAuth
       {% endif -%}
       report-result
-      {% if cifmw_repo_setup_component_name | length > 0%}
+      {% if (cifmw_repo_setup_component_name is defined) and (cifmw_repo_setup_component_name | length > 0) %}
       {% if (cifmw_repo_setup_extended_hash is defined) and (cifmw_repo_setup_extended_hash | length > 0) -%}
       --extended-hash {{ cifmw_repo_setup_extended_hash }}
       {% endif -%}


### PR DESCRIPTION
DLRN promote jobs in integration lines are failing this check as cifmw_repo_setup_component_name
is not defined. Add a check for the var definition before checking length.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
