### PR TITLE
Remove redundant adoption nodeset and update novacells to crc 2.36

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -349,7 +349,7 @@
     voting: false
     timeout: 10800
     attempts: 1
-    nodeset: centos-9-multinode-rhel-9-2-crc-extracted-2.30-3xl-novacells
+    nodeset: centos-9-multinode-rhel-9-2-crc-extracted-2-36-0-3xl-novacells
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run: *multinode-prerun

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -826,6 +826,15 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/cifmw_external_dns/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-cifmw_external_dns
+    parent: cifmw-molecule-noop
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/openshift_adm/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -44,56 +44,6 @@
         label: centos-9-stream-crc-2-30-0-xxl
 
 - nodeset:
-    name: centos-9-rhel-9-2-crc-extracted-2.30-3xl
-    nodes:
-      - name: controller
-        label: cloud-centos-9-stream-tripleo
-      - name: crc
-        label: coreos-crc-extracted-2-30-0-3xl
-      - name: standalone
-        label: cloud-rhel-9-2-tripleo
-    groups:
-      - name: computes
-        nodes: []
-      - name: ocps
-        nodes:
-          - crc
-      - name: rh-subscription
-        nodes:
-          - standalone
-
-- nodeset:
-    name: centos-9-multinode-rhel-9-2-crc-extracted-2.30-3xl-novacells
-    nodes:
-      - name: controller
-        label: cloud-centos-9-stream-tripleo
-      - name: crc
-        label: coreos-crc-extracted-2-30-0-3xl
-      - name: undercloud
-        label: cloud-rhel-9-2-tripleo
-      - name: overcloud-controller-0
-        label: cloud-rhel-9-2-tripleo
-      - name: cell1-controller-0
-        label: cloud-rhel-9-2-tripleo
-      - name: cell1-compute-0
-        label: cloud-rhel-9-2-tripleo
-      - name: cell2-controller-compute-0
-        label: cloud-rhel-9-2-tripleo
-    groups:
-      - name: computes
-        nodes: []
-      - name: ocps
-        nodes:
-          - crc
-      - name: rh-subscription
-        nodes:
-          - undercloud
-          - overcloud-controller-0
-          - cell1-controller-0
-          - cell2-controller-compute-0
-          - cell1-compute-0
-
-- nodeset:
     name: centos-9-medium-centos-9-crc-extracted-2.30-3xl
     nodes:
       - name: controller
@@ -258,6 +208,37 @@
           - overcloud-novacompute-0
           - overcloud-novacompute-1
           - overcloud-novacompute-2
+
+- nodeset:
+    name: centos-9-multinode-rhel-9-2-crc-extracted-2-36-0-3xl-novacells
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: coreos-crc-extracted-2-36-0-3xl
+      - name: undercloud
+        label: cloud-rhel-9-2-tripleo
+      - name: overcloud-controller-0
+        label: cloud-rhel-9-2-tripleo
+      - name: cell1-controller-0
+        label: cloud-rhel-9-2-tripleo
+      - name: cell1-compute-0
+        label: cloud-rhel-9-2-tripleo
+      - name: cell2-controller-compute-0
+        label: cloud-rhel-9-2-tripleo
+    groups:
+      - name: computes
+        nodes: []
+      - name: ocps
+        nodes:
+          - crc
+      - name: rh-subscription
+        nodes:
+          - undercloud
+          - overcloud-controller-0
+          - cell1-controller-0
+          - cell2-controller-compute-0
+          - cell1-compute-0
 
 - nodeset:
     name: centos-9-medium-centos-9-crc-extracted-2-36-0-3xl

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -31,6 +31,7 @@
       - cifmw-molecule-cifmw_ceph_spec
       - cifmw-molecule-cifmw_cephadm
       - cifmw-molecule-cifmw_create_admin
+      - cifmw-molecule-cifmw_external_dns
       - cifmw-molecule-cifmw_test_role
       - cifmw-molecule-config_drive
       - cifmw-molecule-copy_container


### PR DESCRIPTION
This removes the redundant centos-9-rhel-9-2-crc-extracted-2.30-3xl nodeset left over after moving to crc 2.36. It also updates the novacells adoption nodeset to use 2.36 so it is not left behind.

Related: https://issues.redhat.com/browse/OSPRH-8450

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
