### PR TITLE
[reproducer] Clean last mentions of ipv4-only

### DIFF
--- a/roles/reproducer/tasks/configure_computes.yml
+++ b/roles/reproducer/tasks/configure_computes.yml
@@ -5,7 +5,7 @@
     - name: Ensure we can ping controller-0 from ctlplane
       ansible.builtin.command:
         cmd: |
-          ping -c2 {{ _controller_ip4 }}
+          ping -c2 controller-0.utility
 
     - name: Tweak dnf configuration
       become: true

--- a/roles/reproducer/tasks/libvirt_layout.yml
+++ b/roles/reproducer/tasks/libvirt_layout.yml
@@ -128,11 +128,6 @@
       (compute.key in (groups['networkers'] | default([])))
   vars:
     _host: "{{ compute.key }}"
-    _dns4: "{{ cifmw_networking_env_definition.networks.ctlplane.dns_v4[0] }}"
-    _iface: "{{ compute.value.networks.ctlplane.interface_name }}"
-    _ip4: "{{ compute.value.networks.ctlplane.ip_v4 }}"
-    _gw4: "{{ cifmw_networking_env_definition.networks.ctlplane.gw_v4 }}"
-    _controller_ip4: "{{ cifmw_networking_env_definition.instances['controller-0'].networks.ctlplane.ip_v4 }}"
     _prefix: "{{cifmw_networking_env_definition.networks.ctlplane.network_v4 | ansible.utils.ipaddr('prefix') }}"
   ansible.builtin.include_tasks: configure_computes.yml
   loop: >-

--- a/roles/reproducer/tasks/prepare_networking.yml
+++ b/roles/reproducer/tasks/prepare_networking.yml
@@ -201,6 +201,7 @@
             state: present
           - names:
               - "sushy.utility"
+              - "controller-0.utility"
             ips:
               - "{{ _controller_net.ctlplane.ip_v4 | default('') }}"
               - "{{ _controller_net.ctlplane.ip_v6 | default('') }}"


### PR DESCRIPTION
With this patch, we should at last get a full ipv6 support in the
reproducer role:
- switched the last hard-coded ipv4 references to DNS
- removed the last hard-coded ipv4-only extractions

There might be some more iterations, but we're in a really good position
now that we have the `.utility` zone (see #1968)

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
