### PR TITLE
Wait until OpenStack operators ready in kustomize_deploy role

### DIFF
--- a/roles/kustomize_deploy/tasks/install_operators.yml
+++ b/roles/kustomize_deploy/tasks/install_operators.yml
@@ -260,3 +260,27 @@
           type: Available
           status: "True"
         wait_timeout: 300
+
+- name: Wait until OpenStack operators are deployed and ready
+  when: not cifmw_kustomize_deploy_generate_crs_only
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    kind: Deployment
+    namespace: openstack-operators
+    label_selectors:
+      - "{{ item }}"
+    wait: true
+    wait_condition:
+      type: Available
+      status: "True"
+    wait_timeout: 600
+  check_mode: >-
+    {{
+      cifmw_kustomize_deploy_check_mode |
+      default(false, true)
+    }}
+  with_items:
+    - openstack.org/operator-name
+    # The RabbitMQ operator does not share our openstack.org/operator-name label
+    # and must be checked independently
+    - app.kubernetes.io/name=rabbitmq-cluster-operator


### PR DESCRIPTION
In the `kustomize_deploy` role, we wait until NMState and MetalLB operators are ready, but we do not currently do so for our OpenStack operators.  It is speculated that this is leading to a race condition where, if the OpenStack operators happen to be slow in reaching the ready state, later tasks can fail when trying to apply OpenStack CRs (because the webhooks in the OpenStack operators are not available yet).  Let's try waiting for our OpenStack operators' availability before moving forward.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
