### PR TITLE
Add override-checkout option to cifmw_reproducer_default_repositories

### DIFF
--- a/roles/reproducer/tasks/default_repositories.yml
+++ b/roles/reproducer/tasks/default_repositories.yml
@@ -13,3 +13,4 @@
       ansible.builtin.git:  # noqa: latest[git]
         dest: "{{ repository.dest }}"
         repo: "{{ repository.src }}"
+        version: "{{ repository['override-checkout'] | default(omit) }}"


### PR DESCRIPTION
In downstream, Devs uses cifmw_reproducer_default_repositories var to clone downstream repositories on the controller-0. The default branch `main` of these downstream repos does not contains any repo/code files, which causes issues while running VA deployment due to missing files.

Defining cifmw_reproducer_default_repositories with override-checkout will allow users to checkout specific version/branch code on controller-0.

override-checkout key is optional.

Extended syntax will look like this:
cifmw_reproducer_default_repositories:
  - src: <repo_url>
    dest: <repo_dest>
    override-checkout: <branch name>

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

