### PR TITLE
 Add the data-plane-adoption-no-ceph job to adoption zuul templates 

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -30,9 +30,8 @@
     github-check:
       jobs:
         - openstack-k8s-operators-content-provider
-        - cifmw-data-plane-adoption-osp-17-to-extracted-crc:
-            dependencies:
-              - openstack-k8s-operators-content-provider
+        - cifmw-data-plane-adoption-osp-17-to-extracted-crc: *content_provider
+        - cifmw-data-plane-adoption-osp-17-to-extracted-crc-minimal-no-ceph: *content_provider
 
 - project-template:
     name: podified-ironic-operator-pipeline
@@ -72,6 +71,5 @@
             requires:
               - cifmw-pod-pre-commit
               - cifmw-molecule
-        - cifmw-data-plane-adoption-osp-17-to-extracted-crc:
-            dependencies:
-              - openstack-k8s-operators-content-provider
+        - cifmw-data-plane-adoption-osp-17-to-extracted-crc: *content_provider
+        - cifmw-data-plane-adoption-osp-17-to-extracted-crc-minimal-no-ceph: *content_provider


### PR DESCRIPTION
This adds cifmw-data-plane-adoption-osp-17-to-extracted-crc-minimal-no-ceph to the two adoption zuul templates.

https://issues.redhat.com/browse/OSPRH-7331

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
