### PR TITLE
manila default share type: enable snapshot extra spec

### DIFF
--- a/hooks/playbooks/manila_create_default_resources.yml
+++ b/hooks/playbooks/manila_create_default_resources.yml
@@ -10,3 +10,5 @@
       ansible.builtin.shell: |
         oc -n {{ namespace }} exec -it pod/openstackclient \
           -- openstack share type create default false
+        oc -n {{ namespace }} exec -it pod/openstackclient \
+          -- openstack share type set default --extra-specs snapshot_support=True


### PR DESCRIPTION
The manila backends which are mainly targeted by deployment and testing with ci-framework (cephfs, cephfs/NFS, netapp) do all support snapshots.
Testing snapshots can always be disabled through tempest configuration. So always define the extra spec for snapshot support in the default share type.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
