### PR TITLE
Ensure we're targeting the right VMs

### DIFF
--- a/roles/libvirt_manager/tasks/manage_vms.yml
+++ b/roles/libvirt_manager/tasks/manage_vms.yml
@@ -105,12 +105,10 @@
 
 - name: Inject nodes in the ansible inventory
   delegate_to: localhost
-  vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
   ansible.builtin.add_host:
     name: "{{ vm_ip.nic.host }}"
     groups: "{{ (vm_type == 'crc') | ternary('ocp', vm_type) }}s"
-    ansible_host: "{{ extracted_ip }}"
+    ansible_host: "{{ vm_ip.nic.host }}.{{ inventory_hostname }}"
     ansible_ssh_user: "{{ _cifmw_libvirt_manager_layout.vms[vm_type].admin_user | default(_init_admin_user) }}"
   loop: "{{ vm_ips.results }}"
   loop_control:
@@ -137,7 +135,7 @@
   loop: "{{ vm_ips.results }}"
   loop_control:
     loop_var: vm_ip
-    label: "{{ extracted_ip }}"
+    label: "{{ vm_ip.nic.host }}"
 
 - name: "Configure ssh access on type {{ vm_type }}"
   when:
@@ -152,7 +150,7 @@
     cmd: >-
       set -o pipefail;
       cat ~/.ssh/authorized_keys |
-      ssh -v {{ _user }}@{{ vm_ip.nic.host }} "cat >> ~/.ssh/authorized_keys"
+      ssh -v {{ _user }}@{{ vm_ip.nic.host }}.{{ inventory_hostname }} "cat >> ~/.ssh/authorized_keys"
   retries: 5
   delay: 10
   register: _ssh_access
@@ -166,14 +164,14 @@
   when:
     - vm_type is not match('^(crc|ocp).*$')
     - _need_start | bool
-  delegate_to: "{{ vm_ip.nic.host }}"
+  delegate_to: "{{ vm_ip.nic.host }}.{{ inventory_hostname }}"
   remote_user: "{{ _init_admin_user }}"
   ansible.builtin.shell:
     executable: /bin/bash
     cmd: |-
       test -d /home/zuul && exit 0;
       set -xe -o pipefail;
-      echo "{{ vm_ip.nic.host }}" | sudo tee /etc/hostname;
+      echo "{{ vm_ip.nic.host }}.{{ inventory_hostname }}" | sudo tee /etc/hostname;
       sudo hostname -F /etc/hostname;
       sudo useradd -m -d /home/zuul zuul;
       echo "zuul ALL=(ALL)  NOPASSWD: ALL" | sudo tee /etc/sudoers.d/zuul;
@@ -189,7 +187,7 @@
   when:
     - vm_type is match('^controller.*$')
     - _need_start | bool
-  delegate_to: "{{ vm_ip.nic.host }}"
+  delegate_to: "{{ vm_ip.nic.host }}.{{ inventory_hostname }}"
   remote_user: "{{ _init_admin_user }}"
   ansible.builtin.copy:
     dest: "/home/zuul/.ssh/id_cifw"
@@ -206,7 +204,7 @@
   when:
     - vm_type is match('^controller.*$')
     - _need_start | bool
-  delegate_to: "{{ vm_ip.nic.host }}"
+  delegate_to: "{{ vm_ip.nic.host }}.{{ inventory_hostname }}"
   remote_user: "{{ _init_admin_user }}"
   ansible.builtin.copy:
     dest: "/home/zuul/.ssh/id_cifw.pub"
@@ -221,12 +219,10 @@
 
 - name: Update inventory to consume correct user
   delegate_to: localhost
-  vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
   ansible.builtin.add_host:
     name: "{{ vm_ip.nic.host }}"
     groups: "{{ (vm_type == 'crc') | ternary('ocp', vm_type) }}s"
-    ansible_host: "{{ extracted_ip }}"
+    ansible_host: "{{ vm_ip.nic.host }}.{{ inventory_hostname }}"
     ansible_ssh_user: "{{ _cifmw_libvirt_manager_layout.vms[vm_type].admin_user | default('zuul') }}"
   loop: "{{ vm_ips.results }}"
   loop_control:


### PR DESCRIPTION
If a user has multiple deployments, they therefore have mutliple blocks
in their `~/.ssh/config`.

While the ssh configuration allows to chose the right VM using the
hypervisor name (for instance controller-0.builder2), the dynamic
inventory built using `ansible.builtin.add_host` doesn't target the
specific host.

With `delegate_to`, it may happen ansible connects to a wrong VM from a
previous deployment that's still running, and the user will face some
really weird situations - for instance, facts being wrongs (this hit the
networking_mapper and the fetched MAC addresses).

With this patch, we now have specific host targeting, and we also get it
in the logs, for example:
```
changed: [builder2 -> controller-0(controller-0.builder2)]
```

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
