### PR TITLE
Add steps to run minor version update

### DIFF
--- a/playbooks/update.yml
+++ b/playbooks/update.yml
@@ -11,11 +11,12 @@
       ansible.builtin.include_role:
         name: repo_setup
 
-    - name: Update all openstack services containers env vars in meta operator with tag from delorean
+    - name: Update all openstack services containers env vars in meta operator with tag from delorean and update OPENSTACK_RELEASE_VERSION
       vars:
         cifmw_set_openstack_containers_dlrn_md5_path: "{{ cifmw_basedir }}/artifacts/repositories/delorean.repo.md5"
         cifmw_set_openstack_containers_tag_from_md5: true
         cifmw_set_openstack_containers_extra_vars: "{{ cifmw_edpm_prepare_extra_vars }}"
+        cifmw_set_openstack_containers_openstack_version_change: true
       ansible.builtin.include_role:
         name: set_openstack_containers
 

--- a/roles/repo_setup/tasks/configure.yml
+++ b/roles/repo_setup/tasks/configure.yml
@@ -5,6 +5,7 @@
   when:
     - content_provider_dlrn_md5_hash is defined
     - content_provider_dlrn_md5_hash | length > 0
+    - (not cifmw_run_update|default(false)) or (update_playbook_run is defined and cifmw_run_update|default(false))
 
 - name: Run repo-setup
   become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"

--- a/roles/update/README.md
+++ b/roles/update/README.md
@@ -3,5 +3,6 @@ Role to run update
 
 ## Parameters
 * ``cifmw_update_extras`: (hash) Hold job variable that get set when running the update playbook.
-
-## Examples
+* ``cifmw_update_openstack_update_run_operators_updated`: (Boolean) Set if openstack_update_run make target should not modify openstack-operator csv to fake openstack services container change. Default to `True`.
+* ``cifmw_update_openstack_update_run_target_version`: (String) Define openstack target version to run update to.
+* `cifmw_update_run_dryrun`: (Boolean) Do a dry run on make openstack_update_run command. Defaults to `False`.

--- a/roles/update/defaults/main.yml
+++ b/roles/update/defaults/main.yml
@@ -17,3 +17,10 @@
 
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_update"
+
+cifmw_update_openstack_update_run_target_version: "0.0.2"
+cifmw_update_openstack_update_run_operators_updated: true
+cifmw_update_openstack_update_run_containers_namespace: "podified-antelope-centos9"
+cifmw_update_openstack_update_run_containers_target_tag: "current-podified"
+
+cifmw_update_run_dryrun: false

--- a/roles/update/molecule/default/converge.yml
+++ b/roles/update/molecule/default/converge.yml
@@ -17,5 +17,8 @@
 
 - name: Converge
   hosts: all
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_update_run_dryrun: true
   roles:
     - role: "update"

--- a/roles/update/molecule/default/molecule.yml
+++ b/roles/update/molecule/default/molecule.yml
@@ -7,5 +7,3 @@ log: true
 provisioner:
   name: ansible
   log: true
-  env:
-    ANSIBLE_STDOUT_CALLBACK: yaml

--- a/roles/update/molecule/default/prepare.yml
+++ b/roles/update/molecule/default/prepare.yml
@@ -17,5 +17,18 @@
 
 - name: Prepare
   hosts: all
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_install_yamls_tasks_out: "{{ ansible_user_dir }}/zuul-jobs/roles/install_yamls_makes/tasks"
+    cifmw_installyamls_repos: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
+    cifmw_install_yamls_defaults:
+      NAMESPACE: openstack
   roles:
     - role: test_deps
+    - role: ci_setup
+    - role: install_yamls
+  tasks:
+    - name: Set custom cifmw PATH reusable fact
+      ansible.builtin.set_fact:
+        cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+        cacheable: true

--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -14,6 +14,25 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Hello World
-  ansible.builtin.debug:
-    msg: "Hello World from update"
+- name: Set openstack_update_run Makefile environment variables
+  tags:
+    - always
+  ansible.builtin.set_fact:
+    _make_openstack_update_run_params: |
+      {% if not cifmw_update_openstack_update_run_operators_updated -%}
+      FAKE_UPDATE: true
+      CONTAINERS_NAMESPACE: {{ cifmw_update_openstack_update_run_containers_namespace }}
+      CONTAINERS_TARGET_TAG: {{ cifmw_update_openstack_update_run_containers_target_tag }}
+      OPENSTACK_VERSION: {{ cifmw_update_openstack_update_run_target_version }}
+      {% else -%}
+      OPENSTACK_VERSION: {{ cifmw_update_openstack_update_run_target_version }}
+      {% endif -%}
+
+- name: Run make openstack_update_run
+  vars:
+    make_openstack_update_run_env: "{{ cifmw_install_yamls_environment | combine({'PATH': cifmw_path }) }}"
+    make_openstack_update_run_params: "{{ _make_openstack_update_run_params | from_yaml }}"
+    make_openstack_update_run_dryrun: "{{ cifmw_update_run_dryrun | bool }}"
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_openstack_update_run'


### PR DESCRIPTION
Integrate set_openstack_container role and install_yaml openstack_update_run target to run openstack minor update.

This pr introduces following changes:
 - Adjust update playbook to use new vars from set_openstack_containers role
 - Run openstack minor update using openstack_update_run target from install_yaml
 - Add molecule testing to test update role in dryrun mode


As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
