### PR TITLE
Prepare networking as early as possible

### DIFF
--- a/roles/devscripts/tasks/133_host_network.yml
+++ b/roles/devscripts/tasks/133_host_network.yml
@@ -56,49 +56,6 @@
         list
       }}
   block:
-    - name: Ensure firewalld is installed
-      ansible.builtin.package:
-        name:
-          - firewalld
-
-    - name: Ensure br_netfilter module is loaded.
-      community.general.modprobe:
-        name: br_netfilter
-        state: present
-
-    - name: Ensure IP forwarding is enabled.
-      ansible.posix.sysctl:
-        name: net.ipv4.ip_forward
-        value: 1
-        state: present
-
-    - name: Ensure the required parameters are loaded.
-      ansible.posix.sysctl:
-        name: "net.bridge.bridge-nf-call-{{ item }}"
-        value: 0
-        state: present
-      loop:
-        - arptables
-        - iptables
-        - ip6tables
-      loop_control:
-        label: "{{ item }}"
-
-    - name: Ensure firewall service is enabled and started.
-      ansible.builtin.service:
-        name: firewalld
-        enabled: true
-        state: started
-
-    - name: Create the virtual networks.
-      vars:
-        cifmw_libvirt_manager_net_prefix_add: false
-        _cifmw_libvirt_manager_layout:
-          networks: "{{ cifmw_libvirt_manager_configuration.networks }}"
-      ansible.builtin.include_role:
-        name: libvirt_manager
-        tasks_from: create_networks.yml
-
     - name: Ensure masquerading for external network
       become: true
       vars:

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -22,12 +22,16 @@
     name: discover_latest_image
 
 - name: Load CI job environment
+  tags:
+    - bootstrap_layout
   when:
     - cifmw_job_uri is defined
   ansible.builtin.include_tasks: ci_data.yml
 
-- name: Update libvirt layout
-  ansible.builtin.import_role:
+- name: Build final libvirt layout
+  when:
+    - cifmw_use_libvirt | default(false) | bool
+  ansible.builtin.include_role:
     name: "libvirt_manager"
     tasks_from: "generate_layout.yml"
 
@@ -53,7 +57,7 @@
       cifmw_install_ca_url to download from a url or cifmw_install_ca_bundle_src
       to use a file present on the host.
 
-- name: Set _use_crc before layout update
+- name: Set _use_crc based on actual layout
   ansible.builtin.set_fact:
     _use_crc: >-
       {{
@@ -84,6 +88,21 @@
     apply:
       tags:
         - bootstrap_libvirt
+
+- name: Deploy networks in libvirt
+  when:
+    - cifmw_use_libvirt | default(false) | bool
+  tags:
+    - bootstrap
+    - bootstrap_env
+    - bootstrap_layout
+  ansible.builtin.include_tasks:
+    file: prepare_networking.yml
+    apply:
+      tags:
+        - bootstrap
+        - bootstrap_env
+        - bootstrap_layout
 
 - name: Deploy CRC if needed
   when:

--- a/roles/reproducer/tasks/prepare_networking.yml
+++ b/roles/reproducer/tasks/prepare_networking.yml
@@ -1,0 +1,42 @@
+---
+- name: Ensure basic host configurations are present
+  become: true
+  block:
+    - name: Ensure firewalld is installed
+      ansible.builtin.package:
+        name:
+          - firewalld
+
+    - name: Ensure br_netfilter module is loaded
+      community.general.modprobe:
+        name: br_netfilter
+        state: present
+
+    - name: Ensure IP forwarding is enabled
+      ansible.posix.sysctl:
+        name: net.ipv4.ip_forward
+        value: 1
+        state: present
+
+    - name: Ensure the required parameters are loaded
+      ansible.posix.sysctl:
+        name: "net.bridge.bridge-nf-call-{{ item }}"
+        value: 0
+        state: present
+      loop:
+        - arptables
+        - iptables
+        - ip6tables
+      loop_control:
+        label: "{{ item }}"
+
+    - name: Ensure firewall service is enabled and started
+      ansible.builtin.service:
+        name: firewalld
+        enabled: true
+        state: started
+
+- name: Create the virtual networks
+  ansible.builtin.import_role:
+    name: libvirt_manager
+    tasks_from: create_networks.yml


### PR DESCRIPTION
In order to change how we provision networking, especially DHCP, we have
to get the virtual networks as early as possible in place.

Doing so, we'll be able to inject some specific VM, such as the nat64,
and properly manage networks, even for devscripts layout.


As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running

@cjeanner testing notes:
- [X] CRC layout is passing fine, networks are present and working as expected
- [X] 3-OCP layout is passing fine as well, networks are present and working as expected