### PR TITLE
Add a new extra variable for holding the update's parameters

### DIFF
--- a/ci/playbooks/edpm/update.yml
+++ b/ci/playbooks/edpm/update.yml
@@ -33,4 +33,8 @@
           {%- endif %}
           -e update_playbook_run=true
           -e "@{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml"
-          -e "cifmw_repo_setup_promotion={{ cifmw_repo_setup_promotion_target }}"
+          {%- if cifmw_update_extras is defined %}
+          {%-   for key, value in cifmw_update_extras.items() %}
+          -e "{{key}}={{value}}"
+          {%-   endfor %}
+          {%- endif %}

--- a/roles/update/README.md
+++ b/roles/update/README.md
@@ -2,6 +2,6 @@
 Role to run update
 
 ## Parameters
-* `param_1`: this is an example
+* ``cifmw_update_extras`: (hash) Hold job variable that get set when running the update playbook.
 
 ## Examples


### PR DESCRIPTION
Make sure that, when we use downstream repo setup we don't hardcode
cifmw_repo_setup_promotion.

To that end, and to add more flexibility to the variables that need to
be overwritten during update, take the key/value of the
`cifmw_update_extras` hash. It should be defined in a job and would
look like this:

```
cifmw_update_extras:
 cifmw_repo_setup_promotion: promotion
 other_var: value
 ...
```

That enables the job definition to pass all variables needed for the
update job with having new variable name for each override.

It also solves the problem of the hardcoded
`cifmw_repo_setup_promotion` as now the job has total control over the
variables passed.

Jira: https://issues.redhat.com/browse/OSPRH-7811
-------

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes