### PR TITLE
Bump openshift version to 4.16.0

### DIFF
--- a/roles/devscripts/vars/main.yml
+++ b/roles/devscripts/vars/main.yml
@@ -34,7 +34,7 @@ cifmw_devscripts_config_defaults:
   working_dir: "/home/dev-scripts"
   assets_extra_folder: "/home/dev-scripts/assets"
   openshift_release_type: "ga"
-  openshift_version: "4.15.18"
+  openshift_version: "4.16.0"
   cluster_name: "ocp"
   base_domain: "openstack.lab"
   ntp_servers: "clock.corp.redhat.com"


### PR DESCRIPTION
We need to merge this to test the GA content.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running on
   - [x] VA HCI
   - [x] VA HCI with trunk repos and fips 

