### PR TITLE
Ensure we don't expose kuebconfig in custom-params.yml

### DIFF
--- a/playbooks/01-bootstrap.yml
+++ b/playbooks/01-bootstrap.yml
@@ -19,7 +19,8 @@
           {{
             hostvars[inventory_hostname] |
             dict2items |
-            selectattr("key", "match", "^(cifmw|pre|post)_(?!install_yamls|openshift_token|openshift_login).*") |
+            selectattr("key", "match",
+                       "^(cifmw|pre|post)_(?!install_yamls|openshift_token|openshift_login|openshift_kubeconfig).*") |
             list | items2dict
           }}
 

--- a/roles/reproducer/tasks/ci_deploy_data.yml
+++ b/roles/reproducer/tasks/ci_deploy_data.yml
@@ -9,10 +9,6 @@
     - parameters/install-yamls-params.yml
     - parameters/zuul-params.yml
 
-- name: Load parameters in current runtime
-  ansible.builtin.include_vars:
-    dir: "{{ _reproducer_basedir }}/parameters"
-
 - name: Extract compute count
   vars:
     zuul_inventory: >-


### PR DESCRIPTION
This patch also prevents loading all of the CI env in the runtime. This
would expose zuul-params.yml content, which contains unfiltered
parameters, among them the kubeconfig one.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
