### PR TITLE
nat64 - pin dnsmasq to v2.89 tag

### DIFF
--- a/roles/nat64_appliance/files/elements/nat64-router/install.d/70-dnsmasq
+++ b/roles/nat64_appliance/files/elements/nat64-router/install.d/70-dnsmasq
@@ -21,7 +21,7 @@ set -o pipefail
 
 pushd /root
 
-git clone git://thekelleys.org.uk/dnsmasq.git
+git clone --depth 1 --branch v2.89 git://thekelleys.org.uk/dnsmasq.git
 
 pushd dnsmasq
 make

--- a/roles/nat64_appliance/molecule/default/converge.yml
+++ b/roles/nat64_appliance/molecule/default/converge.yml
@@ -277,6 +277,9 @@
       delegate_to: test-node
       register: _ping_example_com
       ansible.builtin.command: "ping -c 2 example.com"
+      until: _ping_example_com.rc == 0
+      retries: 60
+      delay: 10
 
     - name: Debug the ping example.com result
       ansible.builtin.debug:


### PR DESCRIPTION
Experiencing some issues, the nat64 stops responding to dns requests and strace on unbound shows:
  `recvfrom(3, 0x5641a194bcf0, 65552, 0, 0x7ffcbbc34438, [128]) = -1 EAGAIN (Resource temporarily unavailable)`

I guess the main branch of dnsmasq is having some issue. Let's try to pin on the v2.89 release tag.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running

