### PR TITLE
OSPCIX-372 Fix race in ironic tls patch sequence

### DIFF
--- a/hooks/playbooks/ironic_inject_tls.yml
+++ b/hooks/playbooks/ironic_inject_tls.yml
@@ -56,6 +56,7 @@
         image: "{{ ironic_python_image }}"
         name: ironic-python-agent
         rm: true
+        detach: false
         volumes:
           - "{{ cifmw_basedir }}/artifacts/ironic_ipa_tls/:/target:Z"
 
@@ -66,6 +67,7 @@
         executable: "/bin/bash"
         script: |
           set -xe -o pipefail
+          ls -la {{ cifmw_basedir }}/artifacts/ironic_ipa_tls/
           zcat {{ cifmw_basedir }}/artifacts/ironic_ipa_tls/ironic-python-agent.initramfs | cpio -idmv
           cp {{ cifmw_basedir }}/artifacts/ironic_ipa_tls/internal-ca-bundle.pem etc/pki/ca-trust/source/anchors/
           chroot {{ cifmw_basedir }}/artifacts/ironic_ipa_tls/initramfs << EOF_CHROOT_SCRIPT


### PR DESCRIPTION
In order for ironic agent ramdisks to work, they need to contain the CA certificate of the deployment such that they can talk to the OCP TLS endpoint.

Unfortunately, the sequence of invocation to patch the ramdisk images, which was merged, contains an invocation of a podman plugin, which by default launches containers as detached operations. The net result is the command can return almost immediately, and then the next step attempts to execute and then fails because files it expects may not appear for several seconds. So the correct path is to disable the detach operation call so when podman exits, we know the task has been completed to allow for the next task to execute.

Also adds an ls -la of the folder we expect files to be in to aid in future ci framework troubleshooting.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
