### PR TITLE
Add support for running tests locally in git worktree

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,6 +3,7 @@ profile: production
 exclude_paths:
   - ../
   - .cache/
+  - .venv/
   - build/
   - containerfiles/
   - docs/

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,13 @@ run_ctx_all_tests: run_ctx_pre_commit run_ctx_molecule run_ctx_ansible_test run_
 
 .PHONY: run_ctx_pre_commit
 run_ctx_pre_commit: ci_ctx ## Run pre-commit check in a container
+	@if [ -f .git ]; then \
+		echo "" ; \
+		echo 'If you are using git worktrees you must use \
+		"make pre_commit" or "make pre_commit_nodeps" as \
+		the git mapping fails inside the container.' ; \
+		false ; \
+	fi
 	podman run \
 		--rm \
 		--security-opt label=disable \

--- a/containerfiles/Containerfile.tests
+++ b/containerfiles/Containerfile.tests
@@ -16,5 +16,5 @@ RUN /usr/bin/make setup_molecule USE_VENV=${USE_VENV}
 RUN dnf clean all
 
 USER prow
-RUN git config core.fileMode false
+RUN [ -d .git ] && git config core.fileMode false || true
 CMD /usr/bin/make help


### PR DESCRIPTION
This patch adds a warning for users using git worktrees to use non container based pre-commit make target and adds a test to the container file to skip running the git commit command which fails in a worktree.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
