### PR TITLE
Move Tofu resource creation to hooks dir

### DIFF
--- a/hooks/playbooks/run_tofu.yml
+++ b/hooks/playbooks/run_tofu.yml
@@ -19,6 +19,21 @@
   gather_facts: true
   run_once: true
   tasks:
+    - name: Create openstack config dir
+      ansible.builtin.file:
+        path: "{{ ansible_user_dir }}/.config/openstack/"
+        owner: zuul
+        group: zuul
+        mode: '0744'
+        state: directory
+    - name: Fetch cloud congig to host
+      kubernetes.core.k8s_cp:
+        kubeconfig: "{{ cifmw_tofu_kubeconfig }}"
+        namespace: openstack
+        pod: openstackclient
+        remote_path: /home/cloud-admin/.config/openstack/
+        local_path: "{{ ansible_user_dir }}/.config/openstack/"
+        state: from_pod
     - name: Deploy Tufo Environment
       ansible.builtin.import_role:
         name: tofu

--- a/roles/tofu/tasks/plan.yml
+++ b/roles/tofu/tasks/plan.yml
@@ -18,8 +18,6 @@
   environment:
     TF_CLI_ARGS: '-no-color'
     TF_IN_AUTOMATION: 'true'
-  vars:
-    tf_project_path: "{{ cifmw_tofu_remote_execution | ternary(cifmw_tofu_project_temp_dir['path'], cifmw_tofu_project_path) }}"
   community.general.terraform:
     binary_path: "{{ tofu_binary_path.stdout }}"
     state: "{{ cifmw_tofu_plan_state }}"
@@ -29,6 +27,6 @@
     backend_config_files: "{{ cifmw_tofu_backend_config_files | default(omit) }}"
     force_init: true
     init_reconfigure: true
-    project_path: "{{ tf_project_path }}"
+    project_path: "{{ cifmw_tofu_project_path }}"
   check_mode: "{{ cifmw_tofu_check_mode }}"
   register: _tofu_plan_execution

--- a/roles/tofu/tasks/prepare.yml
+++ b/roles/tofu/tasks/prepare.yml
@@ -14,12 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Create Tofu Directory
-  ansible.builtin.file:
-    path: '{{ cifmw_tofu_dir_path }}'
-    state: directory
-    mode: '0644'
-
 - name: Add OpenTofu repository
   ansible.builtin.yum_repository:
     name: opentofu
@@ -40,6 +34,6 @@
     state: installed
   become: true
 
-- name: Return motd to registered var
+- name: Return tofu to registered var
   ansible.builtin.command: which tofu
   register: tofu_binary_path


### PR DESCRIPTION
moved tofu to hooks dir and removed unnecessary vars and plays

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
