### PR TITLE
Add cifmw olm subscription channel var

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/common/olm-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/common/olm-values/values.yaml.j2
@@ -1,3 +1,6 @@
 # source: common/olm-values/values.yaml.j2
 data:
     openstack-operator-image: {{ cifmw_ci_gen_kustomize_values_ooi_image | default('quay.io/openstack-k8s-operators/openstack-operator-index:latest', true) }}
+{% if cifmw_ci_gen_kustomize_values_sub_channel is defined %}
+    openstack-operator-channel: {{ cifmw_ci_gen_kustomize_values_sub_channel }}
+{% endif %}


### PR DESCRIPTION
Adds cifmw_ci_gen_kustomize_values_sub_channel var to olm-values template to allow CI jobs to customize subscription channel.

Depends-On: https://github.com/openstack-k8s-operators/architecture/pull/331

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
