### PR TITLE
[libvirt_manager] Do not add dummys to populated bridges

### DIFF
--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -41,6 +41,7 @@ Used for checking if:
 * `cifmw_libvirt_manager_firewalld_zone_libvirt_forward`: (Bool) Enable forwarding in the libvirt firewall zone. Defaults to: `true`
 * `cifmw_libvirt_manager_firewalld_default_zone`: (String) Name of the default firewall zone. Defaults to `public`.
 * `cifmw_libvirt_manager_firewalld_default_zone_masquerade`: (Bool) Enable masquerading on the default firewall zone. Defaults to `true`.
+* `cifmw_libvirt_manager_attach_dummy_interface_on_bridges`: (Bool) Attach dummy interface on bridges. Defaults to `true`.
 
 ### Structure for `cifmw_libvirt_manager_configuration`
 

--- a/roles/libvirt_manager/defaults/main.yml
+++ b/roles/libvirt_manager/defaults/main.yml
@@ -84,3 +84,4 @@ cifmw_libvirt_manager_spineleaf_setup: false
 cifmw_libvirt_manager_firewalld_zone_libvirt_forward: true
 cifmw_libvirt_manager_firewalld_default_zone: public
 cifmw_libvirt_manager_firewalld_default_zone_masquerade: true
+cifmw_libvirt_manager_attach_dummy_interface_on_bridges: true

--- a/roles/libvirt_manager/tasks/create_networks.yml
+++ b/roles/libvirt_manager/tasks/create_networks.yml
@@ -81,38 +81,10 @@
   loop_control:
     label: "{{ item.name }}"
 
-# NOTE(hjensas): Using a random string for dummy interface names because
-#                otherwise we hit the 15 char limitation on ifname.
-- name: Create dummy interfaces to ensure bridges are UP
-  vars:
-    cifmw_ci_nmstate_unmanaged_node_config: >-
-      {%- set interfaces = []                                            -%}
-      {%- for network in networks | map(attribute="name") | flatten
-            if cifmw_libvirt_manager_network_interface_types[network | regex_replace('cifmw[-_]','')]
-            | default('bridge') == 'bridge'                              -%}
-      {%- set suffix = lookup('password',
-                              '/dev/null',
-                              chars=['ascii_lowercase', 'digits'],
-                              length=8,
-                              seed=network)                              -%}
-      {%- set _ = interfaces.append(
-        {
-          'name': 'dummy-' + suffix,
-          'type': 'dummy',
-          'ipv4': {'enabled': false},
-          'ipv6': {'enabled': false},
-          'controller': network,
-          'description': (
-            'Dummy for bridge: ' + network +
-            ' - to ensure bridge UP and IPv6 link-local addr is assigned.')
-        }
-      )                                                                  -%}
-      {%- endfor                                                         -%}
-      {{ {'interfaces': interfaces } }}
-    cifmw_ci_nmstate_unmanaged_host: "{{ inventory_hostname }}"
-  ansible.builtin.include_role:
-    name: "ci_nmstate"
-    tasks_from: "nmstate_unmanaged_provision_node.yml"
+
+- name: Add a dummy interface to bridges if required
+  when: cifmw_libvirt_manager_attach_dummy_interface_on_bridges | bool
+  ansible.builtin.include_tasks: create_networks_dummy_interfaces.yml
 
 ## Ensure we get dnsmasq DHCP service for all created networks
 # Refreshing network facts will ensure we get the new interfaces.

--- a/roles/libvirt_manager/tasks/create_networks_dummy_interfaces.yml
+++ b/roles/libvirt_manager/tasks/create_networks_dummy_interfaces.yml
@@ -1,0 +1,68 @@
+---
+- name: Fetch present bridge interfaces
+  ansible.builtin.command:
+    cmd: "ip -j link show type bridge"
+  register: _cifmw_libvirt_manager_ip_bridges_out
+  changed_when: false
+
+- name: Fetch bridges ports link info
+  vars:
+    _brige_ifaces: >-
+      {{
+        _cifmw_libvirt_manager_ip_bridges_out.stdout | from_json |
+        selectattr('ifname', 'defined') |
+        map(attribute='ifname')
+      }}
+  when:
+    - item in _brige_ifaces
+  ansible.builtin.command:
+    cmd: "ip -j link show master {{ item }}"
+  loop: "{{ networks | map(attribute='name') | flatten }}"
+  register: _cifmw_libvirt_manager_bridges_ports
+  changed_when: false
+
+# NOTE(hjensas): Using a random string for dummy interface names because
+#                otherwise we hit the 15 char limitation on ifname.
+- name: Create dummy interfaces to ensure bridges are UP
+  vars:
+    cifmw_ci_nmstate_unmanaged_node_config: >-
+      {%- set interfaces = []                                            -%}
+      {%- for network in networks | map(attribute="name") | flatten
+            if
+              (
+                cifmw_libvirt_manager_network_interface_types[network |
+                regex_replace('cifmw[-_]','')] |
+                default('bridge') == 'bridge'
+              ) and
+              (
+                (
+                  _cifmw_libvirt_manager_bridges_ports.results |
+                  selectattr('item', 'equalto', network) |
+                  selectattr('stdout', 'defined') | first |
+                  default({'stdout': '[]'})
+                ).stdout | from_json | length == 0
+              )                                                          -%}
+      {%- set suffix = lookup('password',
+                              '/dev/null',
+                              chars=['ascii_lowercase', 'digits'],
+                              length=8,
+                              seed=network)                              -%}
+      {%- set _ = interfaces.append(
+        {
+          'name': 'dummy-' + suffix,
+          'type': 'dummy',
+          'ipv4': {'enabled': false},
+          'ipv6': {'enabled': false},
+          'controller': network,
+          'description': (
+            'Dummy for bridge: ' + network +
+            ' - to ensure bridge UP and IPv6 link-local addr is assigned.')
+        }
+      )                                                                  -%}
+      {%- endfor                                                         -%}
+      {{ {'interfaces': interfaces } }}
+    cifmw_ci_nmstate_unmanaged_host: "{{ inventory_hostname }}"
+  when: "cifmw_ci_nmstate_unmanaged_node_config['interfaces'] | length > 0"
+  ansible.builtin.include_role:
+    name: "ci_nmstate"
+    tasks_from: "nmstate_unmanaged_provision_node.yml"


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
