### PR TITLE
Changes to virtualbmc shouldn't trigger a deployment

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -60,6 +60,7 @@
       - roles/dnsmasq
       - roles/nat64_appliance
       - roles/reproducer
+      - roles/virtualbmc
       - zuul.d/molecule.*
       # Other openstack operators
       - containers/ci


### PR DESCRIPTION
Nothing uses VBMC in upstream CI, we don't need to trigger deployments
upon changes to this role.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
