### PR TITLE
Remove podified-multinode-edpm-e2e-nobuild-tagged-crc job def

### DIFF
--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -288,26 +288,6 @@
       - ^scenarios/centos-9/hci_ceph_backends.yml
       - ^scenarios/centos-9/multinode-ci.yml
 
-- job:
-    name: podified-multinode-edpm-e2e-nobuild-tagged-crc
-    parent: cifmw-podified-multinode-edpm-base-crc
-    nodeset: centos-9-medium-centos-9-crc-extracted-2.30-3xl
-    vars:
-      cifmw_extras:
-        - '@scenarios/centos-9/ci.yml'
-        - '@scenarios/centos-9/multinode-ci.yml'
-        - '@scenarios/centos-9/ceph_backends.yml'
-    run:
-      - ci/playbooks/e2e-run.yml
-    irrelevant-files:
-      - ^roles/.*_build
-      - ^roles/build.*
-      - ^ci/templates
-      - ^docs
-      - ^.*/*.md
-      - ^OWNERS
-      - ^.github
-
 #
 # Jobs using ci-bootstrap layout
 #


### PR DESCRIPTION
https://review.rdoproject.org/r/c/rdo-jobs/+/53191 drops this job from operator line as this job is no longer maintained and runned.

This merge request removes the job definition from this file.

Depends-On: https://review.rdoproject.org/r/c/rdo-jobs/+/53191

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

