### PR TITLE
Allow skipping public network creation

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -39,6 +39,7 @@ are shared among multiple roles:
 - `cifmw_config_nmstate`: (Bool) toggle NMstate networking deployment. Default to false.
 - `cifmw_config_bmh`: (Bool) toggle Metal3 BareMetalHost CRs deployment. Default to false.
 - `cifmw_config_certmanager`: (Bool) toggle cert-manager deployment. Default to false.
+- `cifmw_skip_os_net_setup`: (bool) Specifies whether os_net_setup should be executed. Default to false.
 - `cifmw_ssh_keytype`: (String) Type of ssh keys that will be injected into the controller in order to connect to the rest of the nodes. Defaults to `ecdsa`.
 - `cifmw_ssh_keysize`: (Integer) Size of ssh keys that will be injected into the controller in order to connect to the rest of the nodes. Defaults to 521.
 - `cifmw_architecture_repo`: (String) Path of the architecture repository on the controller node.

--- a/playbooks/07-admin-setup.yml
+++ b/playbooks/07-admin-setup.yml
@@ -14,6 +14,7 @@
     - name: Create openstack network elements
       ansible.builtin.import_role:
         name: os_net_setup
+      when: not cifmw_skip_os_net_setup | default('false') | bool
 
 - name: Run post_admin_setup hooks
   vars:


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes

NFV sets up resources using openTofu this step is creating an extra network which blocks our automation, added a condition to allow skipping it.