### PR TITLE
Allow ignoring test failures

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -15,6 +15,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_default_jobs`: (List) List of jobs in the exclude list to search for tests to be excluded. Default value: `[ 'default' ]`
 * `cifmw_test_operator_dry_run`: (Boolean) Whether test-operator should run or not. Default value: `false`
 * `cifmw_test_operator_fail_fast`: (Boolean) Whether the test results are evaluated when each test framework execution finishes or when all test frameworks are done. Default value: `false`
+* `cifmw_test_operator_fail_on_test_failure`: (Boolean) Whether the role should fail on any test failure or not. Default value: `true`
 * `cifmw_test_operator_controller_ip`: (String) An ip address of the controller node. Default value: `ansible_default_ipv4.address` which defaults to (`""`).
 * `cifmw_test_operator_tolerations`: (Dict) `tolerations` value that is applied to all pods spawned by the test-operator and to the test-operator-controller-manager and test-operator-logs pods. Default value: `{}`
 * `cifmw_test_operator_node_selector`: (Dict) `nodeSelector` value that is applied to all pods spawned by the test-operator and to the test-operator-controller-manager and test-operator-logs pods. Default value: `{}`

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -19,6 +19,7 @@
 # All variables within this role should have a prefix of "cifmw_test_operator"
 
 # Section 1: generic parameters (applied to all supported test frameworks)
+cifmw_test_operator_fail_on_test_failure: true
 cifmw_test_operator_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}/tests/test_operator"
 cifmw_test_operator_namespace: openstack
 cifmw_test_operator_index: quay.io/openstack-k8s-operators/test-operator-index:latest

--- a/roles/test_operator/tasks/main.yml
+++ b/roles/test_operator/tasks/main.yml
@@ -170,7 +170,9 @@
   when: cifmw_test_operator_cleanup | bool and not cifmw_test_operator_dry_run | bool
 
 - name: Fail when any tests failed
-  when: not cifmw_test_operator_dry_run | bool
+  when:
+    - not cifmw_test_operator_dry_run | bool
+    - cifmw_test_operator_fail_on_test_failure | bool
   ansible.builtin.assert:
     that:
       - item.value


### PR DESCRIPTION
added an option to allow avoiding test-operator role failure if it is not required

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
