### PR TITLE
[test-operator] Remove ntp_extra_image

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -31,7 +31,6 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_tempest_ssh_key_secret_name`: (String) Name of a secret that contains ssh-privatekey field with a private key. The private key is mounted to `/var/lib/tempest/.ssh/id_ecdsa`
 * `cifmw_test_operator_tempest_config_overwrite`: (Dict) Dictionary where key is name of a file and value is content of the file. All files mentioned in this field are mounted to `/etc/test_operator/<filename>`
 * `cifmw_test_operator_tempest_workflow`: (List) Definition of a Tempest workflow that consists of multiple steps. Each step can contain all values from Spec section of [Tempest CR](https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource).
-* `cifmw_test_operator_tempest_ntp_extra_image`: (String) URL that points to an extra image that is used by [whitebox-neutron-tempest-plugin](https://opendev.org/x/whitebox-neutron-tempest-plugin). Default value: `''`
 * `cifmw_test_operator_tempest_network_attachments`: (List) List of network attachment definitions to attach to the tempest pods spawned by test-operator. Default value: `[]`.
 * `cifmw_test_operator_tempest_config`: (Object) Definition of Tempest CRD instance that is passed to the test-operator (see [the test-operator documentation](https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource)). Default value:
 ```

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -62,7 +62,6 @@ cifmw_test_operator_tempest_config:
         {{ cifmw_test_operator_tempest_exclude_list | default('') }}
       concurrency: "{{ cifmw_test_operator_concurrency }}"
       externalPlugin: "{{ cifmw_test_operator_tempest_external_plugin | default([]) }}"
-      neutronExtraImage: "{{ cifmw_test_operator_tempest_ntp_extra_image | default('') }}"
     tempestconfRun: "{{ cifmw_tempest_tempestconf_config | default(omit) }}"
     workflow: "{{ cifmw_test_operator_tempest_workflow }}"
 


### PR DESCRIPTION
The cifmw_test_operator_ntp_extra_images was created with the neutron team in mind. The cifmw_test_operator_extra_images is more generic version of the previous var and it is now the recommended way how to configure jobs with extra images.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
