### PR TITLE
Don't run nfs.yml when architecture is defined

### DIFF
--- a/playbooks/nfs.yml
+++ b/playbooks/nfs.yml
@@ -21,6 +21,7 @@
     - name: End play early if no NFS is needed
       when:
         - not cifmw_edpm_deploy_nfs | default('false') | bool
+        - cifmw_architecture_scenario is defined
       ansible.builtin.meta: end_play
   vars:
     nftables_path: /etc/nftables


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
