### PR TITLE
[ci_gen_kustomize] Do ctlplane assertion only if hosts are present

### DIFF
--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -17,6 +17,10 @@
         - cifmw_architecture_scenario is not defined
       ansible.builtin.meta: end_play
 
+    - name: Debug cifmw_baremetal_hosts
+      ansible.builtin.debug:
+        msg: "{{ cifmw_baremetal_hosts | default('Empty') }}"
+
     - name: Load Networking Environment Definition
       tags:
         - always
@@ -110,6 +114,10 @@
       ansible.builtin.slurp:
         path: "{{ cifmw_architecture_automation_file }}"
 
+    - name: Debug cifmw_baremetal_hosts
+      ansible.builtin.debug:
+        msg: "{{ cifmw_baremetal_hosts | default('Empty') }}"
+
     - name: Prepare automation data
       tags:
         - edpm_deploy
@@ -149,6 +157,10 @@
       tags:
         - storage
         - edpm_bootstrap
+
+    - name: Debug cifmw_baremetal_hosts
+      ansible.builtin.debug:
+        msg: "{{ cifmw_baremetal_hosts | default('Empty') }}"
 
     - name: Execute deployment steps
       tags:

--- a/roles/ci_gen_kustomize_values/tasks/edpm_core_asserts.yml
+++ b/roles/ci_gen_kustomize_values/tasks/edpm_core_asserts.yml
@@ -28,7 +28,7 @@
 
 - name: Ensure the required baremetal host parameters are configured.
   when:
-    - cifmw_baremetal_hosts is defined
+    - cifmw_baremetal_hosts | default({}) | length > 0
   ansible.builtin.assert:
     that:
       - cifmw_ci_gen_kustomize_values_ctlplane_interface is defined

--- a/roles/ci_gen_kustomize_values/tasks/edpm_core_asserts.yml
+++ b/roles/ci_gen_kustomize_values/tasks/edpm_core_asserts.yml
@@ -26,6 +26,10 @@
       - cifmw_ci_gen_kustomize_values_ssh_public_key is defined
       - cifmw_ci_gen_kustomize_values_ssh_public_key != ''
 
+- name: Debug cifmw_baremetal_hosts
+  ansible.builtin.debug:
+    msg: "{{ cifmw_baremetal_hosts | default('Empty') }}"
+
 - name: Ensure the required baremetal host parameters are configured.
   when:
     - cifmw_baremetal_hosts | default({}) | length > 0

--- a/roles/ci_gen_kustomize_values/tasks/main.yml
+++ b/roles/ci_gen_kustomize_values/tasks/main.yml
@@ -14,6 +14,10 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Debug cifmw_baremetal_hosts
+  ansible.builtin.debug:
+    msg: "{{ cifmw_baremetal_hosts | default('Empty') }}"
+
 - name: Generate snippets files
   ansible.builtin.include_tasks: generate_snippets.yml
 


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
