### PR TITLE
No group in inventory for `managed: false` vms.

### DIFF
--- a/roles/libvirt_manager/templates/all-inventory.yml.j2
+++ b/roles/libvirt_manager/templates/all-inventory.yml.j2
@@ -1,6 +1,6 @@
 all:
   children:
-{% for vm in _cifmw_libvirt_manager_layout.vms.keys() %}
+{% for vm in _cifmw_libvirt_manager_layout.vms.keys() if _cifmw_libvirt_manager_layout.vms[vm].manage | default(true) %}
     {{ (vm == 'crc') | ternary('ocp', vm) }}s:
       vars:
 {% if _cifmw_libvirt_manager_layout.vms[vm].target is defined %}


### PR DESCRIPTION
If the VM is created as `managed: false`, it is not added to the inventory. This change ensure no group is created in the inventory as well.

Fixes whitebox_neutron_tempest_plugin which rely on the inventory.

```
setUpClass (whitebox_neutron_tempest_plugin.tests.scenario.test_broadcast.BroadcastTestVlanTransparency)
--------------------------------------------------------------------------------------------------------

Captured traceback:
~~~~~~~~~~~~~~~~~~~
    Traceback (most recent call last):

      File "/usr/lib/python3.9/site-packages/tempest/test.py", line 191, in setUpClass
    raise value.with_traceback(trace)

      File "/usr/lib/python3.9/site-packages/tempest/test.py", line 184, in setUpClass
    cls.resource_setup()

      File "/usr/lib/python3.9/site-packages/whitebox_neutron_tempest_plugin/tests/scenario/test_broadcast.py", line 73, in resource_setup
    super(BaseBroadcastTest, cls).resource_setup()

      File "/usr/lib/python3.9/site-packages/whitebox_neutron_tempest_plugin/tests/scenario/base.py", line 988, in resource_setup
    cls.discover_nodes()

      File "/usr/lib/python3.9/site-packages/whitebox_neutron_tempest_plugin/tests/scenario/base.py", line 264, in discover_nodes
    cls.nodes = cls.get_podified_nodes_data()

      File "/usr/lib/python3.9/site-packages/whitebox_neutron_tempest_plugin/tests/scenario/base.py", line 244, in get_podified_nodes_data
    hosts_data.update(inventory_data[host_type]['hosts'])

    KeyError: 'ironics'
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
