### PR TITLE
[lvms] Allow passing of cifmw_use_lvms variable to controller-0

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -348,6 +348,7 @@
             dict2items |
             selectattr('key', 'match',
                        '^(pre|post|cifmw)_(?!install_yamls|devscripts).*') |
+            selectattr('key', 'equalto', 'cifmw_use_lvms') |
             rejectattr('key', 'equalto', 'cifmw_target_host') |
             rejectattr('key', 'equalto', 'cifmw_basedir') |
             rejectattr('key', 'equalto', 'cifmw_path') |


### PR DESCRIPTION
This change allows passing for cifmw_use_lvms variable to controller-0. Doing so helps deploy lvms-operator on the deployed control plane.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
