### PR TITLE
Improve network assertions in reproducer

### DIFF
--- a/roles/reproducer/molecule/network_validations/vars/scenarios.yml
+++ b/roles/reproducer/molecule/network_validations/vars/scenarios.yml
@@ -32,3 +32,11 @@ scenarios:
           spineleafnets:
             - l00-s0
             - l00-s1
+
+  - scenario: No network for a VM
+    env_file: simple-nets.yml
+    should_fail: true
+    patch:
+      vms:
+        foo:
+          disksize: 10

--- a/roles/reproducer/tasks/network_assertions.yml
+++ b/roles/reproducer/tasks/network_assertions.yml
@@ -1,34 +1,58 @@
 ---
-- name: Shared variables
-  vars:
-    _attached: >-
-      {{
-        _cifmw_libvirt_manager_layout.vms | dict2items |
-        map(attribute='value.nets') | flatten | unique
-      }}
-    _spine: >-
-      {{
-        _cifmw_libvirt_manager_layout.vms | dict2items |
-        map(attribute='value.spineleafnets', default=[]) | flatten | unique
-      }}
-    _all_nets: "{{ _attached + _spine }}"
-    _defined: "{{ _cifmw_libvirt_manager_layout.networks.keys() }}"
+- name: Try/catch block
   block:
-    - name: Ensure all standard attached networks are defined
+    - name: Ensure all VM types have defined nets parameter
       ansible.builtin.assert:
         quiet: true
         that:
-          - _all_nets | difference(_defined) | length == 0
+          - item.value.nets is defined
         msg: >-
-          Inconsistency detected: ensure you're defining all of the
-          attached networks. Those nets don't seem to be defined:
-          {{ _all_nets | difference(_defined) }}
+          Inconsistency detected: VM type "{{ item.key }}"
+          doesn't seem to have any network.
+      loop: "{{ _cifmw_libvirt_manager_layout.vms | dict2items }}"
+      loop_control:
+        label: "{{ item.key }}"
 
-    - name: Ensure we don't have extra network defined
-      ansible.builtin.assert:
-        that:
-          - _defined | difference(_all_nets) | length == 0
+    - name: Shared variables
+      vars:
+        _attached: >-
+          {{
+            _cifmw_libvirt_manager_layout.vms | dict2items |
+            map(attribute='value.nets') | flatten | unique
+          }}
+        _spine: >-
+          {{
+            _cifmw_libvirt_manager_layout.vms | dict2items |
+            map(attribute='value.spineleafnets', default=[]) | flatten | unique
+          }}
+        _all_nets: "{{ _attached + _spine }}"
+        _defined: "{{ _cifmw_libvirt_manager_layout.networks.keys() }}"
+      block:
+        - name: Ensure all standard attached networks are defined
+          ansible.builtin.assert:
+            quiet: true
+            that:
+              - _all_nets | difference(_defined) | length == 0
+            msg: >-
+              Inconsistency detected: ensure you're defining all of the
+              attached networks. Those nets don't seem to be defined:
+              {{ _all_nets | difference(_defined) }}
+
+        - name: Ensure we don't have extra network defined
+          ansible.builtin.assert:
+            that:
+              - _defined | difference(_all_nets) | length == 0
+            msg: >-
+              Inconsistency detected: ensure you're attaching all of the
+              defined networks. Those nets don't seem to be attached:
+              {{ _defined | difference(_all_nets) }}
+  rescue:
+    - name: Dump built layout
+      ansible.builtin.debug:
+        var: _cifmw_libvirt_manager_layout
+
+    - name: Fail for good
+      ansible.builtin.fail:
         msg: >-
-          Inconsistency detected: ensure you're attaching all of the
-          defined networks. Those nets don't seem to be attached:
-          {{ _defined | difference(_all_nets) }}
+          Error detected, please check assertions and
+          debugging output above.


### PR DESCRIPTION
We now ensure all VMs have attached networks, and we also output the
built layout in case of failure. This should help debugging issues
without the need to dig into the whole scenario tree.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
