### PR TITLE
Ensure to run cephfs task for nfs ganesha

### DIFF
--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -368,10 +368,17 @@
         cifmw_cephadm_dashboard_key: "{{ cifmw_cephadm_key }}"
 
     - name: Create cephfs volume
-      when: cifmw_ceph_daemons_layout.cephfs_enabled  | default(true) | bool
+      when: (cifmw_ceph_daemons_layout.cephfs_enabled | default(true) | bool) or
+            (cifmw_ceph_daemons_layout.ceph_nfs_enabled | default(false) | bool)
       ansible.builtin.import_role:
         name: cifmw_cephadm
         tasks_from: cephfs
+
+    - name: Deploy cephnfs
+      when: cifmw_ceph_daemons_layout.ceph_nfs_enabled | default(false) | bool
+      ansible.builtin.import_role:
+        name: cifmw_cephadm
+        tasks_from: cephnfs
       vars:
         # we reuse the same VIP reserved for rgw
         cifmw_cephadm_nfs_vip: "{{ cifmw_cephadm_vip }}/24"

--- a/roles/cifmw_cephadm/tasks/cephfs.yml
+++ b/roles/cifmw_cephadm/tasks/cephfs.yml
@@ -61,15 +61,3 @@
 - name: Apply the MDS spec
   ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} orch apply --in-file {{ cifmw_cephadm_container_spec }}"
   become: true
-
-# waiting for https://github.com/ceph/ceph/pull/53108
-# to appear in the next Ceph container build
-# disabling this task by default for now
-- name: Create NFS Ganesha Cluster
-  when: cifmw_ceph_daemons_layout.ceph_nfs_enabled | default(false) | bool
-  ansible.builtin.command: |
-    {{ cifmw_cephadm_ceph_cli }} nfs cluster create {{ cifmw_cephadm_cephfs_name }} \
-    --ingress --virtual-ip={{ cifmw_cephadm_nfs_vip }} \
-    --ingress-mode=haproxy-protocol '--placement={{ placement }}'
-  changed_when: false
-  become: true

--- a/roles/cifmw_cephadm/tasks/cephnfs.yml
+++ b/roles/cifmw_cephadm/tasks/cephnfs.yml
@@ -1,0 +1,23 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Create NFS Ganesha Cluster
+  ansible.builtin.command: >
+    {{ cifmw_cephadm_ceph_cli }} nfs cluster create {{ cifmw_cephadm_cephfs_name }}
+    --ingress --virtual-ip={{ cifmw_cephadm_nfs_vip }}
+    --ingress-mode=haproxy-protocol '--placement={{ placement }}'
+  changed_when: false
+  become: true


### PR DESCRIPTION
This patch updates when condition for cephfs task in ceph playbook so that nfs ganesha deployment is never skipped if ceph_nfs_enabled is true.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
