### PR TITLE
hook ironic_network - neutron availability zone

### DIFF
--- a/hooks/playbooks/ironic_network.yml
+++ b/hooks/playbooks/ironic_network.yml
@@ -10,6 +10,7 @@
     _subnet_alloc_pool_end: '172.20.1.200'
     _provider_physical_network: ironic
     _provider_network_type: flat
+    _availability_zone_hints: null  # Comma separated list of strings
   environment:
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
     PATH: "{{ cifmw_path }}"
@@ -22,6 +23,11 @@
           openstack network create provisioning \
             --share \
             --provider-physical-network {{ _provider_physical_network }} \
+            {% if _availability_zone_hints is not none -%}
+            {% for zone in _availability_zone_hints | split(',') -%}
+            --availability-zone-hint {{ zone }} \
+            {% endfor -%}
+            {% endif -%}
             --provider-network-type {{ _provider_network_type }}
         oc rsh openstackclient \
           openstack subnet create provisioning-subnet \


### PR DESCRIPTION
Add variable _availability_zone_hints. Defaults to `null`. When a list of one or more availability zone hints are defined the network create command includes the --availability-zone-hint option so that the networks availability zone hints are set.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
