### PR TITLE
[ci_nmstate] Allow users to directly use the unprovisioned tasks

### DIFF
--- a/roles/ci_nmstate/README.md
+++ b/roles/ci_nmstate/README.md
@@ -93,3 +93,27 @@ cifmw_ci_nmstate_instance_config:
       ansible.builtin.include_role:
         name: "ci_nmstate"
 ```
+
+```YAML
+- name: Apply an NMstate state to a unmanaged host
+  vars:
+    cifmw_ci_nmstate_unmanaged_node_config:
+      interfaces:
+      - name: eth0
+        type: ethernet
+        state: up
+        ipv4:
+          address:
+          - ip: 192.168.122.250
+            prefix-length: 24
+          enabled: true
+        ipv6:
+          address:
+          - ip: 2001:db8::1:1
+            prefix-length: 64
+          enabled: true
+    cifmw_ci_nmstate_unmanaged_host: compute-1
+  ansible.builtin.include_role:
+    name: "ci_nmstate"
+    tasks_from: "nmstate_unmanaged_provision_node.yml"
+```

--- a/roles/ci_nmstate/filter_plugins/ci_nmstate_map_instance_nets.py
+++ b/roles/ci_nmstate/filter_plugins/ci_nmstate_map_instance_nets.py
@@ -158,14 +158,12 @@ class FilterModule:
     def __map_instance_vlan(instance_net_data):
         if "vlan_id" not in instance_net_data:
             return {}
+        content = {"type": "vlan", "vlan": {"id": int(instance_net_data["vlan_id"])}}
 
-        return {
-            "type": "vlan",
-            "vlan": {
-                "id": int(instance_net_data["vlan_id"]),
-                "base-iface": instance_net_data["parent_interface"],
-            },
-        }
+        if "parent_interface" in instance_net_data:
+            content["vlan"]["base-iface"] = instance_net_data["parent_interface"]
+
+        return content
 
     @classmethod
     def __map_instance_net_interface(cls, instance_net_data):

--- a/roles/ci_nmstate/tasks/main.yml
+++ b/roles/ci_nmstate/tasks/main.yml
@@ -14,14 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Create role needed directories
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: directory
-  loop:
-    - "{{ cifmw_ci_nmstate_configs_dir }}"
-    - "{{ cifmw_ci_nmstate_manifests_dir }}"
-
 - name: Load Networking Environment Definition
   when: cifmw_ci_nmstate_instance_config is not defined
   ansible.builtin.import_role:

--- a/roles/ci_nmstate/tasks/nmstate_k8s_install.yml
+++ b/roles/ci_nmstate/tasks/nmstate_k8s_install.yml
@@ -1,4 +1,9 @@
 ---
+- name: "Create the target dir to dump NMstate manifests"
+  ansible.builtin.file:
+    path: "{{ cifmw_ci_nmstate_manifests_dir }}"
+    state: directory
+
 - name: Create the nmstate namespace
   kubernetes.core.k8s:
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"

--- a/roles/ci_nmstate/tasks/nmstate_unmanaged_provision_node.yml
+++ b/roles/ci_nmstate/tasks/nmstate_unmanaged_provision_node.yml
@@ -21,6 +21,11 @@
     state: latest  # noqa: package-latest
     use: "{{ hostvars[cifmw_ci_nmstate_unmanaged_host]['ansible_facts']['pkg_mgr'] }}"
 
+- name: "Create the target NMstate dump directory"
+  ansible.builtin.file:
+    path: "{{ cifmw_ci_nmstate_configs_dir }}"
+    state: directory
+
 - name: "Save nmstate state for {{ cifmw_ci_nmstate_unmanaged_host }}"
   ansible.builtin.copy:
     dest: "{{ cifmw_ci_nmstate_configs_dir }}/{{ cifmw_ci_nmstate_unmanaged_host }}-state.yaml"


### PR DESCRIPTION
At the same time, fix a format issue in the Net Env Def that assumes the parent_interface is always present. That's no longer true since we added the new mapper that works in best effort mode.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
