### PR TITLE
hook: nova_manage_discover_hosts.yml

### DIFF
--- a/hooks/playbooks/nova_manage_discover_hosts.yml
+++ b/hooks/playbooks/nova_manage_discover_hosts.yml
@@ -1,0 +1,23 @@
+---
+- name: Run nova-manage discover_hosts
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  vars:
+    _cell_conductors: null  # Comma separated list of strings
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  tasks:
+    - name: "Run nova-manage discover_hosts on {{ _cell_conductors }}"
+      cifmw.general.ci_script:
+        output_dir: "{{ cifmw_basedir }}/artifacts"
+        executable: "/bin/bash"
+        script: |
+          set -xe -o pipefail
+          {% if _cell_conductors is not none %}
+          oc project {{ namespace }}
+          {% for cell_conductor in _cell_conductors | split(',') %}
+          oc rsh {{ cell_conductor }} \
+            nova-manage cell_v2 discover_hosts --verbose
+          {% endfor %}
+          {% endif %}


### PR DESCRIPTION
Add a hook to run `nova-manage cell_v2 discover_hosts` one a given list of cell conductor pods.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running