### PR TITLE
Add multinode-tempest job to ci-framework pipeline

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -60,6 +60,7 @@
         - podified-multinode-edpm-deployment-crc: *content_provider
         - cifmw-crc-podified-edpm-baremetal: *content_provider
         - podified-multinode-hci-deployment-crc: *content_provider
+        - cifmw-multinode-tempest: *content_provider
 
 - project-template:
     name: data-plane-adoption-ci-framework-pipeline


### PR DESCRIPTION
The multinode tempest job should run on changes to the test operator and to the scnarios files which
it uses.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
