### PR TITLE
Correct prefix replacement in network names

### DIFF
--- a/roles/libvirt_manager/tasks/reserve_dnsmasq_ips.yml
+++ b/roles/libvirt_manager/tasks/reserve_dnsmasq_ips.yml
@@ -10,7 +10,7 @@
   vars:
     _net_name: >-
       {{ (net.name is match '.*osp_trunk$') | ternary('ctlplane', net.name) }}
-    _cleaned_netname: "{{ _net_name | replace('cifmw_', '') }}"
+    _cleaned_netname: "{{ _net_name | regex_replace('^cifmw[_-]', '') }}"
     _net_data: "{{ host_data.value.networks[_cleaned_netname] }}"
     _ocp_name: >-
       {{
@@ -48,7 +48,7 @@
   vars:
     _net_name: >-
       {{ (net.name is match '.*osp_trunk$') | ternary('ctlplane', net.name) }}
-    _cleaned_netname: "{{ _net_name | replace('cifmw_', '') }}"
+    _cleaned_netname: "{{ _net_name | regex_replace('^cifmw[_-]', '') }}"
     _net_data: "{{ host_data.value.networks[_cleaned_netname] }}"
     _ocp_name: >-
       {{


### PR DESCRIPTION
Usually we have `cifmw-` prefix, but the `replace` was looking for
`cifmw_` instead.
While it didn't create any issue in CI nor apparently in most of the
other scenarios, DCN had an issue.

This patch replaces the `replace` by `regex_replace` to ensure we're
properly catching both of `cifmw_` and `cifmw-` like some other places.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
