### PR TITLE
Add includepkgs into yum_repository call

### DIFF
--- a/roles/reproducer/tasks/configure_computes.yml
+++ b/roles/reproducer/tasks/configure_computes.yml
@@ -62,6 +62,7 @@
         gpgcheck: "{{ item.gpgcheck | default(omit) }}"
         enabled: "{{ item.enabled | default(omit) }}"
         priority: "{{ item.priority | default(omit) }}"
+        includepkgs: "{{ item.includepkgs | default(omit) }}"
       loop: "{{ cifmw_reproducer_compute_repos }}"
       loop_control:
         label: "{{ item.name }}"


### PR DESCRIPTION
We use this task to include repositories inside
compute nodes, and some repositories should be
limited to install a list of packages.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
