### PR TITLE
Modify libvirt_manager to run linear instead of batches

### DIFF
--- a/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/roles/libvirt_manager/tasks/clean_layout.yml
@@ -56,7 +56,7 @@
       community.libvirt.virt:
         command: undefine
         flags:
-          - keep_nvram
+          - nvram
           - snapshots_metadata
         name: "{{ item }}"
         uri: "qemu:///system"
@@ -187,7 +187,7 @@
            default([])
         }}
 
-    - name: Remove cifmw storage pool
+    - name: Remove OCP volumes storage pool
       tags:
         - never
         - deepscrub

--- a/roles/libvirt_manager/tasks/create_networks.yml
+++ b/roles/libvirt_manager/tasks/create_networks.yml
@@ -81,7 +81,6 @@
   loop_control:
     label: "{{ item.name }}"
 
-
 ## Ensure we get dnsmasq DHCP service for all created networks
 # Refreshing network facts will ensure we get the new interfaces.
 # They (usually?) have the same name as the network itself.
@@ -178,29 +177,22 @@
   loop_control:
     label: "{{ item.name }}"
 
-- name: Ensure network is not in public zone
+- name: Ensure network is in correct zone
   become: true
   notify: Restart firewalld
-  ansible.builtin.command:
+  ansible.builtin.shell:
     cmd: >-
       firewall-cmd --zone public
       --remove-interface={{ item.name }}
-      --permanent
-  loop: "{{ networks }}"
-  loop_control:
-    label: "{{ item.name }}"
-
-- name: Ensure network is in libvirt zone
-  become: true
-  notify: Restart firewalld
-  ansible.builtin.command:
-    cmd: >-
+      --permanent;
       firewall-cmd --zone libvirt
       --add-interface={{ item.name }}
-      --permanent
+      --permanent;
   loop: "{{ networks }}"
   loop_control:
     label: "{{ item.name }}"
+  async: 120
+  poll: 0
 
 - name: Extract public IP address from network bridge
   block:

--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -4,14 +4,18 @@
   vars:
     _base_img_name: >-
       {{
-        (vm_data.value.image_local_dir | default(ansible_user_dir),
-         vm_data.value.disk_file_name) |
+        (vm_data.image_local_dir | default(ansible_user_dir),
+         vm_data.disk_file_name) |
          path_join
+      }}
+    _vm_id: >-
+      {{
+        vm | split('-') | last
       }}
     _img: >-
       {{
-        (vm_type is match('.*ocp.*')) |
-        ternary(_base_img_name ~ "-" ~ vm_id ~ ".qcow2",
+        (vm is match('.*ocp.*')) |
+        ternary(_base_img_name ~ "-" ~ _vm_id ~ ".qcow2",
                 _base_img_name)
       }}
     _workload: "{{ cifmw_libvirt_manager_basedir }}/workload"
@@ -19,151 +23,103 @@
     _chdir: >-
       {{ (is_base_img | default(false) | bool) | ternary(_img_dir, _workload) }}
   block:
-    - name: "Create VM image for {{ vm_type }}"
+    - name: "Create VM image for {{ vm }}"
       vars:
         _vm_img: >-
-          {{ vm_type }}-{{ vm_id }}.qcow2
+          {{ vm }}.qcow2
       ansible.builtin.command:
         cmd: >-
           qemu-img create
-          {% if vm_data.value.disk_file_name != 'blank' %}
+          {% if vm_data.disk_file_name != 'blank' %}
           -o backing_file={{ _img }},backing_fmt=qcow2
           {% endif %}
           -f qcow2
           "{{ _vm_img }}"
-          "{{ vm_data.value.disksize|default ('40') }}G"
+          "{{ vm_data.disksize | default ('40') }}G"
         creates: "{{ _vm_img }}"
         chdir: "{{ _chdir }}"
-      loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
-      loop_control:
-        index_var: vm_id
-        label: "{{ vm_type }}-{{ vm_id }}"
 
-    - name: "Ensure file ownership and rights for {{ vm_type }}"
+    - name: "Ensure file ownership and rights for {{ vm }}"
       become: true
       vars:
         _vm_img: >-
-          {{ vm_type }}-{{ vm_id }}.qcow2
+          {{ vm }}.qcow2
       ansible.builtin.file:
         path: "{{ (_chdir, _vm_img) | path_join }}"
         group: "qemu"
         mode: "0664"
         owner: "{{ ansible_user_id }}"
         state: file
-      loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
-      loop_control:
-        index_var: vm_id
-        label: "{{ vm_type }}-{{ vm_id }}"
 
-    - name: "Define VMs for type {{ vm_type }}"
+    - name: "Define VMs for type {{ vm }}"
       community.libvirt.virt:
         command: define
         xml: "{{ lookup('template', cifmw_libvirt_manager_vm_template) }}"
         uri: "qemu:///system"
-      loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
-      loop_control:
-        index_var: vm_id
-        label: "{{ vm_type }}-{{ vm_id }}"
 
-- name: "Attach listed networks to the VMs {{ vm_type }}"  # noqa: no-handler
+- name: "Attach listed networks to the VMs {{ vm }}"
   vars:
-    vm_item: >-
-      {{ vm_type }}-{{ vm_id }}
-    networks: "{{ vm_data.value.nets }}"
+    vm_item: "{{ vm }}"
+    networks: "{{ vm_data.nets }}"
   ansible.builtin.include_tasks: net_to_vms.yml
-  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
-  loop_control:
-    index_var: vm_id
-    label: "{{ vm_type }}-{{ vm_id }}"
 
-- name: "Attach spines/leafs networks to the VMs {{ vm_type }}"
+- name: "Attach spines/leafs networks to the VMs {{ vm }}"
   when:
     - cifmw_libvirt_manager_spineleaf_setup
-    - vm_data.value.spineleafnets is defined
+    - vm_data.spineleafnets is defined
   vars:
-    vm_item: >-
-      {{ vm_type }}-{{ vm_id }}
-    networks: "{{ vm_data.value.spineleafnets[vm_id] }}"
+    _vm_id: >-
+      {{
+        vm | split('-') | last
+      }}
+    vm_item: "{{ vm }}"
+    networks: "{{ vm_data.spineleafnets[_vm_id | int] }}"
   ansible.builtin.include_tasks: net_to_vms.yml
-  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
-  loop_control:
-    index_var: vm_id
-    label: "{{ vm_type }}-{{ vm_id }}"
 
-- name: "Manage volumes for VMs {{ vm_type }}"
+- name: "Manage volumes for VMs {{ vm }}"
   when:
-    - vm_data.value.extra_disks_num is defined
-    - vm_data.value.extra_disks_num | int > 0
+    - vm_data.extra_disks_num is defined
+    - vm_data.extra_disks_num | int > 0
   vars:
     _pool_dir: >-
       {{
-        (vm_type is match('^ocp.*')) |
+        (vm is match('^ocp.*')) |
         ternary(cifmw_libvirt_manager_ocp_pool_dir,
                 cifmw_libvirt_manager_pool_dir)
       }}
-    _vname: "{{ (vm_type == 'ocp') | ternary('ocp_master', vm_type)}}"
+    _vname: >-
+      {{
+        vm | regex_replace('ocp-([0-9]+)', 'ocp_master-\1')
+      }}
+    vol_prefix: >-
+      {{
+        [cifmw_libvirt_manager_vol_prefix,
+        'cifmw-', _vname] | join('')
+      }}
   block:
-    - name: "Create the requested extra disks for {{ vm_type }}"
+    - name: "Create the requested extra disks for {{ vm }}"
       vars:
-        vol_prefix: >-
-          {{
-            [cifmw_libvirt_manager_vol_prefix,
-            'cifmw-', _vname, '-', vm_id] | join('')
-          }}
-        vol_num: "{{ vm_data.value.extra_disks_num }}"
-        vol_size: "{{ vm_data.value.extra_disks_size }}"
+        vol_num: "{{ vm_data.extra_disks_num }}"
+        vol_size: "{{ vm_data.extra_disks_size }}"
       ansible.builtin.include_tasks: volumes.yml
-      loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
-      loop_control:
-        index_var: vm_id
-        label: "{{ vm_type }}-{{ vm_id }}"
-        loop_var: vms_id
 
-    - name: "Find volume attachments for VMs {{ vm_type }}"
+    - name: "Find volume attachments for VM {{ vm }}"
       register: _found_vols
-      vars:
-        vol_prefix: >-
-          {{
-            [cifmw_libvirt_manager_vol_prefix,
-            'cifmw-', _vname, '-', vm_id] | join('')
-          }}
       ansible.builtin.find:
         path: "{{ _pool_dir }}"
         pattern: "{{ vol_prefix }}-vol-*.xml"
-      loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
-      loop_control:
-        index_var: vm_id
-        label: "{{ vm_type }}-{{ vm_id }}"
 
-    - name: "Attach volumes for VMs {{ vm_type }}"
-      register: _attach
+    - name: "Attach volumes for VM {{ vm }}"
       when:
-        - _res.matched != 0
+        - _found_vols.matched != 0
       vars:
-        _vm_name: "cifmw-{{ vm_type }}-{{ _res.item }}"
+        _vm_name: "cifmw-{{ vm }}"
       ansible.builtin.shell:
         cmd: >-
           set -o pipefail;
-          {% for f in _res.files -%}
+          {% for f in _found_vols.files -%}
           {% set _vol = f.path | basename | replace('.xml', '') -%}
           virsh domblklist {{ _vm_name }} | grep {{ _vol }} ||
           virsh -c qemu:///system attach-device {{ _vm_name }} {{ f.path }}
           --config --persistent;
           {% endfor -%}
-      loop: "{{ _found_vols.results }}"
-      loop_control:
-        loop_var: _res
-        label: "cifmw-{{ vm_type }}-{{ _res.item }}"
-
-- name: "Start (power-on) {{ vm_type }}"
-  when:
-    - vm_data.value.start | default(true) | bool
-    - "vm_data.value.disk_file_name != 'blank'"
-  ansible.builtin.include_tasks: start_vms.yml
-
-- name: "Grab IP address and manage {{ vm_type }}"
-  when:
-    - vm_data.value.manage | default(true) | bool
-    - vm_data.value.start | default(true) | bool
-    - "vm_data.value.disk_file_name != 'blank'"
-  ansible.builtin.include_tasks: manage_vms.yml

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -199,21 +199,54 @@
        (vm_data.value.amount | int) > 0) or
       vm_data.value.amount is undefined
   vars:
-    vm_type: "{{ vm_data.key }}"
+    _matcher: >-
+      {{
+        '(cifmw-)?' ~
+        '([a-z0-9]+)-[0-9]+'
+      }}
+    vm_type: "{{ vm | regex_replace(_matcher, '\\2') }}"
+    vm_data: >-
+      {{
+        _cifmw_libvirt_manager_layout.vms[vm_type]
+      }}
     pub_key: "{{ pub_ssh_key.content | b64decode }}"
     priv_key: "{{ priv_ssh_key.content | b64decode }}"
-    _init_admin_user: "{{ vm_data.value.admin_user | default('root') }}"
   ansible.builtin.include_tasks:
     file: create_vms.yml
-  loop: >-
-    {{
-      _cifmw_libvirt_manager_layout.vms | dictsort(reverse=true) |
-      community.general.dict | dict2items
-    }}
+  loop: "{{ cifmw_libvirt_manager_all_vms }}"
   loop_control:
-    label: "{{ vm_data.key }}"
-    loop_var: vm_data
-    index_var: family_id
+    loop_var: vm
+
+- name: "Start (power-on) VMs"
+  ansible.builtin.include_tasks: start_vms.yml
+
+- name: "Configure managed VMs"
+  when:
+    - vm_data.manage | default(true) | bool
+    - vm_data.start | default(true) | bool
+    - vm_data.disk_file_name != 'blank'
+  vars:
+    _matcher: >-
+      {{
+        '(cifmw-)?' ~
+        '([a-z0-9]+)-[0-9]+'
+      }}
+    vm_type: "{{ vm | regex_replace(_matcher, '\\2') }}"
+    vm_data: >-
+      {{
+        _cifmw_libvirt_manager_layout.vms[vm_type]
+      }}
+    _init_admin_user: "{{ vm_data.value.admin_user | default('root') }}"
+    extracted_ip: >-
+      {{
+        _libvirt_manager_networking.instances[vm].networks[cifmw_libvirt_manager_pub_net]['ip_v4']
+      }}
+    pub_key: "{{ pub_ssh_key.content | b64decode }}"
+    priv_key: "{{ priv_ssh_key.content | b64decode }}"
+  ansible.builtin.include_tasks: manage_vms.yml
+  loop: "{{ cifmw_libvirt_manager_all_vms }}"
+  loop_control:
+    loop_var: vm
 
 - name: Create VBMC entity
   when:

--- a/roles/libvirt_manager/tasks/generate_networking_data.yml
+++ b/roles/libvirt_manager/tasks/generate_networking_data.yml
@@ -60,6 +60,8 @@
 #
 # START generate all IPs using networking_mapper role/module
 - name: Inject all VMs in the inventory
+  when:
+    - (_cifmw_libvirt_manager_layout.vms[_vm_type].amount | default(1) | int) > 0
   vars:
     _vm_type: "{{ item.key | regex_replace('(cifmw\\-)?([a-z]+)\\-[0-9]+', '\\2') }}"
     _std_group: "{{ (_vm_type == 'crc') | ternary('ocp', _vm_type) }}"

--- a/roles/libvirt_manager/tasks/manage_vms.yml
+++ b/roles/libvirt_manager/tasks/manage_vms.yml
@@ -1,106 +1,60 @@
 ---
-- name: "(localhost) Inject ssh jumpers for {{ vm_type }}"
+- name: "(localhost) Inject ssh jumpers for {{ vm }}"
   when:
-    - vm_ip.key is match(vm_type ~ '-[0-9]+')
     - inventory_hostname != 'localhost'
     - inventory_hostname != 'instance'  # needed for molecule
   delegate_to: localhost
   vars:
-    extracted_ip: >-
-      {{
-        vm_ip.value.networks[cifmw_libvirt_manager_pub_net]['ip_v4']
-      }}
     proxy_hostname: "{{ ansible_host | default(inventory_hostname) }}"
-    vm_name: "{{ vm_ip.key }}"
   ansible.builtin.blockinfile:
     create: true
     path: "{{ lookup('env', 'HOME') }}/.ssh/config"
-    marker: "## {mark} {{ vm_name }} {{ inventory_hostname }}"
+    marker: "## {mark} {{ vm }} {{ inventory_hostname }}"
     mode: "0600"
     block: |-
-      Host {{ vm_name }} {{ vm_name }}.{{ inventory_hostname }} cifmw-{{ vm_name }} {{ extracted_ip }}
+      Host {{ vm }} {{ vm }}.{{ inventory_hostname }} cifmw-{{ vm }} {{ extracted_ip }}
         ProxyJump {{ ansible_user | default(lookup('env', 'USER')) }}@{{ proxy_hostname }}
         Hostname {{ extracted_ip }}
-        User {{ 'core' if vm_name is match('^(crc|ocp).*') else 'zuul' }}
+        User {{ 'core' if vm is match('^(crc|ocp).*') else 'zuul' }}
         StrictHostKeyChecking no
         UserKnownHostsFile /dev/null
-  loop: "{{ _libvirt_manager_networking.instances | dict2items }}"
-  loop_control:
-    loop_var: vm_ip
-    label: "{{ vm_name }}"
 
-- name: "({{ inventory_hostname }}) Inject ssh jumpers for {{ vm_type }}"  # noqa: name[template]
-  when:
-    - vm_ip.key is match(vm_type ~ '-[0-9]+')
+- name: "({{ inventory_hostname }}) Inject ssh jumpers for {{ vm }}"  # noqa: name[template]
   vars:
-    extracted_ip: >-
-      {{
-        vm_ip.value.networks[cifmw_libvirt_manager_pub_net]['ip_v4']
-      }}
     identity_file: >-
       {{
         cifmw_libvirt_manager_basedir ~ '/artifacts/cifmw_ocp_access_key' if vm_type is match('^ocp.*') else
         ansible_user_dir ~ '/.crc/machines/crc/id_ecdsa' if vm_type == 'crc' else
         ansible_user_dir ~ '/.ssh/cifmw_reproducer_key'
       }}
-    vm_name: "{{ vm_ip.key }}"
   ansible.builtin.blockinfile:
     create: true
     path: "{{ ansible_user_dir }}/.ssh/config"
-    marker: "## {mark} {{ vm_name }}"
+    marker: "## {mark} {{ vm }}"
     mode: "0600"
     block: |-
-      Host {{ vm_name }} {{ vm_name }}.{{ inventory_hostname }} cifmw-{{ vm_name }} {{ extracted_ip }}
+      Host {{ vm }} {{ vm }}.{{ inventory_hostname }} cifmw-{{ vm }} {{ extracted_ip }}
         Hostname {{ extracted_ip }}
-        User {{ 'core' if vm_name is match('^(crc|ocp)') else 'zuul' }}
+        User {{ 'core' if vm is match('^(crc|ocp)') else 'zuul' }}
         IdentityFile {{ identity_file }}
         StrictHostKeyChecking no
         UserKnownHostsFile /dev/null
-  loop: "{{ _libvirt_manager_networking.instances | dict2items }}"
-  loop_control:
-    loop_var: vm_ip
-    label: "{{ vm_name }}"
 
 - name: Inject nodes in the ansible inventory
-  when:
-    - vm_ip.key is match(vm_type ~ '-[0-9]+')
   delegate_to: localhost
-  vars:
-    vm_name: "{{ vm_ip.key }}"
+  when:
+    - (_cifmw_libvirt_manager_layout.vms[vm_type].amount | default(1) | int) > 0
   ansible.builtin.add_host:
-    name: "{{ vm_name }}"
+    name: "{{ vm }}"
     groups: "{{ (vm_type == 'crc') | ternary('ocp', vm_type) }}s"
-    ansible_host: "{{ vm_ip.key }}.{{ inventory_hostname }}"
+    ansible_host: "{{ vm }}.{{ inventory_hostname }}"
     ansible_ssh_user: >-
       {{
         _cifmw_libvirt_manager_layout.vms[vm_type].admin_user |
         default(_init_admin_user)
       }}
-  loop: "{{ _libvirt_manager_networking.instances | dict2items }}"
-  loop_control:
-    loop_var: vm_ip
-    label: "{{ vm_name }}"
 
-- name: "Wait for SSH on VMs type {{ vm_type }}"
-  when:
-    - vm_ip.key is match(vm_type ~ '-[0-9]+')
-  vars:
-    extracted_ip: >-
-      {{
-        vm_ip.value.networks[cifmw_libvirt_manager_pub_net]['ip_v4']
-      }}
-  ansible.builtin.wait_for:
-    host: "{{ extracted_ip }}"
-    port: 22
-    delay: 5
-  loop: "{{ _libvirt_manager_networking.instances | dict2items }}"
-  loop_control:
-    loop_var: vm_ip
-    label: "{{ vm_ip.key }}"
-
-- name: "Configure ssh access on type {{ vm_type }}"
-  when:
-    - vm_ip.key is match(vm_type ~ '-[0-9]+')
+- name: "Configure ssh access on type {{ vm }}"
   vars:
     _user: >-
       {{
@@ -111,60 +65,45 @@
     cmd: >-
       set -o pipefail;
       cat ~/.ssh/authorized_keys |
-      ssh -v {{ _user }}@{{ vm_ip.key }}.{{ inventory_hostname }} "cat >> ~/.ssh/authorized_keys"
+      ssh -v {{ _user }}@{{ vm }}.{{ inventory_hostname }} "cat >> ~/.ssh/authorized_keys"
   retries: 5
   delay: 10
   register: _ssh_access
   until: _ssh_access.rc == 0
-  loop: "{{ _libvirt_manager_networking.instances | dict2items }}"
-  loop_control:
-    loop_var: "vm_ip"
-    label: "{{ vm_ip.key }}"
 
-- name: "Configure VMs type {{ vm_type }}"
+- name: "Configure VMs type {{ vm }}"
   when:
-    - vm_ip.key is match(vm_type ~ '-[0-9]+')
     - vm_type is not match('^(crc|ocp).*$')
-  delegate_to: "{{ vm_ip.key }}.{{ inventory_hostname }}"
+  delegate_to: "{{ vm }}.{{ inventory_hostname }}"
   remote_user: "{{ _init_admin_user }}"
   ansible.builtin.shell:
     executable: /bin/bash
     cmd: |-
       test -d /home/zuul && exit 0;
       set -xe -o pipefail;
-      echo "{{ vm_ip.key }}" | sudo tee /etc/hostname;
+      echo "{{ vm }}" | sudo tee /etc/hostname;
       sudo hostname -F /etc/hostname;
       sudo useradd -m -d /home/zuul zuul;
       echo "zuul ALL=(ALL)  NOPASSWD: ALL" | sudo tee /etc/sudoers.d/zuul;
       sudo -u zuul mkdir -p /home/zuul/.ssh /home/zuul/src/github.com/openstack-k8s-operators;
       sudo cp ${HOME}/.ssh/authorized_keys /home/zuul/.ssh/;
       chown -R zuul: /home/zuul/.ssh;
-  loop: "{{ _libvirt_manager_networking.instances | dict2items }}"
-  loop_control:
-    loop_var: "vm_ip"
-    label: "{{ vm_ip.key }}"
 
 # TODO: consider https://docs.fedoraproject.org/en-US/fedora-coreos/storage/#_sizing_the_root_partition
 - name: Ensure we grow volume for OCP cluster members
   when:
-    - vm_ip.key is match(vm_type ~ '-[0-9]+')
-    - vm_ip.key is match('^ocp.*')
+    - vm is match('^ocp.*')
   vars:
-    _root_part: "{{ vm_data.value.root_part_id | default('1') }}"
+    _root_part: "{{ vm_data.root_part_id | default('1') }}"
   ansible.builtin.shell:
     cmd: >-
-      ssh core@{{ vm_ip.key }}.{{ inventory_hostname }}
-      "sudo growpart /dev/sda 4; sudo xfs_growfs /;"
-  loop: "{{ _libvirt_manager_networking.instances | dict2items }}"
-  loop_control:
-    loop_var: "vm_ip"
-    label: "{{ vm_ip.key }}"
+      ssh core@{{ vm }}.{{ inventory_hostname }}
+      "sudo growpart /dev/sda {{ _root_part }}; sudo xfs_growfs /;"
 
-- name: "Inject private key on hosts {{ vm_type }}"
+- name: "Inject private key on hosts {{ vm }}"
   when:
-    - vm_ip.key is match(vm_type ~ '-[0-9]+')
     - vm_type is match('^controller.*$')
-  delegate_to: "{{ vm_ip.key }}.{{ inventory_hostname }}"
+  delegate_to: "{{ vm }}.{{ inventory_hostname }}"
   remote_user: "{{ _init_admin_user }}"
   ansible.builtin.copy:
     dest: "/home/zuul/.ssh/id_cifw"
@@ -172,16 +111,11 @@
     owner: zuul
     group: zuul
     mode: "0400"
-  loop: "{{ _libvirt_manager_networking.instances | dict2items }}"
-  loop_control:
-    loop_var: "vm_ip"
-    label: "{{ vm_ip.key }}"
 
-- name: "Inject public key on hosts {{ vm_type }}"
+- name: "Inject public key on hosts {{ vm }}"
   when:
-    - vm_ip.key is match(vm_type ~ '-[0-9]+')
     - vm_type is match('^controller.*$')
-  delegate_to: "{{ vm_ip.key }}.{{ inventory_hostname }}"
+  delegate_to: "{{ vm }}.{{ inventory_hostname }}"
   remote_user: "{{ _init_admin_user }}"
   ansible.builtin.copy:
     dest: "/home/zuul/.ssh/id_cifw.pub"
@@ -189,27 +123,17 @@
     owner: zuul
     group: zuul
     mode: "0444"
-  loop: "{{ _libvirt_manager_networking.instances | dict2items }}"
-  loop_control:
-    loop_var: "vm_ip"
-    label: "{{ vm_ip.key }}"
 
 - name: Update inventory to consume correct user
   delegate_to: localhost
   when:
-    - vm_ip.key is match(vm_type ~ '-[0-9]+')
-  vars:
-    extracted_ip: >-
-      {{
-        vm_ip.value.networks[cifmw_libvirt_manager_pub_net]['ip_v4']
-      }}
+    - (_cifmw_libvirt_manager_layout.vms[vm_type].amount | default(1) | int) > 0
   ansible.builtin.add_host:
-    name: "{{ vm_ip.key }}"
+    name: "{{ vm }}"
     groups: "{{ (vm_type == 'crc') | ternary('ocp', vm_type) }}s"
-    ansible_host: "{{ vm_ip.key }}.{{ inventory_hostname }}"
-    ansible_ssh_user: "{{ _cifmw_libvirt_manager_layout.vms[vm_type].admin_user | default('zuul') }}"
+    ansible_host: "{{ vm }}.{{ inventory_hostname }}"
+    ansible_ssh_user: >-
+      {{
+        _cifmw_libvirt_manager_layout.vms[vm_type].admin_user | default('zuul')
+      }}
     host_ip: "{{ extracted_ip }}"
-  loop: "{{ _libvirt_manager_networking.instances | dict2items }}"
-  loop_control:
-    loop_var: vm_ip
-    label: "{{ vm_ip.key }}"

--- a/roles/libvirt_manager/tasks/ocp_layout.yml
+++ b/roles/libvirt_manager/tasks/ocp_layout.yml
@@ -59,16 +59,23 @@
 
     - name: Create blank images for OCP cluster resources
       vars:
-        vm_type: "{{ vm_data.key }}"
+        _matcher: >-
+          {{
+            '(cifmw-)?' ~
+            '([a-z0-9]+)-[0-9]+'
+          }}
+        vm_type: "{{ vm | regex_replace(_matcher, '\\2') }}"
+        vm_data: >-
+          {{
+            _ocp_layout.vms[vm_type]
+          }}
         is_base_img: true
       ansible.builtin.include_role:
         name: "libvirt_manager"
         tasks_from: "create_vms.yml"
-      loop: "{{ _ocp_layout['vms'] | dict2items }}"
+      loop: "{{ _vm_list }}"
       loop_control:
-        label: "{{ vm_data.key }}"
-        loop_var: vm_data
-        index_var: family_id
+        loop_var: vm
 
     - name: Create VBMC entities for OCP
       vars:

--- a/roles/libvirt_manager/tasks/start_vms.yml
+++ b/roles/libvirt_manager/tasks/start_vms.yml
@@ -9,16 +9,69 @@
   loop_control:
     label: "{{ item.key }}"
 
-# Start and manage VMs, such as injecting SSH configurations,
-# inject the VMs in the live inventory for later reference, and so on.
-# In case we create a "blank" VM, without any OS, it shouldn't be known by
-# ansible, so no access should be done.
 - name: "Start VMs for type {{ vm_type }}"
+  when:
+    - vm_data.start | default(true) | bool
+    - vm_data.disk_file_name != 'blank'
+  vars:
+    _matcher: >-
+      {{
+        '(cifmw-)?' ~
+        '([a-z0-9]+)-[0-9]+'
+      }}
+    vm_type: "{{ vm | regex_replace(_matcher, '\\2') }}"
+    vm_data: >-
+      {{
+        _cifmw_libvirt_manager_layout.vms[vm_type]
+      }}
   community.libvirt.virt:
     state: running
-    name: "cifmw-{{ vm_type }}-{{ vm_id }}"
+    name: "cifmw-{{ vm }}"
     uri: "qemu:///system"
-  loop: "{{ range(0, vm_data.value.amount | default(1) | int) }}"
+  loop: "{{ cifmw_libvirt_manager_all_vms }}"
   loop_control:
-    index_var: vm_id
-    label: "{{ vm_type }}-{{ vm_id }}"
+    loop_var: vm
+    pause: 1
+
+- name: "Wait for SSH on started VMs"
+  register: _async_wait_ssh
+  when:
+    - vm_data.start | default(true) | bool
+    - vm_data.disk_file_name != 'blank'
+  vars:
+    _matcher: >-
+      {{
+        '(cifmw-)?' ~
+        '([a-z0-9]+)-[0-9]+'
+      }}
+    vm_type: "{{ vm | regex_replace(_matcher, '\\2') }}"
+    vm_data: >-
+      {{
+        _cifmw_libvirt_manager_layout.vms[vm_type]
+      }}
+    extracted_ip: >-
+      {{
+        _libvirt_manager_networking.instances[vm].networks[cifmw_libvirt_manager_pub_net]['ip_v4']
+      }}
+  ansible.builtin.wait_for:
+    host: "{{ extracted_ip }}"
+    port: 22
+    delay: 2
+  loop: "{{ cifmw_libvirt_manager_all_vms }}"
+  loop_control:
+    loop_var: vm
+  async: 120
+  poll: 0
+
+- name: Ensure we get SSH on nodes
+  when:
+    - a_result.ansible_job_id is defined
+  ansible.builtin.async_status:
+    jid: "{{ a_result.ansible_job_id }}"
+  loop: "{{ _async_wait_ssh.results }}"
+  loop_control:
+    loop_var: a_result
+  register: a_poll_result
+  until: a_poll_result.finished
+  retries: 60
+  delay: 2

--- a/roles/libvirt_manager/tasks/volumes.yml
+++ b/roles/libvirt_manager/tasks/volumes.yml
@@ -25,7 +25,7 @@
     _vol_name: >-
       {{
         ['base-',
-         vol_prefix, '-vol-',vol_id] | join('')
+         vol_prefix, '-vol-', vol_id] | join('')
       }}
   ansible.builtin.stat:
     get_attributes: false

--- a/roles/libvirt_manager/templates/all-inventory.yml.j2
+++ b/roles/libvirt_manager/templates/all-inventory.yml.j2
@@ -1,6 +1,8 @@
 all:
   children:
-{% for vm in _cifmw_libvirt_manager_layout.vms.keys() if _cifmw_libvirt_manager_layout.vms[vm].manage | default(true) %}
+{% for vm in _cifmw_libvirt_manager_layout.vms.keys() if
+    (_cifmw_libvirt_manager_layout.vms[vm].manage | default(true) and
+     _cifmw_libvirt_manager_layout.vms[vm].amount | default(1) | int > 0) %}
     {{ (vm == 'crc') | ternary('ocp', vm) }}s:
       vars:
 {% if _cifmw_libvirt_manager_layout.vms[vm].target is defined %}

--- a/roles/libvirt_manager/templates/domain.xml.j2
+++ b/roles/libvirt_manager/templates/domain.xml.j2
@@ -1,8 +1,8 @@
 <domain type='kvm'>
-  <name>cifmw-{{ vm_type }}-{{ vm_id }}</name>
-  <memory unit='GB'>{{ vm_data.value.memory | default(2) }}</memory>
-  <vcpu placement='static'>{{ vm_data.value.cpus | default(2) }}</vcpu>
-{% if vm_data.value.uefi | default(false) | bool %}
+  <name>cifmw-{{ vm }}</name>
+  <memory unit='GB'>{{ vm_data.memory | default(2) }}</memory>
+  <vcpu placement='static'>{{ vm_data.cpus | default(2) }}</vcpu>
+{% if vm_data.uefi | default(false) | bool %}
   <os firmware="efi">
     <type arch="x86_64" machine="q35">hvm</type>
     <firmware>
@@ -13,7 +13,7 @@
     <type arch='x86_64' machine='q35'>hvm</type>
 {% endif %}
     <boot dev='hd'/>
-    <bootmenu enable='{{ vm_data.value.bootmenu_enable | default('no') }}'/>
+    <bootmenu enable='{{ vm_data.bootmenu_enable | default('no') }}'/>
   </os>
   <cpu mode='host-passthrough' check='none'/>
   <clock offset='utc'>
@@ -29,7 +29,7 @@
     <emulator>/usr/libexec/qemu-kvm</emulator>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2'/>
-      <source file='{{ _chdir }}/{{ vm_type }}-{{ vm_id }}.qcow2'/>
+      <source file='{{ _chdir }}/{{ vm }}.qcow2'/>
       <target dev='sda' bus='scsi'/>
     </disk>
     <controller type='scsi' index='0' model='virtio-scsi'>
@@ -64,14 +64,14 @@
     </controller>
     <serial type='pty'>
       <source path='/dev/pts/1'/>
-      <log file="/var/log/libvirt/qemu/{{ vm_type }}-{{ vm_id }}-serial.log" append="off"/>
+      <log file="/var/log/libvirt/qemu/{{ vm }}-serial.log" append="off"/>
       <target type='isa-serial' port='0'>
         <model name='isa-serial'/>
       </target>
       <alias name='serial0'/>
     </serial>
     <console type='pty' tty='/dev/pts/1'>
-      <log file="/var/log/libvirt/qemu/{{ vm_type }}-{{ vm_id }}-console.log" append="off"/>
+      <log file="/var/log/libvirt/qemu/{{ vm }}-console.log" append="off"/>
       <source path='/dev/pts/1'/>
       <target type='serial' port='0'/>
       <alias name='serial0'/>


### PR DESCRIPTION
The initial approach was batching VMs, meaning we were having multiple
times the same kind of `wait for SSH` and related "pause".

This patch changes how we define, start and configure the various VM, by
using `cifmw_libvirt_manager_all_vms` available since #1777.
This list is showing all of the VM created by the libvirt_manager role,
and with "simple" string transformation, we can extract the VM family
(compute, ocp, networker, etc) so that we can still access the various
configurations for each of them.

This linear approach allows to leverage `async` in various places, as
well as some other helpers to make the whole run smoother and faster.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

### not in commit message: testing
- [x] OCP deployment from scratch (via NFV TP)
- [x] OCP deployment, reusing existing base images (via spine/leaf run)
- [x] OCP deployment with volumes, from scratch
- [x] OCP deployment with volumes, reusing existing base images
- [x] OCP deployment with worker, from scratch
- [x] OCP deployment with worker, reusing existing base images
- [x] Spine/Leaf
- [x] 3-nodes (CRC) layout from scratch
- [x] 3-nodes (CRC) layout reusing existing base CRC
- [x] molecule reproducer run (cifmw_job_uri pointing to a molecule run)
- [x] NFV