### PR TITLE
Ensure no default network is around

### DIFF
--- a/roles/reproducer/tasks/prepare_networking.yml
+++ b/roles/reproducer/tasks/prepare_networking.yml
@@ -1,4 +1,14 @@
 ---
+- name: Ensure no default networks exists
+  vars:
+    net_name: "{{ item }}"
+  ansible.builtin.include_role:
+    name: libvirt_manager
+    tasks_from: delete_network.yml
+  loop:
+    - crc
+    - default
+
 - name: Ensure basic host configurations are present
   become: true
   block:


### PR DESCRIPTION
the `default` network is usually creating issues with the range overlap
for osp_trunk managed net.

`crc` network doesn't create issue *now* but will be an issue once we
get our own dnsmasq integrated: there might be some service collision
with the DNS and DHCP services listening on that network.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
