### PR TITLE
Add cifmw_edpm_build_images_host_extra_packages

### DIFF
--- a/roles/edpm_build_images/README.md
+++ b/roles/edpm_build_images/README.md
@@ -9,10 +9,15 @@ the variables "cifmw_edpm_build_images_ironic_python_agent_package" and
 ## Privilege escalation
 None
 
+## Vars
+These variables should not be updated.
+* `cifmw_edpm_build_images_host_packages`: List of packages required to build the images.
+
+
 ## Parameters
 * `cifmw_edpm_build_images_basedir`: Base directory. Defaults to `cifmw_basedir` which  defaults to `~/ci-framework`.
 * `cifmw_edpm_build_images_via_rpm`: Whether to install `edpm-image-builder` repo using rpm or not.
-* `cifmw_build_host_packages`: List of packages required to build the images.
+* `cifmw_edpm_build_images_host_extra_packages`: List of packages that are installed on EDPM node images for other purposes, such as testing. Defaults to empty list.
 * `cifmw_edpm_build_images_elements`: Elements path which contains `edpm-image-builder` and `ironic-python-agent-builder` repo.
 * `cifmw_edpm_build_images_all`: (Boolean) Build both the `edpm-hardened-uefi` and `ironic-python-agent` images when it true. Default to false.
 * `cifmw_edpm_build_images_hardened_uefi`: (Boolean) Build `edpm-hardened-uefi` image when it true. Default to false.

--- a/roles/edpm_build_images/defaults/main.yml
+++ b/roles/edpm_build_images/defaults/main.yml
@@ -20,10 +20,7 @@
 
 cifmw_edpm_build_images_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_edpm_build_images_via_rpm: true
-cifmw_edpm_build_images_host_packages:
-  - diskimage-builder
-  - openstack-ironic-python-agent-builder
-  - buildah
+cifmw_edpm_build_images_host_extra_packages: []
 cifmw_edpm_image_builder_repo_path: >-
   {%- if cifmw_edpm_build_images_via_rpm | bool -%}
     /usr/share/edpm-image-builder/

--- a/roles/edpm_build_images/tasks/install.yml
+++ b/roles/edpm_build_images/tasks/install.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add edpm-image-builder to the list of packages to be installed on host
   ansible.builtin.set_fact:
-    cifmw_edpm_build_images_host_packages: "{{ cifmw_edpm_build_images_host_packages + ['edpm-image-builder'] }}"
+    _host_packages: "{{ cifmw_edpm_build_images_host_packages + ['edpm-image-builder'] + cifmw_edpm_build_images_host_extra_packages }}"
   when:
     - cifmw_edpm_build_images_via_rpm
     - not cifmw_edpm_build_images_dry_run
@@ -11,7 +11,7 @@
     - not cifmw_edpm_build_images_dry_run
   become: true
   ansible.builtin.package:
-    name: "{{ cifmw_edpm_build_images_host_packages }}"
+    name: "{{ _host_packages }}"
     state: latest  # noqa: package-latest
   tags:
     - bootstrap

--- a/roles/edpm_build_images/vars/main.yaml
+++ b/roles/edpm_build_images/vars/main.yaml
@@ -1,0 +1,20 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+cifmw_edpm_build_images_host_packages:
+  - diskimage-builder
+  - openstack-ironic-python-agent-builder
+  - buildah


### PR DESCRIPTION
When some extra packages need to be installed on the EDPM images (for example, for testing purposes), this new parameter can be used. The legacy `cifmw_edpm_build_images_host_packages` parameter should not be overwritten.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
