### PR TITLE
[ci_gen_kustomize] Preserve additional non ConfigMap manifests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,4 @@ repos:
       - id: ansible-lint
         additional_dependencies:
           - netaddr
+          - jmespath

--- a/plugins/filter/to_nice_yaml_all.py
+++ b/plugins/filter/to_nice_yaml_all.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = """
+    name: to_nice_yaml_all
+    short_description: Convert list of variables to a single YAML string
+    description:
+    - Converts an Ansible variable into a YAML string representation.
+    - This filter functions as a wrapper to the L(Python PyYAML library, https://pypi.org/project/PyYAML/)'s C(yaml.dump) function.
+    - Ansible internally auto-converts YAML strings into variable structures so this plugin is used to force it into a YAML string.
+    options:
+        _input:
+            description: A variable or expression that returns a data structure.
+            type: raw
+            required: true
+        indent:
+            description: Number of spaces to indent Python structures, mainly used for display to humans.
+            type: integer
+"""
+
+EXAMPLES = """
+    # dump variable in a template to create a YAML document
+    {{ github_workflow | to_nice_yaml_all }}
+"""
+
+RETURN = """
+  _value:
+    description: The YAML serialized string representing the variable structure inputted.
+    type: string
+"""
+
+import yaml
+
+from ansible.module_utils._text import to_native, to_text
+from ansible.errors import AnsibleFilterError
+from ansible.parsing.yaml.dumper import AnsibleDumper
+
+
+class FilterModule:
+
+    @staticmethod
+    def __to_nice_yaml_all(a, indent=4, *args, **kw):
+        """Make verbose, human readable multi manifest yaml"""
+        try:
+            transformed = to_text(
+                yaml.dump_all(
+                    a,
+                    Dumper=AnsibleDumper,
+                    indent=indent,
+                    allow_unicode=True,
+                    default_flow_style=False,
+                    **kw
+                )
+            )
+        except Exception as e:
+            raise AnsibleFilterError("to_nice_yaml_all - %s" % to_native(e), orig_exc=e)
+        return to_text(transformed)
+
+    def filters(self):
+        return {
+            "to_nice_yaml_all": self.__to_nice_yaml_all,
+        }

--- a/roles/ci_gen_kustomize_values/tasks/generate_snippets.yml
+++ b/roles/ci_gen_kustomize_values/tasks/generate_snippets.yml
@@ -31,11 +31,37 @@
 
 - name: Expose common data for future usage
   vars:
-    _original_content: "{{ _original.content | b64decode | from_yaml }}"
+    _raw_manifests: "{{ _original.content | b64decode | from_yaml_all }}"
+    _raw_config_maps: >-
+      {{
+         _raw_manifests |
+         selectattr('kind', 'defined') |
+         selectattr('kind', 'equalto', 'ConfigMap')
+      }}
+    _target_config_map: >-
+      {{
+         (
+          _raw_config_maps |
+          selectattr('metadata.annotations', 'defined') |
+          selectattr('metadata.name', 'equalto', cifmw_ci_gen_kustomize_values_name) |
+          first | default({})
+         ) if cifmw_ci_gen_kustomize_values_name is defined and cifmw_ci_gen_kustomize_values_name != ""
+         else {}
+      }}
+    _local_config_query: >-
+          [?(metadata.annotations."config.kubernetes.io/local-config")=='true']
+    _config_map_content: >-
+      {{
+        _target_config_map |
+        default(
+            _raw_config_maps | default([]) |
+            json_query(_local_config_query) | first | default({})
+          , true)
+      }}
     _datatype: >-
       {{
         cifmw_ci_gen_kustomize_values_name |
-        default(_original_content.metadata.name, true)
+        default(_config_map_content.metadata.name, true)
       }}
     _dest_dir: >-
       {{
@@ -46,7 +72,17 @@
   ansible.builtin.set_fact:
     values_datatype: "{{ _datatype }}"
     snippet_datadir: "{{ _dest_dir }}"
-    original_content: "{{ _original_content }}"
+    original_content: "{{ _config_map_content }}"
+    _cifmw_gen_kustomize_values_extra_manifests: >-
+      {{
+        _raw_manifests | reject('equalto', _config_map_content)
+      }}
+    _cifmw_gen_kustomize_values_base_cm_content: >-
+      {{
+        _config_map_content |
+        ansible.utils.remove_keys(target=['^nodes?(_[0-9]+)?$'],
+                                  matching_parameter='regex')
+      }}
     cacheable: false
 
 - name: Ensure we get the needed data depending on the values type
@@ -61,23 +97,6 @@
     path: "{{ snippet_datadir }}"
     state: directory
     mode: "0755"
-
-- name: Copy original values.yaml
-  ansible.builtin.copy:
-    backup: true
-    content: >-
-      {{
-        original_content |
-        ansible.utils.remove_keys(target=['^nodes?(_[0-9]+)?$'],
-                                  matching_parameter='regex') |
-        to_nice_yaml
-      }}
-    dest: >-
-      {{
-        (snippet_datadir,
-         '01_original.yaml') | path_join
-      }}
-    mode: "0644"
 
 - name: Generate CI snippet
   when:
@@ -148,5 +167,18 @@
         cifmw_ci_gen_kustomize_values_userdata |
         default({}) |
         to_nice_yaml
+      }}
+    mode: "0644"
+
+- name: Copy the base values.yaml
+  ansible.builtin.copy:
+    backup: true
+    content: "{{ _cifmw_gen_kustomize_values_base_cm_content |to_nice_yaml }}"
+    dest: >-
+      {{
+        (
+          snippet_datadir,
+          cifmw_ci_gen_kustomize_values_original_cm_content_file_name
+        ) | path_join
       }}
     mode: "0644"

--- a/roles/ci_gen_kustomize_values/tasks/generate_values.yml
+++ b/roles/ci_gen_kustomize_values/tasks/generate_values.yml
@@ -23,7 +23,7 @@
       Please do not call this tasks file without
       calling the generate_snippet.yml first!
 
-- name: Ensure we have content to combine
+- name: List snippets
   vars:
     _dir_name: >-
       {{
@@ -37,20 +37,12 @@
            _dir_name) | path_join
         )
       }}
-  block:
-    - name: List snippets
-      register: _snippets
-      ansible.builtin.find:
-        paths: "{{ _dir_path }}"
-        patterns: "*.yml,*.yaml"
-        recurse: false
-
-    - name: Assert we do have content to combine
-      ansible.builtin.assert:
-        that:
-          - _snippets.files | length > 0
-        msg: >-
-          No file found in {{ _dir_path }}
+  ansible.builtin.find:
+    paths: "{{ _dir_path }}"
+    patterns: "*.yml,*.yaml"
+    excludes: "{{ cifmw_ci_gen_kustomize_values_original_cm_content_file_name }}"
+    recurse: false
+  register: _snippets
 
 - name: Ensure _content is empty
   ansible.builtin.set_fact:
@@ -77,6 +69,7 @@
     _content: >
       {{
         _content |
+        default(_cifmw_gen_kustomize_values_base_cm_content, true) |
         combine(_parsed, recursive=true)
       }}
   loop: "{{ _snippets_content.results }}"
@@ -108,6 +101,8 @@
           }}
         content: >-
           {{
-            _content | to_nice_yaml
+            (
+              [ _content ] + _cifmw_gen_kustomize_values_extra_manifests
+            ) | cifmw.general.to_nice_yaml_all
           }}
         mode: "0644"

--- a/roles/ci_gen_kustomize_values/vars/main.yml
+++ b/roles/ci_gen_kustomize_values/vars/main.yml
@@ -1,0 +1,24 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# While options found within the vars/ path can be overridden using extra
+# vars, items within this path are considered part of the role and not
+# intended to be modified.
+
+# All variables within this role should have a prefix of "cifmw_ci_gen_kustomize_values"
+
+cifmw_ci_gen_kustomize_values_original_cm_content_file_name: "01_original.yaml"


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
