### PR TITLE
[DUP without nodeset]Add controller-0 group name in zuul nodeset

### DIFF
--- a/hooks/playbooks/fetch_compute_facts.yml
+++ b/hooks/playbooks/fetch_compute_facts.yml
@@ -4,7 +4,7 @@
   gather_facts: true
   tasks:
     - name: Check for gating repo on controller
-      delegate_to: controller
+      delegate_to: "{{ groups['all'] | select('match', 'controller') | first }}"
       ansible.builtin.stat:
         path: "{{ cifmw_basedir }}/artifacts/repositories/gating.repo"
       register: _gating_repo


### PR DESCRIPTION
In crc reproducer, we have controller-0 as a host for ansible controller but in Zuul CI, we use controller as a hostname.

When fetch_compute_facts runs on controller-0 in CI, it does not resolve the hostname in CI but should work in reproducer.

In order to fix that, we are adding a controller-0 group in the zuul extracted crc nodeset to fix that.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
