### PR TITLE
dnsmasq: Use network/prefix in --domain option

### DIFF
--- a/roles/dnsmasq/templates/network.conf.j2
+++ b/roles/dnsmasq/templates/network.conf.j2
@@ -9,7 +9,7 @@ enable-ra
 dhcp-range=set:{{ range.label }},{{ range.start_v4 }},static,{{ (range.start_v4 + "/" + range.prefix_length_v4 | default(24) | string) | ansible.utils.ipaddr('netmask') }},{{ range.ttl | default('1h') }}
 {%      if range.domain is defined and range.domain | length > 0                                   -%}
 {%          set range_v4_allowed = (range.start_v4 ~ "/" ~ range.prefix_length_v4 | default('24')) |
-                                    ansible.utils.ipaddr('range_usable') | replace("-",",")         %}
+                                    ansible.utils.ipaddr('network/prefix')                          %}
 domain={{ range.domain }},{{ range_v4_allowed }},local
 {%      endif                                                                                       %}
 {%   endif                                                                                          %}
@@ -17,7 +17,7 @@ domain={{ range.domain }},{{ range_v4_allowed }},local
 dhcp-range=set:{{ range.label }},{{ range.start_v6 }},static,{{ range.prefix_length_v6 | default('64') }},{{ range.ttl | default('1h') }}
 {%      if range.domain is defined and range.domain | length > 0                                   -%}
 {%          set range_v6_allowed = (range.start_v6 ~ "/" ~ range.prefix_length_v6 | default('64')) |
-                                    ansible.utils.ipaddr('range_usable') | replace("-",",")         %}
+                                    ansible.utils.ipaddr('network/prefix')                          %}
 domain={{ range.domain }},{{ range_v6_allowed }},local
 {%      endif                                                                                       %}
 {%   endif                                                                                          %}


### PR DESCRIPTION
We add the `,local` option to --domain configuration statements. According to dnsmasq manual page this only works if using network/prefix for the range.

```
--domain=<domain>[[,<address range>[,local]]|<interface>]

If the address range is given as ip-address/network-size, then a additional
flag "local" may be supplied which has the effect of adding --local declarations
for forward and reverse DNS  queries.
Eg.   --domain=thekelleys.org.uk,192.168.0.0/24,local is identical to
      --domain=thekelleys.org.uk,192.168.0.0/24 --local=/thekelleys.org.uk/ --local=/0.168.192.in-addr.arpa/
```

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running

