### PR TITLE
[devscripts] Configure cinder-volumes vg only for specific disks

### DIFF
--- a/roles/devscripts/README.md
+++ b/roles/devscripts/README.md
@@ -49,6 +49,9 @@ networks.
 * `cifmw_devscripts_external_net` (dict) Key/value pair containing information
   about the network infrastructure.
   Refer [section](#supported-keys-in-cifmw_devscripts_external_net).
+* `cifmw_devscripts_cinder_volume_pvs` (list) a list of physical disks to be
+  used for creating cinder-volumes volume-group. By default, the list contains
+  `/dev/vda`.
 
 ### Secrets management
 

--- a/roles/devscripts/defaults/main.yml
+++ b/roles/devscripts/defaults/main.yml
@@ -59,10 +59,13 @@ cifmw_devscripts_dry_run: false
 cifmw_devscripts_enable_ocp_nodes_host_routing: false
 cifmw_devscripts_enable_iscsi_on_ocp_nodes: false
 cifmw_devscripts_enable_multipath_on_ocp_nodes: false
-cifmw_devscripts_create_logical_volume: false
 cifmw_devscripts_remove_libvirt_net_default: false
 cifmw_devscripts_use_static_ip_addr: false
 
 cifmw_devscripts_user: "{{ ansible_user_id }}"
+
+cifmw_devscripts_create_logical_volume: false
+cifmw_devscripts_cinder_volume_pvs:
+  - /dev/vda
 
 cifmw_devscripts_config_overrides: {}

--- a/roles/devscripts/files/lv-cinder-volumes.sh
+++ b/roles/devscripts/files/lv-cinder-volumes.sh
@@ -1,15 +1,15 @@
 #! /usr/bin/bash
 set -euo pipefail
 
+_disks=${OSP_CINDER_VOL_DISKS:-''}
+
 if [[ $(vgdisplay cinder-volumes) ]]; then
     echo "cinder-volumes vg exists."
     exit 0
 fi
 
-disks=$(lsblk -o NAME,TYPE | awk '{ if ($2 == "disk" && $1 != "sda") print "/dev/"$1}')
 disk_str=''
-
-for disk in ${disks}; do
+for disk in ${_disks}; do
     pvcreate ${disk}
     disk_str="${disk_str} ${disk}"
 done

--- a/roles/devscripts/tasks/137_custom_install.yml
+++ b/roles/devscripts/tasks/137_custom_install.yml
@@ -82,6 +82,7 @@
 - name: Add cinder-volumes lv customization
   when:
     - cifmw_devscripts_create_logical_volume | bool
+    - cifmw_devscripts_cinder_volume_pvs | default([]) | length | int > 0
     - cifmw_devscripts_config.vm_extradisks | default(false) | bool
     - cifmw_devscripts_config.vm_extradisks_list is defined
   vars:
@@ -90,10 +91,7 @@
         lookup('ansible.builtin.file', 'files/lv-cinder-volumes.sh') |
         ansible.builtin.b64encode
       }}
-    _disk_names: >-
-      {{
-        cifmw_devscripts_config.vm_extradisks_list | split
-      }}
+    _vol_pvs: "{{ cifmw_devscripts_cinder_volume_pvs | join(' ') }}"
   ansible.builtin.template:
     src: templates/lv.j2
     dest: >-

--- a/roles/devscripts/templates/lv.j2
+++ b/roles/devscripts/templates/lv.j2
@@ -12,8 +12,8 @@ spec:
       version: 3.2.0
     storage:
       disks:
-{% for _disk in _disk_names %}
-        - device: "/dev/{{ _disk }}"
+{% for _disk in cifmw_devscripts_cinder_volume_pvs %}
+        - device: "{{ _disk }}"
           wipeTable: true
 {% endfor %}
       files:
@@ -37,6 +37,7 @@ spec:
 
             [Service]
             Type=oneshot
+            Environment=OSP_CINDER_VOL_DISKS="{{ _vol_pvs }}"
             ExecStart=/usr/local/bin/lv-cinder-volumes.sh
             RemainAfterExit=yes
 


### PR DESCRIPTION
This patch changes the current behavior of picking all extra disks attached to OCP nodes for creating the cinder-volumes volume group.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

Fixes: [OSPRH-7225](https://issues.redhat.com//browse/OSPRH-7225)

_Logs_

Snippet of cluster ready
```
2024-05-30 06:51:54 level=info msg=To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/home/zuul/src/github.com/openshift-metal3/dev-scripts/ocp/ocp/auth/kubeconfig'
2024-05-30 06:51:54 level=info msg=Access the OpenShift web-console here: https://console-openshift-console.apps.ocp.openstack.lab
2024-05-30 06:51:54 level=debug msg=Time elapsed per stage:
2024-05-30 06:51:54 level=debug msg=                  bootstrap: 13s
2024-05-30 06:51:54 level=debug msg=                    masters: 12m8s
2024-05-30 06:51:54 level=debug msg=         Bootstrap Complete: 19m25s
2024-05-30 06:51:54 level=debug msg=                        API: 1s
2024-05-30 06:51:54 level=debug msg=          Bootstrap Destroy: 9s
2024-05-30 06:51:54 level=debug msg=Cluster Operators Available: 11m42s
2024-05-30 06:51:54 level=debug msg=   Cluster Operators Stable: 3m42s
2024-05-30 06:51:54 level=info msg=Time elapsed: 47m57s
```

OSO Deployment status
```
[zuul@controller-0 ~]$ oc get osdpns
NAME              STATUS   MESSAGE
networker-nodes   True     NodeSet Ready
openstack-edpm    True     NodeSet Ready
[zuul@controller-0 ~]$ oc get osdpd
NAME               NODESETS              STATUS   MESSAGE
edpm-deployment    ["openstack-edpm"]    True     Setup complete
networker-deploy   ["networker-nodes"]   True     Setup complete
[zuul@controller-0 ~]$ oc get osctlplane
NAME           STATUS   MESSAGE
controlplane   True     Setup complete
[zuul@controller-0 ~]$
```
