### PR TITLE
Add variables to check if the pod is running or not

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -20,6 +20,9 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_node_selector`: (Dict) `nodeSelector` value that is applied to all pods spawned by the test-operator and to the test-operator-controller-manager and test-operator-logs pods. Default value: `{}`
 * `cifmw_test_operator_storage_class_prefix`: (String) Prefix for `storageClass` in generated Tempest CRD file. Defaults to `"lvms-"` only if `cifmw_use_lvms` is True, otherwise it defaults to `""`. The prefix is prepended to the `cifmw_test_operator_storage_class`. It is not recommended to override this value, instead set `cifmw_use_lvms` True or False.
 * `cifmw_test_operator_storage_class`: (String) Value for `storageClass` in generated Tempest or Tobiko CRD file. Defaults to `"lvms-local-storage"` only if `cifmw_use_lvms` is True, otherwise it defaults to `"local-storage"`.
+* `cifmw_test_operator_storage_class`: (String) Value for `storageClass` in generated Tempest CRD file. Defaults to `"lvms-local-storage"` only if `cifmw_use_lvms` is True, otherwise it defaults to `"local-storage"`.
+* `cifmw_test_operator_check_pod_retries`: (Integer) How many times to check if the test-operator-logs-pod is running. Default value: `20`
+* `cifmw_test_operator_check_pod_delay`: (Integer) How long is the delay between retries when check if test-operator-logs-pod is running
 
 ## Tempest specific parameters
 * `cifmw_test_operator_tempest_registry`: (String) The registry where to pull tempest container. Default value: `quay.io`

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -34,6 +34,8 @@ cifmw_test_operator_default_jobs:
 cifmw_test_operator_fail_fast: false
 cifmw_test_operator_storage_class_prefix: "{{ 'lvms-' if cifmw_use_lvms | default(false) | bool  else '' }}"
 cifmw_test_operator_storage_class: "{{ cifmw_test_operator_storage_class_prefix }}local-storage"
+cifmw_test_operator_check_pod_delay: 10
+cifmw_test_operator_check_pod_retries: 20
 
 # Section 2: tempest parameters - used when run_test_fw is 'tempest'
 cifmw_test_operator_tempest_registry: quay.io

--- a/roles/test_operator/tasks/run-test-operator-job.yml
+++ b/roles/test_operator/tasks/run-test-operator-job.yml
@@ -111,8 +111,8 @@
         wait: true
       register: logs_pod
       until: logs_pod.resources[0].status.phase == "Running"
-      delay: 10
-      retries: 20
+      delay: "{{ cifmw_test_operator_check_pod_delay }}"
+      retries: "{{ cifmw_test_operator_check_pod_retries }}"
 
     - name: Get logs from test-operator-logs-pod
       environment:


### PR DESCRIPTION
Usually, the default values to check if the pod is running or not is enough for normal jobs, but we notice an increase in time waiting when we are running unijobs, maybe because the amount of services running. Adding variables to set this values, will ensure we can defined a bigger timeout while checking for this without disrupt other jobs.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
