### PR TITLE
Fix condition in tcib playbook when change list is empty

### DIFF
--- a/ci/playbooks/tcib/tcib.yml
+++ b/ci/playbooks/tcib/tcib.yml
@@ -44,7 +44,9 @@
         - "'change_url' in item"
 
     - name: Build containers when needed
-      when: "'os-net-config' not in zuul_change_list"
+      when:
+        - zuul_change_list is defined
+        - "'os-net-config' not in zuul_change_list"
       block:
         - name: Deploy local registry
           tags:


### PR DESCRIPTION
If there is no item in zuul items list with the field change_url'
defined, e.g. a periodic jobs, skip the block, as 'zuul_change_list'
will be undefined.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
