### PR TITLE
Use the same OpenStackVersion CR name

### DIFF
--- a/scenarios/centos-9/edpm_ci.yml
+++ b/scenarios/centos-9/edpm_ci.yml
@@ -12,6 +12,10 @@ cifmw_edpm_prepare_skip_crc_storage_creation: true
 # edpm_deploy role vars
 cifmw_deploy_edpm: true
 
+# update containers vars
+cifmw_update_containers: true
+cifmw_update_containers_metadata: openstack-galera-network-isolation
+
 # openshift_setup role vars
 cifmw_openshift_setup_skip_internal_registry: true
 


### PR DESCRIPTION
When building containers if we don't use the same OpenStackVersion name as OpenStackControlPlane then multiple OpenStackVersion CRs can be created and subsequent dataplane deployment would fail.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
