### PR TITLE
Add bind-dynamic to dnsmasq conf

### DIFF
--- a/roles/dnsmasq/templates/cifmw-dnsmasq.conf.j2
+++ b/roles/dnsmasq/templates/cifmw-dnsmasq.conf.j2
@@ -2,6 +2,7 @@
 port=0
 # Avoid conflict with other DNS listening on lo
 except-interface=lo
+bind-dynamic
 user=dnsmasq
 group=dnsmasq
 pid-file=/var/run/cifmw-dnsmasq.pid


### PR DESCRIPTION
We should enable the bind-dynamic option to allow our DHCP server to co-exist with other DHCP services - such as one for a libvirt network.

Without this the service will fail to start if there is a livirt network with DHCP enabled.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
