### PR TITLE
Rename OSDPS play to playbookContents

### DIFF
--- a/roles/validations/tasks/edpm/hugepages_and_reboot.yml
+++ b/roles/validations/tasks/edpm/hugepages_and_reboot.yml
@@ -60,7 +60,7 @@
         name: reboot-adhoc
         namespace: {{ cifmw_validations_namespace }}
       spec:
-        play: |
+        playbookContents: |
           - hosts: all
             become: true
             tasks:


### PR DESCRIPTION
This change is in-line with the change proposed to dataplane-operator to rectify our use of play vs playbook Ansible terminology: https://github.com/openstack-k8s-operators/dataplane-operator/pull/922

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
