### PR TITLE
Update end to end and edpm* Zuul jobs to CRC 2.39 - OCP 4.16

### DIFF
--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -11,7 +11,7 @@
 # Virtual Baremetal job with CRC and single compute node.
 - job:
     name: cifmw-crc-podified-edpm-baremetal
-    nodeset: centos-9-crc-2-36-0-6xlarge
+    nodeset: centos-9-crc-2-39-0-6xlarge
     parent: cifmw-base-crc-openstack
     run: ci/playbooks/edpm_baremetal_deployment/run.yml
     vars:

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -2,7 +2,7 @@
 - job:
     name: podified-multinode-edpm-deployment-crc-3comp
     parent: podified-multinode-edpm-deployment-crc
-    nodeset: centos-9-medium-3x-centos-9-crc-extracted-2-36-0-xxl
+    nodeset: centos-9-medium-3x-centos-9-crc-extracted-2-39-0-xxl
     vars:
       crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"
       crc_ci_bootstrap_networking:
@@ -78,7 +78,7 @@
 - job:
     name: podified-multinode-hci-deployment-crc-3comp
     parent: podified-multinode-edpm-deployment-crc
-    nodeset: centos-9-medium-3x-centos-9-crc-extracted-2-36-0-xxl
+    nodeset: centos-9-medium-3x-centos-9-crc-extracted-2-39-0-xxl
     vars:
       cifmw_edpm_deploy_hci: true
       crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"
@@ -169,7 +169,7 @@
 - job:
     name: podified-multinode-hci-deployment-crc-1comp
     parent: podified-multinode-edpm-deployment-crc
-    nodeset: centos-9-medium-centos-9-crc-extracted-2-36-0-3xl
+    nodeset: centos-9-medium-centos-9-crc-extracted-2-39-0-3xl
     vars:
       cifmw_edpm_deploy_hci: true
       cifmw_cephadm_single_host_defaults: true

--- a/zuul.d/end-to-end.yaml
+++ b/zuul.d/end-to-end.yaml
@@ -2,7 +2,7 @@
 # cifmw base job
 - job:
     name: cifmw-end-to-end-base
-    nodeset: centos-9-crc-2-36-0-3xl
+    nodeset: centos-9-crc-2-39-0-3xl
     parent: base-simple-crc
     vars:
       crc_parameters: "--memory 24000 --disk-size 120 --cpus 8"


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSPRH-8665

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

Jobs to check:
- [x] openstack-operator-tempest-multinode - [Result](https://review.rdoproject.org/zuul/build/8400ffb8307842799b90391f9f7a6f31)
- [x] podified-multinode-hci-deployment-crc - [Result](https://review.rdoproject.org/zuul/build/821086312b524410b3225aeff3d7402c)
- [x] periodic-podified-edpm-baremetal-antelope-ocp-crc - [Results](https://review.rdoproject.org/zuul/build/c3f0dafeb46247eb9babdb728a8c18af) - Job failed due to DLRN but tempest passed as seen below
```
2024-07-16 07:53:27.090062 | controller | TASK [tempest : Fail if podman container did not succeed that=['tempest_run_output.failed == false']] ***
2024-07-16 07:53:27.090072 | controller | Tuesday 16 July 2024  07:53:27 -0400 (0:00:00.379)       0:48:54.080 **********
2024-07-16 07:53:27.090085 | controller | ok: [localhost] => changed=false
2024-07-16 07:53:27.149575 | controller |   msg: All assertions passed
```