### PR TITLE
Add bgp_dt01 kustomize values.yaml templates

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2
@@ -1,0 +1,69 @@
+# source: bgp_dt01/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2
+{% set instances_names = []                                                            %}
+{% for _inst in cifmw_networking_env_definition.instances.keys()                       %}
+{%   if node_type in _inst                                                             %}
+{%     set _ = instances_names.append(_inst)                                           %}
+{%   endif                                                                             %}
+{% endfor                                                                              %}
+data:
+  ssh_keys:
+    authorized: {{ cifmw_ci_gen_kustomize_values_ssh_authorizedkeys | b64encode }}
+    private: {{ cifmw_ci_gen_kustomize_values_ssh_private_key | b64encode }}
+    public: {{ cifmw_ci_gen_kustomize_values_ssh_public_key | b64encode }}
+  nova:
+    migration:
+      ssh_keys:
+        private: {{ cifmw_ci_gen_kustomize_values_migration_priv_key | b64encode }}
+        public: {{ cifmw_ci_gen_kustomize_values_migration_pub_key | b64encode }}
+  nodeset:
+    ansible:
+      ansibleUser: "zuul"
+      ansibleVars:
+        edpm_fips_mode: "{{ 'enabled' if cifmw_fips_enabled|default(false)|bool else 'check' }}"
+        timesync_ntp_servers:
+          - hostname: "{{ cifmw_ci_gen_kustomize_values_ntp_srv | default('pool.ntp.org') }}"
+{% if cifmw_ci_gen_kustomize_values_sshd_ranges | default([]) | length > 0             %}
+        edpm_sshd_allowed_ranges:
+{%   for range in cifmw_ci_gen_kustomize_values_sshd_ranges                            %}
+          - "{{ range }}"
+{%   endfor                                                                            %}
+{% endif                                                                               %}
+    nodes:
+{% for instance in instances_names                                                     %}
+      {{ instance }}:
+        ansibleVars:
+{%        set rack_number = instance.split('-')[1]                                     %}
+{%        set peer_suffix = 1 if 'compute' in instance else 5                          %}
+          edpm_ovn_bgp_agent_local_ovn_peer_ips:
+            - 100.64.{{ rack_number }}.{{ peer_suffix }}
+            - 100.65.{{ rack_number }}.{{ peer_suffix }}
+          edpm_frr_bgp_peers:
+            - 100.64.{{ rack_number }}.{{ peer_suffix }}
+            - 100.65.{{ rack_number }}.{{ peer_suffix }}
+        ansible:
+          host: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.ip_v4 }}
+        hostName: {{ instance }}
+        networks:
+{%      for net in cifmw_networking_env_definition.instances[instance].networks.keys() %}
+{%        if net is not match('storagemgmt')                                           %}
+          - name: {{ net }}
+            subnetName: subnet1
+{%          if net is match('ctlplane')                                                %}
+            defaultRoute: true
+            fixedIP: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.ip_v4 }}
+{%          endif                                                                      %}
+{%        endif                                                                        %}
+{%      endfor                                                                         %}
+          - name: BgpNet0
+            subnetName: subnet{{ rack_number }}
+            fixedIP: 100.64.{{ rack_number }}.{{ peer_suffix + 1 }}
+          - name: BgpNet1
+            subnetName: subnet{{ rack_number }}
+            fixedIP: 100.65.{{ rack_number }}.{{ peer_suffix + 1 }}
+          - name: BgpMainNet
+            subnetName: subnet{{ rack_number }}
+            fixedIP: 172.30.{{ rack_number }}.{{ peer_suffix + 1 }}
+          - name: BgpMainNetV6
+            subnetName: subnet{{ rack_number }}
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:00{{ (rack_number | int) + 1 }}{{ 2 if 'compute' in instance else 3 }}
+{% endfor                                                                              %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-compute-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-compute-nodeset-values/values.yaml.j2
@@ -1,0 +1,4 @@
+---
+# source: bgp_dt01/edpm-compute-nodeset-values/values.yaml.j2
+{% set node_type = "compute"                                               %}
+{% include 'templates/bgp_dt01/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-networker-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-networker-nodeset-values/values.yaml.j2
@@ -1,0 +1,4 @@
+---
+# source: bgp_dt01/edpm-networker-nodeset-values/values.yaml.j2
+{% set node_type = "networker"                                             %}
+{% include 'templates/bgp_dt01/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/network-values/values.yaml.j2
@@ -1,0 +1,167 @@
+---
+# source: bgp_dt01/network-values/values.yaml.j2
+{% set ns = namespace(interfaces={},
+                      ocp_index=0,
+                      lb_tools={}) %}
+data:
+{% for host in cifmw_networking_env_definition.instances.keys() -%}
+{%   set hostname = cifmw_networking_env_definition.instances[host]['hostname'] %}
+{%   for network in cifmw_networking_env_definition.instances[host]['networks'].values() -%}
+{%     if 'worker-3' != hostname %}
+{%       set ns.interfaces = ns.interfaces |
+                             combine({network.network_name: (network.parent_interface |
+                                                             default(network.interface_name)
+                                                            )
+                                     },
+                                     recursive=true) -%}
+{%     endif %}
+{%   endfor -%}
+{%   if host is match('^(ocp|crc).*') %}
+  node_{{ ns.ocp_index }}:
+    name: {{ hostname }}
+{%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
+    {{ network.network_name }}_ip: {{ network.ip_v4 }}
+{%       if 'worker-3' == hostname and 'ctlplane' == network.network_name %}
+    base_if: {{ network.interface_name }}
+{%       endif %}
+{%     endfor %}
+{%     set node_net_orig_content = original_content.data.bgp['net-attach-def']['node' ~ ns.ocp_index] %}
+{%     set node_bgp_net0 = node_net_orig_content.bgpnet0 | from_json %}
+{%     if 'worker-3' != hostname %}
+{%       set node_bgp_net1 = node_net_orig_content.bgpnet1 | from_json %}
+{%     endif %}
+    bgp_peers:
+      - {{ node_bgp_net0.ipam.range_start }}
+{%     if 'worker-3' != hostname %}
+      - {{ node_bgp_net1.ipam.range_start }}
+{%     endif %}
+    bgp_ip:
+      - {{ node_bgp_net0.ipam.range_start | ansible.utils.ipmath(1) }}
+{%     if 'worker-3' != hostname %}
+      - {{ node_bgp_net1.ipam.range_start | ansible.utils.ipmath(1) }}
+{%     endif %}
+{%     set subnet_index = (hostname | split('-'))[-1] | int %}
+{%     set ip_index = 1 if ('master-' in hostname or 'worker-3' == hostname) else 2  %}
+{%     set loopback_ip = original_content.data.bgp.subnets.bgpmainnet[subnet_index].allocationRanges[0].start |
+                         ansible.utils.ipmath(ip_index) %}
+{%     set loopback_ipv6 = original_content.data.bgp.subnets.bgpmainnetv6[subnet_index].allocationRanges[0].start |
+                           ansible.utils.ipmath(ip_index) %}
+    loopback_ip: {{ loopback_ip }}
+    loopback_ipv6: {{ loopback_ipv6 }}
+{%     if node_net_orig_content.routes | default(false) %}
+    routes: {{ node_net_orig_content.routes }}
+{%     endif %}
+{%     set ns.ocp_index = ns.ocp_index+1 %}
+{%   endif %}
+{% endfor %}
+
+{% for network in cifmw_networking_env_definition.networks.values() %}
+{% set ns.lb_tools = {} %}
+  {{ network.network_name }}:
+    dnsDomain: {{ network.search_domain }}
+{%  if network.tools is defined and network.tools.keys() | length > 0 %}
+    subnets:
+{%    for tool in network.tools.keys() %}
+{%      if tool is match('.*lb$') %}
+{%        set _ = ns.lb_tools.update({tool: []}) %}
+{%      endif %}
+{%    endfor %}
+      - allocationRanges:
+{%    for range in network.tools.netconfig.ipv4_ranges %}
+        - end: {{ range.end }}
+          start: {{ range.start }}
+{%    endfor %}
+        cidr: {{ network.network_v4 }}
+{%      if network.gw_v4 is defined %}
+        gateway: {{ network.gw_v4 }}
+{%      endif %}
+        name: subnet1
+{%  if network.vlan_id is defined  %}
+        vlan: {{ network.vlan_id }}
+{%  endif %}
+{%    if ns.lb_tools | length > 0 %}
+    lb_addresses:
+{%      for tool in ns.lb_tools.keys() %}
+{%        for lb_range in network.tools[tool].ipv4_ranges %}
+      - {{ lb_range.start }}-{{ lb_range.end }}
+{%          set _ = ns.lb_tools[tool].append(lb_range.start) %}
+{%        endfor %}
+    endpoint_annotations:
+      {{ tool }}.universe.tf/address-pool: {{ network.network_name }}
+      {{ tool }}.universe.tf/allow-shared-ip: {{ network.network_name }}
+      {{ tool }}.universe.tf/loadBalancerIPs: {{ ','.join(ns.lb_tools[tool]) }}
+{%      endfor %}
+{%    endif %}
+{%  endif %}
+    prefix-length: {{ network.network_v4 | ansible.utils.ipaddr('prefix') }}
+    mtu: {{ network.mtu | default(1500) }}
+{%  if network.vlan_id is defined  %}
+    vlan: {{ network.vlan_id }}
+{%    if ns.interfaces[network.network_name] is defined %}
+    iface: {{ network.network_name }}
+    base_iface: {{ ns.interfaces[network.network_name] }}
+{%    endif %}
+{%  else %}
+{%    if ns.interfaces[network.network_name] is defined %}
+    iface: {{ ns.interfaces[network.network_name] }}
+{%    endif %}
+{%  endif %}
+{%  if network.tools.multus is defined %}
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "{{ network.network_name }}",
+{%  if network.network_name == "octavia" %}
+        "type": "bridge",
+{%  else %}
+        "type": "macvlan",
+{%  endif %}
+{%  if network.network_name == "octavia" %}
+        "bridge": "octbr",
+{%  elif network.vlan_id is defined %}
+        "master": "{{ network.network_name }}",
+{%  elif network.network_name == "ctlplane" %}
+        "master": "ospbr",
+{%  else %}
+        "master": "{{ ns.interfaces[network.network_name] }}",
+{%  endif %}
+        "ipam": {
+          "type": "whereabouts",
+          "range": "{{ network.network_v4 }}",
+          "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
+          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}"
+        }
+      }
+{%  endif %}
+{% endfor %}
+
+  dns-resolver:
+    config:
+      server:
+        - "{{ cifmw_networking_env_definition.networks.ctlplane.gw_v4 }}"
+      search: []
+    options:
+      - key: server
+        values:
+          - {{ cifmw_networking_env_definition.networks.ctlplane.gw_v4 }}
+{% for nameserver in cifmw_ci_gen_kustomize_values_nameservers %}
+      - key: server
+        values:
+          - {{ nameserver }}
+{% endfor %}
+
+  routes:
+    config: []
+
+# Hardcoding the last IP bit since we don't have support for endpoint_annotations in the networking_mapper output
+  rabbitmq:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(85) }}
+  rabbitmq-cell1:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(86) }}
+
+  lbServiceType: LoadBalancer
+  storageClass: local-storage


### PR DESCRIPTION
network and edpm values.yaml files are needed to deploy BGP DT01.
This patch includes those files.
    
Related-PR: https://github.com/openstack-k8s-operators/architecture/pull/237
Related-Issue: [OSPRH-6932](https://issues.redhat.com//browse/OSPRH-6932)

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running