### PR TITLE
Add support for uni07eta in ci_gen_kustomize_values

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/uni07eta/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni07eta/network-values/values.yaml.j2
@@ -1,0 +1,160 @@
+---
+# source: uni07eta/network-values/values.yaml.j2
+{% set ns = namespace(interfaces={},
+                      ocp_index=0,
+                      lb_tools={}) %}
+data:
+{% for host in cifmw_networking_env_definition.instances.keys() -%}
+{%   for network in cifmw_networking_env_definition.instances[host]['networks'].values() -%}
+{%     set ns.interfaces = ns.interfaces |
+                           combine({network.network_name: (network.parent_interface |
+                                                           default(network.interface_name)
+                                                          )
+                                   },
+                                   recursive=true) -%}
+{%   endfor -%}
+{%   if host is match('^(ocp|crc).*') %}
+  node_{{ ns.ocp_index }}:
+{%     set ns.ocp_index = ns.ocp_index+1 %}
+    name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}
+{%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
+    {{ network.network_name }}_ip: {{ network.ip_v4 }}
+{%     endfor %}
+{%   endif %}
+{% endfor %}
+
+{% for network in cifmw_networking_env_definition.networks.values() %}
+{% set ns.lb_tools = {} %}
+  {{ network.network_name }}:
+    dnsDomain: {{ network.search_domain }}
+{%  if network.tools is defined and network.tools.keys() | length > 0 %}
+{%    for tool in network.tools.keys() %}
+{%      if tool is match('.*lb$') %}
+{%        set _ = ns.lb_tools.update({tool: []}) %}
+{%      endif %}
+{%    endfor %}
+{%    if network.tools.netconfig is defined  %}
+    subnets:
+      - name: subnet1
+        cidr: {{ network.network_v4 }}
+        gateway: {{ omit if network.gw_v4 is not defined else network.gw_v4 }}
+        vlan: {{ omit if network.vlan_id is not defined else network.vlan_id }}
+        allocationRanges:
+{%    for range in network.tools.netconfig.ipv4_ranges %}
+          - end: {{ range.end }}
+            start: {{ range.start }}
+{%    endfor %}
+{%  endif %}
+{%    if ns.lb_tools | length > 0 %}
+    lb_addresses:
+{%      for tool in ns.lb_tools.keys() %}
+{%        for lb_range in network.tools[tool].ipv4_ranges %}
+      - {{ lb_range.start }}-{{ lb_range.end }}
+{%          set _ = ns.lb_tools[tool].append(lb_range.start) %}
+{%        endfor %}
+    endpoint_annotations:
+      {{ tool }}.universe.tf/address-pool: {{ network.network_name }}
+      {{ tool }}.universe.tf/allow-shared-ip: {{ network.network_name }}
+      {{ tool }}.universe.tf/loadBalancerIPs: {{ ','.join(ns.lb_tools[tool]) }}
+{%      endfor %}
+{%    endif %}
+{%  endif %}
+    prefix-length: {{ network.network_v4 | ansible.utils.ipaddr('prefix') }}
+    mtu: {{ network.mtu | default(1500) }}
+{%  if network.vlan_id is defined  %}
+    vlan: {{ network.vlan_id }}
+    iface: {{ omit if ns.interfaces[network.network_name] is not defined else network.network_name }}
+    base_iface: {{ omit if ns.interfaces[network.network_name] is not defined else ns.interfaces[network.network_name] }}
+{%  elif network.network_name != "ironic" %}
+    iface: {{ omit if ns.interfaces[network.network_name] is not defined else ns.interfaces[network.network_name] }}
+{% else %}
+    iface: {{ omit if ns.interfaces[network.network_name] is not defined else network.network_name }}
+{%  endif %}
+{%  if network.tools.multus is defined and network.network_name == "ctlplane" %}
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "{{ network.network_name }}",
+        "type": "macvlan",
+        "master": "ospbr",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "{{ network.network_v4 }}",
+          "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
+          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}"
+        }
+      }
+{%  endif %}
+{%  if network.tools.multus is defined and network.network_name == "octavia" %}
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "octavia",
+        "type": "bridge",
+        "bridge": "octbr",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "{{ network.network_v4 }}",
+          "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
+          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}"
+        }
+      }
+{%  endif %}
+{%  if network.tools.multus is defined and network.network_name == "ironic" %}
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "ironic",
+        "type": "bridge",
+        "bridge": "ironic",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "{{ network.network_v4 }}",
+          "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
+          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}"
+        }
+      }
+{%  endif %}
+{%  if network.tools.multus is defined and network.network_name not in ["ctlplane", "octavia", "ironic"] %}
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "{{ network.network_name }}",
+        "type": "macvlan",
+        "master": "{{ network.network_name if network.vlan_id is defined else ns.interfaces[network.network_name] }}",
+        "ipam": {
+          "type": "whereabouts",
+          "range": "{{ network.network_v4 }}",
+          "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
+          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}"
+        }
+      }
+{%  endif %}
+{% endfor %}
+  dns-resolver:
+    config:
+      server:
+        - "{{ cifmw_networking_env_definition.networks.ctlplane.gw_v4 }}"
+      search: []
+    options:
+      - key: server
+        values:
+          - {{ cifmw_networking_env_definition.networks.ctlplane.gw_v4 }}
+{% for nameserver in cifmw_ci_gen_kustomize_values_nameservers %}
+      - key: server
+        values:
+          - {{ nameserver }}
+{% endfor %}
+
+# Hardcoding the last IP bit since we don't have support for endpoint_annotations in the networking_mapper output
+  rabbitmq:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(85) }}
+  rabbitmq-cell1:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(86) }}
+
+  lbServiceType: LoadBalancer
+  storageClass: {{ cifmw_ci_gen_kustomize_values_storage_class }}


### PR DESCRIPTION
This change introduces the network-values for uni07eta in the ci_gen_kustomize_values role that helps in configuring the networker node.

This is basically a copy of current uni01alpha config.

Originally introduced by Pragadeeswaran with commit: 8303a9321dca4d1781d496bdeb0c8cfc70cdc147

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
