### PR TITLE
Update auto-draft workflow to use pull_request_target event

### DIFF
--- a/.github/workflows/auto-draft.yml
+++ b/.github/workflows/auto-draft.yml
@@ -4,7 +4,7 @@
 # Run only on opened and reopened pull request events
 name: Set to draft status when PR is [re]opened
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened]
 
 jobs:


### PR DESCRIPTION
Currently the auto-draft workflow is failing on PRs submitted via forks [1]

This is due to using the `pull_request` event, it overrides permissions in the workflow to read-only to protect you from leaking secrets etc.

The `pull_request` event is required when building or running code from a pull request however this workflow is admin only so we should use `pull_request_target`

`pull_request_target` allows you to use write permissions on PRs originating from forks, it allows this because it doesn't use the PR content, like a config repo operates so is safe to do so.[2]

[1] https://github.com/openstack-k8s-operators/ci-framework/actions/runs/9017563161
[2] https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
