### PR TITLE
[DNM] Save ssh_config so it can be reused later

### DIFF
--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -286,3 +286,8 @@
         mode: "0755"
         owner: "zuul"
         group: "zuul"
+
+    - name: Save ssh config on the hypervisor
+      copy:
+        src: ~/.ssh/config
+        dest: "{{ cifmw_reproducer_controller_basedir }}/reproducer-inventory/ssh_config"


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
