### PR TITLE
nit: Ensure sushy is installed after base packages

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -116,34 +116,6 @@
         dest: "{{ _ctl_reproducer_basedir }}/parameters/interfaces-info.yml"
         content: "{{ cifmw_libvirt_manager_mac_map | to_nice_yaml }}"
 
-    # Deploy Sushy Emulator on the Ansible controller,
-    - name: Deploy Sushy Emulator service container
-      tags:
-        - bootstrap
-        - bootstrap_layout
-      when: cifmw_use_sushy_emulator | default(true) | bool
-      block:
-        - name: Deploy Sushy Emulator
-          vars:
-            cifmw_sushy_emulator_hypervisor_target: "{{ cifmw_target_host | default('localhost') }}"
-            cifmw_sushy_emulator_install_type: podman
-            cifmw_sushy_emulator_hypervisor_target_connection_ip: "{{ network_bridge_info['cifmw-public'] }}"
-          ansible.builtin.include_role:
-            name: sushy_emulator
-
-        - name: Let the project know we have Sushy Emulator available
-          ansible.builtin.set_fact:
-            _sushy_emulator_available: true
-
-    - name: Generate baremetal-info fact
-      ansible.builtin.import_tasks: generate_bm_info.yml
-
-    - name: Verify connection to baremetal VMs via Sushy Emulator
-      when: _sushy_emulator_available
-      ansible.builtin.include_role:
-        name: sushy_emulator
-        tasks_from: verify.yml
-
     - name: Inject other Hypervisor SSH keys
       when:
         - hostvars[host]['priv_ssh_key'] is defined
@@ -325,6 +297,34 @@
           until: _async_status.finished
           retries: 100
           delay: 5
+
+    # Deploy Sushy Emulator on the Ansible controller,
+    - name: Deploy Sushy Emulator service container
+      tags:
+        - bootstrap
+        - bootstrap_layout
+      when: cifmw_use_sushy_emulator | default(true) | bool
+      block:
+        - name: Deploy Sushy Emulator
+          vars:
+            cifmw_sushy_emulator_hypervisor_target: "{{ cifmw_target_host | default('localhost') }}"
+            cifmw_sushy_emulator_install_type: podman
+            cifmw_sushy_emulator_hypervisor_target_connection_ip: "{{ network_bridge_info['cifmw-public'] }}"
+          ansible.builtin.include_role:
+            name: sushy_emulator
+
+        - name: Let the project know we have Sushy Emulator available
+          ansible.builtin.set_fact:
+            _sushy_emulator_available: true
+
+    - name: Generate baremetal-info fact
+      ansible.builtin.import_tasks: generate_bm_info.yml
+
+    - name: Verify connection to baremetal VMs via Sushy Emulator
+      when: _sushy_emulator_available
+      ansible.builtin.include_role:
+        name: sushy_emulator
+        tasks_from: verify.yml
 
     - name: Install ansible dependencies
       ansible.builtin.pip:


### PR DESCRIPTION
Base packages are installed using `async` to allow generating most of
not all the relevant content instead of waiting.

This leads to a race condition, where sushy_emulator role wants to
install dependency packages and fails, because the RPM database is still
locked with the dependency async run.

This patch moves the sushy bootstrap and installation to a later step,
ensuring we're not coliding with the async task.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
