### PR TITLE
Allow to patch devscripts config overrides

### DIFF
--- a/roles/devscripts/README.md
+++ b/roles/devscripts/README.md
@@ -23,7 +23,11 @@ networks.
 * `cifmw_devscripts_artifacts_dir` (str) path to the directory to store the
   role artifacts.
 * `cifmw_devscripts_config_overrides` (dict) key/value pairs to be used for
-  overriding the default configuration. Refer
+  overriding the default configuration. Refer to
+  [section](#supported-keys-in-cifmw_devscripts_config_overrides) for more
+  information.
+* `cifmw_devscripts_config_overrides_patch.*`: (dict) key/value pair to be used
+  for overriding the default configuration. Refer to
   [section](#supported-keys-in-cifmw_devscripts_config_overrides) for more
   information.
 * `cifmw_devscripts_dry_run` (bool) If enabled, the workflow is evaluated.

--- a/roles/devscripts/molecule/default/converge.yml
+++ b/roles/devscripts/molecule/default/converge.yml
@@ -62,6 +62,8 @@
           - cifmw_devscripts_config.num_masters == 3
           - cifmw_devscripts_config.num_workers == 0
           - cifmw_devscripts_config.assets_extra_folder == '/home/dev-scripts/assets'
+          - cifmw_devscripts_config.external_bootstrap_mac is defined
+          - cifmw_devscripts_config.external_bootstrap_mac == '52:54:ab:83:31:87'
 
     - name: Collect stat information
       ansible.builtin.stat:

--- a/roles/devscripts/molecule/default/molecule.yml
+++ b/roles/devscripts/molecule/default/molecule.yml
@@ -9,3 +9,8 @@ log: true
 provisioner:
   name: ansible
   log: true
+  inventory:
+    group_vars:
+      all:
+        cifmw_devscripts_config_overrides_patch_01_override_br_management:
+          external_bootstrap_mac: '52:54:ab:83:31:87'

--- a/roles/devscripts/tasks/110_check_ocp.yml
+++ b/roles/devscripts/tasks/110_check_ocp.yml
@@ -15,6 +15,17 @@
 # under the License.
 
 
+- name: Build configuration if needed
+  when:
+    - cifmw_devscripts_config is undefined
+  tags:
+    - always
+  ansible.builtin.include_tasks:
+    file: build_config.yml
+    apply:
+      tags:
+        - always
+
 - name: Assign default values to OpenShift cluster check variables.
   ansible.builtin.set_fact:
     cifmw_devscripts_ocp_exists: false

--- a/roles/devscripts/tasks/133_host_network.yml
+++ b/roles/devscripts/tasks/133_host_network.yml
@@ -56,6 +56,11 @@
         list
       }}
   block:
+    - name: Ensure firewalld is installed
+      ansible.builtin.package:
+        name:
+          - firewalld
+
     - name: Ensure br_netfilter module is loaded.
       community.general.modprobe:
         name: br_netfilter
@@ -88,7 +93,7 @@
     - name: Create the virtual networks.
       vars:
         cifmw_libvirt_manager_net_prefix_add: false
-        _layout:
+        _cifmw_libvirt_manager_layout:
           networks: "{{ cifmw_libvirt_manager_configuration.networks }}"
       ansible.builtin.include_role:
         name: libvirt_manager

--- a/roles/devscripts/tasks/build_config.yml
+++ b/roles/devscripts/tasks/build_config.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Gather the configurations to be passed to dev-scripts.
+  vars:
+    devscripts_config_patches: >-
+      {{
+        hostvars[inventory_hostname] |
+        dict2items |
+        selectattr("key", "match",
+                   "^cifmw_devscripts_config_overrides_patch.*") |
+        sort(attribute='key') |
+        map(attribute='value') |
+        list
+      }}
+  ansible.builtin.set_fact:
+    cacheable: true
+    cifmw_devscripts_config: >-
+      {{
+        cifmw_devscripts_config | default({}) |
+        combine(item, recursive=true)
+      }}
+  loop: >-
+    {{
+      [cifmw_devscripts_config_defaults] +
+      [cifmw_devscripts_config_overrides] +
+      devscripts_config_patches
+    }}

--- a/roles/devscripts/tasks/main.yml
+++ b/roles/devscripts/tasks/main.yml
@@ -14,17 +14,16 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
-- name: Gather the configurations to be passed to dev-scripts.
+- name: Build configuration if needed
+  when:
+    - cifmw_devscripts_config is undefined
   tags:
     - always
-  ansible.builtin.set_fact:
-    cifmw_devscripts_config: >-
-      {{
-        cifmw_devscripts_config_defaults |
-        combine(cifmw_devscripts_config_overrides, recursive=true)
-      }}
-    cacheable: true
+  ansible.builtin.include_tasks:
+    file: build_config.yml
+    apply:
+      tags:
+        - always
 
 - name: Check and prepare the environment
   tags:


### PR DESCRIPTION
The Framework (or a job) might need to inject specific configurations in
devscripts.

This pach proposes an interface to inject as many configuration snippets
as needed - in the exact same way other roles expose such feature.

As the molecule test has been updated, it now hits a specific path in
the deployment that wasn't tested before. In molecule, it leads to a
failure, because `firewalld` isn't present.
This patch also ensures this package is installed.

We also expose the "build devscripts config" as a dedicated tasks file,
allowing to get it "on-demand", and avoid code duplication:
it might happen someone wants to just know if there's an OCP cluster or
not, so patching the 110_check_ocp.yml to call the "config builder" if
needed allows to call it directly.

Added fix:
this patch also fix a missed renamed from `_layout` to
`_cifmw_libvirt_manager_layout`.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
