### PR TITLE
Fix sushy_emulator integration in reproducer

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -58,6 +58,8 @@
     timeout: 5400
     files:
       - ^roles/libvirt_manager/(?!meta|README).*
+      - ^roles/podman/(?!meta|README).*
+      - ^roles/sushy_emulator/(?!meta|README).*
 - job:
     name: cifmw-molecule-cert_manager
     nodeset: centos-9-crc-2-30-0-xxl

--- a/roles/podman/README.md
+++ b/roles/podman/README.md
@@ -10,6 +10,7 @@ Requested to install packages.
 
 * `cifmw_podman_packages`: (List) list of packages to install for Podman. Defaults to `[podman]`.
 * `cifmw_podman_enable_linger`: (Bool) toggle session linger. Defaults to `true`.
+* `cifmw_podman_user_linger`: (String) target user for session lingering. Defaults to `ansible_user_id`.
 
 ## Examples
 

--- a/roles/podman/defaults/main.yml
+++ b/roles/podman/defaults/main.yml
@@ -18,3 +18,4 @@
 cifmw_podman_packages:
   - podman
 cifmw_podman_enable_linger: true
+cifmw_podman_user_linger: "{{ ansible_user_id }}"

--- a/roles/podman/tasks/main.yml
+++ b/roles/podman/tasks/main.yml
@@ -24,4 +24,4 @@
   when:
     - cifmw_podman_enable_linger | bool
   ansible.builtin.command:
-    cmd: "loginctl enable-linger {{ ansible_user_id }}"
+    cmd: "loginctl enable-linger {{ cifmw_podman_user_linger }}"

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -20,6 +20,14 @@
       _cifmw_libvirt_manager_layout.vms.controller.target is undefined
   delegate_to: controller-0
   delegate_facts: false
+  vars:
+    cifmw_sushy_emulator_basedir: "{{ _ctl_reproducer_basedir }}"
+    cifmw_sushy_emulator_sshkey_path: >-
+      {{
+        [_ctl_reproducer_basedir, '../.ssh/sushy_emulator-key'] |
+        path_join | realpath
+      }}
+    cifmw_podman_user_linger: "zuul"
   block:
     - name: Ensure directories exist
       ansible.builtin.file:

--- a/roles/sushy_emulator/README.md
+++ b/roles/sushy_emulator/README.md
@@ -14,7 +14,7 @@ Required to installed required packages.
 
 ## Parameters
 
-* `cifmw_sushy_emulator_basedir`: (String) Base directory. Defaults to `{{ ansible_user_dir ~ '/ci-framework-data' }}`
+* `cifmw_sushy_emulator_basedir`: (String) Base directory. Defaults to `cifmw_basedir`, which defaults to `{{ ansible_user_dir ~ '/ci-framework-data' }}`
 * `cifmw_sushy_emulator_container_name`: (String) Name of Podman container created. Defaults to `cifmw-sushy_emulator`
 * `cifmw_sushy_emulator_driver`: (String) Select between `openstack` and `libvirt` sushy emulator driver. Defaults to `libvirt`
 * `cifmw_sushy_emulator_driver_openstack_client_config_file`: (String) Path to OpenStack config file, used by OpenStack Sushi Emulator driver. Defaults to `/etc/openstack/clouds.yaml`

--- a/roles/sushy_emulator/defaults/main.yml
+++ b/roles/sushy_emulator/defaults/main.yml
@@ -18,7 +18,8 @@
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_sushy_emulator"
 
-cifmw_sushy_emulator_basedir: "{{ ansible_user_dir ~ '/ci-framework-data' }}"
+cifmw_sushy_emulator_basedir: >-
+  {{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}
 cifmw_sushy_emulator_container_name: "cifmw-sushy_emulator"
 cifmw_sushy_emulator_driver: libvirt
 cifmw_sushy_emulator_driver_openstack_client_config_file: /etc/openstack/clouds.yaml

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -632,6 +632,8 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     - ^roles/libvirt_manager/(?!meta|README).*
+    - ^roles/podman/(?!meta|README).*
+    - ^roles/sushy_emulator/(?!meta|README).*
     name: cifmw-molecule-reproducer
     nodeset: centos-9-crc-2-30-0-xxl
     parent: cifmw-molecule-base


### PR DESCRIPTION
A series of assumptions were made and lead to some issues with the way
the reproducer works.

Mostly, it can happen a hypervisor doesn't have the "zuul" user (for
example a home lab), leading to issues when facts such as
`ansible_user_id`, `ansible_user_dir` and related are used in conjuction
with `delegate_to`.

This patch allows the reproducer to properly works with the
sushy_emulator integration, and fixes some of those assumptions.

It also ensure the molecule tests for reproducer role is triggered uppon
podman and sushy_emulator role modifications.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
