### PR TITLE
Add namespace to osdpns lookup

### DIFF
--- a/roles/validations/tasks/edpm/hugepages_and_reboot.yml
+++ b/roles/validations/tasks/edpm/hugepages_and_reboot.yml
@@ -22,7 +22,7 @@
   cifmw.general.ci_script:
     output_dir: "{{ cifmw_validations_basedir }}/artifacts"
     script: >-
-      oc get osdpns --no-headers -o custom-columns=":metadata.name"
+      oc get -n {{ cifmw_validations_namespace }} osdpns --no-headers -o custom-columns=":metadata.name"
   register: deployed_nodeset_name
 
 # collect initial confighash from the nodeset
@@ -58,6 +58,7 @@
       kind: OpenStackDataPlaneService
       metadata:
         name: reboot-adhoc
+        namespace: {{ cifmw_validations_namespace }}
       spec:
         play: |
           - hosts: all


### PR DESCRIPTION
This change adds the namespace variable to the initial osdpns lookup in the hugepages_and_reboot validation.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
