### PR TITLE
Enable trash purge scheduler

### DIFF
--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -56,7 +56,7 @@ cifmw_cephadm_deployed_ceph: false
 cifmw_cephadm_backend: ''
 cifmw_cephadm_action: disable
 cifmw_cephadm_rbd_trash_interval: 15
-cifmw_cephadm_enable_trash_scheduler: false
+cifmw_cephadm_enable_trash_scheduler: true
 cifmw_cephadm_apply_ceph_conf_overrides_on_update: false
 cifmw_cephadm_standalone: false
 cifmw_cephadm_default_container: false


### PR DESCRIPTION
'cifmw_cephadm_enable_trash_scheduler' is set to true by default, it can be disabled if required.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
