### PR TITLE
Refine a bit validate-architecture related make targets

### DIFF
--- a/roles/ci_setup/tasks/directories.yml
+++ b/roles/ci_setup/tasks/directories.yml
@@ -1,10 +1,22 @@
 ---
+# Using "become: true" allows these directories to
+# be created when running the role from within a
+# container, with a bind-mounted volume, for example:
+# mkdir /home/toto/foo
+# podman unshare chown 1000:1000 /home/toto/foo
+# podman run --rm -v /home/toto/foo:/home/container/ci-framework-data \
+#   ansible-playbook ...
+
 - name: Manage directories
   tags:
     - always
+  become: true
   ansible.builtin.file:
     path: "{{ item }}"
     state: "{{ directory_state }}"
+    mode: "0755"
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_id }}"
   loop:
     - "{{ cifmw_manifests | default(cifmw_ci_setup_basedir ~ '/artifacts/manifests') }}/\
     {{ cifmw_install_yamls_defaults['NAMESPACE'] | default('openstack') }}/cr"


### PR DESCRIPTION
This patch refines a bit the targets involved in the
"architecture_test". It now creates a new volume to store your generated
snippets, allowing to review them once the container is removed.
It also allows to pass any arbitrary `ansible-playbook` options down to
the test run, so that you can point to additional environment files,
pass extra parameters and so on.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
