### PR TITLE
Disable GSSAPI authentication in vbmc container

### DIFF
--- a/roles/virtualbmc/molecule/default/prepare.yml
+++ b/roles/virtualbmc/molecule/default/prepare.yml
@@ -26,6 +26,11 @@
     - role: libvirt_manager
     - role: discover_latest_image
   tasks:
+    - name: Load networking definition
+      ansible.builtin.include_vars:
+        file: "net-def.yml"
+        name: cifmw_networking_definition
+
     - name: Deploy a single VM
       vars:
         cifmw_libvirt_manager_configuration:

--- a/roles/virtualbmc/molecule/default/vars/net-def.yml
+++ b/roles/virtualbmc/molecule/default/vars/net-def.yml
@@ -1,0 +1,95 @@
+---
+networks:
+  ctlplane:
+    network: "192.168.122.0/24"
+    gateway: "192.168.122.1"
+    dns:
+      - "192.168.122.253"
+      - "192.168.122.254"
+    search-domain: "ctlplane.example.local"
+    mtu: 1500
+    tools:
+      multus:
+        ranges:
+          - start: 30
+            end: 39
+      netconfig:
+        ranges:
+          - start: "192.168.122.40"
+            end: "192.168.122.49"
+      metallb:
+        ranges:
+          - start: "192.168.122.80"
+            end: "192.168.122.90"
+  internalapi:
+    network: "172.17.0.0/24"
+    gateway: "172.17.0.1"
+    vlan: 20
+    mtu: 1496
+    tools:
+      metallb:
+        ranges:
+          - start: "172.17.0.90"
+            end: "172.17.0.100"
+      netconfig:
+        ranges:
+          - start: "172.17.0.40"
+            end: "172.17.0.49"
+      multus:
+        ranges:
+          - start: 50
+            end: 59
+  storage:
+    network: "172.18.0.0/24"
+    vlan: 21
+    mtu: 1496
+    tools:
+      netconfig:
+        ranges:
+          - start: "172.18.0.40"
+            end: "172.18.0.49"
+  tenant:
+    network: "172.19.0.0/24"
+    gateway-v4: "172.19.0.1"
+    search-domain: "tenant.example.local"
+    dns-v4:
+      - "8.8.8.8"
+      - "172.19.0.1"
+    tools:
+      netconfig:
+        ranges:
+          - start: "172.19.0.40"
+            end: "172.19.0.49"
+    vlan: 22
+    mtu: 1496
+group-templates:
+  computes:
+    network-template:
+      range:
+        start: 10
+        end: 15
+    networks: &computes_nets
+      ctlplane: {}
+      internalapi: {}
+      tenant: {}
+      storage: {}
+  sl-computes:
+    network-template:
+      range:
+        start: 16
+        length: 2
+    networks: *computes_nets
+  baremetals:
+    networks:
+      ctlplane:
+        range: "192.168.122.20-192.168.122.24"
+      internalapi:
+        range: "20-24"
+      tenant:
+        range:
+          start: 20
+          length: 5
+      storage:
+        range:
+          start: 20
+          length: 5

--- a/roles/virtualbmc/tasks/main.yml
+++ b/roles/virtualbmc/tasks/main.yml
@@ -57,6 +57,16 @@
         key: "{{ _vbmc_key.public_key }}"
         state: present
 
+    - name: Create ssh_config snippet for VBMC
+      ansible.builtin.copy:
+        dest: "{{ dest_dir }}/vbmc_ssh_config.conf"
+        mode: "0644"
+        content: |
+          Host *
+            # Avoid trying gssapi, it takes too long and
+            # leads to vbmcd timeout
+            GSSAPIAuthentication no
+
     - name: Create vbmc server configuration file
       ansible.builtin.copy:
         dest: "{{ dest_dir }}/virtualbmc.conf"
@@ -89,4 +99,5 @@
     volumes:
       - "{{ cifmw_virtualbmc_sshkey_path }}:{{ cifmw_virtualbmc_ipmi_key_path }}:ro,Z"
       - "{{ dest_dir }}/virtualbmc.conf:/etc/virtualbmc/virtualbmc.conf:ro,Z"
+      - "{{ dest_dir }}/vbmc_ssh_config.conf:/etc/ssh/ssh_config.d/zzz-gssapi.conf:ro,Z"
       - "{{ dest_dir }}/vbmcd.sh:/vbmcd.sh:ro,Z"


### PR DESCRIPTION
It's mostly useless and might lead to timeout in vbmcd trying to connect
via SSH, and SSH taking too long to get an acceptable result.

Since we know we're using keypair authentication, let's just disable
GSSAPI.

This also fixes broken molecule run due to the major changes in
libvirt_manager.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
