### PR TITLE
Remove whitespace around '=' in dnsmasq conf

### DIFF
--- a/ci/playbooks/multinode-customizations.yml
+++ b/ci/playbooks/multinode-customizations.yml
@@ -118,6 +118,35 @@
                 line: "listen-address={{ _crc_default_net_ip | ansible.utils.ipaddr('address') }}"
                 validate: "{{ _validate }}"
 
+            - name: Ensure upstream dns servers are not present in resolv.conf
+              become: true
+              ansible.builtin.lineinfile:
+                path: "/etc/resolv.conf"
+                state: absent
+                regexp: "{{ item }}"
+              loop:
+                - 8.8.8.8
+                - 1.1.1.1
+
+            - name: Remove upstream servers from dsnamsq config
+              become: true
+              ansible.builtin.lineinfile:
+                path: "{{ _dnsmasq_config }}"
+                state: absent
+                regexp: "{{ item }}"
+              loop:
+                - 8.8.8.8
+                - 1.1.1.1
+
+            - name: Configure proper dns servers in /etc/resolv.conf
+              become: true
+              ansible.builtin.blockinfile:
+                path: "/etc/resolv.conf"
+                block: |-
+                  {% for dns_server in _crc_default_net_dns %}
+                  nameserver {{ dns_server }}
+                  {% endfor %}
+
           rescue:
             - name: Debug _dnsmasq_config
               ansible.builtin.debug:


### PR DESCRIPTION
The dnsmasq config ends up with a name server configured with a space
after the equal sign, which seems to cause problems downstream. This
change adds a task to remove any whitespace space around the equal sign
in that file.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
