### PR TITLE
Improve testing and documentation for run_hook role

### DIFF
--- a/roles/run_hook/README.md
+++ b/roles/run_hook/README.md
@@ -36,7 +36,7 @@ name:
 * `inventory`: (String) Refer to the `--inventory` option for `ansible-playbook`. Defaults to `inventory_file`.
 * `source`: (String) Source of the playbook. If it's a filename, the playbook is expected in `hooks/playbooks`. It can be an absolute path.
 * `type`: (String) Type of the hook. In this case, set it to `playbook`.
-* `extra_vars`: (Dict) Structure listing the extra variables you want to pass down
+* `extra_vars`: (Dict) Structure listing the extra variables you would like to pass down ([extra_vars explained](#extra_vars-explained))
 
 ##### About OpenShift namespaces and install_yamls
 
@@ -54,7 +54,7 @@ Since `install_yamls` might not be initialized, the `run_hook` is exposing two n
 * `name`: (String) Describe the hook.
 * `source`: (String) Source of the playbook. If it's a filename, the playbook is expected in `hooks/playbooks`. It can be an absolute path.
 * `type`: (String) Type of the hook. In this case, set it to `playbook`.
-* `extra_vars`: (Dict) Structure listing the extra variables you want to pass down
+* `extra_vars`: (Dict) Structure listing the extra variables you would like to pass down ([extra_vars explained](#extra_vars-explained))
 
 #### Hook callback
 
@@ -81,6 +81,36 @@ Note that `step` is fixed in the main playbooks, and are following the name of
 the various hook "timing" (`pre_infra`, `post_infra`, etc). The `hook_name` is
 a cleaned version of the `name` parameter you pass down in the hook description.
 
+#### extra_vars explained
+
+`playbook` type hooks support passing extra_vars either as a list of variables, in a variable file or both.
+
+The variable method should only be used for simple key/value variables:
+
+```yaml
+pre_deploy:
+    - name: My hook
+      source: ceph-deploy.yml
+      type: playbook
+      extra_vars:
+        UUID: <some generated UUID>
+```
+
+This will be passed to the resulting ansible-playbook command as an extra var argument `-e "UUID=<some generated UUID>"`
+
+When multiple extra_vars are passed or more complex variables like lists and dictionaries are required a variable file should be utilized:
+
+```yaml
+pre_deploy:
+    - name: My hook
+      source: ceph-deploy.yml
+      type: playbook
+      extra_vars:
+        file: "ceph_env.yml"
+```
+
+This will be passed to the resulting ansible-playbook command as an extra var file argument `-e "@ceph_env.yml"`
+
 #### Examples
 
 ```YAML
@@ -94,6 +124,16 @@ pre_deploy:
 pre_infra_my_nice_hook:
     source: noop.yml
     type: playbook
+    extra_vars:
+      file: "ceph_env.yml"
+
+pre_deploy:
+    - name: My hook
+      source: ceph-deploy.yml
+      type: playbook
+      extra_vars:
+        UUID: <some generated UUID>
+        file: "ceph_env.yml"
 ```
 
 ### CR

--- a/roles/run_hook/molecule/default/converge.yml
+++ b/roles/run_hook/molecule/default/converge.yml
@@ -14,7 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
 - name: Converge
   hosts: all
   vars_files:
@@ -76,7 +75,7 @@
             type: playbook
             extra_vars:
               foo: bar
-              file: '/tmp/dummy-env.yml'
+              file: "/tmp/dummy-env.yml"
       ansible.builtin.include_role:
         name: run_hook
 
@@ -98,3 +97,9 @@
         that:
           - ceph_uuid is defined
           - ceph_uuid == 'dummy-6.yml'
+
+    - name: Ensure we have the test_list variable now
+      ansible.builtin.assert:
+        that:
+          - test_list is defined
+          - test_list | length == 2

--- a/roles/run_hook/molecule/default/molecule.yml
+++ b/roles/run_hook/molecule/default/molecule.yml
@@ -3,6 +3,7 @@
 # By default, it uses the "config_podman.yml" - in CI, it will use
 # "config_local.yml".
 log: true
+prerun: false
 
 provisioner:
   name: ansible
@@ -19,13 +20,13 @@ provisioner:
             type: playbook
             extra_vars:
               foo: bar
-              file: '/tmp/dummy-env.yml'
+              file: "/tmp/dummy-env.yml"
           - name: Run dummy-3
             source: /tmp/dummy-3.yml
             type: playbook
             extra_vars:
               foo: bar
-              file: '/tmp/dummy-env.yml'
+              file: "/tmp/dummy-env.yml"
         # fill up _list_hooks and _filtered_hooks
         # Also ensure ordering is properly taken
         run_molecule:
@@ -40,7 +41,7 @@ provisioner:
           type: playbook
           extra_vars:
             foo: bar
-            file: '/tmp/dummy-env.yml'
+            file: "/tmp/dummy-env.yml"
 
         # Fill only _filtered_hooks
         filtered_hooks_01_my_hook:
@@ -48,4 +49,4 @@ provisioner:
           type: playbook
           extra_vars:
             foo: bar
-            file: '/tmp/dummy-env.yml'
+            file: "/tmp/dummy-env.yml"

--- a/roles/run_hook/molecule/default/prepare.yml
+++ b/roles/run_hook/molecule/default/prepare.yml
@@ -14,7 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
 - name: Prepare
   hosts: all
   vars:
@@ -26,6 +25,9 @@
         content: |
           star: wars
           other_star: trek
+          test_list:
+           - starwars
+           - startrek
 
     - name: Create dummy playbook
       ansible.builtin.template:

--- a/roles/run_hook/molecule/default/templates/dummy.yml.j2
+++ b/roles/run_hook/molecule/default/templates/dummy.yml.j2
@@ -15,5 +15,11 @@
       ansible.builtin.copy:
         dest: "{{ cifmw_basedir }}/artifacts/{{ step }}_{{ hook_name }}.yml"
         content: |
+          {% if test_list is not none %}
+          test_list:
+          {% for star in test_list %}
+            - {{ star }}
+          {% endfor -%}
+          {% endif -%}
 {% endraw %}
           ceph_uuid: {{ item }}

--- a/roles/run_hook/tasks/playbook.yml
+++ b/roles/run_hook/tasks/playbook.yml
@@ -62,7 +62,7 @@
         (cifmw_basedir, 'artifacts/parameters') | path_join
       }}
     file_type: file
-    patterns: '*.yml'
+    patterns: "*.yml"
   register: cifmw_run_hook_parameters_files
 
 - name: "Add parameters artifacts as extra variables"
@@ -116,7 +116,6 @@
       ansible.builtin.stat:
         path: "{{ cifmw_basedir }}/artifacts/{{ step }}_{{ hook_name }}.yml"
     - name: Load generated content in main playbook
-      when:
-        hook_callback.stat.exists
+      when: hook_callback.stat.exists
       ansible.builtin.include_vars:
         file: "{{ cifmw_basedir }}/artifacts/{{ step }}_{{ hook_name }}.yml"


### PR DESCRIPTION
Support for passing var files to the run_hook role was added in [1]
but the documentation did not mention this.

This patch also adds a test case for passing a list in a variable file.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/151

JIRA: https://issues.redhat.com/browse/OSPRH-7702

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
