### PR TITLE
[reproducer] Add support for installing kustomize

### DIFF
--- a/roles/reproducer/defaults/main.yml
+++ b/roles/reproducer/defaults/main.yml
@@ -37,3 +37,5 @@ cifmw_reproducer_supported_hypervisor_os:
     minimum_version: 9
   RedHat:
     minimum_version: 9.3
+cifmw_reproducer_kustomize_install_script: >-
+  https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -83,6 +83,10 @@
           - wget
           - jq
 
+    - name: Install kustomize binary
+      ansible.builtin.include_tasks:
+        file: install_kustomize.yml
+
     - name: Build job inventory for hook usage
       tags:
         - bootstrap

--- a/roles/reproducer/tasks/install_kustomize.yml
+++ b/roles/reproducer/tasks/install_kustomize.yml
@@ -1,0 +1,73 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Ensure the directories exist
+  ansible.builtin.file:
+    path: "{{ item.dir_name }}"
+    mode: "{{ item.mode }}"
+    state: "directory"
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_id }}"
+  loop:
+    - dir_name: >-
+        {{
+          (cifmw_reproducer_basedir, 'tmp') | ansible.builtin.path_join
+        }}
+      mode: "0755"
+    - dir_name: >- 
+        {{
+          (ansible_user_dir, '.local') | ansible.builtin.path_join
+        }}
+      mode: "0700"
+    - dir_name: >-
+        {{
+          (ansible_user_dir, '.local', 'bin') | ansible.builtin.path_join
+        }}
+      mode: "0755"
+  loop_control:
+    label: "{{ item.dir_name }}"
+
+- name: Download the kustomize install script
+  ansible.builtin.get_url:
+    url: "{{ cifmw_reproducer_kustomize_install_script }}"
+    dest: >-
+      {{
+        (
+          cifmw_reproducer_basedir,
+          'tmp',
+          'install-kustomize.sh'
+        ) | ansible.builtin.path_join
+      }}
+    mode: '0755'
+    validate_certs: false
+
+- name: Execute the kustomize install script
+  ansible.builtin.command:
+    chdir: >-
+      {{
+        (ansible_user_dir, '.local', 'bin') | ansible.builtin.path_join
+      }}
+    cmd: >-
+      {{
+        (cifmw_reproducer_basedir, 'tmp', 'install-kustomize.sh')
+        | ansible.builtin.path_join
+      }}
+    creates: >-
+      {{
+        (ansible_user_dir, '.local', 'bin', 'kustomize')
+        | ansible.builtin.path_join
+      }}


### PR DESCRIPTION
This change installs kustomize binary on the controller type nodes as required by kustomize_deploy role.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes

*Error*
```
2024-05-14 21:48:24,938 p=22441 u=zuul n=ansible | TASK [kustomize_deploy : Build kustomized content for examples/dt/uni01alpha/control-plane/nncp chdir={{ _chdir }}, _raw_params=kustomize build] ***
2024-05-14 21:48:24,939 p=22441 u=zuul n=ansible | Tuesday 14 May 2024  21:48:24 -0400 (0:00:00.079)       0:07:54.690 *********** 
2024-05-14 21:48:25,261 p=22441 u=zuul n=ansible | fatal: [localhost]: FAILED! => changed=false 
  cmd: kustomize build
  msg: '[Errno 2] No such file or directory: b''kustomize'''
  rc: 2
  stderr: ''
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
```
