### PR TITLE
Update some jobs to CRC 2.36 (OCP4.15)

### DIFF
--- a/docs/source/cookbooks/zuul-job-nodeset.md
+++ b/docs/source/cookbooks/zuul-job-nodeset.md
@@ -17,7 +17,7 @@ job parameter:
 - job:
     name: my-job-with-2-nodes
     parent: podified-multinode-edpm-deployment-crc
-    nodeset: centos-9-medium-crc-extracted-2-30-0-3xl
+    nodeset: centos-9-medium-crc-extracted-2-36-0-3xl
     vars:
       cifmw_deploy_edpm: false
       podified_validation: true

--- a/zuul.d/kuttl_multinode.yaml
+++ b/zuul.d/kuttl_multinode.yaml
@@ -4,7 +4,7 @@
     parent: cifmw-podified-multinode-edpm-base-crc
     timeout: 5400
     abstract: true
-    nodeset: centos-9-medium-crc-extracted-2-30-0-3xl
+    nodeset: centos-9-medium-crc-extracted-2-36-0-3xl
     vars:
       zuul_log_collection: true
     extra-vars:

--- a/zuul.d/podified_multinode.yaml
+++ b/zuul.d/podified_multinode.yaml
@@ -12,7 +12,7 @@
     parent: cifmw-podified-multinode-edpm-base-crc
     timeout: 5400
     abstract: true
-    nodeset: centos-9-medium-crc-extracted-2-30-0-3xl
+    nodeset: centos-9-medium-crc-extracted-2-36-0-3xl
     run:
       - ci/playbooks/edpm/run.yml
     extra-vars:

--- a/zuul.d/tempest_multinode.yaml
+++ b/zuul.d/tempest_multinode.yaml
@@ -4,7 +4,7 @@
     parent: cifmw-podified-multinode-edpm-base-crc
     timeout: 5400
     abstract: true
-    nodeset: centos-9-medium-crc-extracted-2-30-0-3xl
+    nodeset: centos-9-medium-crc-extracted-2-36-0-3xl
     description: |
       Base multinode job definition for running test-operator.
     vars:


### PR DESCRIPTION
Update the following jobs to OCP 4.15:
- cifmw-base-multinode-kuttl
- cifmw-base-multinode-tempest
- cifmw-base-multinode-podified

Marks centos-9-medium-crc-extracted-2-34-1-3xl nodeset for deletion once migration is complete due to dependency from Nova operator repo.

JIRA: [OSPRH-6868](https://issues.redhat.com//browse/OSPRH-6868)

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1761

As a pull request owner and reviewers, I checked that:
- [x] Appropriate documentation exists and/or is up-to-date:

