### PR TITLE
Put ssh_jumper to use in libvirt_manager role

### DIFF
--- a/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/roles/libvirt_manager/tasks/clean_layout.yml
@@ -62,6 +62,7 @@
         uri: "qemu:///system"
       loop: "{{ cleanup_vms }}"
 
+    # KEEP this for now to ensure smoother migration
     - name: "(localhost) Clean ssh jumpers"
       when:
         - inventory_hostname != 'localhost'
@@ -75,19 +76,7 @@
         create: true
       loop: "{{ cleanup_vms }}"
 
-    - name: "(localhost) Clean old ssh jumpers"
-      when:
-        - inventory_hostname != 'localhost'
-      delegate_to: localhost
-      vars:
-        vm: "{{ item | replace('cifmw-', '') }}"
-      ansible.builtin.blockinfile:
-        path: "{{ lookup('env', 'HOME') }}/.ssh/config"
-        marker: "## {mark} {{ vm }}"
-        state: absent
-        create: true
-      loop: "{{ cleanup_vms }}"
-
+    # KEEP this for now to ensure smoother migration
     - name: "({{ inventory_hostname }}) Clean ssh jumpers"  # noqa: name[template]
       vars:
         vm: "{{ item | replace('cifmw-', '') }}"
@@ -290,6 +279,21 @@
   ansible.builtin.import_role:
     name: virtualbmc
     tasks_from: cleanup.yml
+
+- name: Clean remote ssh config
+  vars:
+    cifmw_ssh_jumper_config_dir: "{{ ansible_user_dir }}/.ssh"
+  ansible.builtin.include_role:
+    name: "ssh_jumper"
+    tasks_from: "cleanup.yml"
+
+- name: Clean local ssh config
+  vars:
+    cifmw_ssh_jumper_target: 'localhost'
+    cifmw_ssh_jumper_config_dir: "{{ lookup('env', 'HOME') }}/.ssh"
+  ansible.builtin.include_role:
+    name: "ssh_jumper"
+    tasks_from: "cleanup.yml"
 
 - name: Clean dnsmasq
   ansible.builtin.import_role:

--- a/roles/libvirt_manager/tasks/manage_vms.yml
+++ b/roles/libvirt_manager/tasks/manage_vms.yml
@@ -1,44 +1,37 @@
 ---
-- name: "(localhost) Inject ssh jumpers for {{ vm }}"
-  when:
-    - inventory_hostname != 'localhost'
-    - inventory_hostname != 'instance'  # needed for molecule
-  delegate_to: localhost
+- name: "Push ssh jumper/configuration for {{ vm }}"
   vars:
-    proxy_hostname: "{{ ansible_host | default(inventory_hostname) }}"
-  ansible.builtin.blockinfile:
-    create: true
-    path: "{{ lookup('env', 'HOME') }}/.ssh/config"
-    marker: "## {mark} {{ vm }} {{ inventory_hostname }}"
-    mode: "0600"
-    block: |-
-      Host {{ vm }} {{ vm }}.{{ inventory_hostname }} cifmw-{{ vm }} {{ extracted_ip }}
-        ProxyJump {{ ansible_user | default(lookup('env', 'USER')) }}@{{ proxy_hostname }}
-        Hostname {{ extracted_ip }}
-        User {{ 'core' if vm is match('^(crc|ocp).*') else 'zuul' }}
-        StrictHostKeyChecking no
-        UserKnownHostsFile /dev/null
-
-- name: "({{ inventory_hostname }}) Inject ssh jumpers for {{ vm }}"  # noqa: name[template]
-  vars:
-    identity_file: >-
-      {{
-        cifmw_libvirt_manager_basedir ~ '/artifacts/cifmw_ocp_access_key' if vm_type is match('^ocp.*') else
-        ansible_user_dir ~ '/.crc/machines/crc/id_ecdsa' if vm_type == 'crc' else
-        ansible_user_dir ~ '/.ssh/cifmw_reproducer_key'
-      }}
-  ansible.builtin.blockinfile:
-    create: true
-    path: "{{ ansible_user_dir }}/.ssh/config"
-    marker: "## {mark} {{ vm }}"
-    mode: "0600"
-    block: |-
-      Host {{ vm }} {{ vm }}.{{ inventory_hostname }} cifmw-{{ vm }} {{ extracted_ip }}
-        Hostname {{ extracted_ip }}
-        User {{ 'core' if vm is match('^(crc|ocp)') else 'zuul' }}
-        IdentityFile {{ identity_file }}
-        StrictHostKeyChecking no
-        UserKnownHostsFile /dev/null
+    _user: "{{ 'core' if vm is match('^(crc|ocp).*') else 'zuul' }}"
+    dataset:
+      ssh_dir: "{{ ansible_user_dir }}/.ssh"
+      user: "{{ _user }}"
+      hostname: "{{ extracted_ip }}"
+      patterns:
+        - "{{ vm }}"
+        - "{{ vm }}.{{ inventory_hostname }}"
+        - "cifmw-{{ vm }}"
+    proxy_data:
+      target: localhost
+      proxy_host: "{{ ansible_host | default(inventory_hostname) }}"
+      proxy_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+      ssh_dir: "{{ lookup('env', 'HOME') }}/.ssh"
+    ssh_ident:
+      identity_file: >-
+        {{
+          cifmw_libvirt_manager_basedir ~ '/artifacts/cifmw_ocp_access_key' if vm_type is match('^ocp.*') else
+          ansible_user_dir ~ '/.crc/machines/crc/id_ecdsa' if vm_type == 'crc' else
+          ansible_user_dir ~ '/.ssh/cifmw_reproducer_key'
+        }}
+    config: >-
+      {% set output = [] -%}
+      {% if inventory_hostname not in ['localhost', 'instance'] -%}
+      {% set _ = output.append(dataset | combine(proxy_data) ) -%}
+      {% endif -%}
+      {% set _ = output.append(dataset | combine(ssh_ident)) -%}
+      {{ output }}
+    cifmw_ssh_jumper_config: "{{ config }}"
+  ansible.builtin.include_role:
+    name: "ssh_jumper"
 
 - name: Inject nodes in the ansible inventory
   delegate_to: localhost

--- a/roles/ssh_jumper/README.md
+++ b/roles/ssh_jumper/README.md
@@ -10,7 +10,7 @@ Required:
 * `hostname`: (String) Hostname (or IP address).
 
 Optional:
-* `target`: (String) Inventory host target to configure. Defaults to: `{{ inventory_hostname }}`.
+* `target`: (String) Inventory host target to configure. Defaults to: `omit`.
 * `ssh_dir`: (String) SSH directory. Defaults to: `{{ ansible_user_dir }}/.ssh`.
 * `patterns`: (List) Patterns to match the host.
 * `user`: (String) Specifies the user to log in as. Defaults to: `zuul`.
@@ -20,12 +20,18 @@ Optional:
 * `strict_host_key_checking`: (String) If set to `yes` host keys are checked. Defaults to: `no`.
 * `user_known_hosts_file`: (String)' File to use for user host key database. Defaults to: `/dev/null`.
 
+#### cleanup.yml dedicated parameter
+
+* `cifmw_ssh_jumper_target`: (String) Target host to run the cleanup commands. Defaults to `omit`.
+* `cifmw_ssh_jumper_config_dir`: (String) .ssh path on the target host. Defaults to `{{ cifmw_ssh_jumper_config.ssh_dir }}`.
+
 ## Examples
 
 ```yaml
 - name: "Add SSH jumper entries"
   vars:
     cifmw_ssh_jumper_config:
+      # Will delegate_to: localhost to push the configuration
       - target: localhost
         ssh_dir: "/home/zuul/.ssh"
         hostname: '192.168.250.10'
@@ -34,8 +40,8 @@ Optional:
         patterns:
           - test
           - test.node
-      - target: instance
-        ssh_dir: "/home/zuul/.ssh"
+      # Will push the configuration on the remote host
+      - ssh_dir: "/home/zuul/.ssh"
         hostname: '192.168.250.10'
         identity_file: "/home/zuul/.ssh/id_foo"
         patterns:

--- a/roles/ssh_jumper/molecule/default/converge.yml
+++ b/roles/ssh_jumper/molecule/default/converge.yml
@@ -53,25 +53,25 @@
       ansible.builtin.slurp:
         src: "{{ cifmw_basedir }}/ssh/config"
 
-    - name: Slurp ssh/cifw_ssh_config.d/minimal.example.com.conf
+    - name: Slurp ssh/cifmw_ssh_config.d/minimal.example.com.conf
       register: cifmw_minimal_example_com
       ansible.builtin.slurp:
-        src: "{{ cifmw_basedir }}/ssh/cifw_ssh_config.d/instance/minimal.example.com.conf"
+        src: "{{ cifmw_basedir }}/ssh/cifmw_ssh_config.d/instance/minimal.example.com.conf"
 
-    - name: Slurp ssh/cifw_ssh_config.d/192.168.250.10.conf
-      register: cifw_ssh_config_d_192_168_250_10
+    - name: Slurp ssh/cifmw_ssh_config.d/192.168.250.10.conf
+      register: cifmw_ssh_config_d_192_168_250_10
       ansible.builtin.slurp:
-        src: "{{ cifmw_basedir }}/ssh/cifw_ssh_config.d/instance/192.168.250.10-via-proxy.example.com.conf"
+        src: "{{ cifmw_basedir }}/ssh/cifmw_ssh_config.d/instance/192.168.250.10-via-proxy.example.com.conf"
 
-    - name: Slurp ssh/cifw_ssh_config.d/192.168.250.11.conf
-      register: cifw_ssh_config_d_192_168_250_11
+    - name: Slurp ssh/cifmw_ssh_config.d/192.168.250.11.conf
+      register: cifmw_ssh_config_d_192_168_250_11
       ansible.builtin.slurp:
-        src: "{{ cifmw_basedir }}/ssh/cifw_ssh_config.d/instance/192.168.250.11.conf"
+        src: "{{ cifmw_basedir }}/ssh/cifmw_ssh_config.d/instance/192.168.250.11.conf"
 
     - name: Assert Include in ssh_config
       vars:
         _ref: |
-          Include cifw_ssh_config.d/instance/*.conf
+          Include cifmw_ssh_config.d/instance/*.conf
         _res: "{{ ssh_config['content'] | b64decode }}"
       ansible.builtin.assert:
         that:
@@ -104,7 +104,7 @@
               User zuul
               StrictHostKeyChecking no
               UserKnownHostsFile /dev/null
-        _res: "{{ cifw_ssh_config_d_192_168_250_10['content'] | b64decode }}"
+        _res: "{{ cifmw_ssh_config_d_192_168_250_10['content'] | b64decode }}"
       ansible.builtin.assert:
         that:
           - _ref == _res
@@ -123,7 +123,7 @@
               IdentityFile /opt/basedir/ssh/id_test
               StrictHostKeyChecking no
               UserKnownHostsFile /dev/null
-        _res: "{{ cifw_ssh_config_d_192_168_250_11['content'] | b64decode }}"
+        _res: "{{ cifmw_ssh_config_d_192_168_250_11['content'] | b64decode }}"
       ansible.builtin.assert:
         that:
           - _ref == _res

--- a/roles/ssh_jumper/tasks/cleanup.yml
+++ b/roles/ssh_jumper/tasks/cleanup.yml
@@ -14,13 +14,27 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Remove Include cifw_ssh_config.d
+- name: Remove Include cifmw_ssh_config.d
+  delegate_to: "{{ cifmw_ssh_jumper_target | default(omit) }}"
+  vars:
+    _path: >-
+      {{
+          cifmw_ssh_jumper_config_dir |
+          default(cifmw_ssh_jumper_config.ssh_dir)
+      }}
   ansible.builtin.lineinfile:
     state: absent
-    path: "{{ cifmw_ssh_jumper_config.ssh_dir }}/config"
-    regexp: '^Include cifw_ssh_config.d/{{ inventory_hostname }}/.*conf$'
+    path: "{{ _path }}/config"
+    regexp: '^Include cifmw_ssh_config.d/{{ inventory_hostname }}/.*conf$'
 
-- name: Remove cifw_ssh_config.d directory
+- name: Remove cifmw_ssh_config.d directory
+  delegate_to: "{{ cifmw_ssh_jumper_target | default(omit) }}"
+  vars:
+    _path: >-
+      {{
+          cifmw_ssh_jumper_config_dir |
+          default(cifmw_ssh_jumper_config.ssh_dir)
+      }}
   ansible.builtin.file:
     state: absent
-    path: "{{ cifmw_ssh_jumper_config.ssh_dir }}/cifw_ssh_config.d/{{ inventory_hostname }}/"
+    path: "{{ _path }}/cifmw_ssh_config.d/{{ inventory_hostname }}/"

--- a/roles/ssh_jumper/tasks/main.yml
+++ b/roles/ssh_jumper/tasks/main.yml
@@ -15,8 +15,8 @@
 # under the License.
 
 - name: Create ssh-jumper entries
-  vars:
-    _config: "{{ item }}"
   ansible.builtin.include_tasks:
     file: manage_ssh_jumper_entry.yml
   loop: "{{ cifmw_ssh_jumper_config }}"
+  loop_control:
+    loop_var: _config

--- a/roles/ssh_jumper/tasks/manage_ssh_jumper_entry.yml
+++ b/roles/ssh_jumper/tasks/manage_ssh_jumper_entry.yml
@@ -14,20 +14,21 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Make sure ~/.ssh/cifw_ssh_config.d directory exists
-  delegate_to: "{{ _config.target | default(cifmw_ssh_jumper_defaults.target) }}"
+- name: Make sure ~/.ssh/cifmw_ssh_config.d directory exists
+  delegate_to: "{{ _config.target | default(omit) }}"
   vars:
-    _ssh_dir: "{{ _config.ssh_dir | default(cifmw_ssh_jumper_defaults.ssh_dir) }}"
+    _ssh_dir: >-
+      {{
+        _config.ssh_dir |
+        default(cifmw_ssh_jumper_defaults.ssh_dir)
+      }}
   ansible.builtin.file:
-    path: "{{ item }}"
+    path: "{{ _ssh_dir }}/cifmw_ssh_config.d//{{ inventory_hostname }}"
     state: directory
     mode: '0700'
-  loop:
-    - "{{ _ssh_dir | default((ansible_user_dir, '/.ssh') | path_join) }}/cifw_ssh_config.d"
-    - "{{ _ssh_dir | default((ansible_user_dir, '/.ssh') | path_join) }}/cifw_ssh_config.d/{{ inventory_hostname }}"
 
-- name: Include ~/.ssh/cifw_ssh_config.d/inventory_hostname/*.conf
-  delegate_to: "{{ _config.target | default(cifmw_ssh_jumper_defaults.target) }}"
+- name: Include ~/.ssh/cifmw_ssh_config.d/inventory_hostname/*.conf
+  delegate_to: "{{ _config.target | default(omit) }}"
   vars:
     _ssh_dir: "{{ _config.ssh_dir | default(cifmw_ssh_jumper_defaults.ssh_dir) }}"
   ansible.builtin.lineinfile:
@@ -36,13 +37,13 @@
     state: present
     path: "{{ _ssh_dir | default((ansible_user_dir, '/.ssh') | path_join) }}/config"
     mode: '0600'
-    line: 'Include cifw_ssh_config.d/{{ inventory_hostname }}/*.conf'
+    line: 'Include cifmw_ssh_config.d/{{ inventory_hostname }}/*.conf'
 
 - name: "Inject ssh jumpers for {{ _config.hostname }}"
-  delegate_to: "{{ _config.target | default(cifmw_ssh_jumper_defaults.target) }}"
+  delegate_to: "{{ _config.target | default(omit) }}"
   vars:
     _ssh_dir: "{{ _config.ssh_dir | default(cifmw_ssh_jumper_defaults.ssh_dir) }}"
-    _dir: "{{ _ssh_dir }}/cifw_ssh_config.d/{{ inventory_hostname }}"
+    _dir: "{{ _ssh_dir }}/cifmw_ssh_config.d/{{ inventory_hostname }}"
     _filename: >-
       {%- if _config.proxy_host is defined and _config.proxy_host is not none -%}
       {{ _config.hostname }}-via-{{ _config.proxy_host }}.conf

--- a/roles/ssh_jumper/vars/main.yml
+++ b/roles/ssh_jumper/vars/main.yml
@@ -15,7 +15,6 @@
 # under the License.
 
 cifmw_ssh_jumper_defaults:
-  target: "{{ inventory_hostname }}"
   ssh_dir: "{{ ansible_user_dir }}/.ssh"
   user: zuul
   patterns: []


### PR DESCRIPTION
This patch changes some behavior in ssh_jumper to make its integration
smoother.

It also integrate the role in libvirt_manager in order to manage the
various ssh configuration we usually inject on the hypervisor and
ansible controller (laptop, etc).

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
