### PR TITLE
Remove conflicting and useless parameter

### DIFF
--- a/scenarios/reproducers/va-common.yml
+++ b/scenarios/reproducers/va-common.yml
@@ -10,12 +10,6 @@
 
 
 # Ensure some basic directories and parameter are set
-cifmw_install_yamls_repo: >-
-  {{
-    (ansible_user_dir,
-     'src/github.com/openstack-k8s-operators/install_yamls') |
-     path_join
-  }}
 cifmw_basedir: "{{ ansible_user_dir }}/ci-framework-data"
 cifmw_path: "{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
 


### PR DESCRIPTION
ansible_user_dir points to the directory on the hypervisor, while we're
wanting the one on controller-0 - if the hypervisor user isn't the same
as the controller-0, we're facing an issue.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
