### PR TITLE
Fix some hardcoded repository locations

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -379,9 +379,8 @@
           cifmw_architecture_automation_file: >-
             {{
               (
-                ansible_user_dir,
-                'src/github.com/openstack-k8s-operators',
-                'architecture/automation/vars',
+                cifmw_architecture_repo | default(ansible_user_dir+'/src/github.com/openstack-k8s-operators/architecture'),
+                'automation/vars',
                 cifmw_arch_automation_file | default('default.yaml')
               ) | ansible.builtin.path_join
             }}

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -221,9 +221,17 @@
         - name: Install dev tools from install_yamls on controller-0
           environment:
             ANSIBLE_LOG_PATH: "~/ansible-bootstrap.log"
+          vars:
+            _devsetup_path: >-
+              {{
+                (
+                  cifmw_install_yamls_repo | default('/home/zuul/src/github.com/openstack-k8s-operators/install_yamls'),
+                  'devsetup'
+                ) | ansible.builtin.path_join
+              }}
           no_log: true
           ansible.builtin.command:
-            chdir: "/home/zuul/src/github.com/openstack-k8s-operators/install_yamls/devsetup"
+            chdir: "{{ _devsetup_path }}"
             cmd: >-
               ansible-playbook -i ~/ci-framework-data/artifacts/zuul_inventory.yml
               download_tools.yaml --tags kustomize,kubectl


### PR DESCRIPTION
While deploying with a different repository location we found these 2 places that have code location hardcoded. This PR allow these commands to check for cifmw known vaiables for these specific repositories.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
