### PR TITLE
Fix sushy_emulator integration in reproducer

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -25,9 +25,10 @@
     cifmw_sushy_emulator_sshkey_path: >-
       {{
         [_ctl_reproducer_basedir, '../.ssh/sushy_emulator-key'] |
-        path_join | realpath
+        path_join
       }}
     cifmw_podman_user_linger: "zuul"
+    cifmw_sushy_emulator_libvirt_user: "{{ hostvars[cifmw_sushy_emulator_hypervisor_target].ansible_user_id | default('zuul') }}"
   block:
     - name: Ensure directories exist
       ansible.builtin.file:


### PR DESCRIPTION
It's a followup of #1753.
We get rid of realpath filter which resolves the path using the controller's filesystem [1]. When the filesystems don't match between the controller and the remote machine, we might hit somme issues. For instance, when running controller on a Fedora CoreOS system, the `/home` gets resolved as `/var/home` by realpath, leading to incorrect path in remote machine.
Without `realpath`, we end up with the `..` in the path which is a bit uggly but we keep the consistency.

Also, we set the hypervisor ansible user used as the emulator libvirt user in order to have a more dynamic configuration, otherwise it fails by default if hypervisor ansible user is not `zuul` (i.e default user).

[1] https://docs.ansible.com/ansible/latest/collections/ansible/builtin/realpath_filter.html#synopsis

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
