### PR TITLE
Build os-net-config package and serve gating repo on compute

### DIFF
--- a/ci/playbooks/tcib/run.yml
+++ b/ci/playbooks/tcib/run.yml
@@ -26,6 +26,7 @@
           -e @scenarios/centos-9/base.yml
           -e @scenarios/centos-9/tcib.yml
           -e "cifmw_rp_registry_ip={{ node_ip }}"
+          -e "cifmw_rp_registry_port=5001"
           {%- if cifmw_extras is defined %}
           {%-   for extra_vars in cifmw_extras %}
           -e "{{   extra_vars }}"

--- a/ci/playbooks/tcib/tcib.yml
+++ b/ci/playbooks/tcib/tcib.yml
@@ -34,32 +34,44 @@
       ansible.builtin.include_role:
         name: build_openstack_packages
 
-    - name: Deploy local registry
-      tags:
-        - container_img_build
-      ansible.builtin.include_role:
-        name: registry_deploy
-
-    - name: Set fact for cifmw_build_containers_image_tag var
-      tags:
-        - container_img_build
+    - name: Construct project change list
       ansible.builtin.set_fact:
-        cifmw_build_containers_image_tag: "{{ cifmw_repo_setup_full_hash }}"
+        zuul_change_list: "{{ zuul_change_list | default([]) + [item.project.short_name] }}"
+        cacheable: true
+      with_items: "{{ zuul['items'] }}"
+      when:
+        - zuul is defined
+        - "'change_url' in item"
 
-    - name: Build containers
-      tags:
-        - container_img_build
-      ansible.builtin.include_role:
-        name: build_containers
+    - name: Build containers when needed
+      when: "'os-net-config' not in zuul_change_list"
+      block:
+        - name: Deploy local registry
+          tags:
+            - container_img_build
+          ansible.builtin.include_role:
+            name: registry_deploy
 
-    - name: Get the containers list from container registry
-      ansible.builtin.uri:
-        url: "http://{{ cifmw_rp_registry_ip }}:5001/v2/_catalog"
-        return_content: true
-      register: cp_imgs
+        - name: Set fact for cifmw_build_containers_image_tag var
+          tags:
+            - container_img_build
+          ansible.builtin.set_fact:
+            cifmw_build_containers_image_tag: "{{ cifmw_repo_setup_full_hash }}"
 
-    - name: Add the container list to file
-      ansible.builtin.copy:
-        content: "{{ cp_imgs.content }}"
-        dest: "{{ ansible_user_dir }}/local_registry.log"
-        mode: "0644"
+        - name: Build containers
+          tags:
+            - container_img_build
+          ansible.builtin.include_role:
+            name: build_containers
+
+        - name: Get the containers list from container registry
+          ansible.builtin.uri:
+            url: "http://{{ cifmw_rp_registry_ip }}:{{ cifmw_rp_registry_port }}/v2/_catalog"
+            return_content: true
+          register: cp_imgs
+
+        - name: Add the container list to file
+          ansible.builtin.copy:
+            content: "{{ cp_imgs.content }}"
+            dest: "{{ ansible_user_dir }}/local_registry.log"
+            mode: "0644"

--- a/hooks/playbooks/fetch_compute_facts.yml
+++ b/hooks/playbooks/fetch_compute_facts.yml
@@ -1,12 +1,18 @@
 ---
-- name: Sync repos for controller to compute for periodic jobs
+- name: Sync repos for controller to compute for periodic jobs and gating repo
   hosts: computes
   gather_facts: true
   tasks:
+    - name: Check for gating repo on controller
+      delegate_to: controller
+      ansible.builtin.stat:
+        path: "{{ cifmw_basedir }}/artifacts/repositories/gating.repo"
+      register: _gating_repo
+
     - name: Copy repositories from controller to computes
       when:
         - zuul is defined
-        - "'periodic' in zuul.job"
+        - ("'periodic' in zuul.job") or (_gating_repo.stat.exists)
       become: true
       ansible.builtin.copy:
         dest: "/etc/yum.repos.d/"

--- a/roles/build_openstack_packages/defaults/main.yml
+++ b/roles/build_openstack_packages/defaults/main.yml
@@ -60,6 +60,7 @@ cifmw_bop_timestamper_cmd: >-
 
 cifmw_bop_branchless_projects:
   - openstack-k8s-operators/tcib
+  - os-net-config/os-net-config
 
 cifmw_bop_change_list: []
 

--- a/scenarios/centos-9/tcib.yml
+++ b/scenarios/centos-9/tcib.yml
@@ -3,8 +3,7 @@ cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-o
 ansible_user_dir: "{{ lookup('env', 'HOME') }}"
 cifmw_build_containers_tcib_src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/tcib"
 cifmw_repo_setup_src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/repo-setup"
-
 cifmw_build_containers_repo_dir: "{{ cifmw_basedir }}/artifacts/repositories"
-cifmw_build_containers_push_registry: "{{ cifmw_rp_registry_ip }}:5001"
+cifmw_build_containers_push_registry: "{{ cifmw_rp_registry_ip }}:{{ cifmw_rp_registry_port }}"
 cifmw_build_containers_push_containers: false
 cifmw_build_containers_buildah_push: true


### PR DESCRIPTION
This pr will build os-net-config pr changes and creates the gating repo.
    
Whenever gating repo is created, it also needs to be present on the compute node so that depends-on rpm packages gets installed from gating repo on compute node.

tested here: https://github.com/os-net-config/os-net-config/pull/20#issuecomment-2146841767

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/830
