### PR TITLE
Stop hard-coding the framework path

### DIFF
--- a/roles/reproducer/tasks/ci_job.yml
+++ b/roles/reproducer/tasks/ci_job.yml
@@ -47,7 +47,7 @@
           tags:
             - bootstrap
           ansible.builtin.template:
-            dest: "/home/zuul/src/github.com/openstack-k8s-operators/ci-framework/{{ job_id }}_play.yml"
+            dest: "{{ _cifmw_reproducer_framework_location }}/{{ job_id }}_play.yml"
             src: "play.yml.j2"
 
         - name: Push content-provider playbook if needed
@@ -57,7 +57,7 @@
              (operator_content_provider| default(false) | bool) or
              (openstack_content_provider| default(false) | bool)
           ansible.builtin.template:
-            dest: "/home/zuul/src/github.com/openstack-k8s-operators/ci-framework/{{ job_id }}_content-provider.yml"
+            dest: "{{ _cifmw_reproducer_framework_location }}/{{ job_id }}_content-provider.yml"
             src: "content-provider.yml.j2"
 
         - name: Push extracted network data on controller-0
@@ -73,7 +73,7 @@
       tags:
         - bootstrap
       ansible.builtin.copy:
-        dest: "/home/zuul/src/github.com/openstack-k8s-operators/ci-framework/pre-ci-play.yml"
+        dest: "{{ _cifmw_reproducer_framework_location }}/pre-ci-play.yml"
         src: "pre-ci-play.yml"
 
     - name: Push zuul-params.yml to expected location
@@ -106,7 +106,7 @@
     - name: Generate and run scripts
       vars:
         _home: "/home/zuul"
-        run_directory: "{{ _home }}/src/github.com/openstack-k8s-operators/ci-framework/"
+        run_directory: "{{ _cifmw_reproducer_framework_location }}"
       block:
         - name: Generate pre-ci-play script
           vars:

--- a/roles/reproducer/tasks/configure_architecture.yml
+++ b/roles/reproducer/tasks/configure_architecture.yml
@@ -4,7 +4,7 @@
   block:
     - name: Push script
       vars:
-        run_directory: "src/github.com/openstack-k8s-operators/ci-framework"
+        run_directory: "{{ _cifmw_reproducer_framework_location }}"
         exports:
           ANSIBLE_LOG_PATH: "~/ansible-deploy-architecture.log"
         default_extravars:

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -28,6 +28,32 @@
     - cifmw_job_uri is defined
   ansible.builtin.include_tasks: ci_data.yml
 
+- name: Discover and expose CI Framework path on remote node
+  vars:
+    default_path: >-
+      {{
+        cifmw_reproducer_default_repositories |
+        selectattr('src', 'match', '^.*/ci[_\-]framework$') |
+        map(attribute='dest') | first
+      }}
+    custom_path: >-
+      {{
+        cifmw_reproducer_repositories |
+        selectattr('src', 'match', '^.*/ci-framework$') |
+        map(attribute='dest')
+      }}
+    _path: >-
+      {{
+        (custom_path | length > 0) |
+        ternary(custom_path | first, default_path)
+      }}
+  ansible.builtin.set_fact:
+    _cifmw_reproducer_framework_location: >-
+      {{
+        (_path is match('.*/ci-framwork/?$')) |
+        ternary(_path, [_path, 'ci-framework'] | path_join)
+      }}
+
 - name: Build final libvirt layout
   when:
     - cifmw_use_libvirt | default(false) | bool
@@ -228,7 +254,7 @@
             ANSIBLE_LOG_PATH: "~/ansible-bootstrap.log"
           no_log: "{{ cifmw_nolog | default(true) | bool }}"
           ansible.builtin.command:
-            chdir: "/home/zuul/src/github.com/openstack-k8s-operators/ci-framework"
+            chdir: "{{ _cifmw_reproducer_framework_location }}"
             cmd: >-
               ansible-playbook -i ~/ci-framework-data/artifacts/zuul_inventory.yml
               -e @~/ci-framework-data/parameters/reproducer-variables.yml
@@ -289,7 +315,7 @@
         - cifmw_job_uri is undefined
       delegate_to: controller-0
       vars:
-        run_directory: "src/github.com/openstack-k8s-operators/ci-framework"
+        run_directory: "{{ _cifmw_reproducer_framework_location }}"
         exports:
           ANSIBLE_LOG_PATH: "~/ansible-deploy-edpm.log"
         default_extravars:

--- a/roles/reproducer/tasks/push_code.yml
+++ b/roles/reproducer/tasks/push_code.yml
@@ -153,5 +153,5 @@
 - name: Install collections on controller-0
   delegate_to: controller-0
   ansible.builtin.command:
-    chdir: "/home/zuul/src/github.com/openstack-k8s-operators/ci-framework"
+    chdir: "{{ _cifmw_reproducer_framework_location }}"
     cmd: ansible-galaxy collection install --upgrade --force .

--- a/roles/reproducer/templates/content-provider.yml.j2
+++ b/roles/reproducer/templates/content-provider.yml.j2
@@ -45,6 +45,7 @@
   vars:
     cifmw_rp_registry_firewall: false
     job_id: "{{ job_id }}"
+    _cifmw_reproducer_framework_location: "{{ _cifmw_reproducer_framework_location }}"
   tasks:
 {% if operator_content_provider | default('false') | bool %}
 {% raw %}
@@ -114,7 +115,7 @@
       environment:
         ANSIBLE_LOG_PATH: "~/ansible-openstack-content-provider-{{job_id }}.log"
       ansible.builtin.command:
-        chdir: "/home/zuul/src/github.com/openstack-k8s-operators/ci-framework"
+        chdir: "{{ _cifmw_reproducer_framework_location }}"
         cmd: >-
           ansible-playbook ci/playbooks/tcib/tcib.yml
           -i "~/ci-framework-data/artifacts/zuul_inventory.yml"


### PR DESCRIPTION
It may happen a user doesn't want to copy the framework in the
"standard" location, or that they are using some other tools that clone
the framework from another provider.

In such case, controller-0 might see the framework cloned in some other
tree, meaning all of the generated content.

Let's try to be more flexible by using the user provided data, while
defaulting to the standard location.

The internal _cifmw_reproducer_framework_location fact is available
since the very start of the reproducer role call, ensuring we're able to
use it even for new features.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
