### PR TITLE
Expose cifmw_repo_setup_dlrn_url from repo-setup-get-hash utility

### DIFF
--- a/roles/repo_setup/tasks/artifacts.yml
+++ b/roles/repo_setup/tasks/artifacts.yml
@@ -43,5 +43,6 @@
         cifmw_repo_setup_distro_hash: "{{ _repo_setup_json['distro_hash'] }}"
         cifmw_repo_setup_extended_hash: "{{ _repo_setup_json['extended_hash'] }}"
         cifmw_repo_setup_dlrn_api_url: "{{ _repo_setup_json['dlrn_api_url'] }}"
+        cifmw_repo_setup_dlrn_url: "{{ _repo_setup_json['dlrn_url'] }}"
         cifmw_repo_setup_release: "{{ _repo_setup_json['release'] }}"
         cacheable: true


### PR DESCRIPTION
cifmw_repo_setup_dlrn_url contains the dlrn component commit.yaml url in case of component line and dlrn url in case of integration line.

This url will be further used in dlrn_promote role to promote proper hashes for a component.

Below is the repo-get-hash output for a component:
```
TASK [repo_setup : Run repo-setup-get-hash]
2024-06-12 20:16:01.961407 | primary | {"commit_hash": "5b9b80e3c9f3723c1a935c4874d9c531c1155ddd", "distro_hash": "e9379d39a4311a34176ac93c7a4120ca09621849", "full_hash": "5b9b80e3c9f3723c1a935c4874d9c531c1155ddd_e9379d39", "extended_hash": "b8d346224382545224845b490360b0710e87c9da_27cf37ef6776f54394cff5be5357164c82c6ab44", "dlrn_url": "https://osp-trunk.hosted.upshift.rdu2.redhat.com/rhel9-osp18/component/tempest/component-ci-testing/commit.yaml", "dlrn_api_url": "https://osp-trunk.hosted.upshift.rdu2.redhat.com/api-rhel9-osp18", "os_version": "rhel9", "release": "osp18", "component": "tempest", "tag": "component-ci-testing"}
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

