### PR TITLE
Revert "Use translated network name"

### DIFF
--- a/roles/libvirt_manager/tasks/reserve_dnsmasq_ips.yml
+++ b/roles/libvirt_manager/tasks/reserve_dnsmasq_ips.yml
@@ -52,7 +52,7 @@
         ternary(_translate[net.name], [net.name])
       }}
     _net_name: >-
-      {{ _net_domain | first }}
+      {{ (net.name is match '.*osp_trunk$') | ternary('ctlplane', net.name) }}
     _cleaned_netname: "{{ _net_name | regex_replace('^cifmw[_-]', '') }}"
   block:
     - name: Create host records


### PR DESCRIPTION
This reverts commit bcc9b65c602b8794178c7f47c5cded585e59a505.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
