### PR TITLE
Remove change_message from zuul parameters

### DIFF
--- a/ci/playbooks/dump_zuul_data.yml
+++ b/ci/playbooks/dump_zuul_data.yml
@@ -31,10 +31,13 @@
               to_nice_yaml
           }}
 
-    - name: Save zuul vars
+    - name: Save zuul vars without the change_message
       vars:
         _original_inventory: "{{ _inventory_yaml['content'] | b64decode | from_yaml }}"
+        _vars_to_keep: |
+          {% set msg = _original_inventory.all.vars.zuul.pop('change_message', None) %}
+          {{ _original_inventory.all.vars  }}
       ansible.builtin.copy:
-        content: '{{ _original_inventory.all.vars | to_nice_yaml }}'
+        content: '{{ _vars_to_keep | to_nice_yaml }}'
         dest: "{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml"
         mode: "0644"


### PR DESCRIPTION
After a recent Zuul update, zuul was putting the first comment of the PR
as the change_message in the zuul var. If that message contained ansible code,
it would get parsed and in all likelihood cause an error. This change
removes the change_message field from the zuul var to allow yaml to be
used in the PR comment.

Adding some yaml below to make sure it works.

###
Proof of work
`test.yml` playbook:
```YAML
---
- hosts: localhost
  gather_facts: false
  pre_tasks:
    - name: Load master parameter file
      when:
        - var_file is defined
        - var_file is exists
      ansible.builtin.include_vars:
        file: "{{ var_file }}"

  tasks:
    - name: Output va_parameter if available
      when:
        - va_parameter is defined
      ansible.builtin.debug:
        var: va_parameter

    - name: Output dt_parameter if available
      when:
        - dt_parameter is defined
      ansible.builtin.debug:
        var: dt_parameter

    - name: Output overridden parameter if available
      when:
        - my_parameter is defined
      ansible.builtin.debug:
        var: my_parameter
```
`va.yml` parameter file:
```YAML
---
my_parameter: starwars
va_parameter: foo
```

`dt.yml` parameter file:
```YAML
---
var_file: va.yml
my_parameter: foo_bar
dt_parameter: bar
```

Output:
```
PLAY
[localhost] ************************************************************************

TASK
[Load master parameter file] *********************************************************
ok: [localhost]

TASK [Output va_parameter if available] ****************************************************
ok:
[localhost] => {
    "va_parameter": "foo"
}

TASK [Output
dt_parameter if available] *****************************************************
ok: [localhost] => {
    "dt_parameter": "bar"
}

TASK [Output
overridden parameter if available] **********************************************
ok: [localhost] => {
    "my_parameter": "foo_bar"
}

PLAY RECAP
*****************************************************************************
localhost                   : ok=4    changed=0    unreachable=0    failed=0    skipped=0   rescued=0    ignored=0
```

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
