### PR TITLE
[shiftstack] Templates for rendering the right values to be used in the DT

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/shiftstack/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/shiftstack/edpm-nodeset-values/values.yaml.j2
@@ -1,0 +1,107 @@
+---
+# source: shiftstack/edpm-nodeset-values/values.yaml.j2
+{% set instances_names = []                                                            %}
+{% set _original_nodeset = (original_content.data | default({})).nodeset | default({}) %}
+{% set _original_nodes = _original_nodeset.nodes | default({})                         %}
+{% set _original_services = _original_nodeset['services'] | default([])                %}
+{% set _vm_type = (_original_nodes.keys() | first).split('-')[1]                       %}
+{% if 'ceph' in _vm_type                                                               %}
+{%     set _vm_names = cifmw_networking_env_definition.instances.keys()                %}
+{% else                                                                                %}
+{%     set _vm_names = cifmw_baremetal_hosts.keys()                                    %}
+{% endif                                                                               %}
+{% for _inst in _vm_names                                                              %}
+{%     if _inst.startswith(_vm_type)                                                   %}
+{%         set _ = instances_names.append(_inst)                                       %}
+{%     endif                                                                           %}
+{% endfor                                                                              %}
+data:
+  ssh_keys:
+    authorized: {{ cifmw_ci_gen_kustomize_values_ssh_authorizedkeys | b64encode }}
+    private: {{ cifmw_ci_gen_kustomize_values_ssh_private_key | b64encode }}
+    public: {{ cifmw_ci_gen_kustomize_values_ssh_public_key | b64encode }}
+
+{% if 'compute' in _vm_type                                                            %}
+  nova:
+    migration:
+      ssh_keys:
+        private: {{ cifmw_ci_gen_kustomize_values_migration_priv_key | b64encode }}
+        public: {{ cifmw_ci_gen_kustomize_values_migration_pub_key | b64encode }}
+{% endif                                                                               %}
+
+  nodeset:
+    ansible:
+      ansibleUser: "zuul"
+      ansibleVars:
+        edpm_fips_mode: "{{ 'enabled' if cifmw_fips_enabled | default(false) | bool else 'check' }}"
+        timesync_ntp_servers:
+          - hostname: "{{ cifmw_ci_gen_kustomize_values_ntp_srv | default('pool.ntp.org') }}"
+        edpm_network_config_os_net_config_mappings:
+{% if 'ceph' in _vm_type                                                               %}
+{%   for instance in instances_names                                                   %}
+          edpm-{{ instance }}:
+{%     if hostvars[instance] is defined                                                %}
+            nic1: "{{ hostvars[instance].ansible_default_ipv4.macaddress }}"
+{%     endif                                                                           %}
+            nic2: "{{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.mac_addr }}"
+{%   endfor                                                                            %}
+{% else                                                                                %}
+{%   for _bm in cifmw_baremetal_hosts.keys()                                           %}
+          edpm-{{ _bm }}:
+            nic1: "{{ cifmw_baremetal_hosts[_bm]['nics'][0]['mac'] }}"
+            nic2: "{{ cifmw_baremetal_hosts[_bm]['nics'][1]['mac'] }}"
+{%   endfor                                                                            %}
+{% endif                                                                               %}
+
+{% if cifmw_ci_gen_kustomize_values_sshd_ranges | default([]) | length > 0             %}
+        edpm_sshd_allowed_ranges:
+{%   for range in cifmw_ci_gen_kustomize_values_sshd_ranges                            %}
+          - "{{ range }}"
+{%   endfor                                                                            %}
+{% endif                                                                               %}
+
+{% if ('repo-setup' not in (_original_nodeset['services'] | default([]))) and
+      ('repo-setup' in ci_gen_kustomize_edpm_nodeset_predeployed_services)             %}
+    services:
+      - "repo-setup"
+{%   for svc in _original_services                                                     %}
+      - "{{ svc }}"
+{%   endfor                                                                            %}
+{% endif                                                                               %}
+
+    nodes:
+{% for instance in instances_names                                                     %}
+      edpm-{{ instance }}:
+        hostName: {{ instance }}
+{%   if 'ceph' in _vm_type                                                             %}
+        ansible:
+          host: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.ip_v4 }}
+        networks:
+{%     for net in cifmw_networking_env_definition.instances[instance].networks.keys()  %}
+          - name: {{ net }}
+            subnetName: subnet1
+{%       if net is match('ctlplane')                                                   %}
+            defaultRoute: true
+            fixedIP: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.ip_v4 }}
+{%       elif net is match('external')                                                 %}
+            fixedIP: {{ hostvars[instance].ansible_default_ipv4.address }}
+{%       endif                                                                         %}
+{%     endfor                                                                          %}
+{%   else                                                                              %}
+        ansible:
+          host: {{ "192.168.122.10" ~ loop.index0 }}
+        networks:
+          - defaultRoute: true
+            fixedIP: {{ "192.168.122.10" ~ loop.index0 }}
+            name: ctlplane
+            subnet: subnet1
+          - name: internalapi
+            subnet: subnet1
+          - name: storage
+            subnetName: subnet1
+          - name: tenant
+            subnetName: subnet1
+          - name: external
+            subnetName: subnet1
+{%   endif                                                                             %}
+{% endfor                                                                              %}

--- a/roles/ci_gen_kustomize_values/templates/shiftstack/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/shiftstack/network-values/values.yaml.j2
@@ -1,0 +1,117 @@
+---
+# source: shiftstack/network-values/values.yaml.j2
+{% set ns = namespace(interfaces={}, ocp_index=0, lb_tools={}) %}
+
+data:
+{% for host in cifmw_networking_env_definition.instances.keys() -%}
+{%   for network in cifmw_networking_env_definition.instances[host]['networks'].values() -%}
+{%     set ns.interfaces = ns.interfaces |
+                           combine({network.network_name: (network.parent_interface |
+                                                           default(network.interface_name)
+                                                          )
+                                   },
+                                   recursive=true) -%}
+{%   endfor -%}
+{%   if host is match('^(ocp|crc).*') %}
+  node_{{ ns.ocp_index }}:
+{%     set ns.ocp_index = ns.ocp_index+1 %}
+    name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}
+{%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
+    {{ network.network_name }}_ip: {{ network.ip_v4 }}
+{%     endfor %}
+{%   endif %}
+{% endfor %}
+
+{% for network in cifmw_networking_env_definition.networks.values() %}
+{% set ns.lb_tools = {} %}
+  {{ network.network_name }}:
+    dnsDomain: {{ network.search_domain }}
+{%  if network.tools is defined and network.tools.keys() | length > 0 %}
+    subnets:
+{%    for tool in network.tools.keys() %}
+{%      if tool is match('.*lb$') %}
+{%        set _ = ns.lb_tools.update({tool: []}) %}
+{%      endif %}
+{%    endfor %}
+      - allocationRanges:
+{%    for range in network.tools.netconfig.ipv4_ranges %}
+        - end: {{ range.end }}
+          start: {{ range.start }}
+{%    endfor %}
+        cidr: {{ network.network_v4 }}
+{%      if network.gw_v4 is defined %}
+        gateway: {{ network.gw_v4 }}
+{%      endif %}
+        name: subnet1
+{%  if network.vlan_id is defined  %}
+        vlan: {{ network.vlan_id }}
+{%  endif %}
+{%    if ns.lb_tools | length > 0 %}
+    lb_addresses:
+{%      for tool in ns.lb_tools.keys() %}
+{%        for lb_range in network.tools[tool].ipv4_ranges %}
+      - {{ lb_range.start }}-{{ lb_range.end }}
+{%          set _ = ns.lb_tools[tool].append(lb_range.start) %}
+{%        endfor %}
+    endpoint_annotations:
+      {{ tool }}.universe.tf/address-pool: {{ network.network_name }}
+      {{ tool }}.universe.tf/allow-shared-ip: {{ network.network_name }}
+      {{ tool }}.universe.tf/loadBalancerIPs: {{ ','.join(ns.lb_tools[tool]) }}
+{%      endfor %}
+{%    endif %}
+{%  endif %}
+    prefix-length: {{ network.network_v4 | ansible.utils.ipaddr('prefix') }}
+    mtu: {{ network.mtu | default(1500) }}
+{%  if network.vlan_id is defined  %}
+    vlan: {{ network.vlan_id }}
+{%    if ns.interfaces[network.network_name] is defined %}
+    iface: {{ network.network_name }}
+    base_iface: {{ ns.interfaces[network.network_name] }}
+{%    endif %}
+{%  else %}
+{%    if ns.interfaces[network.network_name] is defined %}
+    iface: {{ ns.interfaces[network.network_name] }}
+{%    endif %}
+{%  endif %}
+{%  if network.tools.multus is defined %}
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "{{ network.network_name }}",
+{%  if network.network_name == "octavia" %}
+        "type": "bridge",
+{%  else %}
+        "type": "macvlan",
+{%  endif %}
+{%  if network.network_name == "octavia" %}
+        "bridge": "octbr",
+{%  elif network.vlan_id is defined %}
+        "master": "{{ network.network_name }}",
+{%  elif network.network_name == "ctlplane" %}
+        "master": "ospbr",
+{%  else %}
+        "master": "{{ ns.interfaces[network.network_name] }}",
+{%  endif %}
+        "ipam": {
+          "type": "whereabouts",
+          "range": "{{ network.network_v4 }}",
+          "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
+          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}"
+        }
+      }
+{%  endif %}
+{% endfor %}
+
+# Hardcoding the last IP bit since we don't have support for endpoint_annotations in the networking_mapper output
+  rabbitmq:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(85) }}
+  rabbitmq-cell1:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(86) }}
+
+  lbServiceType: LoadBalancer
+  storageClass: local-storage
+  bridgeName: ospbr


### PR DESCRIPTION
Adding the templates required for rendering the config map that will be used for deploying OpenStack Services.

*edpm-nodeset-values*
- key difference from common is the support for external network's fixed IP address incase of Ceph nodes.

*network-values*
- key difference from common is the support for Octavia bridge

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

*logs*
https://review.rdoproject.org/zuul/buildset/771618eb32c94bb99b1b0b11025389d9

