### PR TITLE
Small improvement in edpm logs collection

### DIFF
--- a/roles/artifacts/tasks/edpm.yml
+++ b/roles/artifacts/tasks/edpm.yml
@@ -79,7 +79,9 @@
           sudo ip a > /tmp/{{ host_ip }}/network.txt
           sudo ip ro ls >> /tmp/{{ host_ip }}/network.txt
           sudo rpm -qa > /tmp/{{ host_ip }}/rpm_qa.txt
-          sudo podman images > /tmp/{{ host_ip }}/podman_images.txt
+          sudo dnf list installed > /tmp/{{ host_ip }}/dnf_list_installed.txt
+          sudo podman images --digests > /tmp/{{ host_ip }}/podman_images.txt
+          sudo fips-mode-setup --check > /tmp/{{ host_ip }}/fips_check.txt
           mkdir -p /tmp/{{ host_ip }}/service_logs
           systemctl list-units | awk '/virt|edpm/ {print $1}' | grep -v sys | xargs -I {} sudo bash -c 'journalctl -u {} > /tmp/{{ host_ip }}/service_logs/{}.log'
           sudo ausearch -i | grep denied > /tmp/{{ host_ip }}/selinux-denials.log || true


### PR DESCRIPTION
- now collects info about installed packages and source repository.
- now prints additional image digest info in podman_images.
- now it saves the current FIPS mode setup.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [X] README in the role
  - [X] Content of the docs/source is reflecting the changes
