### PR TITLE
Remove default_style="\"" from to_nice_yaml

### DIFF
--- a/roles/config_drive/templates/meta-data.j2
+++ b/roles/config_drive/templates/meta-data.j2
@@ -1,3 +1,3 @@
 ---
 instance-id: {{ cifmw_config_drive_uuid }}
-hostname: {{ cifmw_config_drive_hostname }}
+local-hostname: {{ cifmw_config_drive_hostname }}

--- a/roles/config_drive/templates/user-data.j2
+++ b/roles/config_drive/templates/user-data.j2
@@ -1,4 +1,4 @@
 #cloud-config
 {% if cifmw_config_drive_userdata is defined and cifmw_config_drive_userdata is not none -%}
-{{ cifmw_config_drive_userdata | to_nice_yaml(indent=2, default_style="\"") }}
+{{ cifmw_config_drive_userdata | to_nice_yaml(indent=2) }}
 {% endif %}


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
