### PR TITLE
Copy gating repo to /etc/yum.repos.d to install tcib from it

### DIFF
--- a/ci/playbooks/meta_content_provider/meta_content_provider.yml
+++ b/ci/playbooks/meta_content_provider/meta_content_provider.yml
@@ -49,6 +49,15 @@
         - "'os-net-config' not in zuul_change_list"
         - _gating_repo.stat.exists
       block:
+        # It is needed to install built python-tcib package on the controller
+        - name: Populate gating repo in /etc/yum.repos.d
+          vars:
+            cifmw_repo_setup_output: "/etc/yum.repos.d"
+            content_provider_registry_ip: "{{ cifmw_rp_registry_ip }}"
+          ansible.builtin.include_role:
+            name: repo_setup
+            tasks_from: populate_gating_repo.yml
+
         - name: Build OpenStack services containers
           ansible.builtin.include_role:
             name: build_containers

--- a/roles/repo_setup/tasks/populate_gating_repo.yml
+++ b/roles/repo_setup/tasks/populate_gating_repo.yml
@@ -7,6 +7,7 @@
 
 - name: Construct gating repo
   when: _url_status.status == 200
+  become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"
   block:
     - name: Populate gating repo from content provider ip
       ansible.builtin.copy:


### PR DESCRIPTION
Currently gating repo is populated in ci-framework-data/artifacts/repositories directory. Duing container build process, we are installing tcib package using dlrn repo.
    
If a tcib change gets built on the host. tcib rpm under test will not get installed on the host leaving untested code.
In order to fix that. This pr generates the gating repo in /etc/yum.repos.d directory and installs it.
    
It also modifies the repo setup gating repo tasks to use become:true when /etc/yum.repos.d is used.

As a pull request owner and reviewers, I checked that:
- [x] [test results](https://github.com/openstack-k8s-operators/ci-framework/pull/2115#issuecomment-2251806211)
