### PR TITLE
Change the python script shebang to a sane default

### DIFF
--- a/plugins/action/ci_kustomize.py
+++ b/plugins/action/ci_kustomize.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 # Copyright Red Hat, Inc.
 # Apache License Version 2.0 (see LICENSE)

--- a/plugins/action/ci_net_map.py
+++ b/plugins/action/ci_net_map.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 # Copyright Red Hat, Inc.
 # Apache License Version 2.0 (see LICENSE)

--- a/plugins/filter/reproducer_gerrit_infix.py
+++ b/plugins/filter/reproducer_gerrit_infix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 __metaclass__ = type
 

--- a/plugins/filter/reproducer_refspec.py
+++ b/plugins/filter/reproducer_refspec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 __metaclass__ = type
 

--- a/plugins/filter/to_nice_yaml_all.py
+++ b/plugins/filter/to_nice_yaml_all.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 from __future__ import absolute_import, division, print_function
 

--- a/roles/ci_gen_kustomize_values/filter_plugins/cifmw_gen_kustomize_values_b64_combine.py
+++ b/roles/ci_gen_kustomize_values/filter_plugins/cifmw_gen_kustomize_values_b64_combine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 __metaclass__ = type
 

--- a/roles/ci_nmstate/filter_plugins/ci_nmstate_map_instance_nets.py
+++ b/roles/ci_nmstate/filter_plugins/ci_nmstate_map_instance_nets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 __metaclass__ = type
 

--- a/roles/ci_nmstate/library/ci_nmstate_apply_state.py
+++ b/roles/ci_nmstate/library/ci_nmstate_apply_state.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 # Copyright: (c) 2023, Pablo Rodriguez <pabrodri@redhat.com>
 # Apache License Version 2.0 (see LICENSE)

--- a/roles/kustomize_deploy/filter_plugins/ci_kustomize_deploy_combine_base64_patch_dict.py
+++ b/roles/kustomize_deploy/filter_plugins/ci_kustomize_deploy_combine_base64_patch_dict.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 __metaclass__ = type
 

--- a/scripts/create_role_molecule.py
+++ b/scripts/create_role_molecule.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 # Copyright Red Hat, Inc.
 # All Rights Reserved.


### PR DESCRIPTION
In rare corner case, the shebang `#!/usr/bin/env python3` wasn't interpreted correctly by ansible and it led to failures during tasks involving module called with `become: true` arguments.

It's a cheap workaround, but it won't hurt.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
