### PR TITLE
Move update_containers related task under kustomize_and_deploy

### DIFF
--- a/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
+++ b/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
@@ -74,6 +74,15 @@
         ).metadata.name
       }}
 
+- name: Update BM CSV or Ansibleee CSV to update proper image
+  when: >-
+      (cifmw_update_containers_edpm_image_url is defined) or
+      (cifmw_update_containers_ansibleee_image_url is defined)
+  vars:
+    cifmw_update_containers_metadata: "{{ _ctlplane_name }}"
+  ansible.builtin.include_role:
+    name: update_containers
+
 - name: Wait for OpenStack controlplane to be deployed
   environment:
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"

--- a/roles/edpm_prepare/tasks/main.yml
+++ b/roles/edpm_prepare/tasks/main.yml
@@ -144,15 +144,6 @@
   tags:
     - control-plane
 
-- name: Update BM CSV or Ansibleee CSV to update proper image
-  when: >-
-      (cifmw_update_containers_edpm_image_url is defined) or
-      (cifmw_update_containers_ansibleee_image_url is defined)
-  vars:
-    cifmw_update_containers_metadata: "{{ _ctlplane_name }}"
-  ansible.builtin.include_role:
-    name: update_containers
-
 - name: Deploy NetConfig
   vars:
     make_netconfig_deploy_env: "{{ cifmw_edpm_prepare_common_env }}"


### PR DESCRIPTION
Currently update_containers related task is failing with ''_ctlplane_name'' is undefined error.

_ctlplane_name is set in kustomize_and_deploy.yml task file and way before that update_containers related task is called. that's why above error is coming.

Moving the update_containers related task in kustomize_and_deploy.yml fixes the issue.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running

