### PR TITLE
[Test-operator] Expose extraRPMs parameter

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -37,6 +37,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_tempest_workflow`: (List) Definition of a Tempest workflow that consists of multiple steps. Each step can contain all values from Spec section of [Tempest CR](https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource).
 * `cifmw_test_operator_tempest_extra_images`: (List) A list of images that should be uploaded to OpenStack before the tests are executed. The value is passed to extraImages parameter in the [Tempest CR](https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource). Default value: `[]`
 * `cifmw_test_operator_tempest_network_attachments`: (List) List of network attachment definitions to attach to the tempest pods spawned by test-operator. Default value: `[]`.
+* `cifmw_test_operator_tempest_extra_rpms`: (List) . A list of URLs that point to RPMs that should be installed before the execution of tempest. Note that this parameter has no effect when `cifmw_test_operator_tempest_external_plugin` is used. Default value: `[]`
 * `cifmw_test_operator_tempest_config`: (Object) Definition of Tempest CRD instance that is passed to the test-operator (see [the test-operator documentation](https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource)). Default value:
 ```
   apiVersion: test.openstack.org/v1beta1
@@ -55,6 +56,8 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
         {{ cifmw_test_operator_tempest_exclude_list | default('') }}
       concurrency: "{{ cifmw_test_operator_concurrency }}"
       externalPlugin: "{{ cifmw_test_operator_tempest_external_plugin | default([]) }}"
+      extraRPMs: "{{ cifmw_test_operator_tempest_extra_rpms | default([]) }}"
+      extraImages: "{{ cifmw_test_operator_tempest_extra_images | default([]) }}"
     tempestconfRun: "{{ cifmw_tempest_tempestconf_config | default(omit) }}"
 ```
 

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -67,6 +67,7 @@ cifmw_test_operator_tempest_config:
         {{ cifmw_test_operator_tempest_exclude_list | default('') }}
       concurrency: "{{ cifmw_test_operator_concurrency }}"
       externalPlugin: "{{ cifmw_test_operator_tempest_external_plugin | default([]) }}"
+      extraRPMs: "{{ cifmw_test_operator_tempest_extra_rpms | default([]) }}"
       extraImages: "{{ cifmw_test_operator_tempest_extra_images | default([]) }}"
     tempestconfRun: "{{ cifmw_tempest_tempestconf_config | default(omit) }}"
     workflow: "{{ cifmw_test_operator_tempest_workflow }}"


### PR DESCRIPTION
This commit exposes the extraRPMs parameter that was introduced by this PR [1]. The parameter is exposed via
`cifmw_test_operator_tempest_extra_rpms`.

[1] https://github.com/openstack-k8s-operators/test-operator/pull/102

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
