### PR TITLE
Fixed validate-architecture zuul job

### DIFF
--- a/ci/playbooks/architecture/run.yml
+++ b/ci/playbooks/architecture/run.yml
@@ -10,9 +10,10 @@
         - inventory_hostname != cifmw_zuul_target_host
       ansible.builtin.meta: end_host
 
-    - name: Run Podified EDPM deployment
+    - name: Run playbook
       ansible.builtin.command:
         chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
         cmd: >-
           ansible-playbook -i localhost, -c local
           ci/playbooks/architecture/validate-architecture.yml
+          -e "@{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml"

--- a/ci/playbooks/architecture/validate-architecture.yml
+++ b/ci/playbooks/architecture/validate-architecture.yml
@@ -17,7 +17,7 @@
 # cifmw_zuul_target_host: target host. Defaults to localhost
 
 - name: Test architecture automations
-  hosts: "{{ cifmw_zuul_target_host | default('controller') }}"
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: true
   vars:
     cifmw_kustomize_deploy_generate_crs_only: true
@@ -79,13 +79,13 @@
         - name: Copy file on localhost
           delegate_to: localhost
           ansible.builtin.copy:
-            dest: "{{ lookup('env', 'HOME') }}/{{ cifmw_architecture_scenario }}.yml }}"
+            dest: "{{ lookup('env', 'HOME') ~ '/' ~ cifmw_architecture_scenario ~ '.yml' }}"
             mode: "0644"
             content: "{{ _mock_content.content | b64decode }}"
 
         - name: Include var file
           ansible.builtin.include_vars:
-            file: "{{ lookup('env', 'HOME') }}/{{ cifmw_architecture_scenario }}.yml }}"
+            file: "{{ lookup('env', 'HOME') ~ '/' ~ cifmw_architecture_scenario ~ '.yml' }}"
 
     - name: Ensure kustomize_deploy is bootstraped
       ansible.builtin.import_role:

--- a/zuul.d/architecture-jobs.yaml
+++ b/zuul.d/architecture-jobs.yaml
@@ -9,18 +9,24 @@
     name: cifmw-architecture-validate-base
     parent: cifmw-base-minimal
     vars:
-      cifmw_networking_mapper_networking_env_def_path: >-
-        {{
-          [ansible_user_dir,
-           zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
-           'ci/playbooks/files/networking-env-definition.yml']
-           | path_join
-        }}
       cifmw_architecture_repo: >-
         {{
           [ansible_user_dir,
            zuul.projects['github.com/openstack-k8s-operators/architecture'].src_dir]
            | path_join
+        }}
+      cifmw_networking_env_def_file_local: >-
+        {{
+          "" if not cifmw_networking_env_def_file else
+          ([ cifmw_architecture_repo,
+            cifmw_networking_env_def_file ] | path_join)
+        }}
+      cifmw_networking_mapper_networking_env_def_path: >-
+        {{
+          cifmw_networking_env_def_file_local |
+          default([ansible_user_dir,
+          zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
+          'ci/playbooks/files/networking-env-definition.yml'] | path_join, true)
         }}
     run:
       - ci/playbooks/architecture/run.yml


### PR DESCRIPTION
* Fixed file name generation typo in `validate-architecture` playbook
* Added the ability of overriding `cifmw_networking_mapper_networking_env_def_path` job

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

