### PR TITLE
Update workflow - remove the set_openstack_container.

### DIFF
--- a/playbooks/update.yml
+++ b/playbooks/update.yml
@@ -11,14 +11,6 @@
       ansible.builtin.include_role:
         name: repo_setup
 
-    - name: Update all openstack services containers env vars in meta operator with tag from delorean
-      vars:
-        cifmw_set_openstack_containers_dlrn_md5_path: "{{ cifmw_basedir }}/artifacts/repositories/delorean.repo.md5"
-        cifmw_set_openstack_containers_tag_from_md5: true
-        cifmw_set_openstack_containers_extra_vars: "{{ cifmw_edpm_prepare_extra_vars }}"
-      ansible.builtin.include_role:
-        name: set_openstack_containers
-
 - name: Sync repos for controller to compute
   hosts: computes
   gather_facts: true

--- a/playbooks/update.yml
+++ b/playbooks/update.yml
@@ -10,6 +10,10 @@
     - name: Run repo_setup
       ansible.builtin.include_role:
         name: repo_setup
+    - name: Run update-containers
+      ansible.builtin.include_role:
+        name: update_containers
+      when: cifmw_update_containers | bool
 
 - name: Sync repos for controller to compute
   hosts: computes


### PR DESCRIPTION
This triggers an update of all the pods which triggers an update of
all the containers outside of the update procedure.

We will have a another way to pass the new pods definition.

Jira: [OSPRH-7721](https://issues.redhat.com//browse/OSPRH-7721)

-------

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes