### PR TITLE
increase cpu/ram specs for ocp nodes in va-hci scenario

### DIFF
--- a/scenarios/reproducers/va-hci.yml
+++ b/scenarios/reproducers/va-hci.yml
@@ -70,8 +70,8 @@ cifmw_libvirt_manager_configuration:
       image_local_dir: "{{ cifmw_basedir }}/images/"
       disk_file_name: "ocp_master"
       disksize: "100"
-      cpus: 10
-      memory: 16
+      cpus: 16
+      memory: 32
       root_part_id: 4
       uefi: true
       nets:
@@ -105,7 +105,6 @@ cifmw_libvirt_manager_configuration:
       nets:
         - ocpbm
         - osp_trunk
-
 
 ## devscript support for OCP deploy
 cifmw_devscripts_config_overrides:


### PR DESCRIPTION
Trying to deploy the hci scenario, during the control-plane deployment, some pods were in "pending" status due to lack of resources so this PR should address that issue. 

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running