### PR TITLE
Add again DNS configuration for crc reproducer path 

### DIFF
--- a/roles/openshift_setup/tasks/restart_dns.yml
+++ b/roles/openshift_setup/tasks/restart_dns.yml
@@ -1,0 +1,40 @@
+- name: Check which dnsmasq config we must edit
+  register: _dnsmasq
+  ansible.builtin.stat:
+    path: '/srv/dnsmasq.conf'
+    get_attributes: false
+    get_checksum: false
+    get_mime: false
+
+- name: Restart dnsmasq service if used
+  become: true
+  when:
+    - not _dnsmasq.stat.exists
+  ansible.builtin.service:
+    name: dnsmasq
+    state: restarted
+
+- name: Manage old dnsmasq container
+  when:
+    - _dnsmasq.stat.exists
+  block:
+    # Avoid 'state: restarted' due to issues with IP not
+    # available when crc-dnsmasq starts
+    - name: Stop dnsmasq
+      become: true
+      ansible.builtin.systemd:
+        state: stopped
+        name: crc-dnsmasq
+
+    - name: Start dnsmasq
+      become: true
+      ansible.builtin.systemd:
+        state: started
+        name: crc-dnsmasq
+      register: _dnsmasq_start_reg
+      retries: 15
+      delay: 20
+      until:
+        - _dnsmasq_start_reg.failed is false
+        - _dnsmasq_start_reg.status is defined
+        - _dnsmasq_start_reg.status.ActiveState == "active"

--- a/roles/reproducer/tasks/configure_crc.yml
+++ b/roles/reproducer/tasks/configure_crc.yml
@@ -5,6 +5,47 @@
   ansible.builtin.slurp:
     path: /etc/ci/env/networking-environment-definition.yml
 
+- name: Configure CRC services
+  delegate_to: crc-0
+  vars:
+    _parsed: "{{ _net_conf.content | b64decode | from_yaml}}"
+    _crc: "{{ _parsed.instances['crc-0'].networks.ctlplane }}"
+  block:
+    - name: Check which dnsmasq config we must edit
+      register: _dnsmasq
+      ansible.builtin.stat:
+        path: '/srv/dnsmasq.conf'
+        get_attributes: false
+        get_checksum: false
+        get_mime: false
+
+    - name: Configure local DNS for CRC pod
+      become: true
+      vars:
+        _config_file: >-
+          {{
+            _dnsmasq.stat.exists |
+            ternary(_dnsmasq.stat.path, '/etc/dnsmasq.d/crc-dnsmasq.conf')
+          }}
+      block:
+        - name: Configure local DNS for CRC pod
+          register: last_modification
+          ansible.builtin.replace:
+            path: "{{ _config_file }}"
+            regexp: "192.168.130.11"
+            replace: "{{ _crc.ip_v4 }}"
+
+        - name: Ensure dnsmasq listens on correct interfaces
+          ansible.builtin.replace:
+            path: "{{ _config_file }}"
+            regexp: "listen-address={{ _crc.ip_v4 }}"
+            replace: "listen-address={{ _crc.ip_v4 }},127.0.0.1"
+
+    - name: Restart DNS in CRC VM
+      ansible.builtin.include_role:
+        name: openshift_setup
+        tasks_from: restart_dns.yml
+
 - name: Remove entry from /etc/hosts
   become: true
   vars:


### PR DESCRIPTION
Add again some tasks to properly configure dnsmasq for crc in the
reproducer. This is needed to make the zuul reproducer job green again.
Now the crc node should have the hypervisor in the resolv.conf but
dnsmasq listening on the right addresses.

Started as a duplicate
https://github.com/openstack-k8s-operators/ci-framework/pull/1944/
without zuul changes to test with downstream zuul, but now proposing this fix for the crc reproducer path to close CIX.


As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running