### PR TITLE
Hook: Set properties on default volume type

### DIFF
--- a/hooks/playbooks/cinder-default-volume-type-props.yml
+++ b/hooks/playbooks/cinder-default-volume-type-props.yml
@@ -1,0 +1,16 @@
+---
+# Cinder always creates the __DEFAULT__ volume type
+# This hook sets properties of this default volume type based on key-value from cifmw_cinder_default_type_properties
+- name: Add properties to default volume type
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Set all properties
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.shell: |
+        oc project {{ namespace }}
+        oc rsh openstackclient \
+           openstack volume type set --property {{ cifmw_cinder_default_type_properties|items|map('join', '=')|join(' --property') }} __DEFAULT__
+      when: "cifmw_cinder_default_type_properties | default('') | length > 0"


### PR DESCRIPTION
Cinder always creates a default volume type called __DEFAULT__, and this type is unrestricted, so new volumes can go to any volume back-end running on the deployment if an unrestricted volume type is not specified.

This can be problematic for some tempest tests when running on a multi back-end deployment.

This hook allows a job to define the properties (extra specs) of the default volume type. The most common way of using it is to set the `volume_backend_name` so volumes are created in a specific back-end, but other properties can be added as well.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
