### PR TITLE
Loop through .xml files for jump

### DIFF
--- a/roles/polarion/tasks/main.yml
+++ b/roles/polarion/tasks/main.yml
@@ -90,17 +90,16 @@
         var: pylero_output.stdout_lines
 
     - name: Update Test Runs
-      vars:
-        found_xml_files: "{{ xml_files.files | map(attribute='path') | join(',') }}"
       ansible.builtin.shell:
         chdir: "{{ cifmw_polarion_jump_repo_dir }}"
         cmd: >-
           source "{{ cifmw_polarion_jump_repo_dir }}/jump-venv/bin/activate" &&
           {{ cifmw_polarion_jump_repo_dir }}/jump-venv/bin/python jump.py
           --testrun-id={{ cifmw_polarion_testrun_id }}
-          --xml-file={{ found_xml_files }}
+          --xml-file={{ item.path | map(attribute='path') }}
           --update_testcases={{ cifmw_polarion_update_testcases | default(false) }}
           {{ cifmw_polarion_jump_extra_vars | default ('') }}
+        loop: "{{ xml_files.files }}"
       register: jump_script
 
     - name: Output of jump


### PR DESCRIPTION
Jump tool does take only one file at the time, however, we may have multiple files, .xml reports, we want Jump to report.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
