### PR TITLE
Drop all references to change_message from zuul vars

### DIFF
--- a/ci/playbooks/dump_zuul_data.yml
+++ b/ci/playbooks/dump_zuul_data.yml
@@ -35,13 +35,7 @@
       vars:
         _original_inventory: "{{ _inventory_yaml['content'] | b64decode | from_yaml }}"
         _vars_to_keep: |
-          {% set msg = _original_inventory.all.vars.zuul.pop('change_message', None) %}
-          {% for item in _original_inventory.all.vars.zuul['items'] %}
-          {% set msg = item.pop('change_message', None) %}
-          {% endfor %}
-          {% set msg = _original_inventory.all.vars.zuul.pop('build_refs', None) %}
-          {% set msg = _original_inventory.all.vars.zuul.pop('buildset_refs', None) %}
-          {{ _original_inventory.all.vars  }}
+          {{ _original_inventory.all.vars | ansible.utils.remove_keys(target=['change_message']) }}
       ansible.builtin.copy:
         content: '{{ _vars_to_keep | to_nice_yaml }}'
         dest: "{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml"

--- a/ci/playbooks/dump_zuul_data.yml
+++ b/ci/playbooks/dump_zuul_data.yml
@@ -36,6 +36,11 @@
         _original_inventory: "{{ _inventory_yaml['content'] | b64decode | from_yaml }}"
         _vars_to_keep: |
           {% set msg = _original_inventory.all.vars.zuul.pop('change_message', None) %}
+          {% for item in _original_inventory.all.vars.zuul['items'] %}
+          {% set msg = item.pop('change_message', None) %}
+          {% endfor %}
+          {% set msg = _original_inventory.all.vars.zuul.pop('build_refs', None) %}
+          {% set msg = _original_inventory.all.vars.zuul.pop('buildset_refs', None) %}
           {{ _original_inventory.all.vars  }}
       ansible.builtin.copy:
         content: '{{ _vars_to_keep | to_nice_yaml }}'


### PR DESCRIPTION
After a new update, the change_message is appearing in more fields. As
observed recently [1], if the first comment on the PR contains some mock
ansible, if that is saved into the zuul_vars, it'll crash when trying to
load them. This change drops the newly introduced vars 'build_refs' and
'buildset_refs', whihc contain the change_message.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/1879

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
