### PR TITLE
Add support for live documentation editing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,10 @@ enable-git-hooks:
 docs: ## Create documentation under docs/build/html
 	./docs/source/build-docs.sh
 
+.PHONY: docs_live
+docs_live: ## Create documentation live after any changes
+	BUILD_TYPE=live ./docs/source/build-docs.sh
+
 .PHONY: spelling
 spelling: docs ## Run spell check as in CI
 	if [ -f docs/dictionary/tmp ]; then \

--- a/docs/source/Makefile
+++ b/docs/source/Makefile
@@ -39,3 +39,6 @@ role_doc:
 		test -L ./roles/$${role_name}.md || \
 		ln -s ../$$i ./roles/$${role_name}.md; \
 	done
+
+.PHONY: autobuild_pre
+autobuild_pre: utils_doc plugin_doc role_doc

--- a/docs/source/build-docs.sh
+++ b/docs/source/build-docs.sh
@@ -2,8 +2,10 @@
 
 set -euxo pipefail
 DOCS_DIR="./docs"
-VENV_DIR=${DOCS_DIR}/_venv
+VENV_DIR="${DOCS_DIR}/_venv"
+BUILD_TYPE="${BUILD_TYPE:=static}"
 
+# Create a virtual environment and activate it
 python -m venv ${VENV_DIR} && source ${VENV_DIR}/bin/activate
 pip3 install -r ${DOCS_DIR}/doc-requirements.txt
 
@@ -16,6 +18,16 @@ SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[0])')
 ansible-galaxy collection install -U ../.. -p "${SITE_PACKAGES}"
 
 make clean
-make html
 
+# Build the documentation based on the specified build type
+if [[ $BUILD_TYPE == "static" ]]; then
+    make html
+elif [[ $BUILD_TYPE == "live" ]]; then
+    sphinx-autobuild --pre-build "make autobuild_pre" \
+        --watch ../../plugins \
+        --re-ignore '(plugins|module_utils|roles)/.*.rst' \
+        . ../_build
+fi
+
+# Deactivate the virtual environment
 deactivate


### PR DESCRIPTION
This patch adds the docs-live make target. This make target uses
`sphinx-autobuild` to rebuild and reload docuemtnation content in the
browser.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running