### PR TITLE
nat64 - do-daemonize: no

### DIFF
--- a/roles/nat64_appliance/files/elements/nat64-router/static/etc/unbound/unbound.conf
+++ b/roles/nat64_appliance/files/elements/nat64-router/static/etc/unbound/unbound.conf
@@ -1,6 +1,7 @@
 include: "/etc/unbound/conf.d/*.conf"
 server:
   use-systemd: yes
+  do-daemonize: no
   do-not-query-localhost: no
   module-config: "dns64 validator iterator"
   interface: ::1


### PR DESCRIPTION
There is a warning in the logs:

unbound[4558:0] warning:
  use-systemd and do-daemonize should not be enabled at the same time

Manual page:

  do-daemonize: <yes or no>
      Enable or disable whether the Unbound server forks into the
      background as a daemon.  Set the value to no when Unbound
      runs as systemd service.  Default is yes.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
