### PR TITLE
Enforce some kind of timeout for selected tasks

### DIFF
--- a/roles/openshift_adm/tasks/shutdown.yml
+++ b/roles/openshift_adm/tasks/shutdown.yml
@@ -31,12 +31,17 @@
     - not cifmw_openshift_adm_dry_run
   ansible.builtin.include_tasks: api_cert.yml
 
-- name: Gather the list of nodes
+- name: Gather list of nodes to shutdown
   kubernetes.core.k8s_info:
     kind: Node
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
     validate_certs: false
   register: _nodes
+  until: _nodes.resources is defined
+  retries: "{{ cifmw_openshift_adm_retry_count }}"
+  delay: 2
+  async: 10
+  poll: 2
 
 - name: Shutdown the nodes participating in the cluster.
   when:

--- a/roles/openshift_adm/tasks/wait_for_cluster.yml
+++ b/roles/openshift_adm/tasks/wait_for_cluster.yml
@@ -38,6 +38,8 @@
   until: _nodes.resources is defined
   retries: "{{ cifmw_openshift_adm_retry_count }}"
   delay: 2
+  async: 10
+  poll: 5
 
 - name: Ensure the nodes are in ready state.
   when:
@@ -52,6 +54,8 @@
   until: _node_status.result is defined
   retries: "{{ cifmw_openshift_adm_retry_count }}"
   delay: 5
+  async: 10
+  poll: 5
 
 - name: Check for pending certificate approval.
   when:


### PR DESCRIPTION
There is no "timeout" for ansible tasks. We therefore must work around
that lacking feature using `async` and related `poll`.

With those small changes, the node list gathering will:
- run for 10 seconds
- show a "ASYNC POLL on..." message every 2 second
- in case of failure, retry for the set amount

In the end, it can take up to (10 * COUNT * 2) time before failing
for good (2 being the "delay" between retries).

We may need to adjust the "async" value.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
