### PR TITLE
Patch network operator for OCP 4.15

### DIFF
--- a/roles/openshift_setup/tasks/main.yml
+++ b/roles/openshift_setup/tasks/main.yml
@@ -167,5 +167,8 @@
             additionalTrustedCA:
               name: "registry-cas"
 
+- name: Patch network operator when using OVNKubernetes backend
+  ansible.builtin.import_tasks: patch_network_operator.yml
+
 - name: Fix openshift-marketplace pods
   ansible.builtin.import_tasks: fix_openshift_marketplace.yml

--- a/roles/openshift_setup/tasks/patch_network_operator.yml
+++ b/roles/openshift_setup/tasks/patch_network_operator.yml
@@ -1,0 +1,37 @@
+- name: Patch network operator when using OVNKubernetes backend
+  when:
+    - not cifmw_openshift_setup_dry_run
+  block:
+    - name: Gather network.operator info
+      register: _network
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit)}}"
+        context: "{{ cifmw_openshift_context | default(omit)}}"
+        api_version: "operator.openshift.io/v1"
+        kind: Network
+        name: cluster
+
+    - name: Patch network operator
+      vars:
+        _network_backend: >-
+          {{
+            _network.resources |
+            map(attribute="spec.defaultNetwork.type") |
+            first
+          }}
+      when:
+        - _network_backend == "OVNKubernetes"
+      kubernetes.core.k8s_json_patch:
+        api_version: "operator.openshift.io/v1"
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        kind: Network
+        name: cluster
+        persist_config: true
+        patch:
+          - path: "/spec/defaultNetwork/ovnKubernetesConfig/gatewayConfig/routingViaHost"
+            value: true
+            op: replace
+          - path: "/spec/defaultNetwork/ovnKubernetesConfig/gatewayConfig/ipForwarding"
+            value: "Global"
+            op: replace

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -243,41 +243,11 @@
             - (_cifmw_libvirt_manager_layout.vms.crc.amount is defined and
                (_cifmw_libvirt_manager_layout.vms.crc.amount | int ) > 0) or
               _cifmw_libvirt_manager_layout.vms.crc.amount is undefined
-          environment:
-            KUBECONFIG: "/home/zuul/.kube/config"
-            PATH: "{{ cifmw_path }}"
-          block:
-            - name: Gather network.operator info
-              register: _network
-              kubernetes.core.k8s_info:
-                api_version: "operator.openshift.io/v1"
-                kubeconfig: "~/.kube/config"
-                kind: Network
-                name: cluster
-
-            - name: Patch network operator
-              vars:
-                _network_backend: >-
-                  {{
-                    _network.resources |
-                    map(attribute="spec.defaultNetwork.type") |
-                    first
-                  }}
-              when:
-                - _network_backend == "OVNKubernetes"
-              kubernetes.core.k8s_json_patch:
-                api_version: "operator.openshift.io/v1"
-                kubeconfig: "~/.kube/config"
-                kind: Network
-                name: cluster
-                persist_config: true
-                patch:
-                  - path: "/spec/defaultNetwork/ovnKubernetesConfig/gatewayConfig/routingViaHost"
-                    value: true
-                    op: replace
-                  - path: "/spec/defaultNetwork/ovnKubernetesConfig/gatewayConfig/ipForwarding"
-                    value: "Global"
-                    op: replace
+          vars:
+            cifmw_openshift_kubeconfig: "/home/zuul/.kube/config"
+          ansible.builtin.include_role:
+            name: openshift_setup
+            tasks_from: patch_network_operator.yml
 
     - name: Emulate CI job
       when:


### PR DESCRIPTION
CRC 2.36 now uses 4.15 and defaults to ovnKubernetes network CNI. Without enabling both `routingViaHost: true` and `ipForwarding: Global` requests are not routed from secondary interfaces causing dns requests to the openstack dnsmasq pod to fail.

Proof < OCP 4.15 won't be affected by this change: CRC 2.36:
```
[zuul@controller ~]$ oc get network.operator cluster -o json | jq '.spec["defaultNetwork"].type'
"OVNKubernetes"
```

CRC: 2.30
```
[zuul@controller ~]$ oc get network.operator cluster -o json | jq '.spec["defaultNetwork"].type'
"OpenShiftSDN"
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
  
  Jira: https://issues.redhat.com/browse/OSPRH-7573
