### PR TITLE
Use '::' for sushy emulator default listen address

### DIFF
--- a/roles/sushy_emulator/defaults/main.yml
+++ b/roles/sushy_emulator/defaults/main.yml
@@ -33,7 +33,7 @@ cifmw_sushy_emulator_libvirt_uri: >-
   {{- cifmw_sushy_emulator_hypervisor_target_connection_ip | default(hostvars[cifmw_sushy_emulator_hypervisor_target].ansible_host) -}}
   /system?no_tty=1
 cifmw_sushy_emulator_libvirt_user: zuul
-cifmw_sushy_emulator_listen_ip: 0.0.0.0
+cifmw_sushy_emulator_listen_ip: '::'
 cifmw_sushy_emulator_namespace: sushy-emulator
 cifmw_sushy_emulator_parameters_file: >-
   {{


### PR DESCRIPTION
Using `0.0.0.0` makes the sushy emulator only listen on IPv4. 
When we use `::` it will listen on all IPv4 and IPv6 addresses.

With `0.0.0.0` we get:
```
  tcp   LISTEN 0      128          0.0.0.0:8000      0.0.0.0:*    users:(("python",pid=20353,fd=4),("python",pid=20353,fd=3),("sushy-emulator",pid=20333,fd=3))
```

With `::` we get:
```
  tcp   LISTEN 0      128                *:8000            *:*    users:(("python",pid=21650,fd=4),("python",pid=21650,fd=3),("sushy-emulator",pid=21628,fd=3))
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
