### PR TITLE
[dnsmasq] Refactor the role to be consumed by the `ci_network` role

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -283,6 +283,7 @@ modprobe
 mountpoints
 mtcylje
 mtu
+multiline
 multinode
 multipath
 multus

--- a/roles/dnsmasq/README.md
+++ b/roles/dnsmasq/README.md
@@ -29,11 +29,11 @@ supported in libvirt).
 * `cifmw_dnsmasq_listen_addresses`: (List) List of IP addresses on which dnsmasq should be enabled. Defaults to `[]`.
 * `cifmw_dnsmasq_enable_dns`: (Bool) Toggle to enable DNS features of dnsmasq. Defaults to `false`.
 * `cifmw_dnsmasq_addresses`: (List) Specify a list of IP addresses to return for any host in the given domains. Defaults to `[]`.
-* `cifmw_dnsmasq_domain_name`: (String) DNS domain name used for the DHCP server. Defaults to `''`.
 
 #### Ranges mapping
 
 * `label`: (String) Network label ("tag" in dnsmasq manual).
+* `domain`: (String) domain name associated to the dhcp range.
 * `start_v4`: (String) IPv4 starting IP.
 * `start_v6`: (String) IPv6 starting IP.
 * `prefix_length_v4`: (Int) IPv4 prefix length. Defaults to `24`.

--- a/roles/dnsmasq/README.md
+++ b/roles/dnsmasq/README.md
@@ -27,7 +27,7 @@ supported in libvirt).
 * `cifmw_dnsmasq_listen_addresses`: (List) List of IP addresses on which dnsmasq should be enabled. Defaults to `[]`.
 * `cifmw_dnsmasq_enable_dns`: (Bool) Toggle to enable DNS features of dnsmasq. Defaults to `false`.
 * `cifmw_dnsmasq_addresses`: (List) Specify a list of IP addresses to return for any host in the given domains. Defaults to `[]`.
-* `cifmw_dnsmasq_domainname`: (String) DNS domain name used for the DHCP server. Defaults to `''`.
+* `cifmw_dnsmasq_domain_name`: (String) DNS domain name used for the DHCP server. Defaults to `''`.
 
 #### Ranges mapping
 

--- a/roles/dnsmasq/README.md
+++ b/roles/dnsmasq/README.md
@@ -16,7 +16,7 @@ supported in libvirt).
 * `cifmw_dnsmasq_basedir`: (String) Configuration directory location. Defaults to `/etc/cifmw-dnsmasq.d`.
 * `cifmw_dnsmasq_dns_config_file`: (String) DNS related settings configuration file path. Defaults to `{{ cifmw_dnsmasq_basedir }}/dns.conf`.
 * `cifmw_dnsmasq_listener_config_file`: (String) listener related settings configuration file path. Defaults to `{{ cifmw_dnsmasq_basedir }}/listener.conf`.
-* `cifmw_dnsmasq_global_options`: (Dict) Global options for dnsmasq. Defaults to `{}`.
+* `cifmw_dnsmasq_raw_config`: (String) Raw configure options for dnsmasq. Should be passed as a (multiline) string. Defaults to `""`.
 
 ### New network parameters
 

--- a/roles/dnsmasq/README.md
+++ b/roles/dnsmasq/README.md
@@ -22,7 +22,12 @@ supported in libvirt).
 * `cifmw_dnsmasq_network_state`: (String) Network status. Must be either `present` or `absent`.
 * `cifmw_dnsmasq_network_definition`: (Dict) Mapping representing the network definition.
 * `cifmw_dnsmasq_network_definition.ranges`: (List[mapping]) List of ranges associated to the network.
-* `cifmw_dnsmasq_network_listen_dns`: (List) List of IP addresses to listen to for DNS queries.
+* `cifmw_dnsmasq_forwarders`: (List) List of upstream DNS servers used as forwarders. Defaults to `[]`
+* `cifmw_dnsmasq_interfaces`: (List) List of interfaces on which dnsmasq should be enabled. Defaults to `[]`.
+* `cifmw_dnsmasq_listen_addresses`: (List) List of IP addresses on which dnsmasq should be enabled. Defaults to `[]`.
+* `cifmw_dnsmasq_enable_dns`: (Bool) Toggle to enable DNS features of dnsmasq. Defaults to `false`.
+* `cifmw_dnsmasq_addresses`: (List) Specify a list of IP addresses to return for any host in the given domains. Defaults to `[]`.
+* `cifmw_dnsmasq_domainname`: (String) DNS domain name used for the DHCP server. Defaults to `''`.
 
 #### Ranges mapping
 

--- a/roles/dnsmasq/README.md
+++ b/roles/dnsmasq/README.md
@@ -14,6 +14,7 @@ supported in libvirt).
 ## Common Parameters
 
 * `cifmw_dnsmasq_basedir`: (String) Configuration directory location. Defaults to `/etc/cifmw-dnsmasq.d`.
+* `cifmw_dnsmasq_enable_dns`: (Bool) Toggle to enable DNS features of dnsmasq. Defaults to `false`.
 * `cifmw_dnsmasq_dns_config_file`: (String) DNS related settings configuration file path. Defaults to `{{ cifmw_dnsmasq_basedir }}/dns.conf`.
 * `cifmw_dnsmasq_listener_config_file`: (String) listener related settings configuration file path. Defaults to `{{ cifmw_dnsmasq_basedir }}/listener.conf`.
 * `cifmw_dnsmasq_raw_config`: (String) Raw configure options for dnsmasq. Should be passed as a (multiline) string. Defaults to `""`.
@@ -27,7 +28,6 @@ supported in libvirt).
 * `cifmw_dnsmasq_forwarders`: (List) List of upstream DNS servers used as forwarders. Defaults to `[]`
 * `cifmw_dnsmasq_interfaces`: (List) List of interfaces on which dnsmasq should be enabled. Defaults to `[]`.
 * `cifmw_dnsmasq_listen_addresses`: (List) List of IP addresses on which dnsmasq should be enabled. Defaults to `[]`.
-* `cifmw_dnsmasq_enable_dns`: (Bool) Toggle to enable DNS features of dnsmasq. Defaults to `false`.
 * `cifmw_dnsmasq_addresses`: (List) Specify a list of IP addresses to return for any host in the given domains. Defaults to `[]`.
 
 #### Ranges mapping

--- a/roles/dnsmasq/README.md
+++ b/roles/dnsmasq/README.md
@@ -14,6 +14,8 @@ supported in libvirt).
 ## Common Parameters
 
 * `cifmw_dnsmasq_basedir`: (String) Configuration directory location. Defaults to `/etc/cifmw-dnsmasq.d`.
+* `cifmw_dnsmasq_dns_config_file`: (String) DNS related settings configuration file path. Defaults to `{{ cifmw_dnsmasq_basedir }}/dns.conf`.
+* `cifmw_dnsmasq_listener_config_file`: (String) listener related settings configuration file path. Defaults to `{{ cifmw_dnsmasq_basedir }}/listener.conf`.
 * `cifmw_dnsmasq_global_options`: (Dict) Global options for dnsmasq. Defaults to `{}`.
 
 ### New network parameters

--- a/roles/dnsmasq/README.md
+++ b/roles/dnsmasq/README.md
@@ -15,6 +15,7 @@ supported in libvirt).
 
 * `cifmw_dnsmasq_basedir`: (String) Configuration directory location. Defaults to `/etc/cifmw-dnsmasq.d`.
 * `cifmw_dnsmasq_enable_dns`: (Bool) Toggle to enable DNS features of dnsmasq. Defaults to `false`.
+* `cifmw_dnsmasq_exclude_lo`: (Bool) Toggle to disable binding on loopback interface to avoid conflicts. Defaults to `false`.
 * `cifmw_dnsmasq_dns_config_file`: (String) DNS related settings configuration file path. Defaults to `{{ cifmw_dnsmasq_basedir }}/dns.conf`.
 * `cifmw_dnsmasq_listener_config_file`: (String) listener related settings configuration file path. Defaults to `{{ cifmw_dnsmasq_basedir }}/listener.conf`.
 * `cifmw_dnsmasq_raw_config`: (String) Raw configure options for dnsmasq. Should be passed as a (multiline) string. Defaults to `""`.

--- a/roles/dnsmasq/defaults/main.yml
+++ b/roles/dnsmasq/defaults/main.yml
@@ -26,4 +26,3 @@ cifmw_dnsmasq_interfaces: []
 cifmw_dnsmasq_listen_addresses: []
 cifmw_dnsmasq_enable_dns: false
 cifmw_dnsmasq_addresses: []
-cifmw_dnsmasq_domain_name: ''

--- a/roles/dnsmasq/defaults/main.yml
+++ b/roles/dnsmasq/defaults/main.yml
@@ -24,3 +24,4 @@ cifmw_dnsmasq_interfaces: []
 cifmw_dnsmasq_listen_addresses: []
 cifmw_dnsmasq_enable_dns: false
 cifmw_dnsmasq_addresses: []
+cifmw_dnsmasq_domainname: ''

--- a/roles/dnsmasq/defaults/main.yml
+++ b/roles/dnsmasq/defaults/main.yml
@@ -24,4 +24,4 @@ cifmw_dnsmasq_interfaces: []
 cifmw_dnsmasq_listen_addresses: []
 cifmw_dnsmasq_enable_dns: false
 cifmw_dnsmasq_addresses: []
-cifmw_dnsmasq_domainname: ''
+cifmw_dnsmasq_domain_name: ''

--- a/roles/dnsmasq/defaults/main.yml
+++ b/roles/dnsmasq/defaults/main.yml
@@ -20,7 +20,7 @@
 cifmw_dnsmasq_basedir: "/etc/cifmw-dnsmasq.d"
 cifmw_dnsmasq_dns_config_file: "{{ cifmw_dnsmasq_basedir }}/dns.conf"
 cifmw_dnsmasq_listener_config_file: "{{ cifmw_dnsmasq_basedir }}/listener.conf"
-cifmw_dnsmasq_global_options: {}
+cifmw_dnsmasq_raw_config: ""
 cifmw_dnsmasq_forwarders: []
 cifmw_dnsmasq_interfaces: []
 cifmw_dnsmasq_listen_addresses: []

--- a/roles/dnsmasq/defaults/main.yml
+++ b/roles/dnsmasq/defaults/main.yml
@@ -25,4 +25,5 @@ cifmw_dnsmasq_forwarders: []
 cifmw_dnsmasq_interfaces: []
 cifmw_dnsmasq_listen_addresses: []
 cifmw_dnsmasq_enable_dns: false
+cifmw_dnsmasq_exclude_lo: false
 cifmw_dnsmasq_addresses: []

--- a/roles/dnsmasq/defaults/main.yml
+++ b/roles/dnsmasq/defaults/main.yml
@@ -18,6 +18,8 @@
 # All variables within this role should have a prefix of "cifmw_dnsmasq"
 
 cifmw_dnsmasq_basedir: "/etc/cifmw-dnsmasq.d"
+cifmw_dnsmasq_dns_config_file: "{{ cifmw_dnsmasq_basedir }}/dns.conf"
+cifmw_dnsmasq_listener_config_file: "{{ cifmw_dnsmasq_basedir }}/listener.conf"
 cifmw_dnsmasq_global_options: {}
 cifmw_dnsmasq_forwarders: []
 cifmw_dnsmasq_interfaces: []

--- a/roles/dnsmasq/files/cifmw-dnsmasq.service
+++ b/roles/dnsmasq/files/cifmw-dnsmasq.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=CIFMW DHCP server.
+Description=CIFMW dnsmasq server.
 After=network.target
 
 [Service]

--- a/roles/dnsmasq/molecule/default/cleanup.yml
+++ b/roles/dnsmasq/molecule/default/cleanup.yml
@@ -1,0 +1,23 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Cleanup dnsmasq
+      ansible.builtin.import_role:
+        name: "dnsmasq"
+        tasks_from: "cleanup.yml"

--- a/roles/dnsmasq/molecule/default/converge.yml
+++ b/roles/dnsmasq/molecule/default/converge.yml
@@ -21,14 +21,10 @@
     cifmw_dnsmasq_enable_dns: true
     cifmw_dnsmasq_interfaces:
       - mol-test-1
-    cifmw_dnsmasq_addresses:
-      - fqdn: "api.ocp.openstack.lab"
-        address: "192.168.122.2"
-      - fqdn: ".apps.ocp.openstack.lab"
-        address: "192.168.122.3"
+      - mol-test-2
     cifmw_dnsmasq_listen_addresses:
+      - "192.168.253.9"
       - "192.168.254.9"
-    cifmw_dnsmasq_domain_name: "ocp.openstack.lab"
     cifmw_dnsmasq_raw_config: |-
       dhcp-authoritative
       log-dhcp
@@ -44,6 +40,7 @@
             - label: ian
               start_v4: 192.168.254.10
               start_v6: "2345:0425:2CA1::0567:5673:23b5"
+              domain: "starwars.lan"
               options:
                 - "3,192.168.254.1"
                 - "option6:dns-server,[2345:0425:2CA1::0567:5673:0001]"
@@ -61,6 +58,7 @@
         cifmw_dnsmasq_network_definition:
           ranges:
             - label: ian
+              domain: "startrek.lan"
               start_v4: 192.168.253.10
               prefix_length_v4: 26
               start_v6: "2345:0426:2CA1::0567:5673:23b5"

--- a/roles/dnsmasq/molecule/default/converge.yml
+++ b/roles/dnsmasq/molecule/default/converge.yml
@@ -29,9 +29,9 @@
     cifmw_dnsmasq_listen_addresses:
       - "192.168.254.9"
     cifmw_dnsmasq_domain_name: "ocp.openstack.lab"
-    cifmw_dnsmasq_global_options:
-      dhcp-authoritative:
-      log-dhcp:
+    cifmw_dnsmasq_raw_config: |-
+      dhcp-authoritative
+      log-dhcp
   roles:
     - role: "dnsmasq"
   tasks:

--- a/roles/dnsmasq/molecule/default/converge.yml
+++ b/roles/dnsmasq/molecule/default/converge.yml
@@ -110,8 +110,3 @@
         - /etc/cifmw-dnsmasq.d/starwars-hosts.conf
         - /etc/cifmw-dnsmasq.d/startrek.conf
         - /etc/cifmw-dnsmasq.d/startrek-hosts.conf
-
-    - name: Cleanup dnsmasq
-      ansible.builtin.import_role:
-        name: "dnsmasq"
-        tasks_from: "cleanup.yml"

--- a/roles/dnsmasq/molecule/default/converge.yml
+++ b/roles/dnsmasq/molecule/default/converge.yml
@@ -55,7 +55,7 @@
       vars:
         cifmw_dnsmasq_network_name: startrek
         cifmw_dnsmasq_network_state: present
-        cifmw_dnsmasq_network_listen_dns:
+        cifmw_dnsmasq_listen_addresses:
           - "192.168.253.1"
           - "2345:0426:2CA1::0567:5673:23b0"
         cifmw_dnsmasq_network_definition:

--- a/roles/dnsmasq/molecule/default/converge.yml
+++ b/roles/dnsmasq/molecule/default/converge.yml
@@ -110,10 +110,9 @@
              'ci-framework-data',
              'artifacts') | path_join
           }}
-        fname: "{{ item | basename }}"
       ansible.posix.synchronize:
         src: "{{ item }}"
-        dest: "{{ dest_dir }}/{{ fname }}"
+        dest: "{{ dest_dir }}"
       loop:
         - /etc/cifmw-dnsmasq.conf
         - /etc/cifmw-dnsmasq.d/

--- a/roles/dnsmasq/molecule/default/converge.yml
+++ b/roles/dnsmasq/molecule/default/converge.yml
@@ -28,7 +28,7 @@
         address: "192.168.122.3"
     cifmw_dnsmasq_listen_addresses:
       - "192.168.254.9"
-    cifmw_dnsmasq_domainname: "ocp.openstack.lab"
+    cifmw_dnsmasq_domain_name: "ocp.openstack.lab"
     cifmw_dnsmasq_global_options:
       dhcp-authoritative:
       log-dhcp:

--- a/roles/dnsmasq/molecule/default/converge.yml
+++ b/roles/dnsmasq/molecule/default/converge.yml
@@ -18,6 +18,17 @@
 - name: Converge
   hosts: all
   vars:
+    cifmw_dnsmasq_enable_dns: true
+    cifmw_dnsmasq_interfaces:
+      - mol-test-1
+    cifmw_dnsmasq_addresses:
+      - fqdn: "api.ocp.openstack.lab"
+        address: "192.168.122.2"
+      - fqdn: ".apps.ocp.openstack.lab"
+        address: "192.168.122.3"
+    cifmw_dnsmasq_listen_addresses:
+      - "192.168.254.9"
+    cifmw_dnsmasq_domainname: "ocp.openstack.lab"
     cifmw_dnsmasq_global_options:
       dhcp-authoritative:
       log-dhcp:

--- a/roles/dnsmasq/molecule/default/converge.yml
+++ b/roles/dnsmasq/molecule/default/converge.yml
@@ -111,13 +111,9 @@
              'artifacts') | path_join
           }}
         fname: "{{ item | basename }}"
-      ansible.builtin.copy:
-        remote_src: true
+      ansible.posix.synchronize:
         src: "{{ item }}"
         dest: "{{ dest_dir }}/{{ fname }}"
       loop:
         - /etc/cifmw-dnsmasq.conf
-        - /etc/cifmw-dnsmasq.d/starwars.conf
-        - /etc/cifmw-dnsmasq.d/starwars-hosts.conf
-        - /etc/cifmw-dnsmasq.d/startrek.conf
-        - /etc/cifmw-dnsmasq.d/startrek-hosts.conf
+        - /etc/cifmw-dnsmasq.d/

--- a/roles/dnsmasq/tasks/configure.yml
+++ b/roles/dnsmasq/tasks/configure.yml
@@ -60,8 +60,11 @@
     src: "cifmw-dnsmasq.conf.j2"
     validate: "/usr/sbin/dnsmasq -C %s --test"
 
-- name: Render listening directives
+- name: Render listener configuration
   ansible.builtin.include_tasks: listener.yml
+
+- name: Render dns configuration
+  ansible.builtin.include_tasks: dns.yml
 
 - name: Manage and start dnsmasq instance
   become: true

--- a/roles/dnsmasq/tasks/configure.yml
+++ b/roles/dnsmasq/tasks/configure.yml
@@ -60,6 +60,9 @@
     src: "cifmw-dnsmasq.conf.j2"
     validate: "/usr/sbin/dnsmasq -C %s --test"
 
+- name: Render listening directives
+  ansible.builtin.include_tasks: listener.yml
+
 - name: Manage and start dnsmasq instance
   become: true
   when:

--- a/roles/dnsmasq/tasks/dns.yml
+++ b/roles/dnsmasq/tasks/dns.yml
@@ -20,7 +20,7 @@
     - _act == 'install'
   notify: Restart dnsmasq
   ansible.builtin.template:
-    dest: "{{ cifmw_dnsmasq_basedir }}/dns.conf"
+    dest: "{{ cifmw_dnsmasq_dns_config_file }}"
     mode: "0644"
     src: "dns.conf.j2"
     validate: "/usr/sbin/dnsmasq -C %s --test"
@@ -30,5 +30,5 @@
   when:
     - _act == 'cleanup'
   ansible.builtin.file:
-    path: "{{ cifmw_dnsmasq_basedir }}/dns.conf"
+    path: "{{ cifmw_dnsmasq_dns_config_file }}"
     state: absent

--- a/roles/dnsmasq/tasks/dns.yml
+++ b/roles/dnsmasq/tasks/dns.yml
@@ -14,13 +14,21 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Create dns configuration file
+  become: true
+  when:
+    - _act == 'install'
+  notify: Restart dnsmasq
+  ansible.builtin.template:
+    dest: "{{ cifmw_dnsmasq_basedir }}/dns.conf"
+    mode: "0644"
+    src: "dns.conf.j2"
+    validate: "/usr/sbin/dnsmasq -C %s --test"
 
-# All variables within this role should have a prefix of "cifmw_dnsmasq"
-
-cifmw_dnsmasq_basedir: "/etc/cifmw-dnsmasq.d"
-cifmw_dnsmasq_global_options: {}
-cifmw_dnsmasq_forwarders: []
-cifmw_dnsmasq_interfaces: []
-cifmw_dnsmasq_listen_addresses: []
-cifmw_dnsmasq_enable_dns: false
-cifmw_dnsmasq_addresses: []
+- name: Remove dns configuration file
+  become: true
+  when:
+    - _act == 'cleanup'
+  ansible.builtin.file:
+    path: "{{ cifmw_dnsmasq_basedir }}/dns.conf"
+    state: absent

--- a/roles/dnsmasq/tasks/listener.yml
+++ b/roles/dnsmasq/tasks/listener.yml
@@ -14,12 +14,21 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Create listener configuration file
+  become: true
+  when:
+    - _act == 'install'
+  notify: Restart dnsmasq
+  ansible.builtin.template:
+    dest: "{{ cifmw_dnsmasq_basedir }}/listener.conf"
+    mode: "0644"
+    src: "listener.conf.j2"
+    validate: "/usr/sbin/dnsmasq -C %s --test"
 
-# All variables within this role should have a prefix of "cifmw_dnsmasq"
-
-cifmw_dnsmasq_basedir: "/etc/cifmw-dnsmasq.d"
-cifmw_dnsmasq_global_options: {}
-cifmw_dnsmasq_forwarders: []
-cifmw_dnsmasq_interfaces: []
-cifmw_dnsmasq_listen_addresses: []
-cifmw_dnsmasq_enable_dns: false
+- name: Remove listener configuration file
+  become: true
+  when:
+    - _act == 'cleanup'
+  ansible.builtin.file:
+    path: "{{ cifmw_dnsmasq_basedir }}/listener.conf"
+    state: absent

--- a/roles/dnsmasq/tasks/listener.yml
+++ b/roles/dnsmasq/tasks/listener.yml
@@ -20,7 +20,7 @@
     - _act == 'install'
   notify: Restart dnsmasq
   ansible.builtin.template:
-    dest: "{{ cifmw_dnsmasq_basedir }}/listener.conf"
+    dest: "{{ cifmw_dnsmasq_listener_config_file }}"
     mode: "0644"
     src: "listener.conf.j2"
     validate: "/usr/sbin/dnsmasq -C %s --test"
@@ -30,5 +30,5 @@
   when:
     - _act == 'cleanup'
   ansible.builtin.file:
-    path: "{{ cifmw_dnsmasq_basedir }}/listener.conf"
+    path: "{{ cifmw_dnsmasq_listener_config_file }}"
     state: absent

--- a/roles/dnsmasq/templates/cifmw-dnsmasq.conf.j2
+++ b/roles/dnsmasq/templates/cifmw-dnsmasq.conf.j2
@@ -1,17 +1,16 @@
-# Disable DNS
-port=0
-# Avoid conflict with other DNS listening on lo
-except-interface=lo
+# Managed by ci-framework/dnsmasq
+
 user=dnsmasq
 group=dnsmasq
 pid-file=/var/run/cifmw-dnsmasq.pid
 dhcp-leasefile=/var/lib/dnsmasq/cifmw-dnsmasq.leases
-{% for key,val in cifmw_dnsmasq_global_options.items() %}
-{%   if val is not none                                %}
+
+{% for key,val in cifmw_dnsmasq_global_options.items() -%}
+{%-   if val is not none                               -%}
 {{ key }}={{ val }}
-{%   else                                              %}
+{%-  else                                              -%}
 {{ key }}
-{% endif                                               %}
-{% endfor                                              %}
+{% endif                                                %}
+{% endfor                                               %}
 
 conf-dir={{ cifmw_dnsmasq_basedir }},*.conf

--- a/roles/dnsmasq/templates/cifmw-dnsmasq.conf.j2
+++ b/roles/dnsmasq/templates/cifmw-dnsmasq.conf.j2
@@ -5,12 +5,8 @@ group=dnsmasq
 pid-file=/var/run/cifmw-dnsmasq.pid
 dhcp-leasefile=/var/lib/dnsmasq/cifmw-dnsmasq.leases
 
-{% for key,val in cifmw_dnsmasq_global_options.items() -%}
-{%-   if val is not none                               -%}
-{{ key }}={{ val }}
-{%-  else                                              -%}
-{{ key }}
-{% endif                                                %}
-{% endfor                                               %}
+{% if cifmw_dnsmasq_raw_config | length > 0 -%}
+{{ cifmw_dnsmasq_raw_config }}
+{% endif %}
 
 conf-dir={{ cifmw_dnsmasq_basedir }},*.conf

--- a/roles/dnsmasq/templates/dns.conf.j2
+++ b/roles/dnsmasq/templates/dns.conf.j2
@@ -4,11 +4,6 @@
 server={{ forwarder }}
 {% endfor                                     %}
 
-{% if cifmw_dnsmasq_domain_name != ''         -%}
-domain={{ cifmw_dnsmasq_domain_name }}
-local=/{{ cifmw_dnsmasq_domain_name }}/
-{% endif                                      %}
-
 {% for entry in cifmw_dnsmasq_addresses      -%}
 address=/{{ entry.fqdn }}/{{ entry.address }}
 {% endfor                                     %}

--- a/roles/dnsmasq/templates/dns.conf.j2
+++ b/roles/dnsmasq/templates/dns.conf.j2
@@ -4,6 +4,11 @@
 server={{ forwarder }}
 {% endfor                                     %}
 
+{% if cifmw_dnsmasq_domainname != ''         -%}
+domain={{ cifmw_dnsmasq_domainname }}
+local=/{{ cifmw_dnsmasq_domainname }}/
+{% endif                                      %}
+
 {% for entry in cifmw_dnsmasq_addresses      -%}
 address=/{{ entry.fqdn }}/{{ entry.address }}
 {% endfor                                     %}

--- a/roles/dnsmasq/templates/dns.conf.j2
+++ b/roles/dnsmasq/templates/dns.conf.j2
@@ -4,9 +4,9 @@
 server={{ forwarder }}
 {% endfor                                     %}
 
-{% if cifmw_dnsmasq_domainname != ''         -%}
-domain={{ cifmw_dnsmasq_domainname }}
-local=/{{ cifmw_dnsmasq_domainname }}/
+{% if cifmw_dnsmasq_domain_name != ''         -%}
+domain={{ cifmw_dnsmasq_domain_name }}
+local=/{{ cifmw_dnsmasq_domain_name }}/
 {% endif                                      %}
 
 {% for entry in cifmw_dnsmasq_addresses      -%}

--- a/roles/dnsmasq/templates/dns.conf.j2
+++ b/roles/dnsmasq/templates/dns.conf.j2
@@ -1,0 +1,9 @@
+# Managed by ci-framework/dnsmasq
+
+{% for forwarder in cifmw_dnsmasq_forwarders -%}
+server={{ forwarder }}
+{% endfor                                     %}
+
+{% for entry in cifmw_dnsmasq_addresses      -%}
+address=/{{ entry.fqdn }}/{{ entry.address }}
+{% endfor                                     %}

--- a/roles/dnsmasq/templates/listener.conf.j2
+++ b/roles/dnsmasq/templates/listener.conf.j2
@@ -1,21 +1,19 @@
 # Managed by ci-framework/dnsmasq
 
-{% if cifmw_dnsmasq_enable_dns is false               -%}
+{% if cifmw_dnsmasq_enable_dns is false            -%}
 # DNS is disabled
 port=0
-{% endif                                               %}
+{% endif                                            %}
 
 # Avoid conflict with other DNS listening on lo
 except-interface=lo
 
-{% if cifmw_dnsmasq_listen_addresses | length > 0     -%}
-listen_address={{ cifmw_dnsmasq_listen_addresses |
-                  reject('equalto', '127.0.0.1') |
-                  join(',') }}
-{% endif                                               %}
+{% for listener in cifmw_dnsmasq_listen_addresses
+   if listener | length > 0                        -%}
+listen-address={{ listener }}
+{%   endfor                                         %}
 
-{% for interface in cifmw_dnsmasq_interfaces          -%}
-{%-  if interface != "lo"                             -%}
+{% for interface in cifmw_dnsmasq_interfaces
+   if interface != "lo" and interface | length > 0 -%}
 interface={{ interface }}
-{%   endif                                             %}
-{% endfor                                              %}
+{% endfor                                           %}

--- a/roles/dnsmasq/templates/listener.conf.j2
+++ b/roles/dnsmasq/templates/listener.conf.j2
@@ -3,10 +3,13 @@
 {% if cifmw_dnsmasq_enable_dns is false            -%}
 # DNS is disabled
 port=0
-{% endif                                            %}
-
+{% else                                            -%}
+{%   if cifmw_dnsmasq_interfaces | length > 0      -%}
 # Avoid conflict with other DNS listening on lo
 except-interface=lo
+bind-interfaces
+{%   endif                                          %}
+{% endif                                            %}
 
 {% for listener in cifmw_dnsmasq_listen_addresses
    if listener | length > 0                        -%}

--- a/roles/dnsmasq/templates/listener.conf.j2
+++ b/roles/dnsmasq/templates/listener.conf.j2
@@ -1,0 +1,21 @@
+# Managed by ci-framework/dnsmasq
+
+{% if cifmw_dnsmasq_enable_dns is false               -%}
+# DNS is disabled
+port=0
+{% endif                                               %}
+
+# Avoid conflict with other DNS listening on lo
+except-interface=lo
+
+{% if cifmw_dnsmasq_listen_addresses | length > 0     -%}
+listen_address={{ cifmw_dnsmasq_listen_addresses |
+                  reject('equalto', '127.0.0.1') |
+                  join(',') }}
+{% endif                                               %}
+
+{% for interface in cifmw_dnsmasq_interfaces          -%}
+{%-  if interface != "lo"                             -%}
+interface={{ interface }}
+{%   endif                                             %}
+{% endfor                                              %}

--- a/roles/dnsmasq/templates/listener.conf.j2
+++ b/roles/dnsmasq/templates/listener.conf.j2
@@ -3,12 +3,12 @@
 {% if cifmw_dnsmasq_enable_dns is false            -%}
 # DNS is disabled
 port=0
-{% else                                            -%}
-{%   if cifmw_dnsmasq_interfaces | length > 0      -%}
+{% endif                                           -%}
+
+{% if cifmw_dnsmasq_exclude_lo                     -%}
 # Avoid conflict with other DNS listening on lo
 except-interface=lo
-bind-interfaces
-{%   endif                                          %}
+bind-dynamic
 {% endif                                            %}
 
 {% for listener in cifmw_dnsmasq_listen_addresses

--- a/roles/dnsmasq/templates/network.conf.j2
+++ b/roles/dnsmasq/templates/network.conf.j2
@@ -1,16 +1,26 @@
 # Managed by ci-framework/dnsmasq
 
-{% for range in cifmw_dnsmasq_network_definition['ranges']                                          %}
-{%   if range.start_v4 is defined and range.start_v4 | length > 0                                   %}
-dhcp-range=set:{{ range.label }},{{ range.start_v4 }},static,{{ (range.start_v4 + "/" + range.prefix_length_v4 | default(24) | string) |  ansible.utils.ipaddr('netmask') }},{{ range.ttl | default('1h') }}
+{% for range in cifmw_dnsmasq_network_definition['ranges']                                         -%}
+{%   if range.start_v4 is defined and range.start_v4 | length > 0                                  -%}
+dhcp-range=set:{{ range.label }},{{ range.start_v4 }},static,{{ (range.start_v4 + "/" + range.prefix_length_v4 | default(24) | string) | ansible.utils.ipaddr('netmask') }},{{ range.ttl | default('1h') }}
+{%      if range.domain is defined and range.domain | length > 0                                   -%}
+{%          set range_v4_allowed = (range.start_v4 ~ "/" ~ range.prefix_length_v4 | default('24')) |
+                                    ansible.utils.ipaddr('range_usable') | replace("-",",")         %}
+domain={{ range.domain }},{{ range_v4_allowed }},local
+{%      endif                                                                                       %}
 {%   endif                                                                                          %}
-{%   if range.start_v6 is defined and range.start_v6 | length > 0                                   %}
+{%   if range.start_v6 is defined and range.start_v6 | length > 0                                  -%}
 dhcp-range=set:{{ range.label }},{{ range.start_v6 }},static,{{ range.prefix_length_v6 | default('64') }},{{ range.ttl | default('1h') }}
+{%      if range.domain is defined and range.domain | length > 0                                   -%}
+{%          set range_v6_allowed = (range.start_v6 ~ "/" ~ range.prefix_length_v6 | default('64')) |
+                                    ansible.utils.ipaddr('range_usable') | replace("-",",")         %}
+domain={{ range.domain }},{{ range_v6_allowed }},local
+{%      endif                                                                                       %}
 {%   endif                                                                                          %}
-{%   for option in range['options'] | default([])                                                   %}
+{%   for option in range['options'] | default([])                                                  -%}
 dhcp-option=tag:{{ range.label }},{{ option }}
 {%   endfor                                                                                         %}
-{%   for option in range['options_force'] | default([])                                             %}
+{%   for option in range['options_force'] | default([])                                            -%}
 dhcp-option-force=tag:{{ range.label }},{{ option }}
 {%   endfor                                                                                         %}
 {% endfor                                                                                           %}

--- a/roles/dnsmasq/templates/network.conf.j2
+++ b/roles/dnsmasq/templates/network.conf.j2
@@ -1,9 +1,5 @@
 # Managed by ci-framework/dnsmasq
-{% if cifmw_dnsmasq_network_listen_dns is defined and cifmw_dnsmasq_network_listen_dns | length > 0 %}
-{%   for listener in cifmw_dnsmasq_network_listen_dns if listener | length > 0                      %}
-listen-address={{ listener }}
-{%   endfor                                                                                         %}
-{% endif                                                                                            %}
+
 {% for range in cifmw_dnsmasq_network_definition['ranges']                                          %}
 {%   if range.start_v4 is defined and range.start_v4 | length > 0                                   %}
 dhcp-range=set:{{ range.label }},{{ range.start_v4 }},static,{{ (range.start_v4 + "/" + range.prefix_length_v4 | default(24) | string) |  ansible.utils.ipaddr('netmask') }},{{ range.ttl | default('1h') }}

--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -48,7 +48,7 @@ cifmw_libvirt_manager_configuration:
   vms:
     type_name:  # (string, such as "compute", "controller"
       start: (boolean, toggle if the VM should be strated or not. Optional, defaults to true)
-      manage: (boolean, toogle if the VM should be added to the inventory. Managed VM's must be on the cifmw_libvirt_manager_pub_net network. Optional, defaults to true)
+      manage: (boolean, toggle if the VM should be added to the inventory. Managed VM's must be on the cifmw_libvirt_manager_pub_net network. Optional, defaults to true)
       amount: (integer, optional. Optional, defaults to 1, allowed [0-9]+)
       image_url: (string, URI to the base image. Optional if disk_file_name is set to "blank")
       sha256_image_name: (string, image checksum. Optional if disk_file_name is set to "blank")


### PR DESCRIPTION
Since the `ci_network` role has already its own task(s) to manage dns configuration, this PR will try to fill the gap in terms of functionality between both roles, so in the future `dnsmasq` role can be consumed by `ci_network` role with low effort. 

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
