### PR TITLE
Migrate all job definitions to re2

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -2,8 +2,8 @@
 - job:
     name: cifmw-molecule-libvirt_manager
     files:
-      - ^roles/dnsmasq/(?!meta|README).*
-      - ^roles/networking_mapper/(?!meta|README).*
+      - ^roles/dnsmasq/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/networking_mapper/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
 - job:
     name: cifmw-molecule-openshift_login
     nodeset: centos-9-crc-2-36-0-xl
@@ -59,11 +59,11 @@
     nodeset: centos-9-crc-2-36-0-xxl
     timeout: 5400
     files:
-      - ^roles/libvirt_manager/(?!meta|README).*
-      - ^roles/podman/(?!meta|README).*
-      - ^roles/sushy_emulator/(?!meta|README).*
-      - ^roles/dnsmasq/(?!meta|README).*
-      - ^roles/networking_mapper/(?!meta|README).*
+      - ^roles/libvirt_manager/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/podman/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/sushy_emulator/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/dnsmasq/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/networking_mapper/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
 - job:
     name: cifmw-molecule-cert_manager
     nodeset: centos-9-crc-2-36-0-xxl
@@ -73,17 +73,17 @@
 - job:
     name: cifmw_molecule-pkg_build
     files:
-      - ^roles/build_openstack_packages/(?!meta|README).*
+      - ^roles/build_openstack_packages/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
 - job:
     name: cifmw_molecule-build_containers
     files:
-      - ^roles/build_openstack_packages/(?!meta|README).*
-      - ^roles/repo_setup/(?!meta|README).*
+      - ^roles/build_openstack_packages/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/repo_setup/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
 - job:
     name: cifmw-molecule-build_openstack_packages
     files:
-      - ^roles/pkg_build/(?!meta|README).
-      - ^roles/repo_setup/(?!meta|README).*
+      - ^roles/pkg_build/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/repo_setup/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
 - job:
     name: cifmw-molecule-manage_secrets
     nodeset: centos-9-crc-2-36-0-xl

--- a/ci/templates/molecule.yaml.j2
+++ b/ci/templates/molecule.yaml.j2
@@ -1,3 +1,6 @@
+{% set want_list = ['defaults', 'files', 'handlers', 'library',
+                    'lookup_plugins', 'module_utils', 'molecule',
+                    'tasks', 'templates', 'vars'] -%}
 {% for role_name in role_names | sort %}
 - job:
     name: cifmw-molecule-{{ role_name }}
@@ -7,7 +10,7 @@
     files:
       - ^common-requirements.txt
       - ^test-requirements.txt
-      - ^roles/{{ role_name }}/(?!meta|README).*
+      - ^roles/{{ role_name }}/{{ want_list | sort | join('|') }}.*
       - ^ci/playbooks/molecule.*
       - ^.config/molecule/.*
 {% endfor %}

--- a/ci/templates/noop-molecule.yaml.j2
+++ b/ci/templates/noop-molecule.yaml.j2
@@ -1,3 +1,6 @@
+{% set want_list = ['defaults', 'files', 'handlers', 'library',
+                    'lookup_plugins', 'module_utils', 'molecule',
+                    'tasks', 'templates', 'vars'] -%}
 {% for role_name in role_names | sort %}
 - job:
     name: cifmw-molecule-{{ role_name }}
@@ -5,7 +8,7 @@
     files:
       - ^common-requirements.txt
       - ^test-requirements.txt
-      - ^roles/{{ role_name }}/(?!meta|README).*
+      - ^roles/{{ role_name }}/{{ want_list | sort | join('|') }}.*
       - ^ci/playbooks/molecule.*
       - ^.config/molecule/.*
 {% endfor %}

--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -102,13 +102,13 @@
       - ^playbooks/01-bootstrap.yml
       - ^playbooks/02-infra.yml
       - ^playbooks/06-deploy-edpm.yml
-      - ^roles/discover_latest_image/(?!meta|README|molecule).*
-      - ^roles/edpm_prepare/(?!meta|README|molecule).*
-      - ^roles/install_ca/(?!meta|README|molecule).*
-      - ^roles/install_yamls/(?!meta|README|molecule).*
-      - ^roles/openshift_login/(?!meta|README|molecule).*
-      - ^roles/openshift_setup/(?!meta|README|molecule).*
-      - ^roles/repo_setup/(?!meta|README|molecule).*
+      - ^roles/discover_latest_image/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/edpm_prepare/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/install_ca/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/install_yamls/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/openshift_login/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/openshift_setup/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/repo_setup/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
       - ^hooks/playbooks/fetch_compute_facts.yml
       - ^zuul.d/adoption.yaml
       - go.mod

--- a/zuul.d/architecture-jobs.yaml
+++ b/zuul.d/architecture-jobs.yaml
@@ -40,5 +40,5 @@
       cifmw_architecture_scenario: hci
     files:
       - zuul.d/architecture-jobs.yaml
-      - ^roles/ci_gen_kustomize_values/(?!meta|README).*
-      - ^roles/kustomize_deploy/(?!meta|README).*
+      - ^roles/ci_gen_kustomize_values/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/kustomize_deploy/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*

--- a/zuul.d/content_provider.yaml
+++ b/zuul.d/content_provider.yaml
@@ -22,9 +22,9 @@
       against ci-framework repo to validate meta content provider
       changes.
     files:
-      - ^roles/build_containers/(?!meta|README).*
-      - ^roles/build_openstack_packages/(?!meta|README).*
-      - ^roles/registry_deploy/(?!meta|README).*
-      - ^roles/edpm_build_images/(?!meta|README).*
-      - ^roles/operator_build/(?!meta|README).*
+      - ^roles/build_containers/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/build_openstack_packages/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/registry_deploy/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/edpm_build_images/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/operator_build/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
       - ^ci/playbooks/meta_content_provider/.*

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -34,8 +34,8 @@
     parent: cifmw-crc-podified-edpm-deployment
     files:
       - ^playbooks/*
-      - ^roles/edpm_prepare/(?!meta|README).*
-      - ^roles/edpm_deploy/(?!meta|README).*
+      - ^roles/edpm_prepare/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/edpm_deploy/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
       - ^roles/artifacts/tasks/edpm.yml
       - ^deploy-edpm.yml
       - ^scenarios/centos-9/edpm_ci.yml
@@ -45,7 +45,7 @@
     parent: cifmw-crc-podified-galera-deployment
     files:
       - ^playbooks/*
-      - ^roles/edpm_prepare/(?!meta|README).*
+      - ^roles/edpm_prepare/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
       - ^deploy-edpm.yml
       - ^scenarios/centos-9/edpm_ci.yml
 
@@ -54,7 +54,7 @@
     parent: cifmw-crc-podified-edpm-baremetal
     files:
       - ^playbooks/*
-      - ^roles/edpm_deploy_baremetal/(?!meta|README).*
+      - ^roles/edpm_deploy_baremetal/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
       - ^roles/artifacts/tasks/edpm.yml
       - ^ci/playbooks/edpm_baremetal_deployment/run.yml
       - ^deploy-edpm.yml

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -283,11 +283,11 @@
       - ^hooks/playbooks/templates/config_ceph_backends.yaml.j2
       - ^playbooks/06-deploy-edpm.yml
       - ^playbooks/ceph.yml
-      - ^roles/edpm_deploy/(?!meta|README).*
-      - ^roles/hci_prepare/(?!meta|README).*
-      - ^roles/cifmw_ceph.*/(?!meta|README).*
-      - ^roles/cifmw_block_device/(?!meta|README).*
-      - ^roles/cifmw_create_admin/(?!meta|README).*
+      - ^roles/edpm_deploy/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/hci_prepare/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/cifmw_ceph.*/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/cifmw_block_device/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/cifmw_create_admin/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
       - ^scenarios/centos-9/hci_ceph_backends.yml
       - ^scenarios/centos-9/multinode-ci.yml
 

--- a/zuul.d/end-to-end.yaml
+++ b/zuul.d/end-to-end.yaml
@@ -23,9 +23,9 @@
     name: cifmw-end-to-end
     parent: cifmw-end-to-end-base
     files:
-      - ^roles/.*_build/(?!meta|README).*
-      - ^roles/build.*/(?!meta|README).*
-      - ^roles/openshift_.*/(?!meta|README).*
+      - ^roles/.*_build/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/build.*/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/openshift_.*/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
       - ^playbooks/.*build.*.yml
     irrelevant-files:
       - ^.*/*.md
@@ -61,10 +61,10 @@
     name: cifmw-baremetal-nested-crc
     parent: cifmw-crc-podified-edpm-baremetal
     files:
-      - ^roles/rhol_crc/(?!meta|README).*
-      - ^roles/libvirt_manager/(?!meta|README).*
-      - ^roles/cert_manager/(?!meta|README).*
-      - ^roles/edpm_deploy_baremetal/(?!meta|README).*
+      - ^roles/rhol_crc/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/libvirt_manager/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/cert_manager/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/edpm_deploy_baremetal/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
       - scenarios/centos-9/edpm_baremetal_deployment_ci.yml
       - ^plugins/action/ci_script.py
       - ^plugins/modules/generate_make_tasks.py

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -2,7 +2,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/artifacts/(?!meta|README).*
+    - ^roles/artifacts/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-artifacts
@@ -13,7 +13,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/build_containers/(?!meta|README).*
+    - ^roles/build_containers/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-build_containers
@@ -24,11 +24,11 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/build_openstack_packages/(?!meta|README).*
+    - ^roles/build_openstack_packages/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
-    - ^roles/pkg_build/(?!meta|README).
-    - ^roles/repo_setup/(?!meta|README).*
+    - ^roles/pkg_build/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+    - ^roles/repo_setup/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
     name: cifmw-molecule-build_openstack_packages
     parent: cifmw-molecule-base
     vars:
@@ -37,7 +37,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/cert_manager/(?!meta|README).*
+    - ^roles/cert_manager/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cert_manager
@@ -49,7 +49,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/ci_gen_kustomize_values/(?!meta|README).*
+    - ^roles/ci_gen_kustomize_values/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_gen_kustomize_values
@@ -62,7 +62,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/ci_local_storage/(?!meta|README).*
+    - ^roles/ci_local_storage/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_local_storage
@@ -74,7 +74,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/ci_metallb/(?!meta|README).*
+    - ^roles/ci_metallb/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_metallb
@@ -85,7 +85,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/ci_multus/(?!meta|README).*
+    - ^roles/ci_multus/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_multus
@@ -96,7 +96,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/ci_netconfig/(?!meta|README).*
+    - ^roles/ci_netconfig/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_netconfig
@@ -107,7 +107,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/ci_network/(?!meta|README).*
+    - ^roles/ci_network/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_network
@@ -118,7 +118,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/ci_nmstate/(?!meta|README).*
+    - ^roles/ci_nmstate/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_nmstate
@@ -130,7 +130,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/ci_setup/(?!meta|README).*
+    - ^roles/ci_setup/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_setup
@@ -141,7 +141,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/cifmw_block_device/(?!meta|README).*
+    - ^roles/cifmw_block_device/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_block_device
@@ -152,7 +152,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/cifmw_ceph_client/(?!meta|README).*
+    - ^roles/cifmw_ceph_client/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_ceph_client
@@ -163,7 +163,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/cifmw_ceph_spec/(?!meta|README).*
+    - ^roles/cifmw_ceph_spec/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_ceph_spec
@@ -174,7 +174,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/cifmw_cephadm/(?!meta|README).*
+    - ^roles/cifmw_cephadm/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_cephadm
@@ -185,7 +185,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/cifmw_create_admin/(?!meta|README).*
+    - ^roles/cifmw_create_admin/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_create_admin
@@ -196,7 +196,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/cifmw_test_role/(?!meta|README).*
+    - ^roles/cifmw_test_role/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_test_role
@@ -207,7 +207,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/config_drive/(?!meta|README).*
+    - ^roles/config_drive/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-config_drive
@@ -218,7 +218,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/copy_container/(?!meta|README).*
+    - ^roles/copy_container/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-copy_container
@@ -229,7 +229,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/deploy_bmh/(?!meta|README).*
+    - ^roles/deploy_bmh/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-deploy_bmh
@@ -240,7 +240,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/devscripts/(?!meta|README).*
+    - ^roles/devscripts/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-devscripts
@@ -251,7 +251,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/discover_latest_image/(?!meta|README).*
+    - ^roles/discover_latest_image/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-discover_latest_image
@@ -262,7 +262,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/dlrn_promote/(?!meta|README).*
+    - ^roles/dlrn_promote/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-dlrn_promote
@@ -273,7 +273,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/dlrn_report/(?!meta|README).*
+    - ^roles/dlrn_report/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-dlrn_report
@@ -284,7 +284,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/dnsmasq/(?!meta|README).*
+    - ^roles/dnsmasq/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-dnsmasq
@@ -295,7 +295,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/edpm_build_images/(?!meta|README).*
+    - ^roles/edpm_build_images/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-edpm_build_images
@@ -306,7 +306,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/edpm_deploy/(?!meta|README).*
+    - ^roles/edpm_deploy/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-edpm_deploy
@@ -317,7 +317,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/edpm_deploy_baremetal/(?!meta|README).*
+    - ^roles/edpm_deploy_baremetal/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-edpm_deploy_baremetal
@@ -328,7 +328,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/edpm_kustomize/(?!meta|README).*
+    - ^roles/edpm_kustomize/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-edpm_kustomize
@@ -339,7 +339,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/edpm_prepare/(?!meta|README).*
+    - ^roles/edpm_prepare/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-edpm_prepare
@@ -350,7 +350,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/env_op_images/(?!meta|README).*
+    - ^roles/env_op_images/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-env_op_images
@@ -362,7 +362,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/hci_prepare/(?!meta|README).*
+    - ^roles/hci_prepare/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-hci_prepare
@@ -373,7 +373,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/hive/(?!meta|README).*
+    - ^roles/hive/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-hive
@@ -384,7 +384,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/idrac_configuration/(?!meta|README).*
+    - ^roles/idrac_configuration/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-idrac_configuration
@@ -395,7 +395,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/install_ca/(?!meta|README).*
+    - ^roles/install_ca/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-install_ca
@@ -408,7 +408,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/install_openstack_ca/(?!meta|README).*
+    - ^roles/install_openstack_ca/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-install_openstack_ca
@@ -421,7 +421,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/install_yamls/(?!meta|README).*
+    - ^roles/install_yamls/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-install_yamls
@@ -432,7 +432,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/kustomize_deploy/(?!meta|README).*
+    - ^roles/kustomize_deploy/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-kustomize_deploy
@@ -445,11 +445,11 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/libvirt_manager/(?!meta|README).*
+    - ^roles/libvirt_manager/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
-    - ^roles/dnsmasq/(?!meta|README).*
-    - ^roles/networking_mapper/(?!meta|README).*
+    - ^roles/dnsmasq/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+    - ^roles/networking_mapper/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
     name: cifmw-molecule-libvirt_manager
     parent: cifmw-molecule-base
     vars:
@@ -458,7 +458,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/manage_secrets/(?!meta|README).*
+    - ^roles/manage_secrets/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-manage_secrets
@@ -470,7 +470,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/mirror_registry/(?!meta|README).*
+    - ^roles/mirror_registry/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-mirror_registry
@@ -481,7 +481,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/nat64_appliance/(?!meta|README).*
+    - ^roles/nat64_appliance/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-nat64_appliance
@@ -492,7 +492,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/networking_mapper/(?!meta|README).*
+    - ^roles/networking_mapper/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-networking_mapper
@@ -504,7 +504,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/openshift_login/(?!meta|README).*
+    - ^roles/openshift_login/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_login
@@ -516,7 +516,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/openshift_obs/(?!meta|README).*
+    - ^roles/openshift_obs/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_obs
@@ -528,7 +528,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/openshift_provisioner_node/(?!meta|README).*
+    - ^roles/openshift_provisioner_node/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_provisioner_node
@@ -540,7 +540,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/openshift_setup/(?!meta|README).*
+    - ^roles/openshift_setup/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_setup
@@ -552,7 +552,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/operator_build/(?!meta|README).*
+    - ^roles/operator_build/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-operator_build
@@ -563,7 +563,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/operator_deploy/(?!meta|README).*
+    - ^roles/operator_deploy/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-operator_deploy
@@ -575,7 +575,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/os_must_gather/(?!meta|README).*
+    - ^roles/os_must_gather/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-os_must_gather
@@ -586,7 +586,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/os_net_setup/(?!meta|README).*
+    - ^roles/os_net_setup/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-os_net_setup
@@ -597,7 +597,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/pkg_build/(?!meta|README).*
+    - ^roles/pkg_build/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-pkg_build
@@ -608,7 +608,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/podman/(?!meta|README).*
+    - ^roles/podman/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-podman
@@ -619,7 +619,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/registry_deploy/(?!meta|README).*
+    - ^roles/registry_deploy/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-registry_deploy
@@ -630,7 +630,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/repo_setup/(?!meta|README).*
+    - ^roles/repo_setup/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-repo_setup
@@ -641,14 +641,14 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/reproducer/(?!meta|README).*
+    - ^roles/reproducer/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
-    - ^roles/libvirt_manager/(?!meta|README).*
-    - ^roles/podman/(?!meta|README).*
-    - ^roles/sushy_emulator/(?!meta|README).*
-    - ^roles/dnsmasq/(?!meta|README).*
-    - ^roles/networking_mapper/(?!meta|README).*
+    - ^roles/libvirt_manager/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+    - ^roles/podman/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+    - ^roles/sushy_emulator/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+    - ^roles/dnsmasq/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+    - ^roles/networking_mapper/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
     name: cifmw-molecule-reproducer
     nodeset: centos-9-crc-2-36-0-xxl
     parent: cifmw-molecule-base
@@ -659,7 +659,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/rhol_crc/(?!meta|README).*
+    - ^roles/rhol_crc/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-rhol_crc
@@ -672,7 +672,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/run_hook/(?!meta|README).*
+    - ^roles/run_hook/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-run_hook
@@ -683,7 +683,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/set_openstack_containers/(?!meta|README).*
+    - ^roles/set_openstack_containers/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-set_openstack_containers
@@ -694,7 +694,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/shiftstack/(?!meta|README).*
+    - ^roles/shiftstack/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-shiftstack
@@ -706,7 +706,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/ssh_jumper/(?!meta|README).*
+    - ^roles/ssh_jumper/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ssh_jumper
@@ -717,7 +717,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/sushy_emulator/(?!meta|README).*
+    - ^roles/sushy_emulator/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-sushy_emulator
@@ -729,7 +729,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/tempest/(?!meta|README).*
+    - ^roles/tempest/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-tempest
@@ -740,7 +740,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/test_deps/(?!meta|README).*
+    - ^roles/test_deps/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-test_deps
@@ -751,7 +751,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/test_operator/(?!meta|README).*
+    - ^roles/test_operator/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-test_operator
@@ -762,7 +762,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/tofu/(?!meta|README).*
+    - ^roles/tofu/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-tofu
@@ -773,7 +773,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/update/(?!meta|README).*
+    - ^roles/update/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-update
@@ -784,7 +784,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/update_containers/(?!meta|README).*
+    - ^roles/update_containers/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-update_containers
@@ -795,7 +795,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/validations/(?!meta|README).*
+    - ^roles/validations/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-validations
@@ -806,7 +806,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/virtualbmc/(?!meta|README).*
+    - ^roles/virtualbmc/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-virtualbmc
@@ -817,7 +817,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/ci_lvms_storage/(?!meta|README).*
+    - ^roles/ci_lvms_storage/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_lvms_storage
@@ -826,7 +826,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/cifmw_external_dns/(?!meta|README).*
+    - ^roles/cifmw_external_dns/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_external_dns
@@ -835,7 +835,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/openshift_adm/(?!meta|README).*
+    - ^roles/openshift_adm/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_adm
@@ -844,7 +844,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/ovirt/(?!meta|README).*
+    - ^roles/ovirt/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ovirt
@@ -853,7 +853,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/polarion/(?!meta|README).*
+    - ^roles/polarion/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-polarion
@@ -862,7 +862,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/switch_config/(?!meta|README).*
+    - ^roles/switch_config/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-switch_config

--- a/zuul.d/tcib.yaml
+++ b/zuul.d/tcib.yaml
@@ -25,6 +25,6 @@
     name: cifmw-tcib
     parent: cifmw-tcib-base
     files:
-      - ^roles/build_containers/(?!meta|README).*
+      - ^roles/build_containers/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
       - ^scenarios/centos-9/tcib.yml
       - ^ci/playbooks/tcib

--- a/zuul.d/tofu.yaml
+++ b/zuul.d/tofu.yaml
@@ -2,7 +2,7 @@
     files:
       - ^common-requirements.txt
       - ^test-requirements.txt
-      - ^roles/tofu/(?!meta|README).*
+      - ^roles/tofu/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
       - ^ci/playbooks/molecule.*
       - ^ci_framework/playbooks/run_tofu.yml
     name: cifmw-molecule-tofu


### PR DESCRIPTION
A recent Zuul update activated "deprecation warning" on
PCRE regular expression patterns: we're heavily using the
negative look-ahead, and this isn't supported at all by "re2",
the engine chosen by Zuul.

This PR contains one commit per Zuul configuration file, to make
any potential revert slightly easier.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
