### PR TITLE
sushy-emulator podman - restart_policy: on-failure

### DIFF
--- a/roles/sushy_emulator/tasks/create_container.yml
+++ b/roles/sushy_emulator/tasks/create_container.yml
@@ -32,6 +32,7 @@
     network: host
     state: started
     force_restart: true
+    restart_policy: on-failure
     env:
       SUSHY_TOOLS_CONFIG: '/etc/sushy-emulator/config.conf'
     volumes:


### PR DESCRIPTION
I sometimes see sushy-emulator failing - `Exited (1)`. Inspecting logs it failed on binding to the listen address:
```
  + exec /usr/local/bin/sushy-emulator --debug --config /etc/sushy-emulator/config.conf
   * Serving Flask app 'sushy_tools.emulator.main'
   * Debug mode: on Cannot assign requested address
```

A podman restart solves the problem. Let's set `restart_policy: on-failure` to keep trying to re-start on failure.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
