### PR TITLE
Add storageclass in cifmw_test_operator_tobiko_config

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -19,7 +19,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_tolerations`: (Dict) `tolerations` value that is applied to all pods spawned by the test-operator and to the test-operator-controller-manager and test-operator-logs pods. Default value: `{}`
 * `cifmw_test_operator_node_selector`: (Dict) `nodeSelector` value that is applied to all pods spawned by the test-operator and to the test-operator-controller-manager and test-operator-logs pods. Default value: `{}`
 * `cifmw_test_operator_storage_class_prefix`: (String) Prefix for `storageClass` in generated Tempest CRD file. Defaults to `"lvms-"` only if `cifmw_use_lvms` is True, otherwise it defaults to `""`. The prefix is prepended to the `cifmw_test_operator_storage_class`. It is not recommended to override this value, instead set `cifmw_use_lvms` True or False.
-* `cifmw_test_operator_storage_class`: (String) Value for `storageClass` in generated Tempest CRD file. Defaults to `"lvms-local-storage"` only if `cifmw_use_lvms` is True, otherwise it defaults to `"local-storage"`.
+* `cifmw_test_operator_storage_class`: (String) Value for `storageClass` in generated Tempest or Tobiko CRD file. Defaults to `"lvms-local-storage"` only if `cifmw_use_lvms` is True, otherwise it defaults to `"local-storage"`.
 
 ## Tempest specific parameters
 * `cifmw_test_operator_tempest_registry`: (String) The registry where to pull tempest container. Default value: `quay.io`
@@ -47,6 +47,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
     namespace: "{{ cifmw_test_operator_namespace }}"
   spec:
     containerImage: "{{ cifmw_test_operator_tempest_image }}:{{ cifmw_test_operator_tempest_image_tag }}"
+    storageClass: "{{ cifmw_test_operator_storage_class }}"
     tolerations: "{{ cifmw_test_operator_tolerations | default(omit) }}"
     nodeSelector: "{{ cifmw_test_operator_node_selector | default(omit) }}"
     tempestRun:
@@ -86,6 +87,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
     namespace: "{{ cifmw_test_operator_namespace }}"
   spec:
     kubeconfigSecretName: "{{ cifmw_test_operator_tobiko_kubeconfig_secret }}"
+    storageClass: "{{ cifmw_test_operator_storage_class }}"
     containerImage: "{{ cifmw_test_operator_tobiko_image }}:{{ cifmw_test_operator_tobiko_image_tag }}"
     testenv: "{{ cifmw_test_operator_tobiko_testenv }}"
     version: "{{ cifmw_test_operator_tobiko_version }}"

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -134,6 +134,7 @@ cifmw_test_operator_tobiko_config:
     namespace: "{{ cifmw_test_operator_namespace }}"
   spec:
     kubeconfigSecretName: "{{ cifmw_test_operator_tobiko_kubeconfig_secret }}"
+    storageClass: "{{ cifmw_test_operator_storage_class }}"
     containerImage: "{{ cifmw_test_operator_tobiko_image }}:{{ cifmw_test_operator_tobiko_image_tag }}"
     testenv: "{{ cifmw_test_operator_tobiko_testenv }}"
     version: "{{ cifmw_test_operator_tobiko_version }}"


### PR DESCRIPTION
Tobiko_config needs to use the same storageclass chosen in the env.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
