### PR TITLE
Update auto-draft workflow to skip on nit: PRs

### DIFF
--- a/.github/workflows/auto-draft.yml
+++ b/.github/workflows/auto-draft.yml
@@ -20,12 +20,13 @@ jobs:
         continue-on-error: true # We should not block if this action fails for some reason
         if: github.event.pull_request.draft == false
         shell: bash
-        run: >
-          gh pr ready "$URL" --undo &&
-          printf 'Thanks for the PR! :heart:\nI am marking it as a draft,
-          once passing your happy and the PR is passing CI click the
-          \"Ready for review\" button below.' |
-          gh pr comment "$URL" -F -
+        run: |
+          if ! [[ "$TITLE" =~ ^nit:.* ]]; then
+            gh pr ready "$URL" --undo
+            printf "$MESSAGE" | gh pr comment "$URL" -F -
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           URL: ${{ github.event.pull_request.html_url }}
+          TITLE: ${{ github.event.pull_request.title }}
+          MESSAGE: "Thanks for the PR! :heart:\nI'm marking it as a draft, once your happy with it merging and the PR is passing CI, click the \"Ready for review\" button below."

--- a/docs/source/development/01_guidelines.md
+++ b/docs/source/development/01_guidelines.md
@@ -55,7 +55,10 @@ either rely on [molecule](./02_molecule.md) or, maybe,
 
 When a PR is opened or reopened on the CI-Framework repo the Github bot will enable the draft status.
 Once your patch is passing CI and you would be happy with it merging, click the "Ready for review" button,
-this will trigger the review ready workflow
+this will trigger the review ready workflow.
+
+If you have a small patch you would like to skip the auto-draft workflow, you can prefix your git commit title
+with `nit:`
 
 ### Review ready automation
 


### PR DESCRIPTION
Some tiny patches would be best skipping the auto-draft workflow as you are ready for them to be reviewed right away if CI passes. Adding nit: to the start start of your PR title will skip the auto-draft workflow.

Example: `nit: Add full stop to docs`

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] Content of the docs/source is reflecting the changes
