### PR TITLE
nit: Ensure we focus on CI job rerun

### DIFF
--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -260,6 +260,7 @@
     - name: Prepare VA deployment
       when:
         - cifmw_architecture_scenario is defined
+        - cifmw_job_uri is undefined
       tags:
         - deploy_architecture
       ansible.builtin.include_tasks:
@@ -269,6 +270,8 @@
             - deploy_architecture
 
     - name: Prepare ci-like EDPM deploy
+      when:
+        - cifmw_job_uri is undefined
       delegate_to: controller-0
       vars:
         run_directory: "src/github.com/openstack-k8s-operators/ci-framework"


### PR DESCRIPTION
Until now, re-running a Zuul job using the reproducer lead to a "final"
error due to missing data for script generation.

This patch ensures we only get the CI job rerun related content,
avoiding that kind of issues.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
