### PR TITLE
Add repositoryDigestMirrors configuration to openshift_setup

### DIFF
--- a/roles/openshift_setup/README.md
+++ b/roles/openshift_setup/README.md
@@ -15,3 +15,14 @@ should be configured for in an OCP/CRC cluster.
 * `cifmw_openshift_setup_ca_bundle_path`: (String) Path to the CA bundle.
 Defaults to `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`. Only has an
 effect if `cifmw_openshift_setup_ca_registry_to_add` is set.
+* `cifmw_openshift_setup_digest_mirrors`: (List) List of alternative mirrored repository locations. Defaults to `[]`.
+    * Example:
+        ```yaml
+        cifmw_openshift_setup_digest_mirrors:
+          - source: quay.io
+            mirrors:
+              - mirror.quay.io
+          - source: quay.rdoproject.org
+            mirrors:
+              - mirror.quay.rdoproject.org
+        ```

--- a/roles/openshift_setup/defaults/main.yml
+++ b/roles/openshift_setup/defaults/main.yml
@@ -23,3 +23,4 @@ cifmw_openshift_setup_create_namespaces: []
 cifmw_openshift_setup_skip_internal_registry: false
 cifmw_openshift_setup_skip_internal_registry_tls_verify: false
 cifmw_openshift_setup_ca_bundle_path: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+cifmw_openshift_setup_digest_mirrors: []

--- a/roles/openshift_setup/molecule/default/converge.yml
+++ b/roles/openshift_setup/molecule/default/converge.yml
@@ -24,6 +24,10 @@
     cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
     cifmw_openshift_setup_ca_registry_to_add: test.registry.com
     cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+    cifmw_openshift_setup_digest_mirrors:
+      - source: quay.rdoproject.org
+        mirrors:
+          - mirror.quay.rdoproject.org
   roles:
     - role: "openshift_setup"
   tasks:
@@ -56,3 +60,19 @@
       ansible.builtin.assert:
         that:
           - _image_patch.resources[0].spec.additionalTrustedCA.name == "registry-cas"
+
+    - name: Check that registry mirror resource is created
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit)}}"
+        context: "{{ cifmw_openshift_context | default(omit)}}"
+        api_version: operator.openshift.io/v1alpha1
+        kind: ImageContentSourcePolicy
+        name: registry-digest-mirrors
+      register: _registry_mirror
+
+    - name: Assert that digest mirrors are correct
+      ansible.builtin.assert:
+        that:
+          - _registry_mirror.resources[0].spec.repositoryDigestMirrors[0].source == "quay.rdoproject.org"
+          - _registry_mirror.resources[0].spec.repositoryDigestMirrors[0].mirrors[0] == "mirror.quay.rdoproject.org"

--- a/roles/openshift_setup/tasks/main.yml
+++ b/roles/openshift_setup/tasks/main.yml
@@ -167,6 +167,22 @@
             additionalTrustedCA:
               name: "registry-cas"
 
+- name: Create a ICSP with repository digest mirrors
+  when:
+    - cifmw_openshift_setup_digest_mirrors is defined
+    - cifmw_openshift_setup_digest_mirrors | length > 0
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    definition:
+      apiVersion: operator.openshift.io/v1alpha1
+      kind: ImageContentSourcePolicy
+      metadata:
+        name: registry-digest-mirrors
+      spec:
+        repositoryDigestMirrors: "{{ cifmw_openshift_setup_digest_mirrors }}"
+
 - name: Patch network operator when using OVNKubernetes backend
   ansible.builtin.import_tasks: patch_network_operator.yml
 


### PR DESCRIPTION
Adds a new configuration in openshift_setup role to allow configure repository digest mirrors.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
