### PR TITLE
Switch from `kustomize` to `oc kustomize`

### DIFF
--- a/roles/kustomize_deploy/molecule/flexible_loop/prepare.yml
+++ b/roles/kustomize_deploy/molecule/flexible_loop/prepare.yml
@@ -20,6 +20,10 @@
     - ../../defaults/main.yml
     - ./resources/vars.yml
   tasks:
+    - name: Include ci_setup role
+      ansible.builtin.include_role:
+        name: ci_setup
+
     - name: Create nova migration keypair
       community.crypto.openssh_keypair:
         comment: "nova migration"
@@ -37,7 +41,3 @@
         dest: "{{ cifmw_openshift_kubeconfig }}"
         content: |
           {}
-
-- name: Download tools
-  ansible.builtin.import_playbook: >-
-    /home/zuul/src/github.com/openstack-k8s-operators/install_yamls/devsetup/download_tools.yaml

--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -192,7 +192,7 @@
              path_join | realpath
           }}
       block:
-        # We have to use plain `kustomize build`: lookup would
+        # We have to use plain `oc kustomize`: lookup would
         # be executed locally, on the ansible-controller. In CI,
         # that would be the zuul-executor, and we don't manage them,
         # leading to a risk to either NOT have kustomize, or an old,
@@ -203,7 +203,7 @@
             PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
           ansible.builtin.command:
             chdir: "{{ _chdir }}"
-            cmd: kustomize build
+            cmd: "oc kustomize"
 
         - name: Output kustomize build in final file
           ansible.builtin.copy:


### PR DESCRIPTION
We are restoring the "original" behavior but using `oc` instead of `kubectl` since it should be available everywhere.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
