### PR TITLE
Set LVMS for NFV DPDK SR-IOV VA

### DIFF
--- a/scenarios/reproducers/va-nfv-ovs-dpdk-sriov.yml
+++ b/scenarios/reproducers/va-nfv-ovs-dpdk-sriov.yml
@@ -79,6 +79,8 @@ cifmw_libvirt_manager_configuration:
       image_local_dir: "{{ cifmw_basedir }}/images/"
       disk_file_name: "ocp_master"
       disksize: "100"
+      extra_disks_num: 3
+      extra_disks_size: "50G"
       cpus: 10
       memory: 32
       nets:
@@ -101,3 +103,10 @@ cifmw_config_bmh: true
 
 # Use EDPM image for computes
 cifmw_update_containers_edpm_image_url: "{{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/edpm-hardened-uefi:{{ cifmw_update_containers_tag }}"
+
+# Set Logical Volume Manager Storage by default for local storage
+cifmw_use_lvms: true
+cifmw_lvms_disk_list:
+  - /dev/vda
+  - /dev/vdb
+  - /dev/vdc


### PR DESCRIPTION
Customers are recommended to use LVMS.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
