### PR TITLE
dnsmasq - use dhcp-hostdir

### DIFF
--- a/roles/dnsmasq/tasks/configure.yml
+++ b/roles/dnsmasq/tasks/configure.yml
@@ -38,7 +38,7 @@
   become: true
   ansible.builtin.file:
     mode: "0755"
-    path: "{{ cifmw_dnsmasq_basedir }}"
+    path: "{{ cifmw_dnsmasq_basedir }}/dhcp-hosts.d"
     state: "{{ (_act == 'cleanup') | ternary('absent', 'directory') }}"
 
 - name: Manage systemd unit file

--- a/roles/dnsmasq/tasks/manage_host.yml
+++ b/roles/dnsmasq/tasks/manage_host.yml
@@ -44,34 +44,38 @@
 
 - name: Compute entry
   ansible.builtin.set_fact:
-    _host_entry: |
-      {% if cifmw_dnsmasq_host_ipv4 is defined and cifmw_dnsmasq_host_ipv4 | length > 0       -%}
+    _host_entry: >
       {% set data = [cifmw_dnsmasq_host_mac]                                                  -%}
+      {% if cifmw_dnsmasq_host_ipv4 is defined and cifmw_dnsmasq_host_ipv4 | length > 0       -%}
       {% set _ = data.append(cifmw_dnsmasq_host_ipv4)                                         -%}
-      {% set _ = data.append(cifmw_dnsmasq_host_name) if
-                 cifmw_dnsmasq_host_name is defined and cifmw_dnsmasq_host_name | length > 0  -%}
-      dhcp-host={{ data | join(',') }}
       {% endif -%}
       {% if cifmw_dnsmasq_host_ipv6 is defined and cifmw_dnsmasq_host_ipv6 | length > 0       -%}
-      {% set data = [cifmw_dnsmasq_host_mac]                                                  -%}
       {% set _ = data.append('['~cifmw_dnsmasq_host_ipv6~']')                                 -%}
+      {% endif -%}
       {% set _ = data.append(cifmw_dnsmasq_host_name) if
                  cifmw_dnsmasq_host_name is defined and cifmw_dnsmasq_host_name | length > 0  -%}
-      dhcp-host={{ data | join(',') }}
-      {% endif -%}
+      {{ data | join(',') }}
 
 - name: Debug _host_entry
   ansible.builtin.debug:
     var: _host_entry
 
-- name: Manage host entry
+- name: Manage host entry - add
   become: true
+  when:
+    - cifmw_dnsmasq_host_state == 'present'
+  ansible.builtin.copy:
+    content: "{{ _host_entry }}"
+    dest: "{{ cifmw_dnsmasq_basedir }}/dhcp-hosts.d/{{ cifmw_dnsmasq_host_mac }}"
+    mode: '0644'
+    owner: root
+    group: root
+
+- name: Manage host entry - remove
+  become: true
+  when:
+    - cifmw_dnsmasq_host_state == 'absent'
   notify: Restart dnsmasq
-  ansible.builtin.blockinfile:
-    block: "{{ _host_entry }}"
-    dest: "{{ cifmw_dnsmasq_basedir }}/{{ cifmw_dnsmasq_host_network }}-hosts.conf"
-    create: true
-    mode: "0644"
-    state: "{{ cifmw_dnsmasq_host_state }}"
-    marker: "## {mark} {{ cifmw_dnsmasq_host_mac }}"
-    validate: "/usr/sbin/dnsmasq -C %s --test"
+  ansible.builtin.file:
+    state: absent
+    path: "{{ cifmw_dnsmasq_basedir }}/dhcp-hosts.d/{{ cifmw_dnsmasq_host_mac }}"

--- a/roles/dnsmasq/templates/cifmw-dnsmasq.conf.j2
+++ b/roles/dnsmasq/templates/cifmw-dnsmasq.conf.j2
@@ -1,5 +1,4 @@
 # Managed by ci-framework/dnsmasq
-
 user=dnsmasq
 group=dnsmasq
 pid-file=/var/run/cifmw-dnsmasq.pid
@@ -10,3 +9,4 @@ dhcp-leasefile=/var/lib/dnsmasq/cifmw-dnsmasq.leases
 {% endif %}
 
 conf-dir={{ cifmw_dnsmasq_basedir }},*.conf
+dhcp-hostsdir="{{ cifmw_dnsmasq_basedir }}/dhcp-hosts.d"


### PR DESCRIPTION
The restart done by the handler happens only at the very end of the play. By using dhcp-hostsdir we get the benefit of dnsmasq reading any new or changed file in the hosts dir, automatically applying the new dhcp host config on the fly.

Since adding a host is loaded on-the-fly - we don't need to notify the handler when adding hosts.

Removing hosts however, reqires s SIGHUP - so for that case notify the handler.

Also change the computation of _host_entry - it should include both ipv4 and ipv6 address if both are configured.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
