### PR TITLE
Allow passing base64 encoded patches to ci_gen_kustomize

### DIFF
--- a/roles/ci_gen_kustomize_values/README.md
+++ b/roles/ci_gen_kustomize_values/README.md
@@ -30,10 +30,14 @@ with a message.
   Defaults to `[]`.
 * `cifmw_ci_gen_kustomize_values_userdata`: (Dict) Data structure you want to combine in the generated output.
   Defaults to `{}`.
+* `cifmw_ci_gen_kustomize_values_userdata_b64`: (List) Base64 encoded list of data to combine in the generated output.
+  Defaults to `[]`.
 * `ci_gen_kustomize_fetch_ocp_state`: (Boolean) If true it enables generating CI templates based on the OCP state. Defaults to `true`.
 
 ### Specific parameters for edpm-values
-This configMap needs some more parameters in order to properly override the `architecture` provided one. Those parameters aren't set by default, and are mandatory for `edpm-values`.
+This configMap needs some more parameters in order to properly override the `architecture` provided one.
+
+These parameters aren't set by default, and are mandatory for `edpm-values`.
 
 * `cifmw_ci_gen_kustomize_values_ssh_authorizedkeys`: (String) Block of SSH authorized_keys to inject on the deployed nodes.
 * `cifmw_ci_gen_kustomize_values_ssh_private_key`: (String) SSH private key to allow dataplane access on the computes.
@@ -42,7 +46,12 @@ This configMap needs some more parameters in order to properly override the `arc
 * `cifmw_ci_gen_kustomize_values_migration_pub_key`: (String) SSH public key associated to `cifmw_ci_gen_kustomize_values_migration_priv_key`.
 Note that all of the SSH keys should be in `ecdsa` format to comply with FIPS directives.
 
+Optional parameters:
+
+* `cifmw_ci_gen_kustomize_values_edpm_net_template_b64`: (String) The base64 content of `edpm_network_config_template`.
+
 ### Required parameters only when baremetal compute nodes are used.
+
 * `cifmw_ci_gen_kustomize_values_ctlplane_interface`: (String) Used to override default controlplane interface for OSP compute nodes.
 
 ## Adding a new template
@@ -90,6 +99,10 @@ directly in `ci-framework-data/ci_k8s_snippets/TYPE/02_ci_data.yaml`.
       data:
         node_0:
           name: foo_bar
+    cifmw_ci_gen_kustomize_values_userdata_b64:
+      data:
+        node_1:
+          name: Zm9vX2Jhcgo=
   ansible.builtin.import_role:
     name: ci_gen_kustomize_values
 ```

--- a/roles/ci_gen_kustomize_values/defaults/main.yml
+++ b/roles/ci_gen_kustomize_values/defaults/main.yml
@@ -65,6 +65,7 @@ cifmw_ci_gen_kustomize_values_dest_filename: >-
   {{ cifmw_ci_gen_kustomize_values_dest_fname_prefix }}values.yaml
 cifmw_ci_gen_kustomize_values_nameservers: []
 cifmw_ci_gen_kustomize_values_userdata: {}
+cifmw_ci_gen_kustomize_values_userdata_b64: []
 ci_gen_kustomize_fetch_ocp_state: true
 
 # Those parameter must be set if you want to edit an "edpm-values"

--- a/roles/ci_gen_kustomize_values/tasks/generate_snippets.yml
+++ b/roles/ci_gen_kustomize_values/tasks/generate_snippets.yml
@@ -107,13 +107,41 @@
     src: "{{ _tmpl_check_path | first }}"
     mode: "0644"
 
+- name: Generate the base64 CI patches
+  ansible.builtin.set_fact:
+    _b64_patches: >-
+      {{
+       ({} if index == 0 else _b64_patches) |
+        combine(item | b64decode | from_yaml, recursive=True)
+      }}
+  loop: "{{ cifmw_ci_gen_kustomize_values_userdata_b64 }}"
+  loop_control:
+    index_var: index
+    label: "base64 path {{ index }}"
+
+- name: Push base64 CI patches
+  ansible.builtin.copy:
+    backup: true
+    dest: >-
+      {{
+        (snippet_datadir,
+         '03_ci_data_b64.yaml') | path_join
+      }}
+    content: >-
+      {{
+        _b64_patches |
+        default({}) |
+        to_nice_yaml
+      }}
+    mode: "0644"
+
 - name: Push user provided dataset
   ansible.builtin.copy:
     backup: true
     dest: >-
       {{
         (snippet_datadir,
-         '03_user_data.yaml') | path_join
+         '04_user_data.yaml') | path_join
       }}
     content: >-
       {{

--- a/roles/kustomize_deploy/filter_plugins/ci_kustomize_deploy_combine_base64_patch_dict.py
+++ b/roles/kustomize_deploy/filter_plugins/ci_kustomize_deploy_combine_base64_patch_dict.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+__metaclass__ = type
+
+import typing
+
+
+DOCUMENTATION = """
+  name: ci_kustomize_deploy_build_base64_patch_dict
+  short_description: Creates a dictionary with a list of base64 patches as the nested element.
+  options:
+    _input:
+      description:
+        - The list of dicts to merge together.
+      type: str
+      required: true
+"""
+
+from ansible.errors import AnsibleFilterTypeError
+
+
+class FilterModule:
+
+    @staticmethod
+    def __patch(
+        base_content: typing.Dict[str, typing.Dict],
+        patch: typing.Dict[str, typing.Dict],
+    ):
+        for stage_id, values in patch.items():
+            stage_values = base_content.get(stage_id, {})
+            base_content[stage_id] = stage_values
+            for values_id, raw_content in values.items():
+                content = (
+                    raw_content if isinstance(raw_content, list) else [raw_content]
+                )
+                if values_id not in stage_values:
+                    stage_values[values_id] = []
+                stage_values[values_id].extend(content)
+
+    @classmethod
+    def __build_base64_patch_dict(
+        cls, data: typing.List[typing.Dict[str, typing.Dict]]
+    ) -> typing.Dict[str, typing.Any]:
+        if not isinstance(data, list):
+            raise AnsibleFilterTypeError(
+                "ci_kustomize_deploy_combine_base64_patch_dict requires data to be a list of dicts"
+            )
+
+        result = {}
+        for b64_patch_dict in data:
+            cls.__patch(result, b64_patch_dict)
+        return result
+
+    def filters(self):
+        return {
+            "ci_kustomize_deploy_combine_base64_patch_dict": self.__build_base64_patch_dict,
+        }

--- a/roles/kustomize_deploy/tasks/_compute_user_kustomize.yml
+++ b/roles/kustomize_deploy/tasks/_compute_user_kustomize.yml
@@ -27,3 +27,23 @@
     }}
   loop_control:
     label: "{{ item.key }}"
+
+- name: Set the final cifmw_architecture_user_kustomize_base64 based on its patches
+  vars:
+    _b64_kustomize_user_patches: >-
+      {{
+        (
+          hostvars[inventory_hostname] |
+          dict2items |
+          selectattr("key", "match", "^cifmw_architecture_user_base64_kustomize.+") |
+          sort(attribute='key') |
+          map(attribute='value') |
+          list
+        ) + [cifmw_architecture_user_base64_kustomize | default({})]
+      }}
+  ansible.builtin.set_fact:
+    _cifmw_kustomize_deploy_user_base64_kustomize: >-
+      {{
+        _b64_kustomize_user_patches |
+        ci_kustomize_deploy_combine_base64_patch_dict
+      }}

--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -134,6 +134,17 @@
               ternary(_cifmw_kustomize_deploy_user_kustomize[_stage_name][_name], {})
             )
           }}
+        cifmw_ci_gen_kustomize_values_userdata_b64: >-
+          {{
+            (
+              _cifmw_kustomize_deploy_user_base64_kustomize[_stage_name_id][_name] is defined |
+              ternary(_cifmw_kustomize_deploy_user_base64_kustomize[_stage_name_id][_name], [])
+            )
+            + (
+              _cifmw_kustomize_deploy_user_base64_kustomize[_stage_name][_name] is defined |
+              ternary(_cifmw_kustomize_deploy_user_base64_kustomize[_stage_name][_name], [])
+            )
+          }}
       ansible.builtin.include_role:
         name: ci_gen_kustomize_values
       loop: "{{ stage['values'] }}"


### PR DESCRIPTION
Some content passed to the ci_gen_kustomize role can be interpreted by Ansible as a jinja template (edpm_network_config_template). That content, when ingested by the framework, can lead to a crash as Ansible may try to use it as a template. Mechanisms like raw/endraw or !unsafe don't work, as those tags are removed in the first write of the variable to a file (and the framework performs one write of those variables before edpm-deploy).
To allow easily passing those kind of variables this mechanism can be handy, as the content is safely encoded as a plain string before getting applied.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
