### PR TITLE
Multi-node and multi-cell netconfig fixes

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -406,90 +406,74 @@
     vars:
       <<: *adoption_vars
       crc_ci_bootstrap_networking:
-        networks:
-          default:
-            mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
-            router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
-            range: 192.168.122.0/24
-          internal-api:
-            vlan: 20
-            range: 172.17.0.0/16
-          storage:
-            vlan: 21
-            range: 172.18.0.0/16
-          tenant:
-            vlan: 22
-            range: 172.19.0.0/16
-          storage_mgmt:
-            vlan: 23
-            range: 172.20.0.0/16
-          external:
-            vlan: 44
-            range: 172.21.0.0/16
+        networks: *multinode_networks
         instances:
           controller: *multinode-crlr
           crc: *multinode-crc
           undercloud: *multinode-uc
+          # NOTE(bogdando): assuming at most 3 IPs reservations per a cell stack in this flat networking /24 model, we get:
+          # IP_ind = base(103) + cell(0..max_cells-1) * max_cells + ind(0..2)
+          # Here we just provide results as static entries, as in intall_yamls config-download-multistack.j2 (those must be matching)
           overcloud-controller-0: *multinode-crlr-leaf0
           cell1-controller-0:
-            networks:
-              default:
-                ip: 192.168.122.104
-                config_nm: false
-              internal-api:
-                ip: 172.17.1.104
-                config_nm: false
-              storage:
-                ip: 172.18.1.104
-                config_nm: false
-              tenant:
-                ip: 172.19.1.104
-                config_nm: false
-              storage_mgmt:
-                ip: 172.20.1.104
-                config_nm: false
-              external:
-                ip: 172.21.1.104
-                config_nm: false
-          cell2-controller-compute-0:
-            networks:
-              default:
-                ip: 192.168.122.105
-                config_nm: false
-              internal-api:
-                ip: 172.17.2.105
-                config_nm: false
-              storage:
-                ip: 172.18.2.105
-                config_nm: false
-              tenant:
-                ip: 172.19.2.105
-                config_nm: false
-              storage_mgmt:
-                ip: 172.20.2.105
-                config_nm: false
-              external:
-                ip: 172.21.2.105
-                config_nm: false
-          cell1-compute-0:
             networks:
               default:
                 ip: 192.168.122.106
                 config_nm: false
               internal-api:
-                ip: 172.17.1.106
+                ip: 172.17.0.106
                 config_nm: false
               storage:
-                ip: 172.18.1.106
+                ip: 172.18.0.106
                 config_nm: false
               tenant:
-                ip: 172.19.1.106
+                ip: 172.19.0.106
                 config_nm: false
               storage_mgmt:
-                ip: 172.20.1.106
+                ip: 172.20.0.106
                 config_nm: false
               external:
-                ip: 172.21.1.106
+                ip: 172.21.0.106
+                config_nm: false
+          cell1-compute-0:
+            networks:
+              default:
+                ip: 192.168.122.107
+                config_nm: false
+              internal-api:
+                ip: 172.17.0.107
+                config_nm: false
+              storage:
+                ip: 172.18.0.107
+                config_nm: false
+              tenant:
+                ip: 172.19.0.107
+                config_nm: false
+              storage_mgmt:
+                ip: 172.20.0.107
+                config_nm: false
+              external:
+                ip: 172.21.0.107
+                config_nm: false
+          cell2-controller-compute-0:
+            networks:
+              default:
+                ip: 192.168.122.109
+                config_nm: false
+              internal-api:
+                ip: 172.17.0.109
+                config_nm: false
+              storage:
+                ip: 172.18.0.109
+                config_nm: false
+              tenant:
+                ip: 172.19.0.109
+                config_nm: false
+              storage_mgmt:
+                ip: 172.20.0.109
+                config_nm: false
+              external:
+                ip: 172.21.0.109
                 config_nm: false
 
 - job:


### PR DESCRIPTION
* Use /24 CIDR for multi-cell adoption jobs

Unless there is a need in Spine & Leaf or segmented networks
testing coverage, use a flat subnet. It is also not clear
yet how to solve routing issues for external /16 network changes.

Use the same multicloud-network alias for mult-node and multi-cell
jobs networks defintions.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes

Required-By: https://review.rdoproject.org/r/c/rdo-jobs/+/53192
