### PR TITLE
Untar logs for OCP openstack pods

### DIFF
--- a/roles/os_must_gather/tasks/main.yml
+++ b/roles/os_must_gather/tasks/main.yml
@@ -82,6 +82,16 @@
           mv "{{ _must_gather_output_folder.files[0].path  }}/"
           "{{ cifmw_os_must_gather_output_dir }}/logs/openstack-k8s-operators-openstack-must-gather"
 
+    - name: Decompress openstack container logs
+      ansible.builtin.unarchive:
+        src: "{{ item }}"
+        dest: "{{ item | dirname }}/{{ item | basename | splitext | first }}-logs"
+        remote_src: true
+        include:
+          - "podlogs/var/log/pods/openstack-operators_*"
+          - "podlogs/var/log/pods/openstack_*"
+      loop: "{{ q('sosreport-*-UntarWithArg-i.tar.xz', '{{ cifmw_os_must_gather_output_dir }}/logs/openstack-k8s-operators-openstack-must-gather/sos-reports/_all_nodes') }}"
+
   rescue:
     - name: Create oc_inspect log directory
       ansible.builtin.file:


### PR DESCRIPTION
When running openstack-must-gather tool we are instructing the tool not to untar the whole SOS reports, as they contain way too may files and the file count affects zuul jobs (makes them crash).

This has created a situation where we all need to download and untar files to be able to see the container logs making it harder to have quick looks at logs and sharing URLs to have discussions.

This patch forces the untar of just the logs of the OCP cluster SOS reports. Specifically just the openstack and openstack-operators namespaces, which are the most commonly required.

Additional namespaces can be added to the `include` or we could just remove it altogether to get all pods.

We are using `sosreport-*-UntarWithArg-i.tar.xz` instead of `*.tar.xz` so we don't create empty directories for the EDPM nodes.

Related PR: https://github.com/openstack-k8s-operators/openstack-must-gather/pull/62

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
