### PR TITLE
Add missing 'https://' to cifmw_ceph_rgw_keystone_ep

### DIFF
--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -66,7 +66,7 @@ cifmw_cephadm_pacific_filter: "16.*"
 # The path of the rendered rgw spec file
 cifmw_ceph_rgw_spec_path: /tmp/ceph_rgw.yml
 cifmw_ceph_mds_spec_path: /tmp/ceph_mds.yml
-cifmw_ceph_rgw_keystone_ep: "keystone-internal.openstack.svc:5000"
+cifmw_ceph_rgw_keystone_ep: "https://keystone-internal.openstack.svc:5000"
 cifmw_ceph_rgw_keystone_psw: 12345678
 cifmw_ceph_rgw_keystone_user: "swift"
 cifmw_ceph_rgw_config:


### PR DESCRIPTION
The default value for the `cifmw_ceph_rgw_keystone_ep` variable in the role `cifmw_cephadm` was missing the `https://` part of the keystone endpoint URL so RGW was not getting configured with a correct keystone endpoint.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
