### PR TITLE
validate-architecture - sshd_ranges - ipv6

### DIFF
--- a/ci/playbooks/architecture/validate-architecture.yml
+++ b/ci/playbooks/architecture/validate-architecture.yml
@@ -185,9 +185,11 @@
           }}
         cifmw_ci_gen_kustomize_values_sshd_ranges: >-
           {{
-            [cifmw_networking_env_definition.networks.ctlplane.network_v4]
+            [
+              cifmw_networking_env_definition.networks.ctlplane.network_v4 | default (none),
+              cifmw_networking_env_definition.networks.ctlplane.network_v6 | default (none)
+            ] | select()
           }}
-
     - name: Execute deployment steps
       ansible.builtin.include_role:
         name: kustomize_deploy


### PR DESCRIPTION
When setting the cifmw_ci_gen_kustomize_values_sshd_ranges variable, try to load both network_v4 and network_v6 values. Default to `none` and pass the list trough `select()` filter to remove any `none` vlaues in the final result.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
