### PR TITLE
Enable some debugging on failure

### DIFF
--- a/roles/libvirt_manager/tasks/generate_networking_data.yml
+++ b/roles/libvirt_manager/tasks/generate_networking_data.yml
@@ -190,10 +190,6 @@
       {%   endif %}
       {% endif %}
   block:
-    - name: Expose _dataset
-      ansible.builtin.debug:
-        msg: "{{ _dataset }}"
-
     - name: Expose patch for networking_mapper
       vars:
         _filtered: >-
@@ -204,6 +200,20 @@
       ansible.builtin.set_fact:
         cifmw_networking_mapper_definition_patch_01_libvirt: >-
           {{  _filtered }}
+
+  rescue:
+    - name: Failure detected - output _network_data
+      ansible.builtin.debug:
+        var: _network_data
+
+    - name: Failure detected - output _match
+      ansible.builtin.debug:
+        var: _match
+
+    - name: Finally fail for goof
+      ansible.builtin.fail:
+        msg: >-
+          Failure detected. Check the debug outputs above
 
 - name: Save networking_mapper patch
   ansible.builtin.copy:


### PR DESCRIPTION
The content built in the variables might fail - and if does, it's
usually really hard to understand the issue, since ansible doesn't
output anything.

This patch allows to at last know what dataset is consumed by the
parameter build code, while ensure it still fails (rescue clears the
host errors).

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
