### PR TITLE
[docs] Fix files trigger for the docs job

### DIFF
--- a/zuul.d/doc.yaml
+++ b/zuul.d/doc.yaml
@@ -7,7 +7,7 @@
       doc_available: true
     files:
       - ^docs
-      - .*/*.md
+      - .*/.*.md
     pre-run:
       - ci/playbooks/pre-doc.yml
     run:


### PR DESCRIPTION
The docs job has an incorrect regex in the files trigger field. This regex triggers the job when there is no doc file modified. For example:

- cmd/csv-merger/csv-merger.go

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
