### PR TITLE
Add optional hardware validations

### DIFF
--- a/roles/reproducer/README.md
+++ b/roles/reproducer/README.md
@@ -20,6 +20,7 @@ None
 * `cifmw_reproducer_dnf_tweaks`: (List) Options you want to inject in dnf.conf, both on controller-0 and hypervisor. Defaults to `[]`.
 * `cifmw_reproducer_skip_fetch_repositories`: (Bool) Skip fetching repositories from zuul var and simply copy the code from the ansible controller. Defaults to `false`.
 * `cifmw_reproducer_supported_hypervisor_os`: (List) List of supported hypervisor operating systems and their minimum version.
+* `cifmw_reproducer_minimum_hardware_requirements`: (Dict) Define minimum hardware requirements for specific scenarios. Example below
 
 ### Advanced parameters
 Those parameters shouldn't be used, unless the user is able to understand potential issues in their environment.
@@ -77,4 +78,12 @@ cifmw_reproducer_repositories:
   # Just get HEAD
   - src: "https://github.com/openstack-k8s-operators/openstack-operators"
     dest: "{{ remote_base_dir }}/openstack-operators"
+```
+
+#### Example `cifmw_reproducer_minimum_hardware_requirements`:
+```YAML
+cifmw_reproducer_minimum_hardware_requirements:
+  vcpu: 16
+  memory: "32 GB"
+  disk: "200 GB"
 ```

--- a/roles/reproducer/tasks/validations.yml
+++ b/roles/reproducer/tasks/validations.yml
@@ -41,6 +41,38 @@
       {{ cifmw_reproducer_supported_hypervisor_os[ansible_distribution].minimum_version }}
       https://ci-framework.readthedocs.io/en/latest/quickstart/02_prepare_env.html#tested-environment
 
+- name: Validate the hardware requirments
+  when: cifmw_reproducer_minimum_hardware_requirements is defined
+  block:
+    - name: Verfy CPU count exceeds minimum defined in scenario file
+      when: cifmw_reproducer_minimum_hardware_requirements.vcpu is defined
+      ansible.builtin.assert:
+        that: ansible_processor_vcpus >= {{ cifmw_reproducer_minimum_hardware_requirements.vcpu }}
+        msg: >-
+          {{ ansible_hostname }} has {{ ansible_processor_vcpus }} VCPU but must have >=
+          {{ cifmw_reproducer_minimum_hardware_requirements.vcpu }} VCPU as defined by the scenario file
+
+    - name: Validate memory amount exceeds minimum defined in scenario file
+      when: cifmw_reproducer_minimum_hardware_requirements.memory is defined
+      vars:
+        _memory_bytes: "{{ ansible_memtotal_mb * 1048576 }}"
+      ansible.builtin.assert:
+        that: _memory_bytes | int >= cifmw_reproducer_minimum_hardware_requirements.memory | human_to_bytes
+        msg: >-
+          {{ ansible_hostname }} has {{ _memory_bytes | int | human_readable }} of memory but must have >=
+          {{ cifmw_reproducer_minimum_hardware_requirements.memory }} memory as defined by the scenario file
+
+    - name: Validate home disk size exceeds minimum defined in scenario file
+      when: cifmw_reproducer_minimum_hardware_requirements.memory is defined
+      vars:
+        _home_disk_size: >-
+          {{ ansible_mounts | selectattr('mount', 'equalto', '/home') | map(attribute='size_total') | first | human_readable }}
+      ansible.builtin.assert:
+        that: _home_disk_size | human_to_bytes >= cifmw_reproducer_minimum_hardware_requirements.disk | human_to_bytes
+        msg: >-
+          {{ ansible_hostname }} home mount is {{ _home_disk_size }} but must have >=
+          {{ cifmw_reproducer_minimum_hardware_requirements.disk }} as defined by the scenario file.
+
 - name: Verify cifmw_network_dnsmasq_config isn't set
   ansible.builtin.assert:
     quiet: true


### PR DESCRIPTION
With this patch, if a scenario file defines the
cifmw_reproducer_minimum_hardware_requirements dict, we can set the minimum hardware requirements for vcpu, memory and disk ensuring the hypervisor meets the scenarios minimum.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date: