### PR TITLE
Add additional listen-address to CRC dnsmasq service

### DIFF
--- a/ci/playbooks/multinode-customizations.yml
+++ b/ci/playbooks/multinode-customizations.yml
@@ -100,6 +100,16 @@
                 replace: >-
                   {{ _crc_default_net_ip | ansible.utils.ipaddr('address') }}
 
+            # Note(Lewis): Only needed for CRC => 2.32.0-4.14.8
+            - name: Configure dnsmasq listen-address to listen on both br-ex and ci-private-network
+              when:
+                - not _dnsmasq.stat.exists
+              become: true
+              ansible.builtin.lineinfile:
+                path: "{{ _dnsmasq_config }}"
+                insertafter: '^listen-address='
+                line: "listen-address={{ _crc_default_net_ip | ansible.utils.ipaddr('address') }}"
+
     - name: Restart dnsmasq service if used
       become: true
       when:
@@ -196,6 +206,11 @@
       ansible.builtin.set_fact:
         persistent_ssh_key: "{{ pub_key_slurp['content'] | b64decode }}"
 
+    - name: Load network parameters
+      register: _cifmw_multinode_customizations_crc_net_env_slurp
+      ansible.builtin.slurp:
+        src: "/etc/ci/env/networking-info.yml"
+
     - name: Check if cloud-init is overriding NM settings
       become: true
       ansible.builtin.stat:
@@ -223,13 +238,26 @@
       ansible.builtin.command:
         cmd: "nmcli -g general.connection device show eth0"
 
-    - name: Add the deployment DNS in the controller resolv.conf
+    - name: Prepend CRC DNS server in the controllers default Network Manager connection configuation
       vars:
-        dns_servers_string: "192.168.122.10 {{ ansible_facts['dns']['nameservers'][0:1] | join(' ') }}"
+        _decoded_net_env: >-
+          {{
+            _cifmw_multinode_customizations_crc_net_env_slurp['content'] |
+            b64decode | from_yaml
+          }}
+        _crc_default_net_ip: >-
+          {{
+            _decoded_net_env.crc_ci_bootstrap_networks_out.crc.default.ip |
+            ansible.utils.ipaddr('address')
+          }}
+        dns_servers_string: >-
+          {{
+           ( _crc_default_net_ip, ansible_facts['dns']['nameservers'][0:1] | join(' ') ) | list
+          }}
       become: true
       ansible.builtin.shell:
         cmd: |-
-          nmcli con mod '{{ controller_default_connection_out.stdout | trim }}' ipv4.dns '{{ dns_servers_string }}' ipv4.route-metric 100;
+          nmcli con mod '{{ controller_default_connection_out.stdout | trim }}' ipv4.dns '{{ dns_servers_string | join(' ') }}' ipv4.route-metric 100;
           nmcli con up '{{ controller_default_connection_out.stdout | trim }}';
 
 - name: "Ensure persistent SSH access"


### PR DESCRIPTION
Due to this change [1] introduced in CRC 2.32.0[2] the dnsmasq service is now running as a systemd service rather than in a container.

The behavior of the dnsmasq listen-address has now changed, the CRC dnsmasq only listens on the default address provided by Zuul. The Ansible controller is configured to query the interface we control on CRC, `ci-private-network`.

This breaks domain name resolution as dns queries are blocked.

This patch:
- Updates the CRC dnsmasq listen-address configuration to include the `ci-private-network` address allowing the Ansible controller to query it.

- Removes the hard coded `ci-private-network` address from the Ansible controllers default connection dns configuration to ensure they always match.

[1] https://github.com/crc-org/crc/commit/5f49891dc43b104e303fe49583068a40bd55825a
[2] https://github.com/crc-org/crc/releases/tag/v2.32.0

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running