### PR TITLE
Get OpenStackControlPlane to update the OpenStackVersion

### DIFF
--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -144,6 +144,8 @@
         - edpm_bootstrap
 
     - name: Update containers in deployed OSP operators
+      vars:
+        cifmw_update_containers_metadata: controlplane
       ansible.builtin.include_role:
         name: update_containers
       tags:

--- a/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
+++ b/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
@@ -61,9 +61,9 @@
   ansible.builtin.pause:
     seconds: "{{ cifmw_edpm_prepare_wait_controplane_status_change_sec }}"
 
-- name: Wait for OpenStack controlplane to be deployed
-  vars:
-    cr_name: >-
+- name: Get controlplane name
+  ansible.builtin.set_fact:
+    _ctlplane_name: >-
       {{
         (
           cifmw_edpm_prepare_crs_kustomize_result.result |
@@ -73,12 +73,14 @@
           first
         ).metadata.name
       }}
+
+- name: Wait for OpenStack controlplane to be deployed
   environment:
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
     PATH: "{{ cifmw_path }}"
   ansible.builtin.command:
     cmd: >-
-      oc wait OpenStackControlPlane {{ cr_name }}
+      oc wait OpenStackControlPlane {{ _ctlplane_name }}
       --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
       --for=condition=ready
       --timeout={{ cifmw_edpm_prepare_timeout }}m

--- a/roles/edpm_prepare/tasks/main.yml
+++ b/roles/edpm_prepare/tasks/main.yml
@@ -132,13 +132,6 @@
     cacheable: true
   when: cifmw_build_images_output is defined
 
-- name: Update BM CSV or Ansibleee CSV to update proper image
-  when: >-
-      (cifmw_update_containers_edpm_image_url is defined) or
-      (cifmw_update_containers_ansibleee_image_url is defined)
-  ansible.builtin.include_role:
-    name: update_containers
-
 # Prepare and kustomize the OpenStackControlPlane CR
 - name: Prepare OpenStack control plane CR
   vars:
@@ -150,6 +143,15 @@
     tasks_from: 'make_openstack_deploy_prep'
   tags:
     - control-plane
+
+- name: Update BM CSV or Ansibleee CSV to update proper image
+  when: >-
+      (cifmw_update_containers_edpm_image_url is defined) or
+      (cifmw_update_containers_ansibleee_image_url is defined)
+  vars:
+    cifmw_update_containers_metadata: "{{ _ctlplane_name }}"
+  ansible.builtin.include_role:
+    name: update_containers
 
 - name: Deploy NetConfig
   vars:

--- a/roles/update_containers/defaults/main.yml
+++ b/roles/update_containers/defaults/main.yml
@@ -19,7 +19,6 @@
 # All variables within this role should have a prefix of "cifmw_update_containers"
 
 cifmw_update_containers: false
-cifmw_update_containers_metadata: controlplane
 cifmw_update_containers_namespace: openstack
 cifmw_update_containers_base_dir: >-
   {{

--- a/roles/update_containers/molecule/default/converge.yml
+++ b/roles/update_containers/molecule/default/converge.yml
@@ -20,6 +20,7 @@
   vars:
     cifmw_update_containers_openstack: true
     cifmw_update_containers_registry: "quay"
+    cifmw_update_containers_metadata: controlplane
     cifmw_update_containers_org: "moleculetest"
     cifmw_update_containers_tag: foobar
     cifmw_update_containers_cindervolumes:

--- a/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
+++ b/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
@@ -21,7 +21,6 @@ cifmw_edpm_prepare_skip_crc_storage_creation: true
 
 # update containers vars
 cifmw_update_containers: true
-cifmw_update_containers_metadata: openstack-galera-network-isolation
 
 # edpm_deploy role vars
 cifmw_deploy_edpm: true


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes

Depends-On: https://github.com/openstack-k8s-operators/data-plane-adoption/pull/480