### PR TITLE
Added cifmw_install_ca_urls var to pass multiple ca urls

### DIFF
--- a/roles/install_ca/README.md
+++ b/roles/install_ca/README.md
@@ -14,6 +14,7 @@ our capabilities to access remote package repositories, among possible targets.
 * `cifmw_install_ca_trust_dir`: (String) Directory where we put custom CA. Must be known by the update-ca-trust command. Defaults to `/etc/pki/ca-trust/source/anchors/`.
 * `cifmw_install_ca_update_cmd`: (String) Command to run in order to update the CA trust ring. Defaults to `update-ca-trust`.
 * `cifmw_install_ca_url`: (String) URL pointing to a CA bundle that will be stored in `cifmw_install_ca_trust_dir`.
+* `cifmw_install_ca_urls`: (List) A list of urls pointing to CA bundle that will be stored in `cifmw_install_ca_trust_dir`.
 * `cifmw_install_ca_url_validate_certs`: (Bool) Whether to validate SSL
 certificates when pulling a CA bundle from a url, will have no effect if
 `cifmw_install_ca_url` is not set.
@@ -38,6 +39,14 @@ certificates when pulling a CA bundle from a url, will have no effect if
 - name: Inject custom CA from url
   vars:
     cifmw_install_ca_url: https://dummyurl.com/ca_file.pem
+  ansible.builtin.include_role:
+    role: install_ca
+
+- name: Inject multiple custom CA from url
+  vars:
+    cifmw_install_ca_urls:
+      - https://dummyurl.com/ca_file.pem
+      - https://dummyurl.com/ca_bar.pem
   ansible.builtin.include_role:
     role: install_ca
 ```

--- a/roles/install_ca/tasks/main.yml
+++ b/roles/install_ca/tasks/main.yml
@@ -23,11 +23,19 @@
         state: directory
 
     - name: Install internal CA from url
-      when: cifmw_install_ca_url is defined
+      when: (cifmw_install_ca_url is defined) or (cifmw_install_ca_urls is defined)
+      vars:
+        cifmw_install_ca_urls: >-
+            {% if cifmw_install_ca_url is defined %}
+            "{{ cifmw_install_ca_urls | default([]) + [ cifmw_install_ca_url ] }}"
+            {% else %}
+            "{{ cifmw_install_ca_urls }}"
+            {% endif %}
       ansible.builtin.get_url:
-        url: "{{ cifmw_install_ca_url }}"
+        url: "{{ item }}"
         dest: "{{ cifmw_install_ca_trust_dir }}"
         validate_certs: "{{ cifmw_install_ca_url_validate_certs | default(omit) }}"
+      loop: "{{ cifmw_install_ca_urls }}"
 
     - name: Install custom CA bundle from inline
       register: ca_inline


### PR DESCRIPTION
Currently cifmw_install_ca_url takes a single url. What if an user wants to pass multiple ca urls then cifmw_install_ca_urls will help us to achieve that.
    
Since cifmw_install_ca_url is used already. So we are not removing it to avoid breakage.
    
It is just an improvement to the role to pass multiple ca urls.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
