### PR TITLE
libvirt_manager - enable sushy_emulator

### DIFF
--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -36,6 +36,7 @@ Used for checking if:
 * `cifmw_libvirt_manager_spineleaf_setup`: (Boolean) Whether the VMs deployed are connected to a spine/leaf virtual infrastructure or not. When set to `true`, the interfaces of the instances from a certain type of VM are not connected to the same networks, but they can be defined per VM using the `spineleafnets` list (except for the `controller`). Defaults to `false`.
 * `cifmw_libvirt_manager_network_interface_types`: (Dict) By default, interfaces attached to VMs are created with `--type bridge`, but with this parameter, those interfaces can be configured with any other types. Defaults to empty dictionary.
 * `cifmw_libvirt_manager_configuration_patch(.)*`: (Dict) Structure describing the patch to combine on top of `cifmw_libvirt_manager_configuration`.
+* `cifmw_libvirt_manager_enable_sushy_emulator`: (Boolean) Toggle the installation of sushy-emulator (Virtual RedFish BMC). Defaults to: `false`
 
 ### Structure for `cifmw_libvirt_manager_configuration`
 

--- a/roles/libvirt_manager/defaults/main.yml
+++ b/roles/libvirt_manager/defaults/main.yml
@@ -73,3 +73,5 @@ cifmw_libvirt_manager_ip_script_basedir: >-
 
 cifmw_libvirt_manager_network_interface_types: {}
 cifmw_libvirt_manager_spineleaf_setup: false
+
+cifmw_libvirt_manager_enable_sushy_emulator: false

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -228,6 +228,15 @@
     loop_var: vm_data
     index_var: family_id
 
+- name: Install sushy-emulator
+  when:
+    - "cifmw_libvirt_manager_enable_sushy_emulator | bool is true"
+  vars:
+    cifmw_sushy_emulator_libvirt_host: "{{ hostvars[inventory_hostname]['ansible_host'] }}"
+    cifmw_sushy_emulator_install_type: podman
+  ansible.builtin.include_role:
+    name: sushy_emulator
+
 - name: Create "all" group inventory file
   ansible.builtin.template:
     dest: "{{ cifmw_libvirt_manager_basedir }}/reproducer-inventory/all-group.yml"

--- a/roles/sushy_emulator/README.md
+++ b/roles/sushy_emulator/README.md
@@ -13,6 +13,7 @@ Required to installed required packages.
 ## Parameters
 
 * `cifmw_sushy_emulator_driver`: (String) Select between `openstack` and `libvirt` sushy emulator driver. Defaults to `libvirt`
+* `cifmw_sushy_emulator_libvirt_host`: (String) Hostname of hypervisor when using `libvirt` driver.
 * `cifmw_sushy_emulator_sshkey_path`: (String) Path of SSH key used by sushy emulator to talk to libvirt socket. Defaults to `"{{ ansible_user_dir }}/.ssh/id_cifw"`
 * `cifmw_sushy_emulator_libvirt_user`: (String) Username used by Sushi Emulator to connect to Libvirt socket. Defaults to `zuul`
 * `cifmw_sushy_emulator_listen_ip`: (String) IP Sushi Emulator service listens on. Defaults to `0.0.0.0`
@@ -32,7 +33,7 @@ Required to installed required packages.
 ```yaml
 - hosts: all
   vars:
-    cifmw_baremetal_hypervisor_target: baremetal-hypervisor
+    cifmw_sushy_emulator_libvirt_host: hypervisor-1.example.com
   tasks:
     - name: Deploy and configure sushy-emulator
       ansible.builtin.import_role:

--- a/roles/sushy_emulator/defaults/main.yml
+++ b/roles/sushy_emulator/defaults/main.yml
@@ -22,6 +22,7 @@ cifmw_sushy_emulator_driver: libvirt
 cifmw_sushy_emulator_sshkey_path: "{{ ansible_user_dir }}/.ssh/id_cifw"
 cifmw_sushy_emulator_libvirt_user: zuul
 cifmw_sushy_emulator_listen_ip: 0.0.0.0
+cifmw_sushy_emulator_listen_port: 8000
 cifmw_sushy_emulator_driver_openstack_client_config_file: /etc/openstack/clouds.yaml
 cifmw_sushy_emulator_driver_openstack_cloud: None
 cifmw_sushy_emulator_namespace: sushy-emulator

--- a/roles/sushy_emulator/molecule/default/converge.yml
+++ b/roles/sushy_emulator/molecule/default/converge.yml
@@ -29,11 +29,14 @@
         ansible_host: "{{ hostvars[cifmw_baremetal_hypervisor_target]['ansible_default_ipv4']['address'] }}"
 
     - name: Run Sushy Emulator role against OCP
+      vars:
+        cifmw_sushy_emulator_libvirt_host: "{{ hostvars[cifmw_baremetal_hypervisor_target]['ansible_default_ipv4']['address'] }}"
       ansible.builtin.include_role:
         name: sushy_emulator
 
     - name: Run Sushy Emulator role against podman
       vars:
+        cifmw_sushy_emulator_libvirt_host: "{{ hostvars[cifmw_baremetal_hypervisor_target]['ansible_default_ipv4']['address'] }}"
         cifmw_sushy_emulator_install_type: "podman"
       ansible.builtin.include_role:
         name: sushy_emulator

--- a/roles/sushy_emulator/tasks/collect_details.yml
+++ b/roles/sushy_emulator/tasks/collect_details.yml
@@ -44,7 +44,7 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
-      ssh-keyscan -H {{ hostvars[cifmw_baremetal_hypervisor_target].ansible_host }} 2>/dev/null | base64 -w 0
+      ssh-keyscan -H {{ cifmw_sushy_emulator_libvirt_host }} 2>/dev/null | base64 -w 0
   register: _cifmw_sushy_emulator_ssh_known_hosts_b64
 
 - name: Write known hosts for later use
@@ -58,7 +58,7 @@
   block:
     - name: Set vars
       ansible.builtin.set_fact:
-        _libvirt_uri: "qemu+ssh://{{ cifmw_sushy_emulator_libvirt_user }}@{{ hostvars[cifmw_baremetal_hypervisor_target].ansible_host }}/system"
+        _libvirt_uri: "qemu+ssh://{{ cifmw_sushy_emulator_libvirt_user }}@{{ cifmw_sushy_emulator_libvirt_host }}/system"
 
     # todo(Lewis): Once changes are made to the libvirt_manager role, the baremetal-info.yml can be consumed to gather required info
     - name: Get Libvirt instance UUIDs

--- a/roles/sushy_emulator/tasks/main.yml
+++ b/roles/sushy_emulator/tasks/main.yml
@@ -42,6 +42,13 @@
   ansible.builtin.include_tasks: create_container.yml
   when: cifmw_sushy_emulator_install_type == 'podman'
 
+- name: Allow the sushy-emulator port in firewalld
+  ansible.posix.firewalld:
+    port: "{{ cifmw_sushy_emulator_listen_port }}/tcp"
+    permanent: true
+    state: enabled
+  when: cifmw_sushy_emulator_install_type == 'podman'
+
 # todo(Lewis): Once vms deployed by libvirt_manager are working we should
 # add one more basic fuctional test like checking power status
 - name: Test sushy Emulator and connection to hypervisor libvirt socket

--- a/roles/sushy_emulator/tasks/main.yml
+++ b/roles/sushy_emulator/tasks/main.yml
@@ -35,18 +35,18 @@
   ansible.builtin.import_tasks: render_resources.yml
 
 - name: Deploy Sushy Emulator to OCP
-  ansible.builtin.import_tasks: apply_resources.yml
+  ansible.builtin.include_tasks: apply_resources.yml
   when: cifmw_sushy_emulator_install_type == 'ocp'
 
 - name: Deploy Sushy Emulator into Podman container
-  ansible.builtin.import_tasks: create_container.yml
+  ansible.builtin.include_tasks: create_container.yml
   when: cifmw_sushy_emulator_install_type == 'podman'
 
 # todo(Lewis): Once vms deployed by libvirt_manager are working we should
 # add one more basic fuctional test like checking power status
 - name: Test sushy Emulator and connection to hypervisor libvirt socket
   ansible.builtin.uri:
-    url: "{{ sushy_url}}/redfish/v1/Managers"
+    url: "{{ sushy_url }}/redfish/v1/Managers"
     return_content: true
     user: admin
     password: password

--- a/roles/sushy_emulator/templates/config_conf.j2
+++ b/roles/sushy_emulator/templates/config_conf.j2
@@ -2,7 +2,7 @@
 SUSHY_EMULATOR_LISTEN_IP = '{{ cifmw_sushy_emulator_listen_ip }}'
 
 # Bind to TCP port 8000
-SUSHY_EMULATOR_LISTEN_PORT = 8000
+SUSHY_EMULATOR_LISTEN_PORT = '{{ cifmw_sushy_emulator_listen_port | default(8000) }}'
 
 # Serve this SSL certificate to the clients
 SUSHY_EMULATOR_SSL_CERT = None


### PR DESCRIPTION
Add a new boolean option:
 `cifmw_libvirt_manager_enable_sushy_emulator` (defaults to: false).

When enabled - include the sushy_emulator role in deploy_layout.yml to set-up virtual RedFish BMC.

Also:
- Change hos sushy_emulator role builds the libvirt_uri, instead of a lookup from hostvars require the hostname to be defined in a variable when calling the role. This allows use of the role even if the libvirt hypervisor is not managed by ansible.
- Create a firewall rule to allow traffic to the sushy-emulator port when installed as a `podman` container.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
