### PR TITLE
Add STP settings on osppr bridge

### DIFF
--- a/roles/reproducer/tasks/prepare_networking.yml
+++ b/roles/reproducer/tasks/prepare_networking.yml
@@ -108,6 +108,14 @@
               address:
                 - ip: 172.22.0.1
                   prefix-length: 24
+            bridge:
+              options:
+                stp:
+                  enabled: true
+                  forward-delay: 5
+                  hello-time: 2
+                  max-age: 20
+                  priority: 32768
   ansible.builtin.set_fact:
     cifmw_ci_nmstate_instance_config: "{{ _content | from_yaml }}"
 


### PR DESCRIPTION
I sometimes see `PXE-E18: Server response timeout.` when deploying OCP nodes. Setting a short forward-delay for STP on the osppr bridge helps.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
