### PR TITLE
Fix handling of group-template for crc vms

### DIFF
--- a/roles/libvirt_manager/tasks/generate_networking_data.yml
+++ b/roles/libvirt_manager/tasks/generate_networking_data.yml
@@ -144,10 +144,11 @@
           ((_cifmw_libvirt_manager_layout.vms[group].amount is defined and
             (_cifmw_libvirt_manager_layout.vms[group].amount | int) > 0) or
           _cifmw_libvirt_manager_layout.vms[group].amount is undefined) %}
-        {{ (group == 'crc') | ternary('ocp', group) }}s:
+      {% set _gr = (group == 'crc') | ternary('ocp', group)                                                             %}
+        {{ _gr }}s:
           networks:
             {{ _lnet_data.name | replace('cifmw_', '') }}:
-      {% if cifmw_networking_definition['group-templates'][group ~ 's']['network-template'] is undefined %}
+      {% if cifmw_networking_definition['group-templates'][_gr ~ 's']['network-template'] is undefined %}
       {%   if net_4 is defined %}
               range-v4:
                 start: {{  net_4 | ansible.utils.nthhost(ns.ip_start | int ) }}


### PR DESCRIPTION
Regression from [1], group template for crc vms is ocp, which got dropped as part of [1] and causing issues with default 3-node scenario deployment.

Closes-Issue: [OSPRH-7994](https://issues.redhat.com//browse/OSPRH-7994)
[1] https://github.com/openstack-k8s-operators/ci-framework/commit/1484aafa

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
