### PR TITLE
Add tasks to serve gating repo over content provider

### DIFF
--- a/roles/build_openstack_packages/README.md
+++ b/roles/build_openstack_packages/README.md
@@ -20,6 +20,7 @@ An Ansible role for generating custom RPMSs of OpenStack Projects using DLRN
 * `cifmw_bop_openstack_project_path`: (String) The full path of openstack cloned project to be built.
 * `cifmw_bop_gating_repo_dest`: (String) The path of directory to store gating repo file and repo metadata.
   Defaults to `cifmw_bop_build_repo_dir` var.
+* `cifmw_bop_gating_port`: Port number to serve gating repo. Default to `8766`.
 * `cifmw_bop_dlrn_cleanup`: (Boolean) Clean up the DLRN artifacts. Defaults to `False`.
 * `cifmw_bop_branchless_projects`: List of project does not have stable branches.
 * `cifmw_bop_skipped_projects`: List of projects on which DLRN build needs to be skipped.

--- a/roles/build_openstack_packages/defaults/main.yml
+++ b/roles/build_openstack_packages/defaults/main.yml
@@ -96,6 +96,8 @@ cifmw_bop_skipped_projects:
   - openstack-k8s-operators/swift-operator
   - openstack-k8s-operators/telemetry-operator
 
+cifmw_bop_gating_port: 8766
+
 # Downstream only variables:
 #
 # cifmw_bop_rhospkg_repo_url

--- a/roles/build_openstack_packages/tasks/create_repo.yml
+++ b/roles/build_openstack_packages/tasks/create_repo.yml
@@ -51,6 +51,9 @@
       priority=1
     dest: "{{ cifmw_bop_gating_repo_dest }}/gating.repo"
 
+- name: Serve gating repo
+  ansible.builtin.import_tasks: serve_gating_repo.yml
+
 - name: Check for DLRN repo at the destination
   ansible.builtin.stat:
     path: "{{ cifmw_bop_gating_repo_dest }}/delorean.repo"

--- a/roles/build_openstack_packages/tasks/serve_gating_repo.yml
+++ b/roles/build_openstack_packages/tasks/serve_gating_repo.yml
@@ -1,0 +1,35 @@
+---
+- name: Install python-psutil
+  become: true
+  ansible.builtin.package:
+    name: python-psutil
+
+- name: Getting process IDs of the python http server
+  community.general.pids:
+    pattern: "python -m http.server {{ cifmw_bop_gating_port }}"
+  register: _pids_of_python
+
+- name: Printing the process IDs obtained
+  ansible.builtin.debug:
+    msg: "{{ _pids_of_python.pids }}"
+
+- name: Force kill the running process
+  ansible.builtin.command: "kill -9 {{ item }}"
+  loop: "{{ _pids_of_python.pids }}"
+
+- name: Open port 8766 to serve repos
+  become: true
+  ansible.builtin.command: "{{ item }}"
+  with_items:
+    - "nft add table ip filter"
+    - "nft add chain ip filter INPUT { type filter hook input priority 0 \\; }"
+    - "nft insert rule ip filter INPUT tcp dport {{ cifmw_bop_gating_port }} counter accept"
+  changed_when: true
+
+- name: Serve gating repos
+  become: true
+  ansible.builtin.shell:
+    cmd: >-
+      nohup python -m http.server {{ cifmw_bop_gating_port }} 1>{{ cifmw_bop_build_repo_dir }}/pkg_mgr_mirror.log 2>{{ cifmw_bop_build_repo_dir }}/pkg_mgr_mirror_error.log &
+  args:
+    chdir: "{{ cifmw_bop_gating_repo_dest }}"

--- a/roles/repo_setup/tasks/main.yml
+++ b/roles/repo_setup/tasks/main.yml
@@ -29,5 +29,8 @@
   when: cifmw_repo_setup_enable_rhos_release | bool
 - name: Update generated repos with mirror repos
   ansible.builtin.import_tasks: ci_mirror.yml
+- name: Add gating repo
+  ansible.builtin.import_tasks: populate_gating_repo.yml
+  when: content_provider_registry_ip is defined
 - name: Sync generated repos to yum.repos.d
   ansible.builtin.import_tasks: sync_repos.yml

--- a/roles/repo_setup/tasks/populate_gating_repo.yml
+++ b/roles/repo_setup/tasks/populate_gating_repo.yml
@@ -1,0 +1,31 @@
+---
+- name: Check for gating.repo file on content provider
+  ansible.builtin.uri:
+    url: "http://{{ content_provider_registry_ip }}:8766/gating.repo"
+  register: _url_status
+  ignore_errors: true
+
+- name: Construct gating repo
+  when: _url_status.status == 200
+  block:
+    - name: Populate gating repo from content provider ip
+      ansible.builtin.copy:
+        content: |
+          [gating-repo]
+          baseurl=http://{{ content_provider_registry_ip }}:8766/
+          enabled=1
+          gpgcheck=0
+          priority=1
+        dest: "{{ cifmw_repo_setup_output }}/gating.repo"
+
+    - name: Check for DLRN repo at the destination
+      ansible.builtin.stat:
+        path: "{{ cifmw_repo_setup_output }}/delorean.repo"
+      register: _dlrn_repo
+
+    - name: Lower the priority of DLRN repos to allow installation from gating repo
+      when: _dlrn_repo.stat.exists
+      ansible.builtin.replace:
+        path: "{{ cifmw_repo_setup_output }}/delorean.repo"
+        regexp: "priority=1"
+        replace: "priority=20"


### PR DESCRIPTION
The build_openstack_packages role will build the packages, creates the gating repo and then serves the gating repo over simple http server.
    
The repo-setup role will run on the dependent job and populate gating repo on the controller. Gating repo will be used to pull build rpms from content provider.

Tested here: https://github.com/os-net-config/os-net-config/pull/20#issuecomment-2146841767

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

