### PR TITLE
nit: Remove redundant ansible-galaxy_install

### DIFF
--- a/ci/playbooks/pod-jobs.yml
+++ b/ci/playbooks/pod-jobs.yml
@@ -1,6 +1,8 @@
 ---
 - name: Run light checks in pod
   hosts: all
+  vars:
+    _log_dir: "{{ ansible_user_dir }}/zuul-output/logs"
   tasks:
     - name: Install packages
       become: true
@@ -12,13 +14,13 @@
 
     - name: Ensure zuul-output exists
       ansible.builtin.file:
-        path: "{{ ansible_user_dir }}/zuul-output/logs"
+        path: "{{ _log_dir }}"
         state: directory
         mode: "0755"
 
     - name: Run make targets
       vars:
-        src_dir: >-
+        _src_dir: >-
           {{
             zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir
           }}
@@ -26,28 +28,31 @@
         - name: Install dependencies
           register: _setup
           community.general.make:
-            chdir: "{{ src_dir }}"
+            chdir: "{{ _src_dir }}"
             target: setup_molecule
             params:
               USE_VENV: "no"
+              LOG_DIR: "{{ _log_dir }}"
           retries: 5
           delay: 2
           until: _setup is success
 
         - name: Run check
           community.general.make:
-            chdir: "{{ src_dir }}"
+            chdir: "{{ _src_dir }}"
             target: "{{ run_test }}"
             params:
               USE_VENV: "no"
-              LOG_DIR: "{{ ansible_user_dir }}/zuul-output/logs"
+              LOG_DIR: "{{ _log_dir }}"
       always:
         - name: Expose check log as artifact
           vars:
-            log_name: "{{ run_test | replace('_nodeps', '') }}"
+            _log_name: "{{ run_test | replace('_nodeps', '') }}"
           zuul_return:
             data:
               zuul:
                 artifacts:
-                  - name: "{{ log_name }} logfile"
-                    url: "{{ log_name }}.log"
+                  - name: "{{ _log_name }} logfile"
+                    url: "{{ _log_name }}.log"
+                  - name: "setup_molecule logfile"
+                    url: "setup_molecule.log"

--- a/containerfiles/Containerfile.ci
+++ b/containerfiles/Containerfile.ci
@@ -4,6 +4,6 @@ LABEL summary="Provides root image for openstack-k8s-operators projects in Prow"
 USER root
 # workaround for RHBZ#2184640
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
-RUN dnf update -y && dnf install -y git python3-pip python3-netaddr make gcc sudo rsync && yum clean all
+RUN dnf update -y && dnf install -y git python3-pip python3-netaddr make gcc sudo rsync && dnf clean all
 RUN mkdir -p /home/zuul/src/github.com/openstack-k8s-operators
 RUN git clone https://github.com/openstack-k8s-operators/install_yamls /home/zuul/src/github.com/openstack-k8s-operators/install_yamls

--- a/containerfiles/Containerfile.tests
+++ b/containerfiles/Containerfile.tests
@@ -3,18 +3,12 @@ USER root
 ENV USE_VENV=no
 ENV MOLECULE_CONFIG=.config/molecule/config_local.yml
 
-RUN adduser -d / -M prow
-RUN mkdir -p /home/prow && chown prow: /home/prow
-RUN echo "prow ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/prow
-
 RUN --mount=type=bind,source=../,destination=/tmp/project-code cp -ra /tmp/project-code /opt/sources
-RUN chown -R prow: /opt/sources
 WORKDIR /opt/sources
 RUN find . -type d -exec chmod g+rwx {} \;
 RUN find . -type f -exec chmod g+rw {} \;
 RUN /usr/bin/make setup_molecule USE_VENV=${USE_VENV}
 RUN dnf clean all
 
-USER prow
 RUN git config core.fileMode false
 CMD /usr/bin/make help

--- a/scripts/run_ansible_test
+++ b/scripts/run_ansible_test
@@ -38,8 +38,6 @@ case ${USE_VENV} in
         ;;
 esac
 
-ansible-galaxy collection install --upgrade --force ${PROJECT_DIR}
-
 # Create/append the sanity exceptions for the current ansible version
 ansible_version=$(python3 -c "import ansible; print(ansible.__version__)" | sed 's/\.[^.]*$//')
 cat  "${HOME}/.ansible/collections/ansible_collections/cifmw/general/tests/sanity/ignore.txt" >> \

--- a/scripts/setup_env
+++ b/scripts/setup_env
@@ -43,7 +43,7 @@ case ${USE_VENV} in
         PIP="${HOME}/test-python/bin/pip3"
         USE_VENV='yes'
         echo
-        echo ### USING VIRTUALENV
+        echo "USING VIRTUALENV"
         echo
         ;;
     *)
@@ -54,7 +54,7 @@ case ${USE_VENV} in
             PIP_INSTALL_ARGUMENTS="--user ${PIP_INSTALL_ARGUMENTS}"
         fi
         echo
-        echo ### NO VENV - may break your system!
+        echo "NO VENV - may break your system!"
         echo
         ;;
 esac

--- a/scripts/setup_molecule
+++ b/scripts/setup_molecule
@@ -21,6 +21,8 @@ set -xeuo
 
 ## Vars ----------------------------------------------------------------------
 export PROJECT_DIR="$(dirname $(dirname $(readlink -f ${BASH_SOURCE[0]})))"
+HOME=${HOME:-/tmp}
+export HOME=${HOME}
 # NOTE(cloudnull): Disable ansible compat check, caters to the case where
 #                  system ansible may be installed.
 export ANSIBLE_SKIP_CONFLICT_CHECK=1


### PR DESCRIPTION
We aimed to fix issues like [1] in https://github.com/openstack-k8s-operators/ci-framework/pull/1539 but e install the dependency twice.

Once in setup_molecule[2] (which has great retries thanks to @Cédric Jeanneret++) but then again in run_ansible_test [3] due to the --force.

The two paths we support are using `make run_ctx_ansible_test` locally and `cifmw-pod-ansible-test` job in CI.

Both of which already install dependencies before calling  `run_ansible_test`

[1] ERROR! Failed to clone a Git repository from `https://github.com/ansible-collections/community.general`.
[2] https://github.com/openstack-k8s-operators/ci-framework/blob/main/scripts/setup_molecule#L51
[3] https://github.com/openstack-k8s-operators/ci-framework/blob/main/scripts/run_ansible_test#L41

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
