### PR TITLE
Add retries/delays when applying LVMS manifests

### DIFF
--- a/roles/ci_lvms_storage/tasks/main.yml
+++ b/roles/ci_lvms_storage/tasks/main.yml
@@ -46,6 +46,10 @@
     context: "{{ cifmw_openshift_context | default(omit) }}"
     src: "{{ cifmw_lvms_manifests_dir }}/lvms-namespace.yaml"
     state: present
+  retries: "{{ cifmw_lvms_retries }}"
+  delay: "{{ cifmw_lvms_delay }}"
+  register: result
+  until: result.failed == false
 
 - name: Wait for lvms-operator namespace to be active
   kubernetes.core.k8s_info:
@@ -70,6 +74,10 @@
     context: "{{ cifmw_openshift_context | default(omit) }}"
     src: "{{ cifmw_lvms_manifests_dir }}/operator-group.yaml"
     state: present
+  retries: "{{ cifmw_lvms_retries }}"
+  delay: "{{ cifmw_lvms_delay }}"
+  register: result
+  until: result.failed == false
 
 - name: Ensure we can get info from lvms-operator group
   kubernetes.core.k8s_info:
@@ -91,6 +99,10 @@
     context: "{{ cifmw_openshift_context | default(omit) }}"
     src: "{{ cifmw_lvms_manifests_dir }}/subscription.yaml"
     state: present
+  retries: "{{ cifmw_lvms_retries }}"
+  delay: "{{ cifmw_lvms_delay }}"
+  register: result
+  until: result.failed == false
 
 - name: Wait for lvms operator pod to be running
   kubernetes.core.k8s_info:
@@ -117,6 +129,10 @@
     context: "{{ cifmw_openshift_context | default(omit) }}"
     src: "{{ cifmw_lvms_manifests_dir }}/lvms-cluster.yaml"
     state: present
+  retries: "{{ cifmw_lvms_retries }}"
+  delay: "{{ cifmw_lvms_delay }}"
+  register: result
+  until: result.failed == false
 
 - name: Wait for vg-manger and topolvm controller and node to be running
   kubernetes.core.k8s_info:

--- a/roles/ci_lvms_storage/tasks/status.yml
+++ b/roles/ci_lvms_storage/tasks/status.yml
@@ -22,6 +22,9 @@
     kind: Pod
     namespace: "{{ cifmw_lvms_namespace }}"
   register: pod_info
+  retries: "{{ cifmw_lvms_retries }}"
+  delay: "{{ cifmw_lvms_delay }}"
+  until: pod_info.failed == false
 
 - name: Display pod names and status
   ansible.builtin.debug:
@@ -39,6 +42,9 @@
     api_version: lvm.topolvm.io/v1alpha1
     namespace: "{{ cifmw_lvms_namespace }}"
   register: lvm_cluster
+  retries: "{{ cifmw_lvms_retries }}"
+  delay: "{{ cifmw_lvms_delay }}"
+  until: lvm_cluster.failed == false
 
 - name: Display deviceClassStatuses
   ansible.builtin.debug:
@@ -54,6 +60,9 @@
     name: "lvms-{{ cifmw_lvms_storage_class }}"
     namespace: "{{ cifmw_lvms_namespace }}"
   register: sc
+  retries: "{{ cifmw_lvms_retries }}"
+  delay: "{{ cifmw_lvms_delay }}"
+  until: sc.failed == false
 
 - name: Display StorageClass
   ansible.builtin.debug:

--- a/roles/ci_lvms_storage/tasks/test.yml
+++ b/roles/ci_lvms_storage/tasks/test.yml
@@ -31,6 +31,10 @@
     context: "{{ cifmw_openshift_context | default(omit) }}"
     src: "{{ cifmw_lvms_manifests_dir }}/test-pvc.yaml"
     state: present
+  retries: "{{ cifmw_lvms_retries }}"
+  delay: "{{ cifmw_lvms_delay }}"
+  register: result
+  until: result.failed == false
 
 - name: Wait for test PVC to be pending
   kubernetes.core.k8s_info:
@@ -60,6 +64,10 @@
     context: "{{ cifmw_openshift_context | default(omit) }}"
     src: "{{ cifmw_lvms_manifests_dir }}/test-pod.yaml"
     state: present
+  retries: "{{ cifmw_lvms_retries }}"
+  delay: "{{ cifmw_lvms_delay }}"
+  register: result
+  until: result.failed == false
 
 - name: Wait for test pod to be running
   kubernetes.core.k8s_info:


### PR DESCRIPTION
In the `ci_lvms_storage` role, the kubernetes.core.k8s module will occasionally attempt to apply a manifest before an end point is available for a service which was created in the previous task as reported in [OSPRH-7460](https://issues.redhat.com//browse/OSPRH-7460).

Add retries and delays to all calls to this module within the role so that it retries if the module fails.

Closes: https://issues.redhat.com/browse/OSPRH-7460

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
