### PR TITLE
Chasing down last import vs include in reproducer role

### DIFF
--- a/roles/reproducer/tasks/crc_layout.yml
+++ b/roles/reproducer/tasks/crc_layout.yml
@@ -17,7 +17,7 @@
 - name: Deploy CRC if needed
   when:
     - not _crc_available.stat.exists
-  ansible.builtin.import_role:
+  ansible.builtin.include_role:
     name: rhol_crc
 
 - name: Ensure CRC is stopped
@@ -43,7 +43,7 @@
 - name: Ensure we expose openshift_login related facts
   when:
     - _crc_available.stat.exists
-  ansible.builtin.import_role:
+  ansible.builtin.include_role:
     name: rhol_crc
     tasks_from: set_cluster_fact.yml
 


### PR DESCRIPTION
When we have conditional import, it's better to switch to include, since
the condition will be applied to the "do I include this content" rather
than "I'll apply the condition to all of the imported element and
evaluate it again and again".

Note that some stay as "import" to keep loading the role parameters
nevertheless. We've seen issues switching some of them to "include", see
comments in the affected parts.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
