### PR TITLE
Reparent adoption github-check job for new job naming scheme

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -95,9 +95,17 @@
                 ip: 172.20.0.100
                 config_nm: false
 
+# TODO(marios): remove this once we finish rename OSPRH-8452
 - job:
     name: cifmw-data-plane-adoption-osp-17-to-extracted-crc
-    parent: data-plane-adoption-osp-17-to-extracted-crc
+    parent: adoption-standalone-to-crc-ceph-provider
+
+- job:
+    name: adoption-standalone-to-crc-ceph-provider
+    description: |
+        Standalone source OSP 17.1 node adopted to crc RHOSO 18.
+        Has ceph, not TLS. Uses a content provider.
+    parent: adoption-standalone-to-crc-ceph
     files:
       - ^playbooks/01-bootstrap.yml
       - ^playbooks/02-infra.yml
@@ -125,9 +133,17 @@
       - OWNERS
       - .*/*.md
 
+# TODO(marios): remove this once we finish rename OSPRH-8452
 - job:
     name: cifmw-data-plane-adoption-osp-17-to-extracted-crc-minimal-no-ceph
-    parent: cifmw-data-plane-adoption-osp-17-to-extracted-crc
+    parent: adoption-standalone-to-crc-no-ceph-provider
+
+- job:
+    name: adoption-standalone-to-crc-no-ceph-provider
+    description: |
+        Standalone source OSP 17.1 node adopted to crc RHOSO 18.
+        Has TLS, not ceph. Uses a content provider.
+    parent: adoption-standalone-to-crc-ceph-provider
     vars:
       enable_tls: "true"
       cloud_domain: "ooo.test"

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -24,17 +24,6 @@
         - podified-multinode-hci-deployment-crc: *content_provider
 
 - project-template:
-    name: data-plane-adoption-pipeline
-    description: |
-      Project template to run content provider with data-plane adoption job.
-    github-check:
-      jobs:
-        - openstack-k8s-operators-content-provider
-        - cifmw-data-plane-adoption-osp-17-to-extracted-crc:
-            dependencies:
-              - openstack-k8s-operators-content-provider
-
-- project-template:
     name: podified-ironic-operator-pipeline
     description: |
       Project template to run content provider with ironic podified job.
@@ -73,6 +62,17 @@
             requires:
               - cifmw-pod-pre-commit
               - cifmw-molecule
-        - cifmw-data-plane-adoption-osp-17-to-extracted-crc:
+        - adoption-standalone-to-crc-ceph-provider:
+            dependencies:
+              - openstack-k8s-operators-content-provider
+
+- project-template:
+    name: data-plane-adoption-pipeline
+    description: |
+      Project template to run content provider with data-plane adoption job.
+    github-check:
+      jobs:
+        - openstack-k8s-operators-content-provider
+        - adoption-standalone-to-crc-ceph-provider:
             dependencies:
               - openstack-k8s-operators-content-provider


### PR DESCRIPTION
This reparents the cifmw-data-plane-adoption-osp-17-to-extracted-crc
to the re-named parent job in rdo-jobs (done with the depends-on).

It keeps the existing jobs for now until we can complete the reparenting
across the other repos that reference these [1][2]

[1] https://github.com/openstack-k8s-operators/install_yamls/pull/872
[2] https://github.com/openstack-k8s-operators/edpm-ansible/pull/698

Depends-On: https://review.rdoproject.org/r/c/rdo-jobs/+/53788

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
