### PR TITLE
[uni01alpha] Add support for testing DT

### DIFF
--- a/ci/playbooks/files/networking-env-definition.yml
+++ b/ci/playbooks/files/networking-env-definition.yml
@@ -37,6 +37,82 @@ instances:
                 parent_interface: eth1
                 skip_nm: false
                 vlan_id: 22
+    compute-1:
+        hostname: compute-1
+        name: compute-1
+        networks:
+            ctlplane:
+                interface_name: eth1
+                ip_v4: 192.168.122.101
+                mac_addr: '52:54:00:17:05:44'
+                mtu: 1500
+                network_name: ctlplane
+                skip_nm: false
+            internalapi:
+                interface_name: eth1.20
+                ip_v4: 172.17.0.101
+                mac_addr: '52:54:00:05:db:00'
+                mtu: 1500
+                network_name: internalapi
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 20
+            storage:
+                interface_name: eth1.21
+                ip_v4: 172.18.0.101
+                mac_addr: '52:54:00:59:8a:4e'
+                mtu: 1500
+                network_name: storage
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 21
+            tenant:
+                interface_name: eth1.22
+                ip_v4: 172.19.0.101
+                mac_addr: '52:54:00:0b:1c:d5'
+                mtu: 1500
+                network_name: tenant
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 22
+    compute-2:
+        hostname: compute-2
+        name: compute-2
+        networks:
+            ctlplane:
+                interface_name: eth1
+                ip_v4: 192.168.122.102
+                mac_addr: '52:54:00:17:05:46'
+                mtu: 1500
+                network_name: ctlplane
+                skip_nm: false
+            internalapi:
+                interface_name: eth1.20
+                ip_v4: 172.17.0.102
+                mac_addr: '52:54:00:05:db:02'
+                mtu: 1500
+                network_name: internalapi
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 20
+            storage:
+                interface_name: eth1.21
+                ip_v4: 172.18.0.102
+                mac_addr: '52:54:00:59:8a:50'
+                mtu: 1500
+                network_name: storage
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 21
+            tenant:
+                interface_name: eth1.22
+                ip_v4: 172.19.0.102
+                mac_addr: '52:54:00:0b:1c:d7'
+                mtu: 1500
+                network_name: tenant
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 22
     controller-0:
         hostname: controller-0
         name: controller-0
@@ -48,6 +124,66 @@ instances:
                 mtu: 1500
                 network_name: ctlplane
                 skip_nm: false
+    networker-0:
+        hostname: networker-0
+        name: networker-0
+        networks:
+            ctlplane:
+                interface_name: eth1
+                ip_v4: 192.168.122.110
+                mac_addr: '52:54:00:17:15:43'
+                mtu: 1500
+                network_name: ctlplane
+                skip_nm: false
+            internalapi:
+                interface_name: eth1.20
+                ip_v4: 172.17.0.110
+                mac_addr: '52:54:00:05:ea:ef'
+                mtu: 1500
+                network_name: internalapi
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 20
+    networker-1:
+        hostname: networker-1
+        name: networker-1
+        networks:
+            ctlplane:
+                interface_name: eth1
+                ip_v4: 192.168.122.111
+                mac_addr: '52:54:00:17:16:43'
+                mtu: 1500
+                network_name: ctlplane
+                skip_nm: false
+            internalapi:
+                interface_name: eth1.20
+                ip_v4: 172.17.0.111
+                mac_addr: '52:54:00:05:eb:ef'
+                mtu: 1500
+                network_name: internalapi
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 20
+    networker-2:
+        hostname: networker-1
+        name: networker-1
+        networks:
+            ctlplane:
+                interface_name: eth1
+                ip_v4: 192.168.122.111
+                mac_addr: '52:54:00:17:16:43'
+                mtu: 1500
+                network_name: ctlplane
+                skip_nm: false
+            internalapi:
+                interface_name: eth1.20
+                ip_v4: 172.17.0.111
+                mac_addr: '52:54:00:05:eb:ef'
+                mtu: 1500
+                network_name: internalapi
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 20
     ocp-master-0:
         hostname: ocp-master-0
         name: ocp-master-0
@@ -252,6 +388,19 @@ networks:
                     start_host: 100
                 ipv6_ranges: []
         vlan_id: 20
+    octavia:
+        dns_v4: []
+        dns_v6: []
+        mtu: 1500
+        network_name: octavia
+        network_v4: 172.23.0.0/24
+        search_domain: octavia.example.com
+        tools:
+            netconfig:
+                ipv4_ranges:
+                - end: 172.23.0.200
+                  start: 172.23.0.100
+                ipv6_ranges: []
     storage:
         dns_v4: []
         dns_v6: []


### PR DESCRIPTION
This change adds networker nodes to solve the below error observed during gate checking.

error: accumulating components: accumulateDirectory: "recursed accumulation of path '/home/zuul/src/github.com/openstack-k8s-operators/architecture/dt/uni01alpha/networker': accumulating components: accumulateDirectory: \"recursed accumulation of path '/home/zuul/src/github.com/openstack-k8s-operators/architecture/lib/dataplane': accumulating components: accumulateDirectory: \\\"recursed accumulation of path '/home/zuul/src/github.com/openstack-k8s-operators/architecture/lib/dataplane/nodeset': fieldPath `data.nodeset.nodes` is missing for replacement source ConfigMap.[noVer].[noGrp]/edpm-nodeset-values.[noNs]\\\"\""

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

*Logs*
https://review.rdoproject.org/zuul/build/6746ef28e48f4bc5a27f366a1df40204/console