### PR TITLE
[rhol_crc]Set default version of CRC deployed

### DIFF
--- a/roles/rhol_crc/README.md
+++ b/roles/rhol_crc/README.md
@@ -12,10 +12,10 @@ Become - required for the tasks in `sudoers_grant.yml` and `sudoers_revoke.yml` 
 * `cifmw_rhol_crc_use_installyamls`: (Boolean) Mimic some steps of the install_yamls way to deploy CRC. Defaults to `False`.
 * `cifmw_rhol_crc_dryrun`: (Boolean) Toggle the `ci_make` `dry_run` parameter. Defaults to `False`.
 * `cifmw_rhol_crc_config`: (Dict) This structure is merged with the `cifmw_rhol_crc_config_defaults` dictionary. We can add extra properties or override the existing one using this parameter. We can know the parameters that can be used with the output of the `crc config --help` command. Defaults to `{}`.
-* `cifmw_rhol_crc_version`: (String) RHOL/CRC binary version we want to use. Default: `latest`.
+* `cifmw_rhol_crc_version`: (String) RHOL/CRC binary version we want to use, set to `latest` to deploy latest CRC release. Default: `2.36.0`.
 * `cifmw_rhol_crc_tarball_name`: (String) RHOL/CRC tarball name depending on the architecture. Defaults to `crc-linux-amd64.tar.xz`.
 * `cifmw_rhol_crc_tarball_checksum_name`: (String) RHOL/CRC tarball file checksum name. Defaults to `crc-linux-amd64.tar.xz.sha256`.
-* `cifmw_rhol_crc_base_url`: (String) RHOL/CRC URL base. Defaults to `https://mirror.openshift.com/pub/openshift-v4/clients/crc/2.14.0`.
+* `cifmw_rhol_crc_base_url`: (String) RHOL/CRC URL base. Defaults to `https://mirror.openshift.com/pub/openshift-v4/clients/crc/{{ cifmw_rhol_crc_version }}`.
 * `cifmw_rhol_crc_binary_folder`: (String) Folder that will be used to store the RHOL/CRC binary. Defaults to `{{ cifmw_rhol_crc_basedir }}/bin`.
 * `cifmw_rhol_crc_binary`: (String) Path of the RHOL/CRC downloaded binary for executing the commands. Defaults to `{{ cifmw_rhol_crc_basedir }}/bin/crc`.
 * `cifmw_rhol_crc_force_cleanup`: (Boolean) In case this variable is `true` it will delete if exists the actual crc instance, domain and linked resources and recreate it with the new configuration. Defaults to `False`.

--- a/roles/rhol_crc/defaults/main.yml
+++ b/roles/rhol_crc/defaults/main.yml
@@ -28,7 +28,7 @@ cifmw_rhol_crc_kubeadmin_pwd: 12345678
 cifmw_rhol_crc_dryrun: false
 
 # Binary variables:
-cifmw_rhol_crc_version: latest
+cifmw_rhol_crc_version: 2.36.0
 cifmw_rhol_crc_tarball_name: crc-linux-amd64.tar.xz
 cifmw_rhol_crc_tarball_checksum_name: crc-linux-amd64.tar.xz.sha256
 cifmw_rhol_crc_base_url: https://mirror.openshift.com/pub/openshift-v4/clients/crc/{{ cifmw_rhol_crc_version }}


### PR DESCRIPTION
This default is used when deploying the reproducer layout. We should deploy the version we default to across CI and allow overriding to deploy latest rather than defaulting to latest.

Jira: https://issues.redhat.com/browse/OSPRH-6871

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
