### PR TITLE
Add ssh_jumper role

### DIFF
--- a/roles/ssh_jumper/README.md
+++ b/roles/ssh_jumper/README.md
@@ -1,0 +1,46 @@
+# ssh_jumper
+Configure SSH client configuration host specifications.
+
+## Parameters
+* `cifmw_ssh_jumper_config: (List) SSH client host configuration.
+
+### `cifmw_ssh_jumper_config` parameters
+
+Required:
+* `hostname`: (String) Hostname (or IP address).
+
+Optional:
+* `target`: (String) Inventory host target to configure. Defaults to: `{{ inventory_hostname }}`.
+* `ssh_dir`: (String) SSH directory. Defaults to: `{{ ansible_user_dir }}/.ssh`.
+* `patterns`: (List) Patterns to match the host.
+* `user`: (String) Specifies the user to log in as. Defaults to: `zuul`.
+* `proxy_host`: (String) SSH jump proxy hostname.
+* `proxy_user`: (String) SSH jump proxy username. Defaults to: `zuul`.
+* `identity_file`: (String) File from which identity is read.
+* `strict_host_key_checking`: (String) If set to `yes` host keys are checked. Defaults to: `no`.
+* `user_known_hosts_file`: (String)' File to use for user host key database. Defaults to: `/dev/null`.
+
+## Examples
+
+```yaml
+- name: "Add SSH jumper entries"
+  vars:
+    cifmw_ssh_jumper_config:
+      - target: localhost
+        ssh_dir: "/home/zuul/.ssh"
+        hostname: '192.168.250.10'
+        proxy_host: "proxy.example.com"
+        proxy_user: zuul
+        patterns:
+          - test
+          - test.node
+      - target: instance
+        ssh_dir: "/home/zuul/.ssh"
+        hostname: '192.168.250.10'
+        identity_file: "/home/zuul/.ssh/id_foo"
+        patterns:
+          - test
+          - test.node
+  ansible.builtin.include_role:
+    name: ssh_jumper
+```

--- a/roles/ssh_jumper/defaults/main.yml
+++ b/roles/ssh_jumper/defaults/main.yml
@@ -1,0 +1,31 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_ssh_jumper"
+
+cifmw_ssh_jumper_config:
+  - hostname:
+    proxy_host:
+    identity_file:
+    patterns: "{{ cifmw_ssh_jumper_defaults.patterns }}"
+    target: "{{ cifmw_ssh_jumper_defaults.target }}"
+    ssh_dir: "{{ cifmw_ssh_jumper_defaults.ssh_dir }}"
+    user: "{{ cifmw_ssh_jumper_defaults.user }}"
+    proxy_user: "{{ cifmw_ssh_jumper_defaults.proxy_user }}"
+    strict_host_key_checking: "{{ cifmw_ssh_jumper_defaults.strict_host_key_checking }}"
+    user_known_hosts_file: "{{ cifmw_ssh_jumper_defaults.user_known_hosts_file }}"

--- a/roles/ssh_jumper/meta/main.yml
+++ b/roles/ssh_jumper/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- ssh_jumper
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: cifmw
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - cifmw
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/ssh_jumper/molecule/default/cleanup.yml
+++ b/roles/ssh_jumper/molecule/default/cleanup.yml
@@ -1,0 +1,12 @@
+- name: Cleanup
+  hosts: instance
+  vars:
+    cifmw_basedir: "/opt/basedir"
+  tasks:
+    - name: Cleanup SSH jumper hosts
+      vars:
+        cifmw_ssh_jumper_config:
+          ssh_dir: "{{ cifmw_basedir }}/ssh"
+      ansible.builtin.include_role:
+        name: ssh_jumper
+        tasks_from: cleanup.yml

--- a/roles/ssh_jumper/molecule/default/converge.yml
+++ b/roles/ssh_jumper/molecule/default/converge.yml
@@ -1,0 +1,134 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: instance
+  vars:
+    cifmw_basedir: "/opt/basedir"
+  tasks:
+    - name: Crate SSH keypair
+      register: _test_key
+      community.crypto.openssh_keypair:
+        comment: "test-key"
+        path: "{{ (cifmw_basedir, 'ssh/id_test') | path_join }}"
+        type: "ecdsa"
+
+    - name: Add SSH jumper entries
+      vars:
+        cifmw_ssh_jumper_config:
+          - ssh_dir: "{{ cifmw_basedir }}/ssh"
+            hostname: '192.168.250.10'
+            proxy_host: "proxy.example.com"
+            proxy_user: cloud-user
+            patterns:
+              - test
+              - test.node
+          - hostname: minimal.example.com
+            ssh_dir: "{{ cifmw_basedir }}/ssh"
+          - target: instance
+            ssh_dir: "{{ cifmw_basedir }}/ssh"
+            hostname: '192.168.250.11'
+            identity_file: "{{ _test_key.filename }}"
+            patterns:
+              - test
+              - test.node
+      ansible.builtin.include_role:
+        name: ssh_jumper
+
+    - name: Slurp ssh/config
+      register: ssh_config
+      ansible.builtin.slurp:
+        src: "{{ cifmw_basedir }}/ssh/config"
+
+    - name: Slurp ssh/cifw_ssh_config.d/minimal.example.com.conf
+      register: cifmw_minimal_example_com
+      ansible.builtin.slurp:
+        src: "{{ cifmw_basedir }}/ssh/cifw_ssh_config.d/instance/minimal.example.com.conf"
+
+    - name: Slurp ssh/cifw_ssh_config.d/192.168.250.10.conf
+      register: cifw_ssh_config_d_192_168_250_10
+      ansible.builtin.slurp:
+        src: "{{ cifmw_basedir }}/ssh/cifw_ssh_config.d/instance/192.168.250.10-via-proxy.example.com.conf"
+
+    - name: Slurp ssh/cifw_ssh_config.d/192.168.250.11.conf
+      register: cifw_ssh_config_d_192_168_250_11
+      ansible.builtin.slurp:
+        src: "{{ cifmw_basedir }}/ssh/cifw_ssh_config.d/instance/192.168.250.11.conf"
+
+    - name: Assert Include in ssh_config
+      vars:
+        _ref: |
+          Include cifw_ssh_config.d/instance/*.conf
+        _res: "{{ ssh_config['content'] | b64decode }}"
+      ansible.builtin.assert:
+        that:
+          - _ref == _res
+
+    - name: Assert SSH host - minimal config
+      vars:
+        _ref: |
+          Host minimal.example.com
+              Hostname minimal.example.com
+              User zuul
+              StrictHostKeyChecking no
+              UserKnownHostsFile /dev/null
+        _res: "{{ cifmw_minimal_example_com['content'] | b64decode }}"
+      ansible.builtin.assert:
+        that:
+          - _ref == _res
+        fail_msg: |
+          Expected:
+          {{ _ref }}
+          Actual:
+          {{ _res }}
+
+    - name: Assert cifmw-192.168.250.10.conf
+      vars:
+        _ref: |
+          Host test test.node 192.168.250.10
+              Hostname 192.168.250.10
+              ProxyJump cloud-user@proxy.example.com
+              User zuul
+              StrictHostKeyChecking no
+              UserKnownHostsFile /dev/null
+        _res: "{{ cifw_ssh_config_d_192_168_250_10['content'] | b64decode }}"
+      ansible.builtin.assert:
+        that:
+          - _ref == _res
+        fail_msg: |
+          Expected:
+          {{ _ref }}
+          Actual:
+          {{ _res }}
+
+    - name: Assert cifmw-192.168.250.11.conf
+      vars:
+        _ref: |
+          Host test test.node 192.168.250.11
+              Hostname 192.168.250.11
+              User zuul
+              IdentityFile /opt/basedir/ssh/id_test
+              StrictHostKeyChecking no
+              UserKnownHostsFile /dev/null
+        _res: "{{ cifw_ssh_config_d_192_168_250_11['content'] | b64decode }}"
+      ansible.builtin.assert:
+        that:
+          - _ref == _res
+        fail_msg: |
+          Expected:
+          {{ _ref }}
+          Actual:
+          {{ _res }}

--- a/roles/ssh_jumper/molecule/default/molecule.yml
+++ b/roles/ssh_jumper/molecule/default/molecule.yml
@@ -1,0 +1,11 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/roles/ssh_jumper/molecule/default/prepare.yml
+++ b/roles/ssh_jumper/molecule/default/prepare.yml
@@ -1,0 +1,32 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  vars:
+    cifmw_basedir: "/opt/basedir"
+  pre_tasks:
+    - name: Create custom basedir
+      become: true
+      ansible.builtin.file:
+        path: "{{ cifmw_basedir }}/ssh"
+        state: directory
+        owner: zuul
+        group: zuul
+        mode: "0755"
+  roles:
+    - role: test_deps

--- a/roles/ssh_jumper/tasks/cleanup.yml
+++ b/roles/ssh_jumper/tasks/cleanup.yml
@@ -1,0 +1,26 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Remove Include cifw_ssh_config.d
+  ansible.builtin.lineinfile:
+    state: absent
+    path: "{{ cifmw_ssh_jumper_config.ssh_dir }}/config"
+    regexp: '^Include cifw_ssh_config.d/{{ inventory_hostname }}/.*conf$'
+
+- name: Remove cifw_ssh_config.d directory
+  ansible.builtin.file:
+    state: absent
+    path: "{{ cifmw_ssh_jumper_config.ssh_dir }}/cifw_ssh_config.d/{{ inventory_hostname }}/"

--- a/roles/ssh_jumper/tasks/main.yml
+++ b/roles/ssh_jumper/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Create ssh-jumper entries
+  vars:
+    _config: "{{ item }}"
+  ansible.builtin.include_tasks:
+    file: manage_ssh_jumper_entry.yml
+  loop: "{{ cifmw_ssh_jumper_config }}"

--- a/roles/ssh_jumper/tasks/manage_ssh_jumper_entry.yml
+++ b/roles/ssh_jumper/tasks/manage_ssh_jumper_entry.yml
@@ -1,0 +1,55 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Make sure ~/.ssh/cifw_ssh_config.d directory exists
+  delegate_to: "{{ _config.target | default(cifmw_ssh_jumper_defaults.target) }}"
+  vars:
+    _ssh_dir: "{{ _config.ssh_dir | default(cifmw_ssh_jumper_defaults.ssh_dir) }}"
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0700'
+  loop:
+    - "{{ _ssh_dir | default((ansible_user_dir, '/.ssh') | path_join) }}/cifw_ssh_config.d"
+    - "{{ _ssh_dir | default((ansible_user_dir, '/.ssh') | path_join) }}/cifw_ssh_config.d/{{ inventory_hostname }}"
+
+- name: Include ~/.ssh/cifw_ssh_config.d/inventory_hostname/*.conf
+  delegate_to: "{{ _config.target | default(cifmw_ssh_jumper_defaults.target) }}"
+  vars:
+    _ssh_dir: "{{ _config.ssh_dir | default(cifmw_ssh_jumper_defaults.ssh_dir) }}"
+  ansible.builtin.lineinfile:
+    insertbefore: BOF
+    create: true
+    state: present
+    path: "{{ _ssh_dir | default((ansible_user_dir, '/.ssh') | path_join) }}/config"
+    mode: '0600'
+    line: 'Include cifw_ssh_config.d/{{ inventory_hostname }}/*.conf'
+
+- name: "Inject ssh jumpers for {{ _config.hostname }}"
+  delegate_to: "{{ _config.target | default(cifmw_ssh_jumper_defaults.target) }}"
+  vars:
+    _ssh_dir: "{{ _config.ssh_dir | default(cifmw_ssh_jumper_defaults.ssh_dir) }}"
+    _dir: "{{ _ssh_dir }}/cifw_ssh_config.d/{{ inventory_hostname }}"
+    _filename: >-
+      {%- if _config.proxy_host is defined and _config.proxy_host is not none -%}
+      {{ _config.hostname }}-via-{{ _config.proxy_host }}.conf
+      {%- else -%}
+      {{ _config.hostname }}.conf
+      {%- endif -%}
+  ansible.builtin.template:
+    src: ssh_host.conf.j2
+    dest: "{{ (_dir, _filename) | path_join }}"
+    mode: '0600'

--- a/roles/ssh_jumper/templates/ssh_host.conf.j2
+++ b/roles/ssh_jumper/templates/ssh_host.conf.j2
@@ -1,0 +1,11 @@
+Host {{ (_config.patterns | default(cifmw_ssh_jumper_defaults.patterns) + [_config.hostname]) | join(' ') }}
+    Hostname {{ _config.hostname }}
+{% if _config.proxy_host is defined and _config.proxy_host is not none %}
+    ProxyJump {{ _config.proxy_user | default(cifmw_ssh_jumper_defaults.user) }}@{{ _config.proxy_host }}
+{% endif %}
+    User {{ _config.user | default(cifmw_ssh_jumper_defaults.user) }}
+{% if _config.identity_file is defined and _config.identity_file is not none %}
+    IdentityFile {{ _config.identity_file }}
+{% endif %}
+    StrictHostKeyChecking {{ _config.strict_host_key_checking | default(cifmw_ssh_jumper_defaults.strict_host_key_checking) }}
+    UserKnownHostsFile {{ _config.user_known_hosts_file | default (cifmw_ssh_jumper_defaults.user_known_hosts_file) }}

--- a/roles/ssh_jumper/vars/main.yml
+++ b/roles/ssh_jumper/vars/main.yml
@@ -1,0 +1,24 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+cifmw_ssh_jumper_defaults:
+  target: "{{ inventory_hostname }}"
+  ssh_dir: "{{ ansible_user_dir }}/.ssh"
+  user: zuul
+  patterns: []
+  proxy_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+  strict_host_key_checking: 'no'
+  user_known_hosts_file: '/dev/null'

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -692,6 +692,17 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/ssh_jumper/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-ssh_jumper
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: ssh_jumper
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/sushy_emulator/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -77,6 +77,7 @@
       - cifmw-molecule-run_hook
       - cifmw-molecule-set_openstack_containers
       - cifmw-molecule-shiftstack
+      - cifmw-molecule-ssh_jumper
       - cifmw-molecule-sushy_emulator
       - cifmw-molecule-switch_config
       - cifmw-molecule-tempest


### PR DESCRIPTION
This is same as PR#1781 - but without the changes to libvirt_manager tasks.

We can merge this, without causing conflict.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
