### PR TITLE
Use dedicated edpm_kernel_hugepages var

### DIFF
--- a/roles/validations/tasks/edpm/hugepages_and_reboot.yml
+++ b/roles/validations/tasks/edpm/hugepages_and_reboot.yml
@@ -43,7 +43,7 @@
   cifmw.general.ci_script:
     output_dir: "{{ cifmw_validations_basedir }}/artifacts"
     script: >-
-      oc patch -n {{ cifmw_validations_namespace }} osdpns/"{{ deployed_nodeset_name.stdout | trim }}" --type=merge -p '{"spec": {"nodeTemplate": {"ansible": {"ansibleVars": {"edpm_kernel_args": "default_hugepagesz=1gb hugepagesz=1g hugepages=64 iommu=pt intel_iommu=on tsx=off isolcpus=2-11,14-23"}}}}}'
+      oc patch -n {{ cifmw_validations_namespace }} osdpns/"{{ deployed_nodeset_name.stdout | trim }}" --type=merge -p '{"spec": {"nodeTemplate": {"ansible": {"ansibleVars": {"edpm_kernel_hugepages": {"2048": {"count": 10, "default": true}, "4048": {"count": 10}}}}}}}'
 
 # loop check the status of the openstackdataplanenodeset until it is either SetupReady,
 # or reaches a defined timeout value.


### PR DESCRIPTION
This change switches from using the generic edpm_kernel_args variable to set hugepages, and instead uses the dedicated edpm_kernel_hugepages variable

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
