### PR TITLE
Avoid failures on cleaning

### DIFF
--- a/roles/dnsmasq/handlers/main.yml
+++ b/roles/dnsmasq/handlers/main.yml
@@ -16,6 +16,11 @@
 
 - name: Restart dnsmasq
   become: true
+  register: _dnsmasq
   ansible.builtin.systemd_service:
     name: cifmw-dnsmasq.service
     state: restarted
+  failed_when:
+    - _dnsmasq.msg is defined
+    - _dnsmasq.msg is not
+      match('Could not find the requested service cifmw-dnsmasq.service')

--- a/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/roles/libvirt_manager/tasks/clean_layout.yml
@@ -3,10 +3,12 @@
   ansible.builtin.package_facts: {}
 
 - name: Perform the libvirt cleanup
-  when: >-
-    cifmw_libvirt_manager_dependency_packages |
-    difference(ansible_facts.packages.keys()) |
-    length == 0
+  when:
+    - ansible_facts.packages is defined
+    - >-
+      cifmw_libvirt_manager_dependency_packages |
+      difference(ansible_facts.packages.keys()) |
+      length == 0
   block:
     - name: List all of the existing virtual machines
       register: vms_list


### PR DESCRIPTION
While working on integrating dnsmasq role in the reproducer, a random
issue, related to the facts, might happen.

It seems to be caused by the way ansible manages the handler - the
`ansible_facts.packages` isn't available anymore, and the condition
triggering the libvirt cleanup fails. While it was already done.

This condition arrises when dnsmasq role is in the game, and the handler
kicks at the end of the playbook.

In the same fashion, the handler might be triggered when the service is
already removed, leading to another crash of the cleanup playbook. The
added conditions ensure the handler will succeed even if the service is
already removed, but would still fail if there's a real issue with the
service configuration.

As a pull request owner and reviewers, I checked that:
- [X] getting those tested would be hard for now - dnsmasq isn't integrated yet
