### PR TITLE
Improve async status output for Zuul

### DIFF
--- a/roles/devscripts/tasks/main.yml
+++ b/roles/devscripts/tasks/main.yml
@@ -41,11 +41,20 @@
           (cifmw_devscripts_ocp_online | bool)
         )
       )
+  register: _devscripts_deploy
   community.general.make:
     chdir: "{{ cifmw_devscripts_repo_dir }}"
     target: "all"
   async: "{{ cifmw_devscripts_installer_timeout }}"
-  poll: 30
+  poll: 0
+
+- name: Check async deploy status
+  ansible.builtin.async_status:
+    jid: "{{ _devscripts_deploy.ansible_job_id }}"
+  register: _deploy_status
+  until: _deploy_status.finished
+  retries: "{{ (cifmw_devscripts_installer_timeout / 15) | int }}"
+  delay: 30
 
 - name: Executing dev-scripts post-install tasks.
   when:


### PR DESCRIPTION
It seems Zuul is buffering the async poll status, meaning the "hanging"
task shown in the job console is the one just before the actual deploy,
"Copy the configuration file."
It's slightly misleading and wrong.

This patch decouple the poll from the install task, and should therefore
display the right task in the console, even with the buffering.
The retries is computed based on the installation timeout.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
