### PR TITLE
Hooks for bootstrapping ironic

### DIFF
--- a/hooks/playbooks/ironic_enroll_nodes.yml
+++ b/hooks/playbooks/ironic_enroll_nodes.yml
@@ -1,0 +1,65 @@
+---
+- name: Enroll nodes in ironic
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  vars:
+    _baremetal_info_path: "{{ cifmw_basedir }}/parameters/baremetal-info.yml"
+    _namespace: openstack
+    _ironic_node_name_prefix: ironic-
+    _ironic_network_interface: flat
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  tasks:
+    - name: Slurp baremetal-info YAML
+      register: _baremetal_info
+      ansible.builtin.slurp:
+        src: "{{ _baremetal_info_path }}"
+
+    - name: Load ironic nodes from baremetal-info
+      ansible.builtin.set_fact:
+        _ironic_node_info: >-
+          {{
+            (_baremetal_info.content | b64decode | from_yaml).cifmw_baremetal_hosts
+            | dict2items
+            | selectattr('key', 'match', _ironic_node_name_prefix )
+          }}
+
+    - name: Set ironic-nodes set_fact
+      vars:
+        _conn: "{{ item.value.connection | urlsplit }}"
+      ansible.builtin.set_fact:
+        ironic_nodes:
+          nodes: >-
+            {{
+              ironic_nodes.nodes | default([]) +
+                [
+                  {
+                    'name': item.key,
+                    'driver': 'redfish',
+                    'driver_info': {
+                      'redfish_address':
+                        (_conn.scheme | split('+') | last) + '://' + _conn.hostname + ':' + (_conn.port | string),
+                      'redfish_system_id': _conn.path,
+                      'redfish_username': item.value.username,
+                      'redfish_password': item.value.password,
+                    },
+                    'ports': [{'address': (item.value.nics | first).mac}],
+                    'network_interface': _ironic_network_interface,
+                  }
+                ]
+            }}
+      loop: "{{ _ironic_node_info }}"
+
+    - name: Dump ironic_nodes to file
+      ansible.builtin.copy:
+        dest: "{{ cifmw_basedir }}/parameters/ironic_nodes.yaml"
+        content: "{{ ironic_nodes | to_yaml }}"
+
+    - name: Enroll ironic nodes
+      ansible.builtin.shell: |
+        set -xe -o pipefail
+        oc project {{ _namespace }}
+        oc cp {{ cifmw_basedir }}/parameters/ironic_nodes.yaml {{ _namespace }}/openstackclient:/tmp/
+        oc rsh openstackclient \
+          openstack baremetal create /tmp/ironic_nodes.yaml

--- a/hooks/playbooks/ironic_flavor.yml
+++ b/hooks/playbooks/ironic_flavor.yml
@@ -1,0 +1,26 @@
+---
+- name: Create flavor for ironic baremetal nodes
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  vars:
+    _namespace: openstack
+    _flavor_name: baremetal
+    _boot_mode: uefi
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  tasks:
+    - name: Create baremetal flavor
+      ansible.builtin.shell: |
+        set -xe -o pipefail
+        oc project {{ _namespace }}
+        oc rsh openstackclient \
+          openstack flavor create {{ _flavor_name }} \
+            --ram 1024 \
+            --vcpus 1 \
+            --disk 15 \
+            --property resources:VCPU=0 \
+            --property resources:MEMORY_MB=0 \
+            --property resources:DISK_GB=0 \
+            --property resources:CUSTOM_BAREMETAL=1 \
+            --property capabilities:boot_mode="{{ _boot_mode }}"

--- a/hooks/playbooks/ironic_network.yml
+++ b/hooks/playbooks/ironic_network.yml
@@ -1,0 +1,31 @@
+---
+- name: Create network for ironic provisioning
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  vars:
+    _namespace: openstack
+    _subnet_range: '172.20.1.0/24'
+    _subnet_gateway: '172.20.1.1'
+    _subnet_alloc_pool_start: '172.20.1.100'
+    _subnet_alloc_pool_end: '172.20.1.200'
+    _provider_physical_network: ironic
+    _provider_network_type: flat
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  tasks:
+    - name: Create baremetal network
+      ansible.builtin.shell: |
+        set -xe -o pipefail
+        oc project {{ _namespace }}
+        oc rsh openstackclient \
+          openstack network create provisioning \
+            --share \
+            --provider-physical-network {{ _provider_physical_network }} \
+            --provider-network-type {{ _provider_network_type }}
+        oc rsh openstackclient \
+          openstack subnet create provisioning-subnet \
+            --network provisioning \
+            --subnet-range {{ _subnet_range }} \
+            --gateway {{ _subnet_gateway }} \
+            --allocation-pool start={{ _subnet_alloc_pool_start }},end={{ _subnet_alloc_pool_end }}


### PR DESCRIPTION
Adds three hook playbooks:
* `ironic_flavor.yml` - to create baremetal flavor
* `ironic_network.yml` - to create provisioning network and subnet
* `ironic_enroll_nodes.yml` - Uses baremetal-info.yml to create a nodes YAML and enrolls nodes in Ironic.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
