### PR TITLE
Leverage async for devscripts role feedback

### DIFF
--- a/roles/devscripts/README.md
+++ b/roles/devscripts/README.md
@@ -30,6 +30,8 @@ networks.
   for overriding the default configuration. Refer to
   [section](#supported-keys-in-cifmw_devscripts_config_overrides) for more
   information.
+* `cifmw_devscripts_installer_timeout`: (int) number of second before deployment timeout.
+  Defaults to 7200, 2 hours.
 * `cifmw_devscripts_dry_run` (bool) If enabled, the workflow is evaluated.
 * `cifmw_devscripts_src_dir` (str) The parent folder of dev-scripts repository.
 * `cifmw_devscripts_remove_libvirt_net_default` (bool) Remove the default

--- a/roles/devscripts/defaults/main.yml
+++ b/roles/devscripts/defaults/main.yml
@@ -69,3 +69,4 @@ cifmw_devscripts_cinder_volume_pvs:
   - /dev/vda
 
 cifmw_devscripts_config_overrides: {}
+cifmw_devscripts_installer_timeout: 7200  # 2 hours

--- a/roles/devscripts/tasks/cleanup.yml
+++ b/roles/devscripts/tasks/cleanup.yml
@@ -48,6 +48,8 @@
       community.general.make:
         chdir: "{{ cifmw_devscripts_repo_dir }}"
         target: clean
+      async: 600  # 10 minutes should be more than enough
+      poll: 10
 
     - name: Remove the SSH key generated for accessing the platform
       ansible.builtin.file:

--- a/roles/devscripts/tasks/main.yml
+++ b/roles/devscripts/tasks/main.yml
@@ -46,6 +46,8 @@
   community.general.make:
     chdir: "{{ cifmw_devscripts_repo_dir }}"
     target: "all"
+  async: "{{ cifmw_devscripts_installer_timeout }}"
+  poll: 30
 
 - name: Executing dev-scripts post-install tasks.
   when:


### PR DESCRIPTION
Long running tasks such as the deploy will now have:
- a timeout via async
- display a feedback while still running

The timeout is needed since, under some circumstances, devscripts itself
doesn't seem to timeout, leading to never-ending run.

The deploy will show an ASYNC POLL every 30 seconds, while the cleaning
will show the message every 10 seconds.
The "timeout" for the deployment is set to 2h by default.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
