### PR TITLE
Ensure we don't copy useless venv/tmp

### DIFF
--- a/roles/reproducer/molecule/crc_layout/converge.yml
+++ b/roles/reproducer/molecule/crc_layout/converge.yml
@@ -254,4 +254,6 @@
               ansible.builtin.shell:  # noqa: command-instead-of-module
                 cmd: |-
                   rsync -r zuul@controller-0:"*.log" {{ _log_dest }};
-                  rsync -r zuul@controller-0:ci-framework-data {{ _log_dest }};
+                  rsync -r --exclude "**/venv" --exclude "**/tmp" \
+                    --exclude "**/install_yamls_makes" \
+                    zuul@controller-0:ci-framework-data {{ _log_dest }};


### PR DESCRIPTION
In the "crc_layout" scenario, we deploy an actual layout with
controller-0 and everything done on it, and then we gather everything in
order to make things easier to debug in case of issue.
While it's useful, it also contains useless data, such a virtual env
(venv) and a tmp directory nested in the "path of interest".

This patch excludes those various data to ensure we're not cloaging the
log server.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
