### PR TITLE
[test-operator] Remove ntp_extra_image

### DIFF
--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -67,7 +67,6 @@ cifmw_test_operator_tempest_config:
         {{ cifmw_test_operator_tempest_exclude_list | default('') }}
       concurrency: "{{ cifmw_test_operator_concurrency }}"
       externalPlugin: "{{ cifmw_test_operator_tempest_external_plugin | default([]) }}"
-      neutronExtraImage: "{{ cifmw_test_operator_tempest_ntp_extra_image | default('') }}"
       extraImages: "{{ cifmw_test_operator_tempest_extra_images | default([]) }}"
     tempestconfRun: "{{ cifmw_tempest_tempestconf_config | default(omit) }}"
     workflow: "{{ cifmw_test_operator_tempest_workflow }}"


### PR DESCRIPTION
The cifmw_test_operator_ntp_extra_images was created with the neutron team in mind. The cifmw_test_operator_extra_images is more generic version of the previous var and it is now the recommended way how to configure jobs with extra images.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
