### PR TITLE
dnsmasq - Enable Router Advertisements if v6 range

### DIFF
--- a/roles/dnsmasq/templates/network.conf.j2
+++ b/roles/dnsmasq/templates/network.conf.j2
@@ -1,4 +1,7 @@
 # Managed by ci-framework/dnsmasq
+{% if cifmw_dnsmasq_network_definition['ranges'] | selectattr('start_v6', 'defined')               -%}
+enable-ra
+{% endif                                                                                            %}
 
 {% for range in cifmw_dnsmasq_network_definition['ranges']                                         -%}
 {%   if range.start_v4 is defined and range.start_v4 | length > 0                                  -%}


### PR DESCRIPTION
Add a check in a networks 'ranges' - if 'start_v6' is defined in any range add 'enable-ra' to the dnsmasq config.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
