### PR TITLE
Add is_vlan_transparent in os_net_setup role

### DIFF
--- a/roles/os_net_setup/tasks/subtask_net.yml
+++ b/roles/os_net_setup/tasks/subtask_net.yml
@@ -8,6 +8,7 @@
     dns_domain: '{{ net_args.dns_domain | default(omit) }}'
     external: '{{ net_args.external | default(omit) }}'
     is_default: '{{ net_args.is_default | default(omit) }}'
+    is_vlan_transparent: '{{ net_args.is_vlan_transparent | default(omit) }}'
     mtu: '{{ net_args.mtu | default(omit) }}'
     name: '{{ net_args.name | default(omit) }}'
     port_security_enabled: '{{ net_args.port_security_enabled | default(omit) }}'


### PR DESCRIPTION
vlan_transparent patch[1] was merged in ansible-collections. It can be set vlan_transparent flag when creating a network.

[1] https://review.opendev.org/c/openstack/ansible-collections-openstack/+/922309

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

