### PR TITLE
Add tolerations and nodeSelector to test-operator-controller-manager

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -16,8 +16,8 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_dry_run`: (Boolean) Whether test-operator should run or not. Default value: `false`
 * `cifmw_test_operator_fail_fast`: (Boolean) Whether the test results are evaluated when each test framework execution finishes or when all test frameworks are done. Default value: `false`
 * `cifmw_test_operator_controller_ip`: (String) An ip address of the controller node. Default value: `ansible_default_ipv4.address` which defaults to (`""`).
-* `cifmw_test_operator_tolerations`: (Dict) `tolerations` value that is applied to all pods spawned by the test-operator. Default value: `{}`
-* `cifmw_test_operator_node_selector`: (Dict) `nodeSelector` value that is applied to all pods spawned by the test-operator. Default value: `{}`
+* `cifmw_test_operator_tolerations`: (Dict) `tolerations` value that is applied to all pods spawned by the test-operator and to the test-operator-controller-manager and test-operator-logs pods. Default value: `{}`
+* `cifmw_test_operator_node_selector`: (Dict) `nodeSelector` value that is applied to all pods spawned by the test-operator and to the test-operator-controller-manager and test-operator-logs pods. Default value: `{}`
 
 ## Tempest specific parameters
 * `cifmw_test_operator_tempest_registry`: (String) The registry where to pull tempest container. Default value: `quay.io`

--- a/roles/test_operator/tasks/main.yml
+++ b/roles/test_operator/tasks/main.yml
@@ -80,6 +80,9 @@
         name: test-operator
         source: test-operator-catalog
         sourceNamespace: "{{ cifmw_test_operator_namespace }}"
+        config:
+          tolerations: "{{ cifmw_test_operator_tolerations | default(omit) }}"
+          nodeSelector: "{{ cifmw_test_operator_node_selector | default(omit) }}"
   when: not cifmw_test_operator_dry_run | bool
 
 - name: Wait until the test-operator csv is present

--- a/roles/test_operator/tasks/run-test-operator-job.yml
+++ b/roles/test_operator/tasks/run-test-operator-job.yml
@@ -97,6 +97,7 @@
               - name: logs-volume
                 persistentVolumeClaim:
                   claimName: "{{ logsPVC.resources[0].metadata.name }}"
+            tolerations: "{{ cifmw_test_operator_tolerations | default(omit) }}"
 
     - name: Ensure that the test-operator-logs-pod is Running
       kubernetes.core.k8s_info:


### PR DESCRIPTION
In previous PR [1], tolerations and nodeSelector parameters were added to the test_operator role in order to configure tempest and tobiko pods. This new PR adds the option to apply those parameters to the test-operator-controller-manager and and test-operator-logs pods as well.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/1716

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
