### PR TITLE
Switch away from `lookup()`

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -30,6 +30,10 @@
     required-projects:
       - openstack-k8s-operators/architecture
 - job:
+    name: cifmw-molecule-kustomize_deploy
+    required-projects:
+      - openstack-k8s-operators/architecture
+- job:
     name: cifmw-molecule-ci_multus
     parent: cifmw-molecule-base-crc
 - job:

--- a/roles/kustomize_deploy/molecule/flexible_loop/converge.yml
+++ b/roles/kustomize_deploy/molecule/flexible_loop/converge.yml
@@ -21,9 +21,12 @@
     - ./resources/vars.yml
   tasks:
     - name: Load networking environment definition
-      ansible.builtin.include_role:
-        name: networking_mapper
-        tasks_from: load_env_definition.yml
+      vars:
+        _file: >-
+          {{ lookup('file', 'files/networking-environment-definition.yml') }}
+      ansible.builtin.set_fact:
+        cifmw_networking_env_definition: >-
+          {{ _file | from_yaml }}
 
     - name: Check requirements
       ansible.builtin.import_role:
@@ -39,12 +42,9 @@
              'architecture/automation/vars',
              'default.yaml') | path_join
           }}
-        _file: "{{ lookup('file', _automation) }}"
+        _file: "{{ lookup('file', _automation) | from_yaml }}"
       ansible.builtin.set_fact:
-        cifmw_deploy_architecture_steps: >-
-          {{
-            _file | from_yaml
-          }}
+        cifmw_deploy_architecture_steps: "{{ _file.vas.hci }}"
         cifmw_ci_gen_kustomize_values_ssh_authorizedkeys: >-
           {{ lookup('file', '~/.ssh/authorized_keys', rstrip=False) }}
         cifmw_ci_gen_kustomize_values_ssh_private_key: >-
@@ -60,7 +60,7 @@
       ansible.builtin.include_role:
         name: "kustomize_deploy"
         tasks_from: execute_step.yml
-      loop: "{{ cifmw_deploy_architecture_steps.vas.hci.stages }}"
+      loop: "{{ cifmw_deploy_architecture_steps.stages }}"
       loop_control:
         label: "{{ stage.path }}"
         loop_var: "stage"
@@ -78,7 +78,7 @@
           ansible.builtin.include_role:
             name: "kustomize_deploy"
             tasks_from: execute_step.yml
-          loop: "{{ cifmw_deploy_architecture_steps.vas.hci.stages }}"
+          loop: "{{ cifmw_deploy_architecture_steps.stages }}"
           loop_control:
             label: "{{ stage.path }}"
             loop_var: "stage"

--- a/roles/kustomize_deploy/molecule/flexible_loop/prepare.yml
+++ b/roles/kustomize_deploy/molecule/flexible_loop/prepare.yml
@@ -20,22 +20,6 @@
     - ../../defaults/main.yml
     - ./resources/vars.yml
   tasks:
-    - name: Ensure we have networking mapper definition
-      become: true
-      block:
-        - name: Ensure ci directory exists
-          ansible.builtin.file:
-            path: "/etc/ci/env"
-            state: directory
-            mode: "0755"
-
-        - name: Copy networking-environment-definition.yml if needed
-          ansible.builtin.copy:
-            src: "networking-environment-definition.yml"
-            dest: "/etc/ci/env/networking-environment-definition.yml"
-            mode: "0644"
-            force: false
-
     - name: Create nova migration keypair
       community.crypto.openssh_keypair:
         comment: "nova migration"

--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -192,17 +192,25 @@
              path_join | realpath
           }}
       block:
+        # We have to use plain `kustomize build`: lookup would
+        # be executed locally, on the ansible-controller. In CI,
+        # that would be the zuul-executor, and we don't manage them,
+        # leading to a risk to either NOT have kustomize, or an old,
+        # deprecated version.
         - name: "Build kustomized content for {{ stage.path }}"
+          register: _kustomize_output
+          environment:
+            PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
+          ansible.builtin.command:
+            chdir: "{{ _chdir }}"
+            cmd: kustomize build
+
+        - name: Output kustomize build in final file
           ansible.builtin.copy:
+            backup: true
             dest: "{{ _output }}"
+            content: "{{ _kustomize_output.stdout }}"
             mode: "0644"
-            content: >-
-              {{
-                lookup(
-                  'kubernetes.core.kustomize',
-                  dir=_chdir
-                )
-              }}
 
         - name: "Store kustomized content in artifacts for {{ stage.path }}"
           ansible.builtin.copy:

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -436,6 +436,8 @@
     - ^.config/molecule/.*
     name: cifmw-molecule-kustomize_deploy
     parent: cifmw-molecule-base
+    required-projects:
+    - openstack-k8s-operators/architecture
     vars:
       TEST_RUN: kustomize_deploy
 - job:


### PR DESCRIPTION
Since we want to run some validations against `architecture` repository,
we end calling the role against a remote node instead of localhost.

The usage of `lookup()` breaks the loop, especially on Zuul: the
`lookup()` is launched onto the zuul-executor node, where we don't
manage anything, and may lead to multiple issues such as:
- collection not present (it seems to be present, but still)
- kustomize being missing from the path (seems to be present for now)
- 
Calling plain `command` ensures we're running the build onto an
environment we 100% manage and know.

This patch also fixes molecule tests on kustomize_deploy.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
