### PR TITLE
Add rp_port to content provider template in reproducer

### DIFF
--- a/roles/reproducer/templates/content-provider.yml.j2
+++ b/roles/reproducer/templates/content-provider.yml.j2
@@ -124,6 +124,7 @@
           -e "cifmw_rp_registry_ip="{{ hostvars['localhost']['cifmw_rp_registry_ip'] }}""
           -e "@{{ ansible_user_dir }}/ci-framework-data/parameters/reproducer-variables.yml"
           -e "@~/{{ job_id }}-params/zuul-params.yml"
+          -e "cifmw_rp_registry_port=5001"
           --skip-tags build_openstack_packages
 
     - name: Output needed content into consumable environment


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
