### PR TITLE
Skip validations in edpm deploy for arch deployment

### DIFF
--- a/playbooks/06-deploy-edpm.yml
+++ b/playbooks/06-deploy-edpm.yml
@@ -159,5 +159,9 @@
   ansible.builtin.import_playbook: ./hooks.yml
 
 - name: Validations workflow
+  # If we're doing an architecture deployment, we need to skip validations here.
+  # Instead, they will be executed in the 06-deploy-architecture.yml playbook.
+  when:
+    - cifmw_architecture_scenario is not defined
+    - cifmw_execute_validations | default('false') | bool
   ansible.builtin.import_playbook: validations.yml
-  when: cifmw_execute_validations | default('false') | bool


### PR DESCRIPTION
When running an architecture deployment, most of the control plane and dataplane setup are skipped in 06-edpm-deploy.yml. Instead, it all gets configured in the 06-deploy-architecture.yml playbook. This means that we need to also skip validations in the 06-epdm-deploy.yml since there is nothing to validate at this stage. We will instead fall back to the validations role execution in the architecture playbook.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
