### PR TITLE
Add octavia net templates including routes

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/uni01alpha/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni01alpha/network-values/values.yaml.j2
@@ -96,6 +96,16 @@ data:
         "ipam": {
           "type": "whereabouts",
           "range": "{{ network[_ipv.network_vX] }}",
+{%  if _ipv.ipvX_routes in network.tools.multus and network.tools.multus[_ipv.ipvX_routes] | length > 0 %}
+          "routes": [
+{%  for route in network.tools.multus[_ipv.ipvX_routes] %}
+             {
+               "dst": "{{ route.destination }}",
+               "gw": "{{ route.gateway }}"
+             }{% if not loop.last %},{% endif %}
+{%  endfor %}
+           ],
+{%  endif %}
           "range_start": "{{ network.tools.multus[_ipv.ipvX_ranges].0.start }}",
           "range_end": "{{ network.tools.multus[_ipv.ipvX_ranges].0.end }}"
         }

--- a/roles/ci_gen_kustomize_values/templates/uni05epsilon/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni05epsilon/network-values/values.yaml.j2
@@ -1,5 +1,5 @@
 ---
-# source: uni07eta/network-values/values.yaml.j2
+# source: uni05epsilon/network-values/values.yaml.j2
 {% set _ipv = cifmw_ci_gen_kustomize_values_ip_version_var_mapping %}
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
@@ -29,23 +29,21 @@ data:
   {{ network.network_name }}:
     dnsDomain: {{ network.search_domain }}
 {%  if network.tools is defined and network.tools.keys() | length > 0 %}
+    subnets:
 {%    for tool in network.tools.keys() %}
 {%      if tool is match('.*lb$') %}
 {%        set _ = ns.lb_tools.update({tool: []}) %}
 {%      endif %}
 {%    endfor %}
-{%    if network.tools.netconfig is defined  %}
-    subnets:
-      - name: subnet1
+      - allocationRanges:
+{%    for range in network.tools.netconfig[_ipv.ipvX_ranges] %}
+        - end: {{ range.end }}
+          start: {{ range.start }}
+{%    endfor %}
         cidr: {{ network[_ipv.network_vX] }}
         gateway: {{ omit if network[_ipv.gw_vX] is not defined else network[_ipv.gw_vX] }}
+        name: subnet1
         vlan: {{ omit if network.vlan_id is not defined else network.vlan_id }}
-        allocationRanges:
-{%    for range in network.tools.netconfig[_ipv.ipvX_ranges] %}
-          - end: {{ range.end }}
-            start: {{ range.start }}
-{%    endfor %}
-{%  endif %}
 {%    if ns.lb_tools | length > 0 %}
     lb_addresses:
 {%      for tool in ns.lb_tools.keys() %}
@@ -64,35 +62,33 @@ data:
     mtu: {{ network.mtu | default(1500) }}
 {%  if network.vlan_id is defined  %}
     vlan: {{ network.vlan_id }}
-    iface: {{ omit if ns.interfaces[network.network_name] is not defined else network.network_name }}
-    base_iface: {{ omit if ns.interfaces[network.network_name] is not defined else ns.interfaces[network.network_name] }}
-{%  elif network.network_name != "ironic" %}
-    iface: {{ omit if ns.interfaces[network.network_name] is not defined else ns.interfaces[network.network_name] }}
-{% else %}
-    iface: {{ omit if ns.interfaces[network.network_name] is not defined else network.network_name }}
+{%    if ns.interfaces[network.network_name] is defined %}
+    iface: {{ network.network_name }}
+    base_iface: {{ ns.interfaces[network.network_name] }}
+{%    endif %}
+{%  else %}
+{%    if ns.interfaces[network.network_name] is defined %}
+    iface: {{ ns.interfaces[network.network_name] }}
+{%    endif %}
 {%  endif %}
-{%  if network.tools.multus is defined and network.network_name == "ctlplane" %}
+{%  if network.tools.multus is defined %}
     net-attach-def: |
       {
         "cniVersion": "0.3.1",
         "name": "{{ network.network_name }}",
-        "type": "macvlan",
-        "master": "ospbr",
-        "ipam": {
-          "type": "whereabouts",
-          "range": "{{ network[_ipv.network_vX] }}",
-          "range_start": "{{ network.tools.multus[_ipv.ipvX_ranges].0.start }}",
-          "range_end": "{{ network.tools.multus[_ipv.ipvX_ranges].0.end }}"
-        }
-      }
-{%  endif %}
-{%  if network.tools.multus is defined and network.network_name == "octavia" %}
-    net-attach-def: |
-      {
-        "cniVersion": "0.3.1",
-        "name": "octavia",
+{%  if network.network_name == "octavia" %}
         "type": "bridge",
         "bridge": "octbr",
+{%  else %}
+        "type": "macvlan",
+{%  if network.vlan_id is defined%}
+        "master": "{{ network.network_name }}",
+{%  elif network.network_name == "ctlplane" %}
+        "master": "ospbr",
+{%  else %}
+        "master": "{{ ns.interfaces[network.network_name] }}",
+{%  endif %}
+{%  endif %}
         "ipam": {
           "type": "whereabouts",
           "range": "{{ network[_ipv.network_vX] }}",
@@ -111,37 +107,8 @@ data:
         }
       }
 {%  endif %}
-{%  if network.tools.multus is defined and network.network_name == "ironic" %}
-    net-attach-def: |
-      {
-        "cniVersion": "0.3.1",
-        "name": "ironic",
-        "type": "bridge",
-        "bridge": "ironic",
-        "ipam": {
-          "type": "whereabouts",
-          "range": "{{ network[_ipv.network_vX] }}",
-          "range_start": "{{ network.tools.multus[_ipv.ipvX_ranges].0.start }}",
-          "range_end": "{{ network.tools.multus[_ipv.ipvX_ranges].0.end }}"
-        }
-      }
-{%  endif %}
-{%  if network.tools.multus is defined and network.network_name not in ["ctlplane", "octavia", "ironic"] %}
-    net-attach-def: |
-      {
-        "cniVersion": "0.3.1",
-        "name": "{{ network.network_name }}",
-        "type": "macvlan",
-        "master": "{{ network.network_name if network.vlan_id is defined else ns.interfaces[network.network_name] }}",
-        "ipam": {
-          "type": "whereabouts",
-          "range": "{{ network[_ipv.network_vX] }}",
-          "range_start": "{{ network.tools.multus[_ipv.ipvX_ranges].0.start }}",
-          "range_end": "{{ network.tools.multus[_ipv.ipvX_ranges].0.end }}"
-        }
-      }
-{%  endif %}
 {% endfor %}
+
   dns-resolver:
     config:
       server:
@@ -157,15 +124,18 @@ data:
           - {{ nameserver }}
 {% endfor %}
 
+  routes:
+    config: []
+
 # Hardcoding the last IP bit since we don't have support for endpoint_annotations in the networking_mapper output
   rabbitmq:
     endpoint_annotations:
       metallb.universe.tf/address-pool: internalapi
-      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'][_ipv.network_vX] | ansible.utils.ipmath(85) }}
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'][_ipv.network_vX]  | ansible.utils.ipmath(85) }}
   rabbitmq-cell1:
     endpoint_annotations:
       metallb.universe.tf/address-pool: internalapi
-      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'][_ipv.network_vX] | ansible.utils.ipmath(86) }}
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'][_ipv.network_vX]  | ansible.utils.ipmath(86) }}
 
   lbServiceType: LoadBalancer
   storageClass: {{ cifmw_ci_gen_kustomize_values_storage_class }}

--- a/roles/ci_gen_kustomize_values/templates/uni06zeta/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni06zeta/network-values/values.yaml.j2
@@ -1,5 +1,5 @@
 ---
-# source: uni07eta/network-values/values.yaml.j2
+# source: uni06zeta/network-values/values.yaml.j2
 {% set _ipv = cifmw_ci_gen_kustomize_values_ip_version_var_mapping %}
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
@@ -29,23 +29,21 @@ data:
   {{ network.network_name }}:
     dnsDomain: {{ network.search_domain }}
 {%  if network.tools is defined and network.tools.keys() | length > 0 %}
+    subnets:
 {%    for tool in network.tools.keys() %}
 {%      if tool is match('.*lb$') %}
 {%        set _ = ns.lb_tools.update({tool: []}) %}
 {%      endif %}
 {%    endfor %}
-{%    if network.tools.netconfig is defined  %}
-    subnets:
-      - name: subnet1
+      - allocationRanges:
+{%    for range in network.tools.netconfig[_ipv.ipvX_ranges] %}
+        - end: {{ range.end }}
+          start: {{ range.start }}
+{%    endfor %}
         cidr: {{ network[_ipv.network_vX] }}
         gateway: {{ omit if network[_ipv.gw_vX] is not defined else network[_ipv.gw_vX] }}
+        name: subnet1
         vlan: {{ omit if network.vlan_id is not defined else network.vlan_id }}
-        allocationRanges:
-{%    for range in network.tools.netconfig[_ipv.ipvX_ranges] %}
-          - end: {{ range.end }}
-            start: {{ range.start }}
-{%    endfor %}
-{%  endif %}
 {%    if ns.lb_tools | length > 0 %}
     lb_addresses:
 {%      for tool in ns.lb_tools.keys() %}
@@ -64,35 +62,33 @@ data:
     mtu: {{ network.mtu | default(1500) }}
 {%  if network.vlan_id is defined  %}
     vlan: {{ network.vlan_id }}
-    iface: {{ omit if ns.interfaces[network.network_name] is not defined else network.network_name }}
-    base_iface: {{ omit if ns.interfaces[network.network_name] is not defined else ns.interfaces[network.network_name] }}
-{%  elif network.network_name != "ironic" %}
-    iface: {{ omit if ns.interfaces[network.network_name] is not defined else ns.interfaces[network.network_name] }}
-{% else %}
-    iface: {{ omit if ns.interfaces[network.network_name] is not defined else network.network_name }}
+{%    if ns.interfaces[network.network_name] is defined %}
+    iface: {{ network.network_name }}
+    base_iface: {{ ns.interfaces[network.network_name] }}
+{%    endif %}
+{%  else %}
+{%    if ns.interfaces[network.network_name] is defined %}
+    iface: {{ ns.interfaces[network.network_name] }}
+{%    endif %}
 {%  endif %}
-{%  if network.tools.multus is defined and network.network_name == "ctlplane" %}
+{%  if network.tools.multus is defined %}
     net-attach-def: |
       {
         "cniVersion": "0.3.1",
         "name": "{{ network.network_name }}",
-        "type": "macvlan",
-        "master": "ospbr",
-        "ipam": {
-          "type": "whereabouts",
-          "range": "{{ network[_ipv.network_vX] }}",
-          "range_start": "{{ network.tools.multus[_ipv.ipvX_ranges].0.start }}",
-          "range_end": "{{ network.tools.multus[_ipv.ipvX_ranges].0.end }}"
-        }
-      }
-{%  endif %}
-{%  if network.tools.multus is defined and network.network_name == "octavia" %}
-    net-attach-def: |
-      {
-        "cniVersion": "0.3.1",
-        "name": "octavia",
+{%  if network.network_name == "octavia" %}
         "type": "bridge",
         "bridge": "octbr",
+{%  else %}
+        "type": "macvlan",
+{%  if network.vlan_id is defined%}
+        "master": "{{ network.network_name }}",
+{%  elif network.network_name == "ctlplane" %}
+        "master": "ospbr",
+{%  else %}
+        "master": "{{ ns.interfaces[network.network_name] }}",
+{%  endif %}
+{%  endif %}
         "ipam": {
           "type": "whereabouts",
           "range": "{{ network[_ipv.network_vX] }}",
@@ -111,37 +107,8 @@ data:
         }
       }
 {%  endif %}
-{%  if network.tools.multus is defined and network.network_name == "ironic" %}
-    net-attach-def: |
-      {
-        "cniVersion": "0.3.1",
-        "name": "ironic",
-        "type": "bridge",
-        "bridge": "ironic",
-        "ipam": {
-          "type": "whereabouts",
-          "range": "{{ network[_ipv.network_vX] }}",
-          "range_start": "{{ network.tools.multus[_ipv.ipvX_ranges].0.start }}",
-          "range_end": "{{ network.tools.multus[_ipv.ipvX_ranges].0.end }}"
-        }
-      }
-{%  endif %}
-{%  if network.tools.multus is defined and network.network_name not in ["ctlplane", "octavia", "ironic"] %}
-    net-attach-def: |
-      {
-        "cniVersion": "0.3.1",
-        "name": "{{ network.network_name }}",
-        "type": "macvlan",
-        "master": "{{ network.network_name if network.vlan_id is defined else ns.interfaces[network.network_name] }}",
-        "ipam": {
-          "type": "whereabouts",
-          "range": "{{ network[_ipv.network_vX] }}",
-          "range_start": "{{ network.tools.multus[_ipv.ipvX_ranges].0.start }}",
-          "range_end": "{{ network.tools.multus[_ipv.ipvX_ranges].0.end }}"
-        }
-      }
-{%  endif %}
 {% endfor %}
+
   dns-resolver:
     config:
       server:
@@ -157,15 +124,18 @@ data:
           - {{ nameserver }}
 {% endfor %}
 
+  routes:
+    config: []
+
 # Hardcoding the last IP bit since we don't have support for endpoint_annotations in the networking_mapper output
   rabbitmq:
     endpoint_annotations:
       metallb.universe.tf/address-pool: internalapi
-      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'][_ipv.network_vX] | ansible.utils.ipmath(85) }}
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'][_ipv.network_vX]  | ansible.utils.ipmath(85) }}
   rabbitmq-cell1:
     endpoint_annotations:
       metallb.universe.tf/address-pool: internalapi
-      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'][_ipv.network_vX] | ansible.utils.ipmath(86) }}
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'][_ipv.network_vX]  | ansible.utils.ipmath(86) }}
 
   lbServiceType: LoadBalancer
   storageClass: {{ cifmw_ci_gen_kustomize_values_storage_class }}

--- a/roles/ci_gen_kustomize_values/vars/main.yml
+++ b/roles/ci_gen_kustomize_values/vars/main.yml
@@ -59,3 +59,8 @@ cifmw_ci_gen_kustomize_values_ip_version_var_mapping:
       (cifmw_ci_gen_kustomize_values_primary_ip_version | int == 4)
       | ternary('ipv4_ranges', 'ipv6_ranges')
     }}
+  ipvX_routes: >-
+    {{
+      (cifmw_ci_gen_kustomize_values_primary_ip_version | int == 4)
+      | ternary('ipv4_routes', 'ipv6_routes')
+    }}


### PR DESCRIPTION
Allow configuring routes on multus network configuration. Initially used for octavia network attachment.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
