### PR TITLE
Switch to dhcp-hostsfile

### DIFF
--- a/roles/dnsmasq/tasks/manage_host.yml
+++ b/roles/dnsmasq/tasks/manage_host.yml
@@ -58,6 +58,7 @@
 
 - name: Manage host entry - add
   become: true
+  notify: Reload dnsmasq
   when:
     - cifmw_dnsmasq_host_state == 'present'
   ansible.builtin.copy:

--- a/roles/dnsmasq/templates/cifmw-dnsmasq.conf.j2
+++ b/roles/dnsmasq/templates/cifmw-dnsmasq.conf.j2
@@ -9,4 +9,4 @@ dhcp-leasefile=/var/lib/dnsmasq/cifmw-dnsmasq.leases
 {% endif %}
 
 conf-dir={{ cifmw_dnsmasq_basedir }},*.conf
-dhcp-hostsdir="{{ cifmw_dnsmasq_basedir }}/dhcp-hosts.d"
+dhcp-hostsfile="{{ cifmw_dnsmasq_basedir }}/dhcp-hosts.d"


### PR DESCRIPTION
We hit a race condition with ansible creating the DHCP file with strict
rights, ionitofy kicking in, dnsmasq trying to read the file and
failing.
This prevented the service to load a DHCP host configuration, leading to
issues.

With this change, we ensure we keep a directory, but we have to trigger
the reload ourself - like before. This ensures the rights are all
applied.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
