### PR TITLE
Set edpmRoleServiceName for nova-custom-ceph

### DIFF
--- a/roles/hci_prepare/templates/dpservice-nova-custom-ceph.yml.j2
+++ b/roles/hci_prepare/templates/dpservice-nova-custom-ceph.yml.j2
@@ -20,4 +20,5 @@ spec:
     networks:
     - ctlplane
     issuer: osp-rootca-issuer-internal
+    edpmRoleServiceName: nova
   caCerts: combined-ca-bundle

--- a/roles/hci_prepare/templates/dpservice-nova-custom-ceph.yml.j2
+++ b/roles/hci_prepare/templates/dpservice-nova-custom-ceph.yml.j2
@@ -22,3 +22,4 @@ spec:
     issuer: osp-rootca-issuer-internal
     edpmRoleServiceName: nova
   caCerts: combined-ca-bundle
+  edpmServiceType: nova


### PR DESCRIPTION
This is now required after
openstack-k8s-operators/edpm-ansible#658 has
merged.

Jira: [OSPRH-7257](https://issues.redhat.com//browse/OSPRH-7257)

Depends-On: https://github.com/openstack-k8s-operators/dataplane-operator/pull/896
Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/814

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
