### PR TITLE
Introduce new cifmw_nolog global parameter

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -64,6 +64,7 @@ are shared among multiple roles:
 - `cifmw_deploy_obs` (Bool) Specifies whether to deploy Cluster Observability operator.
 - `cifmw_openshift_api_ip_address` (String) contains the OpenShift API IP address. Note: it is computed internally and should not be user defined.
 - `cifmw_openshift_ingress_ip_address` (String) contains the OpenShift Ingress IP address. Note: it is computed internally and should not be user defined.
+- `cifmw_nolog`: (Bool) Toggle `no_log` value for selected tasks. Defaults to `true` (hiding those logs by default).
 
 ```{admonition} Words of caution
 :class: danger

--- a/roles/reproducer/tasks/ci_job.yml
+++ b/roles/reproducer/tasks/ci_job.yml
@@ -150,7 +150,7 @@
             - not is_molecule | default(false)
           tags:
             - bootstrap
-          no_log: true
+          no_log: "{{ cifmw_nolog | default(true) | bool }}"
           ansible.builtin.command:
             cmd: "{{ _home }}/01-pre-ci-play.sh"
 
@@ -159,13 +159,13 @@
             - (operator_content_provider | default(false) | bool) or
               (openstack_content_provider | default(false) | bool)
             - cifmw_reproducer_run_content_provider | bool
-          no_log: true
+          no_log: "{{ cifmw_nolog | default(true) | bool }}"
           ansible.builtin.command:
             cmd: "{{ _home }}/02-content-provider.sh"
 
         - name: Run job
           when:
             - cifmw_reproducer_run_job | bool
-          no_log: true
+          no_log: "{{ cifmw_nolog | default(true) | bool }}"
           ansible.builtin.command:
             cmd: "{{ _home }}/03-run-job.sh"

--- a/roles/reproducer/tasks/configure_architecture.yml
+++ b/roles/reproducer/tasks/configure_architecture.yml
@@ -29,7 +29,7 @@
     - name: Run deployment if instructed to
       when:
         - cifmw_deploy_architecture | default(false) | bool
-      no_log: true
+      no_log: "{{ cifmw_nolog | default(true) | bool }}"
       async: "{{ 7200 + cifmw_test_operator_timeout|default(3600) }}"  # 2h should be enough to deploy EDPM and rest for tests.
       poll: 20
       ansible.builtin.command:

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -208,7 +208,7 @@
         - name: Bootstrap environment on controller-0
           environment:
             ANSIBLE_LOG_PATH: "~/ansible-bootstrap.log"
-          no_log: true
+          no_log: "{{ cifmw_nolog | default(true) | bool }}"
           ansible.builtin.command:
             chdir: "/home/zuul/src/github.com/openstack-k8s-operators/ci-framework"
             cmd: >-
@@ -229,7 +229,7 @@
                   'devsetup'
                 ) | ansible.builtin.path_join
               }}
-          no_log: true
+          no_log: "{{ cifmw_nolog | default(true) | bool }}"
           ansible.builtin.command:
             chdir: "{{ _devsetup_path }}"
             cmd: >-

--- a/roles/run_hook/tasks/playbook.yml
+++ b/roles/run_hook/tasks/playbook.yml
@@ -78,7 +78,7 @@
 # is to call a command. Though we may lose some of the data passed to the
 # "main" play.
 - name: "Run {{ hook.name }}"
-  no_log: true
+  no_log: "{{ cifmw_nolog | default(true) | bool }}"
   cifmw.general.ci_script:
     output_dir: "{{ cifmw_basedir }}/artifacts"
     extra_args:


### PR DESCRIPTION
Allow to toggle the no_log value for selected tasks (mostly command,
shell and related modules).

Ceph related content are NOT following that parameter for security
reasons.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
