### PR TITLE
Add some more debugging to the network_assertion failures

### DIFF
--- a/roles/reproducer/tasks/network_assertions.yml
+++ b/roles/reproducer/tasks/network_assertions.yml
@@ -47,6 +47,39 @@
               defined networks. Those nets don't seem to be attached:
               {{ _defined | difference(_all_nets) }}
   rescue:
+    # We don't want it when cifmw_libvirt_manager_configuration_gen is
+    # defined: it could confuse people.
+    - name: Dump initial layout
+      when:
+        - cifmw_libvirt_manager_configuration_gen is undefined
+      ansible.builtin.debug:
+        var: cifmw_libvirt_manager_configuration
+
+    # This param exists only in case of CI reproducer run
+    # so it's expected to usually see it as "undefined" in
+    # the debugging output.
+    - name: Dump CI reproducer generated layout
+      when:
+        - cifmw_libvirt_manager_configuration_gen is defined
+      ansible.builtin.debug:
+        var: cifmw_libvirt_manager_configuration_gen
+
+    - name: Dump layout patches
+      vars:
+        _layout_patches: >-
+          {{
+            hostvars[inventory_hostname] |
+            dict2items |
+            selectattr("key", "match",
+                       "^cifmw_libvirt_manager_configuration_patch.*") |
+            sort(attribute='key')
+          }}
+      ansible.builtin.debug:
+        msg: "{{ item.value }}"
+      loop: "{{ _layout_patches }}"
+      loop_control:
+        label: "{{ item.key }}"
+
     - name: Dump built layout
       ansible.builtin.debug:
         var: _cifmw_libvirt_manager_layout


### PR DESCRIPTION
Having only the final built layout isn't enough whenever we want to
debug some weird situations.

This patch allows to see everything used to build that final layout:
- original configuration
- any applied "patches"
- even the CI reproducer generated layout

This should really help debugging any issues related to the networking
assertions.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
