### PR TITLE
Use dlrnapi repo-status for finding component reported jobs

### DIFF
--- a/roles/dlrn_promote/tasks/check_reported_jobs.yml
+++ b/roles/dlrn_promote/tasks/check_reported_jobs.yml
@@ -1,5 +1,6 @@
 ---
-- name: Check reports from DLRN
+- name: Check reports from DLRN for Integration Lines
+  when: (cifmw_repo_setup_component_name is not defined) or (cifmw_repo_setup_component_name | length == 0)
   ansible.builtin.shell:
     cmd: >-
       set -o pipefail;
@@ -10,6 +11,37 @@
       agg-status
       {% if (cifmw_repo_setup_full_hash is defined) and (cifmw_repo_setup_full_hash | length > 0) -%}
       --agg-hash {{ cifmw_repo_setup_full_hash }}
+      {% endif -%}
+      --success true
+      | tee -a {{ cifmw_dlrn_promote_workspace }}/cifmw_dlrn_promote_repo_success_output.txt
+  environment: |
+    {{ zuul | zuul_legacy_vars | combine({
+      'DLRNAPI_PASSWORD': dlrnapi.password,
+      'DLRNAPI_USERNAME': cifmw_dlrn_report_dlrnapi_user,
+      'SSL_CA_BUNDLE': cifmw_dlrn_promote_ssl_ca_bundle
+      }) }}
+  changed_when: true
+
+- name: Check reports from DLRN for Component Lines
+  when:
+    - cifmw_repo_setup_component_name is defined
+    - cifmw_repo_setup_component_name | length > 0
+  ansible.builtin.shell:
+    cmd: >-
+      set -o pipefail;
+      dlrnapi --url {{ cifmw_repo_setup_dlrn_api_url }}
+      {% if cifmw_dlrn_promote_kerberos_auth|bool -%}
+      --server-principal {{ cifmw_dlrn_promote_dlrnapi_host_principal }} --auth-method kerberosAuth --force-auth
+      {% endif -%}
+      repo-status
+      {% if (cifmw_repo_setup_extended_hash is defined) and (cifmw_repo_setup_extended_hash | length > 0) -%}
+      --extended-hash {{ cifmw_repo_setup_extended_hash }}
+      {% endif -%}
+      {% if (cifmw_repo_setup_commit_hash is defined) and (cifmw_repo_setup_commit_hash | length > 0) -%}
+      --commit-hash {{ cifmw_repo_setup_commit_hash }}
+      {% endif -%}
+      {% if (cifmw_repo_setup_distro_hash is defined) and (cifmw_repo_setup_distro_hash | length > 0) -%}
+      --distro-hash {{ cifmw_repo_setup_distro_hash }}
       {% endif -%}
       --success true
       | tee -a {{ cifmw_dlrn_promote_workspace }}/cifmw_dlrn_promote_repo_success_output.txt


### PR DESCRIPTION
We report the job status by using aggregate hash in integration line but in component jobs, there is no aggregate hash. We use commit, distro and extended hash to report the job status in component pipeline.

We need to use same distro, commit and extended hash to fetch the status of reported job to match the criteria otherwise agg_hash will alwats return empty.

This pr seperates the checking of repos jobs for component and integration lines.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

