### PR TITLE
Allow using parallel option in tempest CR

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -10,6 +10,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_timeout`: (Integer) Timeout in seconds for the execution of the tests. Default value: `3600`
 * `cifmw_test_operator_logs_image`: (String) Image that should be used to collect logs from the pods spawned by the test-operator. Default value: `quay.io/quay/busybox`
 * `cifmw_test_operator_concurrency`: (Integer) Tempest concurrency value. Default value: `8`
+* `cifmw_test_operator_parallel`: (boolean) Reather or not use --parallel flag in tempest run. Default value: `true`
 * `cifmw_test_operator_cleanup`: (Bool) Delete all resources created by the role at the end of the testing. Default value: `false`
 * `cifmw_test_operator_default_groups`: (List) List of groups in the include list to search for tests to be executed. Default value: `[ 'default' ]`
 * `cifmw_test_operator_default_jobs`: (List) List of jobs in the exclude list to search for tests to be excluded. Default value: `[ 'default' ]`

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -25,6 +25,7 @@ cifmw_test_operator_index: quay.io/openstack-k8s-operators/test-operator-index:l
 cifmw_test_operator_timeout: 3600
 cifmw_test_operator_logs_image: quay.io/quay/busybox
 cifmw_test_operator_concurrency: 8
+cifmw_test_operator_parallel: true
 cifmw_test_operator_cleanup: false
 cifmw_test_operator_dry_run: false
 cifmw_test_operator_default_groups:
@@ -104,6 +105,7 @@ cifmw_test_operator_tempest_config:
       excludeList: |
         {{ cifmw_test_operator_tempest_exclude_list | default('') }}
       concurrency: "{{ cifmw_test_operator_concurrency }}"
+      parallel: "{{ cifmw_test_operator_parallel }}"
       externalPlugin: "{{ cifmw_test_operator_tempest_external_plugin | default([]) }}"
       extraRPMs: "{{ cifmw_test_operator_tempest_extra_rpms | default([]) }}"
       extraImages: "{{ cifmw_test_operator_tempest_extra_images | default([]) }}"

--- a/roles/test_operator/tasks/run-test-operator-job.yml
+++ b/roles/test_operator/tasks/run-test-operator-job.yml
@@ -23,6 +23,10 @@
   ansible.builtin.include_tasks: "{{ test_operator_config_playbook }}"
   when: test_operator_config_playbook is defined
 
+- name: Print CR before applying
+  ansible.builtin.debug:
+    msg: "{{ test_operator_cr }}"
+
 - name: Start tests - {{ run_test_fw }}
   kubernetes.core.k8s:
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"


### PR DESCRIPTION
NFV test cases cannot run in parallel added a
parallel option to the CR to allow disabaling it
if required.
https://github.com/openstack-k8s-operators/test-operator/blob/44b0b132e34039dbcb9089ad01d23c873e70e7e4/api/bases/test.openstack.org_tempests.yaml#L98

Print CR before applying

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
