### PR TITLE
Introduce cifmw_external_dns role to configure RGW with TLS

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -78,6 +78,7 @@ configmaps
 configs
 containerfile
 controlplane
+coredns
 coreos
 cpus
 crashloopbackoff
@@ -129,6 +130,7 @@ dlrnrepo
 dm
 dnf
 dns
+dnsdata
 dnsmasq
 dockerfile
 dryrun
@@ -345,6 +347,7 @@ openshiftsdn
 openssh
 openssl
 openstack
+openstackclient
 openstackcontrolplane
 openstackdataplane
 openstackdataplanenodeset

--- a/roles/cifmw_cephadm/README.md
+++ b/roles/cifmw_cephadm/README.md
@@ -55,13 +55,18 @@ need to be changed for a typical EDPM deployment.
 * `cifmw_cephadm_keys`: see below
 
  `cifmw_cephadm_certs`: The path on the ceph host where TLS/SSL certificates
-   are located. It points to '/etc/pki/tls'
+   are located. It points to `/etc/pki/tls`.
 
 * `cifmw_cephadm_certificate`: The SSL/TLS certificate signed by CA which is
-   an optional parameter. If it is provided, ceph dashboard and rgw will be
+   an optional parameter. If it is provided, ceph dashboard and RGW will be
    configured for SSL automatically. Certificate should be made available in
    `cifmw_cephadm_certs` path only. To enable SSL for dashboard, both
-   `cifmw_cephadm_certificate` and `cifmw_cephadm_key` are needed.
+   `cifmw_cephadm_certificate` and `cifmw_cephadm_key` are needed. These
+   certificates can be generated automatically by setting
+   `cifmw_cephadm_certificate` and `cifmw_cephadm_key` to the desired
+   path, provided that the `cifmw_openshift_kubeconfig` is set
+   correctly so that Ansible can request that k8s create a certificate
+   using an existing root CA.
 
 * `cifmw_cephadm_key`: The SSL/TLS certificate key which is an
    optional parameter. If it is provided, ceph dashboard and rgw will be
@@ -93,6 +98,9 @@ need to be changed for a typical EDPM deployment.
 
 * `cifmw_cephadm_ns`: Name of the OpenStack controlplane namespace
    used in configuring swift objects.
+
+* `cifmw_cephadm_config_key_set_ssl_option`: Optional colon separated
+  list of SSL context options (default: `no_sslv2:sslv3:no_tlsv1:no_tlsv1_1`)
 
 Use the `cifmw_cephadm_pools` list of dictionaries to define pools for
 Nova (vms), Cinder (volumes), Cinder-backups (backups), and Glance (images).

--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -105,3 +105,4 @@ cifmw_cephadm_node_exporter_container_image: "{{ cifmw_cephadm_prometheus_contai
 cifmw_cephadm_prometheus_container_image: "{{ cifmw_cephadm_prometheus_container_ns }}/prometheus:v2.43.0"
 cifmw_cephadm_ns: openstack
 cifmw_cephadm_urischeme: "http"
+cifmw_cephadm_config_key_set_ssl_option: no_sslv2:sslv3:no_tlsv1:no_tlsv1_1

--- a/roles/cifmw_cephadm/tasks/configure_object.yml
+++ b/roles/cifmw_cephadm/tasks/configure_object.yml
@@ -83,8 +83,6 @@
   when:
     - cifmw_cephadm_certificate | length > 0
     - cifmw_cephadm_key | length > 0
-    - cert_stat_result.stat.exists | bool
-    - key_stat_result.stat.exists | bool
 
 - name: Configure object store to use rgw
   cifmw.general.ci_script:
@@ -94,8 +92,8 @@
     script: |-
       oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack role add --user {{ all_uuids.results.0.stdout }} --project {{ project_service_uuid.stdout }} {{ all_uuids.results.2.stdout }}
       oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack role add --user {{ all_uuids.results.0.stdout }} --project {{ project_service_uuid.stdout }} {{ all_uuids.results.3.stdout }}
-      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack endpoint create --region regionOne {{ all_uuids.results.1.stdout }} public {{ cifmw_cephadm_urischeme }}://{{ cifmw_cephadm_vip }}:8080/swift/v1/AUTH_%\(tenant_id\)s
-      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack endpoint create --region regionOne {{ all_uuids.results.1.stdout }} internal {{ cifmw_cephadm_urischeme }}://{{ cifmw_cephadm_vip }}:8080/swift/v1/AUTH_%\(tenant_id\)s
+      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack endpoint create --region regionOne {{ all_uuids.results.1.stdout }} public {{ cifmw_cephadm_urischeme }}://{{ cifmw_external_dns_vip_ext.values() | first if cifmw_external_dns_vip_ext is defined else cifmw_cephadm_vip }}:8080/swift/v1/AUTH_%\(tenant_id\)s
+      oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack endpoint create --region regionOne {{ all_uuids.results.1.stdout }} internal {{ cifmw_cephadm_urischeme }}://{{ cifmw_external_dns_vip_int.values() | first if cifmw_external_dns_vip_int is defined else cifmw_cephadm_vip }}:8080/swift/v1/AUTH_%\(tenant_id\)s
       oc -n {{ cifmw_cephadm_ns }} rsh openstackclient openstack role add --project {{ all_uuids.results.4.stdout }} --user {{ all_uuids.results.5.stdout }} {{ all_uuids.results.6.stdout }}
   delegate_to: localhost
   when:

--- a/roles/cifmw_cephadm/tasks/pre.yml
+++ b/roles/cifmw_cephadm/tasks/pre.yml
@@ -158,15 +158,3 @@
     mode: "0644"
     config_overrides: "{{ cifmw_cephadm_conf_overrides }}"
     config_type: ini
-
-- name: Stat cifmw_cephadm_certificate
-  ansible.builtin.stat:
-    path: "{{ cifmw_cephadm_certificate }}"
-  register: cert_stat_result
-  when: cifmw_cephadm_certificate | length > 0
-
-- name: Stat cifmw_cephadm_key
-  ansible.builtin.stat:
-    path: "{{ cifmw_cephadm_key }}"
-  register: key_stat_result
-  when: cifmw_cephadm_key | length > 0

--- a/roles/cifmw_cephadm/tasks/rgw.yml
+++ b/roles/cifmw_cephadm/tasks/rgw.yml
@@ -29,18 +29,47 @@
     _hosts: "{{ _hosts|default([]) + [ hostvars[item][ceph_hostname_var] ] }}"
   loop: "{{ groups[cifmw_ceph_target | default('computes')] | default([]) }}"
 
-- name: Get and save TLS certificate for rgw spec if provided
-  when: cifmw_cephadm_certificate | length > 0 and
-        cifmw_cephadm_key | length > 0
+- name: Create certificate and DNS for RGW if certificate paths are set
+  when:
+    - cifmw_cephadm_certificate | length > 0
+    - cifmw_cephadm_key | length > 0
   block:
+    - name: Define cifmw_external_dns_vip_ext
+      ansible.builtin.set_fact:
+        cifmw_external_dns_vip_ext: "{{ cifmw_external_dns_vip_ext | default({}) |
+          combine({ (cifmw_cephadm_vip): 'rgw-external.ceph.local' }) }}"
+
+    - name: Define cifmw_external_dns_vip_int
+      ansible.builtin.set_fact:
+        cifmw_external_dns_vip_int: "{{ cifmw_external_dns_vip_ext | default({}) |
+          combine({ (cifmw_cephadm_vip): 'rgw-internal.ceph.local' }) }}"
+
+    - name: Create DNS domain and certificate
+      ansible.builtin.include_role:
+        name: cifmw_external_dns
+      vars:
+        cifmw_external_dns_domain: ceph.local
+        cifmw_external_dns_labels:
+          component: ceph-storage
+          service: ceph
+        cifmw_external_dns_certificate: "{{ cifmw_cephadm_certificate }}"
+        cifmw_external_dns_key: "{{ cifmw_cephadm_key }}"
+        cifmw_external_dns_certificate_dir: "{{ cifmw_cephadm_certs }}"
+
     - name: Get the certificate content
       register: slurp_cert
       ansible.builtin.slurp:
         src: "{{ cifmw_cephadm_certificate }}"
 
-    - name: Set rgw_frontend_cert for rgw spec
+    - name: Get the key content
+      register: slurp_key
+      ansible.builtin.slurp:
+        src: "{{ cifmw_cephadm_key }}"
+
+    - name: Set rgw_frontend_cert to cert/key concatenation
       ansible.builtin.set_fact:
-        rgw_frontend_cert: "{{ slurp_cert['content'] | b64decode }}"
+        rgw_frontend_cert: "{{ slurp_cert['content'] | b64decode ~
+                               slurp_key['content'] | b64decode }}"
 
 - name: Create a Ceph RGW spec
   ansible.builtin.template:
@@ -61,6 +90,12 @@
   changed_when: false
   become: true
   loop: "{{ lookup('ansible.builtin.dict', cifmw_ceph_rgw_config) }}"
+
+- name: Apply ceph config-key set ssl_option
+  ansible.builtin.command: |
+    {{ cifmw_cephadm_ceph_cli }} config-key set ssl_option {{ cifmw_cephadm_config_key_set_ssl_option }}
+  changed_when: false
+  become: true
 
 - name: Apply spec
   ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} orch apply --in-file {{ cifmw_cephadm_container_spec }}"

--- a/roles/cifmw_cephadm/templates/ceph_rgw.yml.j2
+++ b/roles/cifmw_cephadm/templates/ceph_rgw.yml.j2
@@ -29,11 +29,11 @@ spec:
     backend_service: rgw.rgw
     frontend_port: 8080
     monitor_port: 8999
-    virtual_ip: {{ cifmw_cephadm_rgw_vip }}
     virtual_interface_networks:
     - {{ cifmw_cephadm_rgw_network }}
-  {% if rgw_frontend_cert is defined %}
+    virtual_ip: {{ cifmw_cephadm_vip }}
+{% if rgw_frontend_cert is defined %}
     ssl_cert: |
-      {{ rgw_frontend_cert | indent( width=4 ) }}
-  {% endif %}
+      {{ rgw_frontend_cert | indent( width=6 ) }}
+{% endif %}
 {% endif %}

--- a/roles/cifmw_external_dns/README.md
+++ b/roles/cifmw_external_dns/README.md
@@ -1,0 +1,274 @@
+# cifmw_external_dns
+
+If an openstack-k8s-operators pod needs to securely access
+an HTTPS endpoint which is hosted outside of k8s, then this
+role can create a DNS domain and certificate for that endpoint.
+
+The `cifmw_external_dns` role creates a `DNSData` domain like
+`myservice.local` so that pods can map hostnames to IPs for
+services which are not hosted on k8s. It then configures
+[DNS Forwarding](https://docs.openshift.com/container-platform/latest/networking/dns-operator.html#nw-dns-forward_dns-operator)
+for that domain with the CoreDNS service.
+
+It also creates a `Certificate`, with the OpenStack public root
+CA, with subject alternative names from the `DNSData` domain.
+Assuming the external endpoint is hosted on EDPM nodes, a copy
+of the certificate and key are placed in paths on the EDPM nodes.
+
+This role can be used to help configure Ceph RGW to mimic Swift
+object storage. A URL like `https://rgw-external.ceph.local:8080`
+can be a registered Keystone endpoint and OpenStack clients running
+on k8s can resolve the host and trust the certificate.
+
+## Privilege escalation
+
+Requires `{{ cifmw_openshift_kubeconfig }}` in order to create k8s CRs
+of kind `Certificate` which use the existing OpenStack root CA. The
+same credential is also required to create a a CR of kind `DNSData`
+and configure DNS Forwarding.
+
+Uses become when necessary to install certificates on EDPM nodes in
+`/etc/pki/tls`.
+
+## Parameters
+
+* `cifmw_external_dns_domain`: The DNS domain created by this
+  role. E.g. `example.com`. This parameter must be set or the role will
+  fail. (default: `""`)
+
+* `cifmw_external_dns_name`: Name of the k8s resource of kind
+  `DNSData`. E.g. `example-com-dns`. (default: `"{{
+  cifmw_external_dns_domain | regex_replace('\\.','-')}}-dns"`)
+
+* `cifmw_external_dns_labels`: Dictionary of labels for the
+  metadata section of the k8s manifest of kind `DNSData`
+  (default: `{}`)
+
+* `cifmw_external_dns_cert_name`: Name of the k8s resource of kind
+  `Certificate`. E.g. `example-com-cert`. (default: `"{{
+  cifmw_external_dns_domain | regex_replace('\\.','-')}}-cert"`)
+
+* `cifmw_external_dns_ns`:  The k8s namespace where the `Certificate`
+  and `DNSData` objects will be created (default: `openstack`)
+
+* `cifmw_external_dns_check_mode`: Create k8s manifests in the
+  `cifmw_external_dns_manifests_dir` directory but do not apply them.
+  (default: `false`)
+
+* `cifmw_external_dns_certificate_dir`: The directory where the
+  certificate will be copied to on the Ansible hosts (default:
+  `/etc/pki/tls/`). After this role runs, `/etc/pki/tls/` should
+  contain files like `example.com.crt` and `example.com.key` which
+  can then be used to configure an HTTPS service hosted on the
+  Ansible target host.
+
+* `cifmw_external_dns_certificate`: The absolute path of the
+  certificate (default `"{{ cifmw_external_dns_certificate_dir ~
+  cifmw_external_dns_domain }}.crt"`)
+
+* `cifmw_external_dns_key`: The absolute path of the private key of
+  the certificate (default `"{{ cifmw_external_dns_certificate_dir ~
+  cifmw_external_dns_domain }}.key"`)
+
+* `cifmw_external_dns_basedir`: Installation base directory. Defaults to
+  `cifmw_basedir` which defaults to `~/ci-framework-data`.
+
+* `cifmw_external_dns_manifests_dir`: Directory where OCP manifests for
+   for cifmw_external_dns role will be placed. Defaults to
+  `"{{ cifmw_manifests | default(cifmw_cls_basedir ~
+  '/artifacts/manifests') }}/cifmw_external_dns"`
+
+* `cifmw_external_dns_cert_issuer_ref`: dictionary passed to `issuerRef`
+  inside k8s manifest of kind `Certificate` for the certificate. (Default:
+  `{"group": "cert-manager.io", "kind": "Issuer", "name": rootca-public}`).
+  By using the existing public root CA for OpenStack (`rootca-public`)
+  OpenStack clients in pods will trust the HTTPS connection.
+
+* `cifmw_external_dns_cert_issuer_duration`: How long the certificate
+  will be valid (default: `43800h0m0s`)
+
+* `cifmw_external_dns_retries`: Ansible `retries` passed to tasks
+  which wait for `kubernetes.core.k8s_info` when applying manifests
+  (default `60`)
+
+* `cifmw_external_dns_delay`: Ansible `delay` passed to tasks
+  which wait for `kubernetes.core.k8s_info` when applying manifests
+  (default `10`)
+
+* `cifmw_external_dns_clean_cert`: When `tasks_from: cleanup.yml`
+  is used, the DNS files and k8s objects created by this role will
+  always be removed. However, the certificate DNS files and k8s
+  objects will only be removed if this boolean is `true` (default:
+  `true`)
+
+* `cifmw_external_dns_masq_cluster_ip`: The IP address of the
+  OpenShift DNS service in the `cifmw_external_dns_ns` namespace. If
+  empty, this value will be looked up through a call like `oc -n
+  openstack get svc dnsmasq-dns -o jsonpath='{.spec.clusterIP}'`
+  (default: `""`)
+
+* `cifmw_external_dns_vip_ext`: Dictionary mapping the IP address
+  (or VIP) of the service to a hostname for which a DNS entry will
+  be created. The IP address should point to a HTTPS service end
+  point which will be configured independently of this role.
+  Some OpenStack services have internal and external endpoints
+  and this variable is intended for external endpoints (so `_ext` is
+  in the name). The hostname will be added as a subject alternative
+  name of the certificate. (default: `{}`)
+
+* `cifmw_external_dns_vip_int`: Dictionary mapping the IP address
+  (or VIP) of the service to a hostname for which a DNS entry will
+  be created. The IP address should point to a HTTPS service end
+  point which will be configured independently of this role.
+  Some OpenStack services have internal and external endpoints and
+  this variable is intended for internal endpoints (so `_int` is in
+  the name). The hostname will be added as a subject alternative name
+  of the certificate. (default: `{}`)
+
+* `cifmw_external_dns_extra_subj_alt_names`: Dictionary mapping IP
+  addresses to hostnames. The IP addresses should point to HTTPS
+  service end points which will be configured independently of this
+  role. Each hostname should end with the `cifmw_external_dns_domain`
+  value. Each hostname will be added as a subject alternative name of
+  the certificate. (default: `{}`)
+
+One of `cifmw_external_dns_vip_ext`, `cifmw_external_dns_vip_int` or
+`cifmw_external_dns_extra_subj_alt_names` must be non-empty or the
+role will fail. I.e. if there is no DNS mapping defined, then it is
+pointless to create a DNS zone.
+
+## Examples
+
+The following playbook calls the `cifmw_external_dns`. Note that it
+has the `cifmw_openshift_kubeconfig` variable which is required in
+order to apply k8s manifests against an existing k8s cluster.
+
+```yaml
+- name: Playbook to test cifmw_external_dns role
+  gather_facts: false
+  hosts: computes[0]
+  vars:
+    cifmw_openshift_kubeconfig: "~/.kube/config"
+    cifmw_external_dns_domain: example.com
+    cifmw_external_dns_vip_ext:
+      192.168.122.2: "external-endpoint-vip.{{ cifmw_external_dns_domain }}"
+    cifmw_external_dns_vip_int:
+      192.168.122.3: "internal-endpoint-vip.{{ cifmw_external_dns_domain }}"
+    cifmw_external_dns_extra_subj_alt_names:
+      192.168.122.100: "host0.{{ cifmw_external_dns_domain }}"
+      192.168.122.101: "host1.{{ cifmw_external_dns_domain }}"
+      192.168.122.102: "host2.{{ cifmw_external_dns_domain }}"
+  tasks:
+    - name: Create DNS domain and certificate
+      ansible.builtin.include_role:
+        name: cifmw_external_dns
+```
+
+After the above playbook runs the following changes should be
+observable.
+
+- `example.com.crt` and `example.com.key` will be on the first node
+  the ansible hosts group called `computes` in the directory
+  `/etc/pki/tls/`.
+
+- On the system where the playbook was run the directory
+  `~/ci-framework-data/artifacts/manifests/cifmw_external_dns/`
+  should contain manifests of kind `Certificate` and `DNSData`.
+
+- `oc get cert example-com-cert` should show that a certificate was created
+
+- `oc get dnsdata example-com-dns` should show that a DNS zone was created
+
+- A [DNS Forward](https://docs.openshift.com/container-platform/latest/networking/dns-operator.html#nw-dns-forward_dns-operator)
+  will have been created for the `example.com` zone.
+  ```
+  $ oc get -n openshift-dns dns.operator/default -o yaml | grep example -B 5
+  servers:
+  - forwardPlugin:
+      policy: Random
+      upstreams:
+      - 172.30.248.195:53
+    name: example-com-dns
+    zones:
+    - example.com
+  $
+  ```
+
+- Within the `openstackclient` pod it should be possible to resolve
+  `external-endpoint-vip.example.com` and `internal-endpoint-vip.example.com`
+  to their respective IPs (`192.168.122.2` and `192.168.122.3`)
+
+- After the HTTPS service hosted on the IP of
+  `external-endpoint-vip.example.com` has been configured with the
+  certificates in `cifmw_external_dns_certificate` and the key in
+  `cifmw_external_dns_key`, the `openstackclient` pod should be
+  able to `curl https://external-endpoint-vip.example.com` and not
+  get an `SSLCertVerificationError` (the same should be the case
+  for `internal-endpoint-vip.example.com` provided the
+  `openstackclient` can reach the network).
+
+## Testing
+
+The `test_dns.yml` tasks file within the role may be used to test the
+role.
+
+The role needs to be run on k8s cluster which has an openstackclient
+pod (which can be set up by ci-framework) and an endpoint must exist
+at an IP address that the pod can ping.
+
+The following playbook can be used to confirm that the openstackclient
+pod can use the DNS configured by the `cifmw_external_dns` role to
+ping a host by DNS name.
+
+```yaml
+- name: Playbook to clean up after the cifmw_external_dns role
+  gather_facts: false
+  hosts: computes[0]
+  vars:
+    cifmw_openshift_kubeconfig: "~/.kube/config"
+    cifmw_external_dns_domain: example.com
+    cifmw_external_dns_vip_ext:
+      192.168.122.2: "external-endpoint-vip.{{ cifmw_external_dns_domain }}"
+  tasks:
+    - name: Test DNS Domain
+      ansible.builtin.include_role:
+        name: cifmw_external_dns
+        tasks_from: test_dns.yml
+```
+In the correct environment the above playbook should have output like this:
+```
+TASK [cifmw_external_dns : Try to ping hostnames from inside openstackclient pod namespace={{ cifmw_external_dns_ns }}, kubeconfig={{ cifmw_openshift_kubeconfig }}, api_key={{ cifmw_openshift_token | default(omit) }}, context={{ cifmw_openshift_context | default(omit) }}, pod=openstackclient, command=ping -c 1 {{ item.value }}] ***
+Saturday 29 June 2024  12:54:50 -0400 (0:00:00.041)       0:00:00.251 *********
+changed: [compute-0 -> localhost] => (item=rgw-external.ceph.local)
+
+TASK [cifmw_external_dns : Show results of ping tests msg={{ item.stdout | regex_search('(\d+ packets transmitted, \d+ received, \d+% packet loss, time \d+ms)') }}] ***
+Saturday 29 June 2024  12:54:57 -0400 (0:00:06.931)       0:00:07.183 *********
+ok: [compute-0] => (item=ping -c 1 rgw-external.ceph.local) =>
+  msg: 1 packets transmitted, 1 received, 0% packet loss, time 0ms
+```
+
+## Cleaning
+
+The `cleanup.yml` tasks file within the role may be used to undo the
+changes made by the role.
+
+The following playbook may be used to delete the certificate file and
+its private key file from the target hosts. It will also remove the
+certificate from k8s. The DNSData object and forward will also be
+removed.
+
+```yaml
+- name: Playbook to clean up after the cifmw_external_dns role
+  gather_facts: false
+  hosts: computes[0]
+  vars:
+    cifmw_openshift_kubeconfig: "~/.kube/config"
+    cifmw_external_dns_domain: example.com
+    cifmw_external_dns_vip_ext:
+      192.168.122.2: "external-endpoint-vip.{{ cifmw_external_dns_domain }}"
+  tasks:
+    - name: Delete certificate, DNS domain and DNS forward
+      ansible.builtin.include_role:
+        name: cifmw_external_dns
+        tasks_from: cleanup.yml
+```

--- a/roles/cifmw_external_dns/defaults/main.yml
+++ b/roles/cifmw_external_dns/defaults/main.yml
@@ -1,0 +1,40 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+cifmw_external_dns_domain: ""
+cifmw_external_dns_name: "{{ cifmw_external_dns_domain | regex_replace('\\.','-')}}-dns"
+cifmw_external_dns_labels: {}
+cifmw_external_dns_cert_name: "{{ cifmw_external_dns_domain | regex_replace('\\.','-')}}-cert"
+cifmw_external_dns_ns: openstack
+cifmw_external_dns_check_mode: false
+cifmw_external_dns_certificate_dir: /etc/pki/tls/
+cifmw_external_dns_certificate: "{{ cifmw_external_dns_certificate_dir ~ cifmw_external_dns_domain }}.crt"
+cifmw_external_dns_key: "{{ cifmw_external_dns_certificate_dir ~ cifmw_external_dns_domain }}.key"
+cifmw_external_dns_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+cifmw_external_dns_manifests_dir: "{{ cifmw_manifests | default(cifmw_external_dns_basedir ~ '/artifacts/manifests') }}/cifmw_external_dns"
+# Important: use the same rootca-public as openstack
+cifmw_external_dns_cert_issuer_ref:
+  group: cert-manager.io
+  kind: Issuer
+  name: rootca-public
+cifmw_external_dns_cert_issuer_duration: 43800h0m0s
+cifmw_external_dns_retries: 60
+cifmw_external_dns_delay: 10
+cifmw_external_dns_clean_cert: true
+cifmw_external_dns_masq_cluster_ip: ""
+cifmw_external_dns_vip_ext: {}
+cifmw_external_dns_vip_int: {}
+cifmw_external_dns_extra_subj_alt_names: {}

--- a/roles/cifmw_external_dns/meta/main.yml
+++ b/roles/cifmw_external_dns/meta/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- cifmw_external_dns
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: cifmw
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - cifmw
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/cifmw_external_dns/tasks/cert.yml
+++ b/roles/cifmw_external_dns/tasks/cert.yml
@@ -1,0 +1,86 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Put the certificate manifest file in place
+  delegate_to: localhost
+  run_once: true
+  ansible.builtin.template:
+    src: "templates/cert.yml.j2"
+    dest: "{{ cifmw_external_dns_manifests_dir }}/{{ cifmw_external_dns_cert_name }}.yml"
+    mode: "0644"
+    force: true
+
+- name: Create certificate
+  when: not (cifmw_external_dns_check_mode | default (false) | bool)
+  block:
+    - name: Apply k8s manifest file of kind Certficate
+      delegate_to: localhost
+      run_once: true
+      kubernetes.core.k8s:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit) }}"
+        context: "{{ cifmw_openshift_context | default(omit) }}"
+        src: "{{ cifmw_external_dns_manifests_dir }}/{{ cifmw_external_dns_cert_name }}.yml"
+        state: present
+      retries: "{{ cifmw_external_dns_retries }}"
+      delay: "{{ cifmw_external_dns_delay }}"
+      register: result
+      until: result.failed == false
+
+    - name: Ask k8s for the new Certficate Secret
+      delegate_to: localhost
+      run_once: true
+      no_log: true
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit) }}"
+        context: "{{ cifmw_openshift_context | default(omit) }}"
+        kind: Secret
+        namespace: "{{ cifmw_external_dns_ns }}"
+        name: "{{ cifmw_external_dns_cert_name }}"
+      register: cert_info
+      retries: "{{ cifmw_external_dns_retries }}"
+      delay: "{{ cifmw_external_dns_delay }}"
+      until: cert_info.failed == false
+
+    - name: Ensure key and certificate directories exist on target host
+      become: true
+      ansible.builtin.file:
+        path: "{{ item | dirname }}"
+        state: directory
+        mode: '0755'
+        seuser: system_u
+        setype: cert_t
+        selevel: s0
+      loop:
+        - "{{ cifmw_external_dns_certificate }}"
+        - "{{ cifmw_external_dns_key }}"
+
+    - name: Populate key and certificate file on target host
+      no_log: true
+      become: true
+      ansible.builtin.copy:
+        dest: "{{ item.path }}"
+        mode: '0644'
+        seuser: unconfined_u
+        setype: cert_t
+        selevel: s0
+        content: "{{ item.content }}"
+      loop:
+        - { path: "{{ cifmw_external_dns_certificate }}",
+            content: "{{ cert_info.resources[0].data['tls.crt'] | b64decode }}" }
+        - { path: "{{ cifmw_external_dns_key }}",
+            content: "{{ cert_info.resources[0].data['tls.key'] | b64decode  }}" }

--- a/roles/cifmw_external_dns/tasks/cleanup.yml
+++ b/roles/cifmw_external_dns/tasks/cleanup.yml
@@ -1,0 +1,73 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Remove key and certificate files on target host
+  no_log: true
+  become: true
+  ansible.builtin.file:
+    state: absent
+    dest: "{{ item }}"
+  loop:
+    - "{{ cifmw_external_dns_certificate }}"
+    - "{{ cifmw_external_dns_key }}"
+  when:
+    - cifmw_external_dns_clean_cert | bool
+
+- name: Get DNS Forward server_index matching cifmw_external_dns_name
+  ansible.builtin.include_tasks: get_dns_forward_index.yml
+
+- name: Remove DNS forwarding by patching dns.operator/default in openshift-dns
+  delegate_to: localhost
+  run_once: true
+  when: (server_index | int) > -1
+  kubernetes.core.k8s_json_patch:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    api_version: operator.openshift.io/v1
+    namespace: openshift-dns
+    kind: DNS
+    name: default
+    patch:
+      - op: remove
+        path: "/spec/servers/{{ server_index }}"
+  retries: "{{ cifmw_external_dns_retries }}"
+  delay: "{{ cifmw_external_dns_delay }}"
+  register: result
+  until: result.failed == false
+
+- name: Ensure manifest files are absent
+  delegate_to: localhost
+  run_once: true
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    src: "{{ cifmw_external_dns_manifests_dir }}/{{ item }}.yml"
+    state: absent
+    wait: true
+  failed_when: false
+  when: item | length > 0
+  loop:
+    - "{{ cifmw_external_dns_name }}"
+    - "{{ cifmw_external_dns_cert_name if cifmw_external_dns_clean_cert }}"
+
+- name: Remove role needed directories
+  delegate_to: localhost
+  run_once: true
+  ansible.builtin.file:
+    path: "{{ cifmw_external_dns_manifests_dir }}"
+    state: absent

--- a/roles/cifmw_external_dns/tasks/dns.yml
+++ b/roles/cifmw_external_dns/tasks/dns.yml
@@ -1,0 +1,73 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Put the DNSdata manifest file in place
+  delegate_to: localhost
+  run_once: true
+  ansible.builtin.template:
+    src: "templates/dns.yml.j2"
+    dest: "{{ cifmw_external_dns_manifests_dir }}/{{ cifmw_external_dns_name }}.yml"
+    mode: "0644"
+    force: true
+
+- name: Create DNS Entries
+  when: not (cifmw_external_dns_check_mode | default (false) | bool)
+  block:
+    - name: Apply k8s manifest file of kind DNSdata
+      delegate_to: localhost
+      run_once: true
+      kubernetes.core.k8s:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit) }}"
+        context: "{{ cifmw_openshift_context | default(omit) }}"
+        src: "{{ cifmw_external_dns_manifests_dir }}/{{ cifmw_external_dns_name }}.yml"
+        state: present
+      retries: "{{ cifmw_external_dns_retries }}"
+      delay: "{{ cifmw_external_dns_delay }}"
+      register: result
+      until: result.failed == false
+
+    - name: Get DNS Forward server_index matching cifmw_external_dns_name (if any)
+      ansible.builtin.include_tasks: get_dns_forward_index.yml
+
+    - name: Configure DNS forwarding by patching dns.operator/default in openshift-dns
+      delegate_to: localhost
+      run_once: true
+      # only create a forward if it is not found (no index)
+      when: (server_index | int) == -1
+      kubernetes.core.k8s_json_patch:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit) }}"
+        context: "{{ cifmw_openshift_context | default(omit) }}"
+        api_version: operator.openshift.io/v1
+        namespace: openshift-dns
+        kind: DNS
+        name: default
+        patch:
+          - op: add
+            path: /spec/servers/-
+            value:
+              forwardPlugin:
+                policy: Random
+                upstreams:
+                  - "{{ cifmw_external_dns_masq_cluster_ip }}:53"
+              name: "{{ cifmw_external_dns_name }}"
+              zones:
+                - "{{ cifmw_external_dns_domain }}"
+      retries: "{{ cifmw_external_dns_retries }}"
+      delay: "{{ cifmw_external_dns_delay }}"
+      register: result
+      until: result.failed == false

--- a/roles/cifmw_external_dns/tasks/get_dns_forward_index.yml
+++ b/roles/cifmw_external_dns/tasks/get_dns_forward_index.yml
@@ -1,0 +1,83 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Get current DNS configuration
+  delegate_to: localhost
+  run_once: true
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    api_version: operator.openshift.io/v1
+    namespace: openshift-dns
+    kind: DNS
+    name: default
+  register: dns_config
+  retries: "{{ cifmw_external_dns_retries }}"
+  delay: "{{ cifmw_external_dns_delay }}"
+  until: dns_config.failed == false
+
+- name: If servers list exists then find index of cifmw_external_dns_name
+  when:
+    - dns_config.resources | length > 0
+    - dns_config.resources[0].spec is defined
+    - dns_config.resources[0].spec.servers is defined
+  block:
+    - name: Find index of the server matching the cifmw_external_dns_name
+      run_once: true
+      ansible.builtin.set_fact:
+        server_index: "{{ item.0 }}"
+      when: item.1.name == cifmw_external_dns_name
+      with_indexed_items: "{{ dns_config.resources[0].spec.servers | default([]) }}"
+      register: server_indices
+
+    - name: Set server index
+      run_once: true
+      when: server_indices is defined
+      ansible.builtin.set_fact:
+        server_index: "{{ server_indices.results | selectattr('ansible_facts.server_index', 'defined') | map(attribute='ansible_facts.server_index') | first | default(-1) }}"
+
+- name: If servers list does not exist then create it as an empty list
+  when:
+    - dns_config.resources | length > 0
+    - dns_config.resources[0].spec is defined
+    - dns_config.resources[0].spec.servers is not defined
+  block:
+    # empty servers list is harmless but needed to add to path '/spec/servers/-' later
+    - name: Patch dns.operator/default openshift-dns to add empty servers list
+      delegate_to: localhost
+      run_once: true
+      kubernetes.core.k8s_json_patch:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit) }}"
+        context: "{{ cifmw_openshift_context | default(omit) }}"
+        api_version: operator.openshift.io/v1
+        namespace: openshift-dns
+        kind: DNS
+        name: default
+        patch:
+          - op: add
+            path: /spec/servers
+            value: []
+      retries: "{{ cifmw_external_dns_retries }}"
+      delay: "{{ cifmw_external_dns_delay }}"
+      register: result
+      until: result.failed == false
+
+    - name: Set server index to -1
+      run_once: true
+      ansible.builtin.set_fact:
+        server_index: -1

--- a/roles/cifmw_external_dns/tasks/main.yml
+++ b/roles/cifmw_external_dns/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure requirements are satisfied before beginning
+  ansible.builtin.include_tasks: requirements.yml
+
+- name: Ensure DNS entry is created
+  ansible.builtin.include_tasks: dns.yml
+
+- name: Create certificate if paths do not exist on target host
+  # cert_stat_result and key_stat_result are created by requirements.yml
+  when: (not cert_stat_result.stat.exists | bool) or
+        (not key_stat_result.stat.exists | bool)
+  ansible.builtin.include_tasks: cert.yml

--- a/roles/cifmw_external_dns/tasks/requirements.yml
+++ b/roles/cifmw_external_dns/tasks/requirements.yml
@@ -1,0 +1,93 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure we have cifmw_openshift_kubeconfig
+  delegate_to: localhost
+  run_once: true
+  ansible.builtin.stat:
+    path: "{{ cifmw_openshift_kubeconfig }}"
+  register: cifmw_openshift_kubeconfig_stat_result
+
+- name: Fail if kube config file is missing
+  delegate_to: localhost
+  run_once: true
+  ansible.builtin.fail:
+    msg: >-
+      Missing kube config file ({{ cifmw_openshift_kubeconfig }})
+      Canot create DNS or certificate without access to k8s
+  when:
+    - not cifmw_openshift_kubeconfig_stat_result.stat.exists | bool
+
+- name: Assert that cifmw_external_dns_domain is non-empty
+  run_once: true
+  ansible.builtin.assert:
+    that:
+      cifmw_external_dns_domain | length > 0
+
+- name: Ensure at least one IP to name mapping is set
+  run_once: true
+  ansible.builtin.assert:
+    that:
+      - item.key | length > 0
+      - item.key | ansible.utils.ipaddr
+      - item.value | length > 0
+  loop: "{{ ip_to_name | dict2items }}"
+  vars:
+    ip_to_name: "{{ cifmw_external_dns_vip_int |
+                    combine(cifmw_external_dns_vip_ext) |
+                    combine(cifmw_external_dns_extra_subj_alt_names) }}"
+
+- name: Create role manifest directory
+  delegate_to: localhost
+  run_once: true
+  ansible.builtin.file:
+    path: "{{ cifmw_external_dns_manifests_dir }}"
+    state: directory
+
+- name: Stat cifmw_external_dns_certificate on target hosts
+  ansible.builtin.stat:
+    path: "{{ cifmw_external_dns_certificate }}"
+  register: cert_stat_result
+  when: cifmw_external_dns_certificate | length > 0
+
+- name: Stat cifmw_external_dns_key on target hosts
+  ansible.builtin.stat:
+    path: "{{ cifmw_external_dns_key }}"
+  register: key_stat_result
+  when: cifmw_external_dns_key | length > 0
+
+- name: Ensure cifmw_external_dns_masq_cluster_ip is set
+  when: cifmw_external_dns_masq_cluster_ip | length == 0
+  block:
+    - name: Get service info for dnsmasq-dns
+      delegate_to: localhost
+      run_once: true
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit) }}"
+        context: "{{ cifmw_openshift_context | default(omit) }}"
+        kind: Service
+        namespace: "{{ cifmw_external_dns_ns }}"
+        name: dnsmasq-dns
+      register: service_info
+      retries: "{{ cifmw_external_dns_retries }}"
+      delay: "{{ cifmw_external_dns_delay }}"
+      until: service_info.failed == false
+
+    - name: Set cifmw_external_dns_masq_cluster_ip
+      run_once: true
+      ansible.builtin.set_fact:
+        cifmw_external_dns_masq_cluster_ip: "{{ service_info.resources[0].spec.clusterIP }}"

--- a/roles/cifmw_external_dns/tasks/test_dns.yml
+++ b/roles/cifmw_external_dns/tasks/test_dns.yml
@@ -1,0 +1,42 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Try to ping hostnames from inside openstackclient pod
+  delegate_to: localhost
+  run_once: true
+  kubernetes.core.k8s_exec:
+    namespace: "{{ cifmw_external_dns_ns }}"
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    pod: openstackclient
+    command: "ping -c 1 {{ item.value }}"
+  register: ping_result
+  loop: "{{ ip_to_name | dict2items }}"
+  loop_control:
+    label: "{{ item.value }}"
+  vars:
+    ip_to_name: "{{ cifmw_external_dns_vip_int |
+                    combine(cifmw_external_dns_vip_ext) |
+                    combine(cifmw_external_dns_extra_subj_alt_names) }}"
+
+- name: Show results of ping tests
+  run_once: true
+  ansible.builtin.debug:
+    msg: "{{ item.stdout | regex_search('(\\d+ packets transmitted, \\d+ received, \\d+% packet loss, time \\d+ms)') }}"
+  loop: "{{ ping_result.results }}"
+  loop_control:
+    label: "{{ item.invocation.module_args.command }}"

--- a/roles/cifmw_external_dns/templates/cert.yml.j2
+++ b/roles/cifmw_external_dns/templates/cert.yml.j2
@@ -1,0 +1,19 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ cifmw_external_dns_cert_name }}
+  namespace: {{ cifmw_external_dns_ns }}
+spec:
+  duration: {{ cifmw_external_dns_cert_issuer_duration }}
+  issuerRef: {{ cifmw_external_dns_cert_issuer_ref }}
+  secretName: {{ cifmw_external_dns_cert_name }}
+  dnsNames:
+{% set dicts_list = [cifmw_external_dns_vip_int,
+                     cifmw_external_dns_vip_ext,
+                     cifmw_external_dns_extra_subj_alt_names] %}
+{% for d in dicts_list %}
+{% for host in d.values() %}
+  - {{ host }}
+{% endfor %}
+{% endfor %}

--- a/roles/cifmw_external_dns/templates/dns.yml.j2
+++ b/roles/cifmw_external_dns/templates/dns.yml.j2
@@ -1,0 +1,20 @@
+---
+apiVersion: network.openstack.org/v1beta1
+kind: DNSData
+metadata:
+  labels: {{ cifmw_external_dns_labels }}
+  name: {{ cifmw_external_dns_name }}
+  namespace: {{ cifmw_external_dns_ns }}
+spec:
+  dnsDataLabelSelectorValue: dnsdata
+  hosts:
+{% set dicts_list = [cifmw_external_dns_vip_int,
+                     cifmw_external_dns_vip_ext,
+                     cifmw_external_dns_extra_subj_alt_names] %}
+{% for d in dicts_list %}
+{% for ip, host in d.items() %}
+  - hostnames:
+    - {{ host }}
+    ip: {{ ip }}
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
Ceph RGW is hosted on EDPM nodes and used by OpenStack pods. In order for Ceph RGW to use HTTPS we need to create a TLS certificate for it which uses OpenStack's public root CA. We also need OpenStack pods to resolve the hostnames of the RGW endpoints so there are no certificate errors.

The cifmw_external_dns role introduced in this PR solves the DNS and Certificate requirements for RGW and the same role may be used to solve the same problem by other services which are hosted externally (outside of k8s).

Jira: https://issues.redhat.com/browse/OSPRH-7245

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
