### PR TITLE
Fix hotfix job for downstream requirements

### DIFF
--- a/roles/validations/defaults/main.yml
+++ b/roles/validations/defaults/main.yml
@@ -43,3 +43,4 @@ cifmw_validations_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-f
 cifmw_validations_namespace: "openstack"
 
 cifmw_validations_hotfixed_edpm_nova_compute_image: quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified
+cifmw_validations_custom_nova_service: "nova-custom-ceph"

--- a/roles/validations/tasks/edpm/hotfix.yml
+++ b/roles/validations/tasks/edpm/hotfix.yml
@@ -65,8 +65,7 @@
 - name: Collect the image currently used by nova_compute on the edpm node
   ansible.builtin.shell:
     cmd: >-
-      set -o pipefail && podman inspect nova_compute | jq '.[].ImageName' | tr -d '"'
-  become: true
+      set -o pipefail && sudo podman inspect nova_compute | jq '.[].ImageName' | tr -d '"'
   delegate_to: "{{ cifmw_validations_edpm_check_node }}"
   register: post_change_nova_compute_image
 

--- a/roles/validations/tasks/edpm/hotfix.yml
+++ b/roles/validations/tasks/edpm/hotfix.yml
@@ -24,7 +24,7 @@
   cifmw.general.ci_script:
     output_dir: "{{ cifmw_validations_basedir }}/artifacts"
     script: >-
-      oc patch -n {{ cifmw_validations_namespace }} osdpns/"{{ deployed_nodeset_name.stdout }}" --type=merge -p '{"spec": {"nodeTemplate": {"ansible": {"ansibleVars": {"edpm_nova_compute_image": "{{ cifmw_validations_hotfixed_edpm_nova_compute_image }}"}}}}}'
+      oc patch -n {{ cifmw_validations_namespace }} osdpns/"{{ deployed_nodeset_name.stdout | trim }}" --type=merge -p '{"spec": {"nodeTemplate": {"ansible": {"ansibleVars": {"edpm_nova_compute_image": "{{ cifmw_validations_hotfixed_edpm_nova_compute_image }}"}}}}}'
 
 # Create a new OpenStackDataPlaneDeployment to apply the hotfixed image
 - name: Create openstackdataplanedeployment to rollout changes
@@ -42,7 +42,7 @@
         namespace: {{ cifmw_validations_namespace }}
       spec:
         nodeSets:
-          - "{{ deployed_nodeset_name.stdout }}"
+          - "{{ deployed_nodeset_name.stdout | trim }}"
         servicesOverride:
           - nova
       EOF

--- a/roles/validations/tasks/edpm/hotfix.yml
+++ b/roles/validations/tasks/edpm/hotfix.yml
@@ -44,7 +44,7 @@
         nodeSets:
           - "{{ deployed_nodeset_name.stdout | trim }}"
         servicesOverride:
-          - nova
+          - "{{ cifmw_validations_custom_nova_service }}"
       EOF
 
 # loop check the status of the openstackdataplanedeployment until it is either completed,


### PR DESCRIPTION
This change fixes the hotfix validation for downstream requirments by:
- Trims the nodeset name to remove the `\n` from the name.
- Allows for the use of a custom nova service name
- Saves and uses the EDPM ssh key to login and verify that the image has indeed been changed after the job has been executed.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
