### PR TITLE
Make sure podman is installed before cleaning vbmc container

### DIFF
--- a/roles/virtualbmc/tasks/cleanup.yml
+++ b/roles/virtualbmc/tasks/cleanup.yml
@@ -14,6 +14,10 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Install podman and configure session linger
+  ansible.builtin.import_role:
+    name: podman
+
 - name: Stop and remove vbmc container
   containers.podman.podman_container:
     name: "{{ cifmw_virtualbmc_container_name }}"


### PR DESCRIPTION
In CRC reproducer job, we run reproducer-clean.yml playbook in the end. The job is failing with following error:
```
 TASK [virtualbmc : Stop and remove vbmc container name={{ cifmw_virtualbmc_container_name }}, state=absent] ***
2024-05-29 23:34:01.173574 | controller | Wednesday 29 May 2024  23:34:01 -0400 (0:00:08.329)       0:00:39.391 *********
2024-05-29 23:34:02.010164 | controller | fatal: [hypervisor]: FAILED! => changed=false
2024-05-29 23:34:02.010211 | controller |   msg: 'Failed to find required executable "podman" in paths: /home/zuul/.local/bin:/home/zuul/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin'
```

Since here we call vbmc cleanup tasks and podman cli is not installed. That's why above error is coming.

Calling podman role to install and configure podman will fix the issue.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

