### PR TITLE
Enable to change OPENSTACK_RELEASE_VERSION to prepare for minor update

### DIFF
--- a/roles/edpm_prepare/tasks/main.yml
+++ b/roles/edpm_prepare/tasks/main.yml
@@ -124,7 +124,7 @@
 - name: Update OpenStack Services containers Env
   when:
     - cifmw_edpm_prepare_update_os_containers | bool
-    - cifmw_update_containers_openstack is not defined
+    - not cifmw_update_containers_openstack | bool
   vars:
     cifmw_set_openstack_containers_extra_vars: "{{ cifmw_edpm_prepare_extra_vars }}"
   ansible.builtin.include_role:

--- a/roles/set_openstack_containers/README.md
+++ b/roles/set_openstack_containers/README.md
@@ -16,6 +16,8 @@ The role will generate two 2 files in ~/ci-framework-data/artifacts/ directory a
 * `cifmw_set_openstack_containers_dlrn_md5_path`: Full path of delorean.repo.md5. Defaults to `/etc/yum.repos.d/delorean.repo.md5`.
 * `cifmw_set_openstack_containers_overrides`: Extra container overrides. Defaults to `{}`
 * `cifmw_set_openstack_containers_prefix`: Update container containing. Defaults to `openstack`
+* `cifmw_set_openstack_containers_openstack_version_change`: (Boolean) Set environment variables for openstack services containers for specific OPENSTACK_RELEASE_VERSION defined in cifmw_set_openstack_containers_update_target_version. It should be used only for meta openstack operator in prepare for openstack minor update. Defaults to `false`.
+* `cifmw_set_openstack_containers_update_target_version`: Value of OPENSTACK_RELEASE_VERSION env in openstack operator that should be set. Defaults to `0.0.2`.
 
 ## Examples
 
@@ -87,6 +89,22 @@ It is used in edpm-ansible job to update the `ANSIBLEEE_IMAGE_URL_DEFAULT`.
         cifmw_set_openstack_containers_operator_name: openstack-ansibleee
         cifmw_set_openstack_containers_overrides:
           ANSIBLEEE_IMAGE_URL_DEFAULT: "{{ ansibleee_runner_img }}"
+      ansible.builtin.include_role:
+        name: set_openstack_containers
+```
+
+### Update all openstack services containers env vars in meta operator with tag from delorean and set OPENSTACK_RELEASE_VERSION env
+
+It is used in update job to set openstack services containers in prepare for running openstack update.
+
+```yaml
+    - name: Update all openstack services containers env vars in meta operator with tag from delorean and set OPENSTACK_RELEASE_VERSION
+      vars:
+        cifmw_set_openstack_containers_dlrn_md5_path:  "~/ci-framework-data//artifacts/repositories/delorean.repo.md5"
+        cifmw_set_openstack_containers_tag_from_md5: true
+        cifmw_set_openstack_containers_registry: quay.rdoproject.org
+        cifmw_set_openstack_containers_openstack_version_change: true
+        cifmw_set_openstack_containers_update_target_version: 0.0.2
       ansible.builtin.include_role:
         name: set_openstack_containers
 ```

--- a/roles/set_openstack_containers/defaults/main.yml
+++ b/roles/set_openstack_containers/defaults/main.yml
@@ -25,6 +25,8 @@ cifmw_set_openstack_containers_prefix: openstack
 cifmw_set_openstack_containers_operator_name: openstack
 cifmw_set_openstack_containers_tag_from_md5: false
 cifmw_set_openstack_containers_dlrn_md5_path: "/etc/yum.repos.d/delorean.repo.md5"
+cifmw_set_openstack_containers_openstack_version_change: false
+cifmw_set_openstack_containers_update_target_version: "0.0.2"
 
 # Set custom image url for non-openstack images
 cifmw_set_openstack_containers_overrides: {}

--- a/roles/set_openstack_containers/templates/update_env_vars.sh.j2
+++ b/roles/set_openstack_containers/templates/update_env_vars.sh.j2
@@ -10,6 +10,10 @@ export PATH="{{ cifmw_path }}"
 {#   Add `-` to the cifmw_set_openstack_containers_prefix to avoid issues with #}
 {#   openstack-openstackclient image name #}
 {% set _container_prefix = cifmw_set_openstack_containers_prefix + '-' -%}
+{# This is required to instruct openstack-operator to place environment variables for openstack services containers entries in openstackversion cr under targeted version #}
+{% if cifmw_set_openstack_containers_openstack_version_change | bool %}
+{%     set _ = containers_dict.update({'OPENSTACK_RELEASE_VERSION': cifmw_set_openstack_containers_update_target_version}) -%}
+{% endif                                       %}
 {# Environment variables contains = sign, Based on that we need to split with key and value #}
 {% for container in containers_env_list.stdout_lines if '=' in container -%}
 {%   set container_data = container.split('=') -%}
@@ -24,7 +28,12 @@ export PATH="{{ cifmw_path }}"
 {#   It filters out the same and update the container address with new url #}
 {%   elif (_container_prefix in _container) and ('operator' not in _container) -%}
 {%     set _container_data = _container.split(_container_prefix)[-1] -%}
-{%     set _container_name = _container_data.split('@sha256')[0] -%}
+{#   There is sha256 tag initially for container tags, but in some jobs we switch to dlrn tag #}
+{%     if '@sha256' in _container_data  -%}
+{%        set _container_name = _container_data.split('@sha256')[0]      -%}
+{%     else                                                              -%}
+{%        set _container_name = _container_data.split(':')[0]            -%}
+{%     endif                                                             -%}
 {%     set _container_address = _container_registry + '/' + _container_prefix + _container_name + ':' + cifmw_set_openstack_containers_tag -%}
 {%     set _ = containers_dict.update({_container_env: _container_address}) -%}
 {%   endif -%}


### PR DESCRIPTION
Add cifmw_set_openstack_containers_openstack_version_change var to set_openstack_containers role that enables to bump OPENSTACK_RELEASE_VERSION in openstack-operator csv.
Changing OPENSTACK_RELEASE_VERSION is required to start openstack minor update.[1]

[1]https://github.com/openstack-k8s-operators/dev-docs/blob/main/version_updates.md#general-update-workflow

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
