### PR TITLE
Reload crc NetworkManager in reproducer

### DIFF
--- a/roles/reproducer/tasks/configure_crc.yml
+++ b/roles/reproducer/tasks/configure_crc.yml
@@ -43,6 +43,12 @@
           # Managed by ansible/cifmw
           nameserver {{ _crc.ip_v4 }}
 
+    - name: Reload NetworkManager to ensure it read the conf changes
+      become: true
+      ansible.builtin.service:
+        name: NetworkManager
+        state: "reloaded"
+
     - name: Check which dnsmasq config we must edit
       register: _dnsmasq
       ansible.builtin.stat:


### PR DESCRIPTION
The fix for reproducer dns[1] does not seem to work in all instances.
NetworkManager was still overwriting the /etc/resolv.conf contents, so
this change reloads the service after changing the config to ensure it
does not modify the resolv.conf on reboot.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/1637
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
