### PR TITLE
Hook : ironic - Use a static UUID for baremeal flavor

### DIFF
--- a/hooks/playbooks/ironic_flavor.yml
+++ b/hooks/playbooks/ironic_flavor.yml
@@ -5,6 +5,7 @@
   vars:
     _namespace: openstack
     _flavor_name: baremetal
+    _flavor_id: 123456789-1234-1234-1234-000000000001
     _boot_mode: uefi
   environment:
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
@@ -16,6 +17,7 @@
         oc project {{ _namespace }}
         oc rsh openstackclient \
           openstack flavor create {{ _flavor_name }} \
+            --id {{ _flavor_id }} \
             --ram 1024 \
             --vcpus 1 \
             --disk 15 \


### PR DESCRIPTION
Tempest requires a uuid in the flavor_ref.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running