### PR TITLE
nat64-appliance - container image

### DIFF
--- a/roles/nat64_appliance/defaults/main.yml
+++ b/roles/nat64_appliance/defaults/main.yml
@@ -21,6 +21,10 @@ cifmw_nat64_appliance_basedir: >-
 cifmw_nat64_appliance_workdir: "{{ cifmw_nat64_appliance_basedir }}/nat64_appliance"
 cifmw_nat64_appliance_venv_dir: "{{ cifmw_nat64_appliance_workdir }}/venv"
 
+cifmw_nat64_appliance_container_image_dir: "{{ cifmw_nat64_appliance_workdir }}/container-image"
+cifmw_nat64_build_container: true
+cifmw_nat64_container_tag: 'quay.io/rhn_gps_hjensas/nat64-appliance:latest'
+
 cifmw_nat64_libvirt_uri: "qemu:///system"
 cifmw_nat64_firewall_zone: libvirt
 cifmw_nat64_network_ipv4_name: nat64-net-v4

--- a/roles/nat64_appliance/files/Containerfile.nat64_appliance
+++ b/roles/nat64_appliance/files/Containerfile.nat64_appliance
@@ -1,0 +1,17 @@
+ARG BASE_IMAGE=quay.io/centos/centos:stream9-minimal
+FROM $BASE_IMAGE
+
+WORKDIR /
+COPY copy_out.sh .
+
+ARG IMAGE_NAME=nat64-appliance
+ARG IMAGE_FILE=$IMAGE_NAME.qcow2
+ARG CHECKSUM_FILE=$IMAGE_FILE.sha256
+
+COPY $IMAGE_FILE .
+COPY $CHECKSUM_FILE .
+ENV SRC_DIR=/
+ENV DEST_DIR=/target
+ENV CHECKSUM_FILE=$CHECKSUM_FILE
+
+CMD ["/copy_out.sh"]

--- a/roles/nat64_appliance/files/copy_out.sh
+++ b/roles/nat64_appliance/files/copy_out.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# A script to be used as the entrypoint in a container to copy out files from the container
+# to a mounted directory. SRC_DIR and CHECKSUM_FILE are expected to be set correctly
+# in the container image. When creating a container, a volume mount must be provided which
+# mounts as the value of DEST_DIR (/target) inside the container.
+#
+# The files to copy are determined by the entries in the checksum file. Copying is skipped
+# if the same checksum file DEST_DIR has a matching entry. Resulting destination files
+# are checked with sha256sum.
+#
+# This script is limited to what is available in centos and ubi minimal container images
+set -eu
+
+SRC_DIR=${SRC_DIR:-/usr/share/images}
+DEST_DIR=${DEST_DIR:-/target}
+CHECKSUM_FILE=${CHECKSUM_FILE:-}
+
+if [ ! -d $DEST_DIR ]; then
+    echo "$DEST_DIR is not a directory, mount $DEST_DIR into the container or set DEST_DIR to a mounted directory to copy files into"
+    exit 1
+fi
+
+if [ ! -d $SRC_DIR ]; then
+    echo "$SRC_DIR is not a directory, rebuild the image with files in $SRC_DIR or set SRC_DIR to the location of files to copy out"
+    exit 1
+fi
+
+if [ -z $CHECKSUM_FILE ]; then
+    echo "CHECKSUM_FILE needs to be set to a checksum file in $SRC_DIR, cannot copy files"
+    exit 1
+fi
+
+src_checksum=${SRC_DIR%%/}/${CHECKSUM_FILE}
+
+if [ ! -f $src_checksum ]; then
+    echo "Checksum file $src_checksum does not exist, cannot copy files"
+    exit 1
+fi
+
+dest_checksum=${DEST_DIR%%/}/${CHECKSUM_FILE}
+touch $dest_checksum
+while read -r checksum_entry; do
+    file_name=$(echo "$checksum_entry" | cut -d " " -f 3)
+    src_file_name=${SRC_DIR%%/}/${file_name}
+    dest_file_name=${DEST_DIR%%/}/${file_name}
+    if [ ! -f $dest_file_name ]; then
+        echo "$dest_file_name does not exist, copying"
+        do_copy=1
+    elif grep -Fxq "$checksum_entry" $dest_checksum ; then
+        echo "$file_name checksum matches in $dest_checksum, skipping"
+        do_copy=0
+    else
+        echo "$file_name checksum failed match in $dest_checksum, copying"
+        do_copy=1
+    fi
+    if [[ $do_copy -eq 1 ]]; then
+        cp -v $src_file_name $dest_file_name
+    fi
+done < $src_checksum
+cp -v $src_checksum $dest_checksum
+sha256sum -c $dest_checksum

--- a/roles/nat64_appliance/molecule/default/converge.yml
+++ b/roles/nat64_appliance/molecule/default/converge.yml
@@ -457,3 +457,12 @@
         - "{{ _ping_example_com.rc }}"
         - "{{ _ping_example_com.stdout_lines }}"
         - "{{ _ping_example_com.stderr_lines }}"
+
+    - name: Display information about container image
+      register: _podman_image_inspect
+      ansible.builtin.command: "podman image inspect quay.io/rhn_gps_hjensas/nat64-appliance:latest"
+
+    - name: Write podman image inspect to file
+      ansible.builtin.copy:
+        dest: "{{ cifmw_basedir }}/logs/podman_image_inspect.log"
+        content: "{{ _podman_image_inspect.stdout }}"

--- a/roles/nat64_appliance/tasks/build_container_image.yml
+++ b/roles/nat64_appliance/tasks/build_container_image.yml
@@ -1,0 +1,70 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure needed directories exist
+  ansible.builtin.file:
+    path: "{{ cifmw_nat64_appliance_container_image_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: Install required RPM packages
+  tags:
+    - packages
+  become: true
+  ansible.builtin.package:
+    name:
+      - buildah
+      - podman
+    state: present
+
+- name: Copy files to container image build dir
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "{{ cifmw_nat64_appliance_container_image_dir }}"
+    mode: preserve
+  loop:
+    - Containerfile.nat64_appliance
+    - copy_out.sh
+
+- name: Make a copy of the built image in container-image build directory
+  become: true
+  ansible.builtin.copy:
+    remote_src: true
+    src: "{{ cifmw_nat64_appliance_workdir }}/nat64-appliance.qcow2"
+    dest: "{{ cifmw_nat64_appliance_container_image_dir }}/nat64-appliance.qcow2"
+    mode: "0644"
+    owner: "{{ ansible_user_uid }}"
+    group: "{{ ansible_user_gid }}"
+
+- name: Create sha254sum for the nat64-appliance image
+  cifmw.general.ci_script:
+    chdir: "{{ cifmw_nat64_appliance_container_image_dir }}"
+    output_dir: "{{ cifmw_nat64_appliance_basedir }}/artifacts"
+    executable: "/bin/bash"
+    creates: "{{ cifmw_nat64_appliance_container_image_dir }}/nat64-appliance.qcow2.sha256"
+    script: "sha256sum --binary nat64-appliance.qcow2 > nat64-appliance.qcow2.sha256"
+
+- name: Build the container image
+  cifmw.general.ci_script:
+    chdir: "{{ cifmw_nat64_appliance_container_image_dir }}"
+    output_dir: "{{ cifmw_nat64_appliance_basedir }}/artifacts"
+    executable: "/bin/bash"
+    script: |
+      buildah build \
+        --file ./Containerfile.nat64_appliance \
+        --format docker \
+        --tls-verify=true \
+        --tag {{ cifmw_nat64_container_tag }}

--- a/roles/nat64_appliance/tasks/main.yml
+++ b/roles/nat64_appliance/tasks/main.yml
@@ -78,3 +78,8 @@
     creates: "{{ cifmw_nat64_appliance_workdir }}/nat64-appliance.qcow2"
     script: "{{ cifmw_nat64_appliance_venv_dir }}/bin/diskimage-builder nat64-appliance.yaml {{ extra_args | default('') }}"
     executable: "/bin/bash"
+
+- name: Build nat64-appliance image copy-out container image
+  when: cifmw_nat64_build_container
+  ansible.builtin.include_tasks:
+    file: build_container_image.yml

--- a/roles/nat64_appliance/tasks/push_container_image.yml
+++ b/roles/nat64_appliance/tasks/push_container_image.yml
@@ -1,0 +1,22 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Push container image to registry
+  cifmw.general.ci_script:
+    chdir: "{{ cifmw_nat64_appliance_container_image_dir }}"
+    output_dir: "{{ cifmw_nat64_appliance_basedir }}/artifacts"
+    executable: "/bin/bash"
+    script: "podman push {{ cifmw_nat64_container_tag }}"


### PR DESCRIPTION
Building the image using diskimage-builder is not very fast. For users and CI jobs it would be better to just pull a pre-built image.

This change adds Containerfile, copy_out.sh (copied from the edpm-image-builder repository) and some ansible tasks to build a container image.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
