### PR TITLE
Inject command aliases for faster debugging

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -93,6 +93,16 @@
           - wget
           - jq
 
+    - name: Inject command aliases for faster debugging
+      become: true
+      ansible.builtin.copy:
+        dest: "/etc/profile.d/cifmw-aliases.sh"
+        mode: "0644"
+        content: |-
+          # Aliases managed by ci-framework/reproducer/configure_controller.yml
+          # Feel free to submit PR to get more aliases in the file.
+          alias oc-job-log="oc logs -f -l job-name=$1"
+
     - name: Build job inventory for hook usage
       tags:
         - bootstrap


### PR DESCRIPTION
We will probably grow a bit that list while we see repetitive commands.

With the first `oc-job-log` we can directly follow logs from specified
job.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
