### PR TITLE
Correct OCP validations

### DIFF
--- a/roles/reproducer/molecule/ocp_validations/converge.yml
+++ b/roles/reproducer/molecule/ocp_validations/converge.yml
@@ -41,7 +41,7 @@
         cifmw_devscripts_create_logical_volume: >-
           {{ item.create_cinder_lvm | default(false) }}
         cifmw_devscripts_cinder_volume_pvs: >-
-          {{ item.volume_pvs | default([])}}
+          {{ item.volume_pvs | default(['/dev/vda'])}}
         cifmw_lvms_disk_list: >-
           {{ item.lvms_disk | default([]) }}
         _cifmw_libvirt_manager_layout: >-

--- a/roles/reproducer/molecule/ocp_validations/vars/scenarios.yml
+++ b/roles/reproducer/molecule/ocp_validations/vars/scenarios.yml
@@ -9,16 +9,12 @@ scenarios:
   - scenario: Volume, no worker
     env_file: with-volume.yml
     create_cinder_lvm: true
-    volume_pvs:
-      - /dev/vda
     lvms_disk:
       - /dev/vdb
 
   - scenario: Volume, with worker
     env_file: volumes-workers.yml
     create_cinder_lvm: true
-    volume_pvs:
-      - /dev/vda
     lvms_disk:
       - /dev/vdb
 
@@ -26,8 +22,6 @@ scenarios:
     env_file: with-volume.yml
     should_fail: true
     create_cinder_lvm: true
-    volume_pvs:
-      - /dev/vda
     lvms_disk:
       - /dev/vdb
       - /dev/vdc

--- a/roles/reproducer/tasks/ocp_layout_assertions.yml
+++ b/roles/reproducer/tasks/ocp_layout_assertions.yml
@@ -136,20 +136,28 @@
 
     - name: Ensure created amount matches at least allocated amounts
       when:
-        - _cifmw_libvirt_manager_layout.vms.ocp_worker is defined
+        - _ocp.extra_disks_num is defined
+        - _ocp.extra_disks_num > 0
+      vars:
+        _cinder_vols: >-
+          {{
+            (cifmw_devscripts_create_logical_volume | bool) |
+            ternary(cifmw_devscripts_cinder_volume_pvs, [])
+          }}
+        _lvms_vols: >-
+          {{
+            (cifmw_use_lvms | default(false) | bool) |
+            ternary(cifmw_lvms_disk_list, [])
+          }}
       ansible.builtin.assert:
         quiet: true
         that:
-          - (_ocp.extra_disks_num is defined and _ocp.extra_disks_num > 0 and
-             (cifmw_devscripts_cinder_volume_pvs | default([]) | length) +
-             (cifmw_lvms_disk_list | default([]) | length) <= _ocp.extra_disks_num)
-            or _ocp.extra_disks_num is undefined or _ocp.extra_disks_num == 0
+          - (_cinder_vols + _lvms_vols) | length
+            <= _ocp.extra_disks_num | int
         msg: >-
-          Inconsistency detected: ensure ocp.extra_disks_num is the same value
-          as ocp_worker.extra_disks_num, ocp.extra_disks_size is the same value
-          as ocp_worker.extra_disks_size. Also ensure you don't allocate more
-          disks in cifmw_lvms_disk_list and cifmw_devscripts_cinder_volume_pvs
-          than available.
+          Inconsistency detected: Created amount of volumes
+          {{ _ocp.extra_disks_num }} is smaller than allocated volumes
+          {{ (_cinder_vols + _lvms_vols) | length }}
 
 - name: Ensure we correctly allocate volumes
   when:
@@ -182,15 +190,24 @@
           Inconsistency detected: you seem to allocate a volume in
           both cinder and lvms
 
-    - name: Ensure all allocated disks are available
+    - name: Ensure LVMS allocated disks are available
       ansible.builtin.assert:
         that:
           - cifmw_lvms_disk_list |
             community.general.lists_intersect(_vm_extradisks_list) ==
             cifmw_lvms_disk_list
+        msg: >-
+          Inconsistency detected: you seem to allocate volumes for LVMS
+          that aren't present on the system.
+
+    - name: Ensure Cinder PVs allocated disks are available
+      when:
+        - cifmw_devscripts_create_logical_volume | bool
+      ansible.builtin.assert:
+        that:
           - cifmw_devscripts_cinder_volume_pvs |
             community.general.lists_intersect(_vm_extradisks_list) ==
             cifmw_devscripts_cinder_volume_pvs
         msg: >-
-          Inconsistency detected: you seem to allocate volumes that
-          aren't present on the system.
+          Inconsistency detected: you seem to allocate volumes for Cinder
+          that aren't present on the system.


### PR DESCRIPTION
Cinder volumes list has a non-empty default, leading to some issues with
the assertions.

This patch corrects the molecule scenarios to match the actual defaults
set in devscripts role, and fixes the validations by considering the
booleans related to volume usage (cifmw_use_lvms and
cifmw_devscripts_create_logical_volume).

This should fix a series of faulty validations hit by end-users.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
