### PR TITLE
Allow to modify VM prefix and index separator

### DIFF
--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -29,6 +29,8 @@ Used for checking if:
 * `cifmw_libvirt_manager_apply_virtproxy_patch` (Boolean) Apply patch virtproxy patch for improved libvirt stability. This is set to `true` by default.
 * `cifmw_libvirt_manager_net_prefix_add` (Boolean) Adds `cifmw-` prefix to the network resources managed by this role. By default, it is set to `true`.
 * `cifmw_libvirt_manager_pub_net`: (String) Network name playing the "public" interface. Defaults to `public`.
+* `cifmw_libvirt_manager_vm_separator`: (Char) Separator to use between VM name and VM index. Defaults to `-`.
+* `cifmw_libvirt_manager_vm_prefix`: (String) Prefix for VM name. Defaults to `cifmw-`.
 * `cifmw_libvirt_manager_vm_net_ip_set`: (Dict) Allow to extend the existing mapping for host family to IP mapping. Defaults to `{}`.
 * `cifmw_libvirt_manager_fixed_networks`: (List) Network names you don't want to prefix with `cifmw-`. It will be concatenated with cifmw_libvirt_manager_fixed_networks_defaults. Defaults to`[]`.
 * `cifmw_libvirt_manager_reproducer_key_type`: (String) Type of ssh key that will be injected into the controller VMs. Defaults to `cifmw_ssh_keytype` which default to `ecdsa`.

--- a/roles/libvirt_manager/defaults/main.yml
+++ b/roles/libvirt_manager/defaults/main.yml
@@ -53,6 +53,8 @@ cifmw_libvirt_manager_daemon: libvirtd.service
 cifmw_libvirt_manager_apply_virtproxy_patch: true
 cifmw_libvirt_manager_net_prefix_add: true
 cifmw_libvirt_manager_pub_net: public
+cifmw_libvirt_manager_vm_separator: "-"
+cifmw_libvirt_manager_vm_prefix: "cifmw-"
 
 # Those parameters are usually set via the reproducer role.
 # We will therefore use them, and default to the same value set in the role.

--- a/roles/libvirt_manager/molecule/prefix_separator/cleanup.yml
+++ b/roles/libvirt_manager/molecule/prefix_separator/cleanup.yml
@@ -1,0 +1,24 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Cleanup
+  hosts: instance
+  gather_facts: true
+  tasks:
+    - name: Clean layout
+      ansible.builtin.import_role:
+        name: libvirt_manager
+        tasks_from: clean_layout.yml

--- a/roles/libvirt_manager/molecule/prefix_separator/converge.yml
+++ b/roles/libvirt_manager/molecule/prefix_separator/converge.yml
@@ -1,0 +1,185 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: One hypervisor
+  hosts: instance
+  gather_facts: true
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_libvirt_manager_vm_separator: "_"
+    cifmw_libvirt_manager_vm_prefix: ""
+    cifmw_basedir: "/opt/basedir"
+    cifmw_libvirt_manager_vm_net_ip_set:
+      compute: 100
+      baremetal: 110
+    _networks:
+      osp_trunk:
+        default: true
+        range: "192.168.140.0/24"
+        mtu: 1500
+      public:
+        range: "192.168.110.0/24"
+      internal-api:
+        range: "172.17.0.0/24"
+        vlan: 20
+    cifmw_libvirt_manager_configuration:
+      vms:
+        compute:
+          amount: 1
+          image_url: "{{ cifmw_discovered_image_url }}"
+          sha256_image_name: "{{ cifmw_discovered_hash }}"
+          image_local_dir: "{{ cifmw_basedir }}/images/"
+          disk_file_name: "centos-stream-9.qcow2"
+          disksize: 20
+          memory: 1
+          cpus: 1
+          nets:
+            - public
+          extra_disks_num: 1
+          extra_disks_size: 1G
+      networks:
+        public: |-
+          <network>
+            <name>public</name>
+            <forward mode='nat'/>
+            <bridge name='public' stp='on' delay='0'/>
+            <ip
+             family='ipv4'
+             address='{{ _networks.public.range | ansible.utils.nthhost(1) }}'
+             prefix='24'>
+              <dhcp>
+                <range start='{{ _networks.public.range | ansible.utils.nthhost(10) }}'
+                end='{{ _networks.public.range | ansible.utils.nthhost(100) }}'/>
+              </dhcp>
+            </ip>
+          </network>
+  roles:
+    - role: "discover_latest_image"
+  tasks:
+    - name: Deploy layout
+      ansible.builtin.import_role:
+        name: libvirt_manager
+        tasks_from: deploy_layout
+
+    - name: Check files and deployed resources
+      block:
+        - name: Get wanted files
+          register: generated_files
+          ansible.builtin.stat:
+            path: "{{ cifmw_basedir }}/{{ item }}"
+          loop:
+            - reproducer-inventory/compute-group.yml
+
+        - name: Assert file availability
+          ansible.builtin.assert:
+            that:
+              - item.stat.exists | bool
+          loop: "{{ generated_files.results }}"
+          loop_control:
+            label: "{{ item.stat.path }}"
+
+        - name: Get virtual network list
+          register: nets
+          community.libvirt.virt_net:
+            command: list_nets
+
+        - name: Get virtual machines
+          register: vms
+          community.libvirt.virt:
+            command: "list_vms"
+
+        - name: Output network list
+          ansible.builtin.debug:
+            msg:
+              - "{{ nets.list_nets | sort }}"
+              - >-
+                {{
+                  ['cifmw-public', 'cifmw-osp_trunk', 'default'] |
+                  sort
+                }}
+
+        - name: Assert resource lists
+          vars:
+            sorted_nets: "{{ nets.list_nets | sort }}"
+            compare_nets: >-
+              {{
+                ['cifmw-public', 'cifmw-osp_trunk', 'default'] |
+                sort
+              }}
+            sorted_vms: "{{ vms.list_vms | sort }}"
+            compare_vms: >-
+              {{
+                ['compute_0',
+                 'compute_1'] | sort
+              }}
+          ansible.builtin.assert:
+            that:
+              - sorted_nets == compare_nets
+              - sorted_vms == compare_vms
+
+    - name: Test volumes.
+      block:
+        - name: Gather the list of created volumes.
+          register: vol_count
+          ansible.builtin.shell:
+            cmd: |
+              set -o pipefail
+              virsh -c qemu:///system vol-list --pool cifmw-pool | \
+              grep -c compute
+
+        - name: Verify the number of created volumes match with the expected count.
+          vars:
+            expect_vol_num: >-
+              {{
+                (_cifmw_libvirt_manager_layout.vms.compute.amount | int) *
+                (_cifmw_libvirt_manager_layout.vms.compute.extra_disks_num | int)
+              }}
+            found_vol_num: "{{ vol_count.stdout | int }}"
+          ansible.builtin.assert:
+            that:
+              - found_vol_num == expect_vol_num
+
+    - name: Test volume attachment.
+      block:
+        - name: Gather the domain information about VMs having extra disks.
+          register: vm_xml
+          community.libvirt.virt:
+            command: "get_xml"
+            name: "{{ item }}"
+            uri: "qemu:///system"
+          loop: "{{ vms.list_vms | select('match', '^compute.*') }}"
+
+        - name: Gather the number of volumes attached.
+          register: volume_count
+          community.general.xml:
+            count: true
+            xmlstring: "{{ item.get_xml }}"
+            xpath: "/domain/devices/disk"
+          loop: "{{ vm_xml.results }}"
+
+        - name: Verify the number of volumes attached match with the expected count.
+          vars:
+            expected_count: >-
+              {{
+                (
+                  cifmw_libvirt_manager_configuration.vms.compute.extra_disks_num | int
+                ) + 1
+              }}
+            found_count: "{{ item.count | int }}"
+          ansible.builtin.assert:
+            that:
+              - expected_count == found_count
+          loop: "{{ volume_count.results }}"

--- a/roles/libvirt_manager/molecule/prefix_separator/molecule.yml
+++ b/roles/libvirt_manager/molecule/prefix_separator/molecule.yml
@@ -1,0 +1,13 @@
+---
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  inventory:
+    host_vars:
+      instance:
+        cifmw_libvirt_manager_configuration_patch_01_more_computes:
+          vms:
+            compute:
+              amount: 2

--- a/roles/libvirt_manager/molecule/prefix_separator/prepare.yml
+++ b/roles/libvirt_manager/molecule/prefix_separator/prepare.yml
@@ -1,0 +1,34 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: instance
+  vars:
+    cifmw_basedir: "/opt/basedir"
+  pre_tasks:
+    - name: Create custom basedir
+      become: true
+      ansible.builtin.file:
+        path: "{{ cifmw_basedir }}"
+        state: directory
+        owner: zuul
+        group: zuul
+        mode: "0755"
+  roles:
+    - role: "test_deps"
+    - role: "ci_setup"
+    - role: "libvirt_manager"

--- a/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/roles/libvirt_manager/tasks/clean_layout.yml
@@ -20,8 +20,10 @@
         uri: "qemu:///system"
 
     - name: Filter out target environment
+      vars:
+        _matcher: "^{{ cifmw_libvirt_manager_vm_prefix }}.*$"
       ansible.builtin.set_fact:
-        cleanup_vms: "{{ vms_list.list_vms | select('match', '^cifmw-.*$') }}"
+        cleanup_vms: "{{ vms_list.list_vms | select('match', _matcher) }}"
 
     - name: Expose cleanup list
       ansible.builtin.debug:
@@ -59,7 +61,8 @@
         - inventory_hostname != 'localhost'
       delegate_to: localhost
       vars:
-        vm: "{{ item | replace('cifmw-', '') }}"
+        _matcher: "{{ cifmw_libvirt_manager_vm_prefix }}"
+        vm: "{{ item | replace(_matcher, '') }}"
       ansible.builtin.blockinfile:
         path: "{{ lookup('env', 'HOME') }}/.ssh/config"
         marker: "## {mark} {{ vm }} {{ inventory_hostname }}"
@@ -72,7 +75,8 @@
         - inventory_hostname != 'localhost'
       delegate_to: localhost
       vars:
-        vm: "{{ item | replace('cifmw-', '') }}"
+        _matcher: "{{ cifmw_libvirt_manager_vm_prefix }}"
+        vm: "{{ item | replace(_matcher, '') }}"
       ansible.builtin.blockinfile:
         path: "{{ lookup('env', 'HOME') }}/.ssh/config"
         marker: "## {mark} {{ vm }}"
@@ -82,7 +86,8 @@
 
     - name: "({{ inventory_hostname }}) Clean ssh jumpers"  # noqa: name[template]
       vars:
-        vm: "{{ item | replace('cifmw-', '') }}"
+        _matcher: "{{ cifmw_libvirt_manager_vm_prefix }}"
+        vm: "{{ item | replace(_matcher, '') }}"
       ansible.builtin.blockinfile:
         path: "{{ ansible_user_dir }}/.ssh/config"
         marker: "## {mark} {{ vm }}"
@@ -97,8 +102,10 @@
         uri: "qemu:///system"
 
     - name: Filter out target nets
+      vars:
+        _matcher: "^{{ cifmw_libvirt_manager_vm_prefix }}.*$"
       ansible.builtin.set_fact:
-        cleanup_nets: "{{ nets_list.list_nets | select('match', '^cifmw-.*$') }}"
+        cleanup_nets: "{{ nets_list.list_nets | select('match', _matcher) }}"
 
     - name: Expose cleanup list
       ansible.builtin.debug:

--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -21,7 +21,8 @@
   block:
     - name: "Create VM overlay for {{ vm_type }}"
       vars:
-        _vm_img: "{{ vm_type }}-{{ vm_id }}.qcow2"
+        _vm_img: >-
+          {{ vm_type }}{{ cifmw_libvirt_manager_vm_separator }}{{ vm_id }}.qcow2
       register: _create_overlays
       ansible.builtin.command:
         cmd: >-
@@ -32,17 +33,20 @@
           -f qcow2
           "{{ _vm_img }}"
           "{{ vm_data.value.disksize|default ('40') }}G"
-        creates: "{{ vm_type }}-{{ vm_id }}.qcow2"
+        creates: >-
+          {{ vm_type }}{{ cifmw_libvirt_manager_vm_separator }}{{ vm_id }}.qcow2
         chdir: "{{ _chdir }}"
       loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
       loop_control:
         index_var: vm_id
-        label: "{{ vm_type }}-{{ vm_id }}"
+        label: >-
+          {{ vm_type }}{{ cifmw_libvirt_manager_vm_separator }}{{ vm_id }}
 
     - name: "Ensure file ownership and rights for {{ vm_type }}"
       become: true
       vars:
-        _vm_img: "{{ vm_type }}-{{ vm_id }}.qcow2"
+        _vm_img: >-
+          {{ vm_type }}{{ cifmw_libvirt_manager_vm_separator }}{{ vm_id }}.qcow2
       ansible.builtin.file:
         path: "{{ (_chdir, _vm_img) | path_join }}"
         group: "qemu"
@@ -52,7 +56,8 @@
       loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
       loop_control:
         index_var: vm_id
-        label: "{{ vm_type }}-{{ vm_id }}"
+        label: >-
+          {{ vm_type }}{{ cifmw_libvirt_manager_vm_separator }}{{ vm_id }}
 
 - name: "Manipulate XMLs and load them if provided for {{ vm_type }}"
   when:
@@ -62,7 +67,8 @@
   loop_control:
     loop_var: "_xml"
     index_var: "_xml_id"
-    label: "{{ vm_type }}-{{ _xml_id }}"
+    label: >-
+      {{ vm_type }}{{ cifmw_libvirt_manager_vm_separator }}{{ _xml_id }}
 
 - name: "Define the requested virtual machines {{ vm_type }}"
   when:
@@ -73,14 +79,19 @@
         - vm_data.value.extra_disks_num is defined
         - vm_data.value.extra_disks_num | int != 0
       vars:
-        vol_prefix: "cifmw-{{ vm_type }}-{{ vm_id }}"
+        vol_prefix: >-
+          {{
+            [cifmw_libvirt_manager_vm_prefix, vm_type,
+             cifmw_libvirt_manager_vm_separator, vm_id] | join('')
+          }}
         vol_num: "{{ vm_data.value.extra_disks_num }}"
         vol_size: "{{ vm_data.value.extra_disks_size }}"
       ansible.builtin.include_tasks: volumes.yml
       loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
       loop_control:
         index_var: vm_id
-        label: "{{ vm_type }}-{{ vm_id }}"
+        label: >-
+          {{ vm_type }}{{ cifmw_libvirt_manager_vm_separator }}{{ vm_id }}
         loop_var: vms_id
 
     - name: "Define VMs with default template for type {{ vm_type }}"
@@ -91,7 +102,8 @@
       loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
       loop_control:
         index_var: vm_id
-        label: "{{ vm_type }}-{{ vm_id }}"
+        label: >-
+          {{ vm_type }}{{ cifmw_libvirt_manager_vm_separator }}{{ vm_id }}
 
 - name: "Attach listed networks to the VMs {{ vm_type }}"  # noqa: no-handler
   when:
@@ -100,13 +112,15 @@
       not cifmw_libvirt_manager_spineleaf_setup or
       'controller' in vm_type
   vars:
-    vm_item: "{{ vm_type }}-{{ vm_id }}"
+    vm_item: >-
+      {{ vm_type }}{{ cifmw_libvirt_manager_vm_separator }}{{ vm_id }}
     networks: "{{ vm_data.value.nets }}"
   ansible.builtin.include_tasks: net_to_vms.yml
   loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
   loop_control:
     index_var: vm_id
-    label: "{{ vm_type }}-{{ vm_id }}"
+    label: >-
+      {{ vm_type }}{{ cifmw_libvirt_manager_vm_separator }}{{ vm_id }}
 
 - name: "Attach spines/leafs networks to the VMs {{ vm_type }}"
   when:
@@ -114,20 +128,28 @@
     - cifmw_libvirt_manager_spineleaf_setup
     - "'controller' not in vm_type"
   vars:
-    vm_item: "{{ vm_type }}-{{ vm_id }}"
+    vm_item: >-
+      {{ vm_type }}{{ cifmw_libvirt_manager_vm_separator }}{{ vm_id }}
     networks: "{{ vm_data.value.spineleafnets[vm_id] }}"
   ansible.builtin.include_tasks: net_to_vms.yml
   loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
   loop_control:
     index_var: vm_id
-    label: "{{ vm_type }}-{{ vm_id }}"
+    label: >-
+      {{ vm_type }}{{ cifmw_libvirt_manager_vm_separator }}{{ vm_id }}
 
 - name: "Fetch per-vm ports for {{ vm_type }}"
   register: _vm_ports
+  vars:
+    _vm: >-
+      {{
+        [cifmw_libvirt_manager_vm_prefix, vm_type,
+         cifmw_libvirt_manager_vm_separator, vm_id] | join()
+      }}
   ansible.builtin.command:
     cmd: >-
       virsh -c qemu:///system -q
-      domiflist cifmw-{{ vm_type }}-{{ vm_id }}
+      domiflist {{ _vm }}
   loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
   loop_control:
     index_var: vm_id
@@ -170,7 +192,8 @@
   loop: "{{ _vm_ports.results }}"
   loop_control:
     index_var: index
-    label: "{{ vm_type }}-{{ index }}"
+    label: >-
+      {{ vm_type }}{{ cifmw_libvirt_manager_vm_separator }}{{ index }}
 
 - name: "Assert we have macs data for {{ vm_type }}"
   ansible.builtin.assert:
@@ -195,7 +218,11 @@
     - _vbmc_available is defined
     - _vbmc_available | bool
   vars:
-    cifmw_virtualbmc_machine: "cifmw-{{ vm_type }}-{{ index }}"
+    cifmw_virtualbmc_machine: >-
+      {{
+        [cifmw_libvirt_manager_vm_prefix, vm_type,
+         cifmw_libvirt_manager_vm_separator, index] | join()
+      }}
     cifmw_virtualbmc_ipmi_port: >-
       {{
         cifmw_virtualbmc_ipmi_base_port + (family_id*10) + index
@@ -217,7 +244,8 @@
   loop: "{{ _vm_ports.results }}"
   loop_control:
     index_var: index
-    label: "{{ vm_type }}-{{ index }}"
+    label: >-
+      {{ vm_type }}{{ cifmw_libvirt_manager_vm_separator }}{{ index }}
 
 - name: "Start (power-on) {{ vm_type }}"
   when:

--- a/roles/libvirt_manager/tasks/gather_vm_networks.yml
+++ b/roles/libvirt_manager/tasks/gather_vm_networks.yml
@@ -26,7 +26,7 @@
   vars:
     _values: "{{ item.split() }}"
     _data:
-      - key: "{{ domain_name | replace('cifmw-', '') }}"
+      - key: "{{ domain_name | replace(cifmw_libvirt_manager_vm_prefix, '') }}"
         value:
           - network: "{{ _values[2] | replace('cifmw-', '') }}"
             mac: "{{ _values[4] }}"

--- a/roles/libvirt_manager/tasks/manage_vms.yml
+++ b/roles/libvirt_manager/tasks/manage_vms.yml
@@ -5,7 +5,7 @@
     cmd: >-
       virsh -c qemu:///system -q
       domifaddr --source arp
-      cifmw-{{ nic.host }} | grep "{{ nic.mac }}"
+      {{ cifmw_libvirt_manager_vm_prefix }}{{ nic.host }} | grep "{{ nic.mac }}"
       {% if cifmw_openshift_api_ip_address | default(false) %}
       | grep -v "{{ cifmw_openshift_api_ip_address }}/"
       {% endif %}
@@ -64,7 +64,7 @@
     marker: "## {mark} {{ vm_ip.nic.host }} {{ inventory_hostname }}"
     mode: "0600"
     block: |-
-      Host {{ vm_ip.nic.host }} {{ vm_ip.nic.host }}.{{ inventory_hostname }} cifmw-{{ vm_ip.nic.host }} {{ extracted_ip }}
+      Host {{ vm_ip.nic.host }} {{ vm_ip.nic.host }}.{{ inventory_hostname }} {{ cifmw_libvirt_manager_vm_prefix }}{{ vm_ip.nic.host }} {{ extracted_ip }}
         ProxyJump {{ ansible_user | default(lookup('env', 'USER')) }}@{{ proxy_hostname }}
         Hostname {{ extracted_ip }}
         User {{ 'core' if vm_ip.nic.host is match('^(crc|ocp).*') else 'zuul' }}
@@ -92,7 +92,7 @@
     marker: "## {mark} {{ vm_ip.nic.host }}"
     mode: "0600"
     block: |-
-      Host {{ vm_ip.nic.host }} {{ vm_ip.nic.host }}.{{ inventory_hostname }} cifmw-{{ vm_ip.nic.host }} {{ extracted_ip }}
+      Host {{ vm_ip.nic.host }} {{ vm_ip.nic.host }}.{{ inventory_hostname }} {{ cifmw_libvirt_manager_vm_prefix }}{{ vm_ip.nic.host }} {{ extracted_ip }}
         Hostname {{ extracted_ip }}
         User {{ 'core' if vm_ip.nic.host is match('^(crc|ocp)') else 'zuul' }}
         IdentityFile {{ identity_file }}

--- a/roles/libvirt_manager/tasks/net_to_vms.yml
+++ b/roles/libvirt_manager/tasks/net_to_vms.yml
@@ -14,7 +14,7 @@
       {{
         net_item is not in _fixed_nets_list
       }}
-    vm_name: "cifmw-{{ vm_item }}"
+    vm_name: "{{ cifmw_libvirt_manager_vm_prefix }}{{ vm_item }}"
     network:
       name: "{{ net_item }}"
   ansible.builtin.include_tasks: attach_interface.yml

--- a/roles/libvirt_manager/tasks/ocp_xml.yml
+++ b/roles/libvirt_manager/tasks/ocp_xml.yml
@@ -13,7 +13,11 @@
       community.general.xml:
         xmlstring: "{{ _xmlstring }}"
         xpath: "/domain/name"
-        value: "cifmw-{{ vm_type }}-{{ _xml_id }}"
+        value: >-
+          {{
+            [cifmw_libvirt_manager_vm_prefix, vm_type,
+             cifmw_libvirt_manager_vm_separator, _xml_id] | join('')
+          }}
 
     - name: Rebuild disk entry
       register: _editor
@@ -22,7 +26,8 @@
         xpath: "/domain/devices/disk/source[@pool='oooq_pool']"
         attribute: "volume"
         state: present
-        value: "{{ vm_type }}-{{ _xml_id }}.qcow2"
+        value: >-
+          {{ vm_type }}{{ cifmw_libvirt_manager_vm_separator }}{{ _xml_id }}.qcow2
 
     - name: "Define VMs with custom XML for {{ vm_type }}"
       vars:

--- a/roles/libvirt_manager/tasks/start_vms.yml
+++ b/roles/libvirt_manager/tasks/start_vms.yml
@@ -14,11 +14,18 @@
 # In case we create a "blank" VM, without any OS, it shouldn't be known by
 # ansible, so no access should be done.
 - name: "Start VMs for type {{ vm_type }}"
+  vars:
+    _vm: >-
+      {{
+        [cifmw_libvirt_manager_vm_prefix, vm_type,
+         cifmw_libvirt_manager_vm_separator, vm_id] | join()
+      }}
   community.libvirt.virt:
     state: running
-    name: "cifmw-{{ vm_type }}-{{ vm_id }}"
+    name: "{{ _vm }}"
     uri: "qemu:///system"
   loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
   loop_control:
     index_var: vm_id
-    label: "{{ vm_type }}-{{ vm_id }}"
+    label: >-
+      {{ vm_type }}{{ cifmw_libvirt_manager_vm_separator }}{{ vm_id }}

--- a/roles/libvirt_manager/templates/domain.xml.j2
+++ b/roles/libvirt_manager/templates/domain.xml.j2
@@ -1,5 +1,5 @@
 <domain type='kvm'>
-  <name>cifmw-{{ vm_type }}-{{ vm_id }}</name>
+  <name>{{ cifmw_libvirt_manager_vm_prefix }}{{ vm_type }}{{ cifmw_libvirt_manager_vm_separator }}{{ vm_id }}</name>
   <memory unit='GB'>{{ vm_data.value.memory | default(2) }}</memory>
   <vcpu placement='static'>{{ vm_data.value.cpus | default(2) }}</vcpu>
 {% if vm_data.value.uefi | default(false) | bool %}
@@ -37,7 +37,7 @@
 {% for n in range(vm_data.value.extra_disks_num) %}
     <disk type='volume' device='disk'>
       <driver name='qemu' type='qcow2' />
-      <source pool='{{ cifmw_libvirt_manager_storage_pool }}' volume='cifmw-{{ vm_type }}-{{ vm_id }}-vol-{{ n }}' />
+      <source pool='{{ cifmw_libvirt_manager_storage_pool }}' volume='{{ cifmw_libvirt_manager_vm_prefix }}{{ vm_type }}{{ cifmw_libvirt_manager_vm_separator }}{{ vm_id }}-vol-{{ n }}' />
       <target dev='vd{{ disk_suffix[n] }}' bus='scsi' />
     </disk>
 {% endfor %}


### PR DESCRIPTION
This change introduces two new parameters - usually for advanced usage
only. They allow to tweak the VM (*not* network!) final name by changing
the prefix (usually `cifmw-`) and the index separator (usually `-`) so
that we can end with VMs named `foo_compute_0` instead of
`cifmw-compute-0`.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
