### PR TITLE
Make compute VMs specs configurable for 3-nodes scenario

### DIFF
--- a/scenarios/reproducers/3-nodes.yml
+++ b/scenarios/reproducers/3-nodes.yml
@@ -22,6 +22,9 @@ cifmw_root_partition_id: >-
     }}
 
 cifmw_libvirt_manager_compute_amount: 1
+cifmw_libvirt_manager_compute_disksize: 50
+cifmw_libvirt_manager_compute_memory: 8
+cifmw_libvirt_manager_compute_cpus: 4
 cifmw_libvirt_manager_configuration:
   vms:
     crc:
@@ -42,9 +45,9 @@ cifmw_libvirt_manager_configuration:
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"
       disk_file_name: "centos-stream-9.qcow2"
-      disksize: 50
-      memory: 8
-      cpus: 4
+      disksize: "{{ [cifmw_libvirt_manager_compute_disksize|int, 50] | max }}"
+      memory: "{{ [cifmw_libvirt_manager_compute_memory|int, 8] | max }}"
+      cpus: "{{ [cifmw_libvirt_manager_compute_cpus|int, 4] | max }}"
       nets:
         - public
         - osp_trunk


### PR DESCRIPTION
Replicate what was made for the va-hci scenario.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes