### PR TITLE
Add extra-disks to va1 scenario file

### DIFF
--- a/scenarios/reproducers/va-hci.yml
+++ b/scenarios/reproducers/va-hci.yml
@@ -70,6 +70,8 @@ cifmw_libvirt_manager_configuration:
       image_local_dir: "{{ cifmw_basedir }}/images/"
       disk_file_name: "ocp_master"
       disksize: "100"
+      extra_disks_num: 3
+      extra_disks_size: "50G"
       cpus: 16
       memory: 32
       root_part_id: 4


### PR DESCRIPTION
Since downstream VA1 jobs uses extra-disks for lvm by default, we are adding this configuration to va-hci scenario file.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
