### PR TITLE
Ensure repositories are cleaned from the hypervisor

### DIFF
--- a/reproducer-clean.yml
+++ b/reproducer-clean.yml
@@ -59,6 +59,20 @@
         path: "{{ lookup('env', 'HOME') }}/ci-framework-data/ci-reproducer"
         state: absent
 
+    - name: Clean repo_setup content
+      tags:
+        - deepscrub
+      ansible.builtin.import_role:
+        name: "repo_setup"
+        tasks_from: "clean_rhos_release.yml"
+
+    - name: Clean ci_setup repositories
+      tags:
+        - deepscrub
+      ansible.builtin.import_role:
+        name: "ci_setup"
+        tasks_from: "cleanup.yml"
+
     - name: Remove basedir
       tags:
         - never

--- a/roles/ci_setup/tasks/cleanup.yml
+++ b/roles/ci_setup/tasks/cleanup.yml
@@ -13,3 +13,10 @@
     rhsm_repo_state: "disabled"
     yum_repo_state: "absent"
   ansible.builtin.import_tasks: repos.yml
+
+- name: Clean EPEL
+  tags:
+    - cleanup
+  vars:
+    epel_status: absent
+  ansible.builtin.import_tasks: epel.yml

--- a/roles/ci_setup/tasks/epel.yml
+++ b/roles/ci_setup/tasks/epel.yml
@@ -1,23 +1,46 @@
 ---
+
+- name: Set epel_status id needed
+  when:
+    - epel_status is undefined
+  ansible.builtin.set_fact:
+    epel_status: present
+
 - name: Ensure we have needed repositories
+  when:
+    - epel_status == 'present'
   ansible.builtin.import_role:
     name: ci_setup
     tasks_from: repos.yml
 
 - name: Install EPEL
   become: true
+  when:
+    - epel_status == 'present'
   ansible.builtin.dnf:
     name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
     disable_gpg_check: true
 
 - name: Deactivate all of EPEL repositories
   become: true
+  when:
+    - epel_status == 'present'
   ansible.builtin.shell:  # noqa: command-instead-of-module
     cmd: sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/epel*
 
 - name: Install packages from EPEL
   become: true
+  when:
+    - epel_status == 'present'
   ansible.builtin.dnf:  # noqa: package-latest
     enablerepo: epel
     name: "{{ cifmw_ci_setup_epel_pkgs }}"
     state: latest
+
+- name: Remove EPEL if instructed
+  become: true
+  when:
+    - epel_status == 'absent'
+  ansible.builtin.package:
+    name: "epel-release"
+    state: absent

--- a/roles/repo_setup/tasks/clean_rhos_release.yml
+++ b/roles/repo_setup/tasks/clean_rhos_release.yml
@@ -14,12 +14,14 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Remove repositories
-  ansible.builtin.file:
-    path: "{{ cifmw_repo_setup_basedir }}/artifacts/repositories"
-    state: absent
+- name: Fetch installed packages fact if needed
+  when:
+    - ansible_facts.packages is undefined
+  ansible.builtin.package_facts: {}
 
-- name: Remove virtualenv
-  ansible.builtin.file:
-    path: "{{ cifmw_repo_setup_basedir }}/venv"
-    state: absent
+- name: Purge rhos-release
+  when:
+    - ansible_facts.packages['rhos-release'] is defined
+  become: true
+  ansible.builtin.command:
+    cmd: rhos-release --purge


### PR DESCRIPTION
Until now, repositories weren't cleaned on the hypervisor, leading to
potential issues when, for instance, rhos-release was called with
different release over different runs.

Same goes for EPEL, someone might remove the repo file, leading to later
issues with "epel-release" installed but absent files.

This patch corrects those potential issues, and should help getting a
cleaner hypervisor, ensuring no repositories leak between runs.

It takes care of:
- epel-release removal
- rhos-release --purge
- reorder a bit things in repo_setup cleanup*

(*) in case we have to start cleaning its deployed repositories. Note
that, for now at least, "repo-setup" is never called against the
hypervisor itself.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
