### PR TITLE
Fix parameter passing to install_yamls from update role.

### DIFF
--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -19,7 +19,7 @@
     - always
   ansible.builtin.set_fact:
     _make_openstack_update_run_params: |
-      {% if not cifmw_update_openstack_update_run_operators_updated -%}
+      {% if not cifmw_update_openstack_update_run_operators_updated | bool -%}
       FAKE_UPDATE: true
       CONTAINERS_NAMESPACE: {{ cifmw_update_openstack_update_run_containers_namespace }}
       CONTAINERS_TARGET_TAG: {{ cifmw_update_openstack_update_run_containers_target_tag }}


### PR DESCRIPTION
It was not possible to reach the FAKE_UPDATE block because
`cifmw_update_openstack_update_run_operators_updated` was always true
because it was interpreted as a string.

By adding the `| bool` filter with prevent this from happening.

-------

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes