### PR TITLE
Allow spine&leaf to not have ctlplane

### DIFF
--- a/roles/libvirt_manager/molecule/spine_leaf/converge.yml
+++ b/roles/libvirt_manager/molecule/spine_leaf/converge.yml
@@ -24,6 +24,8 @@
     cifmw_libvirt_manager_network_interface_types:
       intnet-0: network
       intnet-1: network
+      s0-rtr: network
+      s1-rtr: network
     cifmw_libvirt_manager_vm_net_ip_set:
       sl-compute: 100
     _networks:
@@ -52,12 +54,26 @@
             - public
             - osp_trunk
           spineleafnets:
-            - # sl-compute-0 interfaces
+            -  # sl-compute-0 interfaces
               - public
-            - # sl-compute-1 interfaces
+            -  # sl-compute-1 interfaces
               - public
-          extra_disks_num: 1
-          extra_disks_size: 1G
+        router:
+          amount: 1
+          image_url: "{{ cifmw_discovered_image_url }}"
+          sha256_image_name: "{{ cifmw_discovered_hash }}"
+          image_local_dir: "{{ cifmw_basedir }}/images/"
+          disk_file_name: "spineleaf-centos-stream-9.qcow2"
+          disksize: 20
+          memory: 1
+          cpus: 1
+          nets:
+            - public
+          spineleafnets:
+            -  # router - ocp_tester
+              - "s0-rtr"
+              - "s1-rtr"
+
       networks:
         public: |-
           <network>
@@ -93,6 +109,17 @@
             <name>intnet-1</name>
             <bridge name='intnet-1' stp='on' delay='0'/>
           </network>
+        # spines to router networks
+        s0-rtr: |
+          <network>
+            <name>s0-rtr</name>
+            <bridge name='s0-rtr' stp='on' delay='0'/>
+          </network>
+        s1-rtr: |
+          <network>
+            <name>s1-rtr</name>
+            <bridge name='s1-rtr' stp='on' delay='0'/>
+          </network>
   roles:
     - role: "discover_latest_image"
   tasks:
@@ -105,123 +132,3 @@
       ansible.builtin.import_role:
         name: libvirt_manager
         tasks_from: deploy_layout
-
-    - name: Check files and deployed resources
-      block:
-        - name: Get wanted files
-          register: generated_files
-          ansible.builtin.stat:
-            path: "{{ cifmw_basedir }}/{{ item }}"
-          loop:
-            - reproducer-inventory/sl-compute-group.yml
-
-        - name: Assert file availability
-          ansible.builtin.assert:
-            that:
-              - item.stat.exists | bool
-          loop: "{{ generated_files.results }}"
-          loop_control:
-            label: "{{ item.stat.path }}"
-
-        - name: Get virtual network list
-          register: nets
-          community.libvirt.virt_net:
-            command: list_nets
-
-        - name: Get virtual machines
-          register: vms
-          community.libvirt.virt:
-            command: "list_vms"
-
-        - name: Output network list
-          ansible.builtin.debug:
-            msg:
-              - "{{ nets.list_nets | sort }}"
-              - >-
-                {{
-                  ['cifmw-public', 'cifmw-osp_trunk',
-                   'cifmw-intnet-0', 'cifmw-intnet-1'] | sort
-                }}
-
-        - name: Assert resource lists
-          vars:
-            sorted_nets: "{{ nets.list_nets | sort }}"
-            compare_nets: >-
-              {{
-                ['cifmw-public', 'cifmw-osp_trunk',
-                 'cifmw-intnet-0', 'cifmw-intnet-1'] | sort
-              }}
-            sorted_vms: "{{ vms.list_vms | sort }}"
-            compare_vms: >-
-              {{
-                ['cifmw-sl-compute-0',
-                 'cifmw-sl-compute-1'] | sort
-              }}
-          ansible.builtin.assert:
-            that:
-              - sorted_nets == compare_nets
-              - sorted_vms == compare_vms
-
-        - name: Get sl-compute-0 network interfaces
-          register: cmp_nics_cmp_0
-          ansible.builtin.command:
-            cmd: >-
-              virsh -c qemu:///system -q
-              domiflist cifmw-sl-compute-0
-
-        - name: Ensure sl-compute-0 connections
-          vars:
-            _vals: >-
-              {{
-                cmp_nics_cmp_0.stdout_lines |
-                product([' sl-compute-0']) |
-                map('join') |
-                map('split')
-              }}
-            _nics: >-
-              {{
-                _vals |
-                map('zip',
-                    ['nic', 'type', 'network', 'driver', 'mac', 'host' ]) |
-                map('map', 'reverse') |
-                map('community.general.dict')
-              }}
-          ansible.builtin.assert:
-            that:
-              - item.network in ['cifmw-public', 'cifmw-osp_trunk', 'cifmw-intnet-0']
-          loop: "{{ _nics }}"
-
-        - name: Get sl-compute-1 network interfaces
-          register: cmp_nics_cmp_1
-          ansible.builtin.command:
-            cmd: >-
-              virsh -c qemu:///system -q
-              domiflist cifmw-sl-compute-1
-
-        - name: Ensure sl-compute-1 connections
-          vars:
-            _vals: >-
-              {{
-                cmp_nics_cmp_1.stdout_lines |
-                product([' sl-compute-1']) |
-                map('join') |
-                map('split')
-              }}
-            _nics: >-
-              {{
-                _vals |
-                map('zip',
-                    ['nic', 'type', 'network', 'driver', 'mac', 'host' ]) |
-                map('map', 'reverse') |
-                map('community.general.dict')
-              }}
-          ansible.builtin.assert:
-            that:
-              - item.network in ['cifmw-public', 'cifmw-osp_trunk', 'cifmw-intnet-1']
-          loop: "{{ _nics }}"
-
-        - name: Get osp_trunk network XML
-          register: _net_xml
-          community.libvirt.virt_net:
-            command: "get_xml"
-            name: "cifmw-osp_trunk"

--- a/roles/libvirt_manager/molecule/spine_leaf/verify.yml
+++ b/roles/libvirt_manager/molecule/spine_leaf/verify.yml
@@ -1,0 +1,123 @@
+---
+- name: Verify spine_leaf
+  hosts: instance
+  gather_facts: true
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_basedir: "/opt/basedir"
+    compare_nets: >-
+      {{
+          ['cifmw-public', 'cifmw-osp_trunk',
+           'cifmw-intnet-0', 'cifmw-intnet-1',
+           'cifmw-s0-rtr', 'cifmw-s1-rtr'] | sort
+      }}
+    compare_vms: >-
+      {{
+        ['cifmw-sl-compute-0',
+         'cifmw-sl-compute-1',
+         'cifmw-router-0'] | sort
+      }}
+  tasks:
+    - name: Get wanted files
+      register: generated_files
+      ansible.builtin.stat:
+        path: "{{ cifmw_basedir }}/{{ item }}"
+      loop:
+        - reproducer-inventory/sl-compute-group.yml
+
+    - name: Assert file availability
+      ansible.builtin.assert:
+        that:
+          - item.stat.exists | bool
+      loop: "{{ generated_files.results }}"
+      loop_control:
+        label: "{{ item.stat.path }}"
+
+    - name: Get virtual network list
+      register: nets
+      community.libvirt.virt_net:
+        command: list_nets
+
+    - name: Get virtual machines
+      register: vms
+      community.libvirt.virt:
+        command: "list_vms"
+
+    - name: Output network list
+      ansible.builtin.debug:
+        msg:
+          - "{{ nets.list_nets | sort }}"
+          - "{{ compare_nets }}"
+
+    - name: Assert resource lists
+      vars:
+        sorted_nets: "{{ nets.list_nets | sort }}"
+        sorted_vms: "{{ vms.list_vms | sort }}"
+      ansible.builtin.assert:
+        that:
+          - sorted_nets == compare_nets
+          - sorted_vms == compare_vms
+
+    - name: Get sl-compute-0 network interfaces
+      register: cmp_nics_cmp_0
+      ansible.builtin.command:
+        cmd: >-
+          virsh -c qemu:///system -q
+          domiflist cifmw-sl-compute-0
+
+    - name: Ensure sl-compute-0 connections
+      vars:
+        _vals: >-
+          {{
+            cmp_nics_cmp_0.stdout_lines |
+            product([' sl-compute-0']) |
+            map('join') |
+            map('split')
+          }}
+        _nics: >-
+          {{
+            _vals |
+            map('zip',
+                ['nic', 'type', 'network', 'driver', 'mac', 'host' ]) |
+            map('map', 'reverse') |
+            map('community.general.dict')
+          }}
+      ansible.builtin.assert:
+        that:
+          - item.network in ['cifmw-public', 'cifmw-osp_trunk', 'cifmw-intnet-0']
+      loop: "{{ _nics }}"
+
+    - name: Get sl-compute-1 network interfaces
+      register: cmp_nics_cmp_1
+      ansible.builtin.command:
+        cmd: >-
+          virsh -c qemu:///system -q
+          domiflist cifmw-sl-compute-1
+
+    - name: Ensure sl-compute-1 connections
+      vars:
+        _vals: >-
+          {{
+            cmp_nics_cmp_1.stdout_lines |
+            product([' sl-compute-1']) |
+            map('join') |
+            map('split')
+          }}
+        _nics: >-
+          {{
+            _vals |
+            map('zip',
+                ['nic', 'type', 'network', 'driver', 'mac', 'host' ]) |
+            map('map', 'reverse') |
+            map('community.general.dict')
+          }}
+      ansible.builtin.assert:
+        that:
+          - item.network in ['cifmw-public', 'cifmw-osp_trunk', 'cifmw-intnet-1']
+      loop: "{{ _nics }}"
+
+    - name: Get osp_trunk network XML
+      register: _net_xml
+      community.libvirt.virt_net:
+        command: "get_xml"
+        name: "cifmw-osp_trunk"

--- a/roles/libvirt_manager/tasks/generate_networking_data.yml
+++ b/roles/libvirt_manager/tasks/generate_networking_data.yml
@@ -210,6 +210,10 @@
       ansible.builtin.debug:
         var: _match
 
+    - name: Set molecule fact
+      ansible.builtin.set_fact:
+        molecule_failure_block: "net_map_patch"
+
     - name: Finally fail for goof
       ansible.builtin.fail:
         msg: >-
@@ -270,10 +274,20 @@
   when:
     - _net | length > 0
   vars:
-    _net: >-
+    _ctlplane_net: >-
       {{
         vm.value.networks | dict2items |
         selectattr('key', 'match', '^ctlplane')
+      }}
+    _pub_net_data: >-
+      {{
+        vm.value.networks | dict2items |
+        selectattr('key', 'match', cifmw_libvirt_manager_pub_net)
+      }}
+    _net: >-
+      {{
+        (_ctlplane_net | length > 0 ) |
+        ternary(_ctlplane_net, _pub_net_data)
       }}
     _entry:
       - names:
@@ -288,6 +302,21 @@
   loop_control:
     loop_var: vm
     label: "{{ vm.key }}"
+
+# This task might also be done via the reproducer/prepare_networking.yml
+# but, depending on how we call the libvirt_manager, we might not have it.
+# Using the same filename/permissions/content, we can ensure it's there without
+# re-doing the same tasks.
+# For the record, `local` ensures dnsmasq won't try to resolve names from other places.
+- name: Ensure .utility is local
+  become: true
+  notify: "Restart dnsmasq"
+  ansible.builtin.copy:
+    dest: "/etc/cifmw-dnsmasq.d/utility.conf"
+    mode: "0644"
+    content: |
+      local=/utility/
+    validate: "/usr/sbin/dnsmasq -C %s --test"
 
 - name: Inject VMs in the .utility zone
   vars:

--- a/roles/libvirt_manager/tasks/reserve_dnsmasq_ips.yml
+++ b/roles/libvirt_manager/tasks/reserve_dnsmasq_ips.yml
@@ -52,13 +52,18 @@
         ternary(_translate[net.name], [net.name])
       }}
     _net_name: >-
-      {{ (net.name is match '.*osp_trunk$') | ternary('ctlplane', net.name) }}
-    _cleaned_netname: "{{ _net_name | regex_replace('^cifmw[_-]', '') }}"
+      {{
+        _net_domain |
+        community.general.lists_intersect(host_data.value.networks.keys())
+      }}
   block:
     - name: Create host records
       when:
+        - _net_name | length > 0
         - host_data.value.networks[_cleaned_netname] is defined
       vars:
+        _vm_net_name: "{{ _net_name | first }}"
+        _cleaned_netname: "{{ _vm_net_name | regex_replace('^cifmw[_-]', '') }}"
         _net_data: "{{ host_data.value.networks[_cleaned_netname] }}"
         _ocp_name: >-
           {{
@@ -119,17 +124,46 @@
           ansible.builtin.debug:
             var: _net_domain
 
-        - name: Debug _net_name
+        - name: Debug _vm_net_name
           ansible.builtin.debug:
-            var: _net_name
+            var: _vm_net_name
 
         - name: Debug _cleaned_netname
           ansible.builtin.debug:
             var: _cleaned_netname
 
+        - name: Set molecule fact
+          ansible.builtin.set_fact:
+            molecule_failure_block: "host_loop"
+
         - name: Fail for good
           ansible.builtin.fail:
             msg: "Error detected, please check debug above"
+
+  rescue:
+    - name: Debug _translate
+      ansible.builtin.debug:
+        var: _translate
+
+    - name: Debug _net_domain
+      ansible.builtin.debug:
+        var: _net_domain
+
+    - name: Debug per-host networks
+      ansible.builtin.debug:
+        msg: "{{ host_data.value.networks.keys() }}"
+      loop: "{{ cifmw_networking_env_definition.instances | dict2items }}"
+      loop_control:
+        label: "{{ host_data.key }} - {{ net.name }}"
+        loop_var: "host_data"
+
+    - name: Set molecule fact
+      ansible.builtin.set_fact:
+        molecule_failure_block: "host_loop_prep"
+
+    - name: Fail for good
+      ansible.builtin.fail:
+        msg: "Error detected, please check debug above"
 
 - name: Inject host records
   vars:


### PR DESCRIPTION
Until now, the `.utility` record was only created for nodes connected to
the ctlplane network (or any of its equivalent).
In Spine&Leaf though, some VMs aren't connected to any controlplane,
only to the "Public" network.

This patch:
- allows to fallback on "public network" to create the .utility record
- updated spine_leaf molecule scenario to check that new feature

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
