### PR TITLE
[dlrn_promote]Fixed dlrnapi hash params

### DIFF
--- a/roles/dlrn_promote/tasks/check_for_previous_promotions.yml
+++ b/roles/dlrn_promote/tasks/check_for_previous_promotions.yml
@@ -12,13 +12,13 @@
       --agg-hash {{ cifmw_repo_setup_full_hash }}
       {% endif -%}
       {% if (cifmw_repo_setup_extended_hash is defined) and (cifmw_repo_setup_extended_hash | length > 0) -%}
-      --extended_hash {{ cifmw_repo_setup_extended_hash }}
+      --extended-hash {{ cifmw_repo_setup_extended_hash }}
       {% endif -%}
       {% if (cifmw_repo_setup_commit_hash is defined) and (cifmw_repo_setup_commit_hash | length > 0) -%}
-      --commit_hash {{ cifmw_repo_setup_commit_hash }}
+      --commit-hash {{ cifmw_repo_setup_commit_hash }}
       {% endif -%}
       {% if (cifmw_repo_setup_distro_hash is defined) and (cifmw_repo_setup_distro_hash | length > 0) -%}
-      --distro_hash {{ cifmw_repo_setup_distro_hash }}
+      --distro-hash {{ cifmw_repo_setup_distro_hash }}
       {% endif -%}
       --promote-name {{ cifmw_dlrn_promote_promotion_target }}
       | tee -a {{ cifmw_dlrn_promote_workspace }}/cifmw_dlrn_promote_hash_promote_target_output.txt


### PR DESCRIPTION
The correct params for dlrnapi is as follows/l
```
❯ dlrnapi report-result --help
usage: dlrnapi report-result [-h] --job-id JOB_ID [--commit-hash COMMIT_HASH] [--distro-hash DISTRO_HASH] [--extended-hash EXTENDED_HASH]
                             [--agg-hash AGG_HASH] --info-url INFO_URL --timestamp TIMESTAMP --success SUCCESS [--notes NOTES]

options:
  -h, --help            show this help message and exit
  --job-id JOB_ID       Name of the CI sending the vote
  --commit-hash COMMIT_HASH
                        commit_hash of tested repo
  --distro-hash DISTRO_HASH
                        distro_hash of tested repo
  --extended-hash EXTENDED_HASH
                        extended_hash of tested repo
  --agg-hash AGG_HASH   hash of the tested aggregated repo. Note that either --commit-hash and --distro-hash or --agg-hash must be specified.
  --info-url INFO_URL   URL where to find additional information from the CI execution
  --timestamp TIMESTAMP
                        Timestamp (in seconds since the epoch)
  --success SUCCESS     Was the CI execution successful? Set to true or false.
  --notes NOTES         Additional notes
```

It should be dash instead of underscrore.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

