### PR TITLE
Ensure we install tmux

### DIFF
--- a/roles/ci_setup/vars/main.yml
+++ b/roles/ci_setup/vars/main.yml
@@ -22,6 +22,7 @@ cifmw_ci_setup_packages:
   - git-core
   - bash-completion
   - make
+  - tmux
 
 # openshift client
 cifmw_ci_setup_openshift_client_download_uri: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp"

--- a/roles/ci_setup/vars/redhat.yml
+++ b/roles/ci_setup/vars/redhat.yml
@@ -5,6 +5,7 @@ cifmw_ci_setup_packages:
   - git-core
   - make
   - tar
+  - tmux
 
 cifmw_ci_setup_rhel_rhsm_default_repos:
   - 'rhel-*-baseos-rpms'


### PR DESCRIPTION
tmux is a widely used software, and usually we install it manually as
soon as we jump on a host. It was included only on controller-0, but we
also use it from the hypervisor directly.

Let's make that software available anywhere.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
