### PR TITLE
ci_gen_kustomize_values - IPv6

### DIFF
--- a/roles/ci_gen_kustomize_values/defaults/main.yml
+++ b/roles/ci_gen_kustomize_values/defaults/main.yml
@@ -70,6 +70,8 @@ ci_gen_kustomize_fetch_ocp_state: true
 cifmw_ci_gen_kustomize_values_storage_class_prefix: "{{ 'lvms-' if cifmw_use_lvms | default(false) | bool else '' }}"
 cifmw_ci_gen_kustomize_values_storage_class: "{{ cifmw_ci_gen_kustomize_values_storage_class_prefix }}local-storage"
 
+cifmw_ci_gen_kustomize_values_primary_ip_version: 4
+
 # Those parameter must be set if you want to edit an "edpm-values"
 # cifmw_ci_gen_kustomize_values_ssh_authorizedkeys
 # cifmw_ci_gen_kustomize_values_ssh_private_key

--- a/roles/ci_gen_kustomize_values/molecule/default/converge.yml
+++ b/roles/ci_gen_kustomize_values/molecule/default/converge.yml
@@ -36,7 +36,7 @@
   tasks:
     - name: Ensure architecture repository is building
       ansible.builtin.shell:
-        chdir: "{{ architecture_repo }}/{{ item.path }}"
+        chdir: "{{ architecture_repo }}/{{ item.path }}"
         cmd: >-
           {{ ansible_user_dir }}/bin/kustomize build >
           {{ artifacts }}/vanilla-{{ item.name }}.yaml
@@ -183,7 +183,7 @@
       ansible.builtin.copy:
         remote_src: true
         src: "{{ artifacts }}/ci_gen_kustomize_values/{{ item.key }}/values.yaml"
-        dest: "{{ architecture_repo }}/{{ item.value }}"
+        dest: "{{ architecture_repo }}/{{ item.value }}"
       loop:
         - key: 'network-values'
           value: 'examples/va/hci/control-plane/nncp/values.yaml'
@@ -192,7 +192,7 @@
 
     - name: Ensure kustomize is able to build
       ansible.builtin.shell:
-        chdir: "{{ architecture_repo }}/{{ item.path }}"
+        chdir: "{{ architecture_repo }}/{{ item.path }}"
         cmd: >-
           {{ ansible_user_dir }}/bin/kustomize build >
           {{ artifacts }}/{{ item.name }}.yaml

--- a/roles/ci_gen_kustomize_values/templates/common/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/common/edpm-nodeset-values/values.yaml.j2
@@ -1,5 +1,6 @@
 ---
 # source: common/edpm-nodeset-values/values.yaml.j2
+{% set _ipv = cifmw_ci_gen_kustomize_values_ip_version_var_mapping %}
 {% set instances_names = []                                                            %}
 {% set _original_nodeset = (original_content.data | default({})).nodeset | default({}) %}
 {% set _original_nodes = _original_nodeset.nodes | default({})                         %}
@@ -26,7 +27,7 @@ data:
 {% for instance in instances_names                                                     %}
           edpm-{{ instance }}:
 {%   if hostvars[instance] is defined                                                  %}
-            nic1: "{{ hostvars[instance].ansible_default_ipv4.macaddress }}"
+            nic1: "{{ hostvars[instance][_ipv.ansible_default_ipvX].macaddress }}"
 {%   endif                                                                             %}
             nic2: "{{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.mac_addr }}"
 {% endfor                                                                              %}
@@ -40,7 +41,7 @@ data:
 {% for instance in instances_names                                                     %}
       edpm-{{ instance }}:
         ansible:
-          host: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.ip_v4 }}
+          host: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane[_ipv.ip_vX] }}
         hostName: {{ instance }}
         networks:
 {%      for net in cifmw_networking_env_definition.instances[instance].networks.keys() %}
@@ -48,7 +49,7 @@ data:
             subnetName: subnet1
 {%        if net is match('ctlplane')                                                  %}
             defaultRoute: true
-            fixedIP: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.ip_v4 }}
+            fixedIP: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane[_ipv.ip_vX] }}
 {%        endif                                                                        %}
 {%      endfor                                                                         %}
 {% endfor                                                                              %}

--- a/roles/ci_gen_kustomize_values/templates/common/edpm-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/common/edpm-values/values.yaml.j2
@@ -1,5 +1,6 @@
 ---
 # source: common/edpm-values/values.yaml.j2
+{% set _ipv = cifmw_ci_gen_kustomize_values_ip_version_var_mapping %}
 {% set instances_names = []                                                            %}
 {% set _original_nodeset = (original_content.data | default({})).nodeset | default({}) %}
 {% set _original_nodes = _original_nodeset.nodes | default({})                         %}
@@ -33,7 +34,7 @@ data:
 {% for instance in instances_names                                                     %}
           edpm-{{ instance }}:
 {%   if hostvars[instance] is defined                                                  %}
-            nic1: "{{ hostvars[instance].ansible_default_ipv4.macaddress }}"
+            nic1: "{{ hostvars[instance][_ipv.ansible_default_ipvX].macaddress }}"
 {%   endif                                                                             %}
             nic2: "{{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.mac_addr }}"
 {% endfor                                                                              %}
@@ -56,7 +57,7 @@ data:
 {% for instance in instances_names                                                     %}
       edpm-{{ instance }}:
         ansible:
-          host: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.ip_v4 }}
+          host: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane[_ipv.ip_vX] }}
         hostName: {{ instance }}
         networks:
 {%      for net in cifmw_networking_env_definition.instances[instance].networks.keys() %}
@@ -64,7 +65,7 @@ data:
             subnetName: subnet1
 {%        if net is match('ctlplane')                                                  %}
             defaultRoute: true
-            fixedIP: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.ip_v4 }}
+            fixedIP: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane[_ipv.ip_vX] }}
 {%        endif                                                                        %}
 {%      endfor                                                                         %}
 {% endfor                                                                              %}

--- a/roles/ci_gen_kustomize_values/templates/common/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/common/network-values/values.yaml.j2
@@ -1,5 +1,6 @@
 ---
 # source: common/network-values/values.yaml.j2
+{% set _ipv = cifmw_ci_gen_kustomize_values_ip_version_var_mapping %}
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
                       lb_tools={}) %}
@@ -18,7 +19,7 @@ data:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}
 {%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
-    {{ network.network_name }}_ip: {{ network.ip_v4 }}
+    {{ network.network_name }}_ip: {{ network[_ipv.ip_vX] }}
 {%     endfor %}
 {%   endif %}
 {% endfor %}
@@ -35,22 +36,18 @@ data:
 {%      endif %}
 {%    endfor %}
       - allocationRanges:
-{%    for range in network.tools.netconfig.ipv4_ranges %}
+{%    for range in network.tools.netconfig[_ipv.ipvX_ranges] %}
         - end: {{ range.end }}
           start: {{ range.start }}
 {%    endfor %}
-        cidr: {{ network.network_v4 }}
-{%      if network.gw_v4 is defined %}
-        gateway: {{ network.gw_v4 }}
-{%      endif %}
+        cidr: {{ network[_ipv.network_vX] }}
+        gateway: {{ omit if network[_ipv.gw_vX] is not defined else network[_ipv.gw_vX] }}
         name: subnet1
-{%  if network.vlan_id is defined  %}
-        vlan: {{ network.vlan_id }}
-{%  endif %}
+        vlan: {{ omit if network.vlan_id is not defined else network.vlan_id }}
 {%    if ns.lb_tools | length > 0 %}
     lb_addresses:
 {%      for tool in ns.lb_tools.keys() %}
-{%        for lb_range in network.tools[tool].ipv4_ranges %}
+{%        for lb_range in network.tools[tool][_ipv.ipvX_ranges] %}
       - {{ lb_range.start }}-{{ lb_range.end }}
 {%          set _ = ns.lb_tools[tool].append(lb_range.start) %}
 {%        endfor %}
@@ -61,7 +58,7 @@ data:
 {%      endfor %}
 {%    endif %}
 {%  endif %}
-    prefix-length: {{ network.network_v4 | ansible.utils.ipaddr('prefix') }}
+    prefix-length: {{ network[_ipv.network_vX] | ansible.utils.ipaddr('prefix') }}
     mtu: {{ network.mtu | default(1500) }}
 {%  if network.vlan_id is defined  %}
     vlan: {{ network.vlan_id }}
@@ -89,9 +86,9 @@ data:
 {%  endif %}
         "ipam": {
           "type": "whereabouts",
-          "range": "{{ network.network_v4 }}",
-          "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
-          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}"
+          "range": "{{ network[_ipv.network_vX] }}",
+          "range_start": "{{ network.tools.multus[_ipv.ipvX_ranges].0.start }}",
+          "range_end": "{{ network.tools.multus[_ipv.ipvX_ranges].0.end }}"
         }
       }
 {%  endif %}
@@ -100,12 +97,12 @@ data:
   dns-resolver:
     config:
       server:
-        - "{{ cifmw_networking_env_definition.networks.ctlplane.gw_v4 }}"
+        - "{{ cifmw_networking_env_definition.networks.ctlplane[_ipv.gw_vX] }}"
       search: []
     options:
       - key: server
         values:
-          - {{ cifmw_networking_env_definition.networks.ctlplane.gw_v4 }}
+          - {{ cifmw_networking_env_definition.networks.ctlplane[_ipv.gw_vX] }}
 {% for nameserver in cifmw_ci_gen_kustomize_values_nameservers %}
       - key: server
         values:
@@ -119,11 +116,11 @@ data:
   rabbitmq:
     endpoint_annotations:
       metallb.universe.tf/address-pool: internalapi
-      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(85) }}
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'][_ipv.network_vX]  | ansible.utils.ipmath(85) }}
   rabbitmq-cell1:
     endpoint_annotations:
       metallb.universe.tf/address-pool: internalapi
-      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(86) }}
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'][_ipv.network_vX]  | ansible.utils.ipmath(86) }}
 
   lbServiceType: LoadBalancer
   storageClass: {{ cifmw_ci_gen_kustomize_values_storage_class }}

--- a/roles/ci_gen_kustomize_values/templates/uni01alpha/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni01alpha/network-values/values.yaml.j2
@@ -1,5 +1,6 @@
 ---
 # source: uni01alpha/network-values/values.yaml.j2
+{% set _ipv = cifmw_ci_gen_kustomize_values_ip_version_var_mapping %}
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
                       lb_tools={}) %}
@@ -18,7 +19,7 @@ data:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}
 {%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
-    {{ network.network_name }}_ip: {{ network.ip_v4 }}
+    {{ network.network_name }}_ip: {{ network[_ipv.ip_vX] }}
 {%     endfor %}
 {%   endif %}
 {% endfor %}
@@ -36,11 +37,11 @@ data:
 {%    if network.tools.netconfig is defined  %}
     subnets:
       - name: subnet1
-        cidr: {{ network.network_v4 }}
-        gateway: {{ omit if network.gw_v4 is not defined else network.gw_v4 }}
+        cidr: {{ network[_ipv.network_vX] }}
+        gateway: {{ omit if network[_ipv.gw_vX] is not defined else network[_ipv.gw_vX] }}
         vlan: {{ omit if network.vlan_id is not defined else network.vlan_id }}
         allocationRanges:
-{%    for range in network.tools.netconfig.ipv4_ranges %}
+{%    for range in network.tools.netconfig[_ipv.ipvX_ranges] %}
           - end: {{ range.end }}
             start: {{ range.start }}
 {%    endfor %}
@@ -48,7 +49,7 @@ data:
 {%    if ns.lb_tools | length > 0 %}
     lb_addresses:
 {%      for tool in ns.lb_tools.keys() %}
-{%        for lb_range in network.tools[tool].ipv4_ranges %}
+{%        for lb_range in network.tools[tool][_ipv.ipvX_ranges] %}
       - {{ lb_range.start }}-{{ lb_range.end }}
 {%          set _ = ns.lb_tools[tool].append(lb_range.start) %}
 {%        endfor %}
@@ -59,7 +60,7 @@ data:
 {%      endfor %}
 {%    endif %}
 {%  endif %}
-    prefix-length: {{ network.network_v4 | ansible.utils.ipaddr('prefix') }}
+    prefix-length: {{ network[_ipv.network_vX] | ansible.utils.ipaddr('prefix') }}
     mtu: {{ network.mtu | default(1500) }}
 {%  if network.vlan_id is defined  %}
     vlan: {{ network.vlan_id }}
@@ -79,9 +80,9 @@ data:
         "master": "ospbr",
         "ipam": {
           "type": "whereabouts",
-          "range": "{{ network.network_v4 }}",
-          "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
-          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}"
+          "range": "{{ network[_ipv.network_vX] }}",
+          "range_start": "{{ network.tools.multus[_ipv.ipvX_ranges].0.start }}",
+          "range_end": "{{ network.tools.multus[_ipv.ipvX_ranges].0.end }}"
         }
       }
 {%  endif %}
@@ -94,9 +95,9 @@ data:
         "bridge": "octbr",
         "ipam": {
           "type": "whereabouts",
-          "range": "{{ network.network_v4 }}",
-          "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
-          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}"
+          "range": "{{ network[_ipv.network_vX] }}",
+          "range_start": "{{ network.tools.multus[_ipv.ipvX_ranges].0.start }}",
+          "range_end": "{{ network.tools.multus[_ipv.ipvX_ranges].0.end }}"
         }
       }
 {%  endif %}
@@ -109,9 +110,9 @@ data:
         "bridge": "ironic",
         "ipam": {
           "type": "whereabouts",
-          "range": "{{ network.network_v4 }}",
-          "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
-          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}"
+          "range": "{{ network[_ipv.network_vX] }}",
+          "range_start": "{{ network.tools.multus[_ipv.ipvX_ranges].0.start }}",
+          "range_end": "{{ network.tools.multus[_ipv.ipvX_ranges].0.end }}"
         }
       }
 {%  endif %}
@@ -124,9 +125,9 @@ data:
         "master": "{{ network.network_name if network.vlan_id is defined else ns.interfaces[network.network_name] }}",
         "ipam": {
           "type": "whereabouts",
-          "range": "{{ network.network_v4 }}",
-          "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
-          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}"
+          "range": "{{ network[_ipv.network_vX] }}",
+          "range_start": "{{ network.tools.multus[_ipv.ipvX_ranges].0.start }}",
+          "range_end": "{{ network.tools.multus[_ipv.ipvX_ranges].0.end }}"
         }
       }
 {%  endif %}
@@ -134,12 +135,12 @@ data:
   dns-resolver:
     config:
       server:
-        - "{{ cifmw_networking_env_definition.networks.ctlplane.gw_v4 }}"
+        - "{{ cifmw_networking_env_definition.networks.ctlplane[_ipv.gw_vX] }}"
       search: []
     options:
       - key: server
         values:
-          - {{ cifmw_networking_env_definition.networks.ctlplane.gw_v4 }}
+          - {{ cifmw_networking_env_definition.networks.ctlplane[_ipv.gw_vX] }}
 {% for nameserver in cifmw_ci_gen_kustomize_values_nameservers %}
       - key: server
         values:
@@ -150,11 +151,11 @@ data:
   rabbitmq:
     endpoint_annotations:
       metallb.universe.tf/address-pool: internalapi
-      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(85) }}
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'][_ipv.network_vX] | ansible.utils.ipmath(85) }}
   rabbitmq-cell1:
     endpoint_annotations:
       metallb.universe.tf/address-pool: internalapi
-      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(86) }}
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'][_ipv.network_vX] | ansible.utils.ipmath(86) }}
 
   lbServiceType: LoadBalancer
   storageClass: {{ cifmw_ci_gen_kustomize_values_storage_class }}

--- a/roles/ci_gen_kustomize_values/templates/uni07eta/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni07eta/network-values/values.yaml.j2
@@ -1,5 +1,6 @@
 ---
 # source: uni07eta/network-values/values.yaml.j2
+{% set _ipv = cifmw_ci_gen_kustomize_values_ip_version_var_mapping %}
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
                       lb_tools={}) %}
@@ -18,7 +19,7 @@ data:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}
 {%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
-    {{ network.network_name }}_ip: {{ network.ip_v4 }}
+    {{ network.network_name }}_ip: {{ network[_ipv.ip_vX] }}
 {%     endfor %}
 {%   endif %}
 {% endfor %}
@@ -36,11 +37,11 @@ data:
 {%    if network.tools.netconfig is defined  %}
     subnets:
       - name: subnet1
-        cidr: {{ network.network_v4 }}
-        gateway: {{ omit if network.gw_v4 is not defined else network.gw_v4 }}
+        cidr: {{ network[_ipv.network_vX] }}
+        gateway: {{ omit if network[_ipv.gw_vX] is not defined else network[_ipv.gw_vX] }}
         vlan: {{ omit if network.vlan_id is not defined else network.vlan_id }}
         allocationRanges:
-{%    for range in network.tools.netconfig.ipv4_ranges %}
+{%    for range in network.tools.netconfig[_ipv.ipvX_ranges] %}
           - end: {{ range.end }}
             start: {{ range.start }}
 {%    endfor %}
@@ -48,7 +49,7 @@ data:
 {%    if ns.lb_tools | length > 0 %}
     lb_addresses:
 {%      for tool in ns.lb_tools.keys() %}
-{%        for lb_range in network.tools[tool].ipv4_ranges %}
+{%        for lb_range in network.tools[tool][_ipv.ipvX_ranges] %}
       - {{ lb_range.start }}-{{ lb_range.end }}
 {%          set _ = ns.lb_tools[tool].append(lb_range.start) %}
 {%        endfor %}
@@ -59,7 +60,7 @@ data:
 {%      endfor %}
 {%    endif %}
 {%  endif %}
-    prefix-length: {{ network.network_v4 | ansible.utils.ipaddr('prefix') }}
+    prefix-length: {{ network[_ipv.network_vX] | ansible.utils.ipaddr('prefix') }}
     mtu: {{ network.mtu | default(1500) }}
 {%  if network.vlan_id is defined  %}
     vlan: {{ network.vlan_id }}
@@ -79,9 +80,9 @@ data:
         "master": "ospbr",
         "ipam": {
           "type": "whereabouts",
-          "range": "{{ network.network_v4 }}",
-          "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
-          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}"
+          "range": "{{ network[_ipv.network_vX] }}",
+          "range_start": "{{ network.tools.multus[_ipv.ipvX_ranges].0.start }}",
+          "range_end": "{{ network.tools.multus[_ipv.ipvX_ranges].0.end }}"
         }
       }
 {%  endif %}
@@ -94,9 +95,9 @@ data:
         "bridge": "octbr",
         "ipam": {
           "type": "whereabouts",
-          "range": "{{ network.network_v4 }}",
-          "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
-          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}"
+          "range": "{{ network[_ipv.network_vX] }}",
+          "range_start": "{{ network.tools.multus[_ipv.ipvX_ranges].0.start }}",
+          "range_end": "{{ network.tools.multus[_ipv.ipvX_ranges].0.end }}"
         }
       }
 {%  endif %}
@@ -109,9 +110,9 @@ data:
         "bridge": "ironic",
         "ipam": {
           "type": "whereabouts",
-          "range": "{{ network.network_v4 }}",
-          "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
-          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}"
+          "range": "{{ network[_ipv.network_vX] }}",
+          "range_start": "{{ network.tools.multus[_ipv.ipvX_ranges].0.start }}",
+          "range_end": "{{ network.tools.multus[_ipv.ipvX_ranges].0.end }}"
         }
       }
 {%  endif %}
@@ -124,9 +125,9 @@ data:
         "master": "{{ network.network_name if network.vlan_id is defined else ns.interfaces[network.network_name] }}",
         "ipam": {
           "type": "whereabouts",
-          "range": "{{ network.network_v4 }}",
-          "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
-          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}"
+          "range": "{{ network[_ipv.network_vX] }}",
+          "range_start": "{{ network.tools.multus[_ipv.ipvX_ranges].0.start }}",
+          "range_end": "{{ network.tools.multus[_ipv.ipvX_ranges].0.end }}"
         }
       }
 {%  endif %}
@@ -134,12 +135,12 @@ data:
   dns-resolver:
     config:
       server:
-        - "{{ cifmw_networking_env_definition.networks.ctlplane.gw_v4 }}"
+        - "{{ cifmw_networking_env_definition.networks.ctlplane[_ipv.gw_vX] }}"
       search: []
     options:
       - key: server
         values:
-          - {{ cifmw_networking_env_definition.networks.ctlplane.gw_v4 }}
+          - {{ cifmw_networking_env_definition.networks.ctlplane[_ipv.gw_vX] }}
 {% for nameserver in cifmw_ci_gen_kustomize_values_nameservers %}
       - key: server
         values:
@@ -150,11 +151,11 @@ data:
   rabbitmq:
     endpoint_annotations:
       metallb.universe.tf/address-pool: internalapi
-      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(85) }}
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'][_ipv.network_vX] | ansible.utils.ipmath(85) }}
   rabbitmq-cell1:
     endpoint_annotations:
       metallb.universe.tf/address-pool: internalapi
-      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(86) }}
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'][_ipv.network_vX] | ansible.utils.ipmath(86) }}
 
   lbServiceType: LoadBalancer
   storageClass: {{ cifmw_ci_gen_kustomize_values_storage_class }}

--- a/roles/ci_gen_kustomize_values/vars/main.yml
+++ b/roles/ci_gen_kustomize_values/vars/main.yml
@@ -22,3 +22,40 @@
 # All variables within this role should have a prefix of "cifmw_ci_gen_kustomize_values"
 
 cifmw_ci_gen_kustomize_values_original_cm_content_file_name: "01_original.yaml"
+
+cifmw_ci_gen_kustomize_values_ip_version_var_mapping:
+  ipvX: >-
+   {{
+     (cifmw_ci_gen_kustomize_values_primary_ip_version | int == 4)
+     | ternary('ipv4', 'ipv6')
+   }}
+  ip_vX: >-
+    {{
+      (cifmw_ci_gen_kustomize_values_primary_ip_version | int == 4)
+      | ternary('ip_v4', 'ip_v6')
+    }}
+  ansible_default_ipvX: >-
+    {{
+      (cifmw_ci_gen_kustomize_values_primary_ip_version | int == 4)
+      | ternary('ansible_default_ipv4', 'ansible_default_ipv6')
+    }}
+  network_vX: >-
+    {{
+      (cifmw_ci_gen_kustomize_values_primary_ip_version | int == 4)
+      | ternary('network_v4', 'network_v6')
+    }}
+  vX: >-
+    {{
+      (cifmw_ci_gen_kustomize_values_primary_ip_version | int == 4)
+      | ternary('v4', 'v6')
+    }}
+  gw_vX: >-
+    {{
+      (cifmw_ci_gen_kustomize_values_primary_ip_version | int == 4)
+      | ternary('gw_v4', 'gw_v6')
+    }}
+  ipvX_ranges: >-
+    {{
+      (cifmw_ci_gen_kustomize_values_primary_ip_version | int == 4)
+      | ternary('ipv4_ranges', 'ipv6_ranges')
+    }}


### PR DESCRIPTION
Adds a new role variable: `cifmw_ci_gen_kustomize_values_primary_ip_version` Defaults to `4` 
Set variable `cifmw_ci_gen_kustomize_values_ip_version_var_mapping` with conditionally set `vX` values based on IP version.

In the jinja2 templates, set up variable `_ipv` with the mapping from `cifmw_ci_gen_kustomize_values_ip_version_var_mapping`.

By replacing the version specific variables. i.e `network_v4` with `_ipv.network_vX` etc in the template so that it is easy to switch the primary ip-version when looking up data from facts and loaded data structures.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

### Testing (not in commit message)
- [x] uni01alpha
- [x] uni06zeta
- [x] validate-architecture (via https://github.com/openstack-k8s-operators/architecture/pull/319)
- [x] nfv (ci HW)
