### PR TITLE
Only call configure_object tasks when rgw_enabled is true

### DIFF
--- a/roles/cifmw_cephadm/tasks/configure_object.yml
+++ b/roles/cifmw_cephadm/tasks/configure_object.yml
@@ -35,7 +35,6 @@
     msg: "WARNING: Swift is deployed and the endpoint exists already, ceph RGW cannot be configured as object store service"
   when:
     - cifmw_openshift_kubeconfig is defined
-    - cifmw_ceph_daemons_layout.rgw_enabled | default(true) | bool
     - swift_in_ctlplane.stdout | bool
 
 - name: Get uuid for project 'service'
@@ -59,7 +58,6 @@
   delegate_to: localhost
   when:
     - cifmw_openshift_kubeconfig is defined
-    - cifmw_ceph_daemons_layout.rgw_enabled | default(true) | bool
     - not swift_in_ctlplane.stdout | bool
     - swift_endpoints_count.stdout == "0"
 
@@ -102,6 +100,5 @@
   delegate_to: localhost
   when:
     - cifmw_openshift_kubeconfig is defined
-    - cifmw_ceph_daemons_layout.rgw_enabled | default(true) | bool
     - not swift_in_ctlplane.stdout | bool
     - swift_endpoints_count.stdout == "0"

--- a/roles/cifmw_cephadm/tasks/post.yml
+++ b/roles/cifmw_cephadm/tasks/post.yml
@@ -19,6 +19,7 @@
 
 - name: Configure ceph object store to use external ceph object gateway
   ansible.builtin.include_tasks: configure_object.yml
+  when: cifmw_ceph_daemons_layout.rgw_enabled | default(true) | bool
 
 - name: Get the ceph orchestrator status
   ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} orch status --format json"


### PR DESCRIPTION
RGW related tasks are called by playbooks/ceph.yml only if `cifmw_ceph_daemons_layout.rgw_enabled` is true but the post tasks in the cifmw_cephadm role need the same rule. This patch adds that rule.

We didn't discover this until PR 1821 merged. The "Create swift service, user and roles" task in post, only ran when `cifmw_ceph_daemons_layout.rgw_enabled` was true. When PR 1821 merged it added tasks to do the same but they didn't have this condition. Those conditions are removed by this patch as the entire configure_boject tasks file is no longer included by post (and only post includes that file) unless `cifmw_ceph_daemons_layout.rgw_enabled` is true.

Jira: https://issues.redhat.com/browse/OSPRH-7889

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
