### PR TITLE
use UUIDS while configuring rgw as objectstore

### DIFF
--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -104,3 +104,4 @@ cifmw_cephadm_grafana_container_image: "{{ cifmw_cephadm_container_ns }}/ceph-gr
 cifmw_cephadm_node_exporter_container_image: "{{ cifmw_cephadm_prometheus_container_ns }}/node-exporter:v1.5.0"
 cifmw_cephadm_prometheus_container_image: "{{ cifmw_cephadm_prometheus_container_ns }}/prometheus:v2.43.0"
 cifmw_cephadm_ns: openstack
+cifmw_cephadm_urischeme: "http"

--- a/roles/cifmw_cephadm/tasks/configure_object.yml
+++ b/roles/cifmw_cephadm/tasks/configure_object.yml
@@ -38,21 +38,67 @@
     - cifmw_ceph_daemons_layout.rgw_enabled | default(true) | bool
     - swift_in_ctlplane.stdout | bool
 
-- name: Configure object store to use rgw
+- name: Get uuid for project 'service'
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+  ansible.builtin.command: "oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack project show service -c id -f value"
+  delegate_to: localhost
+  when: cifmw_openshift_kubeconfig is defined
+  register: project_service_uuid
+
+- name: Create swift service, user and roles
   cifmw.general.ci_script:
     extra_args:
       KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
     output_dir: "/home/zuul/ci-framework-data/artifacts"
     script: |-
       oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack service create --name swift --description 'OpenStack Object Storage' object-store
-      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack user create --project service --password {{ cifmw_ceph_rgw_keystone_psw }}  swift
+      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack user create --project {{ project_service_uuid.stdout }} --password {{ cifmw_ceph_rgw_keystone_psw }}  swift
       oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack role create swiftoperator
       oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack role create ResellerAdmin
-      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack role add --user swift --project service member
-      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack role add --user swift --project service admin
-      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack endpoint create --region regionOne object-store public http://{{ cifmw_cephadm_vip }}:8080/swift/v1/AUTH_%\(tenant_id\)s
-      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack endpoint create --region regionOne object-store internal http://{{ cifmw_cephadm_vip }}:8080/swift/v1/AUTH_%\(tenant_id\)s
-      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack role add --project admin --user admin swiftoperator
+  delegate_to: localhost
+  when:
+    - cifmw_openshift_kubeconfig is defined
+    - cifmw_ceph_daemons_layout.rgw_enabled | default(true) | bool
+    - not swift_in_ctlplane.stdout | bool
+    - swift_endpoints_count.stdout == "0"
+
+- name: Capture required UUIDs
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+  delegate_to: localhost
+  when: cifmw_openshift_kubeconfig is defined
+  ansible.builtin.command: "oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack {{ item.os_command }} show {{ item.os_command_object }} -c id -f value"
+  register: all_uuids
+  loop:
+    - { os_command: 'user', os_command_object: 'swift' }
+    - { os_command: 'service', os_command_object: 'swift' }
+    - { os_command: 'role', os_command_object: 'member' }
+    - { os_command: 'role', os_command_object: 'admin' }
+    - { os_command: 'project', os_command_object: 'admin' }
+    - { os_command: 'user', os_command_object: 'admin' }
+    - { os_command: 'role', os_command_object: 'swiftoperator' }
+
+- name: Update urischeme based on cert/key
+  ansible.builtin.set_fact:
+    cifmw_cephadm_urischeme: "https"
+  when:
+    - cifmw_cephadm_certificate | length > 0
+    - cifmw_cephadm_key | length > 0
+    - cert_stat_result.stat.exists | bool
+    - key_stat_result.stat.exists | bool
+
+- name: Configure object store to use rgw
+  cifmw.general.ci_script:
+    extra_args:
+      KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    output_dir: "/home/zuul/ci-framework-data/artifacts"
+    script: |-
+      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack role add --user {{ all_uuids.results.0.stdout }} --project {{ project_service_uuid.stdout }} {{ all_uuids.results.2.stdout }}
+      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack role add --user {{ all_uuids.results.0.stdout }} --project {{ project_service_uuid.stdout }} {{ all_uuids.results.3.stdout }}
+      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack endpoint create --region regionOne {{ all_uuids.results.1.stdout }} public {{ cifmw_cephadm_urischeme }}://{{ cifmw_cephadm_vip }}:8080/swift/v1/AUTH_%\(tenant_id\)s
+      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack endpoint create --region regionOne {{ all_uuids.results.1.stdout }} internal {{ cifmw_cephadm_urischeme }}://{{ cifmw_cephadm_vip }}:8080/swift/v1/AUTH_%\(tenant_id\)s
+      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack role add --project {{ all_uuids.results.4.stdout }} --user {{ all_uuids.results.5.stdout }} {{ all_uuids.results.6.stdout }}
   delegate_to: localhost
   when:
     - cifmw_openshift_kubeconfig is defined

--- a/roles/cifmw_cephadm/tasks/pre.yml
+++ b/roles/cifmw_cephadm/tasks/pre.yml
@@ -158,3 +158,15 @@
     mode: "0644"
     config_overrides: "{{ cifmw_cephadm_conf_overrides }}"
     config_type: ini
+
+- name: Stat cifmw_cephadm_certificate
+  ansible.builtin.stat:
+    path: "{{ cifmw_cephadm_certificate }}"
+  register: cert_stat_result
+  when: cifmw_cephadm_certificate | length > 0
+
+- name: Stat cifmw_cephadm_key
+  ansible.builtin.stat:
+    path: "{{ cifmw_cephadm_key }}"
+  register: key_stat_result
+  when: cifmw_cephadm_key | length > 0


### PR DESCRIPTION
This patch ensures to use UUIDs instead of names of user, service and project while configuring rgw as ceph object store.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes

Jira: https://issues.redhat.com/browse/OSPRH-7408
Jira: https://issues.redhat.com/browse/OSPRH-7245
