### PR TITLE
Add tripleo_controllers tripleo_computes for DPA ci zuul nodeset

### DIFF
--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -63,37 +63,6 @@
           - standalone
 
 - nodeset:
-    name: centos-9-multinode-rhel-9-2-crc-extracted-2.30-3xl
-    nodes:
-      - name: controller
-        label: cloud-centos-9-stream-tripleo
-      - name: crc
-        label: coreos-crc-extracted-2-30-0-3xl
-      - name: undercloud
-        label: cloud-rhel-9-2-tripleo
-      - name: overcloud-controller-0
-        label: cloud-rhel-9-2-tripleo
-      - name: overcloud-controller-1
-        label: cloud-rhel-9-2-tripleo
-      - name: overcloud-controller-2
-        label: cloud-rhel-9-2-tripleo
-      - name: overcloud-novacompute-0
-        label: cloud-rhel-9-2-tripleo
-    groups:
-      - name: computes
-        nodes: []
-      - name: ocps
-        nodes:
-          - crc
-      - name: rh-subscription
-        nodes:
-          - undercloud
-          - overcloud-controller-0
-          - overcloud-controller-1
-          - overcloud-controller-2
-          - overcloud-novacompute-0
-
-- nodeset:
     name: centos-9-multinode-rhel-9-2-crc-extracted-2.30-3xl-novacells
     nodes:
       - name: controller
@@ -276,6 +245,16 @@
           - overcloud-controller-0
           - overcloud-controller-1
           - overcloud-controller-2
+          - overcloud-novacompute-0
+          - overcloud-novacompute-1
+          - overcloud-novacompute-2
+      - name: tripleo_controllers
+        nodes:
+          - overcloud-controller-0
+          - overcloud-controller-1
+          - overcloud-controller-2
+      - name: tripleo_computes
+        nodes:
           - overcloud-novacompute-0
           - overcloud-novacompute-1
           - overcloud-novacompute-2


### PR DESCRIPTION
As part of [1] this add the tripleo_controllers tripleo_computes
groups to the zuul nodeset, to be used by the data plane adoption
ci playbooks in Related below. It also removes a redundant nodeset
no longer used by any job.

[1] https://issues.redhat.com/browse/OSPRH-8291

Related: https://review.rdoproject.org/r/c/rdo-jobs/+/53688

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
