### PR TITLE
Set snapshot specs in manila's default type

### DIFF
--- a/hooks/playbooks/manila_create_default_resources.yml
+++ b/hooks/playbooks/manila_create_default_resources.yml
@@ -9,6 +9,5 @@
         PATH: "{{ cifmw_path }}"
       ansible.builtin.shell: |
         oc -n {{ namespace }} exec -it pod/openstackclient \
-          -- openstack share type create default false
-        oc -n {{ namespace }} exec -it pod/openstackclient \
-          -- openstack share type set default --extra-specs snapshot_support=True
+          -- openstack share type create default false \
+          --snapshot-support True --create-share-from-snapshot-support True


### PR DESCRIPTION
These extra-specs are supported by all share backends
we test currently.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
