### PR TITLE
[run_hook] Fixed `crd_path` content and added CR hook example

### DIFF
--- a/roles/run_hook/README.md
+++ b/roles/run_hook/README.md
@@ -96,6 +96,7 @@ pre_infra_my_nice_hook:
 * `type`: (String) Type of the hook. In this case, set it to `cr`.
 * `source`: (String) Source of the CR. If it's a filename, the CR is expected in `hooks/crs`. It can be an absolute path.
 * `state`: (String) State of the service. Can be `absent | patched | present`. Defaults to `present`.
+* `name`: (String) Describe the hook.
 * `validate_certs`: (Boolean) Whether to validate or not the cluster certificates.
 * `wait_condition`: (Dict) Wait condition for the service.
 * `definition` (Dict) Mapping holding information or configuration of the k8s object.
@@ -109,3 +110,27 @@ Note that the `wait_condition` must match the format used by the
 https://docs.ansible.com/ansible/latest/collections/kubernetes/core/k8s_module.html
 
 OpenShift cluster is accessed using `cifmw_openshift_kubeconfig`.
+
+#### CR Example
+
+```YAML
+pre_stage_2_run:
+  - type: cr
+    name: test
+    state: present
+    source: 'test.yml'
+```
+
+where `test.yml` will be a file into `hooks/crs`
+
+```YAML
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: subscription-manager
+  namespace: openstack
+data:
+  username: changeme
+  password: changeme
+```

--- a/roles/run_hook/tasks/cr.yml
+++ b/roles/run_hook/tasks/cr.yml
@@ -23,7 +23,7 @@
       {%- if hook.source is not ansible.builtin.abs -%}
       {{
         (
-          ansible.builtin.role_path,
+          role_path,
           '../../hooks/crs',
           hook.source
         ) | ansible.builtin.path_join | ansible.builtin.realpath


### PR DESCRIPTION
* `role_path` is an ansible magic variable rather than a module, so calling it with `ansible.builtin.` prefix doesn't work as expected

* A proper example of CR hook has been added in the `README.md` file

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
