### PR TITLE
Fix multiattach volume type create playbook

### DIFF
--- a/hooks/playbooks/cinder_multiattach_volume_type.yml
+++ b/hooks/playbooks/cinder_multiattach_volume_type.yml
@@ -5,16 +5,27 @@
   tasks:
     - name: Set the multiattach volume type name
       ansible.builtin.set_fact:
-        cifmw_volume_multiattach_type: "{{ cifmw_volume_multiattach_type|default('multiattach') }}"
+        cifmw_volume_multiattach_type: >-
+          {{
+            cifmw_volume_multiattach_type | default('multiattach')
+          }}
 
     - name: Set a multiattach volume type and create it if needed
+      vars:
+        _namespace: >-
+          {{
+            cifmw_install_yamls_defaults['NAMESPACE'] | default('openstack')
+          }}
       environment:
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
       ansible.builtin.shell: |
-        oc -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} rsh openstackclient \
-          openstack volume type show {{ cifmw_volume_multiattach_type }} &>/dev/null || \
-            oc -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} rsh openstackclient \
-              openstack volume type create {{ cifmw_volume_multiattach_type }}
-        oc -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} rsh openstackclient \
-          openstack volume type set --property multiattach="<is> True" {{ cifmw_volume_multiattach_type }}
+        set -xe -o pipefail
+        oc project {{ _namespace }}
+        oc rsh openstackclient \
+            openstack volume type show {{ cifmw_volume_multiattach_type }} &>/dev/null || \
+            oc rsh openstackclient \
+            openstack volume type create {{ cifmw_volume_multiattach_type }}
+        oc rsh openstackclient \
+            openstack volume type set --property multiattach="<is> True" \
+            {{ cifmw_volume_multiattach_type }}


### PR DESCRIPTION
For uni* jobs none of the cifmw_install_yamls_* variables are set as the deployment is done via devscripts role. This causes a failure when executing the hook.

This patch sets the default value of the namespace to openstack.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

*Unit testing results*
```
PLAY [Create cinder resources needed for tempest run] **************************

TASK [Set the multiattach volume type name cifmw_volume_multiattach_type={{
  cifmw_volume_multiattach_type | default('multiattach')
}}] ***
Friday 17 May 2024  02:20:37 -0400 (0:00:00.080)       0:00:00.080 ************ 
ok: [localhost]

TASK [Set a multiattach volume type and create it if needed _raw_params=set -xe -o pipefail
oc project {{ _namespace }}
oc rsh openstackclient    openstack volume type show {{ cifmw_volume_multiattach_type }} &>/dev/null ||    oc rsh openstackclient    openstack volume type create {{ cifmw_volume_multiattach_type }}
oc rsh openstackclient    openstack volume type set --property multiattach="<is> True"    {{ cifmw_volume_multiattach_type }}
] ***
Friday 17 May 2024  02:20:37 -0400 (0:00:00.042)       0:00:00.122 ************ 
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

Friday 17 May 2024  02:20:48 -0400 (0:00:11.054)       0:00:11.177 ************ 
=============================================================================== 
Set a multiattach volume type and create it if needed ------------------ 11.05s
Set the multiattach volume type name ------------------------------------ 0.04s
```

_OpenStack entries_
```
sh-5.1$ openstack volume type show multiattach
+--------------------+--------------------------------------+
| Field              | Value                                |
+--------------------+--------------------------------------+
| access_project_ids | None                                 |
| description        | None                                 |
| id                 | a93d6e51-aadf-40c4-a76d-61720b6165fa |
| is_public          | True                                 |
| name               | multiattach                          |
| properties         | multiattach='<is> True'              |
| qos_specs_id       | None                                 |
+--------------------+--------------------------------------+
sh-5.1$ 
```



