### PR TITLE
Update podified, tempest and tofu zuul jobs to CRC 2.39 - OCP 4.16

### DIFF
--- a/zuul.d/podified_multinode.yaml
+++ b/zuul.d/podified_multinode.yaml
@@ -12,7 +12,7 @@
     parent: cifmw-podified-multinode-edpm-base-crc
     timeout: 5400
     abstract: true
-    nodeset: centos-9-medium-crc-extracted-2-36-0-3xl
+    nodeset: centos-9-medium-crc-extracted-2-39-0-3xl
     run:
       - ci/playbooks/edpm/run.yml
     extra-vars:

--- a/zuul.d/tempest_multinode.yaml
+++ b/zuul.d/tempest_multinode.yaml
@@ -4,7 +4,7 @@
     parent: cifmw-podified-multinode-edpm-base-crc
     timeout: 5400
     abstract: true
-    nodeset: centos-9-medium-crc-extracted-2-36-0-3xl
+    nodeset: centos-9-medium-crc-extracted-2-39-0-3xl
     description: |
       Base multinode job definition for running test-operator.
     vars:

--- a/zuul.d/tofu.yaml
+++ b/zuul.d/tofu.yaml
@@ -6,7 +6,7 @@
       - ^ci/playbooks/molecule.*
       - ^ci_framework/playbooks/run_tofu.yml
     name: cifmw-molecule-tofu
-    nodeset: centos-9-crc-2-36-0-xl
+    nodeset: centos-9-crc-2-39-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: openshift_login


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSPRH-8665

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

Jobs to check:
- [x] [podified-multinode-ironic-deployment](https://review.rdoproject.org/zuul/build/fbd61984d8c74ffaa0b123a41b8f59e3)
- [x] cifmw-molecule-tofu - [Result](https://review.rdoproject.org/zuul/build/c4f416942d4a40c2adff0d197436c81b)
