### PR TITLE
Ensure we don't try to set resources via dev-scripts

### DIFF
--- a/roles/reproducer/molecule/ocp_validations/converge.yml
+++ b/roles/reproducer/molecule/ocp_validations/converge.yml
@@ -18,6 +18,9 @@
 - name: Prepare
   hosts: all
   gather_facts: false
+  vars:
+    _default_devscripts:
+      num_extra_workers: 0
   tasks:
     - name: Set failed fact
       ansible.builtin.set_fact:
@@ -45,6 +48,11 @@
           {{
             cifmw_libvirt_manager_configuration |
             combine(item.layout_patch | default({}), recursive=true)
+          }}
+        cifmw_devscripts_config: >-
+          {{
+            _default_devscripts |
+            combine(item.devscripts_conf | default({}), recursive=true)
           }}
       ansible.builtin.include_tasks:
         file: "tasks/test.yml"

--- a/roles/reproducer/molecule/ocp_validations/vars/scenarios.yml
+++ b/roles/reproducer/molecule/ocp_validations/vars/scenarios.yml
@@ -81,3 +81,21 @@ scenarios:
       - /dev/vdb
     lvms_disk:
       - /dev/vda
+
+  - scenario: Config overrides via devscripts
+    should_fail: true
+    env_file: no-volume.yml
+    devscripts_conf:
+      master_memory: 16000
+      vm_extradisks_size: 50G
+
+  - scenario: Inject 10 dev-scripts extra_worker
+    should_fail: true
+    env_file: no-volume.yml
+    devscripts_conf:
+      num_extra_workers: 10
+
+  - scenario: Inject 0 dev-scripts extra_worker
+    env_file: no-volume.yml
+    devscripts_conf:
+      num_extra_workers: 0

--- a/roles/reproducer/tasks/ocp_layout.yml
+++ b/roles/reproducer/tasks/ocp_layout.yml
@@ -1,5 +1,13 @@
 ---
-- name: Import assertions
+# First build devscripts configuration.
+# This will ensure we check the content with the
+# user changes.
+- name: Build devscripts overrides for assertions
+  ansible.builtin.include_role:
+    name: "devscripts"
+    tasks_from: "build_config.yml"
+
+- name: Validate environment parameters
   ansible.builtin.import_tasks: ocp_layout_assertions.yml
 
 - name: Push OCP related DNS entries

--- a/roles/reproducer/tasks/ocp_layout_assertions.yml
+++ b/roles/reproducer/tasks/ocp_layout_assertions.yml
@@ -2,6 +2,37 @@
 # A series of assertions around the OCP layout.
 # They are in a dedicated tasks file so that we can
 # easily test them in molecule.
+
+- name: Ensure we don't try to pass resources via devscripts_overrides
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - cifmw_devscripts_config.master_memory is undefined
+      - cifmw_devscripts_config.master_disk is undefined
+      - cifmw_devscripts_config.master_vcpu is undefined
+      - cifmw_devscripts_config.worker_memory_mb is undefined
+      - cifmw_devscripts_config.worker_disk is undefined
+      - cifmw_devscripts_config.worker_vcpu is undefined
+      - cifmw_devscripts_config.vm_extradisks is undefined
+      - cifmw_devscripts_config.vm_extradisks_list is undefined
+      - cifmw_devscripts_config.vm_extradisks_size is undefined
+    msg: >-
+      Inconsistency detected: your environment wants to provide
+      devscripts configuration overrides. This isn't supported,
+      and you must pass those ressource allocation via the usual
+      cifmw_libvirt_manager_configuration, or patch it.
+
+- name: Ensure we don't try to create extra_workers
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - cifmw_devscripts_config.num_extra_workers is undefined or
+        cifmw_devscripts_config.num_extra_workers == 0
+    msg: >-
+      Inconsistency detected: dev-scripts extra_worker resources
+      aren't supported here. You can create compute, networker or any
+      other kind of VM by defining it as you define OCP cluster nodes.
+
 - name: Ensure we get required data in the layout description
   vars:
     _element: "{{ _cifmw_libvirt_manager_layout.vms.ocp }}"

--- a/scenarios/reproducers/bgp-4-racks-3-ocps.yml
+++ b/scenarios/reproducers/bgp-4-racks-3-ocps.yml
@@ -367,12 +367,6 @@ cifmw_libvirt_manager_configuration:
           - "l31-ocp1"
           - "l31-ocp2"
 
-## devscript support for OCP deploy
-cifmw_devscripts_config_overrides:
-  worker_memory: 16384
-  worker_disk: 100
-  worker_vcpu: 10
-  num_extra_workers: 0
 # Required for egress traffic from pods to the osp_trunk network
 cifmw_devscripts_enable_ocp_nodes_host_routing: true
 

--- a/scenarios/reproducers/va-hci.yml
+++ b/scenarios/reproducers/va-hci.yml
@@ -108,10 +108,6 @@ cifmw_libvirt_manager_configuration:
 
 ## devscript support for OCP deploy
 cifmw_devscripts_config_overrides:
-  worker_memory: 16384
-  worker_disk: 100
-  worker_vcpu: 10
-  num_extra_workers: 0
   fips_mode: "{{ cifmw_fips_enabled | default(false) | bool }}"
 
 # Note: with that extra_network_names "osp_trunk", we instruct


### PR DESCRIPTION
With #1777, we now configure VMs exclusively via the libvirt_manager
role.

In order to avoid any surprise, we now have a validation against any of
the devscripts configuration overrides.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
