### PR TITLE
Use ansible.builtin.stat to check src file existence

### DIFF
--- a/roles/ci_gen_kustomize_values/tasks/generate_snippets.yml
+++ b/roles/ci_gen_kustomize_values/tasks/generate_snippets.yml
@@ -8,11 +8,21 @@
       cifmw_architecture_scenario must be provided.
 
 - name: Ensure source original values file exists
-  ansible.builtin.assert:
-    that:
-      - cifmw_ci_gen_kustomize_values_src_file is ansible.builtin.exists
-    msg: >-
-      {{ cifmw_ci_gen_kustomize_values_src_file }} doesn't exist.
+  block:
+    - name: Stat original source file
+      register: _src_stat
+      ansible.builtin.stat:
+        path: "{{ cifmw_ci_gen_kustomize_values_src_file }}"
+        get_attributes: false
+        get_checksum: false
+        get_mime: false
+
+    - name: Assert source file exists
+      ansible.builtin.assert:
+        that:
+          - _src_stat.stat.exists
+        msg: >-
+          {{ cifmw_ci_gen_kustomize_values_src_file }} doesn't exist.
 
 - name: Load original values file
   register: _original


### PR DESCRIPTION
`ansible.builtin.exists` is a local test only, and therefore doesn't
work against remote files.

This change modify the way we check for source values.yaml availability,
allowing to run against a remote host (mostly for coming testing)

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
