### PR TITLE
Ensure we rely only on dnsmasq

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -469,20 +469,6 @@
             owner: zuul
             group: zuul
 
-        - name: Inject crc related host entry
-          become: true
-          vars:
-            _crc_data: "{{ cifmw_networking_env_definition.instances['crc-0'].networks.ctlplane}}"
-          ansible.builtin.lineinfile:
-            path: /etc/hosts
-            line: >-
-              {{ _crc_data.ip_v4 }} api.crc.testing
-              canary-openshift-ingress-canary.apps-crc.testing
-              console-openshift-console.apps-crc.testing
-              default-route-openshift-image-registry.apps-crc.testing
-              downloads-openshift-console.apps-crc.testing
-              oauth-openshift.apps-crc.testing
-
     - name: Ensure we have all dependencies installed
       ansible.builtin.async_status:
         jid: "{{ _async_dep_install.ansible_job_id }}"

--- a/roles/reproducer/tasks/configure_crc.yml
+++ b/roles/reproducer/tasks/configure_crc.yml
@@ -5,13 +5,6 @@
   ansible.builtin.slurp:
     path: /etc/ci/env/networking-environment-definition.yml
 
-- name: Remove CRC managed zone delegation
-  become: true
-  notify: Restart NetworkManager
-  ansible.builtin.file:
-    path: ""
-    state: absent
-
 - name: Remove entry from /etc/hosts
   become: true
   vars:
@@ -81,3 +74,6 @@
       expand-hosts
       local=/testing/
       domain=crc.testing
+
+- name: Flush handlers
+  ansible.builtin.meta: flush_handlers

--- a/roles/reproducer/tasks/crc_layout.yml
+++ b/roles/reproducer/tasks/crc_layout.yml
@@ -46,3 +46,13 @@
   ansible.builtin.import_role:
     name: rhol_crc
     tasks_from: set_cluster_fact.yml
+
+- name: Remove CRC managed zone delegation
+  become: true
+  notify: Restart NetworkManager
+  ansible.builtin.file:
+    path: "/etc/NetworkManager/{{ item }}"
+    state: absent
+  loop:
+    - "dnsmasq.d/crc.conf"
+    - "conf.d/crc-nm-dnsmasq.conf"


### PR DESCRIPTION
This patch corrects and finalize the move from CRC hard-coded hosts
entries to full dnsmasq DHCP and DNS.

In a previous PR (#1908) we switched CRC dns entries to dnsmasq, but the
base CRC config weren't cleaned, leading to a broken state.
It was mostly working because controller-0 still had some hardcoded
entries in /etc/hosts.

This patch fixes the initial issue with dnsmasq configuration overlaps
(ours vs CRC), and ensures we don't rely on /etc/hosts entries on
controller-0.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
