### PR TITLE
Add ssh_jumper role

### DIFF
--- a/roles/libvirt_manager/tasks/manage_vms.yml
+++ b/roles/libvirt_manager/tasks/manage_vms.yml
@@ -54,22 +54,20 @@
     - inventory_hostname != 'localhost'
     - inventory_hostname != 'instance'  # needed for molecule
     - _need_start | bool
-  delegate_to: localhost
   vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
-    proxy_hostname: "{{ ansible_host | default(inventory_hostname) }}"
-  ansible.builtin.blockinfile:
-    create: true
-    path: "{{ lookup('env', 'HOME') }}/.ssh/config"
-    marker: "## {mark} {{ vm_ip.nic.host }} {{ inventory_hostname }}"
-    mode: "0600"
-    block: |-
-      Host {{ vm_ip.nic.host }} {{ vm_ip.nic.host }}.{{ inventory_hostname }} cifmw-{{ vm_ip.nic.host }} {{ extracted_ip }}
-        ProxyJump {{ ansible_user | default(lookup('env', 'USER')) }}@{{ proxy_hostname }}
-        Hostname {{ extracted_ip }}
-        User {{ 'core' if vm_ip.nic.host is match('^(crc|ocp).*') else 'zuul' }}
-        StrictHostKeyChecking no
-        UserKnownHostsFile /dev/null
+    cifmw_ssh_jumper_config:
+      target: localhost
+      ssh_dir: "{{ lookup('env', 'HOME') }}/.ssh"
+      hostname: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
+      user: "{{ 'core' if vm_ip.nic.host is match('^(crc|ocp).*') else 'zuul' }}"
+      proxy_host: "{{ ansible_host | default(inventory_hostname) }}"
+      proxy_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+      patterns:
+        - "{{ vm_ip.nic.host }}"
+        - "{{ vm_ip.nic.host }}.{{ inventory_hostname }}"
+        - "cifmw-{{ vm_ip.nic.host }}"
+  ansible.builtin.include_role:
+    name: ssh_jumper
   loop: "{{ vm_ips.results }}"
   loop_control:
     loop_var: vm_ip
@@ -79,25 +77,22 @@
   when:
     - _need_start | bool
   vars:
-    extracted_ip: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
-    identity_file: >-
-      {{
-        cifmw_libvirt_manager_basedir ~ '/artifacts/cifmw_ocp_access_key' if vm_type is match('^ocp.*') else
-        ansible_user_dir ~ '/.crc/machines/crc/id_ecdsa' if vm_type == 'crc' else
-        ansible_user_dir ~ '/.ssh/cifmw_reproducer_key'
-      }}
-  ansible.builtin.blockinfile:
-    create: true
-    path: "{{ ansible_user_dir }}/.ssh/config"
-    marker: "## {mark} {{ vm_ip.nic.host }}"
-    mode: "0600"
-    block: |-
-      Host {{ vm_ip.nic.host }} {{ vm_ip.nic.host }}.{{ inventory_hostname }} cifmw-{{ vm_ip.nic.host }} {{ extracted_ip }}
-        Hostname {{ extracted_ip }}
-        User {{ 'core' if vm_ip.nic.host is match('^(crc|ocp)') else 'zuul' }}
-        IdentityFile {{ identity_file }}
-        StrictHostKeyChecking no
-        UserKnownHostsFile /dev/null
+    cifmw_ssh_jumper_config:
+      ssh_dir: "{{ ansible_user_dir }}/.ssh"
+      hostname: "{{ (vm_ip.stdout.split())[3] | ansible.utils.ipaddr('address') }}"
+      user: "{{ 'core' if vm_ip.nic.host is match('^(crc|ocp).*') else 'zuul' }}"
+      identity_file: >-
+        {{
+          cifmw_libvirt_manager_basedir ~ '/artifacts/cifmw_ocp_access_key' if vm_type is match('^ocp.*') else
+          ansible_user_dir ~ '/.crc/machines/crc/id_ecdsa' if vm_type == 'crc' else
+          ansible_user_dir ~ '/.ssh/cifmw_reproducer_key'
+        }}
+      patterns:
+        - "{{ vm_ip.nic.host }}"
+        - "{{ vm_ip.nic.host }}.{{ inventory_hostname }}"
+        - "cifmw-{{ vm_ip.nic.host }}"
+  ansible.builtin.include_role:
+    name: ssh_jumper
   loop: "{{ vm_ips.results }}"
   loop_control:
     loop_var: vm_ip

--- a/roles/ssh_jumper/README.md
+++ b/roles/ssh_jumper/README.md
@@ -1,0 +1,54 @@
+# ssh_jumper
+Configure SSH client configuration host specifications.
+
+## Parameters
+* `cifmw_ssh_jumper_config: (Dictionary) SSH client host configuration.
+
+### `cifmw_ssh_jumper_config` parameters
+
+Required:
+* `hostname`: (String) Hostname (or IP address).
+
+Optional:
+* `target`: (String) Inventory host target to configure. Defaults to: `{{ inventory_hostname }}`.
+* `ssh_dir`: (String) SSH directory. Defaults to: `{{ ansible_user_dir }}/.ssh`.
+* `patterns`: (List) Patterns to match the host.
+* `user`: (String) Specifies the user to log in as. Defaults to: `zuul`.
+* `proxy_host`: (String) SSH jump proxy hostname.
+* `proxy_user`: (String) SSH jump proxy username. Defaults to: `zuul`.
+* `identity_file`: (String) File from which identity is read.
+* `strict_host_key_checking`: (String) If set to `yes` host keys are checked. Defaults to: `no`.
+* `user_known_hosts_file`: (String)' File to use for user host key database. Defaults to: `/dev/null`.
+
+## Examples
+
+```yaml
+- name: "Add SSH jumper with proxy on invenetory host: localhost"
+  vars:
+    cifmw_ssh_jumper_config:
+      target: instance
+      ssh_dir: "/home/zuul/.ssh"
+      hostname: '192.168.250.10'
+      proxy_host: "proxy.example.com"
+      proxy_user: zuul
+      patterns:
+        - test
+        - test.node
+  ansible.builtin.include_role:
+    name: ssh_jumper
+```
+
+```yaml
+- name: "Add SSH jumper without proxy on invnetory host: instance"
+  vars:
+    cifmw_ssh_jumper_config:
+      target: instance
+      ssh_dir: "/home/zuul/.ssh"
+      hostname: '192.168.250.11'
+      identity_file: "/home/zuul/.ssh/id_foo"
+      patterns:
+        - test
+        - test.node
+  ansible.builtin.include_role:
+    name: ssh_jumper
+```

--- a/roles/ssh_jumper/defaults/main.yml
+++ b/roles/ssh_jumper/defaults/main.yml
@@ -1,0 +1,31 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_ssh_jumper"
+
+cifmw_ssh_jumper_config:
+  target: "{{ inventory_hostname }}"
+  hostname:
+  ssh_dir: "{{ ansible_user_dir }}/.ssh"
+  user: zuul
+  proxy_host:
+  patterns: []
+  proxy_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+  identity_file:
+  strict_host_key_checking: 'no'
+  user_known_hosts_file: '/dev/null'

--- a/roles/ssh_jumper/meta/main.yml
+++ b/roles/ssh_jumper/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- ssh_jumper
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: cifmw
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - cifmw
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/ssh_jumper/molecule/default/cleanup.yml
+++ b/roles/ssh_jumper/molecule/default/cleanup.yml
@@ -1,0 +1,12 @@
+- name: Converge
+  hosts: instance
+  vars:
+    cifmw_basedir: "/opt/basedir"
+  tasks:
+    - name: Cleanup SSH jumper hosts
+      vars:
+        cifmw_ssh_jumper_config:
+          ssh_dir: "{{ cifmw_basedir }}/ssh"
+      ansible.builtin.include_role:
+        name: ssh_jumper
+        tasks_from: cleanup.yml

--- a/roles/ssh_jumper/molecule/default/converge.yml
+++ b/roles/ssh_jumper/molecule/default/converge.yml
@@ -1,0 +1,146 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: instance
+  vars:
+    cifmw_basedir: "/opt/basedir"
+  tasks:
+    - name: Crate SSH keypair
+      register: _test_key
+      community.crypto.openssh_keypair:
+        comment: "test-key"
+        path: "{{ (cifmw_basedir, 'ssh/id_test') | path_join }}"
+        type: "ecdsa"
+
+    - name: Add SSH jumper with proxy
+      vars:
+        cifmw_ssh_jumper_config:
+          ssh_dir: "{{ cifmw_basedir }}/ssh"
+          hostname: '192.168.250.10'
+          proxy_host: "proxy.example.com"
+          proxy_user: cloud-user
+          patterns:
+            - test
+            - test.node
+      ansible.builtin.include_role:
+        name: ssh_jumper
+
+    - name: Add SSH host - minimal config
+      vars:
+        cifmw_ssh_jumper_config:
+          hostname: minimal.example.com
+          ssh_dir: "{{ cifmw_basedir }}/ssh"
+      ansible.builtin.include_role:
+        name: ssh_jumper
+
+    - name: Add SSH jumper without proxy
+      vars:
+        cifmw_ssh_jumper_config:
+          target: instance
+          ssh_dir: "{{ cifmw_basedir }}/ssh"
+          hostname: '192.168.250.11'
+          identity_file: "{{ _test_key.filename }}"
+          patterns:
+            - test
+            - test.node
+      ansible.builtin.include_role:
+        name: ssh_jumper
+
+    - name: Slurp ssh/config
+      register: ssh_config
+      ansible.builtin.slurp:
+        src: "{{ cifmw_basedir }}/ssh/config"
+
+    - name: Slurp ssh/cifw_ssh_config.d/cifmw-minimal.example.com.conf
+      register: cifmw_minimal_example_com
+      ansible.builtin.slurp:
+        src: "{{ cifmw_basedir }}/ssh/cifw_ssh_config.d//cifmw-minimal.example.com.conf"
+
+    - name: Slurp ssh/cifw_ssh_config.d/cifmw-192.168.250.10.conf
+      register: cifw_ssh_config_d_192_168_250_10
+      ansible.builtin.slurp:
+        src: "{{ cifmw_basedir }}/ssh/cifw_ssh_config.d//cifmw-192.168.250.10.conf"
+
+    - name: Slurp ssh/cifw_ssh_config.d/cifmw-192.168.250.11.conf
+      register: cifw_ssh_config_d_192_168_250_11
+      ansible.builtin.slurp:
+        src: "{{ cifmw_basedir }}/ssh/cifw_ssh_config.d//cifmw-192.168.250.11.conf"
+
+    - name: Assert Inlcude in ssh_config
+      vars:
+        _ref: |
+          Include cifw_ssh_config.d/*.conf
+        _res: "{{ ssh_config['content'] | b64decode }}"
+      ansible.builtin.assert:
+        that:
+          - _ref == _res
+
+    - name: Assert SSH host - minimal config
+      vars:
+        _ref: |
+          Host minimal.example.com
+              Hostname minimal.example.com
+              User zuul
+              StrictHostKeyChecking no
+              UserKnownHostsFile /dev/null
+        _res: "{{ cifmw_minimal_example_com['content'] | b64decode }}"
+      ansible.builtin.assert:
+        that:
+          - _ref == _res
+        fail_msg: |
+          Expected:
+          {{ _ref }}
+          Actual:
+          {{ _res }}
+
+    - name: Assert cifmw-192.168.250.10.conf
+      vars:
+        _ref: |
+          Host test test.node 192.168.250.10
+              Hostname 192.168.250.10
+              ProxyJump cloud-user@proxy.example.com
+              User zuul
+              StrictHostKeyChecking no
+              UserKnownHostsFile /dev/null
+        _res: "{{ cifw_ssh_config_d_192_168_250_10['content'] | b64decode }}"
+      ansible.builtin.assert:
+        that:
+          - _ref == _res
+        fail_msg: |
+          Expected:
+          {{ _ref }}
+          Actual:
+          {{ _res }}
+
+    - name: Assert cifmw-192.168.250.11.conf
+      vars:
+        _ref: |
+          Host test test.node 192.168.250.11
+              Hostname 192.168.250.11
+              User zuul
+              IdentityFile /opt/basedir/ssh/id_test
+              StrictHostKeyChecking no
+              UserKnownHostsFile /dev/null
+        _res: "{{ cifw_ssh_config_d_192_168_250_11['content'] | b64decode }}"
+      ansible.builtin.assert:
+        that:
+          - _ref == _res
+        fail_msg: |
+          Expected:
+          {{ _ref }}
+          Actual:
+          {{ _res }}

--- a/roles/ssh_jumper/molecule/default/molecule.yml
+++ b/roles/ssh_jumper/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/roles/ssh_jumper/molecule/default/prepare.yml
+++ b/roles/ssh_jumper/molecule/default/prepare.yml
@@ -1,0 +1,32 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  vars:
+    cifmw_basedir: "/opt/basedir"
+  pre_tasks:
+    - name: Create custom basedir
+      become: true
+      ansible.builtin.file:
+        path: "{{ cifmw_basedir }}/ssh"
+        state: directory
+        owner: zuul
+        group: zuul
+        mode: "0755"
+  roles:
+    - role: test_deps

--- a/roles/ssh_jumper/tasks/cleanup.yml
+++ b/roles/ssh_jumper/tasks/cleanup.yml
@@ -1,0 +1,26 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Remove Include cifw_ssh_config.d
+  ansible.builtin.lineinfile:
+    state: absent
+    path: "{{ cifmw_ssh_jumper_config.ssh_dir }}/config"
+    regexp: '^Include cifw_ssh_config.d/.*conf$'
+
+- name: Remove cifw_ssh_config.d directory
+  ansible.builtin.file:
+    state: absent
+    path: "{{ cifmw_ssh_jumper_config.ssh_dir }}/cifw_ssh_config.d/"

--- a/roles/ssh_jumper/tasks/main.yml
+++ b/roles/ssh_jumper/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Make sure ~/.ssh/cifw_ssh_config.d directory exists
+  delegate_to: "{{ cifmw_ssh_jumper_config.target | default(inventory_hostname) }}"
+  ansible.builtin.file:
+    path: "{{ cifmw_ssh_jumper_config.ssh_dir | default((ansible_user_dir, '/.ssh') | path_join) }}/cifw_ssh_config.d"
+    state: directory
+    mode: '0700'
+
+- name: Include ~/.ssh/config.d/*.conf
+  delegate_to: "{{ cifmw_ssh_jumper_config.target | default(inventory_hostname) }}"
+  ansible.builtin.lineinfile:
+    insertbefore: BOF
+    create: true
+    state: present
+    path: "{{ cifmw_ssh_jumper_config.ssh_dir | default((ansible_user_dir, '/.ssh') | path_join) }}/config"
+    mode: '0600'
+    line: 'Include cifw_ssh_config.d/*.conf'
+
+- name: "Inject ssh jumpers for {{ cifmw_ssh_jumper_config.hostname }}"
+  delegate_to: "{{ cifmw_ssh_jumper_config.target | default(inventory_hostname) }}"
+  ansible.builtin.template:
+    src: ssh_host.conf.j2
+    dest: "{{ cifmw_ssh_jumper_config.ssh_dir }}/cifw_ssh_config.d/cifmw-{{ cifmw_ssh_jumper_config.hostname }}.conf"
+    mode: '0600'

--- a/roles/ssh_jumper/templates/ssh_host.conf.j2
+++ b/roles/ssh_jumper/templates/ssh_host.conf.j2
@@ -1,0 +1,11 @@
+Host {{ (cifmw_ssh_jumper_config.patterns | default([]) + [cifmw_ssh_jumper_config.hostname]) | join(' ') }}
+    Hostname {{ cifmw_ssh_jumper_config.hostname }}
+{% if cifmw_ssh_jumper_config.proxy_host is defined and cifmw_ssh_jumper_config.proxy_host is not none %}
+    ProxyJump {{ cifmw_ssh_jumper_config.proxy_user | default('zuul') }}@{{ cifmw_ssh_jumper_config.proxy_host }}
+{% endif %}
+    User {{ cifmw_ssh_jumper_config.user | default('zuul') }}
+{% if cifmw_ssh_jumper_config.identity_file is defined and cifmw_ssh_jumper_config.identity_file is not none %}
+    IdentityFile {{ cifmw_ssh_jumper_config.identity_file }}
+{% endif %}
+    StrictHostKeyChecking {{ cifmw_ssh_jumper_config.strict_host_key_checking | default('no') }}
+    UserKnownHostsFile {{ cifmw_ssh_jumper_config.user_known_hosts_file | default ('/dev/null') }}

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -691,6 +691,17 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/ssh_jumper/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-ssh_jumper
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: ssh_jumper
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/sushy_emulator/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -77,6 +77,7 @@
       - cifmw-molecule-run_hook
       - cifmw-molecule-set_openstack_containers
       - cifmw-molecule-shiftstack
+      - cifmw-molecule-ssh_jumper
       - cifmw-molecule-sushy_emulator
       - cifmw-molecule-switch_config
       - cifmw-molecule-tempest


### PR DESCRIPTION
Currently the ssh jumper is configuerd by tasks in the libvirt_manager role. Adding jumper configuration may be useful for other roles that create VMs outside of the ones defined in the "layout" deployed by the libvirt_manager tasks.

This change adds a new role `ssh_jumper` - and updated the tasks in libvirt_manager role to use this new role when creating the SSH config.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
