### PR TITLE
[anisble_test] Add retries to ansible galaxy install

### DIFF
--- a/scripts/run_ansible_test
+++ b/scripts/run_ansible_test
@@ -24,6 +24,7 @@ set -xeuo
 PROJECT_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))/../"
 USE_VENV=${USE_VENV:-yes}
 HOME=${HOME:-/tmp}
+ANSIBLE_GALAXY_RETIRES=5
 
 export HOME=${HOME}
 export ANSIBLE_LOCAL_TMP=${HOME}
@@ -38,7 +39,12 @@ case ${USE_VENV} in
         ;;
 esac
 
-ansible-galaxy collection install --upgrade --force ${PROJECT_DIR}
+n=0
+until [ "$n" -ge "$ANSIBLE_GALAXY_RETIRES" ]; do
+    ansible-galaxy collection install --upgrade --force "${PROJECT_DIR}" && break
+    n=$((n+1))
+    sleep 15
+done
 
 # Create/append the sanity exceptions for the current ansible version
 ansible_version=$(python3 -c "import ansible; print(ansible.__version__)" | sed 's/\.[^.]*$//')


### PR DESCRIPTION
This patch adds retries to the ansible_test job to avoid errors like [1]

Similar change was made here [2]

Note: This issue could be solved by removing the galaxy install command because it's redundant. Requirements are already installed here [3] but in a different location. That fix requires a much bigger change to do right, let's fix CI now and iterate. 

Jira: https://issues.redhat.com/browse/OSPCIX-314

[1] ERROR! Failed to clone a Git repository from https://github.com/ansible-collections/community.general.

[2] https://github.com/openstack-k8s-operators/ci-framework/pull/1539

[3] https://github.com/openstack-k8s-operators/ci-framework/blob/8c5894f81ded070f3744b5f401a61c1d6ec33310/ci/playbooks/pod-jobs.yml#L26-L35

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running