### PR TITLE
[shiftstack] Allow custom storage class

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/shiftstack/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/shiftstack/edpm-nodeset-values/values.yaml.j2
@@ -94,9 +94,9 @@ data:
           - defaultRoute: true
             fixedIP: {{ "192.168.122.10" ~ loop.index0 }}
             name: ctlplane
-            subnet: subnet1
+            subnetName: subnet1
           - name: internalapi
-            subnet: subnet1
+            subnetName: subnet1
           - name: storage
             subnetName: subnet1
           - name: tenant

--- a/roles/ci_gen_kustomize_values/templates/shiftstack/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/shiftstack/network-values/values.yaml.j2
@@ -113,5 +113,5 @@ data:
       metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(86) }}
 
   lbServiceType: LoadBalancer
-  storageClass: local-storage
+  storageClass: {{ cifmw_ci_gen_kustomize_values_storage_class }}
   bridgeName: ospbr


### PR DESCRIPTION
This change fixes the issues identified during unit testing with compute nodes.

- Allow custom storage class
- suffix `Name` to subnet

Without the suffix, openstackdataplanenodeset fails to apply due the need of network subnet name.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

*Testing results*

```
[zuul@controller-0 ~]$ oc get bmh -n openshift-machine-api
NAME                 STATE                    CONSUMER                   ONLINE   ERROR   AGE
compute-0            provisioning             compute-nodes              true             115m
osasinfra-master-0   externally provisioned   osasinfra-7vkv8-master-0   true             42h
osasinfra-master-1   externally provisioned   osasinfra-7vkv8-master-1   true             42h
osasinfra-master-2   externally provisioned   osasinfra-7vkv8-master-2   true             42h
[zuul@controller-0 ~]$ oc get osdpns
NAME            STATUS   MESSAGE
ceph-nodes      True     NodeSet Ready
compute-nodes   False    NodeSetBaremetalProvisionReady not yet ready
[zuul@controller-0 ~]$ oc get osdpd
NAME          NODESETS         STATUS   MESSAGE
ceph-deploy   ["ceph-nodes"]   True     Setup complete
```
