### PR TITLE
Use DataPlaneService.DataSources

### DIFF
--- a/roles/hci_prepare/templates/dpservice-nova-custom-ceph.yml.j2
+++ b/roles/hci_prepare/templates/dpservice-nova-custom-ceph.yml.j2
@@ -6,12 +6,15 @@ metadata:
   name: nova-custom-ceph
 spec:
   label: dataplane-deployment-nova-custom-ceph
-  configMaps:
-    - ceph-nova
-    - nova-extra-config
-  secrets:
-    - nova-cell1-compute-config
-    - nova-migration-ssh-key
+  dataSources:
+    - configMapRef:
+        name: ceph-nova
+    - configMapRef:
+        name: nova-extra-config
+    - secretRef:
+        name: nova-cell1-compute-config
+    - secretRef:
+        name: nova-migration-ssh-key
   playbook: osp.edpm.nova
   tlsCert:
     contents:


### PR DESCRIPTION
Instead of using DataPlaneService.ConfigMaps or
DataPlaneService.Secrets, use the newly added
DataPlaneService.DataSources. See
https://github.com/openstack-k8s-operators/dataplane-operator/pull/909

Signed-off-by: James Slagle <jslagle@redhat.com>

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
