### PR TITLE
Get just the nmstate operator when waiting for install

### DIFF
--- a/roles/ci_nmstate/tasks/nmstate_k8s_install.yml
+++ b/roles/ci_nmstate/tasks/nmstate_k8s_install.yml
@@ -39,6 +39,7 @@
     cmd: >-
       oc get ClusterServiceVersion
       -n "{{ cifmw_ci_nmstate_namespace }}"
+      -l operators.coreos.com/kubernetes-nmstate-operator.openshift-nmstate
       -o jsonpath='{.items[*].status.phase}'
   changed_when: false
   register: _nsmate_csv_out


### PR DESCRIPTION
When waiting for the nmstate operator to be installed, only that
operator needs to be returned in the results. As CSV's are visible from
all namespaces, restricting by namespace does not have the effect to
only show the CSV's from that namespace.

This task returns all CSV's in the cluster, regardless of namespace, and
fails if more than one CSV is returned as the expected output does not
match.

This commit adds a filter on the expected label for the nmstate operator
so that it will be the only operator returned.

Signed-off-by: James Slagle <jslagle@redhat.com>

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
