### PR TITLE
Allow to specify pool directory

### DIFF
--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -20,6 +20,7 @@ Used for checking if:
 * `cifmw_libvirt_manager_images_url`: (String) Location basedir for the image URI. Defaults to `https://cloud.centos.org/centos/9-stream/x86_64/images`.
 * `cifmw_libvirt_manager_configuration`: (Dict) Structure describing the libvirt layout (networking and VMs).
 * `cifmw_libvirt_manager_crc_pool`: (String) CRC pool machine location. Defaults to `cifmw_crc_pool` which defaults to `~/.crc/machines/crc`.
+* `cifmw_libvirt_manager_pool_dir`: (String) Pool directory. Defaults to `cifmw_libvirt_manager_basedir/volumes`.Advanced use only.
 * `cifmw_libvirt_manager_installyamls`: (String) install_yamls repository location. Defaults to `cifmw_installyamls_repos` which defaults to `../..`
 * `cifmw_libvirt_manager_dryrun`: (Boolean) Toggle ci_make `dry_run` parameter. Defaults to `false`.
 * `cifmw_libvirt_manager_compute_amount`: (Integer) State the amount of computes you want. Defaults to `1`.

--- a/roles/libvirt_manager/defaults/main.yml
+++ b/roles/libvirt_manager/defaults/main.yml
@@ -47,6 +47,7 @@ cifmw_libvirt_manager_configuration:
 
 cifmw_libvirt_manager_crc_pool: "{{ cifmw_crc_pool | default(lookup('env', 'HOME')) ~ '/.crc/machines/crc' }}"
 cifmw_libvirt_manager_pool:
+cifmw_libvirt_manager_pool_dir: "{{ cifmw_libvirt_manager_basedir }}/volumes"
 cifmw_libvirt_manager_installyamls: "{{ cifmw_installyamls_repos | default('../..') }}"
 cifmw_libvirt_manager_dryrun: false
 cifmw_libvirt_manager_daemon: libvirtd.service

--- a/roles/libvirt_manager/tasks/storage_pool.yml
+++ b/roles/libvirt_manager/tasks/storage_pool.yml
@@ -14,6 +14,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Ensure we have a know action
+  ansible.builtin.assert:
+    that:
+      - action is defined
+      - action in ['create', 'delete']
 
 - name: Gather the status of cifmw-pool storage pool.
   register: pool_exists
@@ -35,7 +40,7 @@
           pool-define-as
           --name {{ cifmw_libvirt_manager_storage_pool }}
           --type dir
-          --target {{ cifmw_libvirt_manager_basedir }}/volumes
+          --target {{ cifmw_libvirt_manager_pool_dir }}
 
     - name: Ensure the storage pool is started
       ansible.builtin.command:


### PR DESCRIPTION
This PR adds a new parameter to define the pool directory.

It's mostly for advanced usage, related to the OCP cluster node
provisioning changes coming to the Framework.

This patch also ensures we're passing a valid "action" to the
storage_pool.yml tasks file.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
