### PR TITLE
Update autodraft workflow to skip bots

### DIFF
--- a/.github/workflows/auto-draft.yml
+++ b/.github/workflows/auto-draft.yml
@@ -18,7 +18,10 @@ jobs:
       # and add a helpful comment
       - name: Set to draft and add comment
         continue-on-error: true # We should not block if this action fails for some reason
-        if: github.event.pull_request.draft == false
+        if: |
+          github.event.pull_request.draft == false &&
+          github.actor != 'dependabot[bot]' &&
+          github.actor != 'renovate[bot]'
         shell: bash
         run: |
           if ! [[ "$TITLE" =~ ^nit:.* ]]; then


### PR DESCRIPTION
Auto draft workflow shouldn't run on dependabot[bot] and 'renovate[bot]' PRs.

JIRA: https://issues.redhat.com/browse/OSPRH-7175

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running