### PR TITLE
Updating baremetal provision validations

### DIFF
--- a/roles/ci_gen_kustomize_values/defaults/main.yml
+++ b/roles/ci_gen_kustomize_values/defaults/main.yml
@@ -16,6 +16,7 @@
 
 # Top-level parameter shared with deploy_kustomize role
 cifmw_architecture_scenario: null
+cifw_bmh_pre_provisioned: true
 
 cifmw_ci_gen_kustomize_values_basedir: >-
   {{

--- a/roles/ci_gen_kustomize_values/tasks/edpm_core_asserts.yml
+++ b/roles/ci_gen_kustomize_values/tasks/edpm_core_asserts.yml
@@ -29,6 +29,7 @@
 - name: Ensure the required baremetal host parameters are configured.
   when:
     - cifmw_baremetal_hosts is defined
+    - cifw_bmh_pre_provisioned == false
   ansible.builtin.assert:
     that:
       - cifmw_ci_gen_kustomize_values_ctlplane_interface is defined


### PR DESCRIPTION
This change is to validate provisioning related variables based on pre provisiond or not.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
