### PR TITLE
Use update_containers role to update openstack services container image

### DIFF
--- a/ci/playbooks/build_runner_image.yml
+++ b/ci/playbooks/build_runner_image.yml
@@ -43,5 +43,4 @@
         mode: "0644"
         content: |
           cifmw_update_containers_ansibleee_image_url: "{{ ansibleee_runner_img }}"
-          cifmw_update_containers: true
         dest: "{{ ansible_user_dir }}/ci-framework-data/artifacts/edpm-ansible.yml"

--- a/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
+++ b/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
@@ -74,12 +74,15 @@
         ).metadata.name
       }}
 
-- name: Update BM CSV or Ansibleee CSV to update proper image
+- name: Update Openstack containers or BM CSV or Ansibleee CSV to update proper image
   when: >-
       (cifmw_update_containers_edpm_image_url is defined) or
-      (cifmw_update_containers_ansibleee_image_url is defined)
+      (cifmw_update_containers_ansibleee_image_url is defined) or
+      ((cifmw_update_containers_openstack is defined and
+      cifmw_update_containers_openstack | bool))
   vars:
     cifmw_update_containers_metadata: "{{ _ctlplane_name }}"
+    cifmw_update_containers: true
   ansible.builtin.include_role:
     name: update_containers
 

--- a/roles/edpm_prepare/tasks/main.yml
+++ b/roles/edpm_prepare/tasks/main.yml
@@ -119,8 +119,12 @@
           --namespace={{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }}
           --for=jsonpath='{.status.phase}'=Complete --timeout=20m
 
+  # Note(chkumar): Keeping set_openstack_containers role
+  # till we migrate this task to update_containers role
 - name: Update OpenStack Services containers Env
-  when: cifmw_edpm_prepare_update_os_containers | bool
+  when:
+    - cifmw_edpm_prepare_update_os_containers | bool
+    - cifmw_update_containers_openstack is not defined
   vars:
     cifmw_set_openstack_containers_extra_vars: "{{ cifmw_edpm_prepare_extra_vars }}"
   ansible.builtin.include_role:

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -358,7 +358,7 @@
             rejectattr('key', 'equalto', 'cifmw_extras') |
             rejectattr('key', 'equalto', 'cifmw_openshift_kubeconfig') |
             rejectattr('key', 'equalto', 'cifmw_openshift_token') |
-            rejectattr('key', 'equalto', 'cifmw_set_openstack_containers_registry') |
+            rejectattr('key', 'equalto', 'cifmw_update_containers_registry') |
             rejectattr('key', 'equalto', 'cifmw_networking_env_definition') |
             rejectattr('key', 'match', '^cifmw_use_(?!lvms).*') |
             rejectattr('key', 'match', '^cifmw_reproducer.*') |

--- a/roles/reproducer/templates/content-provider.yml.j2
+++ b/roles/reproducer/templates/content-provider.yml.j2
@@ -103,7 +103,7 @@
           {{
             {'cifmw_operator_build_output': cifmw_operator_build_output,
              'content_provider_registry_ip': cifmw_rp_registry_ip,
-             'cifmw_set_openstack_containers_registry:': cifmw_rp_registry_ip
+             'cifmw_update_containers_registry': cifmw_rp_registry_ip
             } | to_nice_yaml
           }}
 {% endraw %}

--- a/roles/update_containers/templates/update_containers.j2
+++ b/roles/update_containers/templates/update_containers.j2
@@ -57,7 +57,6 @@ spec:
     octaviaHousekeepingImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-octavia-housekeeping:{{ cifmw_update_containers_tag }}
     octaviaWorkerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-octavia-worker:{{ cifmw_update_containers_tag }}
     openstackClientImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-openstackclient:{{ cifmw_update_containers_tag }}
-    osContainerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/edpm-hardened-uefi:{{ cifmw_update_containers_tag }}
     ovnControllerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ovn-controller:{{ cifmw_update_containers_tag }}
     ovnControllerOvsImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ovn-base:{{ cifmw_update_containers_tag }}
     ovnNbDbclusterImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ovn-nb-db-server:{{ cifmw_update_containers_tag }}

--- a/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
+++ b/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
@@ -19,9 +19,6 @@ pre_infra:
 cifmw_operator_build_meta_name: "openstack-operator"
 cifmw_edpm_prepare_skip_crc_storage_creation: true
 
-# update containers vars
-cifmw_update_containers: true
-
 # edpm_deploy role vars
 cifmw_deploy_edpm: true
 cifmw_edpm_deploy_baremetal: true


### PR DESCRIPTION
This pr keeps the set_openstack_containers role when cifmw_update_containers_openstack var is not defined and use update_containers only when cifmw_update_containers_openstack is defined.

Apart from this, this pr also updates:
- Reproducer content provider to use update_containers role var
- Removes duplicates OsContainer Image var from update_containers role
- Move cifmw_update_containers var in edpm_prepare update_containers
  role call

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

