### PR TITLE
[DNM] Switch to best effort strategy

### DIFF
--- a/roles/ci_nmstate/molecule/default/converge.yml
+++ b/roles/ci_nmstate/molecule/default/converge.yml
@@ -92,6 +92,7 @@
                   ip: "{{ hostvars.crc.ansible_default_ipv4.address }}"
                 testing:
                   ip: "172.17.0.5"
+                  trunk-parent: crc-net
             instance:
               networks:
                 default:
@@ -99,11 +100,10 @@
         cifmw_networking_mapper_ifaces_info:
           crc:
             - mac: "{{ hostvars.crc.ansible_default_ipv4.macaddress }}"
-              network: "testing-net"
+              network: "crc-net"
           instance:
             - mac: "{{ ansible_default_ipv4.macaddress }}"
-              network: "testing-net"
-        cifmw_networking_mapper_network_name: "testing-net"
+              network: "default"
       ansible.builtin.include_role:
         name: "networking_mapper"
 

--- a/roles/networking_mapper/README.md
+++ b/roles/networking_mapper/README.md
@@ -5,11 +5,10 @@ networking details of a given environment.
 
 
 ## Parameters
-* `cifmw_networking_definition`: The Networking Definition as a dictionary.
-* `cifmw_networking_mapper_ifaces_info`: The interface information dictionary that holds low-level info for full maps.
-* `cifmw_networking_mapper_network_name`: The network name to filter `cifmw_networking_mapper_ifaces_info` interfaces.
-* `cifmw_networking_mapper_assert_env_load`: Ensures that calling the Networking Environment Definition ends with a valid one loaded. Defaults to `true`.
-
+* `cifmw_networking_definition`: (Dict) The Networking Definition as a dictionary.
+* `cifmw_networking_mapper_ifaces_info`: (Dict) The interface information dictionary that holds low-level info for full maps.
+* `cifmw_networking_mapper_assert_env_load`:(Boolean) Ensures that calling the Networking Environment Definition ends with a valid one loaded. Defaults to `true`.
+* `cifmw_networking_mapper_interfaces_info_translations`: (Dict) Optional dictionary of lists that allows `cifmw_networking_mapper_ifaces_info` use different network names than the Networking Definition networks.
 
 ## Networking Definition patching
 This role allows to use a base Networking Definition, given by `cifmw_networking_definition` and patch it
@@ -32,9 +31,8 @@ The content of the `cifmw_networking_definition` will reflect those patches.
     to create the entire output with all the details for all the involved networks and instances based on the input
     Networking Definition and the Interfaces Information dict, that contains all the details to wire up instances
     interfaces to networks.
-- Interfaces Information: An input to the mapper that enables full maps by providing the mac address of each instance
-  interface for each infrastructure network. The mapper will filter the interface list of each instance based
-  on the `cifmw_networking_mapper_network_name`parameter.
+- Interfaces Information: An input to the mapper, required for full maps, that enables that allows matching interfaces
+    and mac addresses for all the instances.
 
 ## Examples
 ```
@@ -168,7 +166,6 @@ The content of the `cifmw_networking_definition` will reflect those patches.
           network: test-network
         - mac: aa:45:3e:f9:00:c0
           network: test-network-2
-    cifmw_networking_mapper_network_name: "test-network"
   ansible.builtin.include_role:
     name: networking_mapper
 ```

--- a/roles/networking_mapper/defaults/main.yml
+++ b/roles/networking_mapper/defaults/main.yml
@@ -30,3 +30,7 @@ cifmw_networking_mapper_networking_env_def_path: >-
   }}
 cifmw_networking_mapper_ifaces_info_path: "{{ cifmw_networking_mapper_basedir }}/parameters/interfaces-info.yml"
 cifmw_networking_mapper_assert_env_load: true
+cifmw_networking_mapper_interfaces_info_translations:
+  osp_trunk:
+    - controlplane
+    - ctlplane

--- a/roles/networking_mapper/molecule/default/converge.yml
+++ b/roles/networking_mapper/molecule/default/converge.yml
@@ -141,7 +141,6 @@
       vars:
         cifmw_networking_definition: "{{ _testing_net_def }}"
         cifmw_networking_mapper_ifaces_info: "{{ _interfaces_info_content }}"
-        cifmw_networking_mapper_network_name: "{{ _ifaces_info_net }}"
       ansible.builtin.include_role:
         name: networking_mapper
 

--- a/roles/networking_mapper/tasks/main.yml
+++ b/roles/networking_mapper/tasks/main.yml
@@ -93,6 +93,12 @@
       }}
   block:
     - name: Gather the facts
+      vars:
+        _instance_vars: >-
+          {{
+            hostvars[item] | default({})
+          }}
+      when: "'ansible_host' in _instance_vars"
       ansible.builtin.setup:
         gather_subset:
           - network
@@ -101,7 +107,7 @@
       delegate_facts: true
       loop: "{{ _networking_mapper_instance_names }}"
 
-    - name: Save instaces refreshed facts for troubleshooting purposes
+    - name: Save instances refreshed facts for troubleshooting purposes
       ansible.builtin.copy:
         dest: >-
           {{
@@ -133,10 +139,12 @@
         cifmw_networking_mapper_search_domain_base |
         default(omit)
       }}
-    network_name: >-
+    interfaces_info_translations: >-
       {{
-        cifmw_networking_mapper_network_name | default(omit)
+        cifmw_networking_mapper_interfaces_info_translations |
+        default(omit)
       }}
+    full_map: "{{ cifmw_networking_mapper_full_map |  default(omit) }}"
   register: _networking_mapper_out
 
 - name: Set networking mapper facts

--- a/scenarios/reproducers/networking-definition.yml
+++ b/scenarios/reproducers/networking-definition.yml
@@ -100,31 +100,33 @@ cifmw_networking_definition:
           length: 10
       networks:
         ctlplane: {}
-        internalapi: {}
-        tenant: {}
-        storage: {}
+        internalapi:
+          trunk-parent: ctlplane
+        tenant:
+          trunk-parent: ctlplane
+        storage:
+          trunk-parent: ctlplane
     computes:
       network-template:
         range:
           start: 100
           length: 21
-      networks:
+      networks: &computes_nets
         ctlplane: {}
-        internalapi: {}
-        tenant: {}
-        storage: {}
-        storagemgmt: {}
+        internalapi:
+          trunk-parent: ctlplane
+        tenant:
+          trunk-parent: ctlplane
+        storage:
+          trunk-parent: ctlplane
+        storagemgmt:
+          trunk-parent: ctlplane
     cephs:
       network-template:
         range:
           start: 150
           length: 21
-      networks:
-        ctlplane: {}
-        internalapi: {}
-        tenant: {}
-        storage: {}
-        storagemgmt: {}
+      networks: *computes_nets
   instances:
     controller-0:
       networks:

--- a/tests/unit/module_utils/net_map/test_networking_definitions_all.py
+++ b/tests/unit/module_utils/net_map/test_networking_definitions_all.py
@@ -244,14 +244,14 @@ def test_networking_definition_load_networking_definition_all_tools_ipv6_only_ok
     )
     test_net_1 = networking_definition.NetworkingDefinition(raw_definition_1)
     assert test_net_1
-    assert len(test_net_1.networks) == 3
+    assert len(test_net_1.networks) == 4
     assert len(test_net_1.group_templates) == 3
     assert len(test_net_1.instances) == 1
 
     # Check that the expected networks are in
     assert all(
         net_name in test_net_1.networks
-        for net_name in ("network-1", "network-2", "network-3")
+        for net_name in ("network-1", "network-2", "network-3", "network-4")
     )
     assert "group-1" in test_net_1.group_templates
     assert "instance-1" in test_net_1.instances
@@ -307,6 +307,18 @@ def test_networking_definition_load_networking_definition_all_tools_ipv6_only_ok
     assert len(net3_def.netconfig_config.ranges_ipv6) == 1
     assert len(net3_def.metallb_config.ranges_ipv6) == 1
 
+    # Simple basic checks of network-4
+    net4_def = test_net_1.networks["network-4"]
+    net4_ip_netv6 = ipaddress.ip_network("fd98:6d1a:86e7:d5e5::/64")
+    assert net4_def.name == "network-4"
+    assert net4_def.ipv6_network == net4_ip_netv6
+    assert not net4_def.ipv4_network
+    assert not net4_def.mtu
+    assert net4_def.vlan == 22
+    assert not net4_def.metallb_config
+    assert not net4_def.netconfig_config
+    assert not net4_def.multus_config
+
     # Simple basic checks of the group templates
     group1_def = test_net_1.group_templates["group-1"]
     assert group1_def.group_name == "group-1"
@@ -324,9 +336,12 @@ def test_networking_definition_load_networking_definition_all_tools_ipv6_only_ok
     assert not group1_net2_def.ipv4_range
 
     group3_def = test_net_1.group_templates["group-3"]
-    group1_net3_def = group3_def.networks["network-3"]
-    assert group1_net3_def.ipv6_range
-    assert not group1_net3_def.ipv4_range
+    group3_net3_def = group3_def.networks["network-3"]
+    group3_net4_def = group3_def.networks["network-3"]
+    assert group3_net3_def.ipv6_range
+    assert not group3_net3_def.ipv4_range
+    assert group3_net4_def.ipv6_range
+    assert not group3_net4_def.ipv4_range
 
     # Simple basic checks of the explicit instance
     instance1_def = test_net_1.instances["instance-1"]

--- a/tests/unit/module_utils/net_map/test_networking_definitions_group_template.py
+++ b/tests/unit/module_utils/net_map/test_networking_definitions_group_template.py
@@ -292,8 +292,8 @@ def test_group_template_definition_parse_trunk_parent_ok():
     net_b = list(networks_definitions.values())[1]
     group_template_definition_raw = {
         "networks": {
-            net_a.name: {"trunk_parent": net_b.name},
-            net_b.name: {"is_trunk_parent": True},
+            net_a.name: {"trunk-parent": net_b.name},
+            net_b.name: {"is-trunk-parent": True},
         },
     }
 
@@ -311,8 +311,11 @@ def test_group_template_definition_parse_trunk_parent_ok():
     # Ensure nets were parsed
     assert net_a.name in group_template_def.networks
     assert net_b.name in group_template_def.networks
-    assert group_template_def.networks[net_a.name].trunk_parent == net_b.name
-    assert group_template_def.networks[net_b.name].is_trunk_parent is True
+    trunk_parent = group_template_def.networks[net_a.name].trunk_parent
+    assert isinstance(
+        trunk_parent, networking_definition.GroupTemplateNetworkDefinition
+    )
+    assert trunk_parent.network.name == net_b.name
 
 
 def test_group_template_definition_parse_trunk_parent_fail():
@@ -322,8 +325,8 @@ def test_group_template_definition_parse_trunk_parent_fail():
     net_b = list(networks_definitions.values())[1]
     group_template_definition_raw = {
         "networks": {
-            net_a.name: {"is_trunk_parent": True},
-            net_b.name: {"trunk_parent": "does-not-exist-parent"},
+            net_a.name: {"is-trunk-parent": True},
+            net_b.name: {"trunk-parent": "does-not-exist-parent"},
         },
     }
 
@@ -345,7 +348,7 @@ def test_group_template_definition_parse_no_trunk_parent_fail():
     group_template_definition_raw = {
         "networks": {
             net_a.name: {},
-            net_b.name: {"trunk_parent": "does-not-exist-parent"},
+            net_b.name: {"trunk-parent": "does-not-exist-parent"},
         },
     }
 
@@ -386,4 +389,3 @@ def test_group_template_definition_parse_trunk_parent_no_trunks_ok():
     assert net_a.name in group_template_def.networks
     assert net_b.name in group_template_def.networks
     assert group_template_def.networks[net_a.name].trunk_parent is None
-    assert group_template_def.networks[net_b.name].is_trunk_parent is None

--- a/tests/unit/module_utils/net_map/test_networking_definitions_instance.py
+++ b/tests/unit/module_utils/net_map/test_networking_definitions_instance.py
@@ -306,8 +306,8 @@ def test_instance_definition_parse_trunk_parent_ok():
     net_b = list(networks_definitions.values())[1]
     instance_definition_raw = {
         "networks": {
-            net_a.name: {"trunk_parent": net_b.name},
-            net_b.name: {"is_trunk_parent": True},
+            net_a.name: {"trunk-parent": net_b.name},
+            net_b.name: {"is-trunk-parent": True},
         },
     }
 
@@ -323,8 +323,9 @@ def test_instance_definition_parse_trunk_parent_ok():
     # Ensure nets were parsed
     assert net_a.name in instance_def.networks
     assert net_b.name in instance_def.networks
-    assert instance_def.networks[net_a.name].trunk_parent == net_b.name
-    assert instance_def.networks[net_b.name].is_trunk_parent is True
+    trunk_parent = instance_def.networks[net_a.name].trunk_parent
+    assert isinstance(trunk_parent, networking_definition.InstanceNetworkDefinition)
+    assert trunk_parent.network.name == net_b.name
 
 
 def test_instance_definition_parse_trunk_parent_fail():
@@ -334,8 +335,8 @@ def test_instance_definition_parse_trunk_parent_fail():
     net_b = list(networks_definitions.values())[1]
     instance_definition_raw = {
         "networks": {
-            net_a.name: {"is_trunk_parent": True},
-            net_b.name: {"trunk_parent": "does-not-exist-parent"},
+            net_a.name: {"is-trunk-parent": True},
+            net_b.name: {"trunk-parent": "does-not-exist-parent"},
         },
     }
 
@@ -357,7 +358,7 @@ def test_instance_definition_parse_no_trunk_parent_fail():
     instance_definition_raw = {
         "networks": {
             net_a.name: {},
-            net_b.name: {"trunk_parent": "does-not-exist-parent"},
+            net_b.name: {"trunk-parent": "does-not-exist-parent"},
         },
     }
 
@@ -396,4 +397,3 @@ def test_instance_definition_parse_trunk_parent_no_trunks():
     assert net_a.name in instance_def.networks
     assert net_b.name in instance_def.networks
     assert instance_def.networks[net_a.name].trunk_parent is None
-    assert instance_def.networks[net_b.name].is_trunk_parent is None

--- a/tests/unit/module_utils/net_map/test_networking_mapper.py
+++ b/tests/unit/module_utils/net_map/test_networking_mapper.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import copy
+import json
+import os.path
 
 import pytest
 from ansible_collections.cifmw.general.plugins.module_utils.net_map import (
@@ -131,7 +133,7 @@ def test_networking_mapper_full_partial_map_ok(
             else net_map_stub_data.TEST_GROUPS_REDUCED
         ),
     )
-    mapped_content = mapper.map_partial(
+    mapped_content = mapper.map(
         net_map_stub_data.get_test_file_yaml_content(test_input_config_file)
     )
     assert mapped_content == net_map_stub_data.get_test_file_json_content(
@@ -140,37 +142,94 @@ def test_networking_mapper_full_partial_map_ok(
 
 
 @pytest.mark.parametrize(
-    "test_input_config_file,test_golden_file",
+    "test_input_config_file,test_golden_file,test_interfaces_info",
     [
         (
             "networking-definition-valid-all-tools-dual-stack.yml",
             "networking-definition-valid-all-tools-dual-stack-full-map-out.json",
+            None,
         ),
         (
             "networking-definition-valid.yml",
             "networking-definition-valid-full-map-out.json",
+            None,
         ),
         (
             "networking-definition-valid-all-tools-ipv6-only.yml",
             "networking-definition-valid-all-tools-ipv6-only-full-map-out.json",
+            net_map_stub_data.patch_interfaces_info_dicts(
+                net_map_stub_data.TEST_IFACES_INFO,
+                {
+                    net_map_stub_data.INSTANCE_1_NAME: [
+                        {
+                            net_map_stub_data.TEST_IFACES_INFO_MAC_FIELD: net_map_stub_data.INSTANCE_1_ALTERNATE_MACADDR,
+                            net_map_stub_data.TEST_IFACES_INFO_NETWORK_FIELD: "network-4",
+                        },
+                    ],
+                    net_map_stub_data.INSTANCE_2_NAME: [
+                        {
+                            net_map_stub_data.TEST_IFACES_INFO_MAC_FIELD: net_map_stub_data.INSTANCE_2_ALTERNATE_MACADDR,
+                            net_map_stub_data.TEST_IFACES_INFO_NETWORK_FIELD: "network-4",
+                        },
+                    ],
+                    net_map_stub_data.INSTANCE_3_NAME: [
+                        {
+                            net_map_stub_data.TEST_IFACES_INFO_MAC_FIELD: net_map_stub_data.INSTANCE_3_ALTERNATE_MACADDR,
+                            net_map_stub_data.TEST_IFACES_INFO_NETWORK_FIELD: "network-4",
+                        },
+                    ],
+                },
+            ),
         ),
         (
             "networking-definition-valid-all-tools.yml",
             "networking-definition-valid-all-tools-full-map-out.json",
+            net_map_stub_data.patch_interfaces_info_dicts(
+                net_map_stub_data.TEST_IFACES_INFO,
+                {
+                    net_map_stub_data.INSTANCE_1_NAME: [
+                        {
+                            net_map_stub_data.TEST_IFACES_INFO_MAC_FIELD: net_map_stub_data.INSTANCE_1_ALTERNATE_MACADDR,
+                            net_map_stub_data.TEST_IFACES_INFO_NETWORK_FIELD: "tenant",
+                        },
+                    ],
+                    net_map_stub_data.INSTANCE_2_NAME: [
+                        {
+                            net_map_stub_data.TEST_IFACES_INFO_MAC_FIELD: net_map_stub_data.INSTANCE_2_ALTERNATE_MACADDR,
+                            net_map_stub_data.TEST_IFACES_INFO_NETWORK_FIELD: "tenant",
+                        },
+                    ],
+                    net_map_stub_data.INSTANCE_3_NAME: [
+                        {
+                            net_map_stub_data.TEST_IFACES_INFO_MAC_FIELD: net_map_stub_data.INSTANCE_3_ALTERNATE_MACADDR,
+                            net_map_stub_data.TEST_IFACES_INFO_NETWORK_FIELD: "tenant",
+                        },
+                    ],
+                },
+            ),
         ),
         (
             "network-definition-valid-all-tools-no-group-templates.yml",
             "network-definition-valid-all-tools-no-group-templates-out.json",
+            None,
         ),
     ],
 )
-def test_networking_mapper_full_map_ok(test_input_config_file, test_golden_file):
+def test_networking_mapper_full_map_ok(
+    test_input_config_file, test_golden_file, test_interfaces_info
+):
     mapper = networking_mapper.NetworkingDefinitionMapper(
-        net_map_stub_data.TEST_HOSTVARS, net_map_stub_data.TEST_GROUPS
+        net_map_stub_data.TEST_HOSTVARS,
+        net_map_stub_data.TEST_GROUPS,
+        options=networking_mapper.NetworkingMapperOptions(
+            interfaces_info_translations={
+                net_map_stub_data.NETWORK_1_NAME: ["ctlplane"]
+            }
+        ),
     )
-    mapped_content = mapper.map_complete(
+    mapped_content = mapper.map(
         net_map_stub_data.get_test_file_yaml_content(test_input_config_file),
-        net_map_stub_data.TEST_IFACES_INFO,
+        test_interfaces_info or net_map_stub_data.TEST_IFACES_INFO,
     )
     assert mapped_content == net_map_stub_data.get_test_file_json_content(
         test_golden_file
@@ -187,7 +246,7 @@ def test_networking_mapper_full_map_invalid_facts_fail():
         mapper = networking_mapper.NetworkingDefinitionMapper(
             test_hostvars, net_map_stub_data.TEST_GROUPS
         )
-        mapper.map_complete(
+        mapper.map(
             net_map_stub_data.get_test_file_yaml_content(
                 "networking-definition-valid-all-tools-dual-stack.yml"
             ),
@@ -195,90 +254,107 @@ def test_networking_mapper_full_map_invalid_facts_fail():
         )
     assert "ansible_eth0" in str(exc_info.value)
 
-    # Ensure that ansible_interfaces exists
-    with pytest.raises(exceptions.NetworkMappingError) as exc_info:
-        test_hostvars = copy.deepcopy(net_map_stub_data.TEST_HOSTVARS)
-        test_hostvars[net_map_stub_data.INSTANCE_2_NAME].pop(
-            net_map_stub_data.ANSIBLE_HOSTVARS_INTERFACES
-        )
-        mapper = networking_mapper.NetworkingDefinitionMapper(
-            test_hostvars, net_map_stub_data.TEST_GROUPS
-        )
-        mapper.map_complete(
-            net_map_stub_data.get_test_file_yaml_content(
-                "networking-definition-valid-all-tools-dual-stack.yml"
-            ),
-            net_map_stub_data.TEST_IFACES_INFO,
-        )
-    assert "ansible_interfaces" in str(exc_info.value)
 
-    # Ensure that ansible_hostname exists
-    with pytest.raises(exceptions.NetworkMappingError) as exc_info:
-        test_hostvars = copy.deepcopy(net_map_stub_data.TEST_HOSTVARS)
-        test_hostvars[net_map_stub_data.INSTANCE_1_NAME].pop(
-            net_map_stub_data.ANSIBLE_HOSTVARS_HOSTNAME
-        )
-        mapper = networking_mapper.NetworkingDefinitionMapper(
-            test_hostvars, net_map_stub_data.TEST_GROUPS
-        )
-        mapper.map_complete(
-            net_map_stub_data.get_test_file_yaml_content(
-                "networking-definition-valid-all-tools-dual-stack.yml"
-            ),
-            net_map_stub_data.TEST_IFACES_INFO,
-        )
-    assert "ansible_hostname" in str(exc_info.value)
+def test_networking_mapper_full_map_missing_ansible_interfaces_ok():
+    test_hostvars = copy.deepcopy(net_map_stub_data.TEST_HOSTVARS)
+    test_hostvars[net_map_stub_data.INSTANCE_2_NAME].pop(
+        net_map_stub_data.ANSIBLE_HOSTVARS_INTERFACES
+    )
+    mapper = networking_mapper.NetworkingDefinitionMapper(
+        test_hostvars, net_map_stub_data.TEST_GROUPS
+    )
+    network_env = mapper.map(
+        net_map_stub_data.get_test_file_yaml_content(
+            "networking-definition-valid-all-tools-dual-stack.yml"
+        ),
+        net_map_stub_data.TEST_IFACES_INFO,
+    )
+    assert net_map_stub_data.INSTANCE_2_NAME in network_env["instances"]
+    instance_2_nets = network_env["instances"][net_map_stub_data.INSTANCE_2_NAME][
+        "networks"
+    ]
+    network_1 = instance_2_nets.get("network-1", None)
+    network_3 = instance_2_nets.get("network-3", None)
+    assert network_1
+    assert network_3
+
+    network_1_mac = network_1.get("mac_addr", None)
+    assert (
+        net_map_stub_data.TEST_IFACES_INFO[net_map_stub_data.INSTANCE_2_NAME][0][
+            net_map_stub_data.TEST_IFACES_INFO_MAC_FIELD
+        ]
+        == network_1_mac
+    )
+    assert "interface_name" not in network_1
+    assert "interface_name" not in network_3
+    assert "mac_addr" in network_3
 
 
-def test_networking_mapper_full_map_invalid_ifaces_info_fail():
+def test_networking_mapper_full_map_missing_ansible_hostname_ok():
+    test_hostvars = copy.deepcopy(net_map_stub_data.TEST_HOSTVARS)
+    test_hostvars[net_map_stub_data.INSTANCE_1_NAME].pop(
+        net_map_stub_data.ANSIBLE_HOSTVARS_HOSTNAME
+    )
+    mapper = networking_mapper.NetworkingDefinitionMapper(
+        test_hostvars, net_map_stub_data.TEST_GROUPS
+    )
+    network_env = mapper.map(
+        net_map_stub_data.get_test_file_yaml_content(
+            "networking-definition-valid-all-tools-dual-stack.yml"
+        ),
+        net_map_stub_data.TEST_IFACES_INFO,
+    )
+    assert net_map_stub_data.INSTANCE_1_NAME in network_env["instances"]
+    assert "hostname" not in network_env["instances"][net_map_stub_data.INSTANCE_1_NAME]
+
+
+def test_networking_mapper_map_invalid_ifaces_info_fail():
     # Ensure that interfaces_info 'mac' field is mandatory
     with pytest.raises(exceptions.NetworkMappingError) as exc_info:
         mapper = networking_mapper.NetworkingDefinitionMapper(
             net_map_stub_data.TEST_HOSTVARS, net_map_stub_data.TEST_GROUPS
         )
         ifaces_info = copy.deepcopy(net_map_stub_data.TEST_IFACES_INFO)
-        ifaces_info[net_map_stub_data.INSTANCE_1_NAME].pop(
+        ifaces_info[net_map_stub_data.INSTANCE_1_NAME][0].pop(
             net_map_stub_data.TEST_IFACES_INFO_MAC_FIELD
         )
-        mapper.map_complete(
+        mapper.map(
             net_map_stub_data.get_test_file_yaml_content(
                 "networking-definition-valid-all-tools-dual-stack.yml"
             ),
             ifaces_info,
         )
-    assert "does not contain mac address" in str(exc_info.value)
+    assert "does not contain `mac` field" in str(exc_info.value)
 
-    # Ensure that the ansible instance can be located by MAC
-    with pytest.raises(exceptions.NetworkMappingError) as exc_info:
-        mapper = networking_mapper.NetworkingDefinitionMapper(
-            net_map_stub_data.TEST_HOSTVARS, net_map_stub_data.TEST_GROUPS
-        )
-        ifaces_info = copy.deepcopy(net_map_stub_data.TEST_IFACES_INFO)
-        ifaces_info[net_map_stub_data.INSTANCE_1_NAME][
-            net_map_stub_data.TEST_IFACES_INFO_MAC_FIELD
-        ] = "ab:cd:de:f0:12:34"
-        mapper.map_complete(
-            net_map_stub_data.get_test_file_yaml_content(
-                "networking-definition-valid-all-tools-dual-stack.yml"
-            ),
-            ifaces_info,
-        )
-    assert "not found" in str(exc_info.value)
 
-    # Ensure that the all instances are present in ifaces_info
-    with pytest.raises(exceptions.NetworkMappingError) as exc_info:
-        mapper = networking_mapper.NetworkingDefinitionMapper(
-            net_map_stub_data.TEST_HOSTVARS, net_map_stub_data.TEST_GROUPS
-        )
-        ifaces_info = copy.deepcopy(net_map_stub_data.TEST_IFACES_INFO)
-        ifaces_info.pop(net_map_stub_data.INSTANCE_1_NAME)
-        mapper.map_complete(
-            net_map_stub_data.get_test_file_yaml_content(
-                "networking-definition-valid-all-tools-dual-stack.yml"
-            ),
-            ifaces_info,
-        )
-    assert "does not contain information for instance-1" in str(exc_info.value)
+def test_networking_mapper_full_map_mac_not_found_ok():
+    # As the mapper works in best-effort mode, if the mac is
+    # not found, the map will succeed fetching the mac from
+    # the interfaces-info but not mapping ansible_facts
+    # fields like the interface_name
+
+    mapper = networking_mapper.NetworkingDefinitionMapper(
+        net_map_stub_data.TEST_HOSTVARS, net_map_stub_data.TEST_GROUPS
+    )
+    ifaces_info = copy.deepcopy(net_map_stub_data.TEST_IFACES_INFO)
+    iface_info_mac = "ab:cd:de:f0:12:34"
+    ifaces_info[net_map_stub_data.INSTANCE_1_NAME][0][
+        net_map_stub_data.TEST_IFACES_INFO_MAC_FIELD
+    ] = iface_info_mac
+    network_env = mapper.map(
+        net_map_stub_data.get_test_file_yaml_content(
+            "networking-definition-valid-all-tools-dual-stack.yml"
+        ),
+        ifaces_info,
+    )
+    assert net_map_stub_data.INSTANCE_1_NAME in network_env["instances"]
+    instance_1_nets = network_env["instances"][net_map_stub_data.INSTANCE_1_NAME][
+        "networks"
+    ]
+    network_1 = instance_1_nets.get("network-1", None)
+    assert network_1
+    assert iface_info_mac == network_1.get("mac_addr", None)
+    assert "interface_name" not in network_1
 
 
 def test_networking_mapper_search_domain_override_ok():
@@ -340,7 +416,7 @@ def test_networking_mapper_invalid_instance_fail():
         ifaces_info = copy.deepcopy(net_map_stub_data.TEST_IFACES_INFO)
         ifaces_info["non-existing-instance"] = ifaces_info["instance-1"]
         ifaces_info.pop("instance-1")
-        mapper.map_complete(
+        mapper.map(
             net_def_raw,
             ifaces_info,
         )
@@ -361,7 +437,7 @@ def test_networking_mapper_map_duplicated_net_group_templates_fail():
         )
         net_def_raw["group-templates"]["group-1"]["networks"]["network-2"] = {}
         net_def_raw["group-templates"]["group-1"]["networks"]["network-3"] = {}
-        mapper.map_partial(
+        mapper.map(
             net_def_raw,
         )
     assert (

--- a/tests/unit/module_utils/test_files/network-definition-valid-all-tools-no-group-templates-out.json
+++ b/tests/unit/module_utils/test_files/network-definition-valid-all-tools-no-group-templates-out.json
@@ -1,165 +1,173 @@
 {
+  "networks": {
+    "ctlplane": {
+      "network_name": "ctlplane",
+      "search_domain": "ctlplane.example.com",
+      "tools": {},
+      "dns_v4": [],
+      "dns_v6": [],
+      "network_v4": "192.168.122.0/24",
+      "gw_v4": "192.168.122.1",
+      "mtu": 1500
+    },
+    "internal-api": {
+      "network_name": "internal-api",
+      "search_domain": "internal-api.example.com",
+      "tools": {},
+      "dns_v4": [],
+      "dns_v6": [],
+      "network_v4": "172.17.0.0/24",
+      "vlan_id": 20,
+      "mtu": 1496
+    },
+    "storage": {
+      "network_name": "storage",
+      "search_domain": "storage.example.com",
+      "tools": {},
+      "dns_v4": [],
+      "dns_v6": [],
+      "network_v4": "172.18.0.0/24",
+      "vlan_id": 21,
+      "mtu": 1496
+    },
+    "tenant": {
+      "network_name": "tenant",
+      "search_domain": "tenant.example.com",
+      "tools": {},
+      "dns_v4": [],
+      "dns_v6": [],
+      "network_v4": "172.19.0.0/24",
+      "vlan_id": 22,
+      "mtu": 1496
+    }
+  },
   "instances": {
     "instance-1": {
-      "hostname": "instance-1-hostname",
       "name": "instance-1",
       "networks": {
         "ctlplane": {
+          "network_name": "ctlplane",
+          "skip_nm": false,
+          "mac_addr": "27:b9:47:74:b3:02",
           "interface_name": "eth1",
           "ip_v4": "192.168.122.100",
-          "mac_addr": "27:b9:47:74:b3:02",
-          "mtu": 1500,
           "netmask_v4": "255.255.255.0",
-          "network_name": "ctlplane",
           "prefix_length_v4": 24,
-          "skip_nm": false,
+          "mtu": 1500,
           "is_trunk_parent": true
         },
         "internal-api": {
+          "network_name": "internal-api",
+          "skip_nm": false,
+          "mac_addr": "52:54:00:20:5e:5b",
           "interface_name": "eth1.20",
           "ip_v4": "172.17.0.100",
-          "mac_addr": "52:54:00:57:a5:bd",
-          "mtu": 1496,
           "netmask_v4": "255.255.255.0",
-          "network_name": "internal-api",
-          "parent_interface": "eth1",
           "prefix_length_v4": 24,
-          "skip_nm": false,
+          "mtu": 1496,
+          "parent_interface": "eth1",
           "vlan_id": 20,
+          "is_trunk_parent": false,
           "trunk_parent": "ctlplane"
         },
         "storage": {
+          "network_name": "storage",
+          "skip_nm": false,
+          "mac_addr": "52:54:00:7e:b2:1c",
           "interface_name": "eth1.21",
           "ip_v4": "172.18.0.100",
-          "mac_addr": "52:54:00:3b:4c:47",
-          "mtu": 1496,
           "netmask_v4": "255.255.255.0",
-          "network_name": "storage",
-          "parent_interface": "eth1",
           "prefix_length_v4": 24,
-          "skip_nm": false,
+          "mtu": 1496,
+          "parent_interface": "eth1",
           "vlan_id": 21,
+          "is_trunk_parent": false,
           "trunk_parent": "ctlplane"
         },
         "tenant": {
+          "network_name": "tenant",
+          "skip_nm": false,
+          "mac_addr": "52:54:00:12:d1:e1",
           "interface_name": "eth1.22",
           "ip_v4": "172.19.0.100",
-          "mac_addr": "52:54:00:5b:40:e3",
-          "mtu": 1496,
           "netmask_v4": "255.255.255.0",
-          "network_name": "tenant",
-          "parent_interface": "eth1",
           "prefix_length_v4": 24,
-          "skip_nm": false,
+          "mtu": 1496,
+          "parent_interface": "eth1",
           "vlan_id": 22,
+          "is_trunk_parent": false,
           "trunk_parent": "ctlplane"
         }
-      }
+      },
+      "hostname": "instance-1-hostname"
     },
     "instance-2": {
-      "hostname": "instance-2-hostname",
       "name": "instance-2",
       "networks": {
         "ctlplane": {
+          "network_name": "ctlplane",
+          "skip_nm": false,
+          "mac_addr": "a1:69:da:21:aa:03",
           "interface_name": "eth2",
           "ip_v4": "192.168.122.101",
-          "mac_addr": "a1:69:da:21:aa:03",
-          "mtu": 1500,
           "netmask_v4": "255.255.255.0",
-          "network_name": "ctlplane",
           "prefix_length_v4": 24,
-          "skip_nm": false,
+          "mtu": 1500,
           "is_trunk_parent": true
         },
         "internal-api": {
+          "network_name": "internal-api",
+          "skip_nm": false,
+          "mac_addr": "52:54:00:20:5e:5b",
           "interface_name": "eth2.20",
           "ip_v4": "172.17.0.101",
-          "mac_addr": "52:54:00:67:13:df",
-          "mtu": 1496,
           "netmask_v4": "255.255.255.0",
-          "network_name": "internal-api",
-          "parent_interface": "eth2",
           "prefix_length_v4": 24,
-          "skip_nm": false,
+          "mtu": 1496,
+          "parent_interface": "eth2",
           "vlan_id": 20,
+          "is_trunk_parent": false,
           "trunk_parent": "ctlplane"
         },
         "storage": {
+          "network_name": "storage",
+          "skip_nm": false,
+          "mac_addr": "52:54:00:7e:b2:1c",
           "interface_name": "eth2.21",
           "ip_v4": "172.18.0.101",
-          "mac_addr": "52:54:00:69:83:6c",
-          "mtu": 1496,
           "netmask_v4": "255.255.255.0",
-          "network_name": "storage",
-          "parent_interface": "eth2",
           "prefix_length_v4": 24,
-          "skip_nm": false,
+          "mtu": 1496,
+          "parent_interface": "eth2",
           "vlan_id": 21,
+          "is_trunk_parent": false,
           "trunk_parent": "ctlplane"
         },
         "tenant": {
+          "network_name": "tenant",
+          "skip_nm": false,
+          "mac_addr": "52:54:00:12:d1:e1",
           "interface_name": "eth2.22",
           "ip_v4": "172.19.0.101",
-          "mac_addr": "52:54:00:51:4f:fb",
-          "mtu": 1496,
           "netmask_v4": "255.255.255.0",
-          "network_name": "tenant",
-          "parent_interface": "eth2",
           "prefix_length_v4": 24,
-          "skip_nm": false,
+          "mtu": 1496,
+          "parent_interface": "eth2",
           "vlan_id": 22,
+          "is_trunk_parent": false,
           "trunk_parent": "ctlplane"
         }
-      }
+      },
+      "hostname": "instance-2-hostname"
     }
-  },
-  "networks": {
-      "ctlplane": {
-        "dns_v4": [],
-        "dns_v6": [],
-        "gw_v4": "192.168.122.1",
-        "mtu": 1500,
-        "network_name": "ctlplane",
-        "network_v4": "192.168.122.0/24",
-        "search_domain": "ctlplane.example.com",
-        "tools": {}
-      },
-        "internal-api": {
-        "dns_v4": [],
-        "dns_v6": [],
-        "mtu": 1496,
-        "network_name": "internal-api",
-        "network_v4": "172.17.0.0/24",
-        "search_domain": "internal-api.example.com",
-        "tools": {},
-        "vlan_id": 20
-      },
-      "storage": {
-        "dns_v4": [],
-        "dns_v6": [],
-        "mtu": 1496,
-        "network_name": "storage",
-        "network_v4": "172.18.0.0/24",
-        "search_domain": "storage.example.com",
-        "tools": {},
-        "vlan_id": 21
-      },
-      "tenant": {
-        "dns_v4": [],
-        "dns_v6": [],
-        "mtu": 1496,
-        "network_name": "tenant",
-        "network_v4": "172.19.0.0/24",
-        "search_domain": "tenant.example.com",
-        "tools": {},
-        "vlan_id": 22
-      }
   },
   "routers": {
     "default": {
-        "router_name": "default",
-        "external_network": "provider",
-        "networks": ["ctlplane"]
+      "router_name": "default",
+      "networks": [
+        "ctlplane"
+      ],
+      "external_network": "provider"
     }
   }
 }

--- a/tests/unit/module_utils/test_files/network-definition-valid-all-tools-no-group-templates.yml
+++ b/tests/unit/module_utils/test_files/network-definition-valid-all-tools-no-group-templates.yml
@@ -25,27 +25,25 @@ instances:
     networks:
       ctlplane:
         ip: "192.168.122.100"
-        is_trunk_parent: true
       internal-api:
         ip: "172.17.0.100"
-        trunk_parent: "ctlplane"
+        trunk-parent: "ctlplane"
       storage:
         ip: "172.18.0.100"
-        trunk_parent: "ctlplane"
+        trunk-parent: "ctlplane"
       tenant:
         ip: "172.19.0.100"
-        trunk_parent: "ctlplane"
+        trunk-parent: "ctlplane"
   instance-2:
     networks:
       ctlplane:
         ip: "192.168.122.101"
-        is_trunk_parent: true
       internal-api:
         ip: "172.17.0.101"
-        trunk_parent: "ctlplane"
+        trunk-parent: "ctlplane"
       storage:
         ip: "172.18.0.101"
-        trunk_parent: "ctlplane"
+        trunk-parent: "ctlplane"
       tenant:
         ip: "172.19.0.101"
-        trunk_parent: "ctlplane"
+        trunk-parent: "ctlplane"

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-dual-stack-full-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-dual-stack-full-map-out.json
@@ -1,5 +1,4 @@
 {
-  "routers": {},
   "networks": {
     "network-1": {
       "network_name": "network-1",
@@ -282,37 +281,30 @@
         "network-2": {
           "network_name": "network-2",
           "skip_nm": false,
-          "mac_addr": "52:54:00:3b:4c:47",
-          "interface_name": "eth1.21",
+          "mac_addr": "52:54:00:54:9d:f3",
           "ip_v4": "172.18.0.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
-          "parent_interface": "eth1",
           "vlan_id": 21
         },
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
-          "mac_addr": "52:54:00:57:a5:bd",
-          "interface_name": "eth1.20",
+          "mac_addr": "52:54:00:5e:d1:a6",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:0037",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
           "mtu": 1496,
-          "parent_interface": "eth1",
           "vlan_id": 20
         },
         "network-4": {
           "network_name": "network-4",
           "skip_nm": false,
-          "mac_addr": "52:54:00:5b:40:e3",
-          "interface_name": "eth1.22",
+          "mac_addr": "52:54:00:2f:eb:98",
           "ip_v4": "172.19.0.37",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
-          "mtu": 1500,
-          "parent_interface": "eth1",
           "vlan_id": 22
         }
       },
@@ -337,13 +329,11 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
-          "mac_addr": "52:54:00:67:13:df",
-          "interface_name": "eth2.20",
+          "mac_addr": "52:54:00:5e:d1:a6",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:0038",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
           "mtu": 1496,
-          "parent_interface": "eth2",
           "vlan_id": 20
         }
       },
@@ -368,5 +358,6 @@
       },
       "hostname": "instance-3-hostname"
     }
-  }
+  },
+  "routers": {}
 }

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-dual-stack-partial-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-dual-stack-partial-map-out.json
@@ -1,5 +1,4 @@
 {
-  "routers": {},
   "networks": {
     "network-1": {
       "network_name": "network-1",
@@ -269,6 +268,7 @@
         "network-1": {
           "network_name": "network-1",
           "skip_nm": false,
+          "mac_addr": "52:54:00:18:3e:dd",
           "ip_v4": "192.168.122.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -280,6 +280,7 @@
         "network-2": {
           "network_name": "network-2",
           "skip_nm": false,
+          "mac_addr": "52:54:00:54:9d:f3",
           "ip_v4": "172.18.0.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -289,6 +290,7 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
+          "mac_addr": "52:54:00:5e:d1:a6",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:0037",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
@@ -298,6 +300,7 @@
         "network-4": {
           "network_name": "network-4",
           "skip_nm": false,
+          "mac_addr": "52:54:00:2f:eb:98",
           "ip_v4": "172.19.0.37",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -312,6 +315,7 @@
         "network-1": {
           "network_name": "network-1",
           "skip_nm": false,
+          "mac_addr": "52:54:00:18:3e:dd",
           "ip_v4": "192.168.122.11",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -323,6 +327,7 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
+          "mac_addr": "52:54:00:5e:d1:a6",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:0038",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
@@ -338,6 +343,7 @@
         "network-1": {
           "network_name": "network-1",
           "skip_nm": false,
+          "mac_addr": "52:54:00:18:3e:dd",
           "ip_v4": "192.168.122.12",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -349,5 +355,6 @@
       },
       "hostname": "instance-3-hostname"
     }
-  }
+  },
+  "routers": {}
 }

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-dual-stack-partial-reduced-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-dual-stack-partial-reduced-map-out.json
@@ -1,5 +1,4 @@
 {
-  "routers": {},
   "networks": {
     "network-1": {
       "network_name": "network-1",
@@ -269,6 +268,7 @@
         "network-2": {
           "network_name": "network-2",
           "skip_nm": false,
+          "mac_addr": "52:54:00:54:9d:f3",
           "ip_v4": "172.18.0.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -278,6 +278,7 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
+          "mac_addr": "52:54:00:5e:d1:a6",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:0037",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
@@ -287,6 +288,7 @@
         "network-4": {
           "network_name": "network-4",
           "skip_nm": false,
+          "mac_addr": "52:54:00:2f:eb:98",
           "ip_v4": "172.19.0.37",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -301,6 +303,7 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
+          "mac_addr": "52:54:00:5e:d1:a6",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:0038",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
@@ -309,5 +312,6 @@
         }
       }
     }
-  }
+  },
+  "routers": {}
 }

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-full-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-full-map-out.json
@@ -1,5 +1,4 @@
 {
-  "routers": {},
   "networks": {
     "ctlplane": {
       "network_name": "ctlplane",
@@ -235,7 +234,7 @@
         "internal-api": {
           "network_name": "internal-api",
           "skip_nm": false,
-          "mac_addr": "52:54:00:57:a5:bd",
+          "mac_addr": "52:54:00:20:5e:5b",
           "interface_name": "eth1.20",
           "ip_v4": "172.17.0.10",
           "netmask_v4": "255.255.255.0",
@@ -243,31 +242,32 @@
           "mtu": 1496,
           "parent_interface": "eth1",
           "vlan_id": 20,
+          "is_trunk_parent": false,
           "trunk_parent": "ctlplane"
         },
         "storage": {
           "network_name": "storage",
           "skip_nm": false,
-          "mac_addr": "52:54:00:3b:4c:47",
-          "interface_name": "eth1.21",
+          "mac_addr": "52:54:00:7e:b2:1c",
+          "interface_name": "eth0.21",
           "ip_v4": "172.18.0.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
-          "parent_interface": "eth1",
+          "parent_interface": "eth0",
           "vlan_id": 21,
+          "is_trunk_parent": false,
           "trunk_parent": "tenant"
         },
         "tenant": {
           "network_name": "tenant",
           "skip_nm": false,
-          "mac_addr": "52:54:00:5b:40:e3",
-          "interface_name": "eth1.22",
+          "mac_addr": "27:b9:47:74:b3:01",
+          "interface_name": "eth0",
           "ip_v4": "172.19.0.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
-          "parent_interface": "eth1",
           "vlan_id": 22,
           "is_trunk_parent": true
         }
@@ -291,7 +291,7 @@
         "internal-api": {
           "network_name": "internal-api",
           "skip_nm": false,
-          "mac_addr": "52:54:00:67:13:df",
+          "mac_addr": "52:54:00:20:5e:5b",
           "interface_name": "eth2.20",
           "ip_v4": "172.17.0.11",
           "netmask_v4": "255.255.255.0",
@@ -299,31 +299,32 @@
           "mtu": 1496,
           "parent_interface": "eth2",
           "vlan_id": 20,
+          "is_trunk_parent": false,
           "trunk_parent": "ctlplane"
         },
         "storage": {
           "network_name": "storage",
           "skip_nm": false,
-          "mac_addr": "52:54:00:69:83:6c",
-          "interface_name": "eth2.21",
+          "mac_addr": "52:54:00:7e:b2:1c",
+          "interface_name": "eth0.21",
           "ip_v4": "172.18.0.11",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
-          "parent_interface": "eth2",
+          "parent_interface": "eth0",
           "vlan_id": 21,
+          "is_trunk_parent": false,
           "trunk_parent": "tenant"
         },
         "tenant": {
           "network_name": "tenant",
           "skip_nm": false,
-          "mac_addr": "52:54:00:51:4f:fb",
-          "interface_name": "eth2.22",
+          "mac_addr": "a1:69:da:21:aa:01",
+          "interface_name": "eth0",
           "ip_v4": "172.19.0.11",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
-          "parent_interface": "eth2",
           "vlan_id": 22,
           "is_trunk_parent": true
         }
@@ -336,31 +337,32 @@
         "storage": {
           "network_name": "storage",
           "skip_nm": true,
-          "mac_addr": "52:54:00:4f:a2:4b",
-          "interface_name": "eth0.21",
+          "mac_addr": "52:54:00:7e:b2:1c",
+          "interface_name": "eth1.21",
           "ip_v4": "172.18.0.12",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
-          "parent_interface": "eth0",
+          "parent_interface": "eth1",
           "vlan_id": 21,
+          "is_trunk_parent": false,
           "trunk_parent": "tenant"
         },
         "tenant": {
           "network_name": "tenant",
           "skip_nm": true,
-          "mac_addr": "52:54:00:4e:f5:61",
-          "interface_name": "eth0.22",
+          "mac_addr": "bf:99:4b:3f:5e:02",
+          "interface_name": "eth1",
           "ip_v4": "172.19.0.12",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
-          "parent_interface": "eth0",
           "vlan_id": 22,
           "is_trunk_parent": true
         }
       },
       "hostname": "instance-3-hostname"
     }
-  }
+  },
+  "routers": {}
 }

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-full-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-full-map-out.json
@@ -1,5 +1,4 @@
 {
-  "routers": {},
   "networks": {
     "network-1": {
       "network_name": "network-1",
@@ -140,6 +139,15 @@
       ],
       "network_v6": "fd5e:bdb2:6091:9306::/64",
       "vlan_id": 21
+    },
+    "network-4": {
+      "network_name": "network-4",
+      "search_domain": "network-4.example.com",
+      "tools": {},
+      "dns_v4": [],
+      "dns_v6": [],
+      "network_v6": "fd98:6d1a:86e7:d5e5::/64",
+      "vlan_id": 22
     }
   },
   "instances": {
@@ -154,31 +162,43 @@
           "ip_v6": "fdc0:8b54:108a:c949:0000:0000:0000:0f1a",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
-          "mtu": 1500
+          "mtu": 1500,
+          "is_trunk_parent": true
         },
         "network-2": {
           "network_name": "network-2",
           "skip_nm": false,
-          "mac_addr": "52:54:00:3b:4c:47",
-          "interface_name": "eth1.21",
+          "mac_addr": "52:54:00:54:9d:f3",
           "ip_v6": "fd5e:bdb2:6091:9306:0000:0000:0000:0190",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
-          "mtu": 1500,
-          "parent_interface": "eth1",
           "vlan_id": 21
         },
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
-          "mac_addr": "52:54:00:57:a5:bd",
+          "mac_addr": "52:54:00:5e:d1:a6",
           "interface_name": "eth1.20",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:0f1a",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
           "mtu": 1496,
           "parent_interface": "eth1",
-          "vlan_id": 20
+          "vlan_id": 20,
+          "is_trunk_parent": false,
+          "trunk_parent": "network-1"
+        },
+        "network-4": {
+          "network_name": "network-4",
+          "skip_nm": false,
+          "mac_addr": "27:b9:47:74:b3:01",
+          "interface_name": "eth0",
+          "ip_v6": "fd98:6d1a:86e7:d5e5:0000:0000:0000:01f4",
+          "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
+          "prefix_length_v6": 64,
+          "mtu": 1500,
+          "vlan_id": 22,
+          "is_trunk_parent": true
         }
       },
       "hostname": "instance-1-hostname"
@@ -189,26 +209,37 @@
         "network-2": {
           "network_name": "network-2",
           "skip_nm": false,
-          "mac_addr": "52:54:00:69:83:6c",
-          "interface_name": "eth2.21",
+          "mac_addr": "52:54:00:54:9d:f3",
           "ip_v6": "fd5e:bdb2:6091:9306:0000:0000:0000:0191",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
-          "mtu": 1500,
-          "parent_interface": "eth2",
           "vlan_id": 21
         },
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
-          "mac_addr": "52:54:00:67:13:df",
-          "interface_name": "eth2.20",
+          "mac_addr": "52:54:00:5e:d1:a6",
+          "interface_name": "eth0.20",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:01f4",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
           "mtu": 1496,
-          "parent_interface": "eth2",
-          "vlan_id": 20
+          "parent_interface": "eth0",
+          "vlan_id": 20,
+          "is_trunk_parent": false,
+          "trunk_parent": "network-4"
+        },
+        "network-4": {
+          "network_name": "network-4",
+          "skip_nm": false,
+          "mac_addr": "a1:69:da:21:aa:01",
+          "interface_name": "eth0",
+          "ip_v6": "fd98:6d1a:86e7:d5e5:0000:0000:0000:01f5",
+          "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
+          "prefix_length_v6": 64,
+          "mtu": 1500,
+          "vlan_id": 22,
+          "is_trunk_parent": true
         }
       },
       "hostname": "instance-2-hostname"
@@ -219,17 +250,31 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
-          "mac_addr": "52:54:00:04:3f:e5",
-          "interface_name": "eth0.20",
+          "mac_addr": "52:54:00:5e:d1:a6",
+          "interface_name": "eth1.20",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:01f5",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
           "mtu": 1496,
-          "parent_interface": "eth0",
-          "vlan_id": 20
+          "parent_interface": "eth1",
+          "vlan_id": 20,
+          "is_trunk_parent": false,
+          "trunk_parent": "network-4"
+        },
+        "network-4": {
+          "network_name": "network-4",
+          "skip_nm": false,
+          "mac_addr": "bf:99:4b:3f:5e:02",
+          "interface_name": "eth1",
+          "ip_v6": "fd98:6d1a:86e7:d5e5:0000:0000:0000:01f6",
+          "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
+          "prefix_length_v6": 64,
+          "vlan_id": 22,
+          "is_trunk_parent": true
         }
       },
       "hostname": "instance-3-hostname"
     }
-  }
+  },
+  "routers": {}
 }

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-networks-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-networks-out.json
@@ -138,5 +138,14 @@
     ],
     "network_v6": "fd5e:bdb2:6091:9306::/64",
     "vlan_id": 21
+  },
+  "network-4": {
+    "network_name": "network-4",
+    "search_domain": "network-4.example.com",
+    "tools": {},
+    "dns_v4": [],
+    "dns_v6": [],
+    "network_v6": "fd98:6d1a:86e7:d5e5::/64",
+    "vlan_id": 22
   }
 }

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-partial-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-partial-map-out.json
@@ -1,5 +1,4 @@
 {
-  "routers": {},
   "networks": {
     "network-1": {
       "network_name": "network-1",
@@ -140,6 +139,15 @@
       ],
       "network_v6": "fd5e:bdb2:6091:9306::/64",
       "vlan_id": 21
+    },
+    "network-4": {
+      "network_name": "network-4",
+      "search_domain": "network-4.example.com",
+      "tools": {},
+      "dns_v4": [],
+      "dns_v6": [],
+      "network_v6": "fd98:6d1a:86e7:d5e5::/64",
+      "vlan_id": 22
     }
   },
   "instances": {
@@ -149,14 +157,17 @@
         "network-1": {
           "network_name": "network-1",
           "skip_nm": false,
+          "mac_addr": "52:54:00:18:3e:dd",
           "ip_v6": "fdc0:8b54:108a:c949:0000:0000:0000:0f1a",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
-          "mtu": 1500
+          "mtu": 1500,
+          "is_trunk_parent": true
         },
         "network-2": {
           "network_name": "network-2",
           "skip_nm": false,
+          "mac_addr": "52:54:00:54:9d:f3",
           "ip_v6": "fd5e:bdb2:6091:9306:0000:0000:0000:0190",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
@@ -165,11 +176,24 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
+          "mac_addr": "52:54:00:5e:d1:a6",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:0f1a",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
           "mtu": 1496,
-          "vlan_id": 20
+          "vlan_id": 20,
+          "is_trunk_parent": false,
+          "trunk_parent": "network-1"
+        },
+        "network-4": {
+          "network_name": "network-4",
+          "skip_nm": false,
+          "mac_addr": "52:54:00:2f:eb:98",
+          "ip_v6": "fd98:6d1a:86e7:d5e5:0000:0000:0000:01f4",
+          "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
+          "prefix_length_v6": 64,
+          "vlan_id": 22,
+          "is_trunk_parent": true
         }
       },
       "hostname": "instance-1-hostname"
@@ -180,6 +204,7 @@
         "network-2": {
           "network_name": "network-2",
           "skip_nm": false,
+          "mac_addr": "52:54:00:54:9d:f3",
           "ip_v6": "fd5e:bdb2:6091:9306:0000:0000:0000:0191",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
@@ -188,11 +213,24 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
+          "mac_addr": "52:54:00:5e:d1:a6",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:01f4",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
           "mtu": 1496,
-          "vlan_id": 20
+          "vlan_id": 20,
+          "is_trunk_parent": false,
+          "trunk_parent": "network-4"
+        },
+        "network-4": {
+          "network_name": "network-4",
+          "skip_nm": false,
+          "mac_addr": "52:54:00:2f:eb:98",
+          "ip_v6": "fd98:6d1a:86e7:d5e5:0000:0000:0000:01f5",
+          "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
+          "prefix_length_v6": 64,
+          "vlan_id": 22,
+          "is_trunk_parent": true
         }
       },
       "hostname": "instance-2-hostname"
@@ -203,14 +241,28 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
+          "mac_addr": "52:54:00:5e:d1:a6",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:01f5",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
           "mtu": 1496,
-          "vlan_id": 20
+          "vlan_id": 20,
+          "is_trunk_parent": false,
+          "trunk_parent": "network-4"
+        },
+        "network-4": {
+          "network_name": "network-4",
+          "skip_nm": false,
+          "mac_addr": "52:54:00:2f:eb:98",
+          "ip_v6": "fd98:6d1a:86e7:d5e5:0000:0000:0000:01f6",
+          "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
+          "prefix_length_v6": 64,
+          "vlan_id": 22,
+          "is_trunk_parent": true
         }
       },
       "hostname": "instance-3-hostname"
     }
-  }
+  },
+  "routers": {}
 }

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-partial-reduced-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-partial-reduced-map-out.json
@@ -1,5 +1,4 @@
 {
-  "routers": {},
   "networks": {
     "network-1": {
       "network_name": "network-1",
@@ -140,6 +139,15 @@
       ],
       "network_v6": "fd5e:bdb2:6091:9306::/64",
       "vlan_id": 21
+    },
+    "network-4": {
+      "network_name": "network-4",
+      "search_domain": "network-4.example.com",
+      "tools": {},
+      "dns_v4": [],
+      "dns_v6": [],
+      "network_v6": "fd98:6d1a:86e7:d5e5::/64",
+      "vlan_id": 22
     }
   },
   "instances": {
@@ -149,22 +157,28 @@
         "network-1": {
           "network_name": "network-1",
           "skip_nm": false,
+          "mac_addr": "52:54:00:18:3e:dd",
           "ip_v6": "fdc0:8b54:108a:c949:0000:0000:0000:0f1a",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
-          "mtu": 1500
+          "mtu": 1500,
+          "is_trunk_parent": true
         },
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
+          "mac_addr": "52:54:00:5e:d1:a6",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:0f1a",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
           "mtu": 1496,
-          "vlan_id": 20
+          "vlan_id": 20,
+          "is_trunk_parent": false,
+          "trunk_parent": "network-1"
         }
       },
       "hostname": "instance-1-hostname"
     }
-  }
+  },
+  "routers": {}
 }

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only.yml
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only.yml
@@ -54,6 +54,9 @@ networks:
         ranges:
           - start: 60
             end: 69
+  network-4:
+    network: "fd98:6d1a:86e7:d5e5::/64"
+    vlan: 22
 group-templates:
   group-1:
     network-template:
@@ -68,14 +71,16 @@ group-templates:
         start: 400
         length: 40
     networks:
-      network-2: { }
+      network-2: {}
   group-3:
     network-template:
       range:
         start: 500
         length: 40
     networks:
-      network-3: { }
+      network-4: {}
+      network-3:
+        trunk-parent: network-4
 instances:
   instance-1:
     networks:
@@ -83,3 +88,4 @@ instances:
         ip: "fdc0:8b54:108a:c949::f1a"
       network-3:
         ip: "fd42:add0:b7d2:09b1::f1a"
+        trunk-parent: network-1

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-partial-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-partial-map-out.json
@@ -1,5 +1,4 @@
 {
-  "routers": {},
   "networks": {
     "ctlplane": {
       "network_name": "ctlplane",
@@ -224,6 +223,7 @@
         "ctlplane": {
           "network_name": "ctlplane",
           "skip_nm": false,
+          "mac_addr": "52:54:00:4f:e0:69",
           "ip_v4": "192.168.122.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -233,26 +233,31 @@
         "internal-api": {
           "network_name": "internal-api",
           "skip_nm": false,
+          "mac_addr": "52:54:00:20:5e:5b",
           "ip_v4": "172.17.0.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
           "vlan_id": 20,
+          "is_trunk_parent": false,
           "trunk_parent": "ctlplane"
         },
         "storage": {
           "network_name": "storage",
           "skip_nm": false,
+          "mac_addr": "52:54:00:7e:b2:1c",
           "ip_v4": "172.18.0.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
           "vlan_id": 21,
+          "is_trunk_parent": false,
           "trunk_parent": "tenant"
         },
         "tenant": {
           "network_name": "tenant",
           "skip_nm": false,
+          "mac_addr": "52:54:00:12:d1:e1",
           "ip_v4": "172.19.0.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -269,6 +274,7 @@
         "ctlplane": {
           "network_name": "ctlplane",
           "skip_nm": false,
+          "mac_addr": "52:54:00:4f:e0:69",
           "ip_v4": "192.168.122.11",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -278,26 +284,31 @@
         "internal-api": {
           "network_name": "internal-api",
           "skip_nm": false,
+          "mac_addr": "52:54:00:20:5e:5b",
           "ip_v4": "172.17.0.11",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
           "vlan_id": 20,
+          "is_trunk_parent": false,
           "trunk_parent": "ctlplane"
         },
         "storage": {
           "network_name": "storage",
           "skip_nm": false,
+          "mac_addr": "52:54:00:7e:b2:1c",
           "ip_v4": "172.18.0.11",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
           "vlan_id": 21,
+          "is_trunk_parent": false,
           "trunk_parent": "tenant"
         },
         "tenant": {
           "network_name": "tenant",
           "skip_nm": false,
+          "mac_addr": "52:54:00:12:d1:e1",
           "ip_v4": "172.19.0.11",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -314,16 +325,19 @@
         "storage": {
           "network_name": "storage",
           "skip_nm": true,
+          "mac_addr": "52:54:00:7e:b2:1c",
           "ip_v4": "172.18.0.12",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
           "vlan_id": 21,
+          "is_trunk_parent": false,
           "trunk_parent": "tenant"
         },
         "tenant": {
           "network_name": "tenant",
           "skip_nm": true,
+          "mac_addr": "52:54:00:12:d1:e1",
           "ip_v4": "172.19.0.12",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -334,5 +348,6 @@
       },
       "hostname": "instance-3-hostname"
     }
-  }
+  },
+  "routers": {}
 }

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools.yml
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools.yml
@@ -81,22 +81,20 @@ group-templates:
         range:
           start: 10
           length: 5
-        is_trunk_parent: true
       internal-api:
         range:
           start: 10
           length: 30
-        trunk_parent: ctlplane
+        trunk-parent: ctlplane
   group-3:
     network-template:
       range:
         start: 10
         length: 5
     networks:
-      tenant:
-        is_trunk_parent: true
+      tenant: {}
       storage:
-        trunk_parent: tenant
+        trunk-parent: tenant
 instances:
   instance-3:
     skip-nm-configuration: true

--- a/tests/unit/module_utils/test_files/networking-definition-valid-full-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-full-map-out.json
@@ -1,5 +1,4 @@
 {
-  "routers": {},
   "networks": {
     "ctlplane": {
       "network_name": "ctlplane",
@@ -68,7 +67,7 @@
         "internal-api": {
           "network_name": "internal-api",
           "skip_nm": false,
-          "mac_addr": "52:54:00:57:a5:bd",
+          "mac_addr": "52:54:00:20:5e:5b",
           "interface_name": "eth1.20",
           "ip_v4": "172.17.0.10",
           "netmask_v4": "255.255.255.0",
@@ -76,12 +75,13 @@
           "mtu": 1496,
           "parent_interface": "eth1",
           "vlan_id": 20,
+          "is_trunk_parent": false,
           "trunk_parent": "ctlplane"
         },
         "storage": {
           "network_name": "storage",
           "skip_nm": true,
-          "mac_addr": "52:54:00:3b:4c:47",
+          "mac_addr": "52:54:00:7e:b2:1c",
           "interface_name": "eth1.21",
           "ip_v4": "172.18.0.100",
           "netmask_v4": "255.255.255.0",
@@ -89,12 +89,13 @@
           "mtu": 1496,
           "parent_interface": "eth1",
           "vlan_id": 21,
+          "is_trunk_parent": false,
           "trunk_parent": "ctlplane"
         },
         "tenant": {
           "network_name": "tenant",
           "skip_nm": true,
-          "mac_addr": "52:54:00:5b:40:e3",
+          "mac_addr": "52:54:00:12:d1:e1",
           "interface_name": "eth1.22",
           "ip_v4": "172.19.0.10",
           "netmask_v4": "255.255.255.0",
@@ -102,10 +103,12 @@
           "mtu": 1496,
           "parent_interface": "eth1",
           "vlan_id": 22,
+          "is_trunk_parent": false,
           "trunk_parent": "ctlplane"
         }
       },
       "hostname": "instance-1-hostname"
     }
-  }
+  },
+  "routers": {}
 }

--- a/tests/unit/module_utils/test_files/networking-definition-valid-network-template.yml
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-network-template.yml
@@ -21,20 +21,18 @@ group-templates:
         start: 10
         length: 5
     networks:
-      ctlplane:
-        is_trunk_parent: true
+      ctlplane: {}
       internal-api:
-        trunk_parent: ctlplane
+        trunk-parent: ctlplane
       tenant:
-        trunk_parent: ctlplane
+        trunk-parent: ctlplane
       storage:
-        trunk_parent: ctlplane
+        trunk-parent: ctlplane
 instances:
   instance-1:
     networks:
       ctlplane:
         ip: "192.168.122.100"
-        is_trunk_parent: true
       storage:
         ip: "172.18.0.100"
-        trunk_parent: "ctlplane"
+        trunk-parent: "ctlplane"

--- a/tests/unit/module_utils/test_files/networking-definition-valid-partial-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-partial-map-out.json
@@ -1,5 +1,4 @@
 {
-  "routers": {},
   "networks": {
     "ctlplane": {
       "network_name": "ctlplane",
@@ -57,6 +56,7 @@
         "ctlplane": {
           "network_name": "ctlplane",
           "skip_nm": false,
+          "mac_addr": "52:54:00:4f:e0:69",
           "ip_v4": "192.168.122.100",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -66,36 +66,42 @@
         "internal-api": {
           "network_name": "internal-api",
           "skip_nm": false,
+          "mac_addr": "52:54:00:20:5e:5b",
           "ip_v4": "172.17.0.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
           "vlan_id": 20,
+          "is_trunk_parent": false,
           "trunk_parent": "ctlplane"
-
         },
         "storage": {
           "network_name": "storage",
           "skip_nm": true,
+          "mac_addr": "52:54:00:7e:b2:1c",
           "ip_v4": "172.18.0.100",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
           "vlan_id": 21,
+          "is_trunk_parent": false,
           "trunk_parent": "ctlplane"
         },
         "tenant": {
           "network_name": "tenant",
           "skip_nm": true,
+          "mac_addr": "52:54:00:12:d1:e1",
           "ip_v4": "172.19.0.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
           "mtu": 1496,
           "vlan_id": 22,
+          "is_trunk_parent": false,
           "trunk_parent": "ctlplane"
         }
       },
       "hostname": "instance-1-hostname"
     }
-  }
+  },
+  "routers": {}
 }

--- a/tests/unit/module_utils/test_files/networking-definition-valid.yml
+++ b/tests/unit/module_utils/test_files/networking-definition-valid.yml
@@ -30,28 +30,26 @@ group-templates:
     networks:
       ctlplane:
         range: "192.168.122.10-192.168.122.14"
-        is_trunk_parent: true
       internal-api:
         range: "10-14"
-        trunk_parent: ctlplane
+        trunk-parent: ctlplane
       tenant:
         skip-nm-configuration: true
         range:
           start: 10
           length: 5
-        trunk_parent: ctlplane
+        trunk-parent: ctlplane
       storage:
         range:
           start: 10
           length: 5
-        trunk_parent: ctlplane
+        trunk-parent: ctlplane
 instances:
   instance-1:
     networks:
       ctlplane:
         ip: "192.168.122.100"
-        is_trunk_parent: true
       storage:
         skip-nm-configuration: true
         ip: "172.18.0.100"
-        trunk_parent: ctlplane
+        trunk-parent: ctlplane

--- a/tests/unit/module_utils/test_utils/net_map_stub_data.py
+++ b/tests/unit/module_utils/test_utils/net_map_stub_data.py
@@ -23,6 +23,7 @@ INSTANCE_1_NAME = "instance-1"
 INSTANCE_2_NAME = "instance-2"
 INSTANCE_3_NAME = "instance-3"
 INSTANCE_1_MACADDR = "27:b9:47:74:b3:02"
+INSTANCE_1_ALTERNATE_MACADDR = "27:b9:47:74:b3:01"
 INSTANCE_1_LO_IFACE_DATA = {
     "device": "lo",
     "macaddress": "27:b9:47:74:b3:00",
@@ -30,7 +31,7 @@ INSTANCE_1_LO_IFACE_DATA = {
 }
 INSTANCE_1_ETH0_IFACE_DATA = {
     "device": "eth0",
-    "macaddress": "27:b9:47:74:b3:01",
+    "macaddress": INSTANCE_1_ALTERNATE_MACADDR,
     "mtu": 1500,
 }
 INSTANCE_1_ETH1_IFACE_DATA = {
@@ -48,6 +49,7 @@ INSTANCE_1_OVS_SYSTEM_IFACE_DATA = {
     "mtu": 1500,
 }
 INSTANCE_2_MACADDR = "a1:69:da:21:aa:03"
+INSTANCE_2_ALTERNATE_MACADDR = "a1:69:da:21:aa:01"
 INSTANCE_2_LO_IFACE_DATA = {
     "device": "lo",
     "macaddress": "a1:69:da:21:aa:00",
@@ -55,7 +57,7 @@ INSTANCE_2_LO_IFACE_DATA = {
 }
 INSTANCE_2_ETH0_IFACE_DATA = {
     "device": "eth0",
-    "macaddress": "a1:69:da:21:aa:01",
+    "macaddress": INSTANCE_2_ALTERNATE_MACADDR,
     "mtu": 1500,
 }
 INSTANCE_2_ETH1_IFACE_DATA = {
@@ -74,6 +76,7 @@ INSTANCE_2_OVS_SYSTEM_IFACE_DATA = {
     "mtu": 1500,
 }
 INSTANCE_3_MACADDR = "bf:99:4b:3f:5e:01"
+INSTANCE_3_ALTERNATE_MACADDR = "bf:99:4b:3f:5e:02"
 INSTANCE_3_LO_IFACE_DATA = {
     "device": "lo",
     "macaddress": "bf:99:4b:3f:5e:00",
@@ -86,7 +89,7 @@ INSTANCE_3_ETH0_IFACE_DATA = {
 }
 INSTANCE_3_ETH1_IFACE_DATA = {
     "device": "eth1",
-    "macaddress": "bf:99:4b:3f:5e:02",
+    "macaddress": INSTANCE_3_ALTERNATE_MACADDR,
 }
 INSTANCE_3_ETH2_IFACE_DATA = {
     "device": "eth2",
@@ -156,16 +159,26 @@ TEST_HOSTVARS = {
     },
 }
 TEST_IFACES_INFO_MAC_FIELD = "mac"
+TEST_IFACES_INFO_NETWORK_FIELD = "network"
 TEST_IFACES_INFO = {
-    INSTANCE_1_NAME: {
-        TEST_IFACES_INFO_MAC_FIELD: INSTANCE_1_MACADDR,
-    },
-    INSTANCE_2_NAME: {
-        TEST_IFACES_INFO_MAC_FIELD: INSTANCE_2_MACADDR,
-    },
-    INSTANCE_3_NAME: {
-        TEST_IFACES_INFO_MAC_FIELD: INSTANCE_3_MACADDR,
-    },
+    INSTANCE_1_NAME: [
+        {
+            TEST_IFACES_INFO_MAC_FIELD: INSTANCE_1_MACADDR,
+            TEST_IFACES_INFO_NETWORK_FIELD: NETWORK_1_NAME,
+        },
+    ],
+    INSTANCE_2_NAME: [
+        {
+            TEST_IFACES_INFO_MAC_FIELD: INSTANCE_2_MACADDR,
+            TEST_IFACES_INFO_NETWORK_FIELD: NETWORK_1_NAME,
+        },
+    ],
+    INSTANCE_3_NAME: [
+        {
+            TEST_IFACES_INFO_MAC_FIELD: INSTANCE_3_MACADDR,
+            TEST_IFACES_INFO_NETWORK_FIELD: NETWORK_1_NAME,
+        },
+    ],
 }
 
 
@@ -431,3 +444,14 @@ def get_test_file_json_content(file_name: str) -> typing.Dict[str, typing.Any]:
     file_path = get_test_file_path(file_name)
     with open(file_path, "r") as file:
         return json.load(file)
+
+
+def patch_interfaces_info_dicts(
+    ifaces_info_1: typing.Dict[str, typing.List[typing.Dict]],
+    ifaces_info_2: typing.Dict[str, typing.List[typing.Dict]],
+) -> typing.Dict[str, typing.List[typing.Dict]]:
+    no = []
+    return dict(
+        (k, ifaces_info_1.get(k, no) + ifaces_info_2.get(k, no))
+        for k in set(ifaces_info_1).union(ifaces_info_2)
+    )


### PR DESCRIPTION
With the introduction of IPv6 the mapper now needs to perform partial maps with hosts in the inventory that are not yet reachable, so it needs to be able to perform the mapping without a full set of ansible facts.

The strategy that the PR follows is the next one:
- Despite the type of mapping, full or partial, do a best effort approach without failing if a fact is missing.
- In partial maps, allow the mapper to take the interfaces-info
- Avoid refreshing networking facts for those hosts that has not ansible_host fact present, assuming those are not reachable.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
