### PR TITLE
Ensure local _cifmw_networking_mapper_definition fact is empty

### DIFF
--- a/roles/networking_mapper/tasks/main.yml
+++ b/roles/networking_mapper/tasks/main.yml
@@ -42,6 +42,10 @@
         file: "{{ cifmw_networking_mapper_ifaces_info_path }}"
         name: cifmw_networking_mapper_ifaces_info
 
+- name: Ensure local fact is empty
+  ansible.builtin.set_fact:
+    _cifmw_networking_mapper_definition: {}
+
 - name: Set the input Networking Definition and patch it if needed
   vars:
     _net_def_patches: >-
@@ -58,7 +62,6 @@
     _cifmw_networking_mapper_definition: >-
       {{
         _cifmw_networking_mapper_definition |
-        default({}) |
         combine(item, recursive=True)
       }}
   loop: "{{ [cifmw_networking_definition] + _net_def_patches }}"


### PR DESCRIPTION
With the coming networking changes in the Framework, we're calling the
networking_mapper role multiple times, and some of those calls involve a
temporary patch to inject a specific network.

This patch ensures we're always taking a clean, empty
_cifmw_networking_mapper_definition in order to ensure we're not
re-applying any previous patch/modification.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
