### PR TITLE
Ensure virtqemud-sock is present before cleaning

### DIFF
--- a/roles/libvirt_manager/molecule/deploy_layout/prepare.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/prepare.yml
@@ -14,7 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
 - name: Prepare
   hosts: instance
   vars:
@@ -31,8 +30,16 @@
   roles:
     - role: "test_deps"
     - role: "ci_setup"
-    - role: "libvirt_manager"
   tasks:
+    - name: Cleanup layout before anything
+      ansible.builtin.import_role:
+        name: libvirt_manager
+        tasks_from: clean_layout.yml
+
+    - name: Deploy libvirt
+      ansible.builtin.import_role:
+        name: libvirt_manager
+
     - name: Ensure default network is removed
       vars:
         net_name: "default"

--- a/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/roles/libvirt_manager/tasks/clean_layout.yml
@@ -2,6 +2,11 @@
 - name: Get installed packages list
   ansible.builtin.package_facts: {}
 
+- name: Get virtqemud socket
+  register: _virtqemud
+  ansible.builtin.stat:
+    path: "/var/run/libvirt/virtqemud-sock"
+
 - name: Perform the libvirt cleanup
   when:
     - ansible_facts.packages is defined
@@ -9,6 +14,7 @@
       cifmw_libvirt_manager_dependency_packages |
       difference(ansible_facts.packages.keys()) |
       length == 0
+    - _virtqemud.stat.exists
   block:
     - name: List all of the existing virtual machines
       register: vms_list


### PR DESCRIPTION
While the usual usage is "deploy, then clean", jobs in CI might start
with a "clean, then deploy".

In such case, it might happen all of the dependencies are installed
during the node bootstrap, but libvirt services aren't switched to the
modular daemons layout, leading to a crash with the current
implementation.

This patch adds a sanity check on the virtqemud-sock file availability,
to ensure everything's fine.

Molecule job has also been modified to "clean" before "deploy" so that
we should hopefully catch issues earlier.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
