### PR TITLE
Add delorean repo filename var to dlrn_promote

### DIFF
--- a/roles/dlrn_promote/README.md
+++ b/roles/dlrn_promote/README.md
@@ -18,7 +18,8 @@ This role does not need privilege escalation.
 * `cifmw_dlrn_promote_hash`: (boolean) Whether to run DLRN promote hash. Default: `false`
 * `cifmw_dlrn_promote_ssl_ca_bundle`: (string) Path to SSL CA cert. Default: `"/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt"`
 * `cifmw_dlrn_promote_hash_promote_content`: (boolean) Whether to promote DLRN content. Default: `false`
-* `cifmw_dlrn_promote_dlrnrepo_path`: (String) Path to delorean.repo file Default: `{{ cifmw_dlrn_promote_workspace }}/artifacts/repositories/delorean.repo`
+* `cifmw_dlrn_promote_dlrnrepo_filename`: (String) Name of the delorean repo file. Default: `delorean.repo`
+* `cifmw_dlrn_promote_dlrnrepo_path`: (String) Path to delorean repo file. Default: `{{ cifmw_dlrn_promote_workspace }}/artifacts/repositories/{{ cifmw_dlrn_promote_dlrnrepo_filename }}`
 
 ## Notes
 

--- a/roles/dlrn_promote/defaults/main.yml
+++ b/roles/dlrn_promote/defaults/main.yml
@@ -26,4 +26,5 @@ cifmw_dlrn_promote_criteria_file: ""
 cifmw_dlrn_promote_hash: false
 cifmw_dlrn_promote_hash_promote_content: false
 cifmw_dlrn_promote_ssl_ca_bundle: "/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt"
-cifmw_dlrn_promote_dlrnrepo_path: "{{ cifmw_dlrn_promote_workspace }}/artifacts/repositories/delorean.repo"
+cifmw_dlrn_promote_dlrnrepo_filename: "delorean.repo"
+cifmw_dlrn_promote_dlrnrepo_path: "{{ cifmw_dlrn_promote_workspace }}/artifacts/repositories/{{ cifmw_dlrn_promote_dlrnrepo_filename }}"


### PR DESCRIPTION
Adds a new variable to dlrn_promote role which allows us to choose another delorean repo filename inside the same directory, without the need to provide the full path to the file. repo_setup role that is called inside dlrn_promote role can generate multiple delerean repo files, and we we should be able to choose the correct file in order to promote a single component.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
