### PR TITLE
Add tolerations to lvms cluster resource

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -482,6 +482,7 @@ tmux
 tobiko
 toctree
 todo
+tolerations
 topolvm
 traceback
 tripleo

--- a/roles/ci_lvms_storage/README.md
+++ b/roles/ci_lvms_storage/README.md
@@ -77,6 +77,23 @@ be controlled with the following parameters.
 * `cifmw_lvms_delay`: (Int) Ansible `delay` passed to tasks which wait for `kubernetes.core.k8s_info` (default `10`)
 * `cifmw_lvms_retries`: (Int) Ansible `retries` passed to tasks which wait for `kubernetes.core.k8s_info` (default `60`)
 
+
+### Optional parameters
+
+* `ci_lvms_storage_tolerations`: (Dict) Allows to pass a set of tolerations to the lvms-operator to configure pods to eventually ignore scheduling restrictions applied to specific workers.
+
+Here an example showing how tolerations can be configured:
+
+```yaml
+ci_lvms_storage_tolerations:
+  - key: "testOperator"
+    value: "true"
+    effect: "NoSchedule"
+  - key: "testOperator"
+    value: "true"
+    effect: "NoExecute"
+```
+
 ## Examples
 
 The example playbook below will create an LVMS cluster using the disks

--- a/roles/ci_lvms_storage/defaults/main.yml
+++ b/roles/ci_lvms_storage/defaults/main.yml
@@ -31,3 +31,4 @@ cifmw_lvms_thin_pool_size_percent: 90
 cifmw_lvms_thin_pool_overprovision_ratio: 10
 cifmw_lvms_retries: 60
 cifmw_lvms_delay: 10
+ci_lvms_storage_tolerations: {}

--- a/roles/ci_lvms_storage/templates/lvms-cluster.yaml.j2
+++ b/roles/ci_lvms_storage/templates/lvms-cluster.yaml.j2
@@ -5,6 +5,14 @@ metadata:
   name: {{ cifmw_lvms_cluster_name }}
   namespace: {{ cifmw_lvms_namespace }}
 spec:
+  {% if ci_lvms_storage_tolerations -%}
+  tolerations:
+  {% for item in ci_lvms_storage_tolerations -%}
+  - key: "{{ item['key'] }}"
+    value: "{{ item['value'] }}"
+    effect: "{{ item['effect'] }}"
+  {% endfor -%}
+  {% endif -%}
   storage:
     deviceClasses:
     - name: {{ cifmw_lvms_storage_class }}


### PR DESCRIPTION
When using specially tainted workers we usually specify tolerations for pods that should land on these nodes like:

  tolerations:
  - key: "testOperator" value: "true" effect: "NoSchedule
  - key: "testOperator" value: "true" effect: "NoExecute

Similar tolerations must be applied to the lvms pods so that the lvms storageclass can be used across the cluster regardless of how workers are tagged/tainted.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
