### PR TITLE
Allow cifmw_use_lvms in the reproducer variables file

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -355,7 +355,7 @@
             rejectattr('key', 'equalto', 'cifmw_openshift_kubeconfig') |
             rejectattr('key', 'equalto', 'cifmw_openshift_token') |
             rejectattr('key', 'equalto', 'cifmw_set_openstack_containers_registry') |
-            rejectattr('key', 'match', '^cifmw_use.*') |
+            rejectattr('key', 'match', '^cifmw_use_(?!lvms).*') |
             rejectattr('key', 'match', '^cifmw_reproducer.*') |
             rejectattr('key', 'match', '^cifmw_rhol.*') |
             rejectattr('key', 'match', '^cifmw_discover.*') |


### PR DESCRIPTION
Update the `reproducer` role to allow the `cifmw_use_lvms` variable to be in the reproducer-variables.yml file.

The `cifmw_use_lvms` variable needs to be in this file so that when the `deploy-edpm.yml` playbook is run by the `deploy-architecture.sh` script it opts to use LVMS and not local-storage. The filter in the `reproducer` role, without this patch, prevents LVMS from getting deployed.

The `rejectattr('key', 'match', '^cifmw_use_(?!lvms).*')` regex rejects all keys starting with `cifmw_use_` except `cifmw_use_lvms`. This fixes LVMS without adding other variables matching `cifmw_use_` to the file.

Jira: https://issues.redhat.com/browse/OSPRH-7424

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
