### PR TITLE
Pass dlrn url without commits.yml as commit_url for component

### DIFF
--- a/roles/dlrn_promote/tasks/get_hashes.yml
+++ b/roles/dlrn_promote/tasks/get_hashes.yml
@@ -29,5 +29,5 @@
     - cifmw_repo_setup_component_name is defined
     - cifmw_repo_setup_component_name | length > 0
   vars:
-    commit_url: "{{ cifmw_repo_setup_dlrn_url }}"
+    commit_url: "{{ cifmw_repo_setup_dlrn_url | dirname }}"
   ansible.builtin.include_tasks: get_hash_from_commit.yaml


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/ci-framework/pull/1871 adds the support of promoting component repos.

cifmw_repo_setup_dlrn_url contains the full path of component commits.yaml. But commit_url expects the url without commits.yml.

Getting the proper dirname of commits.yml url fixes the following issue.
```
2024-06-13 10:28:01.153360 | TASK [dlrn_promote : Get commit.yaml file]
2024-06-13 10:33:04.719710 | primary | ERROR
2024-06-13 10:33:04.720190 | primary | {
2024-06-13 10:33:04.720298 | primary |   "attempts": 6,
2024-06-13 10:33:04.720379 | primary |   "dest": "/home/zuul/ci-framework-data/commit.yaml",
2024-06-13 10:33:04.720471 | primary |   "elapsed": 0,
2024-06-13 10:33:04.720539 | primary |   "msg": "Request failed",
2024-06-13 10:33:04.720580 | primary |   "response": "HTTP Error 404: Not Found",
2024-06-13 10:33:04.720619 | primary |   "status_code": 404,
2024-06-13 10:33:04.720658 | primary |   "url": "https://XXX/rhel9-osp18/component/tempest/component-ci-testing/commit.yaml/commit.yaml"
2024-06-13 10:33:04.720698 | primary | }
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
