### PR TITLE
[uni04delta] Add ceph type nodes to assist gate checks

### DIFF
--- a/ci/playbooks/files/networking-env-definition.yml
+++ b/ci/playbooks/files/networking-env-definition.yml
@@ -1,4 +1,118 @@
 instances:
+    ceph-0:
+        hostname: ceph-0
+        name: ceph-0
+        networks:
+            ctlplane:
+                interface_name: eth1
+                ip_v4: 192.168.122.115
+                mac_addr: '52:54:00:27:05:43'
+                mtu: 1500
+                network_name: ctlplane
+                skip_nm: false
+            internalapi:
+                interface_name: eth1.20
+                ip_v4: 172.17.0.115
+                mac_addr: '52:54:00:15:da:ef'
+                mtu: 1500
+                network_name: internalapi
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 20
+            storage:
+                interface_name: eth1.21
+                ip_v4: 172.18.0.115
+                mac_addr: '52:54:00:69:8a:4c'
+                mtu: 1500
+                network_name: storage
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 21
+            storagemgmt:
+                interface_name: eth1.23
+                ip_v4: 172.20.0.115
+                mac_addr: '52:54:00:1b:1c:d7'
+                mtu: 1500
+                network_name: storagemgmt
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 23
+    ceph-1:
+        hostname: ceph-1
+        name: ceph-1
+        networks:
+            ctlplane:
+                interface_name: eth1
+                ip_v4: 192.168.122.116
+                mac_addr: '52:54:00:37:05:43'
+                mtu: 1500
+                network_name: ctlplane
+                skip_nm: false
+            internalapi:
+                interface_name: eth1.20
+                ip_v4: 172.17.0.116
+                mac_addr: '52:54:00:25:da:ef'
+                mtu: 1500
+                network_name: internalapi
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 20
+            storage:
+                interface_name: eth1.21
+                ip_v4: 172.18.0.116
+                mac_addr: '52:54:00:79:8a:4c'
+                mtu: 1500
+                network_name: storage
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 21
+            storagemgmt:
+                interface_name: eth1.23
+                ip_v4: 172.20.0.116
+                mac_addr: '52:54:00:2b:1c:d7'
+                mtu: 1500
+                network_name: storagemgmt
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 23
+    ceph-2:
+        hostname: ceph-2
+        name: ceph-2
+        networks:
+            ctlplane:
+                interface_name: eth1
+                ip_v4: 192.168.122.117
+                mac_addr: '52:54:00:47:05:43'
+                mtu: 1500
+                network_name: ctlplane
+                skip_nm: false
+            internalapi:
+                interface_name: eth1.20
+                ip_v4: 172.17.0.117
+                mac_addr: '52:54:00:35:da:ef'
+                mtu: 1500
+                network_name: internalapi
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 20
+            storage:
+                interface_name: eth1.21
+                ip_v4: 172.18.0.117
+                mac_addr: '52:54:00:89:8a:4c'
+                mtu: 1500
+                network_name: storage
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 21
+            storagemgmt:
+                interface_name: eth1.23
+                ip_v4: 172.20.0.117
+                mac_addr: '52:54:00:3b:1c:d7'
+                mtu: 1500
+                network_name: storagemgmt
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 23
     compute-0:
         hostname: compute-0
         name: compute-0


### PR DESCRIPTION
Ceph type nodes are added for gate checks. This helps us evaluate any changes occuring with DT.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

*Test logs*
https://review.rdoproject.org/zuul/stream/08e8f69f580f41b59e51c996b693306b?logfile=console.log

