### PR TITLE
[libvirt_manager] Clean last mentions of ipv4-only

### DIFF
--- a/roles/libvirt_manager/molecule/deploy_layout/prepare.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/prepare.yml
@@ -46,3 +46,26 @@
       ansible.builtin.import_role:
         name: libvirt_manager
         tasks_from: delete_network.yml
+
+    - name: Ensure we use dnsmasq for NetworkManager resolver
+      become: true
+      ansible.builtin.copy:
+        dest: "/etc/NetworkManager/conf.d/molecule-dnsmasq.conf"
+        mode: "0644"
+        content: |
+          [main]
+          dns=dnsmasq
+
+    - name: Ensure we delegate .utility zone to our own instance
+      become: true
+      ansible.builtin.copy:
+        dest: "/etc/NetworkManager/dnsmasq.d/molecule-delegate.conf"
+        mode: "0644"
+        content: |
+          server=/utility/127.0.0.2
+
+    - name: Restart NetworkManager
+      become: true
+      ansible.builtin.systemd_service:
+        name: NetworkManager
+        state: restarted

--- a/roles/libvirt_manager/molecule/deploy_layout/vars/input.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/vars/input.yml
@@ -1,67 +1,13 @@
 ---
 networks:
   ctlplane:
-    network: "192.168.122.0/24"
-    gateway: "192.168.122.1"
+    network: "192.168.140.0/24"
+    gateway: "192.168.140.1"
     dns:
-      - "192.168.122.253"
-      - "192.168.122.254"
+      - "192.168.140.253"
+      - "192.168.140.254"
     search-domain: "ctlplane.example.local"
     mtu: 1500
-    tools:
-      multus:
-        ranges:
-          - start: 30
-            end: 39
-      netconfig:
-        ranges:
-          - start: "192.168.122.40"
-            end: "192.168.122.49"
-      metallb:
-        ranges:
-          - start: "192.168.122.80"
-            end: "192.168.122.90"
-  internalapi:
-    network: "172.17.0.0/24"
-    gateway: "172.17.0.1"
-    vlan: 20
-    mtu: 1496
-    tools:
-      metallb:
-        ranges:
-          - start: "172.17.0.90"
-            end: "172.17.0.100"
-      netconfig:
-        ranges:
-          - start: "172.17.0.40"
-            end: "172.17.0.49"
-      multus:
-        ranges:
-          - start: 50
-            end: 59
-  storage:
-    network: "172.18.0.0/24"
-    vlan: 21
-    mtu: 1496
-    tools:
-      netconfig:
-        ranges:
-          - start: "172.18.0.40"
-            end: "172.18.0.49"
-  tenant:
-    network: "172.19.0.0/24"
-    gateway-v4: "172.19.0.1"
-    search-domain: "tenant.example.local"
-    dns-v4:
-      - "8.8.8.8"
-      - "172.19.0.1"
-    tools:
-      netconfig:
-        ranges:
-          - start: "172.19.0.40"
-            end: "172.19.0.49"
-    vlan: 22
-    mtu: 1496
 group-templates:
   computes:
     network-template:
@@ -70,9 +16,6 @@ group-templates:
         end: 15
     networks: &computes_nets
       ctlplane: {}
-      internalapi: {}
-      tenant: {}
-      storage: {}
   sl-computes:
     network-template:
       range:
@@ -82,14 +25,4 @@ group-templates:
   baremetals:
     networks:
       ctlplane:
-        range: "192.168.122.20-192.168.122.24"
-      internalapi:
-        range: "20-24"
-      tenant:
-        range:
-          start: 20
-          length: 5
-      storage:
-        range:
-          start: 20
-          length: 5
+        range: "192.168.140.20-192.168.140.24"

--- a/roles/libvirt_manager/molecule/spine_leaf/prepare.yml
+++ b/roles/libvirt_manager/molecule/spine_leaf/prepare.yml
@@ -16,26 +16,4 @@
 
 
 - name: Prepare
-  hosts: instance
-  vars:
-    cifmw_basedir: "/opt/basedir"
-  pre_tasks:
-    - name: Create custom basedir
-      become: true
-      ansible.builtin.file:
-        path: "{{ cifmw_basedir }}"
-        state: directory
-        owner: zuul
-        group: zuul
-        mode: "0755"
-  roles:
-    - role: "test_deps"
-    - role: "ci_setup"
-    - role: "libvirt_manager"
-  tasks:
-    - name: Ensure default network is removed
-      vars:
-        net_name: "default"
-      ansible.builtin.import_role:
-        name: libvirt_manager
-        tasks_from: delete_network.yml
+  ansible.builtin.import_playbook: ../deploy_layout/prepare.yml

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -259,10 +259,6 @@
         _cifmw_libvirt_manager_layout.vms[vm_type]
       }}
     _init_admin_user: "{{ vm_data.value.admin_user | default('root') }}"
-    extracted_ip: >-
-      {{
-        _libvirt_manager_networking.instances[vm].networks[cifmw_libvirt_manager_pub_net]['ip_v4']
-      }}
     pub_key: "{{ pub_ssh_key.content | b64decode }}"
     priv_key: "{{ priv_ssh_key.content | b64decode }}"
   ansible.builtin.include_tasks: manage_vms.yml
@@ -289,8 +285,7 @@
       {%- else -%}
       {{ inventory_hostname }}
       {%- endif -%}
-    cifmw_virtualbmc_ipmi_address: >-
-      {{ hostvars[_ipmi_host].ansible_default_ipv4.address }}
+    cifmw_virtualbmc_ipmi_address: "{{ _ipmi_host }}.utility"
   ansible.builtin.include_role:
     name: virtualbmc
     tasks_from: manage_host

--- a/roles/libvirt_manager/tasks/generate_networking_data.yml
+++ b/roles/libvirt_manager/tasks/generate_networking_data.yml
@@ -259,6 +259,43 @@
     loop_var: "net"
     label: "{{ net.name }}"
 
+# We match ^ctlplane networks mostly for the DCN case,
+# where they have multiple ctlplane networks in the form:
+# ctlplane_dcn1
+# ctlplane_dcn2
+# ...
+# Using the selectattr + match, then selecting the first
+# matched network should cover most of the cases if not all.
+- name: Create .utility zone entries
+  when:
+    - _net | length > 0
+  vars:
+    _net: >-
+      {{
+        vm.value.networks | dict2items |
+        selectattr('key', 'match', '^ctlplane')
+      }}
+    _entry:
+      - names:
+          - "{{ vm.key }}.utility"
+        ips:
+          - "{{ _net.0.value.ip_v4 | default('') }}"
+          - "{{ _net.0.value.ip_v6 | default('') }}"
+        state: present
+  ansible.builtin.set_fact:
+    _vm_utility: "{{ _vm_utility | default([]) + _entry }}"
+  loop: "{{ _libvirt_manager_networking.instances | dict2items }}"
+  loop_control:
+    loop_var: vm
+    label: "{{ vm.key }}"
+
+- name: Inject VMs in the .utility zone
+  vars:
+    cifmw_dnsmasq_host_record: "{{ _vm_utility }}"
+  ansible.builtin.include_role:
+    name: "dnsmasq"
+    tasks_from: "manage_host_record.yml"
+
 - name: Ensure dnsmasq is reloaded now
   ansible.builtin.meta: flush_handlers
 # END inject reserved IPs

--- a/roles/libvirt_manager/tasks/manage_vms.yml
+++ b/roles/libvirt_manager/tasks/manage_vms.yml
@@ -5,7 +5,7 @@
     dataset:
       ssh_dir: "{{ ansible_user_dir }}/.ssh"
       user: "{{ _user }}"
-      hostname: "{{ extracted_ip }}"
+      hostname: "{{ vm }}.utility"
       patterns:
         - "{{ vm }}"
         - "{{ vm }}.{{ inventory_hostname }}"
@@ -129,4 +129,4 @@
       {{
         _cifmw_libvirt_manager_layout.vms[vm_type].admin_user | default('zuul')
       }}
-    host_ip: "{{ extracted_ip }}"
+    host_ip: "{{ vm }}.utility"

--- a/roles/libvirt_manager/tasks/start_vms.yml
+++ b/roles/libvirt_manager/tasks/start_vms.yml
@@ -49,12 +49,8 @@
       {{
         _cifmw_libvirt_manager_layout.vms[vm_type]
       }}
-    extracted_ip: >-
-      {{
-        _libvirt_manager_networking.instances[vm].networks[cifmw_libvirt_manager_pub_net]['ip_v4']
-      }}
   ansible.builtin.wait_for:
-    host: "{{ extracted_ip }}"
+    host: "{{ vm }}.utility"
     port: 22
     delay: 2
   loop: "{{ cifmw_libvirt_manager_all_vms }}"

--- a/roles/libvirt_manager/templates/inventory.yml.j2
+++ b/roles/libvirt_manager/templates/inventory.yml.j2
@@ -2,7 +2,7 @@
   hosts:
 {% for host in hosts %}
     {{ host.key }}:
-      ansible_host: {{ host.value.networks[cifmw_libvirt_manager_pub_net]['ip_v4'] }}
+      ansible_host: {{ host.key }}.utility
       ansible_user: {{ _cifmw_libvirt_manager_layout.vms[item].admin_user | default('zuul') }}
       ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
 {% if item is match('^crc.*')                            %}


### PR DESCRIPTION
With this patch, we should get rid of the last mentions of hard-coded
references to ipv4-only addresses:
- switched to DNS records where possible
- removed last hard-coded ipv4-only extractions

There might be some more iterations, but we're in a really good position
now that we have the `.utility` zone (see #1968)

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running

### Tested against (not in commit message)
- [x] va-hci deployment
- [x] NFV
- [x] CRC based infra
