### PR TITLE
Avoid printing secret with CA in install_openstack_ca

### DIFF
--- a/roles/install_openstack_ca/tasks/main.yml
+++ b/roles/install_openstack_ca/tasks/main.yml
@@ -21,6 +21,7 @@
   ansible.builtin.command:
     cmd: 'oc get secret combined-ca-bundle -n openstack -o "jsonpath={.data.tls-ca-bundle\.pem}"'
   retries: 10
+  no_log: true
   delay: 3
   until: ca_bundle_data.rc == 0
   register: ca_bundle_data
@@ -28,6 +29,7 @@
 
 - name: Get CA bundle
   when: ca_bundle_data.rc == 0
+  no_log: true
   ansible.builtin.set_fact:
     ca_bundle: >-
       {{ ca_bundle_data.stdout | ansible.builtin.b64decode }}


### PR DESCRIPTION
When we get the combined-ca-bundle secret to install the CA on the
controller, it prints the content of the secret to stdout. This content
is often really big, making the logs much longer without adding much
benefit, so this change adds no_log: true to avoid these lines in the
logs.

As a pull request owner and reviewers, I checked that:

- [x] Appropriate testing is done and actually running
