### PR TITLE
Remove nmcli call on controller-0

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -438,22 +438,6 @@
       ansible.builtin.import_role:
         name: networking_mapper
 
-    - name: Configure ctlplane interface on controller-0
-      become: true
-      vars:
-        _ctlplane_net: "{{ cifmw_networking_env_definition.networks.ctlplane }}"
-        _controller_data: "{{ cifmw_networking_env_definition.instances['controller-0'].networks.ctlplane}}"
-        _prefix: "{{ _ctlplane_net.network_v4 | ansible.utils.ipaddr('prefix') }}"
-      community.general.nmcli:
-        autoconnect: true
-        conn_name: ctlplane
-        dns4: "{{ _ctlplane_net.dns_v4.0 }}"
-        ifname: "{{ _controller_data.interface_name }}"
-        type: ethernet
-        ip4: "{{ _controller_data.ip_v4 }}/{{ _prefix }}"
-        never_default4: true
-        state: present
-
     - name: Inject CRC related content if needed
       when:
         - _cifmw_libvirt_manager_layout.vms.crc is defined


### PR DESCRIPTION
Since we now have proper DHCP with fixed IPs on all managed networks, we
can now rely on it instead of manually fixing the IP on the host.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
