### PR TITLE
Change iscsid login timeout in computes

### DIFF
--- a/hooks/playbooks/compute-iscsi-config.yml
+++ b/hooks/playbooks/compute-iscsi-config.yml
@@ -1,0 +1,19 @@
+---
+- name: Change iscsi login timeout on compute nodes
+  hosts: computes
+  gather_facts: false
+  tasks:
+    - name: Change timeout in iscsid.conf
+      become: true
+      ansible.builtin.lineinfile:
+        path: /etc/iscsi/iscsid.conf
+        line: "{{ item }}"
+      loop:
+        - 'node.session.initial_login_retry_max = 3'
+        - 'node.conn[0].timeo.login_timeout = 5'
+
+    - name: Restart iscsid container to refresh /etcd/iscsid.conf
+      become: true
+      ansible.builtin.systemd:
+        name: edpm_iscsid
+        state: restarted


### PR DESCRIPTION
In a previous patch we changed the iSCSI login timeout for the control plane (OpenShift nodes).

In this patch we add a new hook to do the same thing for the edpm nodes, because the default timeout of 2 minutes is too high for some test scenarios.

It is necessary to do it this way because edpm-ansible doesn't currently have a mechanism to change the iscsid.conf file. Once that feature is added this patch can be reverted.

This patch changes the edpm iscsid timeout default to 3 retries and 5 seconds each (15 seconds in total), which is convenient for testing, as any healthy deployment and backend should be able to login to the backend in that amount of time, and if there is a broken path it will not take 2 minutes to give up, just around 15 seconds.

Related-Jira: https://issues.redhat.com/browse/OSPRH-7614

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
