### PR TITLE
Change to hostname rather than IP for validations check node

### DIFF
--- a/roles/validations/defaults/main.yml
+++ b/roles/validations/defaults/main.yml
@@ -36,7 +36,7 @@ cifmw_validations_default_path: "{{ role_path }}/tasks"
 # cifmw_validations_edpm_check_node is the node that we will validate for edpm jobs. We
 # achieve this by delegating_to the check node and executing the required commands to
 # validate that our desired state change has been achieved.
-cifmw_validations_edpm_check_node: 192.168.122.100
+cifmw_validations_edpm_check_node: compute-0
 
 cifmw_validations_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 


### PR DESCRIPTION
This change switches the default value for cifmw_validations_edpm_check_node to use a hostname rather than an IP address. This will ensure we match against the Ansible inventory host and not depend on the IP address of that node always being the same.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
