### PR TITLE
Ensure libvirt_molecule starts on clean env, each time

### DIFF
--- a/roles/libvirt_manager/molecule/deploy_layout/cleanup.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/cleanup.yml
@@ -19,13 +19,45 @@
   gather_facts: true
   vars:
     cifmw_basedir: "/opt/basedir"
+    molecule_scenario: deploy_layout
   tasks:
+    - name: Ensure we have the destination directory
+      failed_when: false
+      ansible.builtin.file:
+        path: >-
+          {{
+            [ansible_user_dir,
+            'ci-framework-data',
+            'artifacts',
+            molecule_scenario] | path_join
+          }}
+        state: directory
+        mode: "0755"
+
+    - name: Copy generated content to proper location
+      failed_when: false
+      ansible.posix.synchronize:
+        src: "{{ item }}"
+        dest: >-
+          {{
+            [ansible_user_dir,
+            'ci-framework-data',
+            'artifacts',
+            molecule_scenario] | path_join
+          }}
+      loop:
+        - "{{ cifmw_basedir }}/artifacts"
+        - "{{ cifmw_basedir }}/logs"
+        - "/etc/cifmw-dnsmasq.conf"
+        - "/etc/cifmw-dnsmasq.d"
+
     - name: Clean layout
       ansible.builtin.import_role:
         name: libvirt_manager
         tasks_from: clean_layout.yml
 
-    - name: Copy generated content to proper location
-      ansible.posix.synchronize:
-        src: "{{ cifmw_basedir }}/"
-        dest: "{{ ansible_user_dir }}/ci-framework-data"
+    - name: Ensure work directory is removed
+      become: true
+      ansible.builtin.file:
+        path: "{{ cifmw_basedir }}"
+        state: absent

--- a/roles/libvirt_manager/molecule/spine_leaf/cleanup.yml
+++ b/roles/libvirt_manager/molecule/spine_leaf/cleanup.yml
@@ -15,10 +15,6 @@
 # under the License.
 
 - name: Cleanup
-  hosts: instance
-  gather_facts: true
-  tasks:
-    - name: Clean layout
-      ansible.builtin.import_role:
-        name: libvirt_manager
-        tasks_from: clean_layout.yml
+  vars:
+    molecule_scenario: spine_leaf
+  ansible.builtin.import_playbook: ../deploy_layout/cleanup.yml


### PR DESCRIPTION
It appears some data were leaking between the runs, due to dangling
files mostly (wanted feature - at least for now).
This lead to some weird situations where the node list was different
from the expeceted one, even though it didn't lead to actualy failure.

This patch also ensures we gather needed bits from molecule run,
especially in the various directories.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
