### PR TITLE
[os_must_gather] Add SOS_DECOMPRESS environment variable

### DIFF
--- a/roles/os_must_gather/tasks/main.yml
+++ b/roles/os_must_gather/tasks/main.yml
@@ -56,6 +56,7 @@
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
         SOS_EDPM: "all"
+        SOS_DECOMPRESS: "0"
       cifmw.general.ci_script:
         output_dir: "{{ cifmw_os_must_gather_output_dir }}/artifacts"
         script: >-
@@ -63,7 +64,10 @@
           --timeout {{ cifmw_os_must_gather_timeout }}
           --host-network={{ cifmw_os_must_gather_host_network }}
           --dest-dir {{ cifmw_os_must_gather_output_dir }}/logs
-          -- ADDITIONAL_NAMESPACES={{ cifmw_os_must_gather_additional_namespaces }} SOS_EDPM=$SOS_EDPM gather &> {{ cifmw_os_must_gather_output_dir }}/logs/os_must_gather.log
+          -- ADDITIONAL_NAMESPACES={{ cifmw_os_must_gather_additional_namespaces }}
+          SOS_EDPM=$SOS_EDPM
+          SOS_DECOMPRESS=$SOS_DECOMPRESS
+          gather &> {{ cifmw_os_must_gather_output_dir }}/logs/os_must_gather.log
 
     - name: Get exact must-gather output folder name
       ansible.builtin.find:


### PR DESCRIPTION
This environment variable will be used in the os_must_gather project to toggle decompressing sos reports. In CI we don't want to decompress them as it causes issues with Zuul web interface.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes

Depends-On: https://github.com/openstack-k8s-operators/openstack-must-gather/pull/54

Jira: https://issues.redhat.com/browse/OSPRH-7522