### PR TITLE
wip: check disposition of testing of ironic tests

### DIFF
--- a/roles/test_operator/files/list_skipped.yml
+++ b/roles/test_operator/files/list_skipped.yml
@@ -1400,33 +1400,6 @@ known_failures:
         lp: http://no.bug
     jobs:
       - ironic-operator
-  - test: ironic_tempest_plugin.tests.api.rbac_defaults.test_nodes.TestNodeProjectReader
-    deployment:
-      - overcloud
-    releases:
-      - name: master
-        reason: Not supported
-        lp: http://no.bug
-    jobs:
-      - ironic-operator
-  - test: ironic_tempest_plugin.tests.api.rbac_defaults.test_nodes.TestNodeSystemReader
-    deployment:
-      - overcloud
-    releases:
-      - name: master
-        reason: Not supported
-        lp: http://no.bug
-    jobs:
-      - ironic-operator
-  - test: ironic_tempest_plugin.tests.api.admin.test_allocations.TestAllocations
-    deployment:
-      - overcloud
-    releases:
-      - name: master
-        reason: Test bug being fixed in caracal.
-        lp: https://bugs.launchpad.net/ironic/+bug/2054722
-    jobs:
-      - ironic-operator
   - test: ironic_tempest_plugin.tests.api.admin.test_nodes.TestNodesVif.test_vif_attach_node_doesnt_exist
     deployment:
       - overcloud


### PR DESCRIPTION
We've put in fixes for tests, and we likely have tests we should be fixing if they are broken, but don't know why they were disabled.

So this change is to bring some more clarity so the team can figure out the correct course of action.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
