### PR TITLE
Create proper DNS records for each host/network pair

### DIFF
--- a/roles/dnsmasq/molecule/default/cleanup.yml
+++ b/roles/dnsmasq/molecule/default/cleanup.yml
@@ -17,6 +17,21 @@
 - name: Converge
   hosts: all
   tasks:
+    - name: Copy generated content in ci-framework-data/artifacts
+      vars:
+        dest_dir: >-
+          {{
+            (ansible_user_dir,
+             'ci-framework-data',
+             'artifacts') | path_join
+          }}
+      ansible.posix.synchronize:
+        src: "{{ item }}"
+        dest: "{{ dest_dir }}"
+      loop:
+        - /etc/cifmw-dnsmasq.conf
+        - /etc/cifmw-dnsmasq.d/
+
     - name: Remove a domain specific forwarder
       vars:
         cifmw_dnsmasq_forwarder:

--- a/roles/dnsmasq/molecule/default/converge.yml
+++ b/roles/dnsmasq/molecule/default/converge.yml
@@ -67,6 +67,57 @@
         name: dnsmasq
         tasks_from: manage_network.yml
 
+    - name: Check for enable-ra line in startrek
+      block:
+        - name: Inject enable-ra in startrek
+          become: true
+          register: _enable_ra
+          ansible.builtin.lineinfile:
+            line: "enable-ra"
+            path: "/etc/cifmw-dnsmasq.d/startrek.conf"
+
+        - name: Assert no change was done in startrek
+          ansible.builtin.assert:
+            that:
+              - _enable_ra is not changed
+            msg: >-
+              ipv6 not properly detected.
+
+    - name: Create IPv4-only network
+      vars:
+        cifmw_dnsmasq_network_name: oldies
+        cifmw_dnsmasq_network_state: present
+        cifmw_dnsmasq_listen_addresses:
+          - "192.168.252.1"
+        cifmw_dnsmasq_network_definition:
+          ranges:
+            - label: goodies
+              domain: "goodies.lan"
+              start_v4: 192.168.252.10
+              start_v6: ''
+              prefix_length_v4: 26
+      ansible.builtin.include_role:
+        name: dnsmasq
+        tasks_from: manage_network.yml
+
+    - name: Check for enable-ra line in oldies
+      block:
+        - name: Inject enable-ra in oldies
+          become: true
+          register: _set_ra
+          ansible.builtin.lineinfile:
+            line: "enable-ra"
+            path: "/etc/cifmw-dnsmasq.d/oldies.conf"
+
+        - name: Debug
+          ansible.builtin.debug:
+            var: _set_ra
+
+        - name: Assert oldies was changed
+          ansible.builtin.assert:
+            that:
+              - _set_ra is changed
+
     - name: Inject some node in starwars network
       vars:
         cifmw_dnsmasq_host_network: "{{ item.net }}"
@@ -145,18 +196,3 @@
 
     - name: Force reload dnsmasq
       ansible.builtin.meta: flush_handlers
-
-    - name: Copy generated content in ci-framework-data/artifacts
-      vars:
-        dest_dir: >-
-          {{
-            (ansible_user_dir,
-             'ci-framework-data',
-             'artifacts') | path_join
-          }}
-      ansible.posix.synchronize:
-        src: "{{ item }}"
-        dest: "{{ dest_dir }}"
-      loop:
-        - /etc/cifmw-dnsmasq.conf
-        - /etc/cifmw-dnsmasq.d/

--- a/roles/dnsmasq/molecule/default/prepare.yml
+++ b/roles/dnsmasq/molecule/default/prepare.yml
@@ -37,3 +37,11 @@
         ip4: "192.168.253.9/24"
         ip6: "2345:0426:2CA1::0567:5673:23b0/64"
         state: present
+
+    - name: Create 3nd dummy interface with needed IPs
+      become: true
+      community.general.nmcli:
+        type: dummy
+        conn_name: mol-test-3
+        ip4: "192.168.252.9/24"
+        state: present

--- a/roles/dnsmasq/tasks/manage_host_record.yml
+++ b/roles/dnsmasq/tasks/manage_host_record.yml
@@ -20,12 +20,17 @@
 - name: Add/Remove address
   become: true
   notify: Restart dnsmasq
+  vars:
+    _rec: >-
+      {{
+        (item.names + item.ips) | reject('match', '^$')
+      }}
   ansible.builtin.lineinfile:
     create: true
     path: "{{ cifmw_dnsmasq_basedir }}/host_records.conf"
     mode: '0644'
     line: >-
-      host-record={{ (item.names + item.ips) | join(',') }}
+      host-record={{ _rec | join(',') }}
     state: "{{ item.state }}"
     validate: "/usr/sbin/dnsmasq -C %s --test"
   loop: "{{ cifmw_dnsmasq_host_record }}"

--- a/roles/dnsmasq/templates/network.conf.j2
+++ b/roles/dnsmasq/templates/network.conf.j2
@@ -1,7 +1,8 @@
 # Managed by ci-framework/dnsmasq
-{% if cifmw_dnsmasq_network_definition['ranges'] | selectattr('start_v6', 'defined')               -%}
+{% if cifmw_dnsmasq_network_definition.ranges | selectattr('start_v6', 'defined') |
+    rejectattr('start_v6', 'match', '^$')                                                          -%}
 enable-ra
-{% endif                                                                                            %}
+{% endif                                                                                           -%}
 
 {% for range in cifmw_dnsmasq_network_definition['ranges']                                         -%}
 {%   if range.start_v4 is defined and range.start_v4 | length > 0                                  -%}

--- a/roles/libvirt_manager/tasks/create_networks.yml
+++ b/roles/libvirt_manager/tasks/create_networks.yml
@@ -113,6 +113,22 @@
     _dns_listener:
       - "{{ ansible_facts[_name].ipv4.address | default('') }}"
       - "{{ _ipv6.address | default('') }}"
+    _translate: >-
+      {{ cifmw_networking_mapper_interfaces_info_translations | default({}) }}
+    _net_domain: >-
+      {{
+        (_no_prefix_name in _translate) |
+        ternary(_translate[_no_prefix_name], [_no_prefix_name])
+      }}
+    _domain: >-
+      {%- if _no_prefix_name == cifmw_libvirt_manager_pub_net -%}
+      {{ cifmw_reproducer_domain | default('local') }}
+      {%- else -%}
+      {{
+        [_net_domain | first,
+         cifmw_reproducer_domain | default('local')] | join('.')
+      }}
+      {%- endif -%}
     _local_net_info:
       - name: "{{ _no_prefix_name }}"
         original_name: "{{ item }}"
@@ -135,6 +151,7 @@
               {{ _ipv6.prefix }}
               {%- endif -%}
             options: "{{ _dns_options | from_yaml }}"
+            domain: "{{ _domain }}"
   ansible.builtin.set_fact:
     _network_data: "{{ _network_data | default([]) + _local_net_info }}"
     _dns_listeners: >-

--- a/roles/libvirt_manager/tasks/reserve_dnsmasq_ips.yml
+++ b/roles/libvirt_manager/tasks/reserve_dnsmasq_ips.yml
@@ -41,3 +41,64 @@
   loop_control:
     label: "{{ host_data.key }} - {{ net.name }}"
     loop_var: "host_data"
+
+- name: Create host records
+  when:
+    - host_data.value.networks[_cleaned_netname] is defined
+  vars:
+    _net_name: >-
+      {{ (net.name is match '.*osp_trunk$') | ternary('ctlplane', net.name) }}
+    _cleaned_netname: "{{ _net_name | replace('cifmw_', '') }}"
+    _net_data: "{{ host_data.value.networks[_cleaned_netname] }}"
+    _ocp_name: >-
+      {{
+        host_data.key | replace('_', '-') |
+        replace('ocp-worker', 'worker') |
+        replace('ocp', 'master')
+      }}
+    _hostname: >-
+      {{
+        (host_data.key is match('^ocp.*')) |
+        ternary(_ocp_name, host_data.key)
+      }}
+    _translate: >-
+      {{ cifmw_networking_mapper_interfaces_info_translations | default({}) }}
+    _net_domain: >-
+      {{
+        (net.name in _translate) |
+        ternary(_translate[net.name], [net.name])
+      }}
+    _fqdn: >-
+      {%- if net.name == cifmw_libvirt_manager_pub_net -%}
+      {{ [_hostname ~ '.' ~ cifmw_reproducer_domain | default('local')] }}
+      {%- else -%}
+      {{
+        [_hostname] | product(_net_domain) |
+        map('join', '.') |
+        product([cifmw_reproducer_domain | default('local')]) |
+        map('join', '.')
+      }}
+      {%- endif -%}
+    _record:
+      - state: present
+        ips: >-
+          {{
+            [
+              _net_data.ip_v4 | default(''),
+              _net_data.ip_v6 | default('')
+            ]
+          }}
+        names: "{{ _fqdn }}"
+  ansible.builtin.set_fact:
+    host_records: "{{ host_records | default([]) + _record }}"
+  loop: "{{ cifmw_networking_env_definition.instances | dict2items }}"
+  loop_control:
+    label: "{{ host_data.key }} - {{ net.name }}"
+    loop_var: "host_data"
+
+- name: Inject host records
+  vars:
+    cifmw_dnsmasq_host_record: "{{ host_records }}"
+  ansible.builtin.include_role:
+    name: "dnsmasq"
+    tasks_from: "manage_host_record.yml"

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -93,6 +93,12 @@
            _cifmw_libvirt_manager_layout.vms.crc.amount|int > 0) or
         _cifmw_libvirt_manager_layout.vms.crc.amount is undefined)
       }}
+    _use_ocp: >-
+      {{
+        _cifmw_libvirt_manager_layout.vms.ocp is defined and
+        (_cifmw_libvirt_manager_layout.vms.ocp.amount is defined and
+         _cifmw_libvirt_manager_layout.vms.ocp.amount|int > 0)
+      }}
 
 - name: Ensure directories are present
   tags:

--- a/roles/reproducer/tasks/prepare_networking.yml
+++ b/roles/reproducer/tasks/prepare_networking.yml
@@ -123,6 +123,15 @@
   ansible.builtin.include_role:
     name: ci_nmstate
 
+- name: Select right domain
+  ansible.builtin.set_fact:
+    cifmw_reproducer_domain: >-
+      {%- if _use_crc | bool -%}
+      crc.testing
+      {%- elif _use_ocp | bool -%}
+      {{ cifmw_devscripts_config.base_domain }}
+      {%- endif -%}
+
 - name: Create the virtual networks
   when:
     - cifmw_libvirt_manager_mac_map is undefined


### PR DESCRIPTION
Since we now have a nice DNS service, let's use it.

This patch enables a series of features:

From now on, we build a domain based on the network name + deploy domain
(either crc.testing, or the one set in devscripts). A translation is
done for the "control plane" network (usually, osp_trunk is ctlplane).

While we reserve IPs for the nodes on each networks, we also generate
DNS entries. Here again, we translate the "control plane", taking
advantage of the networking_mapper translation table.

These features should make a lot of things far easier to handle. Note
that those records exist only for the networks where dnsmasq is
configured to provide services.

It also corrects a small nit in dnsmasq role where the built host-record
might have "empty field", leading to potential issues, for example:
`host-record=master-2.openstack.lab,192.168.111.13,`

This fix corrects the line to match the expected format:
`host-record=crc-0.crc.testing,192.168.100.30`

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
