### PR TITLE
Setup minimum environment to run update on architecture.

### DIFF
--- a/playbooks/update.yml
+++ b/playbooks/update.yml
@@ -3,6 +3,24 @@
     step: pre_update
   ansible.builtin.import_playbook: ./hooks.yml
 
+- name: Add comptatibility support to install_yamls
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Comptatibility layer with install_yamls
+      when:
+        - cifmw_architecture_scenario is defined
+      block:
+        - name: Prepare install_yamls make targets
+          ansible.builtin.include_role:
+            name: install_yamls
+        - name: Make a viable cifmw_install_yamls_environment
+          ansible.builtin.set_fact:
+            cifmw_install_yamls_environment: "{{ cifmw_install_yamls_environment | default({}) }}"
+        - name: Add a default value cifmw_install_yamls_defaults
+          ansible.builtin.set_fact:
+            cifmw_install_yamls_defaults: "{{ cifmw_install_yamls_defaults | default({'OPERATOR_NAMESPACE': 'openstack-operators'}) }}"
+
 - name: Update repos and openstack services containers
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false

--- a/roles/set_openstack_containers/tasks/main.yml
+++ b/roles/set_openstack_containers/tasks/main.yml
@@ -91,7 +91,29 @@
   ansible.builtin.include_role:
     name: 'install_yamls_makes'
     tasks_from: 'make_openstack_wait'
-  when: operator_name == 'openstack'
+  when:
+    - operator_name == 'openstack'
+    - not cifmw_architecture_scenario is defined
+
+# Needed when the deployment wasn't installed using install_yaml.
+- name: Wait for reinstallation of meta operator with arch scenario
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      oc get csv -l operators.coreos.com/openstack-operator.openstack-operators \
+      --namespace={{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} \
+      --no-headers=true | grep -i "succeeded"
+  register: operator_status
+  until: operator_status.rc == 0
+  changed_when: false
+  retries: 600
+  delay: 1
+  when:
+    - operator_name == 'openstack'
+    - cifmw_architecture_scenario is defined
 
 - name: Wait for reinstallation of operator
   vars:


### PR DESCRIPTION
When the deployment is not using `install_yaml` we need to set up some
variables to be able to trigger the update.

The update is using install_yamls in two places. First, it uses the
`set_openstack_containers` to modify the `openstack-operator` and that
role leverage the `install_yamls` commands.

Second, it uses it for the update itself as it's a target of
`install_yamls`

-------

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes