### PR TITLE
Add redfish bmc protocol to BMH CR

### DIFF
--- a/roles/deploy_bmh/README.md
+++ b/roles/deploy_bmh/README.md
@@ -25,6 +25,7 @@ The resulting CR will contain, for each node, the following objects:
 * `cifmw_deploy_bmh_patch_nmstate`: (*dict*) Dictionary to combine with each of generated BMH nmstate Secret CRs. Defaults to `{}`
 * `cifmw_deploy_bmh_node_patch_nmstate`: (*dict*) Dictionary with an individual BMH nmstate Secret CR patch per node. Defaults to `{}`
 * `cifmw_deploy_bmh_root_device_hint_field`: (*string*) The default field to use in the BMH `rootDeviceHints` when a node has `root_device_hint` populated. Defaults to `deviceName`
+* `cifmw_deploy_bmh_redfish_bmc_protocol`: (*string*) The RedFish BMC protocol you would like to use, options are `redfish` or `redfish-virtualmedia`. Defaults to `redfish-virtualmedia`
 
 ## Examples
 

--- a/roles/deploy_bmh/defaults/main.yml
+++ b/roles/deploy_bmh/defaults/main.yml
@@ -53,3 +53,5 @@ cifmw_deploy_bmh_disable_certificate_validation: true
 cifmw_deploy_bmh_disable_inspection: true
 
 cifmw_deploy_bmh_root_device_hint_field: deviceName
+
+cifmw_deploy_bmh_redfish_bmc_protocol: redfish-virtualmedia

--- a/roles/deploy_bmh/template/bmh.yml.j2
+++ b/roles/deploy_bmh/template/bmh.yml.j2
@@ -13,7 +13,7 @@ metadata:
     workload: {{ node_name.split('-')[0] }}
 spec:
   bmc:
-    address: {{ node_data['connection'] }}
+    address: {{ cifmw_deploy_bmh_redfish_bmc_protocol ~ '+' if 'redfish' in node_data['connection'] }}{{ node_data['connection'] }}
     credentialsName: {{ node_name }}-bmc-secret
     disableCertificateVerification: {{ cifmw_deploy_bmh_disable_certificate_validation }}
 {% for nic in (node_data['nics'] | default([])) if nic['network'] == cifmw_deploy_bmh_boot_interface %}


### PR DESCRIPTION
Currently the connection string is set to `http://$IP:8000/redfish/v1/Systems/$UUID`, the BMH CR expects a bmc protocol of `ipmi, redfish or redfish-virtualmedia`.

This patch adds the `cifmw_deploy_bmh_redfish_bmc_protocol` prefixed to the connection string if the connection type is `redfish`

`cifmw_deploy_bmh_redfish_bmc_protocol` is set to `redfish-virtualmedia` by default to match [1] but is now configurable if needed.

More details can be found [2] [3]

[1] https://github.com/openstack-k8s-operators/install_yamls/blob/6f43dd716e8d1ab7b38926ca29c45699a874e164/devsetup/scripts/edpm-compute-baremetal.sh#L76C14-L76C35
[2] https://github.com/metal3-io/baremetal-operator/blob/b87793e1e394bbc4e4b93fda967e2ff9f1bbbe79/docs/api.md?plain=1#L37-L38
[3] https://book.metal3.io/quick-start.html?highlight=redfish-virtualmedia#create-baremetalhosts

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role

