### PR TITLE
Ensure cifmw_network_dnsmasq_config isn't used

### DIFF
--- a/roles/ci_network/README.md
+++ b/roles/ci_network/README.md
@@ -16,6 +16,8 @@ It needs sudo access to edit Network Manager connections.
 * `cifmw_network_nm_config_dir`: (Str) Path to NetworkManager configuration directory. Defaults to `/etc/NetworkManager`.
 * `cifmw_network_nm_config_file`: (Str) Path to NetworkManager configuration file. Defaults to `cifmw_network_nm_config_dir ~ NetworkManager.conf`.
 * `cifmw_network_nm_config_dnsmasq_file`: (Str) Path to NetworkManager dnsmasq enabling file. Defaults to `cifmw_network_nm_config_dir ~ /conf.d/00-use-dnsmasq.conf`.
+
+### Deprecated parameters
 * `cifmw_network_dnsmasq_config`: (Dict) dnsmasq configuration to be applied on the KVM host.
 * `cifmw_network_dnsmasq_leases_file`: (Str) Path to the dnsmasq DHCP static leases file. Defaults to `cifmw_network_nm_config_dir ~ /dnsmasq.d/98-cifmw-static-leases.conf`.
 * `cifmw_network_dnsmasq_forwarders_file`: (Str) Path to the dnsmasq forwarders file. Defaults to `cifmw_network_nm_config_dir ~ /dnsmasq.d/99-cifmw-dns-forwarders.conf`.
@@ -61,6 +63,8 @@ If it finds it, it will consume it instead of `cifmw_network_layout`.
 
 ## DNS configuration
 
+WARNING: deprecated feature!
+
 The configuration is represented by
 
 ```YAML
@@ -77,6 +81,8 @@ cifmw_network_dnsmasq_config:
 
 
 ## DHCP configuration
+
+WARNING: deprecated feature!
 
 To enable dnsmasq configuration is represented by
 

--- a/roles/reproducer/tasks/validations.yml
+++ b/roles/reproducer/tasks/validations.yml
@@ -40,3 +40,14 @@
       {{ ansible_distribution_version }} is less than the minimum supported version of
       {{ cifmw_reproducer_supported_hypervisor_os[ansible_distribution].minimum_version }}
       https://ci-framework.readthedocs.io/en/latest/quickstart/02_prepare_env.html#tested-environment
+
+- name: Verify cifmw_network_dnsmasq_config isn't set
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - cifmw_network_dnsmasq_config is undefined or
+        cifmw_network_dnsmasq_config | length == 0
+    msg: >-
+      cifmw_network_dnsmasq_config is set and not empty. This feature is NOT
+      supported anymore. Please contact the CI Framework team to check your
+      configuration, and see if you really need to pass anything to dnsmasq.


### PR DESCRIPTION
This feature is mostly deprecated. As far as we know it shouldn't be
used nor needed, since it conflicts directly with the way we set dnsmasq
since #1777.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
