### PR TITLE
Allow to not deploy OpenShift provider

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -244,7 +244,7 @@
         dest: "/home/zuul/.kube/config"
         content: >-
           {{
-            (_cifmw_libvirt_manager_layout.vms.ocp is defined) |
+            (_use_ocp | bool) |
             ternary(_devscripts_kubeconfig.content, _crc_kubeconfig.content) |
             b64decode
           }}
@@ -453,10 +453,7 @@
 
     - name: Inject CRC related content if needed
       when:
-        - _cifmw_libvirt_manager_layout.vms.crc is defined
-        - (_cifmw_libvirt_manager_layout.vms.crc.amount is defined and
-           (_cifmw_libvirt_manager_layout.vms.crc.amount | int ) > 0) or
-          _cifmw_libvirt_manager_layout.vms.crc.amount is undefined
+        - _use_crc | bool
       block:
         - name: Inject CRC ssh key
           ansible.builtin.copy:

--- a/roles/reproducer/tasks/libvirt_layout.yml
+++ b/roles/reproducer/tasks/libvirt_layout.yml
@@ -50,7 +50,7 @@
 
 - name: Run post tasks in OCP cluster case
   when:
-    - _cifmw_libvirt_manager_layout.vms.ocp is defined
+    - _use_ocp | bool
     - (
         _cifmw_libvirt_manager_layout.vms.ocp.target is defined and
         _cifmw_libvirt_manager_layout.vms.ocp.target == inventory_hostname
@@ -74,10 +74,7 @@
 
 - name: Configure CRC node if available
   when:
-    - _cifmw_libvirt_manager_layout.vms.crc is defined
-    - (_cifmw_libvirt_manager_layout.vms.crc.amount is defined and
-       (_cifmw_libvirt_manager_layout.vms.crc.amount | int) > 0) or
-      _cifmw_libvirt_manager_layout.vms.crc.amount is undefined
+    - _use_crc | bool
     - (
         _cifmw_libvirt_manager_layout.vms.crc.target is defined and
         _cifmw_libvirt_manager_layout.vms.crc.target == inventory_hostname

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -84,7 +84,7 @@
       to use a file present on the host.
 
 - name: Set _use_crc based on actual layout
-  ansible.builtin.set_fact:
+  vars:
     _use_crc: >-
       {{
         _cifmw_libvirt_manager_layout.vms.crc is defined and
@@ -99,6 +99,10 @@
         (_cifmw_libvirt_manager_layout.vms.ocp.amount is defined and
          _cifmw_libvirt_manager_layout.vms.ocp.amount|int > 0)
       }}
+  ansible.builtin.set_fact:
+    _use_crc: "{{ _use_crc }}"
+    _use_ocp: "{{ _use_ocp }}"
+    _has_openshift: "{{ _use_ocp or _use_crc }}"
 
 - name: Ensure directories are present
   tags:
@@ -169,7 +173,7 @@
 
 - name: Consume dev-scripts for OCP cluster
   when:
-    - _cifmw_libvirt_manager_layout.vms.ocp is defined
+    - _use_ocp
     - (
         _cifmw_libvirt_manager_layout.vms.ocp.target is defined and
         _cifmw_libvirt_manager_layout.vms.ocp.target == inventory_hostname
@@ -214,7 +218,7 @@
 - name: Apply VLAN ids to TAP type interfaces.
   when:
     - _cifmw_libvirt_manager_layout.networks is defined
-    - _cifmw_libvirt_manager_layout.vms.ocp is defined
+    - _use_ocp
     - (
         _cifmw_libvirt_manager_layout.vms.ocp.target is defined and
         _cifmw_libvirt_manager_layout.vms.ocp.target == inventory_hostname
@@ -289,10 +293,7 @@
 
         - name: Configure CRC network if needed
           when:
-            - _cifmw_libvirt_manager_layout.vms.crc is defined
-            - (_cifmw_libvirt_manager_layout.vms.crc.amount is defined and
-               (_cifmw_libvirt_manager_layout.vms.crc.amount | int ) > 0) or
-              _cifmw_libvirt_manager_layout.vms.crc.amount is undefined
+            - _use_crc | bool
           vars:
             cifmw_openshift_kubeconfig: "/home/zuul/.kube/config"
           ansible.builtin.include_role:
@@ -325,6 +326,7 @@
 
 - name: Run from controller-0
   when:
+    - _has_openshift
     - (
         _cifmw_libvirt_manager_layout.vms.controller.target is defined and
         _cifmw_libvirt_manager_layout.vms.controller.target == inventory_hostname


### PR DESCRIPTION
This PR mostly allows to deploy only the controller-0. It might also
allow deploying computes.

The goal is to allow a quick VM bootstrap by setting the `amount` to 0
for both `crc` and `ocp` VM types. Doing so, you can end with a single
controller-0 with all the toolings needed to run your tests (molecule,
for instance).

It introduces a new `_has_openshift` global parameter that's then used
in order to toggle some specific parts of the controller-0 bootstrap.

We can later revisit it in order to extend that support, so that we can
eventually consume an existing OpenShift provider (Hive, externally
managed OCP cluster, etc).

This PR also consolidate the usage of `_use_crc` and `_use_ocp` boolean
that are built based on the VM layout passed by the user.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
