### PR TITLE
Reuse the preinstalled env in ansible-lint pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,5 +36,4 @@ repos:
     rev: v6.22.1
     hooks:
       - id: ansible-lint
-        additional_dependencies:
-          - netaddr
+        language: system


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
