### PR TITLE
dnsmasq manage forwarder/address/host-record

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -259,6 +259,7 @@ localhost
 localnet
 logfile
 logserver
+lookups
 loopback
 losetup
 lsblk

--- a/roles/dnsmasq/README.md
+++ b/roles/dnsmasq/README.md
@@ -69,6 +69,94 @@ supported in libvirt).
         tasks_from: manage_network.yml
 ```
 
+### Host record parameters
+
+* `cifmw_dnsmasq_host_record`: (List[mapping]) List of host records to add.
+
+#### Host record mapping
+
+* `state`: (String) Host record status. Must be either `present` or `absent`.
+* `ips`: (List[string]) List of IP addresses for the host record.
+* `names`: (List[string]) List of names for the host record.
+
+#### Examples
+
+```yaml
+- name: Add host-records
+  vars:
+    cifmw_dnsmasq_host_record:
+      - state: present
+        ips:
+          - 192.0.2.3
+          - '2001:db8::3'
+        names:
+          - enterprise.staralliance.startrek.lan
+      - state: present
+        ips:
+          - 192.0.2.4
+          - '2001:db8::4'
+        names:
+          - voyager.staralliance.startrek.lan
+  ansible.builtin.include_role:
+    name: dnsmasq
+    tasks_from: manage_host_record.yml
+```
+
+### New forwarder parameters
+
+* `cifmw_dnsmasq_forwarder`: (List[mapping]) List of forwarders, server address and domains the forwarder should used for.
+
+#### Forwarder mapping
+
+* `state`: (String) Forwarder status. Must be either `present` or `absent`.
+* `server`: (String) IP address of the dns server to forward lookups to.
+* `domains`: (List[string]) List of domains to use this server for.
+
+#### Examples
+
+```yaml
+- name: Add forwarder
+  vars:
+    cifmw_dnsmasq_forwarder:
+      - state: present
+        server: 192.0.2.10
+        domains:
+         - theborg.startrek.lab
+         - staralliance.startrek.lab
+  ansible.builtin.include_role:
+    name: dnsmasq
+    tasks_from: manage_forwarder.yml
+```
+
+### New address parameters
+
+* `cifmw_dnsmasq_address`: (List[mapping]) List for address to return for any host in the given domains.
+
+#### Address mapping
+
+* `state`: (String) Address status. Must be either `present` or `absent`.
+* `ipaddr`: (String) IP address to return for hosts in the given domains.
+* `domains`: (List[string]) List of domains.
+
+#### Examples
+
+```yaml
+    - name: Add addresses
+      vars:
+        cifmw_dnsmasq_address:
+          - state: present
+            ipaddr: 192.0.2.20
+            domains:
+              - apps.ocp.theborg.startrek.lab
+          - state: present
+            ipaddr: 192.0.2.30
+            domains:
+              - apps.ocp.staralliance.startrek.lab
+      ansible.builtin.include_role:
+        name: dnsmasq
+        tasks_from: manage_address.yml
+```
+
 ### New host parameters
 
 * `cifmw_dnsmasq_host_network`: (String) Existing network name.

--- a/roles/dnsmasq/molecule/default/cleanup.yml
+++ b/roles/dnsmasq/molecule/default/cleanup.yml
@@ -17,6 +17,51 @@
 - name: Converge
   hosts: all
   tasks:
+    - name: Remove a domain specific forwarder
+      vars:
+        cifmw_dnsmasq_forwarder:
+          - state: absent
+            server: "192.168.100.100"
+            domains:
+              - battlestar.galactica.lan
+      ansible.builtin.include_role:
+        name: dnsmasq
+        tasks_from: manage_forwarder.yml
+
+    - name: Remove some host records
+      vars:
+        cifmw_dnsmasq_host_record:
+          - state: absent
+            ips:
+              - "192.168.253.50"
+              - "2345:0425:2CA1::dead"
+            names:
+              - dead.battlestar.galactica.lan
+          - state: absent
+            ips:
+              - "192.168.253.51"
+              - "2345:0425:2CA1::beef"
+            names:
+              - beef.battlestar.galactica.lan
+      ansible.builtin.include_role:
+        name: dnsmasq
+        tasks_from: manage_host_record.yml
+
+    - name: Remove some wildcard addresses
+      vars:
+        cifmw_dnsmasq_address:
+          - state: absent
+            ipaddr: "1.2.3.4"
+            domains:
+              - apps.ocp.starwars.lan
+          - state: absent
+            ipaddr: "4.3.2.1"
+            domains:
+              - apps.ocp.startrek.lan
+      ansible.builtin.include_role:
+        name: dnsmasq
+        tasks_from: manage_address.yml
+
     - name: Cleanup dnsmasq
       ansible.builtin.import_role:
         name: "dnsmasq"

--- a/roles/dnsmasq/molecule/default/converge.yml
+++ b/roles/dnsmasq/molecule/default/converge.yml
@@ -97,6 +97,51 @@
           ipv4: "192.168.253.12"
           name: "spock"
 
+    - name: Add a domain specific forwarder
+      vars:
+        cifmw_dnsmasq_forwarder:
+          - state: present
+            server: 192.168.254.100
+            domains:
+              - battlestar.galactica.lan
+      ansible.builtin.include_role:
+        name: dnsmasq
+        tasks_from: manage_forwarder.yml
+
+    - name: Add some host records
+      vars:
+        cifmw_dnsmasq_host_record:
+          - state: present
+            ips:
+              - "192.168.253.50"
+              - "2345:0425:2CA1::dead"
+            names:
+              - dead.battlestar.galactica.lan
+          - state: present
+            ips:
+              - "192.168.253.51"
+              - "2345:0425:2CA1::beef"
+            names:
+              - beef.battlestar.galactica.lan
+      ansible.builtin.include_role:
+        name: dnsmasq
+        tasks_from: manage_host_record.yml
+
+    - name: Add some wildcard addresses
+      vars:
+        cifmw_dnsmasq_address:
+          - state: present
+            ipaddr: "1.2.3.4"
+            domains:
+              - apps.ocp.starwars.lan
+          - state: present
+            ipaddr: "4.3.2.1"
+            domains:
+              - apps.ocp.startrek.lan
+      ansible.builtin.include_role:
+        name: dnsmasq
+        tasks_from: manage_address.yml
+
     - name: Force reload dnsmasq
       ansible.builtin.meta: flush_handlers
 

--- a/roles/dnsmasq/tasks/manage_address.yml
+++ b/roles/dnsmasq/tasks/manage_address.yml
@@ -1,0 +1,30 @@
+- name: Assert we have needed address data
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - cifmw_dnsmasq_address is defined
+      - (cifmw_dnsmasq_address | type_debug) == "list"
+
+- name: Assert each address element have needed data
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - item.state is defined
+      - item.state in ['present', 'absent']
+      - item.ipaddr is undefined or (item.ipaddr is defined and (item.ipaddr | ansible.utils.ipaddr))
+      - item.domains is defined
+      - (item.domains | type_debug) == "list"
+  loop: "{{ cifmw_dnsmasq_address }}"
+
+- name: Add/Remove address
+  become: true
+  notify: Restart dnsmasq
+  ansible.builtin.lineinfile:
+    create: true
+    path: "{{ cifmw_dnsmasq_basedir }}/addresses.conf"
+    mode: '0644'
+    line: >-
+      address={{ ([''] + item.domains | default([]) + [item.ipaddr | default('')]) | join('/') }}
+    state: "{{ item.state }}"
+    validate: "/usr/sbin/dnsmasq -C %s --test"
+  loop: "{{ cifmw_dnsmasq_address }}"

--- a/roles/dnsmasq/tasks/manage_forwarder.yml
+++ b/roles/dnsmasq/tasks/manage_forwarder.yml
@@ -1,0 +1,30 @@
+- name: Assert we have needed forwarder data
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - cifmw_dnsmasq_forwarder is defined
+      - (cifmw_dnsmasq_forwarder | type_debug) == "list"
+
+- name: Assert each forwarder element have needed data
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - item.state is defined
+      - item.state in ['present', 'absent']
+      - item.server is defined
+      - item.domains is defined
+      - (item.domains | type_debug) == "list"
+  loop: "{{ cifmw_dnsmasq_forwarder }}"
+
+- name: Add/Remove forwarder
+  become: true
+  notify: Restart dnsmasq
+  ansible.builtin.lineinfile:
+    create: true
+    path: "{{ cifmw_dnsmasq_basedir }}/forwarders.conf"
+    mode: '0644'
+    line: >-
+      server={{ ([''] + item.domains + [item.server]) | join('/') }}
+    state: "{{ item.state }}"
+    validate: "/usr/sbin/dnsmasq -C %s --test"
+  loop: "{{ cifmw_dnsmasq_forwarder }}"

--- a/roles/dnsmasq/tasks/manage_host_record.yml
+++ b/roles/dnsmasq/tasks/manage_host_record.yml
@@ -1,0 +1,31 @@
+- name: Assert we have needed host record data
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - cifmw_dnsmasq_host_record is defined
+      - (cifmw_dnsmasq_host_record | type_debug) == "list"
+
+- name: Assert each address element have needed data
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - item.state is defined
+      - item.state in ['present', 'absent']
+      - item.ips is defined
+      - (item.ips | type_debug) == "list"
+      - item.names is defined
+      - (item.names | type_debug) == "list"
+  loop: "{{ cifmw_dnsmasq_host_record }}"
+
+- name: Add/Remove address
+  become: true
+  notify: Restart dnsmasq
+  ansible.builtin.lineinfile:
+    create: true
+    path: "{{ cifmw_dnsmasq_basedir }}/host_records.conf"
+    mode: '0644'
+    line: >-
+      host-record={{ (item.names + item.ips) | join(',') }}
+    state: "{{ item.state }}"
+    validate: "/usr/sbin/dnsmasq -C %s --test"
+  loop: "{{ cifmw_dnsmasq_host_record }}"


### PR DESCRIPTION
Add task files to the dnsmasq role to manage forwarder, address and host-record config to the running dnsmasq server.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
