### PR TITLE
Call rhos-release command only with rhos_release_args

### DIFF
--- a/roles/reproducer/tasks/configure_computes.yml
+++ b/roles/reproducer/tasks/configure_computes.yml
@@ -31,15 +31,8 @@
         - cifmw_reproducer_compute_set_repositories | bool
         - cifmw_repo_setup_rhos_release_rpm is defined
       block:
-        - name: Get rhos-release
+        - name: Get rhos-release and setup repos
           ansible.builtin.include_tasks: rhos_release.yml
-
-        - name: Configure rhos-release
-          register: _async_rhos_release
-          async: 120  # 2 minutes should be enough?
-          poll: 0
-          ansible.builtin.command:
-            cmd: "rhos-release {{ cifmw_repo_setup_rhos_release_args }}"
 
     - name: Create repositories on computes
       become: true

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -71,7 +71,7 @@
       when:
         - cifmw_repo_setup_rhos_release_rpm is defined
       block:
-        - name: Get rhos-release
+        - name: Get rhos-release and setup repos
           ansible.builtin.import_tasks: rhos_release.yml
 
         - name: Create bundle for CRC

--- a/roles/reproducer/tasks/rhos_release.yml
+++ b/roles/reproducer/tasks/rhos_release.yml
@@ -5,6 +5,9 @@
     state: present
     disable_gpg_check: true
 
-- name: Enable RHEL repos
+- name: Install repos
+  register: _async_rhos_release
+  async: 120  # 2 minutes should be enough?
+  poll: 0
   ansible.builtin.command:
-    cmd: "rhos-release rhel"
+    cmd: "rhos-release {{ cifmw_repo_setup_rhos_release_args | default('rhel') }}"


### PR DESCRIPTION
The reproducer role is configuring repositories twice, and one of them has 'rhel' args hardcoded. This is a problem when we need to configure a different release version since it end up with duplicated repositories.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running