### PR TITLE
Support DCN layout

### DIFF
--- a/roles/libvirt_manager/molecule/deploy_layout/prepare.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/prepare.yml
@@ -62,7 +62,9 @@
         dest: "/etc/NetworkManager/dnsmasq.d/molecule-delegate.conf"
         mode: "0644"
         content: |
+          log-queries
           server=/utility/127.0.0.2
+          server=/local/127.0.0.2
 
     - name: Restart NetworkManager
       become: true

--- a/roles/libvirt_manager/molecule/generate_network_data/cleanup.yml
+++ b/roles/libvirt_manager/molecule/generate_network_data/cleanup.yml
@@ -1,0 +1,20 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Cleanup
+  vars:
+    molecule_scenario: generate_network_data
+  ansible.builtin.import_playbook: ../deploy_layout/cleanup.yml

--- a/roles/libvirt_manager/molecule/generate_network_data/converge.yml
+++ b/roles/libvirt_manager/molecule/generate_network_data/converge.yml
@@ -1,0 +1,110 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: One hypervisor
+  hosts: instance
+  gather_facts: true
+  vars:
+    cifmw_basedir: "/opt/basedir"
+    _output: >-
+      {{
+        [ansible_user_dir, 'ci-framework-data',
+         'artifacts/generate_network_data'] | path_join
+      }}
+    _networks:
+      osp_trunk:
+        default: true
+        range: "192.168.140.0/24"
+        mtu: 1500
+      public:
+        range: "192.168.110.0/24"
+    _net_translate_base:
+      osp_trunk:
+        - controlplane
+        - ctlplane
+    lm_config_base:
+      vms:
+        compute:
+          amount: 1
+          disk_file_name: "blank"
+          disksize: 5
+          memory: 1
+          cpus: 1
+          nets:
+            - public
+            - osp_trunk
+      networks:
+        public: |-
+          <network>
+            <name>public</name>
+            <bridge name='public' stp='on' delay='0'/>
+            <dns enable="no"/>
+            <ip family='ipv4' address='192.168.110.1' prefix='24'/>
+          </network>
+  roles:
+    - role: "discover_latest_image"
+  tasks:
+    - name: Ensure _output exists
+      ansible.builtin.file:
+        path: "{{ _output }}"
+        state: directory
+        mode: "0755"
+
+    - name: Load networking definition
+      ansible.builtin.include_vars:
+        file: input.yml
+        name: cifmw_networking_definition
+
+    - name: Load scenarios
+      ansible.builtin.include_vars:
+        file: scenarios.yml
+
+    - name: Set output facts
+      ansible.builtin.set_fact:
+        is_failed: false
+        failure_list: []
+
+    - name: Test scenarios
+      vars:
+        _cifmw_libvirt_manager_layout: >-
+          {{
+            lm_config_base |
+            combine(scenario.lm_config_patch | default({}), recursive=true)
+          }}
+        cifmw_dnsmasq_raw_config: |
+          log-queries
+        cifmw_networking_mapper_interfaces_info_translations: >-
+          {{ scenario.net_translate | default(_net_translate_base) }}
+        cifmw_baremetal_hosts: >-
+          {{
+            scenario.bm_hosts | default({})
+          }}
+        cifmw_libvirt_manager_pub_net: >-
+          {{ scenario.pub_net | default('public') }}
+      ansible.builtin.include_tasks:
+        file: "tasks/test.yml"
+      loop: "{{ scenarios }}"
+      loop_control:
+        label: "{{ scenario.name }}"
+        loop_var: scenario
+
+    - name: Fail if needed
+      when:
+        - is_failed | bool
+      ansible.builtin.fail:
+        msg: >-
+          Errors were raised during validations:
+          {{ failure_list | join(' || ') }}

--- a/roles/libvirt_manager/molecule/generate_network_data/molecule.yml
+++ b/roles/libvirt_manager/molecule/generate_network_data/molecule.yml
@@ -1,0 +1,13 @@
+---
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  inventory:
+    host_vars:
+      instance:
+        cifmw_libvirt_manager_configuration_patch_01_more_computes:
+          vms:
+            compute:
+              amount: 2

--- a/roles/libvirt_manager/molecule/generate_network_data/prepare.yml
+++ b/roles/libvirt_manager/molecule/generate_network_data/prepare.yml
@@ -1,0 +1,18 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Prepare
+  ansible.builtin.import_playbook: ../deploy_layout/prepare.yml

--- a/roles/libvirt_manager/molecule/generate_network_data/tasks/test.yml
+++ b/roles/libvirt_manager/molecule/generate_network_data/tasks/test.yml
@@ -1,0 +1,176 @@
+---
+- name: Ensure tree exists
+  become: true
+  ansible.builtin.file:
+    path: "{{ cifmw_basedir }}/{{ item }}"
+    state: directory
+    mode: "0755"
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_id }}"
+  loop:
+    - artifacts
+    - logs
+    - parameters
+
+- name: Mark run status
+  ansible.builtin.set_fact:
+    _run_fail: false
+    _failure: false
+
+- name: Use block/rescue/always
+  block:
+    - name: Output scenario name
+      ansible.builtin.debug:
+        msg: "Running: {{ scenario.name }}"
+
+    - name: Generate network data
+      ansible.builtin.include_role:
+        name: "libvirt_manager"
+        tasks_from: "generate_networking_data.yml"
+
+  rescue:
+    - name: Mark run as failed
+      ansible.builtin.set_fact:
+        _run_fail: true
+
+  always:
+    - name: Validate DNS
+      when:
+        - not _run_fail | bool
+        - scenario.check_dns is defined
+      block:
+        - name: Ensure we have expected records
+          vars:
+            _lookup: "{{ lookup('community.general.dig', dns.rec)  }}"
+          ansible.builtin.assert:
+            quiet: true
+            that:
+              - _lookup == dns.ip
+            msg: >-
+              {{ dns.rec }} points to "{{ _lookup }}" while
+              "{{ dns.ip }}" was expected
+          loop: "{{ scenario.check_dns }}"
+          loop_control:
+            loop_var: dns
+
+      rescue:
+        - name: Mark run as failed
+          ansible.builtin.set_fact:
+            _run_fail: true
+            _failure: true
+
+    - name: Validate DHCP files
+      when:
+        - not _run_fail | bool
+        - scenario.check_dhcp is defined
+      block:
+        - name: Glob all dhcp configuration files
+          register: _dhcp_files
+          ansible.builtin.find:
+            paths: "/etc/cifmw-dnsmasq.d/dhcp-hosts.d"
+
+        - name: Ensure files exist
+          vars:
+            matcher: ".*/{{ item }}.*"
+          ansible.builtin.assert:
+            quiet: true
+            that:
+              - _dhcp_files.files |
+                selectattr('path', 'match', matcher) |
+                length == 1
+            msg: >-
+              {{ item }} is missing
+          loop: "{{ scenario.check_dhcp }}"
+
+      rescue:
+        - name: Output found files
+          ansible.builtin.debug:
+            msg: "{{ _dhcp_files.files }}"
+
+        - name: Mark run as failed
+          ansible.builtin.set_fact:
+            _run_fail: true
+            _failure: true
+
+    - name: Assert we have expected facts set
+      block:
+        - name: Ensure it failed at the right place
+          when:
+            - scenario.failed_step is defined
+          ansible.builtin.assert:
+            that:
+              - molecule_failure_block is defined
+              - molecule_failure_block == scenario.failed_step
+
+      rescue:
+        - name: Debug molecule_failure_block
+          ansible.builtin.debug:
+            var: molecule_failure_block
+
+        - name: Mark total failure
+          ansible.builtin.set_fact:
+            _failure: true
+
+    - name: Mark failure
+      when:
+        - (_run_fail | bool and not scenario.should_fail | default(false)) or
+          (not _run_fail and scenario.should_fail | default(false))
+      ansible.builtin.set_fact:
+        is_failed: true
+        _failure: true
+
+    - name: Manage error
+      when:
+        - _failure | bool
+      block:
+        - name: Display error message
+          ansible.builtin.debug:
+            msg: >-
+              Failed to validate {{ scenario.name }}
+
+        - name: Append scenario to list
+          ansible.builtin.set_fact:
+            failure_list: "{{ failure_list + [scenario.name] }}"
+
+    - name: Copy generated contents
+      vars:
+        _dest: >-
+          {{ _output }}/{{ scenario.name | replace(' ', '_') | lower }}
+      block:
+        - name: Ensure directory exists
+          ansible.builtin.file:
+            path: "{{ _dest }}"
+            state: directory
+            mode: "0755"
+
+        - name: Copy files of interest
+          failed_when: false
+          ansible.builtin.copy:
+            remote_src: true
+            src: "{{ cifmw_basedir }}/{{ item }}"
+            dest: "{{ _dest }}/"
+          loop:
+            - artifacts
+            - logs
+            - parameters
+
+        - name: Copy cifmw-dnsmasq
+          failed_when: false
+          ansible.builtin.copy:
+            remote_src: true
+            src: "{{ item }}"
+            dest: "{{ _dest }}/"
+          loop:
+            - /etc/cifmw-dnsmasq.conf
+            - /etc/cifmw-dnsmasq.d
+
+    - name: Clean environment
+      ansible.builtin.include_role:
+        name: "libvirt_manager"
+        tasks_from: "clean_layout.yml"
+
+    - name: Clean leftovers
+      become: true
+      ansible.builtin.file:
+        path: "{{ cifmw_basedir }}"
+        state: absent

--- a/roles/libvirt_manager/molecule/generate_network_data/vars/input.yml
+++ b/roles/libvirt_manager/molecule/generate_network_data/vars/input.yml
@@ -1,0 +1,103 @@
+---
+networks:
+  ctlplane:
+    network: "192.168.140.0/24"
+    gateway: "192.168.140.1"
+    dns:
+      - "192.168.140.253"
+      - "192.168.140.254"
+    search-domain: "ctlplane.example.local"
+    mtu: 1500
+  ctlplanedcn1:
+    network: "192.168.133.0/24"
+    gateway: "192.168.133.1"
+    dns:
+      - "192.168.133.1"
+    mtu: 1500
+    tools:
+      multus:
+        ranges:
+          - start: 30
+            end: 70
+      netconfig:
+        ranges:
+          - start: 100
+            end: 120
+          - start: 150
+            end: 170
+      metallb:
+        ranges:
+          - start: 80
+            end: 90
+  ctlplanedcn2:
+    network: "192.168.144.0/24"
+    gateway: "192.168.144.1"
+    dns:
+      - "192.168.144.1"
+    mtu: 1500
+    tools:
+      multus:
+        ranges:
+          - start: 30
+            end: 70
+      netconfig:
+        ranges:
+          - start: 100
+            end: 120
+          - start: 150
+            end: 170
+      metallb:
+        ranges:
+          - start: 80
+            end: 90
+  internalapi:
+    network: "172.17.0.0/24"
+    vlan: 20
+    mtu: 1496
+    tools:
+      metallb:
+        ranges:
+          - start: 80
+            end: 90
+      netconfig:
+        ranges:
+          - start: 100
+            end: 250
+      multus:
+        ranges:
+          - start: 30
+            end: 70
+group-templates:
+  computes:
+    network-template:
+      range:
+        start: 10
+        end: 15
+    networks: &computes_nets
+      ctlplane: {}
+      internalapi:
+        trunk-parent: ctlplane
+  sl-computes:
+    network-template:
+      range:
+        start: 16
+        length: 2
+    networks: *computes_nets
+  baremetals:
+    networks:
+      ctlplane:
+        range: "192.168.140.20-192.168.140.24"
+  dcn1-computes:
+    network-template:
+      range:
+        start: 150
+        length: 10
+    networks:
+      ctlplanedcn1: {}
+  dcn2-computes:
+    network-template:
+      range:
+        start: 160
+        length: 10
+    networks:
+      ctlplanedcn2: {}

--- a/roles/libvirt_manager/molecule/generate_network_data/vars/scenarios.yml
+++ b/roles/libvirt_manager/molecule/generate_network_data/vars/scenarios.yml
@@ -1,0 +1,185 @@
+---
+# When adding a new scenario, you have to ensure you
+# provide the same hosts as the previous scenario.
+# This is mandatory, else your scenario will fail.
+# Reason:
+# we use ansible.builtin.add_host to populate the inventory
+# and there is *no* way to reset the inventory during the run.
+# Even using the ansible.builtin.meta "refresh_inventory" does
+# not help there. The inventory is then used in the networking_mapper
+# and that would fail if it doesn't have the data for "removed hosts".
+scenarios:
+  - name: Standard osp_trunk with extended translation
+    check_dns:
+      - rec: "compute-0.utility"
+        ip: "192.168.140.10"
+      - rec: "compute-0.ctlplane.local"
+        ip: "192.168.140.10"
+      - rec: "compute-0.public.local"
+        ip: "192.168.110.10"
+    check_dhcp:
+      - osp_trunk_compute-0
+      - public_compute-0
+    lm_config_patch:
+      networks:
+        osp_trunk: |
+          <network>
+            <name>osp_trunk</name>
+            <bridge name='osp_trunk'/>
+            <dns enabled='no'/>
+            <ip family='ipv4' address='192.168.140.1' prefix='24'/>
+          </network>
+
+  - name: Baremetal integration
+    check_dns:
+      - rec: "compute-0.utility"
+        ip: "192.168.140.10"
+      - rec: "compute-0.ctlplane.local"
+        ip: "192.168.140.10"
+      - rec: "compute-0.public.local"
+        ip: "192.168.110.10"
+      - rec: "bm-0.utility"
+        ip: "192.168.140.20"
+      - rec: "bm-0.ctlplane.local"
+        ip: "192.168.140.20"
+    check_dhcp:
+      - osp_trunk_compute-0
+      - public_compute-0
+      - public_bm-0
+    bm_hosts:
+      bm-0:
+        address: 10.10.1.12
+        boot_mode: uefi
+        connection: ipmi://10.10.1.12:6240
+        nics:
+          - mac: 52:54:00:c6:04:90
+            network: public
+          - mac: 52:54:00:ca:a1:e1
+            network: osp_trunk
+        password: password
+        port: 6240
+        status: running
+        username: admin
+        uuid: 6677a9e8-9e6d-44d4-a4b8-236720fd70ab
+    lm_config_patch:
+      networks:
+        osp_trunk: |
+          <network>
+            <name>osp_trunk</name>
+            <bridge name='osp_trunk'/>
+            <dns enabled='no'/>
+            <ip family='ipv4' address='192.168.140.1' prefix='24'/>
+          </network>
+
+  - name: DCN like network layout
+    pub_net: ocpbm
+    net_translate:
+      osp_trunk:
+        - controlplane
+        - ctlplane
+      dcn1_tr:
+        - ctlplanedcn1
+      dcn2_tr:
+        - ctlplanedcn2
+    check_dns:
+      - rec: "compute-0.utility"
+        ip: "192.168.140.10"
+      - rec: "compute-0.ctlplane.local"
+        ip: "192.168.140.10"
+      - rec: "compute-0.ocpbm.local"
+        ip: "192.168.111.10"
+      - rec: "bm-0.utility"
+        ip: "192.168.140.20"
+      - rec: "bm-0.ctlplane.local"
+        ip: "192.168.140.20"
+      - rec: "dcn1-compute-0.utility"
+        ip: "192.168.133.150"
+      - rec: "dcn1-compute-0.ctlplanedcn1.local"
+        ip: "192.168.133.150"
+      - rec: "dcn1-compute-0.ocpbm.local"
+        ip: "192.168.111.150"
+      - rec: "dcn1-compute-1.utility"
+        ip: "192.168.133.151"
+      - rec: "dcn2-compute-0.utility"
+        ip: "192.168.144.160"
+    check_dhcp:
+      - dcn1_tr_dcn1-compute-0
+      - dcn1_tr_dcn1-compute-1
+      - dcn2_tr_dcn2-compute-0
+      - ocpbm_bm-0
+      - ocpbm_compute-0
+      - ocpbm_dcn1-compute-0
+      - ocpbm_dcn1-compute-1
+      - ocpbm_dcn2-compute-0
+      - osp_trunk_bm-0
+      - osp_trunk_compute-0
+      - public_bm-0
+      - public_compute-0
+    bm_hosts:
+      bm-0:
+        address: 10.10.1.12
+        boot_mode: uefi
+        connection: ipmi://10.10.1.12:6240
+        nics:
+          - mac: 52:54:00:c6:04:90
+            network: ocpbm
+          - mac: 52:54:00:ca:a1:e1
+            network: osp_trunk
+        password: password
+        port: 6240
+        status: running
+        username: admin
+        uuid: 6677a9e8-9e6d-44d4-a4b8-236720fd70ab
+    lm_config_patch:
+      networks:
+        osp_trunk: |
+          <network>
+            <name>osp_trunk</name>
+            <bridge name='osp_trunk'/>
+            <dns enabled='no'/>
+            <ip family='ipv4' address='192.168.140.1' prefix='24'/>
+          </network>
+        ocpbm: |
+          <network>
+            <name>ocpbm</name>
+            <forward mode='nat'/>
+            <bridge name='ocpbm' stp='on' delay='0'/>
+            <dns enable="no"/>
+            <ip family='ipv4' address='192.168.111.1' prefix='24'>
+            </ip>
+          </network>
+        dcn1_tr: |
+          <network>
+            <name>dcn1_tr</name>
+              <forward mode='nat'/>
+                <bridge name='dcn1_tr' stp='on' delay='0'/>
+                  <ip family='ipv4' address='192.168.133.1' prefix='24'>
+                  </ip>
+          </network>
+        dcn2_tr: |
+          <network>
+            <name>dcn2_tr</name>
+              <forward mode='nat'/>
+                <bridge name='dcn2_tr' stp='on' delay='0'/>
+                  <ip family='ipv4' address='192.168.144.1' prefix='24'>
+                  </ip>
+          </network>
+      vms:
+        dcn1-compute:
+          amount: 2
+          disk_file_name: "blank"
+          disksize: "2"
+          memory: "1"
+          cpus: "1"
+          nets:
+            - ocpbm
+            - dcn1_tr
+        dcn2-compute:
+          amount: 1
+          disk_file_name: "blank"
+          disksize: "2"
+          memory: "1"
+          cpus: "1"
+          nets:
+            - ocpbm
+            - dcn2_tr

--- a/roles/libvirt_manager/tasks/create_dns_records.yml
+++ b/roles/libvirt_manager/tasks/create_dns_records.yml
@@ -7,21 +7,13 @@
 # Using the selectattr + match, then selecting the first
 # matched network should cover most of the cases if not all.
 - name: Try/catch block with common variables
-  vars:
-    _no_dnsmasq: >-
-      {{
-        cifmw_libvirt_manager_no_dnsmasq_nets_defaults +
-        cifmw_libvirt_manager_no_dnsmasq_nets
-      }}
   block:
     - name: Reserve IPs on networks
-      when:
-        - net.name not in _no_dnsmasq
       ansible.builtin.include_tasks: reserve_dnsmasq_ips.yml
-      loop: "{{ _network_data }}"
+      loop: "{{ cifmw_networking_env_definition.networks.keys() }}"
       loop_control:
-        loop_var: "net"
-        label: "{{ net.name }}"
+        loop_var: "net_name"
+        label: "{{ net_name }}"
 
     - name: Create per-network and .utility DNS entries
       vars:

--- a/roles/libvirt_manager/tasks/reserve_dnsmasq_ips.yml
+++ b/roles/libvirt_manager/tasks/reserve_dnsmasq_ips.yml
@@ -1,43 +1,84 @@
 ---
-# Reserve IPs in dnsmasq service, based on:
-# - networking_mapper output (provides IPs and MAC)
-# - networks configured on the host (_network_data fact built
-#   in the create_networks.yml tasks)
-
-- name: Loop on host IPs
-  when:
-    - host_data.value.networks[_cleaned_netname] is defined
+- name: Try/catch block
   vars:
-    _net_name: >-
-      {{ (net.name is match '.*osp_trunk$') | ternary('ctlplane', net.name) }}
-    _cleaned_netname: "{{ _net_name | regex_replace('^cifmw[_-]', '') }}"
-    _net_data: "{{ host_data.value.networks[_cleaned_netname] }}"
-    _ocp_name: >-
+    _no_dnsmasq: >-
       {{
-        host_data.key | replace('_', '-') |
-        replace('ocp-worker', 'worker') |
-        replace('ocp', 'master')
+        cifmw_libvirt_manager_no_dnsmasq_nets_defaults +
+        cifmw_libvirt_manager_no_dnsmasq_nets
       }}
-    _hostname: >-
+    _translate: "{{ cifmw_networking_mapper_interfaces_info_translations }}"
+    _rev_translate: >-
+      {%- set out = {} -%}
+      {%- for k,v in _translate.items() -%}
+      {%-   set data = v | product([k]) | community.general.dict -%}
+      {%-   set _ = out.update(data) -%}
+      {%- endfor -%}
+      {{ out }}
+    _translated_name: >-
       {{
-        (host_data.key is match('^ocp.*')) |
-        ternary(_ocp_name, host_data.key)
+        _rev_translate[net_name] |
+        default(net_name, true)
       }}
-    cifmw_dnsmasq_host_network: "{{ net.name }}"
-    cifmw_dnsmasq_host_name: "{{ _hostname }}"
-    cifmw_dnsmasq_host_state: 'present'
-    cifmw_dnsmasq_host_mac: "{{ _net_data.mac_addr }}"
-    cifmw_dnsmasq_host_ips: >-
-      {{
-        [
-          _net_data.ip_v4 | default(''),
-          _net_data.ip_v6 | default('')
-        ]
-      }}
-  ansible.builtin.include_role:
-    name: "dnsmasq"
-    tasks_from: "manage_host.yml"
-  loop: "{{ cifmw_networking_env_definition.instances | dict2items }}"
-  loop_control:
-    label: "{{ host_data.key }} - {{ net.name }}"
-    loop_var: "host_data"
+  block:
+    - name: Loop on host IPs
+      when:
+        - _translated_name not in _no_dnsmasq
+        - _translated_name in _cifmw_libvirt_manager_layout.networks.keys()
+        - host_data.value.networks[net_name] is defined
+      vars:
+        _net_data: "{{ host_data.value.networks[net_name] }}"
+        _ocp_name: >-
+          {{
+            host_data.key | replace('_', '-') |
+            replace('ocp-worker', 'worker') |
+            replace('ocp', 'master')
+          }}
+        _hostname: >-
+          {{
+            (host_data.key is match('^ocp.*')) |
+            ternary(_ocp_name, host_data.key)
+          }}
+        cifmw_dnsmasq_host_network: "{{ _translated_name }}"
+        cifmw_dnsmasq_host_name: "{{ _hostname }}"
+        cifmw_dnsmasq_host_state: 'present'
+        cifmw_dnsmasq_host_mac: "{{ _net_data.mac_addr }}"
+        cifmw_dnsmasq_host_ips: >-
+          {{
+            [
+              _net_data.ip_v4 | default(''),
+              _net_data.ip_v6 | default('')
+            ]
+          }}
+      ansible.builtin.include_role:
+        name: "dnsmasq"
+        tasks_from: "manage_host.yml"
+      loop: "{{ cifmw_networking_env_definition.instances | dict2items }}"
+      loop_control:
+        label: "{{ host_data.key }} - {{ net_name }}"
+        loop_var: "host_data"
+
+  rescue:
+    - name: Debug _rev_translate
+      ansible.builtin.debug:
+        var: _rev_translate
+
+    - name: Debug translated name
+      ansible.builtin.debug:
+        var: _translated_name
+
+    - name: Debug net_name
+      ansible.builtin.debug:
+        msg: "{{ net_name }}"
+
+    - name: Debug cifmw_networking_env_definition.instances
+      ansible.builtin.debug:
+        msg: "{{ cifmw_networking_env_definition.instances }}"
+
+    - name: Debug _cifmw_libvirt_manager_layout.vms
+      ansible.builtin.debug:
+        msg: "{{ _cifmw_libvirt_manager_layout.vms }}"
+
+    - name: Fail for good
+      ansible.builtin.fail:
+        msg: >-
+          Error detected. Check the debugging data above


### PR DESCRIPTION
DCN has multiple controplane networks, making it different from any
other layout we had until now.

A compute is usually connected to "a public network", and to a specific,
"local" controlplane, while another compute would be connected to a
different controlplane.

In addition to this, with Linux bridge name length limit, we must also
check in the "translation map" in case a network in libvirt isn't named
like the "interesting" ones used in the networking_mapper output.

This patch makes use of that translation when we generate the DHCP
entries - that was apparently the missing part, since we generate the
DNS entries already based on the networking_mapper output, with a
"match" for the `ctlplane` pattern, allowing to capture any network
starting with that specific pattern.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

### Testing (not in commit message)
- [x] BGP
- [x] NFV
- [x] DCN
