### PR TITLE
Switch back public network to be not shared by default

### DIFF
--- a/roles/os_net_setup/defaults/main.yml
+++ b/roles/os_net_setup/defaults/main.yml
@@ -6,7 +6,7 @@ cifmw_os_net_setup_osp_calls_delay: 5
 cifmw_os_net_setup_config:
   - name: public
     external: true
-    shared: true
+    shared: false
     is_default: true
     provider_network_type: flat
     provider_physical_network: datacentre


### PR DESCRIPTION
Public network created by default by the ci-framework is visible for all tenants to e.g. create Floating IPs from it and that is typically enough for most of our tests.
It is also required to not have shared network in the deployment to run tests from the `tempest.api.compute.admin.test_auto_allocate_network` module.

Public network was changed to be shared by the commit [1] and it was done because some tests from the whitebox_neutron_tempest_plugin needs to plug directly into the public network and for that network needs to be visible for the project used during the test.
But this made tests for the auto_allocate_network to be skipped.

So lets by default create public network as not 'shared' to run auto_allocate_network tests in the u/c ci.
We may try to modify whitebox_neutron_tempest_plugin tests which require shared network to make them run in slightly different way.

Related: #[OSPRH-6541](https://issues.redhat.com//browse/OSPRH-6541)

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
