### PR TITLE
Bump crc resources in centos-9-medium-3x-centos-9-crc-extracted-2-36-0-xxl

### DIFF
--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -321,6 +321,29 @@
           - crc
 
 - nodeset:
+    name: centos-9-medium-3x-centos-9-crc-extracted-2-36-0-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-2
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: coreos-crc-extracted-2-36-0-3xl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+          - compute-2
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
     name: centos-9-crc-2-36-0-6xlarge
     nodes:
       - name: controller


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
