### PR TITLE
Add default to  cifmw_install_yamls_defaults if undefined

### DIFF
--- a/hooks/playbooks/manila_create_default_resources.yml
+++ b/hooks/playbooks/manila_create_default_resources.yml
@@ -8,5 +8,5 @@
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
       ansible.builtin.shell: |
-        oc -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }} exec -it pod/openstackclient \
+        oc -n {{ cifmw_install_yamls_defaults['NAMESPACE'] | default('openstack') }} exec -it pod/openstackclient \
           -- openstack share type create default false


### PR DESCRIPTION
The manila_create_default_resources hook is basically a standalone playbook that assumes  cifmw_install_yamls_defaults have been defined or passed to this stage. This patch adds an opinionated default to not fail when those vars are not defined.
This will fix uni* jobs until something like [1] lands.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/1867

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
