### PR TITLE
nat64: Make VM uuid in mac-address idempotent

### DIFF
--- a/roles/nat64_appliance/molecule/default/converge.yml
+++ b/roles/nat64_appliance/molecule/default/converge.yml
@@ -457,3 +457,27 @@
         - "{{ _ping_example_com.rc }}"
         - "{{ _ping_example_com.stdout_lines }}"
         - "{{ _ping_example_com.stderr_lines }}"
+
+    - name: "Run deploy nat64 appliance again, to test idempotency"
+      vars:
+        cifmw_nat64_appliance_ssh_pub_keys:
+          - "{{ _test_key.public_key }}"
+      ansible.builtin.include_role:
+        name: nat64_appliance
+        tasks_from: deploy.yml
+
+    - name: Ping example.com (delegate to test-node) - post idempotency test
+      delegate_to: test-node
+      register: _ping_example_com
+      ansible.builtin.command: "ping -c 2 example.com"
+      until: _ping_example_com.rc == 0
+      retries: 60
+      delay: 10
+
+    - name: Debug the ping example.com result - post idempotency test
+      ansible.builtin.debug:
+        msg: "{{ item }}"
+      loop:
+        - "{{ _ping_example_com.rc }}"
+        - "{{ _ping_example_com.stdout_lines }}"
+        - "{{ _ping_example_com.stderr_lines }}"

--- a/roles/nat64_appliance/tasks/deploy.yml
+++ b/roles/nat64_appliance/tasks/deploy.yml
@@ -87,7 +87,14 @@
     name: firewalld
     state: restarted
 
+- name: List VMs
+  register: _list_running_vms
+  community.libvirt.virt:
+    command: list_vms
+    state: running
+
 - name: "Create the config-drive ISO for the nat64-appliance"
+  when: 'not cifmw_nat64_appliance_name in _list_running_vms.list_vms'
   vars:
     cifmw_config_drive_iso_image: "{{ cifmw_nat64_appliance_workdir }}/{{ cifmw_nat64_appliance_uuid }}.iso"
     cifmw_config_drive_uuid: "{{ cifmw_nat64_appliance_uuid }}"
@@ -128,12 +135,14 @@
     name: config_drive
 
 - name: "Define nat64-appliance VM"
+  when: 'not cifmw_nat64_appliance_name in _list_running_vms.list_vms'
   community.libvirt.virt:
     command: define
     xml: "{{ lookup('template', 'domain.xml.j2') }}"
     uri: "{{ cifmw_nat64_libvirt_uri }}"
 
 - name: "Start nat64-appliance VM"
+  when: 'not cifmw_nat64_appliance_name in _list_running_vms.list_vms'
   community.libvirt.virt:
     state: running
     name: "{{ cifmw_nat64_appliance_name }}"

--- a/roles/nat64_appliance/tasks/deploy.yml
+++ b/roles/nat64_appliance/tasks/deploy.yml
@@ -1,8 +1,21 @@
 ---
-- name: Set MAC address facts
+- name: Set nat64-appliance VM uuid and mac-address facts
   ansible.builtin.set_fact:
-    cifmw_nat64_appliance_ipv4_mac_address: "{{ '52:54:00' | community.general.random_mac }}"
-    cifmw_nat64_appliance_ipv6_mac_address: "{{ '52:54:00' | community.general.random_mac }}"
+    cifmw_nat64_appliance_uuid: >-
+      {{
+        99999999 | ansible.builtin.random(seed=inventory_hostname + 'nat64')
+        | to_uuid | lower
+      }}
+    cifmw_nat64_appliance_ipv4_mac_address: >-
+      {{
+        '52:54:00' | community.general.random_mac(
+                     seed=inventory_hostname + 'nat64ipv4')
+      }}
+    cifmw_nat64_appliance_ipv6_mac_address: >-
+      {{
+        '52:54:00' | community.general.random_mac(
+                     seed=inventory_hostname + 'nat64ipv6')
+      }}
 
 - name: Create the IPv4 libvirt network for nat64
   community.libvirt.virt_net:
@@ -74,14 +87,10 @@
     name: firewalld
     state: restarted
 
-- name: "Generate nat64-appliance UUID"
-  ansible.builtin.set_fact:
-    nat64_appliance_uuid: "{{ 99999999 | random | to_uuid | lower }}"
-
 - name: "Create the config-drive ISO for the nat64-appliance"
   vars:
-    cifmw_config_drive_iso_image: "{{ cifmw_nat64_appliance_workdir }}/{{ nat64_appliance_uuid }}.iso"
-    cifmw_config_drive_uuid: "{{ nat64_appliance_uuid }}"
+    cifmw_config_drive_iso_image: "{{ cifmw_nat64_appliance_workdir }}/{{ cifmw_nat64_appliance_uuid }}.iso"
+    cifmw_config_drive_uuid: "{{ cifmw_nat64_appliance_uuid }}"
     cifmw_config_drive_name: "{{ cifmw_nat64_appliance_name }}"
     cifmw_config_drive_hostname: "{{ cifmw_nat64_appliance_name }}"
     cifmw_config_drive_userdata:

--- a/roles/nat64_appliance/templates/domain.xml.j2
+++ b/roles/nat64_appliance/templates/domain.xml.j2
@@ -1,6 +1,6 @@
 <domain type='kvm'>
   <name>{{ cifmw_nat64_appliance_name }}</name>
-  <uuid>{{ nat64_appliance_uuid }}</uuid>
+  <uuid>{{ cifmw_nat64_appliance_uuid }}</uuid>
   <memory unit='GB'>{{ cifmw_nat64_appliance_memory }}</memory>
   <vcpu placement='static'>{{ cifmw_nat64_appliance_cpus }}</vcpu>
   <os>
@@ -27,7 +27,7 @@
     </disk>
     <disk type='file' device='cdrom'>
       <driver name='qemu' type='raw'/>
-      <source file='{{ cifmw_nat64_appliance_workdir }}/{{ nat64_appliance_uuid }}.iso'/>
+      <source file='{{ cifmw_nat64_appliance_workdir }}/{{ cifmw_nat64_appliance_uuid }}.iso'/>
       <target dev='sdb' bus='sata'/>
       <readonly/>
     </disk>


### PR DESCRIPTION
Use a seed for the random generator to ensure the uuid and mac-addresses are idempotent on re-runs.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running

