### PR TITLE
Don't advertise route on non-public network

### DIFF
--- a/roles/libvirt_manager/tasks/create_networks.yml
+++ b/roles/libvirt_manager/tasks/create_networks.yml
@@ -108,6 +108,9 @@
       {% if ansible_facts[_name].ipv6 is defined -%}
       - "option6:dns-server,[{{ _ipv6.address }}]"
       {% endif -%}
+      {% if _no_prefix_name != cifmw_libvirt_manager_pub_net -%}
+      - "option:router"
+      {% endif -%}
     _dns_listener:
       - "{{ ansible_facts[_name].ipv4.address | default('') }}"
       - "{{ _ipv6.address | default('') }}"


### PR DESCRIPTION
Until now, dnsmasq was pushing default route for any subnet range,
leading to confusion and potential issues.

Since we have "just" one public network, let's advertise this one as
default route.

With this patch, we now have this on controller-0:
```
[zuul@controller-0 ~]$ ip ro ls
default via 192.168.100.1 dev eth0 proto dhcp src 192.168.100.9 metric 100
192.168.100.0/24 dev eth0 proto kernel scope link src 192.168.100.9 metric 100
192.168.122.0/24 dev eth1 proto kernel scope link src 192.168.122.9 metric 101
```

And the generated configuration in cifmw-dnsmasq.d is:

`osp_trunk`, a "private" network:
```
dhcp-range=set:osp_trunk,192.168.122.2,static,255.255.255.0,1h
dhcp-option=tag:osp_trunk,option:dns-server,192.168.122.1
dhcp-option=tag:osp_trunk,option:router
```

`public`, the public network:
```
dhcp-range=set:public,192.168.100.2,static,255.255.255.0,1h
dhcp-option=tag:public,option:dns-server,192.168.100.1
```

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
