### PR TITLE
Prepare crc job for architecture repo

### DIFF
--- a/ci/playbooks/architecture_crc/prepare-architecture-crc.yml
+++ b/ci/playbooks/architecture_crc/prepare-architecture-crc.yml
@@ -1,0 +1,61 @@
+---
+- hosts: "{{ cifmw_target_host | default('localhost') }}"
+  tasks:
+    # jgilaber: we need to make sure nncp does not touch the vlans, otherwise
+    # it'll create them with the same MAC address as the ospbr bridge and that
+    # causes problems when trying to reach the dnsmasq service from the compute
+    # node. Changing the interface and connnection name to what is used in the
+    # nncp CR avoids the issue
+    - name: Change vlan interface and connection names
+      delegate_to: "crc"
+      become: true
+      vars:
+        old_connn_name: "ci-{{ item.name }}-{{ item.vlan }}"
+      ansible.builtin.shell: |
+        nmcli con down {{ old_connn_name }}
+        nmcli con modify {{ old_connn_name }} connection.interface-name {{ item.name }}
+        nmcli con modify {{ old_connn_name }} connection.id {{ item.name }}
+        nmcli con up {{ item.name }}
+      loop:
+        - name: internalapi
+          vlan: 20
+        - name: storage
+          vlan: 21
+        - name: tenant
+          vlan: 22
+
+    - name: Read os-net-info file
+      ansible.builtin.slurp:
+        src: "/etc/ci/env/os-net-info.yml"
+      register: _ci_bootstrap_os_net_info
+
+    - name: Translate os_net_info into interfaces-info
+      vars:
+        _ci_bootstrap_os_parsed: "{{ _ci_bootstrap_os_net_info['content'] | b64decode | from_yaml }}"
+        _ci_bootstrap_macs: "{{ _ci_bootstrap_os_parsed.ci_bootstrap_os_mac_addr_map }}"
+      ansible.builtin.copy:
+        dest: "{{ cifmw_basedir }}/parameters/interfaces-info.yml"
+        content: |
+          {% for node, net_list in _ci_bootstrap_macs.items() %}
+          {{ node }}:
+          {% for net, mac in net_list.items() %}
+          - network: {{ net }}
+            mac: {{ mac }}
+          {% endfor %}
+          {% endfor %}
+
+    - name: Call networking_mapper again to make sure interfaces names are set in the networking enviornment file
+      ansible.builtin.import_role:
+        name: networking_mapper
+
+- hosts: computes
+  tasks:
+    - name: Setup repos
+      ansible.builtin.include_role:
+        name: repo_setup
+
+    - name: Set hostname to inventory hostname for ceph deployment
+      become: true
+      ansible.builtin.hostname:
+        name: "{{ inventory_hostname }}"
+        use: "systemd"

--- a/ci/playbooks/architecture_crc/run-architecture-crc.yml
+++ b/ci/playbooks/architecture_crc/run-architecture-crc.yml
@@ -1,0 +1,72 @@
+---
+# Usage and expected parameters
+# $ ansible-playbook run-architecture-crc.yml \
+#     -e cifmw_architecture_repo=$HOME/architecture \
+#     -e cifmw_architecture_scenario=hci \
+#     -e cifmw_networking_mapper_networking_env_def_path=$HOME/net-env.yml
+#     [any other parameter/files your VA/DT might need]
+#
+# cifmw_architecture_repo: location of the architecture repository.
+# cifmw_architecture_scenario: the scenario you want to test.
+# cifmw_networking_mapper_networking_env_def_path: path to the
+#        networking-mapper environment definition file.
+#
+# Special parameters set in the playbook (you can override them)
+# cifmw_basedir: defaults to ~/ci-framework-data
+# cifmw_zuul_target_host: target host. Defaults to localhost
+
+- name: Test architecture automations
+  hosts: "{{ cifmw_zuul_target_host | default('controller') }}"
+  gather_facts: true
+  vars:
+    _homedir: "{{ ansible_user_dir | default(lookup('env', 'HOME')) }}"
+    cifmw_basedir: >-
+      {{
+        (_homedir,
+         'ci-framework-data') |
+        path_join
+      }}
+    cifmw_path: >-
+      {{
+        ['~/bin',
+         ansible_env.PATH] | join(':')
+      }}
+    ci_framework_src_dir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
+  pre_tasks:
+    - name: Create needed directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0755"
+      loop:
+        - "{{ cifmw_basedir }}/logs"
+        - "{{ cifmw_basedir }}/artifacts"
+        - "{{ cifmw_basedir }}/parameters"
+
+  tasks:
+    - name: Run preparation steps for VA deployment in crc
+      ansible.builtin.command: >
+        ansible-playbook -i {{ cifmw_basedir }}/artifacts/zuul_inventory.yml
+        ci/playbooks/architecture_crc/prepare-architecture-crc.yml
+        -e cifmw_basedir="{{ cifmw_basedir }}"
+        {%- if cifmw_extras is defined %}
+        {%-   for extra_vars in cifmw_extras %}
+        -e "{{   extra_vars }}"
+        {%-   endfor %}
+        {%- endif %}
+      args:
+        chdir: "{{ ci_framework_src_dir }}"
+
+    - name: Deploy VA with crc
+      ansible.builtin.command: >
+        ansible-playbook -i {{ cifmw_basedir }}/artifacts/zuul_inventory.yml
+        deploy-edpm.yml
+        -e cifmw_basedir="{{ cifmw_basedir }}"
+        -e "@{{ ansible_user_dir  }}/ci-framework-data/artifacts/nodepool_params.yml"
+        {%- if cifmw_extras is defined %}
+        {%-   for extra_vars in cifmw_extras %}
+        -e "{{   extra_vars }}"
+        {%-   endfor %}
+        {%- endif %}
+      args:
+        chdir: "{{ ci_framework_src_dir }}"

--- a/ci/playbooks/multinode-customizations.yml
+++ b/ci/playbooks/multinode-customizations.yml
@@ -26,7 +26,7 @@
           }}
         _crc_default_net_ip: >-
           {{
-            _decoded_net_env.crc_ci_bootstrap_networks_out.crc.default.ip
+            _decoded_net_env.crc_ci_bootstrap_networks_out.crc[cifmw_crc_default_network | default('default')].ip
           }}
       block:
         - name: Manage name resolution and interfaces
@@ -34,15 +34,15 @@
           vars:
             _crc_default_iface: >-
               {{
-                 _decoded_net_env.crc_ci_bootstrap_networks_out.crc.default.iface
+                 _decoded_net_env.crc_ci_bootstrap_networks_out.crc[cifmw_crc_default_network | default('default')].iface
               }}
             _crc_default_gw: >-
               {{
-                 _decoded_net_env.crc_ci_bootstrap_networks_out.crc.default.gw
+                 _decoded_net_env.crc_ci_bootstrap_networks_out.crc[cifmw_crc_default_network | default('default')].gw
               }}
             _crc_private_connection_name: >-
               {{
-                 _decoded_net_env.crc_ci_bootstrap_networks_out.crc.default.connection
+                 _decoded_net_env.crc_ci_bootstrap_networks_out.crc[cifmw_crc_default_network | default('default')].connection
               }}
           block:
             - name: Ensure crc knows about its second NIC
@@ -290,7 +290,7 @@
           }}
         _crc_default_net_ip: >-
           {{
-            _decoded_net_env.crc_ci_bootstrap_networks_out.crc.default.ip |
+            _decoded_net_env.crc_ci_bootstrap_networks_out.crc[cifmw_crc_default_network | default('default')].ip |
             ansible.utils.ipaddr('address')
           }}
         dns_servers_string: >-

--- a/ci/playbooks/pre-ci-bootstrap.yml
+++ b/ci/playbooks/pre-ci-bootstrap.yml
@@ -13,6 +13,15 @@
                 ansible.builtin.include_role:
                   name: networking_mapper
 
+    - name: Store nodepool data if defined so we can set mtu depending on provider
+      when: nodepool is defined
+      ansible.builtin.copy:
+        dest: "{{ ansible_user_dir }}/ci-framework-data/artifacts/nodepool_params.yml"
+        content: |
+          nodepool:
+            {{ nodepool | to_nice_yaml | indent(2) }}
+        mode: '0644'
+
     - name: Run networking_mapper playbook
       environment:
         ANSIBLE_HOST_KEY_CHECKING: false
@@ -23,3 +32,6 @@
           -i {{ ansible_user_dir }}/ci-framework-data/artifacts/zuul_inventory.yml
           -e @scenarios/centos-9/base.yml
           -e "@{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml"
+          {% if nodepool is defined %}
+          -e "@{{ ansible_user_dir }}/ci-framework-data/artifacts/nodepool_params.yml"
+          {% endif %}

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -507,6 +507,7 @@ unclaim
 undefine
 unittest
 unmanaged
+untagged
 uoyt
 uri
 usermod

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -68,6 +68,7 @@ are shared among multiple roles:
 - `cifmw_nolog`: (Bool) Toggle `no_log` value for selected tasks. Defaults to `true` (hiding those logs by default).
 - `cifmw_parent_scenario`: (String or List(String)) path to existing scenario/parameter file to inherit from.
 - `cifmw_configure_switches`: (Bool) Specifies whether switches should be configured. Computes in `reproducer.yml` playbook. Defaults to `false`.
+- `cifmw_crc_default_network`: (String) name of the untagged network used to address DNS on the crc node. Default is `default`.
 
 ```{admonition} Words of caution
 :class: danger

--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -106,15 +106,14 @@
                   {{ lookup('file', _ssh_file ~ '.pub', rstrip=False)}}
                 cifmw_ci_gen_kustomize_values_migration_priv_key: >-
                   {{ lookup('file', _ssh_file, rstrip=False) }}
-                cifmw_ci_gen_kustomize_values_sshd_ranges: >-
-                  {{
-                    [cifmw_networking_env_definition.networks.ctlplane.network_v4] +
-                    (
-                      [
-                        _ipv4_network_data.network + '/' + _ipv4_network_data.prefix
-                      ]
-                    ) if (_ipv4_network_data | length > 0) else []
-                  }}
+                # jgilaber: the previous way of collecting the
+                # sshd ranges sometimes did not work well in vexxhost, if
+                # the controller node ends-up in a different subnet than the
+                # executor node, then the executor would be prevented from
+                # accessing the compute nodes after the edpm deployment, which
+                # would cause post_failures when trying to collect logs
+                cifmw_ci_gen_kustomize_values_sshd_ranges:
+                  - 0.0.0.0/0
           rescue:
             - name: Debug _ctl_data
               ansible.builtin.debug:

--- a/zuul.d/architecture-jobs.yaml
+++ b/zuul.d/architecture-jobs.yaml
@@ -8,7 +8,7 @@
 - job:
     name: cifmw-architecture-validate-base
     parent: cifmw-base-minimal
-    vars:
+    vars: &architecture_vars
       cifmw_architecture_repo: >-
         {{
           [ansible_user_dir,
@@ -42,3 +42,174 @@
       - zuul.d/architecture-jobs.yaml
       - ^roles/ci_gen_kustomize_values/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
       - ^roles/kustomize_deploy/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+
+- job:
+    name: cifmw-architecture-crc-base
+    parent: podified-multinode-edpm-deployment-crc-bootstrap
+    nodeset: centos-9-medium-3x-centos-9-crc-extracted-2-39-0-3xl-vexxhost
+    vars:
+      <<: *architecture_vars
+      cifmw_architecture_automation_file: >-
+        {{
+          (
+            cifmw_architecture_repo,
+            'automation/vars/default.yaml'
+          ) | ansible.builtin.path_join
+        }}
+      cifmw_controller_name: controller
+      cifmw_openshift_setup_skip_internal_registry_tls_verify: true
+      cifmw_networking_env_def_file: "networking-env-definition.yml"
+      cifmw_networking_mapper_networking_env_def_path: "/etc/ci/env/networking-environment-definition.yml"
+      cifmw_run_tempest: true
+      cifmw_run_test_role: test_operator
+      cifmw_run_tests: true
+      cifmw_test_operator_concurrency: 4
+      cifmw_test_operator_timeout: 36000
+      cifmw_architecture_user_kustomize_01_base_dns_override:
+        stage_1:
+          'network-values':
+            data:
+              dns-resolver:
+                options:
+                  - key: server
+                    values:
+                      - 192.168.122.10
+      cifmw_crc_default_network: ctlplane
+    extra-vars:
+      cifmw_bootstrap_cloud_name: >-
+        {%- if 'ibm-bm3' in nodepool.cloud -%}
+        cifmw_ibm3
+        {%- elif 'ibm-bm4' in nodepool.cloud -%}
+        cifmw_ibm4
+        {%- else -%}
+        cifmw_vexxhost
+        {%- endif -%}
+      cifmw_networking_definition:
+        networks:
+          ctlplane:
+            mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
+            router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            network: 192.168.122.0/24
+            gateway: 192.168.122.1
+          internalapi:
+            mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1436', '1496') }}"
+            vlan: 20
+            network: 172.17.0.0/24
+          storage:
+            mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1436', '1496') }}"
+            vlan: 21
+            network: 172.18.0.0/24
+          tenant:
+            mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1436', '1496') }}"
+            vlan: 22
+            network: 172.19.0.0/24
+          storagemgmt:
+            mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1436', '1496') }}"
+            vlan: 23
+            network: 172.20.0.0/24
+        routers:
+          ci-router:
+            external_network: public
+            networks:
+              - ctlplane
+        instances:
+          controller:
+            networks:
+              ctlplane:
+                ip: 192.168.122.11
+          crc:
+            networks:
+              ctlplane:
+                ip: 192.168.122.10
+                is-trunk-parent: true
+              internalapi:
+                ip: 172.17.0.10
+                trunk-parent: ctlplane
+                is-trunk-parent: false
+                vlan_id: 20
+              storage:
+                ip: 172.18.0.10
+                trunk-parent: ctlplane
+                is-trunk-parent: false
+                vlan_id: 21
+              tenant:
+                ip: 172.19.0.10
+                trunk-parent: ctlplane
+                is-trunk-parent: false
+                vlan_id: 22
+          compute-0:
+            networks:
+              ctlplane:
+                ip: 192.168.122.100
+              internalapi:
+                ip: 172.17.0.100
+                trunk-parent: ctlplane
+                skip-nm-configuration: true
+              storage:
+                ip: 172.18.0.100
+                trunk-parent: ctlplane
+                skip-nm-configuration: true
+              tenant:
+                ip: 172.19.0.100
+                trunk-parent: ctlplane
+                skip-nm-configuration: true
+              storagemgmt:
+                ip: 172.20.0.100
+                trunk-parent: ctlplane
+                skip-nm-configuration: true
+          compute-1:
+            networks:
+              ctlplane:
+                ip: 192.168.122.101
+              internalapi:
+                ip: 172.17.0.101
+                skip-nm-configuration: true
+                trunk-parent: ctlplane
+              storage:
+                ip: 172.18.0.101
+                trunk-parent: ctlplane
+                skip-nm-configuration: true
+              tenant:
+                ip: 172.19.0.101
+                trunk-parent: ctlplane
+                skip-nm-configuration: true
+              storagemgmt:
+                ip: 172.20.0.101
+                trunk-parent: ctlplane
+                skip-nm-configuration: true
+          compute-2:
+            networks:
+              ctlplane:
+                ip: 192.168.122.102
+              internalapi:
+                ip: 172.17.0.102
+                trunk-parent: ctlplane
+                skip-nm-configuration: true
+              storage:
+                ip: 172.18.0.102
+                trunk-parent: ctlplane
+                skip-nm-configuration: true
+              tenant:
+                ip: 172.19.0.102
+                trunk-parent: ctlplane
+                skip-nm-configuration: true
+              storagemgmt:
+                ip: 172.20.0.102
+                trunk-parent: ctlplane
+                skip-nm-configuration: true
+    run:
+      - ci/playbooks/architecture_crc/run-architecture-crc.yml
+    required-projects:
+      - openstack-k8s-operators/architecture
+
+- job:
+    name: cifmw-architecture-crc-hci
+    parent: cifmw-architecture-crc-base
+    vars:
+      cifmw_test_operator_tempest_include_list: |
+        tempest.scenario.test_network_basic_ops.TestNetworkBasicOps
+      # 12 pvs is not enough
+      cifmw_cls_pv_count: 20
+      cifmw_extras:
+        - '@scenarios/reproducers/va-hci-reduced.yml'
+        - 'cifmw_run_test_role=test_operator'

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -268,6 +268,32 @@
         nodes:
           - crc
 
+# NOTE jgilaber: using a vexxhost only nodeset for the
+# architecture crc job since we can't run it in ibm cloud
+# because we can't use ci-bootstrap there yet
+- nodeset:
+    name: centos-9-medium-3x-centos-9-crc-extracted-2-39-0-3xl-vexxhost
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-vexxhost-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo-vexxhost
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo-vexxhost
+      - name: compute-2
+        label: cloud-centos-9-stream-tripleo-vexxhost
+      - name: crc
+        label: coreos-crc-extracted-2-39-0-3xl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+          - compute-2
+      - name: ocps
+        nodes:
+          - crc
+
 - nodeset:
     name: centos-9-crc-2-39-0-6xlarge
     nodes:


### PR DESCRIPTION
Create a job that can deploy the HCI VA with an extracted crc layout.
This change introduces the jobs definition and playbooks for such a job.
It creates and extracted crc layout using ci-bootstrap role
and then calls networking mapper to get the required networking config to
deploy a VA. It needs to generate an interfaces-info file.

Additionally, it changes the 06-deploy-architecture playbook to allow
ssh access from any network to the compute nodes. It also modifies the
multinode-customizations playbook to work with a 'ctlplane' network in
the crc, instead of a 'default' one.

It makes use of scenario inhertance proposed in [1] to reuse most of the
existing HCI VA scenario.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/1491
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date: