### PR TITLE
uni01alpha - update network-values values.j2 for ironic

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/uni01alpha/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni01alpha/network-values/values.yaml.j2
@@ -28,24 +28,22 @@ data:
   {{ network.network_name }}:
     dnsDomain: {{ network.search_domain }}
 {%  if network.tools is defined and network.tools.keys() | length > 0 %}
-    subnets:
 {%    for tool in network.tools.keys() %}
 {%      if tool is match('.*lb$') %}
 {%        set _ = ns.lb_tools.update({tool: []}) %}
 {%      endif %}
 {%    endfor %}
-      - allocationRanges:
-{%    for range in network.tools.netconfig.ipv4_ranges %}
-        - end: {{ range.end }}
-          start: {{ range.start }}
-{%    endfor %}
+{%    if network.tools.netconfig is defined  %}
+    subnets:
+      - name: subnet1
         cidr: {{ network.network_v4 }}
-{%      if network.gw_v4 is defined %}
-        gateway: {{ network.gw_v4 }}
-{%      endif %}
-        name: subnet1
-{%  if network.vlan_id is defined  %}
-        vlan: {{ network.vlan_id }}
+        gateway: {{ omit if network.gw_v4 is not defined else network.gw_v4 }}
+        vlan: {{ omit if network.vlan_id is not defined else network.vlan_id }}
+        allocationRanges:
+{%    for range in network.tools.netconfig.ipv4_ranges %}
+          - end: {{ range.end }}
+            start: {{ range.start }}
+{%    endfor %}
 {%  endif %}
 {%    if ns.lb_tools | length > 0 %}
     lb_addresses:
@@ -65,34 +63,65 @@ data:
     mtu: {{ network.mtu | default(1500) }}
 {%  if network.vlan_id is defined  %}
     vlan: {{ network.vlan_id }}
-{%    if ns.interfaces[network.network_name] is defined %}
-    iface: {{ network.network_name }}
-    base_iface: {{ ns.interfaces[network.network_name] }}
-{%    endif %}
-{%  else %}
-{%    if ns.interfaces[network.network_name] is defined %}
-    iface: {{ ns.interfaces[network.network_name] }}
-{%    endif %}
+    iface: {{ omit if ns.interfaces[network.network_name] is not defined else network.network_name }}
+    base_iface: {{ omit if ns.interfaces[network.network_name] is not defined else ns.interfaces[network.network_name] }}
+{%  elif network.network_name != "ironic" %}
+    iface: {{ omit if ns.interfaces[network.network_name] is not defined else ns.interfaces[network.network_name] }}
+{% else %}
+    iface: {{ omit if ns.interfaces[network.network_name] is not defined else network.network_name }}
 {%  endif %}
-{%  if network.tools.multus is defined %}
+{%  if network.tools.multus is defined and network.network_name == "ctlplane" %}
     net-attach-def: |
       {
         "cniVersion": "0.3.1",
         "name": "{{ network.network_name }}",
-{%  if network.network_name == "octavia" %}
-        "type": "bridge",
-{%  else %}
         "type": "macvlan",
-{%  endif %}
-{%  if network.network_name == "octavia" %}
-        "bridge": "octbr",
-{%  elif network.vlan_id is defined %}
-        "master": "{{ network.network_name }}",
-{%  elif network.network_name == "ctlplane" %}
         "master": "ospbr",
-{%  else %}
-        "master": "{{ ns.interfaces[network.network_name] }}",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "{{ network.network_v4 }}",
+          "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
+          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}"
+        }
+      }
 {%  endif %}
+{%  if network.tools.multus is defined and network.network_name == "octavia" %}
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "octavia",
+        "type": "bridge",
+        "bridge": "octbr",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "{{ network.network_v4 }}",
+          "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
+          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}"
+        }
+      }
+{%  endif %}
+{%  if network.tools.multus is defined and network.network_name == "ironic" %}
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "ironic",
+        "type": "bridge",
+        "bridge": "ironic",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "{{ network.network_v4 }}",
+          "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
+          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}"
+        }
+      }
+{%  endif %}
+{%  if network.tools.multus is defined and network.network_name not in ["ctlplane", "octavia", "ironic"] %}
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "{{ network.network_name }}",
+        "type": "macvlan",
+        "master": "{{ network.network_name if network.vlan_id is defined else ns.interfaces[network.network_name] }}",
         "ipam": {
           "type": "whereabouts",
           "range": "{{ network.network_v4 }}",
@@ -102,7 +131,6 @@ data:
       }
 {%  endif %}
 {% endfor %}
-
   dns-resolver:
     config:
       server:


### PR DESCRIPTION
In PR: https://github.com/openstack-k8s-operators/architecture/pull/211 the DT is updated to configure Ironic so that it can be used beyond running API tempest test cases.
    
It adds a network bridge "ironic", and this is attached to the ironic service pods, OVN. Also Nova is configured to run a compute pod with the ironic driver.

This PR updates the values.j2 for the `uni01alpha` job to work with PR#211.
We also need: https://gitlab.cee.redhat.com/ci-framework/ci-framework-jobs/-/merge_requests/282 

Not all networks are neccecarily connected to EDPM nodes. Allow generating network-values for networks without netconfig. For example:
```
    ironic:
      network: "172.20.254.0/24"
      tools:
        metallb:
          ranges:
            - start: 80 end: 90 mtu: 1500
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
