### PR TITLE
Donot filter cifmw_update_containers_registry only for reproducer job

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -358,7 +358,6 @@
             rejectattr('key', 'equalto', 'cifmw_extras') |
             rejectattr('key', 'equalto', 'cifmw_openshift_kubeconfig') |
             rejectattr('key', 'equalto', 'cifmw_openshift_token') |
-            rejectattr('key', 'equalto', 'cifmw_update_containers_registry') |
             rejectattr('key', 'equalto', 'cifmw_networking_env_definition') |
             rejectattr('key', 'match', '^cifmw_use_(?!lvms).*') |
             rejectattr('key', 'match', '^cifmw_reproducer.*') |

--- a/roles/reproducer/templates/content-provider.yml.j2
+++ b/roles/reproducer/templates/content-provider.yml.j2
@@ -102,8 +102,7 @@
         content: |-
           {{
             {'cifmw_operator_build_output': cifmw_operator_build_output,
-             'content_provider_registry_ip': cifmw_rp_registry_ip,
-             'cifmw_update_containers_registry': cifmw_rp_registry_ip
+             'content_provider_registry_ip': cifmw_rp_registry_ip
             } | to_nice_yaml
           }}
 {% endraw %}


### PR DESCRIPTION
in component job, the zuul inventory looks like this
```
cifmw_set_openstack_containers_registry: '{{ content_provider_registry_ip }}:5001'
```
    
We need to set content_provider_registry_ip var via reproducer content provider running from controller-0. Then zuul inventory generated by reproducer edpm job will take care of setting proper var for
cifmw_set_openstack_containers_registry or cifmw_update_containers_registry.
    
We donot need to filter out.
    
Note: cifmw_update_containers_registry was passed to the operator content provider by mistake. It is not needed there.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
