### PR TITLE
Change iscsid login timeout

### DIFF
--- a/roles/devscripts/templates/iscsi.j2
+++ b/roles/devscripts/templates/iscsi.j2
@@ -10,6 +10,17 @@ spec:
   config:
     ignition:
       version: 3.2.0
+    storage:
+      files:
+        - path: /etc/iscsi/iscsid.conf
+          overwrite: true
+          mode: 384
+          user:
+            name: root
+          group:
+            name: root
+          contents:
+            source: data:,node.session.initial_login_retry_max%20%3D%203%0Anode.conn%5B0%5D.timeo.login_timeout%20%3D%205%0A
     systemd:
       units:
         - enabled: true


### PR DESCRIPTION
This patch changes the time to fail an iSCSI login request in our deployments.

The default is 8 retries and 15 seconds for each one, so 120 seconds in total.

This default timeout is too large for our purposes, because it's greater than the default HAProxy or Apache timeouts.  This will create problems creating an image when Glance is using Cinder as a backend and one of the paths to the storage is down.

This patch changes the OpenShift cluster default to 3 retries and 5 seconds each (15 seconds in total), which is convenient for testing, as any healthy deployment and backend should be able to login to the backend in that amount of time, and if there is a broken path it will not take 2 minutes to give up, just around 15 seconds.

This PR together with setting the HAProxy timeouts to 60 seconds (https://github.com/openstack-k8s-operators/architecture/pull/275) shoud allow to use multipathing when glance is using cinder as a backend and there are failing paths.

The testing of the change was done using the equivalent LVM+iSCSI sample change in the cinder-operator (https://github.com/openstack-k8s-operators/cinder-operator/pull/397) deploying it with install_yamls.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes

Jira: https://issues.redhat.com/browse/OSPRH-7393
Jira: https://issues.redhat.com/browse/OSPRH-7415