### PR TITLE
Move periodic-podified-edpm-baremetal-antelope-ocp-crc to test-operator

### DIFF
--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -45,6 +45,7 @@ cifmw_test_operator_tempest_network_attachments: []
 cifmw_test_operator_tempest_tests_include_override_scenario: false
 cifmw_test_operator_tempest_tests_exclude_override_scenario: false
 cifmw_test_operator_tempest_workflow: []
+cifmw_test_operator_edpm_ssh_key: '~/.ssh/id_cifw'
 
 # Enabling SRBAC by default, in jobs where this does not make sense should be turned off explicitly
 #

--- a/roles/test_operator/tasks/tempest-tests.yml
+++ b/roles/test_operator/tasks/tempest-tests.yml
@@ -97,7 +97,7 @@
         name: "{{ cifmw_test_operator_controller_priv_key_secret_name }}"
         namespace: "{{ cifmw_test_operator_namespace }}"
       data:
-        ssh-privatekey: "{{ lookup('file', '~/.ssh/id_cifw', rstrip=False) | b64encode }}"
+        ssh-privatekey: "{{ lookup('file', cifmw_test_operator_edpm_ssh_key|default('~/.ssh/id_cifw'), rstrip=False) | b64encode }}"
 
 - name: Add SSHKeySecretName section to Tempest CR
   when:

--- a/zuul.d/edpm_periodic.yaml
+++ b/zuul.d/edpm_periodic.yaml
@@ -51,6 +51,10 @@
     vars:
       cifmw_repo_setup_branch: antelope
       cifmw_update_containers_org: podified-{{ cifmw_repo_setup_branch }}-centos9
+      cifmw_run_test_role: test_operator
+      cifmw_test_operator_edpm_ssh_key: "/home/zuul/ci-framework-data/artifacts/edpm/ansibleee-ssh-key-id_rsa"
+      cifmw_test_operator_tempest_include_list: |
+        tempest.scenario.test_server_basic_ops.TestServerBasicOps
 
 - job:
     name: periodic-podified-multinode-edpm-deployment-antelope-ocp-crc-cs9


### PR DESCRIPTION
Moves periodic-podified-edpm-baremetal-antelope-ocp-crc to use test-operator instead of the cifmw tempest role (see related issue).

Related: https://issues.redhat.com/browse/OSPCIX-336

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
