### PR TITLE
Add a hook to increase quotas for project service

### DIFF
--- a/hooks/playbooks/service-project-more-quota.yml
+++ b/hooks/playbooks/service-project-more-quota.yml
@@ -1,0 +1,13 @@
+---
+- name: Increase quotas for the service project
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Set the volumes to 50
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.shell: |
+        oc project {{ namespace }}
+        oc rsh openstackclient \
+           openstack quota set --volumes 50 service


### PR DESCRIPTION
When running Glance using Cinder as a backend the `service` project is being used and tests can go over the volume quota.

This patch adds a playbook hook to increase the volume quota for the `service` project to 50.

Uses the region set in the `.config/openstack/clouds.yaml` of the `openstackclient` pod, and assumes the project name is `service`.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
