### PR TITLE
hook - ironic_network - set nameserver

### DIFF
--- a/hooks/playbooks/ironic_network.yml
+++ b/hooks/playbooks/ironic_network.yml
@@ -6,6 +6,7 @@
     _namespace: openstack
     _subnet_range: '172.20.1.0/24'
     _subnet_gateway: '172.20.1.1'
+    _subnet_nameserver: '192.168.122.80'
     _subnet_alloc_pool_start: '172.20.1.100'
     _subnet_alloc_pool_end: '172.20.1.200'
     _provider_physical_network: ironic
@@ -34,4 +35,5 @@
             --network provisioning \
             --subnet-range {{ _subnet_range }} \
             --gateway {{ _subnet_gateway }} \
+            --dns-nameserver {{ _subnet_nameserver }} \
             --allocation-pool start={{ _subnet_alloc_pool_start }},end={{ _subnet_alloc_pool_end }}


### PR DESCRIPTION
We need to resolve the name from the infra dns server on the controlplane infra.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
