### PR TITLE
[networking_mapper] Add hostname to the MAC seed

### DIFF
--- a/plugins/module_utils/net_map/networking_mapper.py
+++ b/plugins/module_utils/net_map/networking_mapper.py
@@ -337,15 +337,15 @@ class NetworkingInstanceMapper:
             )
         return skip_nm
 
-    @staticmethod
     def __map_instance_network_interface_mac(
+        self,
         interface_mac: typing.Optional[str],
         net_def: networking_definition.NetworkDefinition,
     ) -> typing.Optional[str]:
         if interface_mac:
             return interface_mac
         random_inst = random.Random()
-        random_inst.seed(a=net_def.name)
+        random_inst.seed(a=self.__instance_name + net_def.name)
         mac_bytes = [
             0x52,
             0x54,

--- a/tests/unit/module_utils/test_files/network-definition-valid-all-tools-no-group-templates-out.json
+++ b/tests/unit/module_utils/test_files/network-definition-valid-all-tools-no-group-templates-out.json
@@ -59,7 +59,7 @@
         "internal-api": {
           "network_name": "internal-api",
           "skip_nm": false,
-          "mac_addr": "52:54:00:20:5e:5b",
+          "mac_addr": "52:54:00:21:6a:19",
           "interface_name": "eth1.20",
           "ip_v4": "172.17.0.100",
           "netmask_v4": "255.255.255.0",
@@ -73,7 +73,7 @@
         "storage": {
           "network_name": "storage",
           "skip_nm": false,
-          "mac_addr": "52:54:00:7e:b2:1c",
+          "mac_addr": "52:54:00:42:0e:35",
           "interface_name": "eth1.21",
           "ip_v4": "172.18.0.100",
           "netmask_v4": "255.255.255.0",
@@ -87,7 +87,7 @@
         "tenant": {
           "network_name": "tenant",
           "skip_nm": false,
-          "mac_addr": "52:54:00:12:d1:e1",
+          "mac_addr": "52:54:00:2f:ee:c8",
           "interface_name": "eth1.22",
           "ip_v4": "172.19.0.100",
           "netmask_v4": "255.255.255.0",
@@ -118,7 +118,7 @@
         "internal-api": {
           "network_name": "internal-api",
           "skip_nm": false,
-          "mac_addr": "52:54:00:20:5e:5b",
+          "mac_addr": "52:54:00:0a:e2:ae",
           "interface_name": "eth2.20",
           "ip_v4": "172.17.0.101",
           "netmask_v4": "255.255.255.0",
@@ -132,7 +132,7 @@
         "storage": {
           "network_name": "storage",
           "skip_nm": false,
-          "mac_addr": "52:54:00:7e:b2:1c",
+          "mac_addr": "52:54:00:43:1b:1a",
           "interface_name": "eth2.21",
           "ip_v4": "172.18.0.101",
           "netmask_v4": "255.255.255.0",
@@ -146,7 +146,7 @@
         "tenant": {
           "network_name": "tenant",
           "skip_nm": false,
-          "mac_addr": "52:54:00:12:d1:e1",
+          "mac_addr": "52:54:00:24:6d:84",
           "interface_name": "eth2.22",
           "ip_v4": "172.19.0.101",
           "netmask_v4": "255.255.255.0",

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-dual-stack-full-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-dual-stack-full-map-out.json
@@ -301,7 +301,7 @@
         "network-2": {
           "network_name": "network-2",
           "skip_nm": false,
-          "mac_addr": "52:54:00:54:9d:f3",
+          "mac_addr": "52:54:00:6e:bd:31",
           "ip_v4": "172.18.0.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -311,7 +311,7 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
-          "mac_addr": "52:54:00:5e:d1:a6",
+          "mac_addr": "52:54:00:2e:27:ac",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:0037",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
@@ -321,7 +321,7 @@
         "network-4": {
           "network_name": "network-4",
           "skip_nm": false,
-          "mac_addr": "52:54:00:2f:eb:98",
+          "mac_addr": "52:54:00:11:56:a4",
           "ip_v4": "172.19.0.37",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -349,7 +349,7 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
-          "mac_addr": "52:54:00:5e:d1:a6",
+          "mac_addr": "52:54:00:56:bf:4d",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:0038",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-dual-stack-partial-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-dual-stack-partial-map-out.json
@@ -288,7 +288,7 @@
         "network-1": {
           "network_name": "network-1",
           "skip_nm": false,
-          "mac_addr": "52:54:00:18:3e:dd",
+          "mac_addr": "52:54:00:6d:96:a9",
           "ip_v4": "192.168.122.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -300,7 +300,7 @@
         "network-2": {
           "network_name": "network-2",
           "skip_nm": false,
-          "mac_addr": "52:54:00:54:9d:f3",
+          "mac_addr": "52:54:00:6e:bd:31",
           "ip_v4": "172.18.0.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -310,7 +310,7 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
-          "mac_addr": "52:54:00:5e:d1:a6",
+          "mac_addr": "52:54:00:2e:27:ac",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:0037",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
@@ -320,7 +320,7 @@
         "network-4": {
           "network_name": "network-4",
           "skip_nm": false,
-          "mac_addr": "52:54:00:2f:eb:98",
+          "mac_addr": "52:54:00:11:56:a4",
           "ip_v4": "172.19.0.37",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -335,7 +335,7 @@
         "network-1": {
           "network_name": "network-1",
           "skip_nm": false,
-          "mac_addr": "52:54:00:18:3e:dd",
+          "mac_addr": "52:54:00:1e:46:dd",
           "ip_v4": "192.168.122.11",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -347,7 +347,7 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
-          "mac_addr": "52:54:00:5e:d1:a6",
+          "mac_addr": "52:54:00:56:bf:4d",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:0038",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
@@ -363,7 +363,7 @@
         "network-1": {
           "network_name": "network-1",
           "skip_nm": false,
-          "mac_addr": "52:54:00:18:3e:dd",
+          "mac_addr": "52:54:00:57:16:fa",
           "ip_v4": "192.168.122.12",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-dual-stack-partial-reduced-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-dual-stack-partial-reduced-map-out.json
@@ -288,7 +288,7 @@
         "network-2": {
           "network_name": "network-2",
           "skip_nm": false,
-          "mac_addr": "52:54:00:54:9d:f3",
+          "mac_addr": "52:54:00:6e:bd:31",
           "ip_v4": "172.18.0.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -298,7 +298,7 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
-          "mac_addr": "52:54:00:5e:d1:a6",
+          "mac_addr": "52:54:00:2e:27:ac",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:0037",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
@@ -308,7 +308,7 @@
         "network-4": {
           "network_name": "network-4",
           "skip_nm": false,
-          "mac_addr": "52:54:00:2f:eb:98",
+          "mac_addr": "52:54:00:11:56:a4",
           "ip_v4": "172.19.0.37",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -323,7 +323,7 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
-          "mac_addr": "52:54:00:5e:d1:a6",
+          "mac_addr": "52:54:00:56:bf:4d",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:0038",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-full-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-full-map-out.json
@@ -247,7 +247,7 @@
         "internal-api": {
           "network_name": "internal-api",
           "skip_nm": false,
-          "mac_addr": "52:54:00:20:5e:5b",
+          "mac_addr": "52:54:00:21:6a:19",
           "interface_name": "eth1.20",
           "ip_v4": "172.17.0.10",
           "netmask_v4": "255.255.255.0",
@@ -261,7 +261,7 @@
         "storage": {
           "network_name": "storage",
           "skip_nm": false,
-          "mac_addr": "52:54:00:7e:b2:1c",
+          "mac_addr": "52:54:00:42:0e:35",
           "interface_name": "eth0.21",
           "ip_v4": "172.18.0.10",
           "netmask_v4": "255.255.255.0",
@@ -304,7 +304,7 @@
         "internal-api": {
           "network_name": "internal-api",
           "skip_nm": false,
-          "mac_addr": "52:54:00:20:5e:5b",
+          "mac_addr": "52:54:00:0a:e2:ae",
           "interface_name": "eth2.20",
           "ip_v4": "172.17.0.11",
           "netmask_v4": "255.255.255.0",
@@ -318,7 +318,7 @@
         "storage": {
           "network_name": "storage",
           "skip_nm": false,
-          "mac_addr": "52:54:00:7e:b2:1c",
+          "mac_addr": "52:54:00:43:1b:1a",
           "interface_name": "eth0.21",
           "ip_v4": "172.18.0.11",
           "netmask_v4": "255.255.255.0",
@@ -350,7 +350,7 @@
         "storage": {
           "network_name": "storage",
           "skip_nm": true,
-          "mac_addr": "52:54:00:7e:b2:1c",
+          "mac_addr": "52:54:00:28:90:3e",
           "interface_name": "eth1.21",
           "ip_v4": "172.18.0.12",
           "netmask_v4": "255.255.255.0",

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-full-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-full-map-out.json
@@ -177,7 +177,7 @@
         "network-2": {
           "network_name": "network-2",
           "skip_nm": false,
-          "mac_addr": "52:54:00:54:9d:f3",
+          "mac_addr": "52:54:00:6e:bd:31",
           "ip_v6": "fd5e:bdb2:6091:9306:0000:0000:0000:0190",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
@@ -186,7 +186,7 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
-          "mac_addr": "52:54:00:5e:d1:a6",
+          "mac_addr": "52:54:00:2e:27:ac",
           "interface_name": "eth1.20",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:0f1a",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
@@ -218,7 +218,7 @@
         "network-2": {
           "network_name": "network-2",
           "skip_nm": false,
-          "mac_addr": "52:54:00:54:9d:f3",
+          "mac_addr": "52:54:00:55:e0:aa",
           "ip_v6": "fd5e:bdb2:6091:9306:0000:0000:0000:0191",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
@@ -227,7 +227,7 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
-          "mac_addr": "52:54:00:5e:d1:a6",
+          "mac_addr": "52:54:00:56:bf:4d",
           "interface_name": "eth0.20",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:01f4",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
@@ -259,7 +259,7 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
-          "mac_addr": "52:54:00:5e:d1:a6",
+          "mac_addr": "52:54:00:6c:b1:ed",
           "interface_name": "eth1.20",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:01f5",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-partial-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-partial-map-out.json
@@ -166,7 +166,7 @@
         "network-1": {
           "network_name": "network-1",
           "skip_nm": false,
-          "mac_addr": "52:54:00:18:3e:dd",
+          "mac_addr": "52:54:00:6d:96:a9",
           "ip_v6": "fdc0:8b54:108a:c949:0000:0000:0000:0f1a",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
@@ -176,7 +176,7 @@
         "network-2": {
           "network_name": "network-2",
           "skip_nm": false,
-          "mac_addr": "52:54:00:54:9d:f3",
+          "mac_addr": "52:54:00:6e:bd:31",
           "ip_v6": "fd5e:bdb2:6091:9306:0000:0000:0000:0190",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
@@ -185,7 +185,7 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
-          "mac_addr": "52:54:00:5e:d1:a6",
+          "mac_addr": "52:54:00:2e:27:ac",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:0f1a",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
@@ -197,7 +197,7 @@
         "network-4": {
           "network_name": "network-4",
           "skip_nm": false,
-          "mac_addr": "52:54:00:2f:eb:98",
+          "mac_addr": "52:54:00:11:56:a4",
           "ip_v6": "fd98:6d1a:86e7:d5e5:0000:0000:0000:01f4",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
@@ -213,7 +213,7 @@
         "network-2": {
           "network_name": "network-2",
           "skip_nm": false,
-          "mac_addr": "52:54:00:54:9d:f3",
+          "mac_addr": "52:54:00:55:e0:aa",
           "ip_v6": "fd5e:bdb2:6091:9306:0000:0000:0000:0191",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
@@ -222,7 +222,7 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
-          "mac_addr": "52:54:00:5e:d1:a6",
+          "mac_addr": "52:54:00:56:bf:4d",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:01f4",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
@@ -234,7 +234,7 @@
         "network-4": {
           "network_name": "network-4",
           "skip_nm": false,
-          "mac_addr": "52:54:00:2f:eb:98",
+          "mac_addr": "52:54:00:7a:e6:e6",
           "ip_v6": "fd98:6d1a:86e7:d5e5:0000:0000:0000:01f5",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
@@ -250,7 +250,7 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
-          "mac_addr": "52:54:00:5e:d1:a6",
+          "mac_addr": "52:54:00:6c:b1:ed",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:01f5",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
@@ -262,7 +262,7 @@
         "network-4": {
           "network_name": "network-4",
           "skip_nm": false,
-          "mac_addr": "52:54:00:2f:eb:98",
+          "mac_addr": "52:54:00:4d:2d:2f",
           "ip_v6": "fd98:6d1a:86e7:d5e5:0000:0000:0000:01f6",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-partial-reduced-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-ipv6-only-partial-reduced-map-out.json
@@ -166,7 +166,7 @@
         "network-1": {
           "network_name": "network-1",
           "skip_nm": false,
-          "mac_addr": "52:54:00:18:3e:dd",
+          "mac_addr": "52:54:00:6d:96:a9",
           "ip_v6": "fdc0:8b54:108a:c949:0000:0000:0000:0f1a",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,
@@ -176,7 +176,7 @@
         "network-3": {
           "network_name": "network-3",
           "skip_nm": false,
-          "mac_addr": "52:54:00:5e:d1:a6",
+          "mac_addr": "52:54:00:2e:27:ac",
           "ip_v6": "fd42:add0:b7d2:09b1:0000:0000:0000:0f1a",
           "netmask_v6": "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
           "prefix_length_v6": 64,

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-partial-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-partial-map-out.json
@@ -236,7 +236,7 @@
         "ctlplane": {
           "network_name": "ctlplane",
           "skip_nm": false,
-          "mac_addr": "52:54:00:4f:e0:69",
+          "mac_addr": "52:54:00:32:28:d7",
           "ip_v4": "192.168.122.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -246,7 +246,7 @@
         "internal-api": {
           "network_name": "internal-api",
           "skip_nm": false,
-          "mac_addr": "52:54:00:20:5e:5b",
+          "mac_addr": "52:54:00:21:6a:19",
           "ip_v4": "172.17.0.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -258,7 +258,7 @@
         "storage": {
           "network_name": "storage",
           "skip_nm": false,
-          "mac_addr": "52:54:00:7e:b2:1c",
+          "mac_addr": "52:54:00:42:0e:35",
           "ip_v4": "172.18.0.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -270,7 +270,7 @@
         "tenant": {
           "network_name": "tenant",
           "skip_nm": false,
-          "mac_addr": "52:54:00:12:d1:e1",
+          "mac_addr": "52:54:00:2f:ee:c8",
           "ip_v4": "172.19.0.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -287,7 +287,7 @@
         "ctlplane": {
           "network_name": "ctlplane",
           "skip_nm": false,
-          "mac_addr": "52:54:00:4f:e0:69",
+          "mac_addr": "52:54:00:73:35:d3",
           "ip_v4": "192.168.122.11",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -297,7 +297,7 @@
         "internal-api": {
           "network_name": "internal-api",
           "skip_nm": false,
-          "mac_addr": "52:54:00:20:5e:5b",
+          "mac_addr": "52:54:00:0a:e2:ae",
           "ip_v4": "172.17.0.11",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -309,7 +309,7 @@
         "storage": {
           "network_name": "storage",
           "skip_nm": false,
-          "mac_addr": "52:54:00:7e:b2:1c",
+          "mac_addr": "52:54:00:43:1b:1a",
           "ip_v4": "172.18.0.11",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -321,7 +321,7 @@
         "tenant": {
           "network_name": "tenant",
           "skip_nm": false,
-          "mac_addr": "52:54:00:12:d1:e1",
+          "mac_addr": "52:54:00:24:6d:84",
           "ip_v4": "172.19.0.11",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -338,7 +338,7 @@
         "storage": {
           "network_name": "storage",
           "skip_nm": true,
-          "mac_addr": "52:54:00:7e:b2:1c",
+          "mac_addr": "52:54:00:28:90:3e",
           "ip_v4": "172.18.0.12",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -350,7 +350,7 @@
         "tenant": {
           "network_name": "tenant",
           "skip_nm": true,
-          "mac_addr": "52:54:00:12:d1:e1",
+          "mac_addr": "52:54:00:36:d2:fe",
           "ip_v4": "172.19.0.12",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,

--- a/tests/unit/module_utils/test_files/networking-definition-valid-full-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-full-map-out.json
@@ -67,7 +67,7 @@
         "internal-api": {
           "network_name": "internal-api",
           "skip_nm": false,
-          "mac_addr": "52:54:00:20:5e:5b",
+          "mac_addr": "52:54:00:21:6a:19",
           "interface_name": "eth1.20",
           "ip_v4": "172.17.0.10",
           "netmask_v4": "255.255.255.0",
@@ -81,7 +81,7 @@
         "storage": {
           "network_name": "storage",
           "skip_nm": true,
-          "mac_addr": "52:54:00:7e:b2:1c",
+          "mac_addr": "52:54:00:42:0e:35",
           "interface_name": "eth1.21",
           "ip_v4": "172.18.0.100",
           "netmask_v4": "255.255.255.0",
@@ -95,7 +95,7 @@
         "tenant": {
           "network_name": "tenant",
           "skip_nm": true,
-          "mac_addr": "52:54:00:12:d1:e1",
+          "mac_addr": "52:54:00:2f:ee:c8",
           "interface_name": "eth1.22",
           "ip_v4": "172.19.0.10",
           "netmask_v4": "255.255.255.0",

--- a/tests/unit/module_utils/test_files/networking-definition-valid-partial-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-partial-map-out.json
@@ -56,7 +56,7 @@
         "ctlplane": {
           "network_name": "ctlplane",
           "skip_nm": false,
-          "mac_addr": "52:54:00:4f:e0:69",
+          "mac_addr": "52:54:00:32:28:d7",
           "ip_v4": "192.168.122.100",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -66,7 +66,7 @@
         "internal-api": {
           "network_name": "internal-api",
           "skip_nm": false,
-          "mac_addr": "52:54:00:20:5e:5b",
+          "mac_addr": "52:54:00:21:6a:19",
           "ip_v4": "172.17.0.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -78,7 +78,7 @@
         "storage": {
           "network_name": "storage",
           "skip_nm": true,
-          "mac_addr": "52:54:00:7e:b2:1c",
+          "mac_addr": "52:54:00:42:0e:35",
           "ip_v4": "172.18.0.100",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,
@@ -90,7 +90,7 @@
         "tenant": {
           "network_name": "tenant",
           "skip_nm": true,
-          "mac_addr": "52:54:00:12:d1:e1",
+          "mac_addr": "52:54:00:2f:ee:c8",
           "ip_v4": "172.19.0.10",
           "netmask_v4": "255.255.255.0",
           "prefix_length_v4": 24,


### PR DESCRIPTION
Without the hostname as part of the seed the generated MACs are repeated from host to host.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
   - [x]  nfv
   - [x]  uni01alpha (failed at tempest, but it seems the failure is unrelated)
   - [x] hci
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
