### PR TITLE
Switch update playbook to use update_containers role

### DIFF
--- a/playbooks/update.yml
+++ b/playbooks/update.yml
@@ -11,13 +11,12 @@
       ansible.builtin.include_role:
         name: repo_setup
 
-    - name: Update all openstack services containers env vars in meta operator with tag from delorean
+    - name: Update all openstack services containers with tag from delorean
       vars:
-        cifmw_set_openstack_containers_dlrn_md5_path: "{{ cifmw_basedir }}/artifacts/repositories/delorean.repo.md5"
-        cifmw_set_openstack_containers_tag_from_md5: true
-        cifmw_set_openstack_containers_extra_vars: "{{ cifmw_edpm_prepare_extra_vars }}"
+        cifmw_update_containers_tag: "{{ cifmw_repo_setup_full_hash }}"
+        cifmw_update_containers_openstack: true
       ansible.builtin.include_role:
-        name: set_openstack_containers
+        name: update_containers
 
 - name: Sync repos for controller to compute
   hosts: computes


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
