### PR TITLE
Introduce ci_lvms_storage role

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -19,6 +19,7 @@ authfile
 autoscale
 autostart
 awk
+backend
 backends
 baremetal
 baremetalhost
@@ -90,6 +91,7 @@ cri
 crio
 crs
 crypto
+csi
 csr
 csv
 ctl
@@ -262,6 +264,8 @@ losetup
 lsblk
 lv
 lvm
+lvmcluster
+lvms
 lweyzmmtmji
 machinenetwork
 macos
@@ -351,6 +355,7 @@ osd
 osp
 osprh
 otz
+overprovisionratio
 ovirt
 ovirtmgmt
 ovn
@@ -370,6 +375,8 @@ polarion
 polkit
 pragadeeswaran
 pre
+prepend
+prepended
 prikey
 privatekey
 projectquay
@@ -433,6 +440,7 @@ sha
 shiftstack
 shiftstackclient
 sig
+sizepercent
 skbg
 skiplist
 specificities
@@ -472,6 +480,7 @@ tmux
 tobiko
 toctree
 todo
+topolvm
 traceback
 tripleo
 ttl

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -20,6 +20,7 @@ are shared among multiple roles:
 - `cifmw_use_libvirt`: (Bool) toggle libvirt support.
 - `cifmw_use_crc`: (Bool) toggle rhol/crc usage.
 - `cifmw_use_uefi`: (Bool) toggle UEFI support in libvirt_manager provided VMs.
+- `cifmw_use_lvms`: (Bool) toggle LVMS support. Defaults to `false`.
 - `cifmw_openshift_kubeconfig`: (String) Path to the kubeconfig file if externally provided. If provided will be the kubeconfig to use and update after login.
 - `cifmw_openshift_api`: (String) Path to the kubeconfig file. If provided will be the API to authenticate against.
 - `cifmw_openshift_user`: (String) Login user. If provided, the user that logins.

--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -146,6 +146,15 @@
     - name: Configure Storage Class
       ansible.builtin.import_role:
         name: ci_local_storage
+      when: not cifmw_use_lvms | default(false)
+      tags:
+        - storage
+        - edpm_bootstrap
+
+    - name: Configure LVMS Storage Class
+      ansible.builtin.include_role:
+        name: ci_lvms_storage
+      when: cifmw_use_lvms | default(false)
       tags:
         - storage
         - edpm_bootstrap

--- a/playbooks/06-deploy-edpm.yml
+++ b/playbooks/06-deploy-edpm.yml
@@ -23,6 +23,12 @@
     - name: Configure Storage Class
       ansible.builtin.include_role:
         name: ci_local_storage
+      when: not cifmw_use_lvms | default(false)
+
+    - name: Configure LVMS Storage Class
+      ansible.builtin.include_role:
+        name: ci_lvms_storage
+      when: cifmw_use_lvms | default(false)
 
     - name: Run edpm_prepare
       ansible.builtin.include_role:

--- a/roles/ci_gen_kustomize_values/README.md
+++ b/roles/ci_gen_kustomize_values/README.md
@@ -33,6 +33,8 @@ with a message.
 * `cifmw_ci_gen_kustomize_values_userdata_b64`: (List) Base64 encoded list of data to combine in the generated output.
   Defaults to `[]`.
 * `ci_gen_kustomize_fetch_ocp_state`: (Boolean) If true it enables generating CI templates based on the OCP state. Defaults to `true`.
+* `cifmw_ci_gen_kustomize_values_storage_class_prefix`: (String) Prefix for `storageClass` in generated values.yaml files. Defaults to `"lvms-"` only if `cifmw_use_lvms` is True, otherwise it defaults to `""`. The prefix is prepended to the `cifmw_ci_gen_kustomize_values_storage_class`. It is not recommended to override this value, instead set `cifmw_use_lvms` True or False.
+* `cifmw_ci_gen_kustomize_values_storage_class`: (String) Value for `storageClass` in generated values.yaml files. Defaults to `"lvms-local-storage"` only if `cifmw_use_lvms` is True, otherwise it defaults to `"local-storage"`.
 
 ### Specific parameters for edpm-values
 This configMap needs some more parameters in order to properly override the `architecture` provided one.

--- a/roles/ci_gen_kustomize_values/defaults/main.yml
+++ b/roles/ci_gen_kustomize_values/defaults/main.yml
@@ -67,6 +67,8 @@ cifmw_ci_gen_kustomize_values_nameservers: []
 cifmw_ci_gen_kustomize_values_userdata: {}
 cifmw_ci_gen_kustomize_values_userdata_b64: []
 ci_gen_kustomize_fetch_ocp_state: true
+cifmw_ci_gen_kustomize_values_storage_class_prefix: "{{ 'lvms-' if cifmw_use_lvms | default(false) | bool else '' }}"
+cifmw_ci_gen_kustomize_values_storage_class: "{{ cifmw_ci_gen_kustomize_values_storage_class_prefix }}local-storage"
 
 # Those parameter must be set if you want to edit an "edpm-values"
 # cifmw_ci_gen_kustomize_values_ssh_authorizedkeys

--- a/roles/ci_gen_kustomize_values/templates/bgp/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp/network-values/values.yaml.j2
@@ -142,4 +142,4 @@ data:
       metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(86) }}
 
   lbServiceType: LoadBalancer
-  storageClass: local-storage
+  storageClass: {{ cifmw_ci_gen_kustomize_values_storage_class }}

--- a/roles/ci_gen_kustomize_values/templates/common/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/common/network-values/values.yaml.j2
@@ -126,4 +126,4 @@ data:
       metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(86) }}
 
   lbServiceType: LoadBalancer
-  storageClass: local-storage
+  storageClass: {{ cifmw_ci_gen_kustomize_values_storage_class }}

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/network-values/values.yaml.j2
@@ -126,4 +126,4 @@ data:
       metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(86) }}
 
   lbServiceType: LoadBalancer
-  storageClass: local-storage
+  storageClass: {{ cifmw_ci_gen_kustomize_values_storage_class }}

--- a/roles/ci_gen_kustomize_values/templates/uni01alpha/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni01alpha/network-values/values.yaml.j2
@@ -129,4 +129,4 @@ data:
       metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(86) }}
 
   lbServiceType: LoadBalancer
-  storageClass: local-storage
+  storageClass: {{ cifmw_ci_gen_kustomize_values_storage_class }}

--- a/roles/ci_lvms_storage/README.md
+++ b/roles/ci_lvms_storage/README.md
@@ -1,0 +1,153 @@
+# ci_lvms_storage
+
+The `ci_lvms_storage` role aims to be a drop in replacement
+for `ci_local_storage`. It uses LVMS (Logical Volume Manager
+Storage) based on the TopoLVM CSI driver to dynamically
+provision local storage built from block devices on OCP
+nodes.
+
+This role requires `cifmw_lvms_disk_list` to contain a list of
+paths to block devices which already exist on OCP nodes. If
+the `cifmw_devscripts_config_overrides.vm_extradisks_list` list
+contains `"vda vdb"`, then the `devscripts` role will create these
+block devices and `cifmw_lvms_disk_list` should be set to
+`['/dev/vda', '/dev/vdb']`. This role will then pass the disk list
+to the `deviceSelector` list used by the `LVMCluster` CRD.
+
+## Privilege escalation
+
+It does not have any tasks which use become, but it does need to use
+`roles/ci_lvms_storage/templates/lvms-namespace.yaml.j2` to create
+create an OpenShift namespace where it then sets up a subscription
+as per `roles/ci_lvms_storage/templates/subscription.yaml.j2`. It
+uses the `cifmw_lvms_disk_list` list to find disks which it then wipes
+clean and adds to an LVMS cluster.
+
+## Parameters
+
+### ci-framework parameters
+
+* `cifmw_use_lvms`: (Boolean) Whether or not to use LVMS (default: `false`)
+
+If the ci-framework is called and `cifmw_use_lvms` is true, then
+the playbooks `06-deploy-architecture.yml` and `06-deploy-edpm.yml`
+call the `ci_lvms_storage` role to create a storage class called
+`lvms-local-storage` and the `ci_gen_kustomize_values` role will
+set the `storageClass` to `lvms-local-storage` in the generated
+values.yaml files used to build architecture CRs. The Tempest
+CR file, created by the `test_operator` role, will also set its
+`storageClass` value to `lvms-local-storage`.
+
+If the ci-framework is called and `cifmw_use_lvms` is false, then the
+playbooks `06-deploy-architecture.yml` and `06-deploy-edpm.yml`
+call the `ci_local_storage` role to create a storage class called
+`local-storage` and the `ci_gen_kustomize_values` role will set
+the `storageClass` to `local-storage` in the generated values.yaml
+files used to build architecture CRs. The Tempest CR file, created by
+the `test_operator` role, will also set its `storageClass` value to
+`local-storage`.
+
+* `cifmw_lvms_basedir`: (String) Installation base directory. Defaults to `cifmw_basedir` which defaults to `~/ci-framework-data`.
+* `cifmw_lvms_manifests_dir`: (String) Directory in where OCP manifests will be placed. Defaults to `"{{ cifmw_manifests | default(cifmw_cls_basedir ~ '/artifacts/manifests') }}/lvms"`
+
+### LVMCluster CRD Overrides
+
+* `cifmw_lvms_disk_list`: (List) A the list of pre-created block devices on OCP nodes used as PVs of the LVMS cluster.(default `[]`)
+* `cifmw_lvms_cluster_name`: (String) The `LVMCluster CRD` template override for the meta name (default `lvmcluster`)
+* `cifmw_lvms_force_wipe_devices_and_destroy_all_data`: (Boolean) The `LVMCluster CRD` template override for `deviceSelector` `forceWipeDevicesAndDestroyAllData` (default `true`)
+* `cifmw_lvms_fstype`: (String) The `LVMCluster CRD` template override for `deviceClasses` `fstype` (default `xfs`)
+* `cifmw_lvms_thin_pool_name`: (String) The `LVMCluster CRD` template override for `thinPoolConfig` name (default `cifmw_lvms_thin_pool`)
+* `cifmw_lvms_thin_pool_overprovision_ratio`: (Int) The `LVMCluster CRD` template override for `thinPoolConfig` overprovisionRatio (default `10`)
+* `cifmw_lvms_thin_pool_size_percent`: (Int) The `LVMCluster CRD` template override for `thinPoolConfig` sizePercent (default `90`)
+* `cifmw_lvms_storage_class`: (String) The `LVMCluster CRD` template override for the `deviceClasses` `name`. In this Ansible role it defaults to `local-storage` though the LVMS operator will prepend `lvms-` to this value, so the resultant default storage class will be `lvms-local-storage`.
+
+### Kubernetes parameters
+
+* `cifmw_lvms_namespace`: (String) The Kubernetes namespace where the LVMS cluster and operator pods will run (default `openshift-storage`)
+
+### kubernetes.core.k8s_info parameters
+
+After a Kubernetes manifest is placed in `cifmw_lvms_manifests_dir` by
+the `ansible.builtin.template` module, it is applied to the cluster
+with the `kubernetes.core.k8s` module. The `kubernetes.core.k8s_info`
+module then polls Kubernetes for the status of the created resource
+before the role goes on to apply other manifests. The polling can
+be controlled with the following parameters.
+
+* `cifmw_lvms_delay`: (Int) Ansible `delay` passed to tasks which wait for `kubernetes.core.k8s_info` (default `10`)
+* `cifmw_lvms_retries`: (Int) Ansible `retries` passed to tasks which wait for `kubernetes.core.k8s_info` (default `60`)
+
+## Examples
+
+The example playbook below will create an LVMS cluster using the disks
+from the `cifmw_lvms_disk_list` list. An example var for
+`cifmw_devscripts_config_overrides` is also set with a matching
+`vm_extradisks_list`. This parameter will result in the `devscripts`
+role (not called below) creating the devices when it provisions OCP.
+
+The playbook will use the `kubernetes.core.k8s_info` Ansible module
+to ensure the LVMS operator and storage cluster are ready and then
+report on their status. It will then create a test PVC and test pod
+to use the PVC. The last task in the playbook will remove the test
+resources as well as delete the entire LVMS cluster, operator and
+namespace.
+
+```yaml
+- name: LVMS playbook
+  gather_facts: false
+  hosts: all
+  vars:
+    cifmw_openshift_kubeconfig: "~/.kube/config"
+    cifmw_lvms_disk_list:
+      - /dev/vda
+      - /dev/vdb
+    cifmw_devscripts_config_overrides:
+      vm_extradisks: "true"
+      vm_extradisks_list: "vdb vda"
+      vm_extradisks_size: "10G"
+  tasks:
+    - name: Create Storage Class
+      ansible.builtin.include_role:
+        name: ci_lvms_storage
+
+    - name: Report on Storage Class
+      ansible.builtin.include_role:
+        name: ci_lvms_storage
+        tasks_from: status.yml
+
+    - name: Test the Storage Class
+      ansible.builtin.include_role:
+        name: ci_lvms_storage
+        tasks_from: test.yml
+
+    - name: Clean up Storage Class
+      ansible.builtin.include_role:
+        name: ci_lvms_storage
+        tasks_from: cleanup.yml
+```
+
+## Testing the `ci_lvms_storage` role
+
+The `ci_lvms_storage` role is designed to be run on an OCP cluster
+which has unused disks (besides the one where root is mounted). It
+does not have a molecule directory however it can be tested by the
+ci-framework `devscripts` integration by passing the following:
+
+```yaml
+cifmw_devscripts_config_overrides:
+  vm_extradisks: "true"
+  vm_extradisks_list: "vda vdb"
+  vm_extradisks_size: "50G"
+```
+The `lsblk` command on any OCP node should show the extra block
+devices. If the example playbook is then run it will use the same
+parameters to create an LVMS cluster which uses `/dev/vda` and
+`/dev/vdb` for backend storage.
+
+The `tasks_from: status.yml` in the example playbook will show
+the cluster status including the block devices which are used.
+
+The `tasks_from: test.yml` in the example playbook will create
+a PVC and a test POD which mounts the PVC. It will be clear from
+the Ansible output if the storage class provided by this role
+is functional.

--- a/roles/ci_lvms_storage/defaults/main.yml
+++ b/roles/ci_lvms_storage/defaults/main.yml
@@ -1,0 +1,33 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_lvms"
+
+cifmw_lvms_disk_list: []
+cifmw_lvms_cluster_name: lvmcluster
+cifmw_lvms_namespace: openshift-storage
+cifmw_lvms_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+cifmw_lvms_manifests_dir: "{{ cifmw_manifests | default(cifmw_lvms_basedir ~ '/artifacts/manifests') }}/lvms"
+# The "lvms-" prefix is prepended to the cifmw_lvms_storage_class by the lvm-operator
+cifmw_lvms_storage_class: local-storage
+cifmw_lvms_fstype: xfs
+cifmw_lvms_force_wipe_devices_and_destroy_all_data: true
+cifmw_lvms_thin_pool_name: cifmw_lvms_thin_pool
+cifmw_lvms_thin_pool_size_percent: 90
+cifmw_lvms_thin_pool_overprovision_ratio: 10
+cifmw_lvms_retries: 60
+cifmw_lvms_delay: 10

--- a/roles/ci_lvms_storage/meta/main.yml
+++ b/roles/ci_lvms_storage/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- ci_lvms_storage
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: cifmw
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - cifmw
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/ci_lvms_storage/tasks/cleanup.yml
+++ b/roles/ci_lvms_storage/tasks/cleanup.yml
@@ -1,0 +1,35 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure manifest files are absent
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    src: "{{ cifmw_lvms_manifests_dir }}/{{ item }}.yaml"
+    state: absent
+    wait: true
+  failed_when: false
+  loop:
+    - lvms-cluster
+    - subscription
+    - operator-group
+    - lvms-namespace
+
+- name: Remove role needed directories
+  ansible.builtin.file:
+    path: "{{ cifmw_lvms_manifests_dir }}"
+    state: absent

--- a/roles/ci_lvms_storage/tasks/main.yml
+++ b/roles/ci_lvms_storage/tasks/main.yml
@@ -1,0 +1,141 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure cifmw_lvms_disk_list has been set
+  ansible.builtin.fail:
+    msg: >-
+      cifmw_lvms_disk_list must be set to a list of existing block devices
+      on OCP nodes, e.g. `cifmw_lvms_disk_list: [/dev/vda, /dev/vdb]`
+  when:
+    - cifmw_lvms_disk_list is not defined or cifmw_lvms_disk_list | length == 0
+
+- name: Create role needed directories
+  ansible.builtin.file:
+    path: "{{ cifmw_lvms_manifests_dir }}"
+    state: directory
+
+- name: Put the manifest files in place
+  ansible.builtin.template:
+    src: "templates/{{ item }}.yaml.j2"
+    dest: "{{ cifmw_lvms_manifests_dir }}/{{ item }}.yaml"
+    mode: "0644"
+    force: true
+  loop:
+    - lvms-namespace
+    - operator-group
+    - subscription
+    - lvms-cluster
+
+- name: Apply lvms-operator namespace manifest file with annotations
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    src: "{{ cifmw_lvms_manifests_dir }}/lvms-namespace.yaml"
+    state: present
+
+- name: Wait for lvms-operator namespace to be active
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    kind: Namespace
+    name: "{{ cifmw_lvms_namespace }}"
+  register: namespace_info
+  until:
+    - namespace_info.resources | length > 0
+    - namespace_info.resources[0].status is defined
+    - namespace_info.resources[0].status.phase is defined
+    - namespace_info.resources[0].status.phase == "Active"
+  retries: "{{ cifmw_lvms_retries }}"
+  delay: "{{ cifmw_lvms_delay }}"
+
+- name: Apply lvms-operator group manifest file
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    src: "{{ cifmw_lvms_manifests_dir }}/operator-group.yaml"
+    state: present
+
+- name: Ensure we can get info from lvms-operator group
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    kind: OperatorGroup
+    name: "{{ cifmw_lvms_namespace }}-operatorgroup"
+    namespace: "{{ cifmw_lvms_namespace }}"
+  register: og_info
+  until: og_info.failed == false
+  retries: "{{ cifmw_lvms_retries }}"
+  delay: "{{ cifmw_lvms_delay }}"
+
+- name: Apply lvms-operator subscription manifest file
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    src: "{{ cifmw_lvms_manifests_dir }}/subscription.yaml"
+    state: present
+
+- name: Wait for lvms operator pod to be running
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    kind: Pod
+    namespace: "{{ cifmw_lvms_namespace }}"
+    label_selectors:
+      - app.kubernetes.io/name=lvms-operator
+  register: lvms_op_pod
+  until:
+    - lvms_op_pod.resources | length > 0
+    - lvms_op_pod.resources[0].status is defined
+    - lvms_op_pod.resources[0].status.phase is defined
+    - lvms_op_pod.resources[0].status.phase == "Running"
+  retries: "{{ cifmw_lvms_retries }}"
+  delay: "{{ cifmw_lvms_delay }}"
+
+- name: Apply lvms-cluster manifest file
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    src: "{{ cifmw_lvms_manifests_dir }}/lvms-cluster.yaml"
+    state: present
+
+- name: Wait for vg-manger and topolvm controller and node to be running
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    kind: Pod
+    namespace: "{{ cifmw_lvms_namespace }}"
+    label_selectors:
+      - "app.kubernetes.io/component={{ item }}"
+  register: topolvm_pod
+  until:
+    - topolvm_pod.resources | length > 0
+    - topolvm_pod.resources[0].status is defined
+    - topolvm_pod.resources[0].status.phase is defined
+    - topolvm_pod.resources[0].status.phase == "Running"
+  retries: "{{ cifmw_lvms_retries }}"
+  delay: "{{ cifmw_lvms_delay }}"
+  loop:
+    - vg-manager
+    - topolvm-controller
+    - topolvm-node

--- a/roles/ci_lvms_storage/tasks/status.yml
+++ b/roles/ci_lvms_storage/tasks/status.yml
@@ -1,0 +1,60 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Get pods in LVMS namespace
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    kind: Pod
+    namespace: "{{ cifmw_lvms_namespace }}"
+  register: pod_info
+
+- name: Display pod names and status
+  ansible.builtin.debug:
+    msg: "Pod: {{ pod_info.resources[my_loop_index].metadata.name }}, Status: {{ pod_info.resources[my_loop_index].status.phase }}"
+  loop: "{{ range(0, pod_info.resources|length) | list }}"
+  loop_control:
+    loop_var: my_loop_index
+
+- name: Get lvmcluster deviceClassStatuses
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    kind: LVMCluster
+    api_version: lvm.topolvm.io/v1alpha1
+    namespace: "{{ cifmw_lvms_namespace }}"
+  register: lvm_cluster
+
+- name: Display deviceClassStatuses
+  ansible.builtin.debug:
+    var: lvm_cluster.resources[0].status
+
+- name: Get cifmw_lvms_storage_class
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    kind: StorageClass
+    api_version: storage.k8s.io/v1
+    name: "lvms-{{ cifmw_lvms_storage_class }}"
+    namespace: "{{ cifmw_lvms_namespace }}"
+  register: sc
+
+- name: Display StorageClass
+  ansible.builtin.debug:
+    var: sc

--- a/roles/ci_lvms_storage/tasks/test.yml
+++ b/roles/ci_lvms_storage/tasks/test.yml
@@ -1,0 +1,124 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Put the testing manifest files in place
+  ansible.builtin.template:
+    src: "templates/test/{{ item }}.yaml.j2"
+    dest: "{{ cifmw_lvms_manifests_dir }}/{{ item }}.yaml"
+    mode: "0644"
+    force: true
+  loop:
+    - test-pvc
+    - test-pod
+
+- name: Apply test-pvc manifest file
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    src: "{{ cifmw_lvms_manifests_dir }}/test-pvc.yaml"
+    state: present
+
+- name: Wait for test PVC to be pending
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    kind: PersistentVolumeClaim
+    name: lvms-test-pvc
+    namespace: "{{ cifmw_lvms_namespace }}"
+  register: pvc
+  until:
+    - pvc.resources | length > 0
+    - pvc.resources[0].status is defined
+    - pvc.resources[0].status.phase is defined
+    - pvc.resources[0].status.phase == "Pending"
+  retries: "{{ cifmw_lvms_retries }}"
+  delay: "{{ cifmw_lvms_delay }}"
+
+- name: Display test PVC info
+  ansible.builtin.debug:
+    var: pvc
+
+- name: Apply test-pod manifest file
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    src: "{{ cifmw_lvms_manifests_dir }}/test-pod.yaml"
+    state: present
+
+- name: Wait for test pod to be running
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    kind: Pod
+    name: lvms-test-pod
+    namespace: "{{ cifmw_lvms_namespace }}"
+  register: pod
+  until:
+    - pod.resources | length > 0
+    - pod.resources[0].status is defined
+    - pod.resources[0].status.phase is defined
+    - pod.resources[0].status.phase == "Running"
+  retries: "{{ cifmw_lvms_retries }}"
+  delay: "{{ cifmw_lvms_delay }}"
+
+- name: Display test pod volumes
+  ansible.builtin.debug:
+    var: item
+  loop: "{{ pod.resources[0].spec.volumes | list }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - item.name == "lvms-test-volume"
+
+- name: Display test pod volumeMounts
+  ansible.builtin.debug:
+    var: item
+  loop: "{{ pod.resources[0].spec.containers[0].volumeMounts | list }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - item.name == "lvms-test-volume"
+
+- name: Get test PVC information now that test POD is running
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    kind: PersistentVolumeClaim
+    name: lvms-test-pvc
+    namespace: "{{ cifmw_lvms_namespace }}"
+  register: pvc
+
+- name: Display test PVC status
+  ansible.builtin.debug:
+    var: pvc.resources[0].status.phase
+
+- name: Delete resources created by manifest files
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    src: "{{ cifmw_lvms_manifests_dir }}/{{ item }}.yaml"
+    state: absent
+    wait: true
+  failed_when: false
+  loop:
+    - test-pod
+    - test-pvc

--- a/roles/ci_lvms_storage/templates/lvms-cluster.yaml.j2
+++ b/roles/ci_lvms_storage/templates/lvms-cluster.yaml.j2
@@ -1,0 +1,22 @@
+---
+apiVersion: lvm.topolvm.io/v1alpha1
+kind: LVMCluster
+metadata:
+  name: {{ cifmw_lvms_cluster_name }}
+  namespace: {{ cifmw_lvms_namespace }}
+spec:
+  storage:
+    deviceClasses:
+    - name: {{ cifmw_lvms_storage_class }}
+      fstype: {{ cifmw_lvms_fstype }}
+      default: true
+      deviceSelector:
+        paths:
+        {% for item in cifmw_lvms_disk_list -%}
+        - {{ item }}
+        {% endfor -%}
+        forceWipeDevicesAndDestroyAllData: {{ cifmw_lvms_force_wipe_devices_and_destroy_all_data }}
+      thinPoolConfig:
+        name: {{ cifmw_lvms_thin_pool_name }}
+        sizePercent: {{ cifmw_lvms_thin_pool_size_percent }}
+        overprovisionRatio: {{ cifmw_lvms_thin_pool_overprovision_ratio }}

--- a/roles/ci_lvms_storage/templates/lvms-namespace.yaml.j2
+++ b/roles/ci_lvms_storage/templates/lvms-namespace.yaml.j2
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+  name: {{ cifmw_lvms_namespace }}

--- a/roles/ci_lvms_storage/templates/operator-group.yaml.j2
+++ b/roles/ci_lvms_storage/templates/operator-group.yaml.j2
@@ -1,0 +1,9 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: {{ cifmw_lvms_namespace }}-operatorgroup
+  namespace: {{ cifmw_lvms_namespace }}
+spec:
+  targetNamespaces:
+  - {{ cifmw_lvms_namespace }}

--- a/roles/ci_lvms_storage/templates/subscription.yaml.j2
+++ b/roles/ci_lvms_storage/templates/subscription.yaml.j2
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: lvms
+  namespace: {{ cifmw_lvms_namespace }}
+spec:
+  installPlanApproval: Automatic
+  name: lvms-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/roles/ci_lvms_storage/templates/test/test-pod.yaml.j2
+++ b/roles/ci_lvms_storage/templates/test/test-pod.yaml.j2
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: lvms-test-pod
+  namespace: {{ cifmw_lvms_namespace }}
+spec:
+  containers:
+  - name: lvms-test-container
+    image: nginx
+    volumeMounts:
+    - name: lvms-test-volume
+      mountPath: /data
+  volumes:
+  - name: lvms-test-volume
+    persistentVolumeClaim:
+      claimName: lvms-test-pvc

--- a/roles/ci_lvms_storage/templates/test/test-pvc.yaml.j2
+++ b/roles/ci_lvms_storage/templates/test/test-pvc.yaml.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: lvms-test-pvc
+  namespace: {{ cifmw_lvms_namespace }}
+spec:
+  storageClassName: "lvms-{{ cifmw_lvms_storage_class }}"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -18,6 +18,8 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_controller_ip`: (String) An ip address of the controller node. Default value: `ansible_default_ipv4.address` which defaults to (`""`).
 * `cifmw_test_operator_tolerations`: (Dict) `tolerations` value that is applied to all pods spawned by the test-operator and to the test-operator-controller-manager and test-operator-logs pods. Default value: `{}`
 * `cifmw_test_operator_node_selector`: (Dict) `nodeSelector` value that is applied to all pods spawned by the test-operator and to the test-operator-controller-manager and test-operator-logs pods. Default value: `{}`
+* `cifmw_test_operator_storage_class_prefix`: (String) Prefix for `storageClass` in generated Tempest CRD file. Defaults to `"lvms-"` only if `cifmw_use_lvms` is True, otherwise it defaults to `""`. The prefix is prepended to the `cifmw_test_operator_storage_class`. It is not recommended to override this value, instead set `cifmw_use_lvms` True or False.
+* `cifmw_test_operator_storage_class`: (String) Value for `storageClass` in generated Tempest CRD file. Defaults to `"lvms-local-storage"` only if `cifmw_use_lvms` is True, otherwise it defaults to `"local-storage"`.
 
 ## Tempest specific parameters
 * `cifmw_test_operator_tempest_registry`: (String) The registry where to pull tempest container. Default value: `quay.io`

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -32,6 +32,8 @@ cifmw_test_operator_default_groups:
 cifmw_test_operator_default_jobs:
   - default
 cifmw_test_operator_fail_fast: false
+cifmw_test_operator_storage_class_prefix: "{{ 'lvms-' if cifmw_use_lvms | default(false) | bool  else '' }}"
+cifmw_test_operator_storage_class: "{{ cifmw_test_operator_storage_class_prefix }}local-storage"
 
 # Section 2: tempest parameters - used when run_test_fw is 'tempest'
 cifmw_test_operator_tempest_registry: quay.io
@@ -52,6 +54,7 @@ cifmw_test_operator_tempest_config:
     namespace: "{{ cifmw_test_operator_namespace }}"
   spec:
     containerImage: "{{ cifmw_test_operator_tempest_image }}:{{ cifmw_test_operator_tempest_image_tag }}"
+    storageClass: "{{ cifmw_test_operator_storage_class }}"
     SSHKeySecretName: "{{ cifmw_test_operator_tempest_ssh_key_secret_name | default(omit) }}"
     configOverwrite: "{{ cifmw_test_operator_tempest_config_overwrite | default(omit) }}"
     networkAttachments: "{{ cifmw_test_operator_tempest_network_attachments }}"

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -789,6 +789,15 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/ci_lvms_storage/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-ci_lvms_storage
+    parent: cifmw-molecule-noop
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/openshift_adm/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -18,6 +18,7 @@
       - cifmw-molecule-cert_manager
       - cifmw-molecule-ci_gen_kustomize_values
       - cifmw-molecule-ci_local_storage
+      - cifmw-molecule-ci_lvms_storage
       - cifmw-molecule-ci_metallb
       - cifmw-molecule-ci_multus
       - cifmw-molecule-ci_netconfig


### PR DESCRIPTION
The `ci_lvms_storage` role aims to be a drop in replacement for `ci_local_storage`. It uses LVMS (Logical Volume Manager Storage) based on the TopoLVM CSI driver to dynamically provision local storage built from block devices on OCP nodes.

This role requires `cifmw_lvms_disk_list` to contain a list of paths to block devices which already exist on OCP nodes. If the `cifmw_devscripts_config_overrides.vm_extradisks_list` list contains `"vda vdb"`, then it will create these block devices and `cifmw_lvms_disk_list` should be set to `['/dev/vda', '/dev/vdb']`. This role will then pass this list to the `deviceSelector` list used by the `LVMCluster` CRD.

This patch introduces the role but `ci_local_storage` is still used by the `06-deploy-{architecture,edpm}.yml` playbooks unless `cifmw_use_lvms` is true. The `ci_gen_kustomize_values` role has been updated to set the `storageClass` to `lvms-local-storage` only if `cifmw_use_lvms` is true. Otherwise it keeps its default `local-storage`. A similar change has been made to the `test_operator` role so that Tempest uses the chosen storage class.

In a follow up patch we can default `cifmw_use_lvms` to true so that LVMS becomes opt out. For now it is opt in for early testing.


Related: https://issues.redhat.com/browse/OSPRH-2749

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
