### PR TITLE
Extract libvirt_manager layout generation, rename fact

### DIFF
--- a/roles/libvirt_manager/molecule/deploy_layout/converge.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/converge.yml
@@ -219,8 +219,8 @@
           vars:
             expect_vol_num: >-
               {{
-                (_layout.vms.compute.amount | int) *
-                (_layout.vms.compute.extra_disks_num | int)
+                (_cifmw_libvirt_manager_layout.vms.compute.amount | int) *
+                (_cifmw_libvirt_manager_layout.vms.compute.extra_disks_num | int)
               }}
             found_vol_num: "{{ vol_count.stdout | int }}"
           ansible.builtin.assert:

--- a/roles/libvirt_manager/tasks/create_networks.yml
+++ b/roles/libvirt_manager/tasks/create_networks.yml
@@ -40,7 +40,7 @@
         }}
   ansible.builtin.set_fact:
     networks: "{{ (networks | default([])) + [data] }}"
-  loop: "{{ _layout.networks | dict2items }}"
+  loop: "{{ _cifmw_libvirt_manager_layout.networks | dict2items }}"
   loop_control:
     label: "{{ item.key }}"
 

--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -202,10 +202,10 @@
       }}
     cifmw_virtualbmc_action: "add"
     _ipmi_host: >-
-      {%- if _layout.vms.crc.target is defined -%}
-      {{ _layout.vms.crc.target }}
-      {%- elif _layout.vms.ocp.target is defined -%}
-      {{ _layout.vms.ocp.target }}
+      {%- if _cifmw_libvirt_manager_layout.vms.crc.target is defined -%}
+      {{ _cifmw_libvirt_manager_layout.vms.crc.target }}
+      {%- elif _cifmw_libvirt_manager_layout.vms.ocp.target is defined -%}
+      {{ _cifmw_libvirt_manager_layout.vms.ocp.target }}
       {%- else -%}
       {{ inventory_hostname }}
       {%- endif -%}

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -1,25 +1,8 @@
 ---
-- name: Chose right parameter for layout definition
-  ansible.builtin.set_fact:
-    cacheable: true
-    _layout: >-
-      {{ cifmw_libvirt_manager_configuration_gen |
-         default(cifmw_libvirt_manager_configuration) }}
-
-- name: Patch the layout if needed
-  vars:
-    _layout_patches: >-
-      {{
-        hostvars[inventory_hostname] |
-        dict2items |
-        selectattr("key", "match", "^cifmw_libvirt_manager_configuration_patch.*") |
-        sort(attribute='key')
-      }}
-  ansible.builtin.set_fact:
-    _layout: "{{ _layout | combine(item.value, recursive=True) }}"
-  loop: "{{ _layout_patches }}"
-  loop_control:
-    label: "{{ item.key }}"
+- name: Import layout generator if needed
+  when:
+    - _cifmw_libvirt_manager_layout is not defined
+  ansible.builtin.include_tasks: generate_layout.yml
 
 # Deploy VBMC only on the hypervisor running OpenShift services,
 # being OCP cluster or single CRC.
@@ -28,14 +11,14 @@
     - bootstrap
     - bootstrap_layout
   when:
-    - (_layout.vms.crc.target is defined and
-       _layout.vms.crc.target == inventory_hostname) or
-      (_layout.vms.crc is defined and
-       _layout.vms.crc.target is undefined) or
-      (_layout.vms.ocp.target is defined and
-       _layout.vms.ocp.target == inventory_hostname) or
-      (_layout.vms.ocp is defined and
-       _layout.vms.ocp.target is undefined)
+    - (_cifmw_libvirt_manager_layout.vms.crc.target is defined and
+       _cifmw_libvirt_manager_layout.vms.crc.target == inventory_hostname) or
+      (_cifmw_libvirt_manager_layout.vms.crc is defined and
+       _cifmw_libvirt_manager_layout.vms.crc.target is undefined) or
+      (_cifmw_libvirt_manager_layout.vms.ocp.target is defined and
+       _cifmw_libvirt_manager_layout.vms.ocp.target == inventory_hostname) or
+      (_cifmw_libvirt_manager_layout.vms.ocp is defined and
+       _cifmw_libvirt_manager_layout.vms.ocp.target is undefined)
   block:
     - name: Deploy virtualbmc
       ansible.builtin.include_role:
@@ -70,7 +53,7 @@
 
 - name: Manage networks if needed
   when:
-    - _layout.networks is defined
+    - _cifmw_libvirt_manager_layout.networks is defined
   ansible.builtin.import_tasks: create_networks.yml
 
 - name: Ensure storage pool is present.
@@ -80,7 +63,7 @@
     action: "create"
     _extra_disks: >-
       {{
-        _layout.vms |
+        _cifmw_libvirt_manager_layout.vms |
         dict2items |
         selectattr('value.extra_disks_num', 'defined') |
         items2dict
@@ -95,7 +78,7 @@
     image_data: "{{ item.value }}"
   ansible.builtin.include_tasks:
     file: get_image.yml
-  loop: "{{ _layout.vms | dict2items }}"
+  loop: "{{ _cifmw_libvirt_manager_layout.vms | dict2items }}"
   loop_control:
     label: "{{ item.key }}"
 
@@ -133,14 +116,14 @@
 
 - name: Prepare the static IP address for controller.
   when:
-    - _layout.vms.controller.ip_address is defined
+    - _cifmw_libvirt_manager_layout.vms.controller.ip_address is defined
   vars:
     _ip_address: >-
       {{
-        _layout.vms.controller.ip_address.address
+        _cifmw_libvirt_manager_layout.vms.controller.ip_address.address
       }}
-    _ip_gw: "{{ _layout.vms.controller.ip_address.gw }}"
-    _ip_dns: "{{ _layout.vms.controller.ip_address.dns }}"
+    _ip_gw: "{{ _cifmw_libvirt_manager_layout.vms.controller.ip_address.gw }}"
+    _ip_dns: "{{ _cifmw_libvirt_manager_layout.vms.controller.ip_address.dns }}"
   ansible.builtin.template:
     src: templates/static_ip.j2
     dest: >-
@@ -181,7 +164,7 @@
       --truncate /etc/machine-id
       | tee -a {{ item.value.image_local_dir }}/{{ item.value.disk_file_name }}.log
     creates: "{{ item.value.image_local_dir }}/{{ item.value.disk_file_name }}.log"
-  loop: "{{ _layout.vms | dict2items }}"
+  loop: "{{ _cifmw_libvirt_manager_layout.vms | dict2items }}"
   loop_control:
     label: "{{ item.key }}"
 
@@ -220,7 +203,7 @@
     file: create_vms.yml
   loop: >-
     {{
-      _layout.vms | dictsort(reverse=true) |
+      _cifmw_libvirt_manager_layout.vms | dictsort(reverse=true) |
       community.general.dict | dict2items
     }}
   loop_control:
@@ -342,19 +325,19 @@
 
 - name: Ensure we get proper access to CRC
   when:
-    - _layout.vms.crc is defined
-    - (_layout.vms.crc.amount is defined and
-       (_layout.vms.crc.amount | int) > 0) or
-      _layout.vms.crc.amount is undefined
+    - _cifmw_libvirt_manager_layout.vms.crc is defined
+    - (_cifmw_libvirt_manager_layout.vms.crc.amount is defined and
+       (_cifmw_libvirt_manager_layout.vms.crc.amount | int) > 0) or
+      _cifmw_libvirt_manager_layout.vms.crc.amount is undefined
     - (
-        _layout.vms.crc.target is defined and
-        _layout.vms.crc.target == inventory_hostname
+        _cifmw_libvirt_manager_layout.vms.crc.target is defined and
+        _cifmw_libvirt_manager_layout.vms.crc.target == inventory_hostname
       ) or
-      _layout.vms.crc.target is undefined
+      _cifmw_libvirt_manager_layout.vms.crc.target is undefined
   vars:
     crc_private_key: >-
       {{
-        (_layout.vms.crc.image_local_dir, "id_ecdsa") |
+        (_cifmw_libvirt_manager_layout.vms.crc.image_local_dir, "id_ecdsa") |
         path_join
       }}
   block:

--- a/roles/libvirt_manager/tasks/generate_layout.yml
+++ b/roles/libvirt_manager/tasks/generate_layout.yml
@@ -1,0 +1,26 @@
+---
+- name: Chose right parameter for layout definition
+  ansible.builtin.set_fact:
+    _cifmw_libvirt_manager_layout: >-
+      {{ cifmw_libvirt_manager_configuration_gen |
+         default(cifmw_libvirt_manager_configuration) }}
+
+- name: Patch the layout if needed
+  vars:
+    _layout_patches: >-
+      {{
+        hostvars[inventory_hostname] |
+        dict2items |
+        selectattr("key", "match",
+                   "^cifmw_libvirt_manager_configuration_patch.*") |
+        sort(attribute='key')
+      }}
+  ansible.builtin.set_fact:
+    _cifmw_libvirt_manager_layout: >-
+      {{
+        _cifmw_libvirt_manager_layout |
+        combine(item.value, recursive=True)
+      }}
+  loop: "{{ _layout_patches }}"
+  loop_control:
+    label: "{{ item.key }}"

--- a/roles/libvirt_manager/tasks/manage_vms.yml
+++ b/roles/libvirt_manager/tasks/manage_vms.yml
@@ -111,7 +111,7 @@
     name: "{{ vm_ip.nic.host }}"
     groups: "{{ (vm_type == 'crc') | ternary('ocp', vm_type) }}s"
     ansible_host: "{{ extracted_ip }}"
-    ansible_ssh_user: "{{ _layout.vms[vm_type].admin_user | default(_init_admin_user) }}"
+    ansible_ssh_user: "{{ _cifmw_libvirt_manager_layout.vms[vm_type].admin_user | default(_init_admin_user) }}"
   loop: "{{ vm_ips.results }}"
   loop_control:
     loop_var: vm_ip
@@ -227,7 +227,7 @@
     name: "{{ vm_ip.nic.host }}"
     groups: "{{ (vm_type == 'crc') | ternary('ocp', vm_type) }}s"
     ansible_host: "{{ extracted_ip }}"
-    ansible_ssh_user: "{{ _layout.vms[vm_type].admin_user | default('zuul') }}"
+    ansible_ssh_user: "{{ _cifmw_libvirt_manager_layout.vms[vm_type].admin_user | default('zuul') }}"
   loop: "{{ vm_ips.results }}"
   loop_control:
     loop_var: vm_ip

--- a/roles/libvirt_manager/templates/all-inventory.yml.j2
+++ b/roles/libvirt_manager/templates/all-inventory.yml.j2
@@ -1,10 +1,10 @@
 all:
   children:
-{% for vm in _layout.vms.keys() %}
+{% for vm in _cifmw_libvirt_manager_layout.vms.keys() %}
     {{ (vm == 'crc') | ternary('ocp', vm) }}s:
       vars:
-{% if _layout.vms[vm].target is defined %}
-{% set _target = _layout.vms[vm].target %}
+{% if _cifmw_libvirt_manager_layout.vms[vm].target is defined %}
+{% set _target = _cifmw_libvirt_manager_layout.vms[vm].target %}
 {% set _hostname = hostvars[_target]['ansible_host'] | default(hostvars[_target]['inventory_hostname']) %}
 {#
 Here we set ssh options to consume the right private key (one per hypervisor), as well as

--- a/roles/reproducer/tasks/ci_data.yml
+++ b/roles/reproducer/tasks/ci_data.yml
@@ -41,14 +41,6 @@
     - name: Update layout
       ansible.builtin.set_fact:
         is_molecule: "{{ _is_molecule.status == 200 }}"
-        _use_crc: >-
-          {{
-            (updated_layout.vms.crc is defined and
-             ((updated_layout.vms.crc.amount is defined and
-              updated_layout.vms.crc.amount|int > 0) or
-             updated_layout.vms.crc.amount is undefined)) or
-             updated_layout.vms.crc is undefined
-          }}
         cifmw_libvirt_manager_configuration_gen: >-
           {{
             cifmw_libvirt_manager_configuration |

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -14,10 +14,10 @@
 - name: Configure controller-0
   when:
     - (
-        _layout.vms.controller.target is defined and
-        _layout.vms.controller.target == inventory_hostname
+        _cifmw_libvirt_manager_layout.vms.controller.target is defined and
+        _cifmw_libvirt_manager_layout.vms.controller.target == inventory_hostname
       ) or
-      _layout.vms.controller.target is undefined
+      _cifmw_libvirt_manager_layout.vms.controller.target is undefined
   delegate_to: controller-0
   delegate_facts: false
   block:
@@ -124,7 +124,10 @@
               }}
             _uefi: >-
               {% set _type = _host | regex_replace('-[0-9]+$', '') -%}
-              {{ _layout.vms[_type].uefi | default(false) | bool }}
+              {{
+                _cifmw_libvirt_manager_layout.vms[_type].uefi |
+                default(false) | bool
+              }}
             _boot_mode: "{{ _uefi | ternary('UEFI', 'legacy') }}"
             ## TODO: add sushy driver address once we get sushy in
             ## TODO: create new parameter to allow chosing which connection
@@ -209,7 +212,7 @@
         - hostvars[host]['ansible_host'] is defined
       vars:
         _vm_type: "{{ host | regex_replace('\\-[0-9]*', '') }}"
-        _vm_data: "{{ _layout['vms'][_vm_type] }}"
+        _vm_data: "{{ _cifmw_libvirt_manager_layout.vms[_vm_type] }}"
         _proxy_user: >-
           {{
             (hostvars[_vm_data.target]['ansible_user'] |
@@ -234,7 +237,7 @@
             StrictHostKeyChecking no
             UserKnownHostsFile /dev/null
           {% if _vm_data.target is defined and
-             _vm_data.target != _layout.vms.controller.target %}
+             _vm_data.target != _cifmw_libvirt_manager_layout.vms.controller.target %}
             IdentityFile ~/.ssh/ssh_{{ _ssh_host }}
             ProxyJump {{ _proxy_user }}@{{ _proxy_host }}
           {% elif host is match('^ocp.*') %}
@@ -263,7 +266,7 @@
         dest: "/home/zuul/.kube/config"
         content: >-
           {{
-            (_layout.vms.ocp is defined) |
+            (_cifmw_libvirt_manager_layout.vms.ocp is defined) |
             ternary(_devscripts_kubeconfig.content, _crc_kubeconfig.content) |
             b64decode
           }}
@@ -432,7 +435,7 @@
         cifmw_networking_mapper_ifaces_info: >-
           {{ _nic_info.content | b64decode | from_yaml }}
         cifmw_networking_mapper_network_name: >-
-          {{ _layout.vms.controller.nets.1 }}
+          {{ _cifmw_libvirt_manager_layout.vms.controller.nets.1 }}
         cifmw_networking_mapper_basedir: "/home/zuul/ci-framework-data"
       ansible.builtin.import_role:
         name: networking_mapper
@@ -455,10 +458,10 @@
 
     - name: Inject CRC related content if needed
       when:
-        - _layout.vms.crc is defined
-        - (_layout.vms.crc.amount is defined and
-           (_layout.vms.crc.amount | int ) > 0) or
-          _layout.vms.crc.amount is undefined
+        - _cifmw_libvirt_manager_layout.vms.crc is defined
+        - (_cifmw_libvirt_manager_layout.vms.crc.amount is defined and
+           (_cifmw_libvirt_manager_layout.vms.crc.amount | int ) > 0) or
+          _cifmw_libvirt_manager_layout.vms.crc.amount is undefined
       block:
         - name: Inject CRC ssh key
           ansible.builtin.copy:

--- a/roles/reproducer/tasks/crc_layout.yml
+++ b/roles/reproducer/tasks/crc_layout.yml
@@ -4,8 +4,8 @@
   vars:
     _img: >-
       {{
-        (cifmw_libvirt_manager_configuration.vms.crc.image_local_dir,
-         cifmw_libvirt_manager_configuration.vms.crc.disk_file_name) |
+        (_cifmw_libvirt_manager_layout.vms.crc.image_local_dir,
+         _cifmw_libvirt_manager_layout.vms.crc.disk_file_name) |
          path_join
       }}
   ansible.builtin.stat:

--- a/roles/reproducer/tasks/libvirt_layout.yml
+++ b/roles/reproducer/tasks/libvirt_layout.yml
@@ -8,8 +8,8 @@
 
 - name: Get all generated inventory on remote hypervisors
   when:
-    - _layout.vms.controller.target is defined
-    - _layout.vms.controller.target != inventory_hostname
+    - _cifmw_libvirt_manager_layout.vms.controller.target is defined
+    - _cifmw_libvirt_manager_layout.vms.controller.target != inventory_hostname
   block:
     - name: Get deployed VM group inventories
       register: _inventories
@@ -22,7 +22,7 @@
           }}
       loop: >-
           {{
-            _layout.vms |
+            _cifmw_libvirt_manager_layout.vms |
             dict2items |
             selectattr('value.target', 'equalto', inventory_hostname) |
             map(attribute="key")
@@ -31,10 +31,10 @@
 - name: Run tasks on controller-0 hypervisor
   when:
     - (
-        _layout.vms.controller.target is defined and
-        _layout.vms.controller.target == inventory_hostname
+        _cifmw_libvirt_manager_layout.vms.controller.target is defined and
+        _cifmw_libvirt_manager_layout.vms.controller.target == inventory_hostname
       ) or
-      _layout.vms.controller.target is undefined
+      _cifmw_libvirt_manager_layout.vms.controller.target is undefined
   block:
     - name: Inject remote inventories onto main hypervisor
       ansible.builtin.include_tasks: gather_inventories.yml
@@ -50,12 +50,12 @@
 
 - name: Run post tasks in devscripts case
   when:
-    - _layout.vms.ocp is defined
+    - _cifmw_libvirt_manager_layout.vms.ocp is defined
     - (
-        _layout.vms.ocp.target is defined and
-        _layout.vms.ocp.target == inventory_hostname
+        _cifmw_libvirt_manager_layout.vms.ocp.target is defined and
+        _cifmw_libvirt_manager_layout.vms.ocp.target == inventory_hostname
       ) or
-      _layout.vms.ocp.target is undefined
+      _cifmw_libvirt_manager_layout.vms.ocp.target is undefined
   tags:
     - boostrap
     - bootstrap_layout
@@ -74,15 +74,15 @@
 
 - name: Configure CRC node if available
   when:
-    - _layout.vms.crc is defined
-    - (_layout.vms.crc.amount is defined and
-       (_layout.vms.crc.amount | int) > 0) or
-      _layout.vms.crc.amount is undefined
+    - _cifmw_libvirt_manager_layout.vms.crc is defined
+    - (_cifmw_libvirt_manager_layout.vms.crc.amount is defined and
+       (_cifmw_libvirt_manager_layout.vms.crc.amount | int) > 0) or
+      _cifmw_libvirt_manager_layout.vms.crc.amount is undefined
     - (
-        _layout.vms.crc.target is defined and
-        _layout.vms.crc.target == inventory_hostname
+        _cifmw_libvirt_manager_layout.vms.crc.target is defined and
+        _cifmw_libvirt_manager_layout.vms.crc.target == inventory_hostname
       ) or
-      _layout.vms.crc.target is undefined
+      _cifmw_libvirt_manager_layout.vms.crc.target is undefined
   tags:
     - bootstrap
     - bootstrap_layout

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -21,13 +21,23 @@
   ansible.builtin.import_role:
     name: discover_latest_image
 
+- name: Load CI job environment
+  when:
+    - cifmw_job_uri is defined
+  ansible.builtin.include_tasks: ci_data.yml
+
+- name: Update libvirt layout
+  ansible.builtin.import_role:
+    name: "libvirt_manager"
+    tasks_from: "generate_layout.yml"
+
 - name: Assert no conflicting parameters were passed
   ansible.builtin.assert:
     that:
-      - (cifmw_libvirt_manager_configuration.vms.crc is defined) or
-        (cifmw_libvirt_manager_configuration.vms.ocp is defined)
-      - not ((cifmw_libvirt_manager_configuration.vms.crc is defined) and
-             (cifmw_libvirt_manager_configuration.vms.ocp is defined))
+      - (_cifmw_libvirt_manager_layout.vms.crc is defined) or
+        (_cifmw_libvirt_manager_layout.vms.ocp is defined)
+      - not ((_cifmw_libvirt_manager_layout.vms.crc is defined) and
+             (_cifmw_libvirt_manager_layout.vms.ocp is defined))
     quiet: true
     msg: >-
       You cannot get both OpenShift cluster types.
@@ -47,11 +57,11 @@
   ansible.builtin.set_fact:
     _use_crc: >-
       {{
-        cifmw_libvirt_manager_configuration.vms.crc is defined and
+        _cifmw_libvirt_manager_layout.vms.crc is defined and
         (
-          (cifmw_libvirt_manager_configuration.vms.crc.amount is defined and
-           cifmw_libvirt_manager_configuration.vms.crc.amount|int > 0) or
-        cifmw_libvirt_manager_configuration.vms.crc.amount is undefined)
+          (_cifmw_libvirt_manager_layout.vms.crc.amount is defined and
+           _cifmw_libvirt_manager_layout.vms.crc.amount|int > 0) or
+        _cifmw_libvirt_manager_layout.vms.crc.amount is undefined)
       }}
 
 - name: Ensure directories are present
@@ -63,11 +73,6 @@
   loop:
     - artifacts
     - logs
-
-- name: Load CI job environment
-  when:
-    - cifmw_job_uri is defined
-  ansible.builtin.include_tasks: ci_data.yml
 
 - name: Bootstrap libvirt if needed
   when:
@@ -97,12 +102,12 @@
 
 - name: Consume dev-scripts for OCP cluster
   when:
-    - cifmw_libvirt_manager_configuration.vms.ocp is defined
+    - _cifmw_libvirt_manager_layout.vms.ocp is defined
     - (
-        cifmw_libvirt_manager_configuration.vms.ocp.target is defined and
-        cifmw_libvirt_manager_configuration.vms.ocp.target == inventory_hostname
+        _cifmw_libvirt_manager_layout.vms.ocp.target is defined and
+        _cifmw_libvirt_manager_layout.vms.ocp.target == inventory_hostname
       ) or
-      cifmw_libvirt_manager_configuration.vms.ocp.target is undefined
+      _cifmw_libvirt_manager_layout.vms.ocp.target is undefined
   tags:
     - bootstrap
     - boostrap_layout
@@ -139,13 +144,13 @@
 
 - name: Apply VLAN ids to TAP type interfaces.
   when:
-    - cifmw_libvirt_manager_configuration.networks is defined
-    - cifmw_libvirt_manager_configuration.vms.ocp is defined
+    - _cifmw_libvirt_manager_layout.networks is defined
+    - _cifmw_libvirt_manager_layout.vms.ocp is defined
     - (
-        cifmw_libvirt_manager_configuration.vms.ocp.target is defined and
-        cifmw_libvirt_manager_configuration.vms.ocp.target == inventory_hostname
+        _cifmw_libvirt_manager_layout.vms.ocp.target is defined and
+        _cifmw_libvirt_manager_layout.vms.ocp.target == inventory_hostname
       ) or
-      cifmw_libvirt_manager_configuration.vms.ocp.target is undefined
+      _cifmw_libvirt_manager_layout.vms.ocp.target is undefined
   tags:
     - bootstrap
     - bootstrap_layout
@@ -153,17 +158,17 @@
   cifmw.general.bridge_vlan:
     networks: >-
       {{
-        cifmw_libvirt_manager_configuration.networks.keys() | list
+        _cifmw_libvirt_manager_layout.networks.keys() | list
       }}
   failed_when: false
 
 - name: Run only on hypervisor with controller-0
   when:
     - (
-        _layout.vms.controller.target is defined and
-        _layout.vms.controller.target == inventory_hostname
+        _cifmw_libvirt_manager_layout.vms.controller.target is defined and
+        _cifmw_libvirt_manager_layout.vms.controller.target == inventory_hostname
       ) or
-      _layout.vms.controller.target is undefined
+      _cifmw_libvirt_manager_layout.vms.controller.target is undefined
   block:
     - name: Push local code
       tags:
@@ -207,10 +212,10 @@
 
         - name: Configure CRC network if needed
           when:
-            - _layout.vms.crc is defined
-            - (_layout.vms.crc.amount is defined and
-               (_layout.vms.crc.amount | int ) > 0) or
-              _layout.vms.crc.amount is undefined
+            - _cifmw_libvirt_manager_layout.vms.crc is defined
+            - (_cifmw_libvirt_manager_layout.vms.crc.amount is defined and
+               (_cifmw_libvirt_manager_layout.vms.crc.amount | int ) > 0) or
+              _cifmw_libvirt_manager_layout.vms.crc.amount is undefined
           environment:
             KUBECONFIG: "/home/zuul/.kube/config"
             PATH: "{{ cifmw_path }}"


### PR DESCRIPTION
In order to get some more convenient features in the reproducer, we now
expose the "layout update" steps from libvirt_manager into its own tasks
file.

In order to make the `_layout` name slightly less "anonymous", it's also
renamed to `_cifmw_libvirt_manager_layout` in order to show its origin.
The `_` prefix should show "that's private, don't override it".

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
