### PR TITLE
Sets install_yamls branches based on zuul.branch

### DIFF
--- a/roles/install_yamls/molecule/default/converge.yml
+++ b/roles/install_yamls/molecule/default/converge.yml
@@ -23,6 +23,7 @@
     ansible_user_dir: "{{ lookup('env', 'HOME') }}"
     cifmw_install_yamls_repo: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
     zuul:
+      branch: main
       items:
         - project:
             short_name: ci-framework

--- a/roles/install_yamls/tasks/main.yml
+++ b/roles/install_yamls/tasks/main.yml
@@ -48,7 +48,8 @@
         combine({
           'OUT': cifmw_install_yamls_manifests_dir,
           'OUTPUT_DIR': cifmw_install_yamls_edpm_dir,
-          'CHECKOUT_FROM_OPENSTACK_REF': cifmw_install_yamls_checkout_openstack_ref
+          'CHECKOUT_FROM_OPENSTACK_REF': cifmw_install_yamls_checkout_openstack_ref,
+          'OPENSTACK_K8S_BRANCH': (zuul is defined and zuul.branch != 'master') | ternary(zuul.branch, 'main')
         }) |
         combine(install_yamls_operators_repos)
       }}


### PR DESCRIPTION
Since install_yamls needs to clone operators repositories to deploy controlplace and dataplane, we should set the proper branch based on Zuul branch (the branch where the job was triggered)

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
