### PR TITLE
Use host_ip in _sushy_url

### DIFF
--- a/roles/sushy_emulator/tasks/create_container.yml
+++ b/roles/sushy_emulator/tasks/create_container.yml
@@ -42,11 +42,12 @@
       - "{{ cifmw_sushy_emulator_sshkey_path }}:/root/.ssh/id_rsa:ro,Z"
       - "{{ cifmw_sushy_emulator_sshkey_path }}.pub:/root/.ssh/id_rsa.pub:ro,Z"
 
+# TODO(hjensas): We should probably change to use a DNS name once #1777 has landed.
 - name: Set Sushy Emulator URL for Podman installation
   vars:
     _ip_address: >-
       {%- if cifmw_sushy_emulator_listen_ip in ['::', '0.0.0.0'] -%}
-      {{ hostvars['controller-0']['ansible_host'] }}
+      {{ hostvars['controller-0'].host_ip | default(hostvars['controller-0']['ansible_host']) }}
       {%- else -%}
       {{ cifmw_sushy_emulator_listen_ip }}
       {%- endif -%}


### PR DESCRIPTION
The `ansible_host` contains a name only available in the ssh client configuration. This results in connection URI with a name that cannot be resolved:
 connection: redfish-virtualmedia+http://controller-0.hypervisor-1:8000/[...]

Instead of using ansible host, use the host_ip which contains the IP address.

This is an intermidiate fix, once we have the changes to use DNS more extensively we should change this to use the FQDN of the controller - or possibly add a CNAME in DNS with `sushy-emulator.$DOMAIN`.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
