### PR TITLE
nit: Correct the used SSH key in ansible inventory

### DIFF
--- a/roles/libvirt_manager/templates/inventory.yml.j2
+++ b/roles/libvirt_manager/templates/inventory.yml.j2
@@ -4,10 +4,12 @@
     {{ host.nic.host }}:
       ansible_host: {{ (host.stdout.split())[3] | ansible.utils.ipaddr('address') }}
       ansible_user: {{ admin_user }}
-{% if vm_type is match('^crc.*') %}
+      ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+{% if vm_type is match('^crc.*')                            %}
       ansible_ssh_private_key_file: ~/.ssh/crc_key
-{% endif %}
-{% if vm_type is match('^ocp.*') %}
+{% elif vm_type is match('^ocp.*')                          %}
       ansible_ssh_private_key_file: ~/.ssh/devscripts_key
-{% endif %}
+{% else                                                     %}
+      ansible_ssh_private_key_file: ~/.ssh/id_cifw
+{% endif                                                    %}
 {% endfor %}


### PR DESCRIPTION
We were missing the right ssh key configuration in the generated ansible
inventory, leading to "some" issues.

We also ensure ansible won't complain about the remote host keys. A
better solution might come later, once we're over the deep network
refactoring

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
