### PR TITLE
devscripts - allow overriding branch on git checkout

### DIFF
--- a/roles/devscripts/tasks/134_workspace.yml
+++ b/roles/devscripts/tasks/134_workspace.yml
@@ -39,7 +39,7 @@
     depth: 1
     single_branch: true
     force: true
-    version: HEAD  # noqa: latest[git]
+    version: "{{ cifmw_devscripts_repo_branch }}"
   register: clone_out
   retries: 3
   delay: 15

--- a/roles/devscripts/vars/main.yml
+++ b/roles/devscripts/vars/main.yml
@@ -28,6 +28,7 @@ cifmw_devscripts_packages:
   - python3-jmespath
 
 cifmw_devscripts_repo: "https://github.com/openshift-metal3/dev-scripts.git"
+cifmw_devscripts_repo_branch: HEAD
 
 cifmw_devscripts_config_defaults:
   working_dir: "/home/dev-scripts"


### PR DESCRIPTION
Use a variable for the branch when doing git checkout of devscripts.

For exameple:
  cifmw_devscripts_repo: 'https://github.com/hjensas/dev-scripts.git'
  cifmw_devscripts_repo_branch: support-ipv6-connected

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
