### PR TITLE
[networking_mapper] Make null templates behave like an empty one

### DIFF
--- a/plugins/module_utils/net_map/networking_definition.py
+++ b/plugins/module_utils/net_map/networking_definition.py
@@ -2056,7 +2056,7 @@ class InstanceDefinition:
         for network_name, network_data in child_nets.items():
             self.__parse_raw_net(
                 network_name,
-                network_data,
+                network_data or {},
                 network_definitions,
                 trunk_parents=set(trunk_parents.keys()),
             )


### PR DESCRIPTION
Now, if the data inside a template network is null the mapper will raise an unhandled exception, that may be fine, but for this particular case making null and empty behave the same way will allow the mapper to raise a meaningful error letting him know the field cannot be empty as some child elements are mandatory.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
