### PR TITLE
test_operator/tempest: auth.tempest_roles empty by default

### DIFF
--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -47,8 +47,18 @@ cifmw_test_operator_tempest_tests_exclude_override_scenario: false
 cifmw_test_operator_tempest_workflow: []
 
 # Enabling SRBAC by default, in jobs where this does not make sense should be turned off explicitly
+#
+# auth.tempest_roles is set to an empty value because otherwise
+# python-tempestconf sets its value as 'member' and this causes
+# failures to SRBAC reader tests, because it assigns both roles to the user.
+# Beyond that, the roles are defined and assigned in the tests themselves,
+# therefore this parameter isn't needed and should have an empty value
+# by default.
 cifmw_tempest_tempestconf_config_defaults:
   deployerInput: |
+    [auth]
+    tempest_roles =
+
     [enforce_scope]
     nova = true
     neutron = true


### PR DESCRIPTION
auth.tempest_roles is set to an empty value because otherwise python-tempestconf sets its value as 'member' and this causes failures to SRBAC reader tests, because it assigns both roles to the user.

Beyond that, the roles are defined and assigned in the tests themselves, therefore this parameter isn't needed and should have an empty value by default.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
