### PR TITLE
Move and add retries to ci_local_storage

### DIFF
--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -135,6 +135,14 @@
       tags:
         - edpm_bootstrap
 
+    - name: Configure Storage Class
+      ansible.builtin.import_role:
+        name: ci_local_storage
+      when: not cifmw_use_lvms | default(false)
+      tags:
+        - storage
+        - edpm_bootstrap
+
     - name: Deploy OSP operators
       ansible.builtin.import_role:
         name: kustomize_deploy
@@ -150,14 +158,6 @@
         name: update_containers
       tags:
         - update_containers
-        - edpm_bootstrap
-
-    - name: Configure Storage Class
-      ansible.builtin.import_role:
-        name: ci_local_storage
-      when: not cifmw_use_lvms | default(false)
-      tags:
-        - storage
         - edpm_bootstrap
 
     - name: Configure LVMS Storage Class

--- a/roles/ci_local_storage/tasks/fetch_names.yml
+++ b/roles/ci_local_storage/tasks/fetch_names.yml
@@ -10,9 +10,11 @@
   register: cifmw_ci_local_storage_k8s_nodes_out
 
 - name: Fetch hostnames for all hosts
-  register: _hostnames
+  vars:
+    ansible_ssh_retries: 5
   ansible.builtin.command:
     cmd: hostname
+  register: _hostnames
   delegate_to: "{{ item }}"
   loop: "{{ hostvars.keys() | list }}"
 


### PR DESCRIPTION
SSH connection when fetching hostnames seems to be lost randomly. Add SSH retries and moving the role before OSP operators deployment may help the connection role to succeed.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
