### PR TITLE
test_operator: more tempest-related SRBAC keyword

### DIFF
--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -60,16 +60,18 @@ cifmw_tempest_tempestconf_config_defaults:
     tempest_roles =
 
     [enforce_scope]
-    nova = true
-    neutron = true
-    glance = true
+    barbican = true
     cinder = true
+    designate = true
+    glance = true
+    ironic = true
+    ironic_inspector = true
+    neutron = true
+    nova = true
+    octavia = true
     keystone = true
-    placement = true
     manila = true
-
-    [barbican_rbac_scope_verification]
-    enforce_scope = true
+    placement = true
 
     [identity-feature-enabled]
     enforce_scope = true


### PR DESCRIPTION
- Enable SRBAC tests for more components.
- Use the new consistent keyword for barbican, available since barbican-tempest-plugin 4.0.0 (last current tag).
- Finally, reorder the list so that it is alphabetically sorted.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
