### PR TITLE
Fix '_sushy_emulator_available' var when cifmw_use_sushy_emulator=false

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -321,7 +321,7 @@
       ansible.builtin.import_tasks: generate_bm_info.yml
 
     - name: Verify connection to baremetal VMs via Sushy Emulator
-      when: _sushy_emulator_available
+      when: _sushy_emulator_available | default(false)
       ansible.builtin.include_role:
         name: sushy_emulator
         tasks_from: verify.yml


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes

Without this, if  `cifmw_use_sushy_emulator` is set to `false`, then the `_sushy_emulator_available` var is undefined and leads to an error because [1] causes Ansible to skip setting the latter variable.

[1] https://github.com/openstack-k8s-operators/ci-framework/blob/eaff04f2e592f98da8f38a84ffddf909d5dddaab/roles/reproducer/tasks/configure_controller.yml#L314