### PR TITLE
polarion: update the usage of cifmw_polarion_update_testcases

### DIFF
--- a/roles/polarion/README.md
+++ b/roles/polarion/README.md
@@ -7,7 +7,7 @@ Role to setup jump tool and upload XML test results to Polarion.
 * `cifmw_polarion_jump_result_dir`: (String) Test results directory. Based on `cifmw_run_test_role` defaults to `~/ci-framework-data/tests/tempest/` or `~/ci-framework-data/tests/test_operator/`.
 * `cifmw_polarion_jump_repo_url`: (String) URL of jump repository.
 * `cifmw_polarion_testrun_id`: (String) A test run identification provided by Polarion test case.
-* `cifmw_polarion_update_testcases`: (Boolean) A value of True/False to update the testcases.
+* `cifmw_polarion_update_testcases`: (Boolean) A value of True/False to create missing testcases (which should normally _not_ be enabled).
 * `cifmw_polarion_jump_extra_vars`: (String) A list of extra_vars that are being passed to the jump script. Defaults to empty.
 * `cifmw_polarion_use_stage`: (Bool) Flag for using the staging instance of Polarion. Default is False meaning the production instance gets updated. Don't forget to change for testing on stage instance.
 
@@ -19,7 +19,6 @@ Role to setup jump tool and upload XML test results to Polarion.
   vars:
     cifmw_polarion_jump_repo_url: "https://example.com/repo.git"
     cifmw_polarion_testrun_id: "20230101-0001"
-    cifmw_polarion_update_testcases: true
     cifmw_polarion_use_stage: true  # uploading to the staging instance
     cifmw_polarion_jump_extra_vars: >-
       "--dfg '' --jenkins_build_url='' --puddle-id='' --custom-fields build='' --remove-old-tests='' --update-existing-test-cases=''"

--- a/roles/polarion/tasks/main.yml
+++ b/roles/polarion/tasks/main.yml
@@ -19,7 +19,6 @@
     that:
       - cifmw_polarion_jump_repo_url is defined and cifmw_polarion_jump_repo_url != ""
       - cifmw_polarion_testrun_id is defined and cifmw_polarion_testrun_id != ""
-      - cifmw_polarion_update_testcases is defined and cifmw_polarion_update_testcases | bool
 
 - name: Ensure deps are installed
   become: true


### PR DESCRIPTION
cifmw_polarion_update_testcases is named after a parameter of a tool and it doesn't match its behavior: it is about adding missing test cases when they don't exist. But the "normal" workflow is to pre-populate the test cases and only update (for real) their results, so that variable should almost never be enabled.

Also, remove the check about the variable being enabled, as its only usage is guarded by a default() filter.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
