### PR TITLE
Move cifmw-crc-podified-edpm-baremetal back to crc-2-30

### DIFF
--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -11,7 +11,7 @@
 # Virtual Baremetal job with CRC and single compute node.
 - job:
     name: cifmw-crc-podified-edpm-baremetal
-    nodeset: centos-9-crc-2-36-0-6xlarge
+    nodeset: centos-9-crc-2-30-0-6xlarge # TODO(marios) bump crc after OSPCIX-336
     parent: cifmw-base-crc-openstack
     run: ci/playbooks/edpm_baremetal_deployment/run.yml
     vars:


### PR DESCRIPTION
Due to related issue, this moves the cifmw-crc-podified-edpm-baremetal to centos-9-crc-2-30-0-6xlarge, which is a partial revert for [1]

Related: https://issues.redhat.com/browse/OSPCIX-336

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/1830

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
