### PR TITLE
nit: Ensure dnsmasq configuration is really cleaned

### DIFF
--- a/roles/dnsmasq/tasks/configure.yml
+++ b/roles/dnsmasq/tasks/configure.yml
@@ -117,10 +117,13 @@
     path: "/etc/systemd/system/cifmw-dnsmasq.service"
     state: absent
 
-- name: Remove main configuration file
+- name: Remove main configuration files
   become: true
   when:
     - _act == 'cleanup'
   ansible.builtin.file:
-    path: "/etc/cifmw-dnsmasq.conf"
+    path: "{{ item }}"
     state: absent
+  loop:
+    - "/etc/cifmw-dnsmasq.conf"
+    - "{{ cifmw_dnsmasq_basedir }}"


### PR DESCRIPTION
Somewhere in the history of the role, the base configuration directory
wasn't removed anymore, leading to potential conflicts due to dangling
files. This was especially the case when a user had an "old" deployment,
then updates the repository, runs a cleanup, and tries to re-deploy.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
