### PR TITLE
Move final OCP wait closed to end of run

### DIFF
--- a/roles/reproducer/tasks/libvirt_layout.yml
+++ b/roles/reproducer/tasks/libvirt_layout.yml
@@ -93,30 +93,6 @@
         - bootstrap
         - bootstrap_layout
 
-- name: Ensure OCP cluster is stable
-  when:
-    - _wait_ocp_cluster is defined
-    - _wait_ocp_cluster | bool
-  tags:
-    - bootstrap
-    - bootstrap_layout
-  vars:
-    _auth_path: >-
-      {{
-        (
-          cifmw_devscripts_repo_dir,
-          'ocp',
-          cifmw_devscripts_config.cluster_name,
-          'auth'
-        ) | ansible.builtin.path_join
-      }}
-    _k8s_config: "{{ (_auth_path, 'kubeconfig') | ansible.builtin.path_join }}"
-    cifmw_openshift_adm_op: "stable"
-    cifmw_openshift_kubeconfig: >-
-      {{ (_auth_path, 'kubeconfig') | ansible.builtin.path_join }}
-  ansible.builtin.include_role:
-    name: openshift_adm
-
 # ctlplane network is configured for pre-provisioned edpm nodes.
 # In order to do this, we'll consume the generated networking_mapper
 # environment file, and filter on all known edpm node types.

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -299,6 +299,39 @@
             name: openshift_setup
             tasks_from: patch_network_operator.yml
 
+# Run from the hypervisor
+- name: Ensure OCP cluster is stable
+  when:
+    - _wait_ocp_cluster is defined
+    - _wait_ocp_cluster | bool
+  tags:
+    - bootstrap
+    - bootstrap_layout
+  vars:
+    _auth_path: >-
+      {{
+        (
+          cifmw_devscripts_repo_dir,
+          'ocp',
+          cifmw_devscripts_config.cluster_name,
+          'auth'
+        ) | ansible.builtin.path_join
+      }}
+    cifmw_openshift_adm_op: "stable"
+    cifmw_openshift_kubeconfig: >-
+      {{ (_auth_path, 'kubeconfig') | ansible.builtin.path_join }}
+  ansible.builtin.include_role:
+    name: openshift_adm
+
+- name: Run from controller-0
+  when:
+    - (
+        _cifmw_libvirt_manager_layout.vms.controller.target is defined and
+        _cifmw_libvirt_manager_layout.vms.controller.target == inventory_hostname
+      ) or
+      _cifmw_libvirt_manager_layout.vms.controller.target is undefined
+  delegate_to: controller-0
+  block:
     - name: Emulate CI job
       when:
         - cifmw_job_uri is defined


### PR DESCRIPTION
We're now too fast, meaning the OCP might not have enough time to get
stable.
In parallel, we still have "slow" tasks that can kick in before we
actually need OCP, meaning we can improve overal speed by just moving a
block

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
