### PR TITLE
Allow changing CR name and print CR before applying

### DIFF
--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -88,7 +88,7 @@ cifmw_test_operator_tempest_config:
   apiVersion: test.openstack.org/v1beta1
   kind: Tempest
   metadata:
-    name: tempest-tests
+    name: "{{ test_operator_job_name }}"
     namespace: "{{ cifmw_test_operator_namespace }}"
   spec:
     containerImage: "{{ cifmw_test_operator_tempest_image }}:{{ cifmw_test_operator_tempest_image_tag }}"

--- a/roles/test_operator/tasks/run-test-operator-job.yml
+++ b/roles/test_operator/tasks/run-test-operator-job.yml
@@ -23,6 +23,10 @@
   ansible.builtin.include_tasks: "{{ test_operator_config_playbook }}"
   when: test_operator_config_playbook is defined
 
+- name: Print CR before applying
+  ansible.builtin.debug:
+    msg: "{{ test_operator_cr }}"
+
 - name: Start tests - {{ run_test_fw }}
   kubernetes.core.k8s:
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"


### PR DESCRIPTION
Added a var to allow changing tempest job name
Added a debug statment to print the CR that is going to be applied for testing

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
