### PR TITLE
Fix variable name so it reaches reproducer-variables

### DIFF
--- a/roles/ci_lvms_storage/README.md
+++ b/roles/ci_lvms_storage/README.md
@@ -80,12 +80,12 @@ be controlled with the following parameters.
 
 ### Optional parameters
 
-* `ci_lvms_storage_tolerations`: (Dict) Allows to pass a set of tolerations to the lvms-operator to configure pods to eventually ignore scheduling restrictions applied to specific workers.
+* `cifmw_lvms_storage_tolerations`: (Dict) Allows to pass a set of tolerations to the lvms-operator to configure pods to eventually ignore scheduling restrictions applied to specific workers.
 
 Here an example showing how tolerations can be configured:
 
 ```yaml
-ci_lvms_storage_tolerations:
+cifmw_lvms_storage_tolerations:
   - key: "testOperator"
     value: "true"
     effect: "NoSchedule"

--- a/roles/ci_lvms_storage/defaults/main.yml
+++ b/roles/ci_lvms_storage/defaults/main.yml
@@ -31,4 +31,4 @@ cifmw_lvms_thin_pool_size_percent: 90
 cifmw_lvms_thin_pool_overprovision_ratio: 10
 cifmw_lvms_retries: 60
 cifmw_lvms_delay: 10
-ci_lvms_storage_tolerations: {}
+cifmw_lvms_storage_tolerations: {}

--- a/roles/ci_lvms_storage/templates/lvms-cluster.yaml.j2
+++ b/roles/ci_lvms_storage/templates/lvms-cluster.yaml.j2
@@ -5,9 +5,9 @@ metadata:
   name: {{ cifmw_lvms_cluster_name }}
   namespace: {{ cifmw_lvms_namespace }}
 spec:
-  {% if ci_lvms_storage_tolerations -%}
+  {% if cifmw_lvms_storage_tolerations -%}
   tolerations:
-  {% for item in ci_lvms_storage_tolerations -%}
+  {% for item in cifmw_lvms_storage_tolerations -%}
   - key: "{{ item['key'] }}"
     value: "{{ item['value'] }}"
     effect: "{{ item['effect'] }}"


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running