### PR TITLE
Update default openshift version to 4.15.18

### DIFF
--- a/roles/devscripts/vars/main.yml
+++ b/roles/devscripts/vars/main.yml
@@ -33,7 +33,7 @@ cifmw_devscripts_config_defaults:
   working_dir: "/home/dev-scripts"
   assets_extra_folder: "/home/dev-scripts/assets"
   openshift_release_type: "ga"
-  openshift_version: "4.15.15"
+  openshift_version: "4.15.18"
   cluster_name: "ocp"
   base_domain: "openstack.lab"
   ntp_servers: "clock.corp.redhat.com"


### PR DESCRIPTION
The OCP 4.15.18 has a fix needed for deploying clusters with FIPS enabled[1].

[1] https://issues.redhat.com/browse/OCPBUGS-33736

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
