### PR TITLE
Move cifmw_update_containers var to scenario file

### DIFF
--- a/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
+++ b/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
@@ -82,7 +82,6 @@
       cifmw_update_containers_openstack | bool))
   vars:
     cifmw_update_containers_metadata: "{{ _ctlplane_name }}"
-    cifmw_update_containers: true
   ansible.builtin.include_role:
     name: update_containers
 

--- a/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
+++ b/scenarios/centos-9/edpm_baremetal_deployment_ci.yml
@@ -19,6 +19,9 @@ pre_infra:
 cifmw_operator_build_meta_name: "openstack-operator"
 cifmw_edpm_prepare_skip_crc_storage_creation: true
 
+# Update Containers Vars
+cifmw_update_containers: true
+
 # edpm_deploy role vars
 cifmw_deploy_edpm: true
 cifmw_edpm_deploy_baremetal: true

--- a/scenarios/centos-9/multinode-ci.yml
+++ b/scenarios/centos-9/multinode-ci.yml
@@ -17,6 +17,9 @@ post_ctlplane_deploy:
     type: playbook
     source: rabbitmq_tuning.yml
 
+# Update Containers Vars
+cifmw_update_containers: true
+
 # Enable tempest
 cifmw_run_tests: true
 

--- a/scenarios/centos-9/podified_common.yml
+++ b/scenarios/centos-9/podified_common.yml
@@ -13,6 +13,9 @@ cifmw_openshift_setup_skip_internal_registry: true
 # Disables EDPM deployment
 cifmw_deploy_edpm: false
 
+# Update Containers Vars
+cifmw_update_containers: true
+
 # Enable tempest on Podified control plane
 cifmw_run_tests: true
 


### PR DESCRIPTION
It will allow users to override the var via zuul job vars.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
