### PR TITLE
Fix download tool step of the reproducer role.

### DIFF
--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -289,7 +289,7 @@
             cmd: >-
               ansible-playbook -i ~/ci-framework-data/artifacts/zuul_inventory.yml
               download_tools.yaml --tags kustomize,kubectl
-            creates: "/home/zuul/bin/operator-sdk"
+            creates: "/home/zuul/bin/kubectl"
 
         - name: Configure CRC network if needed
           when:


### PR DESCRIPTION
Given the tags in that task, choose kubectl instead of operator-sdk as
a anchor to check if the task has been done.

-------

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running