### PR TITLE
Drop set_openstack_containers from edpm_prepare role

### DIFF
--- a/roles/edpm_prepare/tasks/main.yml
+++ b/roles/edpm_prepare/tasks/main.yml
@@ -119,17 +119,6 @@
           --namespace={{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }}
           --for=jsonpath='{.status.phase}'=Complete --timeout=20m
 
-  # Note(chkumar): Keeping set_openstack_containers role
-  # till we migrate this task to update_containers role
-- name: Update OpenStack Services containers Env
-  when:
-    - cifmw_edpm_prepare_update_os_containers | bool
-    - cifmw_update_containers_openstack is not defined
-  vars:
-    cifmw_set_openstack_containers_extra_vars: "{{ cifmw_edpm_prepare_extra_vars }}"
-  ansible.builtin.include_role:
-    name: set_openstack_containers
-
 - name: Set facts for baremetal UEFI image url
   ansible.builtin.set_fact:
     cifmw_update_containers_edpm_image_url: "{{ cifmw_build_images_output['images']['edpm-hardened-uefi']['image'] }}"


### PR DESCRIPTION
All the reference of set_openstack_containers role is replace with update_containers role.

We are keeping set_openstack_containers role as update team wants to use it to perform minor update with installed operators.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

