### PR TITLE
Add become in bootstrap-hypervisor.yml

### DIFF
--- a/docs/source/files/bootstrap-hypervisor.yml
+++ b/docs/source/files/bootstrap-hypervisor.yml
@@ -4,6 +4,7 @@
     _user: "{{ remote_user | default('zuul') }}"
   tasks:
     - name: Create user on remote host
+      become: true
       ansible.builtin.user:
         name: "{{ _user }}"
         state: present
@@ -34,6 +35,7 @@
 
     - name: Add RSA pub key to authorized keys
       when: rsa_pub_key.stat.exists
+      become: true
       ansible.posix.authorized_key:
         user: "{{ _user }}"
         state: present
@@ -47,6 +49,7 @@
         key: "{{ lookup('file', lookup('env','HOME') + '/.ssh/id_ed25519.pub') }}"
 
     - name: Grant sudo privileges to remote user
+      become: true
       ansible.builtin.copy:
         content: |
           "{{ _user }}" ALL=(ALL) NOPASSWD:ALL
@@ -56,6 +59,7 @@
         mode: 0640
 
     - name: Install basic packages
+      become: true
       ansible.builtin.package:
         name:
           - git
@@ -70,6 +74,7 @@
           - guestfs-tools
 
     - name: Allow qemu user on user home directory for VM storage accesses
+      become: true
       ansible.posix.acl:
         path: "/home/{{ _user }}"
         entity: qemu
@@ -78,6 +83,7 @@
         state: present
 
     - name: Add non-root user to libvirt group
+      become: true
       ansible.builtin.user:
         name: "{{ _user }}"
         groups: libvirt


### PR DESCRIPTION
Let's not assume it is possible to login as root.
Add's "become: true" to the tasks that require priviliges.

As a pull request owner and reviewers, I checked that:
- [X] No actual test for that playbook - it's provided as an extra.
