### PR TITLE
[arch] include octavia vlan id in mock

### DIFF
--- a/ci/playbooks/files/networking-env-definition.yml
+++ b/ci/playbooks/files/networking-env-definition.yml
@@ -515,6 +515,7 @@ networks:
                 - end: 172.23.0.200
                   start: 172.23.0.100
                 ipv6_ranges: []
+        vlan_id: 24
     storage:
         dns_v4: []
         dns_v6: []


### PR DESCRIPTION
Adding missing vlan id for octaciva

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
