### PR TITLE
Pull ansible-utils from github

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -74,6 +74,7 @@ dependencies:
   'git+https://github.com/containers/ansible-podman-collections': 'master'
   'git+https://github.com/ansible-collections/community.general': 'main'
   'git+https://github.com/ansible-collections/ansible.posix': 'main'
+  'git+https://github.com/ansible-collections/ansible.utils': 'main'
   'git+https://github.com/ansible-collections/community.libvirt': 'main'
   'git+https://github.com/ansible-collections/community.crypto': 'main'
   'git+https://github.com/ansible-collections/kubernetes.core': 'main'

--- a/requirements.yml
+++ b/requirements.yml
@@ -17,6 +17,8 @@
 collections:
   - name: https://github.com/ansible-collections/ansible.posix
     type: git
+  - name: https://github.com/ansible-collections/ansible.utils
+    type: git
   - name: https://github.com/ansible-collections/community.general
     type: git
   - name: https://github.com/ansible-collections/community.crypto


### PR DESCRIPTION
Seems galaxy.ansible.com has some issues serving ansible.utils
collection.

Swithing it to github in order to unlock the situation.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
