### PR TITLE
libvirt_manager: dummy interfaces toggle option

### DIFF
--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -41,6 +41,7 @@ Used for checking if:
 * `cifmw_libvirt_manager_firewalld_zone_libvirt_forward`: (Bool) Enable forwarding in the libvirt firewall zone. Defaults to: `true`
 * `cifmw_libvirt_manager_firewalld_default_zone`: (String) Name of the default firewall zone. Defaults to `public`.
 * `cifmw_libvirt_manager_firewalld_default_zone_masquerade`: (Bool) Enable masquerading on the default firewall zone. Defaults to `true`.
+* `cifmw_libvirt_manager_attach_dummy_interface_on_bridges`: (Bool) Attach dummy interface on bridges. Defaults to `true`.
 
 ### Structure for `cifmw_libvirt_manager_configuration`
 

--- a/roles/libvirt_manager/defaults/main.yml
+++ b/roles/libvirt_manager/defaults/main.yml
@@ -84,3 +84,4 @@ cifmw_libvirt_manager_spineleaf_setup: false
 cifmw_libvirt_manager_firewalld_zone_libvirt_forward: true
 cifmw_libvirt_manager_firewalld_default_zone: public
 cifmw_libvirt_manager_firewalld_default_zone_masquerade: true
+cifmw_libvirt_manager_attach_dummy_interface_on_bridges: true

--- a/roles/libvirt_manager/tasks/create_networks.yml
+++ b/roles/libvirt_manager/tasks/create_networks.yml
@@ -84,6 +84,7 @@
 # NOTE(hjensas): Using a random string for dummy interface names because
 #                otherwise we hit the 15 char limitation on ifname.
 - name: Create dummy interfaces to ensure bridges are UP
+  when: cifmw_libvirt_manager_attach_dummy_interface_on_bridges | bool
   vars:
     cifmw_ci_nmstate_unmanaged_node_config: >-
       {%- set interfaces = []                                            -%}


### PR DESCRIPTION
Parameter `cifmw_libvirt_manager_attach_dummy_interface_on_bridges`, allows disabling the creation of dummy interfaces on bridge interfaces. Defaults to: `true`.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
