### PR TITLE
Use translated network name

### DIFF
--- a/roles/libvirt_manager/tasks/reserve_dnsmasq_ips.yml
+++ b/roles/libvirt_manager/tasks/reserve_dnsmasq_ips.yml
@@ -52,7 +52,7 @@
         ternary(_translate[net.name], [net.name])
       }}
     _net_name: >-
-      {{ (net.name is match '.*osp_trunk$') | ternary('ctlplane', net.name) }}
+      {{ _net_domain | first }}
     _cleaned_netname: "{{ _net_name | regex_replace('^cifmw[_-]', '') }}"
   block:
     - name: Create host records


### PR DESCRIPTION
Instead of hard-coding a name translation, let's use the "translator"
provided by the networking_mapper directly.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
