### PR TITLE
Remove async from rhos-release command

### DIFF
--- a/roles/reproducer/tasks/libvirt_layout.yml
+++ b/roles/reproducer/tasks/libvirt_layout.yml
@@ -108,25 +108,3 @@
   loop_control:
     loop_var: compute
     label: "{{ compute.key }}"
-
-- name: Ensure rhos-release is configured
-  become: true
-  when:
-    - cifmw_reproducer_compute_set_repositories | bool
-    - _async_rhos_release.ansible_job_id is defined
-  block:
-    - name: Ensure async flag still exists
-      register: _async_flag
-      ansible.builtin.stat:
-        path: >-
-          /root/.ansible_async/{{ _async_rhos_release.ansible_job_id }}
-
-    - name: Ensure rhos-release task is over
-      when:
-        - _async_flag.stat.exists
-      ansible.builtin.async_status:
-        jid: "{{ _async_rhos_release.ansible_job_id }}"
-      register: _async_result
-      until: _async_result.finished
-      retries: 20
-      delay: 10

--- a/roles/reproducer/tasks/rhos_release.yml
+++ b/roles/reproducer/tasks/rhos_release.yml
@@ -6,8 +6,5 @@
     disable_gpg_check: true
 
 - name: Install repos
-  register: _async_rhos_release
-  async: 120  # 2 minutes should be enough?
-  poll: 0
   ansible.builtin.command:
     cmd: "rhos-release {{ cifmw_repo_setup_rhos_release_args | default('rhel') }}"


### PR DESCRIPTION
Some jobs are failing to install packages and the async task may be the culprit. Reverting to the previous behavior here, but keeping the possiblity of providing args, instead of always install 'rhel' repos.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
