### PR TITLE
Use tlse in adoption standalone no ceph job

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -129,6 +129,8 @@
     name: cifmw-data-plane-adoption-osp-17-to-extracted-crc-minimal-no-ceph
     parent: cifmw-data-plane-adoption-osp-17-to-extracted-crc
     vars:
+      enable_tls: "true"
+      cloud_domain: "ooo.test"
       use_ceph: "false"
       dpa_test_suite: "test-minimal"
 


### PR DESCRIPTION
Enable tlse for the standalone no ceph job which runs in cifmw,
install_yamls, openstack-operator and edpm-ansible, so we have
the exact same coverage as we do in check.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
