### PR TITLE
Ensure we clean dnsmasq lease file upon cleanup

### DIFF
--- a/roles/dnsmasq/tasks/cleanup.yml
+++ b/roles/dnsmasq/tasks/cleanup.yml
@@ -18,3 +18,9 @@
   vars:
     _act: 'cleanup'
   ansible.builtin.include_tasks: configure.yml
+
+- name: Remove lease file
+  become: true
+  ansible.builtin.file:
+    path: "/var/lib/dnsmasq/cifmw-dnsmasq.leases"
+    state: absent


### PR DESCRIPTION
Else, we hit an issue where dnsmasq won't give an IP because its lease
is still running.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
