### PR TITLE
Update cifmw-molecule-rhol_crc zuul job to CRC 2.39 - OCP 4.16

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -15,7 +15,7 @@
     nodeset: centos-9-crc-2-39-0-xl
 - job:
     name: cifmw-molecule-rhol_crc
-    nodeset: centos-9-crc-2-36-0-xxl #TODO(Lewis): Bump to 2-39 once OSPCIX-376 is resolved
+    nodeset: centos-9-crc-2-39-0-xxl
     timeout: 5400
 - job:
     name: cifmw-molecule-operator_deploy

--- a/roles/rhol_crc/defaults/main.yml
+++ b/roles/rhol_crc/defaults/main.yml
@@ -14,7 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_rhol_crc"
 
@@ -28,7 +27,7 @@ cifmw_rhol_crc_kubeadmin_pwd: 12345678
 cifmw_rhol_crc_dryrun: false
 
 # Binary variables:
-cifmw_rhol_crc_version: 2.36.0
+cifmw_rhol_crc_version: 2.39.0
 cifmw_rhol_crc_tarball_name: crc-linux-amd64.tar.xz
 cifmw_rhol_crc_tarball_checksum_name: crc-linux-amd64.tar.xz.sha256
 cifmw_rhol_crc_base_url: https://mirror.openshift.com/pub/openshift-v4/clients/crc/{{ cifmw_rhol_crc_version }}

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -662,7 +662,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-rhol_crc
-    nodeset: centos-9-crc-2-36-0-xxl
+    nodeset: centos-9-crc-2-39-0-xxl
     parent: cifmw-molecule-base
     timeout: 5400
     vars:


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSPRH-8665
Jira: https://issues.redhat.com/browse/OSPCIX-376

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
