### PR TITLE
Fix image pushing to local registry

### DIFF
--- a/ci/playbooks/edpm_build_images/edpm_build_images_content_provider.yaml
+++ b/ci/playbooks/edpm_build_images/edpm_build_images_content_provider.yaml
@@ -35,7 +35,7 @@
       containers.podman.podman_image:
         name: "{{ item }}"
         push_args:
-          dest: "{{ cifmw_rp_registry_ip | default('localhost') }}:5001"
+          dest: "{{ cifmw_rp_registry_ip | default('localhost') }}:5001/{{ item }}:{{ pr_sha }}"
         tag: "{{ pr_sha }}"
         push: true
       loop:


### PR DESCRIPTION
With new podman_image one must specify image in push_args in order to push it to local registry. It doesn't work currently because of podman trying to push it to
"docker.io/library/localhost" taking "localhost" as an image name.
Specify exact image name in push args when registry doens't have any org, only IP.

https://issues.redhat.com/browse/OSPCIX-319

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
