### PR TITLE
Trick ansible in loading mock data

### DIFF
--- a/ci/playbooks/validate-architecture.yml
+++ b/ci/playbooks/validate-architecture.yml
@@ -35,6 +35,11 @@
         ['~/bin',
          ansible_env.PATH] | join(':')
       }}
+    _mock_file: >-
+      {{
+        [cifmw_architecture_repo, 'automation/mocks',
+         cifmw_architecture_scenario ~ '.yaml'] | path_join
+      }}
   pre_tasks:
     - name: Assert we have the bare minimum to run
       ansible.builtin.assert:
@@ -48,22 +53,6 @@
       ansible.builtin.import_role:
         name: 'ci_setup'
 
-    - name: Install kustomize
-      when:
-        - zuul.projects is defined
-        - zuul.projects['github.com/openstack-k8s-operators/install_yamls'] is defined
-      vars:
-        _chdir: >-
-          {{
-            [zuul.projects['github.com/openstack-k8s-operators/install_yamls'].src_dir,
-             'devsetup'] | path_join
-          }}
-      ansible.builtin.command:
-        chdir: "{{ _chdir }}"
-        cmd: >-
-          ansible-playbook -i localhost, -c local
-          download_tools.yaml --tags kustomize
-
     - name: Create needed directories
       ansible.builtin.file:
         path: "{{ item }}"
@@ -73,18 +62,37 @@
         - "{{ cifmw_basedir }}/logs"
         - "{{ cifmw_basedir }}/artifacts"
 
+    - name: Check if we have a mock file
+      register: _mock_state
+      ansible.builtin.stat:
+        path: "{{ _mock_file }}"
+
+    - name: Copy file to facts.d as YAML
+      when:
+        - _mock_state.stat.exists
+      block:
+        - name: Slurp file from remote
+          register: _mock_content
+          ansible.builtin.slurp:
+            src: "{{ _mock_file }}"
+
+        - name: Copy file on localhost
+          delegate_to: localhost
+          ansible.builtin.copy:
+            dest: "{{ lookup('env', 'HOME') }}/{{ cifmw_architecture_scenario }}.yml }}"
+            mode: "0644"
+            content: "{{ _mock_content.content | b64decode }}"
+
+        - name: Include var file
+          ansible.builtin.include_vars:
+            file: "{{ lookup('env', 'HOME') }}/{{ cifmw_architecture_scenario }}.yml }}"
+
     - name: Ensure kustomize_deploy is bootstraped
       ansible.builtin.import_role:
         name: "kustomize_deploy"
         tasks_from: "check_requirements.yml"
-  tasks:
-    - name: Output kubectl data
-      ansible.builtin.shell:
-        cmd: |
-          which kubectl
-          kubectl version --client=true
-          kubectl kustomize --help
 
+  tasks:
     - name: Load networking mapper environment
       ansible.builtin.import_role:
         name: "networking_mapper"


### PR DESCRIPTION
Fetch the remote mock file, inject it locally, and call include_vars to
load the mocked data.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
