### PR TITLE
Update Kuttl and Molecule zuul jobs to CRC 2.39 - OCP 4.16

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -6,20 +6,20 @@
       - ^roles/networking_mapper/(?!meta|README).*
 - job:
     name: cifmw-molecule-openshift_login
-    nodeset: centos-9-crc-2-36-0-xl
+    nodeset: centos-9-crc-2-39-0-xl
 - job:
     name: cifmw-molecule-openshift_provisioner_node
-    nodeset: centos-9-crc-2-36-0-xl
+    nodeset: centos-9-crc-2-39-0-xl
 - job:
     name: cifmw-molecule-openshift_setup
-    nodeset: centos-9-crc-2-36-0-xl
+    nodeset: centos-9-crc-2-39-0-xl
 - job:
     name: cifmw-molecule-rhol_crc
-    nodeset: centos-9-crc-2-36-0-xxl
+    nodeset: centos-9-crc-2-36-0-xxl #TODO(Lewis): Bump to 2-39 once OSPCIX-376 is resolved
     timeout: 5400
 - job:
     name: cifmw-molecule-operator_deploy
-    nodeset: centos-9-crc-2-36-0-xl
+    nodeset: centos-9-crc-2-39-0-xl
 - job:
     name: cifmw-molecule-set_openstack_containers
     parent: cifmw-molecule-base-crc
@@ -49,13 +49,13 @@
 - job:
     name: cifmw-molecule-install_openstack_ca
     parent: cifmw-molecule-base-crc
-    nodeset: centos-9-crc-2-36-0-3xl
+    nodeset: centos-9-crc-2-39-0-3xl
     timeout: 5400
     extra-vars:
       crc_parameters: "--memory 29000 --disk-size 100 --cpus 8"
 - job:
     name: cifmw-molecule-reproducer
-    nodeset: centos-9-crc-2-36-0-xxl
+    nodeset: centos-9-crc-2-39-0-xxl
     timeout: 5400
     files:
       - ^roles/libvirt_manager/(?!meta|README).*
@@ -65,10 +65,10 @@
       - ^roles/networking_mapper/(?!meta|README).*
 - job:
     name: cifmw-molecule-cert_manager
-    nodeset: centos-9-crc-2-36-0-xxl
+    nodeset: centos-9-crc-2-39-0-xxl
 - job:
     name: cifmw-molecule-env_op_images
-    nodeset: centos-9-crc-2-36-0-xl
+    nodeset: centos-9-crc-2-39-0-xl
 - job:
     name: cifmw_molecule-pkg_build
     files:
@@ -85,19 +85,19 @@
       - ^roles/repo_setup/(?!meta|README).*
 - job:
     name: cifmw-molecule-manage_secrets
-    nodeset: centos-9-crc-2-36-0-xl
+    nodeset: centos-9-crc-2-39-0-xl
 - job:
     name: cifmw-molecule-ci_local_storage
-    nodeset: centos-9-crc-2-36-0-xl
+    nodeset: centos-9-crc-2-39-0-xl
 - job:
     name: cifmw-molecule-networking_mapper
     nodeset: 4x-centos-9-medium
 - job:
     name: cifmw-molecule-openshift_obs
-    nodeset: centos-9-crc-2-36-0-xxl
+    nodeset: centos-9-crc-2-39-0-xxl
 - job:
     name: cifmw-molecule-sushy_emulator
-    nodeset: centos-9-crc-2-36-0-xl
+    nodeset: centos-9-crc-2-39-0-xl
 - job:
     name: cifmw-molecule-shiftstack
-    nodeset: centos-9-crc-2-36-0-xl
+    nodeset: centos-9-crc-2-39-0-xl

--- a/zuul.d/kuttl.yaml
+++ b/zuul.d/kuttl.yaml
@@ -1,7 +1,7 @@
 ---
 - job:
     name: cifmw-base-kuttl
-    nodeset: centos-9-crc-2-36-0-xxl
+    nodeset: centos-9-crc-2-39-0-xxl
     timeout: 5400
     abstract: true
     vars:

--- a/zuul.d/kuttl_multinode.yaml
+++ b/zuul.d/kuttl_multinode.yaml
@@ -4,7 +4,7 @@
     parent: cifmw-podified-multinode-edpm-base-crc
     timeout: 5400
     abstract: true
-    nodeset: centos-9-medium-crc-extracted-2-36-0-3xl
+    nodeset: centos-9-medium-crc-extracted-2-39-0-3xl
     vars:
       zuul_log_collection: true
     extra-vars:

--- a/zuul.d/molecule-base.yaml
+++ b/zuul.d/molecule-base.yaml
@@ -19,7 +19,7 @@
 
 - job:
     name: cifmw-molecule-base-crc
-    nodeset: centos-9-crc-2-36-0-xxl
+    nodeset: centos-9-crc-2-39-0-xxl
     parent: base-simple-crc
     provides:
       - cifmw-molecule

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -41,7 +41,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cert_manager
-    nodeset: centos-9-crc-2-36-0-xxl
+    nodeset: centos-9-crc-2-39-0-xxl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: cert_manager
@@ -66,7 +66,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_local_storage
-    nodeset: centos-9-crc-2-36-0-xl
+    nodeset: centos-9-crc-2-39-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: ci_local_storage
@@ -353,7 +353,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-env_op_images
-    nodeset: centos-9-crc-2-36-0-xl
+    nodeset: centos-9-crc-2-39-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: env_op_images
@@ -411,7 +411,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-install_openstack_ca
-    nodeset: centos-9-crc-2-36-0-3xl
+    nodeset: centos-9-crc-2-39-0-3xl
     parent: cifmw-molecule-base-crc
     timeout: 5400
     vars:
@@ -461,7 +461,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-manage_secrets
-    nodeset: centos-9-crc-2-36-0-xl
+    nodeset: centos-9-crc-2-39-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: manage_secrets
@@ -507,7 +507,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_login
-    nodeset: centos-9-crc-2-36-0-xl
+    nodeset: centos-9-crc-2-39-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: openshift_login
@@ -519,7 +519,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_obs
-    nodeset: centos-9-crc-2-36-0-xxl
+    nodeset: centos-9-crc-2-39-0-xxl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: openshift_obs
@@ -531,7 +531,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_provisioner_node
-    nodeset: centos-9-crc-2-36-0-xl
+    nodeset: centos-9-crc-2-39-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: openshift_provisioner_node
@@ -543,7 +543,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_setup
-    nodeset: centos-9-crc-2-36-0-xl
+    nodeset: centos-9-crc-2-39-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: openshift_setup
@@ -566,7 +566,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-operator_deploy
-    nodeset: centos-9-crc-2-36-0-xl
+    nodeset: centos-9-crc-2-39-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: operator_deploy
@@ -649,7 +649,7 @@
     - ^roles/dnsmasq/(?!meta|README).*
     - ^roles/networking_mapper/(?!meta|README).*
     name: cifmw-molecule-reproducer
-    nodeset: centos-9-crc-2-36-0-xxl
+    nodeset: centos-9-crc-2-39-0-xxl
     parent: cifmw-molecule-base
     timeout: 5400
     vars:
@@ -697,7 +697,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-shiftstack
-    nodeset: centos-9-crc-2-36-0-xl
+    nodeset: centos-9-crc-2-39-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: shiftstack
@@ -720,7 +720,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-sushy_emulator
-    nodeset: centos-9-crc-2-36-0-xl
+    nodeset: centos-9-crc-2-39-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: sushy_emulator


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSPRH-8665

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
