### PR TITLE
Don't hardcode device image file in unit template

### DIFF
--- a/roles/cifmw_block_device/templates/ceph-osd-losetup.service.j2
+++ b/roles/cifmw_block_device/templates/ceph-osd-losetup.service.j2
@@ -9,7 +9,7 @@ After=syslog.target
 [Service]
 Type=oneshot
 ExecStart=/bin/bash -c '/sbin/losetup {{ cifmw_block_device_loop }} || \
-/sbin/losetup {{ cifmw_block_device_loop }} /var/lib/ceph-osd.img ; partprobe {{ cifmw_block_device_loop }}'
+/sbin/losetup {{ cifmw_block_device_loop }} {{ cifmw_block_device_image_file }} ; partprobe {{ cifmw_block_device_loop }}'
 ExecStop=/sbin/losetup -d {{ cifmw_block_device_loop }}
 RemainAfterExit=yes
 


### PR DESCRIPTION
The cifmw_block_device role creatas a systemd unit that harcodes the
device image file to user for ceph-osd-losetup. Instead it should use
the cifmw_block_device_image_file var, since that var will always point
to correct path for the file (as it has a default).

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
