### PR TITLE
Add retries on task: Configure VMs type {{ vm }}

### DIFF
--- a/roles/libvirt_manager/tasks/manage_vms.yml
+++ b/roles/libvirt_manager/tasks/manage_vms.yml
@@ -47,7 +47,7 @@
         default(_init_admin_user)
       }}
 
-- name: "Configure ssh access on type {{ vm }}"
+- name: "Configure ssh access on VM {{ vm }}"
   vars:
     _user: >-
       {{
@@ -64,7 +64,7 @@
   register: _ssh_access
   until: _ssh_access.rc == 0
 
-- name: "Configure VMs type {{ vm }}"
+- name: "Configure VM {{ vm }}"
   when:
     - vm_type is not match('^(crc|ocp).*$')
   delegate_to: "{{ vm }}.{{ inventory_hostname }}"
@@ -81,6 +81,10 @@
       sudo -u zuul mkdir -p /home/zuul/.ssh /home/zuul/src/github.com/openstack-k8s-operators;
       sudo cp ${HOME}/.ssh/authorized_keys /home/zuul/.ssh/;
       chown -R zuul: /home/zuul/.ssh;
+  retries: 5
+  delay: 10
+  register: _vm_config
+  until: _vm_config.rc == 0
 
 # TODO: consider https://docs.fedoraproject.org/en-US/fedora-coreos/storage/#_sizing_the_root_partition
 - name: Ensure we grow volume for OCP cluster members


### PR DESCRIPTION
In my IPv6 environment I often see connection related errors in this task. Error is "Connection timed out during banner exchange"

I think this may have something to do with MaxStartups (ref: sshd_config(5)). We just added the host to the ansible inventory -> added ssh keys -> connect again as _init_admin_user etc - so there is potentially a lot of connections going on.

Adding some retires worksaround the issue.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

