### PR TITLE
Update adoption and base zuul jobs to CRC 2.39 - OCP 4.16

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -7,7 +7,7 @@
     abstract: true
     timeout: 10800
     attempts: 1
-    nodeset: centos-9-rhel-9-2-crc-extracted-2-36-0-3xl
+    nodeset: centos-9-rhel-9-2-crc-extracted-2-39-0-3xl
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run:
@@ -140,7 +140,7 @@
     abstract: true
     timeout: 10800
     attempts: 1
-    nodeset: centos-9-multinode-rhel-9-2-crc-extracted-2-36-0-3xl
+    nodeset: centos-9-multinode-rhel-9-2-crc-extracted-2-39-0-3xl
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run: &multinode-prerun
@@ -349,7 +349,7 @@
     voting: false
     timeout: 10800
     attempts: 1
-    nodeset: centos-9-multinode-rhel-9-2-crc-extracted-2-36-0-3xl-novacells
+    nodeset: centos-9-multinode-rhel-9-2-crc-extracted-2-39-0-3xl-novacells
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run: *multinode-prerun

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -125,7 +125,7 @@
     parent: base-extracted-crc
     timeout: 10800
     attempts: 1
-    nodeset: centos-9-medium-centos-9-crc-extracted-2-36-0-3xl
+    nodeset: centos-9-medium-centos-9-crc-extracted-2-39-0-3xl
     irrelevant-files: *ir_files
     required-projects: &multinode_edpm_rp
       - openstack-k8s-operators/ci-framework
@@ -212,7 +212,7 @@
     parent: base-extracted-crc-ci-bootstrap
     timeout: 10800
     attempts: 1
-    nodeset: centos-9-medium-centos-9-crc-extracted-2-36-0-3xl
+    nodeset: centos-9-medium-centos-9-crc-extracted-2-39-0-3xl
     irrelevant-files: *ir_files
     required-projects: *multinode_edpm_rp
     roles: *multinode_edpm_roles
@@ -232,7 +232,7 @@
     parent: base-extracted-crc-ci-bootstrap-staging
     timeout: 10800
     attempts: 1
-    nodeset: centos-9-medium-centos-9-crc-extracted-2-36-0-3xl
+    nodeset: centos-9-medium-centos-9-crc-extracted-2-39-0-3xl
     irrelevant-files: *ir_files
     required-projects: *multinode_edpm_rp
     roles: *multinode_edpm_roles
@@ -251,7 +251,7 @@
 #
 - job:
     name: cifmw-base-crc
-    nodeset: centos-9-crc-2-36-0-3xl
+    nodeset: centos-9-crc-2-39-0-3xl
     timeout: 10800
     abstract: true
     parent: base-simple-crc


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSPRH-8665

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

Extra jobs to test:
- [x] podified-multinode-edpm-deployment-crc - [Result](https://review.rdoproject.org/zuul/build/61221aeaf9d34f61884ffab8b8de5365)
- [x] cifmw-crc-podified-edpm-baremetal - [Result](https://review.rdoproject.org/zuul/build/ca9b1fb1b4694f70ac957416012e2a4c)
- [x] periodic-data-plane-adoption-multinode-osp-17-to-extracted-crc-with-ceph - [Results](https://review.rdoproject.org/zuul/buildset/f0d0211f4d8f40e0a079e6ec86fa0784) - Job failed due to DLRN but tempest passed as seen below
```
2024-07-16 07:53:27.090062 | controller | TASK [tempest : Fail if podman container did not succeed that=['tempest_run_output.failed == false']] ***
2024-07-16 07:53:27.090072 | controller | Tuesday 16 July 2024  07:53:27 -0400 (0:00:00.379)       0:48:54.080 **********
2024-07-16 07:53:27.090085 | controller | ok: [localhost] => changed=false
2024-07-16 07:53:27.149575 | controller |   msg: All assertions passed
```
