### PR TITLE
Allow custom VM template

### DIFF
--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -19,6 +19,7 @@ Used for checking if:
 * `cifmw_libvirt_manager_user`: (String) User used for libvirt. Default: the one in the environment variable `USER`.
 * `cifmw_libvirt_manager_images_url`: (String) Location basedir for the image URI. Defaults to `https://cloud.centos.org/centos/9-stream/x86_64/images`.
 * `cifmw_libvirt_manager_configuration`: (Dict) Structure describing the libvirt layout (networking and VMs).
+* `cifmw_libvirt_manager_vm_template`: (String) Template name to use to define the virtual machines. Defaults to `domain.xml.j2`. Advanced use only.
 * `cifmw_libvirt_manager_crc_pool`: (String) CRC pool machine location. Defaults to `cifmw_crc_pool` which defaults to `~/.crc/machines/crc`.
 * `cifmw_libvirt_manager_installyamls`: (String) install_yamls repository location. Defaults to `cifmw_installyamls_repos` which defaults to `../..`
 * `cifmw_libvirt_manager_dryrun`: (Boolean) Toggle ci_make `dry_run` parameter. Defaults to `false`.

--- a/roles/libvirt_manager/defaults/main.yml
+++ b/roles/libvirt_manager/defaults/main.yml
@@ -22,6 +22,7 @@ cifmw_libvirt_manager_basedir: "{{ cifmw_basedir | default( ansible_user_dir ~ '
 cifmw_libvirt_manager_enable_virtualization_module: false
 cifmw_libvirt_manager_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
 cifmw_libvirt_manager_images_url: https://cloud.centos.org/centos/9-stream/x86_64/images
+cifmw_libvirt_manager_vm_template: "domain.xml.j2"
 
 cifmw_libvirt_manager_compute_amount: 1
 cifmw_libvirt_manager_compute_disksize: 20

--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -86,7 +86,7 @@
     - name: "Define VMs with default template for type {{ vm_type }}"
       community.libvirt.virt:
         command: define
-        xml: "{{ lookup('template', 'domain.xml.j2') }}"
+        xml: "{{ lookup('template', cifmw_libvirt_manager_vm_template) }}"
         uri: "qemu:///system"
       loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
       loop_control:


### PR DESCRIPTION
This introduces a new parameter in libvirt_manager, allowing to use
another template than the current one.

This parameter is intended for advanced use, and will enable further
features, such as OCP node provisioning.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
