### PR TITLE
Change chap algorithms

### DIFF
--- a/roles/devscripts/templates/iscsi.j2
+++ b/roles/devscripts/templates/iscsi.j2
@@ -20,7 +20,7 @@ spec:
           group:
             name: root
           contents:
-            source: data:,node.session.initial_login_retry_max%20%3D%203%0Anode.conn%5B0%5D.timeo.login_timeout%20%3D%205%0A
+            source: data:,node.session.initial_login_retry_max%20%3D%203%0Anode.conn%5B0%5D.timeo.login_timeout%20%3D%205%0Anode.session.auth.chap_algs%20%3D%20SHA3%2D256%2CSHA256%0A
     systemd:
       units:
         - enabled: true


### PR DESCRIPTION
The default CHAP algorithms include MD5 will does not work under FIPS.  Set this parameter to exclude MD5 and SHA-1

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
