### PR TITLE
sushy-emulator - use listening addr in _sushy_url

### DIFF
--- a/roles/sushy_emulator/tasks/create_container.yml
+++ b/roles/sushy_emulator/tasks/create_container.yml
@@ -41,9 +41,13 @@
       - "{{ cifmw_sushy_emulator_sshkey_path }}:/root/.ssh/id_rsa:ro,Z"
       - "{{ cifmw_sushy_emulator_sshkey_path }}.pub:/root/.ssh/id_rsa.pub:ro,Z"
 
-# We only support deploying Sushy Emulator Podman container on controller-0
 - name: Set Sushy Emulator URL for Podman installation
   vars:
-    _ip_address: "{{ hostvars['controller-0']['ansible_host'] }}"
+    _ip_address: >-
+      {%- if cifmw_sushy_emulator_listen_ip in ['::', '0.0.0.0'] -%}
+      {{ hostvars['controller-0']['ansible_host'] }}
+      {%- else -%}
+      {{ cifmw_sushy_emulator_listen_ip }}
+      {%- endif -%}
   ansible.builtin.set_fact:
-    _sushy_url: "http://{{ _ip_address }}:8000"
+    _sushy_url: "http://{{ _ip_address | ansible.utils.ipwrap }}:8000"


### PR DESCRIPTION
If listining address is set to something other than `::` or `0.0.0.0`, then use the listening address as _ip_address in the _sushy_url fact.

Also use ansible.utils.ipwrap to ensure address is wrapped in brackets when needed.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
