### PR TITLE
[edpm_build_images] Run buildah command as a root

### DIFF
--- a/roles/edpm_build_images/tasks/package.yml
+++ b/roles/edpm_build_images/tasks/package.yml
@@ -1,5 +1,6 @@
 ---
 - name: Package edpm-hardened-uefi image inside container image
+  become: true
   when:
     - (cifmw_edpm_build_images_hardened_uefi | bool) or (cifmw_edpm_build_images_all | bool)
     - cifmw_edpm_build_images_hardened_uefi_package | bool
@@ -14,6 +15,7 @@
       --logfile {{ cifmw_edpm_build_images_basedir }}/logs/edpm_images/edpm_hardened_uefi_container_package.log
 
 - name: Package ironic-python-agent image inside container image
+  become: true
   when:
     - (cifmw_edpm_build_images_ironic_python_agent | bool) or (cifmw_edpm_build_images_all | bool)
     - cifmw_edpm_build_images_ironic_python_agent_package | bool

--- a/roles/edpm_build_images/tasks/post.yaml
+++ b/roles/edpm_build_images/tasks/post.yaml
@@ -1,5 +1,6 @@
 ---
 - name: "Push images to registry with tag {{ cifmw_edpm_build_images_tag }}"
+  become: true
   containers.podman.podman_image:
     name: "{{ item }}"
     push_args:
@@ -12,6 +13,7 @@
     - ironic-python-agent
 
 - name: Retag and push the images with podified-ci-testing tag
+  become: true
   when: cifmw_repo_setup_promotion == "podified-ci-testing"
   block:
     - name: Retag the images with podified-ci-testing tag
@@ -36,6 +38,7 @@
         - ironic-python-agent
 
 - name: Dump edpm container images in the file  # noqa: risky-shell-pipe
+  become: true
   args:
     chdir: "{{ cifmw_edpm_image_builder_repo_path }}"
   ansible.builtin.shell: >-


### PR DESCRIPTION
In Downstream, we perform podman/buildah login as a root to pull base containers.

Here we are building containers as a normal user. the buildah commands are failing with base containers not found.

Running buildah command as a root fixes the issue.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running

