### PR TITLE
Converge namespace for hooks

### DIFF
--- a/hooks/playbooks/cinder_multiattach_volume_type.yml
+++ b/hooks/playbooks/cinder_multiattach_volume_type.yml
@@ -11,17 +11,12 @@
           }}
 
     - name: Set a multiattach volume type and create it if needed
-      vars:
-        _namespace: >-
-          {{
-            cifmw_install_yamls_defaults['NAMESPACE'] | default('openstack')
-          }}
       environment:
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
       ansible.builtin.shell: |
         set -xe -o pipefail
-        oc project {{ _namespace }}
+        oc project {{ namespace }}
         oc rsh openstackclient \
             openstack volume type show {{ cifmw_volume_multiattach_type }} &>/dev/null || \
             oc rsh openstackclient \

--- a/hooks/playbooks/control_plane_hci_pre_deploy.yml
+++ b/hooks/playbooks/control_plane_hci_pre_deploy.yml
@@ -15,7 +15,7 @@
           apiVersion: kustomize.config.k8s.io/v1beta1
           kind: Kustomization
           resources:
-          namespace: {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+          namespace: {{ namespace }}
           patches:
           - target:
               kind: OpenStackControlPlane

--- a/hooks/playbooks/control_plane_ironic.yml
+++ b/hooks/playbooks/control_plane_ironic.yml
@@ -15,7 +15,7 @@
           apiVersion: kustomize.config.k8s.io/v1beta1
           kind: Kustomization
           resources:
-          namespace: {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+          namespace: {{ namespace }}
           patches:
           - target:
               kind: OpenStackControlPlane

--- a/hooks/playbooks/fetch_compute_facts.yml
+++ b/hooks/playbooks/fetch_compute_facts.yml
@@ -76,7 +76,7 @@
           apiVersion: kustomize.config.k8s.io/v1beta1
           kind: Kustomization
           resources:
-          namespace: {{ cifmw_install_yamls_defaults.NAMESPACE }}
+          namespace: {{ namespace }}
           patches:
           - target:
               kind: OpenStackControlPlane
@@ -125,7 +125,7 @@
               apiVersion: kustomize.config.k8s.io/v1beta1
               kind: Kustomization
               resources:
-              namespace: {{ cifmw_install_yamls_defaults.NAMESPACE }}
+              namespace: {{ namespace }}
               patches:
               - target:
                   kind: OpenStackDataPlaneNodeSet

--- a/hooks/playbooks/manila_create_default_resources.yml
+++ b/hooks/playbooks/manila_create_default_resources.yml
@@ -8,5 +8,5 @@
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
       ansible.builtin.shell: |
-        oc -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} exec -it pod/openstackclient \
+        oc -n {{ namespace }} exec -it pod/openstackclient \
           -- openstack share type create default false

--- a/hooks/playbooks/rabbitmq_tuning.yml
+++ b/hooks/playbooks/rabbitmq_tuning.yml
@@ -8,12 +8,12 @@
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
       ansible.builtin.shell: |
-        crname=$(oc get openstackcontrolplane -o name -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }})
-        oc patch ${crname} --type json -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} \
+        crname=$(oc get openstackcontrolplane -o name -n {{ namespace }})
+        oc patch ${crname} --type json -n {{ namespace }} \
           -p='[{"op": "replace", "path": "/spec/rabbitmq/templates/rabbitmq/resources/requests/cpu", "value": 500m}]'
-        oc patch ${crname} --type json -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} \
+        oc patch ${crname} --type json -n {{ namespace }} \
           -p='[{"op": "replace", "path": "/spec/rabbitmq/templates/rabbitmq/resources/requests/memory", "value": 500Mi}]'
-        oc patch ${crname} --type json -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} \
+        oc patch ${crname} --type json -n {{ namespace }} \
           -p='[{"op": "replace", "path": "/spec/rabbitmq/templates/rabbitmq-cell1/resources/requests/cpu", "value": 500m}]'
-        oc patch ${crname} --type json -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} \
+        oc patch ${crname} --type json -n {{ namespace }} \
           -p='[{"op": "replace", "path": "/spec/rabbitmq/templates/rabbitmq-cell1/resources/requests/memory", "value": 500Mi}]'

--- a/hooks/playbooks/restart_nova_scheduler.yml
+++ b/hooks/playbooks/restart_nova_scheduler.yml
@@ -8,4 +8,4 @@
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
       ansible.builtin.command: >-
-        oc delete pod -n {{ cifmw_install_yamls_defaults['NAMESPACE'] | default('openstack') }} -l service=nova-scheduler
+        oc delete pod -n {{ namespace }} -l service=nova-scheduler

--- a/hooks/playbooks/templates/config_ceph_backends.yaml.j2
+++ b/hooks/playbooks/templates/config_ceph_backends.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-namespace: {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
+namespace: {{ namespace }}
 patches:
 - target:
     kind: OpenStackControlPlane

--- a/roles/run_hook/README.md
+++ b/roles/run_hook/README.md
@@ -38,6 +38,13 @@ name:
 * `type`: (String) Type of the hook. In this case, set it to `playbook`.
 * `extra_vars`: (Dict) Structure listing the extra variables you want to pass down
 
+##### About OpenShift namespaces and install_yamls
+
+Since `install_yamls` might not be initialized, the `run_hook` is exposing two namespace related parameters to the hook playbook:
+
+* `namespace`: it "proxies" `cifmw_install_yamls_defaults['NAMESPACE']` and fallback on `openstack`.
+* `operator_namespace`: it "proxies" `cifmw_install_yamls_defaults['OPERATOR_NAMESPACE']` and fallback on `openstack-operators`.
+
 #### Multiple hooks in a list
 
 * `config_file`: (String) Ansible configuration file. Defaults to `ansible_config_file`.

--- a/roles/run_hook/tasks/playbook.yml
+++ b/roles/run_hook/tasks/playbook.yml
@@ -14,6 +14,16 @@
       {%- endif -%}
     _bdir: >-
       {{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}
+    _operator_namespace: >-
+      {{
+        cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] |
+        default('openstack-operators')
+      }}
+    _namespace: >-
+      {{
+        cifmw_install_yamls_defaults['NAMESPACE'] |
+        default('openstack')
+      }}
   ansible.builtin.set_fact:
     cifmw_basedir: "{{ _bdir }}"
     hook_name: "{{ _hook_name }}"
@@ -21,6 +31,8 @@
     log_path: >-
       {{ _bdir }}/logs/{{ step }}_{{ _hook_name }}.log
     extra_vars: >-
+      -e operator_namespace={{ _operator_namespace }}
+      -e namespace={{ _namespace}}
       {%- if hook.extra_vars is defined and hook.extra_vars|length > 0 -%}
       {% for key,value in hook.extra_vars.items() -%}
       {%- if key == 'file' %}


### PR DESCRIPTION
When running architecture driven deployment, install_yamls isn't
initialized anymore since it's not used.

This patch allows to converge how we pass the namespace down to the
hooks, by checking if we have the install_yamls data and defaulting to a
"not too bad" default value.

In case a user wants to override that namespace, they can use the
extra_vars parameter - since that content comes after our default
setting, it will take over.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
