### PR TITLE
Newer CentOS image converge with RHEL image

### DIFF
--- a/scenarios/reproducers/3-nodes.yml
+++ b/scenarios/reproducers/3-nodes.yml
@@ -12,14 +12,8 @@ cifmw_rhol_crc_config:
   memory: 24000
 
 cifmw_use_libvirt: true
-cifmw_use_uefi: >-
-  {{ (cifmw_repo_setup_os_release is defined
-      and cifmw_repo_setup_os_release == 'rhel') | bool }}
-cifmw_root_partition_id: >-
-    {{
-      (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
-      ternary(4, 1)
-    }}
+cifmw_use_uefi: true
+cifmw_root_partition_id: 4
 
 cifmw_libvirt_manager_compute_amount: 1
 cifmw_libvirt_manager_configuration:

--- a/scenarios/reproducers/bgp-4-racks-3-ocps.yml
+++ b/scenarios/reproducers/bgp-4-racks-3-ocps.yml
@@ -9,9 +9,6 @@ cifmw_test_operator_tempest_include_list: |
 cifmw_use_devscripts: true
 cifmw_use_libvirt: true
 cifmw_virtualbmc_daemon_port: 50881
-cifmw_use_uefi: >-
-  {{ (cifmw_repo_setup_os_release is defined
-      and cifmw_repo_setup_os_release == 'rhel') | bool }}
 cifmw_libvirt_manager_compute_amount: 3
 cifmw_libvirt_manager_pub_net: ocpbm
 cifmw_libvirt_manager_spineleaf_setup: true
@@ -212,11 +209,8 @@ cifmw_libvirt_manager_configuration:
       </network>
   vms:
     controller:
-      root_part_id: >-
-        {{
-          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
-          ternary(4, 1)
-        }}
+      root_part_id: "{{ cifmw_root_partition_id }}"
+      uefi: "{{ cifmw_use_uefi }}"
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"
@@ -229,11 +223,8 @@ cifmw_libvirt_manager_configuration:
         - osp_trunk
     compute:
       amount: "{{ cifmw_libvirt_manager_compute_amount }}"
-      root_part_id: >-
-        {{
-          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
-          ternary(4, 1)
-        }}
+      root_part_id: "{{ cifmw_root_partition_id }}"
+      uefi: "{{ cifmw_use_uefi }}"
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"
@@ -282,11 +273,8 @@ cifmw_libvirt_manager_configuration:
           - "osp_trunk"
     spine:
       amount: 2
-      root_part_id: >-
-        {{
-          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
-          ternary(4, 1)
-        }}
+      root_part_id: "{{ cifmw_root_partition_id }}"
+      uefi: "{{ cifmw_use_uefi }}"
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"
@@ -317,11 +305,8 @@ cifmw_libvirt_manager_configuration:
           - "ocpbm"
     leaf:
       amount: 8
-      root_part_id: >-
-        {{
-          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
-          ternary(4, 1)
-        }}
+      root_part_id: "{{ cifmw_root_partition_id }}"
+      uefi: "{{ cifmw_use_uefi }}"
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"

--- a/scenarios/reproducers/external-ceph.yml
+++ b/scenarios/reproducers/external-ceph.yml
@@ -28,11 +28,7 @@ cifmw_libvirt_manager_configuration:
         - osp_trunk
     compute:
       uefi: "{{ cifmw_use_uefi | default(false) }}"
-      root_part_id: >-
-        {{
-          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
-          ternary(4, 1)
-        }}
+      root_part_id: 4
       amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 3] | max }}"
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
@@ -46,11 +42,7 @@ cifmw_libvirt_manager_configuration:
         - osp_trunk
     ceph:
       uefi: "{{ cifmw_use_uefi | default(false) }}"
-      root_part_id: >-
-        {{
-          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
-          ternary(4, 1)
-        }}
+      root_part_id: 4
       amount: 3
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
@@ -64,11 +56,7 @@ cifmw_libvirt_manager_configuration:
         - osp_trunk
     controller:
       uefi: "{{ cifmw_use_uefi | default(false) }}"
-      root_part_id: >-
-        {{
-          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
-          ternary(4, 1)
-        }}
+      root_part_id: 4
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"

--- a/scenarios/reproducers/va-common.yml
+++ b/scenarios/reproducers/va-common.yml
@@ -36,16 +36,8 @@ cifmw_test_operator_tempest_include_list: |
   tempest.scenario.test_network_basic_ops.TestNetworkBasicOps
 
 # Set VM partitions and boot mode
-cifmw_use_uefi: >-
-  {{ (cifmw_repo_setup_os_release is defined
-      and cifmw_repo_setup_os_release == 'rhel') | bool }}
-cifmw_root_partition_id: >-
-  {{
-    (cifmw_repo_setup_os_release is defined and
-     cifmw_repo_setup_os_release == 'rhel') |
-    ternary(4, 1)
-  }}
-
+cifmw_use_uefi: true
+cifmw_root_partition_id: 4
 cifmw_libvirt_manager_compute_amount: 3
 cifmw_libvirt_manager_compute_disksize: 20
 cifmw_libvirt_manager_compute_memory: 4


### PR DESCRIPTION
Newer images are all exposing UEFI, meaning the root partition ID is the
fourth for both families.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
