### PR TITLE
Add missing generated cifmw_external_dns job

### DIFF
--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -826,6 +826,15 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/cifmw_external_dns/(?!meta|README).*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-cifmw_external_dns
+    parent: cifmw-molecule-noop
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/openshift_adm/(?!meta|README).*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -31,6 +31,7 @@
       - cifmw-molecule-cifmw_ceph_spec
       - cifmw-molecule-cifmw_cephadm
       - cifmw-molecule-cifmw_create_admin
+      - cifmw-molecule-cifmw_external_dns
       - cifmw-molecule-cifmw_test_role
       - cifmw-molecule-config_drive
       - cifmw-molecule-copy_container


### PR DESCRIPTION
As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
