### PR TITLE
Display debugging information in case of failure

### DIFF
--- a/roles/networking_mapper/tasks/main.yml
+++ b/roles/networking_mapper/tasks/main.yml
@@ -86,26 +86,51 @@
     content: "{{ _cifmw_networking_mapper_definition | to_nice_yaml }}"
     mode: '0644'
 
-- name: Call the networking mapper
-  cifmw.general.ci_net_map:
-    networking_definition: "{{ _cifmw_networking_mapper_definition }}"
-    interfaces_info: >-
-      {{
-        cifmw_networking_mapper_ifaces_info |
-        default(omit)
-      }}
-    search_domain_base: >-
-      {{
-        cifmw_networking_mapper_search_domain_base |
-        default(omit)
-      }}
-    interfaces_info_translations: >-
-      {{
-        cifmw_networking_mapper_interfaces_info_translations |
-        default(omit)
-      }}
-    full_map: "{{ cifmw_networking_mapper_full_map |  default(omit) }}"
-  register: _networking_mapper_out
+- name: Try/catch block
+  block:
+    - name: Call the networking mapper
+      cifmw.general.ci_net_map:
+        networking_definition: "{{ _cifmw_networking_mapper_definition }}"
+        interfaces_info: >-
+          {{
+            cifmw_networking_mapper_ifaces_info |
+            default(omit)
+          }}
+        search_domain_base: >-
+          {{
+            cifmw_networking_mapper_search_domain_base |
+            default(omit)
+          }}
+        interfaces_info_translations: >-
+          {{
+            cifmw_networking_mapper_interfaces_info_translations |
+            default(omit)
+          }}
+        full_map: "{{ cifmw_networking_mapper_full_map |  default(omit) }}"
+      register: _networking_mapper_out
+
+  rescue:
+    - name: Debug interfaces_info
+      ansible.builtin.debug:
+        var: cifmw_networking_mapper_ifaces_info
+
+    - name: Debug search_domain_base
+      ansible.builtin.debug:
+        var: search_domain_base
+
+    - name: Debug interfaces_info_translations
+      ansible.builtin.debug:
+        var: interfaces_info_translations
+
+    - name: Debug full_map
+      ansible.builtin.debug:
+        var: full_map
+
+    - name: Fail for good
+      ansible.builtin.fail:
+        msg: >-
+          Error detected while calling networking_mapper.
+          Check above debug outputs to fix your env.
 
 - name: Set networking mapper facts
   ansible.builtin.set_fact:


### PR DESCRIPTION
Until now, when the networking_mapper plugin failed, we didn't really
know anything about the data it was using.

This change uses the "bloc/rescue" capabilities in ansible to display
all of the passed parameters to the plugin in case of failure, making
debugging easier for everyone.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
