### PR TITLE
Support "reload" action for CIFMW dnsmasq server

### DIFF
--- a/roles/dnsmasq/files/cifmw-dnsmasq.service
+++ b/roles/dnsmasq/files/cifmw-dnsmasq.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 ExecStart=/usr/sbin/dnsmasq -C /etc/cifmw-dnsmasq.conf
+ExecReload=/usr/bin/kill -HUP $MAINPID
 Type=forking
 PIDFile=/run/cifmw-dnsmasq.pid
 

--- a/roles/dnsmasq/handlers/main.yml
+++ b/roles/dnsmasq/handlers/main.yml
@@ -24,3 +24,14 @@
     - _dnsmasq.msg is defined
     - _dnsmasq.msg is not
       match('Could not find the requested service cifmw-dnsmasq.service')
+
+- name: Reload dnsmasq
+  become: true
+  register: _dnsmasq
+  ansible.builtin.systemd_service:
+    name: cifmw-dnsmasq.service
+    state: reloaded
+  failed_when:
+    - _dnsmasq.msg is defined
+    - _dnsmasq.msg is not
+      match('Could not find the requested service cifmw-dnsmasq.service')


### PR DESCRIPTION
Add the ExecReload command to the systemd unit file so that the service can be reloaded.
Also add a handler "Reload dnsmasq".

```
    dnsmasq(8):
      When it receives a SIGHUP, dnsmasq clears its cache and then
      re-loads /etc/hosts and /etc/ethers and any file given by
      --dhcp-hostsfile, --dhcp-hostsdir, --dhcp-optsfile,
      --dhcp-optsdir, --addn-hosts or --hostsdir. The DHCP lease
      change script is called for all existing DHCP leases. If
      --no-poll is set SIGHUP also re-reads /etc/resolv.conf.
      SIGHUP does NOT re-read the configuration file.
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
