### PR TITLE
Re-add the host IPs in controller-0 .ssh/config, revert hostname

### DIFF
--- a/roles/libvirt_manager/tasks/manage_vms.yml
+++ b/roles/libvirt_manager/tasks/manage_vms.yml
@@ -171,7 +171,7 @@
     cmd: |-
       test -d /home/zuul && exit 0;
       set -xe -o pipefail;
-      echo "{{ vm_ip.nic.host }}.{{ inventory_hostname }}" | sudo tee /etc/hostname;
+      echo "{{ vm_ip.nic.host }}" | sudo tee /etc/hostname;
       sudo hostname -F /etc/hostname;
       sudo useradd -m -d /home/zuul zuul;
       echo "zuul ALL=(ALL)  NOPASSWD: ALL" | sudo tee /etc/sudoers.d/zuul;
@@ -219,11 +219,14 @@
 
 - name: Update inventory to consume correct user
   delegate_to: localhost
+  vars:
+    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
   ansible.builtin.add_host:
     name: "{{ vm_ip.nic.host }}"
     groups: "{{ (vm_type == 'crc') | ternary('ocp', vm_type) }}s"
     ansible_host: "{{ vm_ip.nic.host }}.{{ inventory_hostname }}"
     ansible_ssh_user: "{{ _cifmw_libvirt_manager_layout.vms[vm_type].admin_user | default('zuul') }}"
+    host_ip: "{{ extracted_ip }}"
   loop: "{{ vm_ips.results }}"
   loop_control:
     loop_var: vm_ip

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -167,7 +167,7 @@
 
     - name: Inject ProxyJump configuration for remote hypervisor VMs
       when:
-        - hostvars[host]['ansible_host'] is defined
+        - hostvars[host]['host_ip'] is defined
       vars:
         _vm_type: "{{ host | regex_replace('\\-[0-9]*', '') }}"
         _vm_data: "{{ _cifmw_libvirt_manager_layout.vms[_vm_type] }}"
@@ -189,8 +189,8 @@
         path: "/home/zuul/.ssh/config"
         marker: "## {mark} {{ host }}"
         block: |-
-          Host {{ host }} {{ _vm_ip }}
-            Hostname {{ _vm_ip }}
+          Host {{ host }} {{ _vm_ip }} {{ hostvars[host]['host_ip'] }}
+            Hostname {{ hostvars[host]['host_ip'] }}
             User {{ _vm_data['admin_user'] | default('zuul') }}
             StrictHostKeyChecking no
             UserKnownHostsFile /dev/null
@@ -278,6 +278,14 @@
           ansible.builtin.import_role:
             name: manage_secrets
             tasks_from: reproducer.yml
+
+    - name: Inject FQDN in /etc/hosts
+      become: true
+      ansible.builtin.blockinfile:
+        dest: /etc/hosts
+        block: |-
+         127.0.0.2 {{ hostvars['controller-0'].ansible_host }}
+         ::2 {{ hostvars['controller-0'].ansible_host }}
 
     - name: Ensure packages are installed
       become: true


### PR DESCRIPTION
There's some magical things between .ssh/config and ansible that were
broken for HCI, when time comes to deploy ceph using the ceph.yml
playbook.

In parallel, this patch also reverts the hostname of the VMs to its
former "short" format (compute-0, etc) instead of a more FQDN-like
one (compute-1.hypervisor-1, etc).
That change was mostly needed for sushy since it consumes, by default,
the `ansible_host`.
Injecting that value in the /etc/hosts makes it easier to consume.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
