### PR TITLE
Change dhcp-host filename pattern

### DIFF
--- a/roles/dnsmasq/tasks/manage_host.yml
+++ b/roles/dnsmasq/tasks/manage_host.yml
@@ -61,9 +61,16 @@
   notify: Reload dnsmasq
   when:
     - cifmw_dnsmasq_host_state == 'present'
+  vars:
+    _fname: >-
+      {%- set data = [cifmw_dnsmasq_host_network] -%}
+      {%- set _ = data.append(cifmw_dnsmasq_host_name) if
+                  cifmw_dnsmasq_host_name is defined and cifmw_dnsmasq_host_name | length > 0 -%}
+      {%- set _ = data.append(cifmw_dnsmasq_host_mac) -%}
+      {{ data | join('_') }}
   ansible.builtin.copy:
     content: "{{ _host_entry }}"
-    dest: "{{ cifmw_dnsmasq_basedir }}/dhcp-hosts.d/{{ cifmw_dnsmasq_host_mac }}"
+    dest: "{{ cifmw_dnsmasq_basedir }}/dhcp-hosts.d/{{ _fname }}"
     mode: '0644'
     owner: root
     group: root


### PR DESCRIPTION
With the initial name, we just had MAC addresses, and had to open the
file and find which network was associated to the selected IP.

This change allows to know directly which network (and host, if set) is
configured with that file, making debugging and searching faster.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
