### PR TITLE
Add review ready label automation

### DIFF
--- a/.github/workflows/review-ready-label.yml
+++ b/.github/workflows/review-ready-label.yml
@@ -1,0 +1,86 @@
+# Marks a PR with the review_ready_label label if
+# there are:
+#   - There are no failed CI jobs
+#   - There are no Pending CI jobs excluding Tide
+#   - The PR isn't in draft state
+#   - The commit isn't found in more than one PR
+# Removes the label if any of those checks fail.
+
+name: Toggle review ready label
+on:
+  status:
+  pull_request_target:
+    types: [ready_for_review, converted_to_draft]
+jobs:
+  toggle-label:
+    runs-on: ubuntu-latest
+    permissions: # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+      contents: write # Required for Setting label
+      pull-requests: write # Required for Setting label
+    steps:
+      - name: Toggle review ready label
+        shell: bash
+        run: |
+          # Example jq_status_output:
+            # {"state":"success","context":"docs/readthedocs.org:ci-framework"}
+            # {"state":"success","context":"ci/prow/images"}
+            # {"state":"success","context":"ci/prow/ansible-test"}
+            # {"state":"pending","context":"tide"}
+            # {"state":"failure","context":"rdoproject.org/github-check"}
+
+          # Example pr_search_result:
+            # [{"isDraft":false,"number":1159}]
+
+          set -x
+
+          # Get CI job status output and parse it for failed or pending jobs (excluding Tide)
+          status_output=$(gh api -H "${accept_header}" -H "${api_header}" repos/${GITHUB_REPOSITORY}/status/${GH_EVENT_SHA})
+          jq_status_output=$(echo "${status_output}" | jq -c '.statuses[] | {state: .state, context: .context}')
+          ready=true
+          for row in ${jq_status_output}; do
+              _jq() {
+              echo "${row}" | jq -r "${1}"
+              }
+
+              if [ $(_jq '.state') == 'failure' ]; then
+                  echo "$(_jq '.context') failed, exiting"
+                  ready=false
+                  break
+              fi
+              if [ $(_jq '.state') == 'pending' ] && [ $(_jq '.context') != 'tide' ] ; then
+                  echo "$(_jq '.context') still pending, exiting"
+                  ready=false
+                  break
+              fi
+          done
+
+          # Get the PR number and draft state from the commit SHA, to pass the commit SHA must only be in one PR
+          pr_search_result=$(gh pr list --search "${GH_EVENT_SHA}" -R "${GITHUB_REPOSITORY}" --json number,isDraft | jq -c)
+          pr_search_result_length=$(echo "${pr_search_result}" | jq length)
+          if [ "$pr_search_result_length" -ne 1 ]; then
+              echo "Commit not found or in multiple PRs"
+              exit 1
+          fi
+
+          # Define draft_status and set $ready false if PR is in draft state
+          draft_status=$(echo "${pr_search_result}" | jq '.[].isDraft')
+          if [ "$draft_status" = "true" ]; then
+              ready=false
+          fi
+
+          # Define pr_number and set or remove review_ready_label on PR
+          pr_number=$(echo "${pr_search_result}" | jq '.[].number')
+          if [ "$ready" = "true" ]; then
+              echo "Setting label: ${review_ready_label} on PR: ${pr_number}"
+              gh pr edit "${pr_number}" --add-label "${review_ready_label}" -R "${GITHUB_REPOSITORY}"
+          else
+              echo "Removing label: ${review_ready_label} from PR: ${pr_number}"
+              gh pr edit "${pr_number}" --remove-label "${review_ready_label}" -R "${GITHUB_REPOSITORY}"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          accept_header: 'Accept: application/vnd.github+json'
+          api_header: 'X-GitHub-Api-Version: 2022-11-28'
+          GH_PAGER: ''
+          review_ready_label: "Ready For Review"
+          GH_EVENT_SHA: ${{ github.event_name == 'status' && github.event.commit.SHA || github.event.pull_request.head.sha }}

--- a/docs/source/development/01_guidelines.md
+++ b/docs/source/development/01_guidelines.md
@@ -51,12 +51,28 @@ either rely on [molecule](./02_molecule.md) or, maybe,
 
 ## Review workflow
 
-Once your patch is passing CI and not in draft status a reviewer will review your patch.
+### Auto draft status automation
+
+When a PR is opened or reopened on the CI-Framework repo the Github bot will enable the draft status.
+Once your patch is passing CI and you would be happy with it merging, click the "Ready for review" button,
+this will trigger the review ready workflow
+
+### Review ready automation
+
+Once your PR is out of draft status it will be evaluated by the review ready workflow, if your patch passes
+the following evaluations the "Ready for Review" label will be added informing the Ci-Framework maintainers
+to review your patch.
+
+The evaluation steps are:
+
+- There are no failed CI jobs
+- There are no Pending CI jobs excluding Tide
+- The PR isn't in draft state
+- The commit isn't found in more than one PR
+
+If at any time your patch no longer meets this criteria the label will be removed.
+
+### Escalating your review
+
 If you would like to bring attention to your patch before a reviewer has made it to your patch
-reached out in our [slack channel](https://redhat.enterprise.slack.com/archives/C03MD4LG22Z)
-
-### Auto Draft status
-
-When a PR is opened or reopened the Github bot will enable the draft status. Once your patch is
-passing CI and you would be happy with it merging, click the "Ready for review" button, this will
-then trigger the Review workflow mentioned above.
+reach out in our [slack channel](https://redhat.enterprise.slack.com/archives/C03MD4LG22Z)


### PR DESCRIPTION
This patch adds a GitHub workflow that runs on each status update and evaluates if the PR is "Ready for Review"

The evaluation steps are:
- There are no failed CI jobs
- There are no Pending CI jobs excluding Tide
- The PR isn't in draft state
- The commit isn't found in more than one PR

If the evaluation passes the review_ready label is applied, if they fail the review_ready is removed.

The end result after this patch is maintainer can monitor the "Ready for Review" label and be confident if a PR has that label, it's actually really for review.

JIRA: [OSPRH-6939](https://issues.redhat.com//browse/OSPRH-6939)

---

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] Content of the docs/source is reflecting the changes
