### PR TITLE
Set default value to DLRNAPI_PASSWORD

### DIFF
--- a/roles/dlrn_promote/tasks/check_for_previous_promotions.yml
+++ b/roles/dlrn_promote/tasks/check_for_previous_promotions.yml
@@ -24,7 +24,7 @@
       | tee -a {{ cifmw_dlrn_promote_workspace }}/cifmw_dlrn_promote_hash_promote_target_output.txt
   environment: |
     {{ zuul | zuul_legacy_vars | combine({
-      'DLRNAPI_PASSWORD': dlrnapi.password,
+      'DLRNAPI_PASSWORD': "{{ (dlrnapi is defined and dlrnapi.password is defined) | ternary(dlrnapi.password, '') }}",
       'DLRNAPI_USERNAME': cifmw_dlrn_report_dlrnapi_user,
       'SSL_CA_BUNDLE': cifmw_dlrn_promote_ssl_ca_bundle
       }) }}

--- a/roles/dlrn_promote/tasks/check_reported_jobs.yml
+++ b/roles/dlrn_promote/tasks/check_reported_jobs.yml
@@ -16,7 +16,7 @@
       | tee -a {{ cifmw_dlrn_promote_workspace }}/cifmw_dlrn_promote_repo_success_output.txt
   environment: |
     {{ zuul | zuul_legacy_vars | combine({
-      'DLRNAPI_PASSWORD': dlrnapi.password,
+      'DLRNAPI_PASSWORD': "{{ (dlrnapi is defined and dlrnapi.password is defined) | ternary(dlrnapi.password, '') }}",
       'DLRNAPI_USERNAME': cifmw_dlrn_report_dlrnapi_user,
       'SSL_CA_BUNDLE': cifmw_dlrn_promote_ssl_ca_bundle
       }) }}
@@ -47,7 +47,7 @@
       | tee -a {{ cifmw_dlrn_promote_workspace }}/cifmw_dlrn_promote_repo_success_output.txt
   environment: |
     {{ zuul | zuul_legacy_vars | combine({
-      'DLRNAPI_PASSWORD': dlrnapi.password,
+      'DLRNAPI_PASSWORD': "{{ (dlrnapi is defined and dlrnapi.password is defined) | ternary(dlrnapi.password, '') }}",
       'DLRNAPI_USERNAME': cifmw_dlrn_report_dlrnapi_user,
       'SSL_CA_BUNDLE': cifmw_dlrn_promote_ssl_ca_bundle
       }) }}

--- a/roles/dlrn_promote/tasks/promote_hash.yml
+++ b/roles/dlrn_promote/tasks/promote_hash.yml
@@ -19,7 +19,7 @@
       --promote-name {{ cifmw_dlrn_promote_promotion_target }}
   environment: |
     {{ zuul | zuul_legacy_vars | combine({
-      'DLRNAPI_PASSWORD': dlrnapi.password,
+      'DLRNAPI_PASSWORD': "{{ (dlrnapi is defined and dlrnapi.password is defined) | ternary(dlrnapi.password, '') }}",
       'DLRNAPI_USERNAME': cifmw_dlrn_report_dlrnapi_user,
       'SSL_CA_BUNDLE': cifmw_dlrn_promote_ssl_ca_bundle
       }) }}

--- a/roles/dlrn_report/tasks/dlrn_report_results.yml
+++ b/roles/dlrn_report/tasks/dlrn_report_results.yml
@@ -53,7 +53,7 @@
       --success {{ zuul_success | bool }}
   environment: |
     {{ zuul | zuul_legacy_vars | combine({
-      'DLRNAPI_PASSWORD': dlrnapi.password,
+      'DLRNAPI_PASSWORD': "{{ (dlrnapi is defined and dlrnapi.password is defined) | ternary(dlrnapi.password, '') }}",
       'DLRNAPI_USERNAME': cifmw_dlrn_report_dlrnapi_user
       }) }}
   changed_when: true


### PR DESCRIPTION
When using kerberos for dlrn authentication, it is required to set this variable to empty string otherwise, it fails. Instead of set it in the job definition itself, it is better to set the default value directly in the role that is required to report dlrn.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
