### PR TITLE
[polarion] Merge xmls with junitparser 

### DIFF
--- a/roles/polarion/tasks/main.yml
+++ b/roles/polarion/tasks/main.yml
@@ -63,6 +63,12 @@
         state: latest # noqa: package-latest
         extra_args: --upgrade
 
+    - name: Install junitparser
+      ansible.builtin.pip:
+        name: junitparser
+        virtualenv: "{{ cifmw_polarion_jump_repo_dir }}/jump-venv"
+        state: latest # noqa: package-latest
+
     - name: Use polarion-staging
       when:
         - cifmw_polarion_use_stage
@@ -88,6 +94,13 @@
       ansible.builtin.debug:
         var: pylero_output.stdout_lines
 
+    - name: Merge result XML files
+      ansible.builtin.shell:
+        chdir: "{{ cifmw_polarion_jump_result_dir }}"
+        cmd: >-
+          source "{{ cifmw_polarion_jump_repo_dir }}/jump-venv/bin/activate" &&
+          junitparser merge {{ xml_files.files | json_query('[*].path') | join(' ') }} ./results_merged.xml
+
     - name: Update Test Runs
       ansible.builtin.shell:
         chdir: "{{ cifmw_polarion_jump_repo_dir }}"
@@ -95,10 +108,9 @@
           source "{{ cifmw_polarion_jump_repo_dir }}/jump-venv/bin/activate" &&
           {{ cifmw_polarion_jump_repo_dir }}/jump-venv/bin/python jump.py
           --testrun-id={{ cifmw_polarion_testrun_id }}
-          --xml-file={{ item.path }}
+          --xml-file={{ cifmw_polarion_jump_result_dir }}/results_merged.xml
           --update_testcases={{ cifmw_polarion_update_testcases | default(false) }}
           {{ cifmw_polarion_jump_extra_vars | default ('') }}
-      loop: "{{ xml_files.files }}"
       register: jump_script
 
     - name: Output of jump


### PR DESCRIPTION
In case there are multiple xml files that need to be reported
to polarion, we need to merge them before passing them to jump.
Using junitparser even in cases where there is only one xml file
will have these benefits:
* we don't have to write when conditions
* the output xml will have the same structure - the content will
be wrapped in <testsuites> tags whether we have more xml results
or not - testsuite in junitparser context equals to one xml input.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
