### PR TITLE
Allow to enable DNS listener in dnsmasq

### DIFF
--- a/roles/dnsmasq/README.md
+++ b/roles/dnsmasq/README.md
@@ -22,6 +22,7 @@ supported in libvirt).
 * `cifmw_dnsmasq_network_state`: (String) Network status. Must be either `present` or `absent`.
 * `cifmw_dnsmasq_network_definition`: (Dict) Mapping representing the network definition.
 * `cifmw_dnsmasq_network_definition.ranges`: (List[mapping]) List of ranges associated to the network.
+* `cifmw_dnsmasq_network_listen_dns`: (List) List of IP addresses to listen to for DNS queries.
 
 #### Ranges mapping
 
@@ -41,6 +42,10 @@ supported in libvirt).
       vars:
         cifmw_dnsmasq_network_name: starwars
         cifmw_dnsmasq_network_state: present
+        cifmw_dnsmasq_network_listen_dns:
+          - 192.168.199.9
+          - ff99:abcd::9
+          - ''  # empty string is supported as "no entry"
         cifmw_dnsmasq_network_definition:
           ranges:
             - label: ian

--- a/roles/dnsmasq/molecule/default/converge.yml
+++ b/roles/dnsmasq/molecule/default/converge.yml
@@ -44,6 +44,9 @@
       vars:
         cifmw_dnsmasq_network_name: startrek
         cifmw_dnsmasq_network_state: present
+        cifmw_dnsmasq_network_listen_dns:
+          - "192.168.253.1"
+          - "2345:0426:2CA1::0567:5673:23b0"
         cifmw_dnsmasq_network_definition:
           ranges:
             - label: ian
@@ -85,6 +88,9 @@
           ipv4: "192.168.253.12"
           name: "spock"
 
+    - name: Force reload dnsmasq
+      ansible.builtin.meta: flush_handlers
+
     - name: Copy generated content in ci-framework-data/artifacts
       vars:
         dest_dir: >-
@@ -104,3 +110,8 @@
         - /etc/cifmw-dnsmasq.d/starwars-hosts.conf
         - /etc/cifmw-dnsmasq.d/startrek.conf
         - /etc/cifmw-dnsmasq.d/startrek-hosts.conf
+
+    - name: Cleanup dnsmasq
+      ansible.builtin.import_role:
+        name: "dnsmasq"
+        tasks_from: "cleanup.yml"

--- a/roles/dnsmasq/molecule/default/prepare.yml
+++ b/roles/dnsmasq/molecule/default/prepare.yml
@@ -20,11 +20,20 @@
   roles:
     - role: test_deps
   tasks:
-    - name: Create dummy interface with needed IPs
+    - name: Create 1st dummy interface with needed IPs
       become: true
       community.general.nmcli:
         type: dummy
-        conn_name: mol-test
+        conn_name: mol-test-1
         ip4: "192.168.254.9/24"
         ip6: "2345:0425:2CA1::0567:5673:23b0/64"
+        state: present
+
+    - name: Create 2nd dummy interface with needed IPs
+      become: true
+      community.general.nmcli:
+        type: dummy
+        conn_name: mol-test-2
+        ip4: "192.168.253.9/24"
+        ip6: "2345:0426:2CA1::0567:5673:23b0/64"
         state: present

--- a/roles/dnsmasq/templates/network.conf.j2
+++ b/roles/dnsmasq/templates/network.conf.j2
@@ -1,16 +1,21 @@
 # Managed by ci-framework/dnsmasq
-{% for range in cifmw_dnsmasq_network_definition['ranges']                                      %}
-{%   if range.start_v4 is defined and range.start_v4 | length > 0                               %}
+{% if cifmw_dnsmasq_network_listen_dns is defined and cifmw_dnsmasq_network_listen_dns | length > 0 %}
+{%   for listener in cifmw_dnsmasq_network_listen_dns if listener | length > 0                      %}
+listen-address={{ listener }}
+{%   endfor                                                                                         %}
+{% endif                                                                                            %}
+{% for range in cifmw_dnsmasq_network_definition['ranges']                                          %}
+{%   if range.start_v4 is defined and range.start_v4 | length > 0                                   %}
 dhcp-range=set:{{ range.label }},{{ range.start_v4 }},static,{{ (range.start_v4 + "/" + range.prefix_length_v4 | default(24) | string) |  ansible.utils.ipaddr('netmask') }},{{ range.ttl | default('1h') }}
-{%   endif                                                                                      %}
-{%   if range.start_v6 is defined and range.start_v6 | length > 0                               %}
+{%   endif                                                                                          %}
+{%   if range.start_v6 is defined and range.start_v6 | length > 0                                   %}
 dhcp-range=set:{{ range.label }},{{ range.start_v6 }},static,{{ range.prefix_length_v6 | default('64') }},{{ range.ttl | default('1h') }}
-{%   endif                                                                                      %}
-{%   for option in range['options'] | default([])                                               %}
+{%   endif                                                                                          %}
+{%   for option in range['options'] | default([])                                                   %}
 dhcp-option=tag:{{ range.label }},{{ option }}
-{%   endfor                                                                                     %}
-{%   for option in range['options_force'] | default([])                                         %}
+{%   endfor                                                                                         %}
+{%   for option in range['options_force'] | default([])                                             %}
 dhcp-option-force=tag:{{ range.label }},{{ option }}
-{%   endfor                                                                                     %}
-{% endfor                                                                                       %}
+{%   endfor                                                                                         %}
+{% endfor                                                                                           %}
 ## END of network configuration


### PR DESCRIPTION
It might happen we want DNS on specific address, usually one associated
to a specific DHCP network.

Using the new parameter, we allow to pass a list of listeners, per
network. Dnsmasq will then listen and answer to DNS queries on those
addresses.

Note that you want to pass dhcp-options to ensure the DNS resolver is
properly passed, for instance:

```YAML
options:
  - "option:dns-server,192.168.0.1"
```
in the network definition.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
