### PR TITLE
Patch nested CRC dnsmasq 

### DIFF
--- a/ci/playbooks/multinode-customizations.yml
+++ b/ci/playbooks/multinode-customizations.yml
@@ -1,21 +1,12 @@
 ---
-- hosts: crc
-  name: "Tweak CRC node"
+- name: "Tweak CRC node"
+  hosts: crc
   gather_facts: false
   tasks:
-
     - name: Load network parameters
       register: _cifmw_multinode_customizations_crc_net_env_slurp
       ansible.builtin.slurp:
         src: "/etc/ci/env/networking-info.yml"
-
-    - name: Check which dnsmasq config we must edit
-      register: _dnsmasq
-      ansible.builtin.stat:
-        path: '/srv/dnsmasq.conf'
-        get_attributes: false
-        get_checksum: false
-        get_mime: false
 
     - name: Shared parameter across blocks
       vars:
@@ -69,84 +60,11 @@
                 name: NetworkManager
                 state: reloaded
 
-        - name: Configure dnsmasq
-          vars:
-            _dnsmasq_config: >-
-              {{
-                _dnsmasq.stat.exists |
-                ternary(_dnsmasq.stat.path, '/etc/dnsmasq.d/crc-dnsmasq.conf')
-              }}
-            _crc_default_net_dns: >-
-              {{
-                 _decoded_net_env.crc_ci_bootstrap_provider_dns |
-                default([])
-              }}
-          block:
-            - name: Configure dns forwarders
-              become: true
-              ansible.builtin.blockinfile:
-                path: "{{ _dnsmasq_config }}"
-                block: |-
-                  {% for dns_server in _crc_default_net_dns %}
-                  server={{ dns_server }}
-                  {% endfor %}
+    - name: Patch dnsmasq service
+      ansible.builtin.include_role:
+        name: openshift_setup
+        tasks_from: patch_dnsmasq.yml
 
-            - name: Configure local DNS for CRC pod
-              become: true
-              register: last_modification
-              ansible.builtin.replace:
-                path: "{{ _dnsmasq_config }}"
-                regexp: "192.168.130.11"
-                replace: >-
-                  {{ _crc_default_net_ip | ansible.utils.ipaddr('address') }}
-
-            # Note(Lewis): Only needed for CRC => 2.32.0-4.14.8
-            - name: Configure dnsmasq listen-address to listen on both br-ex and ci-private-network
-              when:
-                - not _dnsmasq.stat.exists
-              become: true
-              ansible.builtin.lineinfile:
-                path: "{{ _dnsmasq_config }}"
-                insertafter: '^listen-address='
-                line: "listen-address={{ _crc_default_net_ip | ansible.utils.ipaddr('address') }}"
-
-    - name: Restart dnsmasq service if used
-      become: true
-      when:
-        - not _dnsmasq.stat.exists
-      ansible.builtin.service:
-        name: dnsmasq
-        state: restarted
-
-    - name: Manage old dnsmasq container
-      when:
-        - _dnsmasq.stat.exists
-      block:
-        # Avoid 'state: restarted' due to issues with IP not
-        # available when crc-dnsmasq starts
-        - name: Stop dnsmasq
-          become: true
-          ansible.builtin.systemd:
-            state: stopped
-            name: crc-dnsmasq
-
-        - name: Make sure that crc-dnsmasq is not running
-          containers.podman.podman_container:
-            name: crc-dnsmasq
-            state: absent
-
-        - name: Start dnsmasq
-          become: true
-          ansible.builtin.systemd:
-            state: started
-            name: crc-dnsmasq
-          register: _dnsmasq_start_reg
-          retries: 15
-          delay: 20
-          until:
-            - _dnsmasq_start_reg.failed is false
-            - _dnsmasq_start_reg.status is defined
-            - _dnsmasq_start_reg.status.ActiveState == "active"
 
     - name: Wait for CRC to be ready
       register: wait_crc
@@ -168,8 +86,8 @@
       ansible.builtin.include_tasks: tasks/set_crc_insecure_registry.yml
       when: content_provider_registry_ip is defined
 
-- hosts: controller
-  name: "Tweak Controller"
+- name: "Tweak Controller"
+  hosts: controller
   gather_facts: true
   tasks:
     - name: Install other packages

--- a/roles/openshift_setup/tasks/patch_dnsmasq.yml
+++ b/roles/openshift_setup/tasks/patch_dnsmasq.yml
@@ -1,0 +1,82 @@
+---
+- name: Ensure file is present
+  register: _stat_networking_info
+  ansible.builtin.stat:
+    path: /etc/ci/env/networking-info.yml
+
+- name: Load network parameters
+  when: _stat_networking_info.stat.exists
+  block:
+    - name: Slurp network-info.yml
+      register: _patch_dns_network_info_slurp
+      ansible.builtin.slurp:
+        src: "/etc/ci/env/networking-info.yml"
+
+    - name: Decode network-info.yml
+      ansible.builtin.set_fact:
+        _decoded_net_env: >-
+          {{
+            _patch_dns_network_info_slurp['content'] |
+            b64decode | from_yaml
+          }}
+
+- name: Check which dnsmasq config we must edit
+  register: _dnsmasq
+  ansible.builtin.stat:
+    path: '/srv/dnsmasq.conf'
+    get_attributes: false
+    get_checksum: false
+    get_mime: false
+
+
+- name: Shared parameter across blocks
+  vars:
+    _crc_default_net_ip: >-
+      {{
+        _decoded_net_env.crc_ci_bootstrap_networks_out.crc.default.ip | default('192.168.130.11')
+      }}
+  block:
+    - name: Configure dnsmasq
+      vars:
+        _dnsmasq_config: >-
+          {{
+            _dnsmasq.stat.exists |
+            ternary(_dnsmasq.stat.path, '/etc/dnsmasq.d/crc-dnsmasq.conf')
+          }}
+        _crc_default_net_dns: >-
+          {{
+              _decoded_net_env.crc_ci_bootstrap_provider_dns |
+            default([])
+          }}
+      block:
+        - name: Configure dns forwarders
+          become: true
+          ansible.builtin.blockinfile:
+            path: "{{ _dnsmasq_config }}"
+            block: |-
+              {% for dns_server in _crc_default_net_dns %}
+              server={{ dns_server }}
+              {% endfor %}
+
+        - name: Configure local DNS for CRC pod
+          become: true
+          register: last_modification
+          ansible.builtin.replace:
+            path: "{{ _dnsmasq_config }}"
+            regexp: "192.168.130.11"
+            replace: >-
+              {{ _crc_default_net_ip | ansible.utils.ipaddr('address') }}
+
+        # Note(Lewis): Only needed for CRC => 2.32.0-4.14.8
+        - name: Configure dnsmasq listen-address to listen on both br-ex and ci-private-network
+          when:
+            - not _dnsmasq.stat.exists
+          become: true
+          ansible.builtin.lineinfile:
+            path: "{{ _dnsmasq_config }}"
+            insertafter: '^listen-address='
+            line: "listen-address={{ _crc_default_net_ip | ansible.utils.ipaddr('address') }}"
+
+- name: Restart dnsmasq service
+  ansible.builtin.include_tasks:
+    file: restart_dns.yml

--- a/roles/openshift_setup/tasks/restart_dns.yml
+++ b/roles/openshift_setup/tasks/restart_dns.yml
@@ -1,0 +1,40 @@
+- name: Check which dnsmasq config we must edit
+  register: _dnsmasq
+  ansible.builtin.stat:
+    path: '/srv/dnsmasq.conf'
+    get_attributes: false
+    get_checksum: false
+    get_mime: false
+
+- name: Restart dnsmasq service if used
+  become: true
+  when:
+    - not _dnsmasq.stat.exists
+  ansible.builtin.service:
+    name: dnsmasq
+    state: restarted
+
+- name: Manage old dnsmasq container
+  when:
+    - _dnsmasq.stat.exists
+  block:
+    # Avoid 'state: restarted' due to issues with IP not
+    # available when crc-dnsmasq starts
+    - name: Stop dnsmasq
+      become: true
+      ansible.builtin.systemd:
+        state: stopped
+        name: crc-dnsmasq
+
+    - name: Start dnsmasq
+      become: true
+      ansible.builtin.systemd:
+        state: started
+        name: crc-dnsmasq
+      register: _dnsmasq_start_reg
+      retries: 15
+      delay: 20
+      until:
+        - _dnsmasq_start_reg.failed is false
+        - _dnsmasq_start_reg.status is defined
+        - _dnsmasq_start_reg.status.ActiveState == "active"

--- a/roles/reproducer/tasks/configure_crc.yml
+++ b/roles/reproducer/tasks/configure_crc.yml
@@ -75,5 +75,13 @@
       local=/testing/
       domain=crc.testing
 
+- name: Configure DNS in CRC VM
+  delegate_to: crc-0
+  block:
+    - name: Configure DNS in CRC VM
+      ansible.builtin.include_role:
+        name: openshift_setup
+        tasks_from: patch_dnsmasq.yml
+
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers

--- a/roles/rhol_crc/molecule/default/converge.yml
+++ b/roles/rhol_crc/molecule/default/converge.yml
@@ -22,5 +22,19 @@
     cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
     cifmw_manage_secrets_pullsecret_content: >
       {"auths":{"fake":{"auth": "Zm9vOmJhcgo="}}}
-  roles:
-    - role: "rhol_crc"
+  tasks:
+    - name: Add crc hostname with it's IP to /etc/hosts
+      become: true
+      ansible.builtin.lineinfile:
+        path: /etc/hosts
+        line: "192.168.130.11 crc"
+
+    - name: Add the crc host dynamically
+      ansible.builtin.add_host:
+        name: crc
+        ansible_ssh_private_key_file: "{{ ansible_user_dir }}/.crc/machines/crc/id_ecdsa"
+        ansible_ssh_user: core
+
+    - name: Test role
+      ansible.builtin.include_role:
+        name: rhol_crc

--- a/roles/rhol_crc/tasks/main.yml
+++ b/roles/rhol_crc/tasks/main.yml
@@ -137,3 +137,14 @@
 - name: Add crc kubeconfig
   when: cifmw_rhol_crc_creds | bool
   ansible.builtin.import_tasks: add_crc_creds.yml
+
+- name: Configure DNS in CRC VM
+  delegate_to: crc
+  when:
+    - cifmw_use_crc is defined
+    - cifmw_use_crc | bool
+  block:
+    - name: Patch dnsmasq service
+      ansible.builtin.include_role:
+        name: openshift_setup
+        tasks_from: patch_dnsmasq.yml

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -11,12 +11,23 @@
 # Virtual Baremetal job with CRC and single compute node.
 - job:
     name: cifmw-crc-podified-edpm-baremetal
-    nodeset: centos-9-crc-2-30-0-6xlarge # TODO(marios) bump crc after OSPCIX-336
+    nodeset: centos-9-crc-2-36-0-6xlarge
     parent: cifmw-base-crc-openstack
     run: ci/playbooks/edpm_baremetal_deployment/run.yml
     vars:
       crc_parameters: "--memory 32000 --disk-size 240 --cpus 12"
       cifmw_manage_secrets_pullsecret_content: '{}'
+
+# Virtual Baremetal job with CRC and single compute node.
+- job:
+    name: cifmw-crc-podified-edpm-baremetal-4-14
+    nodeset: centos-9-crc-2-30-0-6xlarge
+    parent: cifmw-base-crc-openstack
+    run: ci/playbooks/edpm_baremetal_deployment/run.yml
+    vars:
+      crc_parameters: "--memory 32000 --disk-size 240 --cpus 12"
+      cifmw_manage_secrets_pullsecret_content: '{}'
+
 
 # Podified galera job
 - job:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -61,6 +61,7 @@
         - cifmw-crc-podified-edpm-baremetal: *content_provider
         - podified-multinode-hci-deployment-crc: *content_provider
         - cifmw-multinode-tempest: *content_provider
+        - cifmw-crc-podified-edpm-baremetal-4-14: *content_provider
 
 - project-template:
     name: data-plane-adoption-ci-framework-pipeline


### PR DESCRIPTION
This patch moves the dns configuration logic into a central location and
calls it for both multinode and nested CRC jobs.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
