### PR TITLE
[test-operator] Expose extraConfigmapsMounts param

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -38,6 +38,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_tempest_extra_images`: (List) A list of images that should be uploaded to OpenStack before the tests are executed. The value is passed to extraImages parameter in the [Tempest CR](https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource). Default value: `[]`
 * `cifmw_test_operator_tempest_network_attachments`: (List) List of network attachment definitions to attach to the tempest pods spawned by test-operator. Default value: `[]`.
 * `cifmw_test_operator_tempest_extra_rpms`: (List) . A list of URLs that point to RPMs that should be installed before the execution of tempest. Note that this parameter has no effect when `cifmw_test_operator_tempest_external_plugin` is used. Default value: `[]`
+* `cifmw_test_operator_tempest_extra_configmaps_mounts`: (List) A list of configmaps that should be mounted into the tempest test pods. Default value: `[]`
 * `cifmw_test_operator_tempest_config`: (Object) Definition of Tempest CRD instance that is passed to the test-operator (see [the test-operator documentation](https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource)). Default value:
 ```
   apiVersion: test.openstack.org/v1beta1

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -98,6 +98,7 @@ cifmw_test_operator_tempest_config:
     networkAttachments: "{{ cifmw_test_operator_tempest_network_attachments }}"
     tolerations: "{{ cifmw_test_operator_tolerations | default(omit) }}"
     nodeSelector: "{{ cifmw_test_operator_node_selector | default(omit) }}"
+    extraConfigmapsMounts: "{{ cifmw_test_operator_tempest_extra_configmaps_mounts | default(omit) }}"
     tempestRun:
       includeList: |
         {{ cifmw_test_operator_tempest_include_list | default('') }}


### PR DESCRIPTION
This PR in test-operator [1] introduced extraConfigmapsMounts param for the Tempest CR. Let's expose this new parameter in the test-operator role.

[1] https://github.com/openstack-k8s-operators/test-operator/pull/126

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
