### PR TITLE
Improve DHCP configuration in dnsmasq

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -4,6 +4,7 @@
     files:
       - ^roles/dnsmasq/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
       - ^roles/networking_mapper/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+    timeout: 3600
 - job:
     name: cifmw-molecule-openshift_login
     nodeset: centos-9-crc-2-39-0-xl

--- a/roles/dnsmasq/README.md
+++ b/roles/dnsmasq/README.md
@@ -159,24 +159,29 @@ supported in libvirt).
 
 ### New host parameters
 
-* `cifmw_dnsmasq_host_network`: (String) Existing network name.
-* `cifmw_dnsmasq_host_state`: (String) Host status. Must be either `present` or `absent`.
-* `cifmw_dnsmasq_host_mac`: (String) Host MAC address.
-* `cifmw_dnsmasq_host_ips`: (List) Host IP addressees.
-* `cifmw_dnsmasq_host_name`: (String) Host name. Optional.
+* `cifmw_dnsmasq_dhcp_entries`: (List[mapping]) List of DHCP entries.
+
+### DHCP entry mapping
+
+* `state`: (String) Entry status. Must be either `present` or `absent`. Defaults to `present`
+* `network`: (String) Entry network. Must already exist in dnsmasq. Mandatory.
+* `mac`: (String) Entry MAC address. Mandatory.
+* `ips`: (List[string]) List of IP addresses associated to the MAC (v4, v6). Mandatory.
+* `name`: (String) Host name. Optional.
 
 #### Examples
 
 ```yaml
     - name: Inject some node in starwars network
       vars:
-        cifmw_dnsmasq_host_network: starwars
-        cifmw_dnsmasq_host_state: present
-        cifmw_dnsmasq_host_mac: "0a:19:02:f8:4c:a7"
-        cifmw_dnsmasq_host_ips:
-          - "2345:0425:2CA1::0567:5673:cafe"
-          - "192.168.254.11"
-        cifmw_dnsmasq_host_name: r2d2
+        cifmw_dnsmasq_dhcp_entries:
+          - network: starwars
+            state: present
+            mac: "0a:19:02:f8:4c:a7"
+            ips:
+              - "2345:0425:2CA1::0567:5673:cafe"
+              - "192.168.254.11"
+            name: r2d2
       ansible.builtin.include_role:
         name: dnsmasq
         tasks_from: manage_host.yml

--- a/roles/dnsmasq/molecule/default/converge.yml
+++ b/roles/dnsmasq/molecule/default/converge.yml
@@ -120,34 +120,30 @@
 
     - name: Inject some node in starwars network
       vars:
-        cifmw_dnsmasq_host_network: "{{ item.net }}"
-        cifmw_dnsmasq_host_state: "{{ item.state }}"
-        cifmw_dnsmasq_host_mac: "{{ item.mac }}"
-        cifmw_dnsmasq_host_ips:
-          - "{{ item.ipv6 }}"
-          - "{{ item.ipv4 }}"
-        cifmw_dnsmasq_host_name: "{{ item.name | default(null) }}"
+        cifmw_dnsmasq_dhcp_entries:
+          - network: starwars
+            state: present
+            mac: "0a:19:02:f8:4c:a7"
+            ips:
+              - "2345:0425:2CA1::0567:5673:cafe"
+              - "192.168.254.11"
+          - network: starwars
+            state: present
+            mac: "0a:19:02:f8:4c:a8"
+            ips:
+              - "2345:0425:2CA1::0567:5673:babe"
+              - "192.168.254.12"
+            name: "solo"
+          - network: startrek
+            state: present
+            mac: "0a:19:02:f8:4c:a8"
+            ips:
+              - "2345:0426:2CA1::0567:5673:babe"
+              - "192.168.253.12"
+            name: "spock"
       ansible.builtin.include_role:
         name: dnsmasq
         tasks_from: manage_host.yml
-      loop:
-        - net: starwars
-          state: present
-          mac: "0a:19:02:f8:4c:a7"
-          ipv6: "2345:0425:2CA1::0567:5673:cafe"
-          ipv4: "192.168.254.11"
-        - net: starwars
-          state: present
-          mac: "0a:19:02:f8:4c:a8"
-          ipv6: "2345:0425:2CA1::0567:5673:babe"
-          ipv4: "192.168.254.12"
-          name: "solo"
-        - net: startrek
-          state: present
-          mac: "0a:19:02:f8:4c:a8"
-          ipv6: "2345:0426:2CA1::0567:5673:babe"
-          ipv4: "192.168.253.12"
-          name: "spock"
 
     - name: Add a domain specific forwarder
       vars:

--- a/roles/dnsmasq/tasks/_check_net_status.yml
+++ b/roles/dnsmasq/tasks/_check_net_status.yml
@@ -1,0 +1,18 @@
+---
+# Check if network is known in our dnsmasq instance
+- name: Check network file status
+  register: _network_exists
+  ansible.builtin.stat:
+    path: "{{ cifmw_dnsmasq_basedir }}/{{ net_name }}.conf"
+    get_attributes: false
+    get_checksum: false
+    get_mime: false
+
+- name: Assert network exists
+  ansible.builtin.assert:
+    that:
+      - _network_exists.stat.exists
+    quiet: true
+    msg: >-
+      You must create {{ net_name }} network first, calling
+      dnsmasq/manage_network.yml task.

--- a/roles/dnsmasq/tasks/manage_host.yml
+++ b/roles/dnsmasq/tasks/manage_host.yml
@@ -14,72 +14,100 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Ensure we have the right data and type
+  ansible.builtin.assert:
+    that:
+      - cifmw_dnsmasq_dhcp_entries is defined
+      - (cifmw_dnsmasq_dhcp_entries | type_debug) == 'list'
+    quiet: true
+    msg: >-
+      Error: cifmw_dnsmasq_dhcp_entries must be a dict. Check
+      documentation for proper format.
+
 - name: Assert we have needed host data
   ansible.builtin.assert:
     quiet: true
     that:
-      - cifmw_dnsmasq_host_network is defined
-      - cifmw_dnsmasq_host_state is defined
-      - cifmw_dnsmasq_host_state in ['present', 'absent']
-      - cifmw_dnsmasq_host_mac is defined
-      - cifmw_dnsmasq_host_ips is defined
+      - (entry | type_debug) == 'dict'
+      - entry.network is defined
+      - (entry.state | default('present')) in ['present', 'absent']
+      - entry.mac is defined
+      - entry.ips is defined
+  loop: "{{ cifmw_dnsmasq_dhcp_entries }}"
+  loop_control:
+    loop_var: entry
 
-- name: Check network file status
-  register: _network_exists
-  ansible.builtin.stat:
-    path: "{{ cifmw_dnsmasq_basedir }}/{{ cifmw_dnsmasq_host_network }}.conf"
-    get_attributes: false
-    get_checksum: false
-    get_mime: false
+- name: Ensure networks exists
+  vars:
+    _nets: >-
+      {{
+        cifmw_dnsmasq_dhcp_entries | map(attribute='network') | unique
+      }}
+  ansible.builtin.include_tasks: _check_net_status.yml
+  loop: "{{ _nets }}"
+  loop_control:
+    loop_var: net_name
 
-- name: Assert network exists
-  ansible.builtin.assert:
-    that:
-      - _network_exists.stat.exists
-    quiet: true
-    msg: >-
-      You must create {{ cifmw_dnsmasq_host_network }} network first, calling
-      dnsmasq/manage_network.yml task.
+- name: Initialize empty dhcp_host_entries
+  ansible.builtin.set_fact:
+    dhcp_host_entries: []
 
 - name: Compute entry
-  ansible.builtin.set_fact:
-    _host_entry: >
-      {% set data = [cifmw_dnsmasq_host_mac]                                                  -%}
-      {% for ip in cifmw_dnsmasq_host_ips if ip is not none and ip | length > 0               -%}
-      {% set _ = data.append(ip | ansible.utils.ipwrap)                                       -%}
-      {% endfor                                                                               -%}
-      {% set _ = data.append(cifmw_dnsmasq_host_name) if
-                 cifmw_dnsmasq_host_name is defined and cifmw_dnsmasq_host_name | length > 0  -%}
+  vars:
+    _state: "{{ entry.state | default('present') }}"
+    _fname: >-
+      {%- set data = [entry.network] -%}
+      {%- set _ = data.append(entry.name) if
+                  entry.name is defined and entry.name | length > 0 -%}
+      {%- set _ = data.append(entry.mac) -%}
+      {{ data | join('_') }}
+    _entry: >-
+      {% set data = [entry.mac]                                     -%}
+      {% for ip in entry.ips if ip is not none and ip | length > 0  -%}
+      {% set _ = data.append(ip | ansible.utils.ipwrap)             -%}
+      {% endfor                                                     -%}
+      {% set _ = data.append(entry.name) if
+                 entry.name is defined and entry.name | length > 0  -%}
       {{ data | join(',') }}
+  ansible.builtin.set_fact:
+    dhcp_host_entries: >-
+      {{
+        dhcp_host_entries + [{'file': _fname, 'entry': _entry, 'state': _state}]
+      }}
+  loop: "{{ cifmw_dnsmasq_dhcp_entries }}"
+  loop_control:
+    loop_var: entry
 
-- name: Debug _host_entry
-  ansible.builtin.debug:
-    var: _host_entry
+- name: Create add/remove sets
+  ansible.builtin.set_fact:
+    _dhcp_add: >-
+      {{
+        dhcp_host_entries | selectattr('state', 'equalto', 'present')
+      }}
+    _dhcp_remove: >-
+      {{
+        dhcp_host_entries | selectattr('state', 'equalto', 'absent')
+      }}
 
-- name: Manage host entry - add
+- name: Add DHCP entries
   become: true
   notify: Reload dnsmasq
-  when:
-    - cifmw_dnsmasq_host_state == 'present'
-  vars:
-    _fname: >-
-      {%- set data = [cifmw_dnsmasq_host_network] -%}
-      {%- set _ = data.append(cifmw_dnsmasq_host_name) if
-                  cifmw_dnsmasq_host_name is defined and cifmw_dnsmasq_host_name | length > 0 -%}
-      {%- set _ = data.append(cifmw_dnsmasq_host_mac) -%}
-      {{ data | join('_') }}
   ansible.builtin.copy:
-    content: "{{ _host_entry }}"
-    dest: "{{ cifmw_dnsmasq_basedir }}/dhcp-hosts.d/{{ _fname }}"
+    content: "{{ entry.entry }}"
+    dest: "{{ cifmw_dnsmasq_basedir }}/dhcp-hosts.d/{{ entry.file }}"
     mode: '0644'
     owner: root
     group: root
+  loop: "{{ _dhcp_add }}"
+  loop_control:
+    loop_var: entry
 
-- name: Manage host entry - remove
+- name: Remove DHCP entries
   become: true
-  when:
-    - cifmw_dnsmasq_host_state == 'absent'
   notify: Restart dnsmasq
   ansible.builtin.file:
     state: absent
-    path: "{{ cifmw_dnsmasq_basedir }}/dhcp-hosts.d/{{ cifmw_dnsmasq_host_mac }}"
+    path: "{{ cifmw_dnsmasq_basedir }}/dhcp-hosts.d/{{ entry.file }}"
+  loop: "{{ _dhcp_remove }}"
+  loop_control:
+    loop_var: entry

--- a/roles/libvirt_manager/molecule/generate_network_data/tasks/test.yml
+++ b/roles/libvirt_manager/molecule/generate_network_data/tasks/test.yml
@@ -71,22 +71,24 @@
 
         - name: Ensure files exist
           vars:
-            matcher: ".*/{{ item }}.*"
+            matcher: "^{{ item }}.*"
+            matched: >-
+              {{
+                _dhcp_files.files |
+                map(attribute='path') |
+                map('basename') |
+                select('match', matcher)
+              }}
           ansible.builtin.assert:
             quiet: true
             that:
-              - _dhcp_files.files |
-                selectattr('path', 'match', matcher) |
-                length == 1
+              - (matched | length) == 1
             msg: >-
-              {{ item }} is missing
+              {{ item }} appears {{ matched | length }} times
+              {{ matched | join(', ') }}
           loop: "{{ scenario.check_dhcp }}"
 
       rescue:
-        - name: Output found files
-          ansible.builtin.debug:
-            msg: "{{ _dhcp_files.files }}"
-
         - name: Mark run as failed
           ansible.builtin.set_fact:
             _run_fail: true

--- a/roles/libvirt_manager/tasks/create_dns_records.yml
+++ b/roles/libvirt_manager/tasks/create_dns_records.yml
@@ -1,4 +1,8 @@
 ---
+- name: Initialize empty _lm_dhcp_entries fact
+  ansible.builtin.set_fact:
+    _lm_dhcp_entries: []
+
 # We match ^ctlplane networks mostly for the DCN case,
 # where they have multiple ctlplane networks in the form:
 # ctlplane_dcn1
@@ -14,6 +18,13 @@
       loop_control:
         loop_var: "net_name"
         label: "{{ net_name }}"
+
+    - name: "Inject DHCP entries for net {{ net_name }}"
+      vars:
+        cifmw_dnsmasq_dhcp_entries: "{{ _lm_dhcp_entries }}"
+      ansible.builtin.include_role:
+        name: "dnsmasq"
+        tasks_from: "manage_host.yml"
 
     - name: Create per-network and .utility DNS entries
       vars:

--- a/roles/libvirt_manager/tasks/reserve_dnsmasq_ips.yml
+++ b/roles/libvirt_manager/tasks/reserve_dnsmasq_ips.yml
@@ -38,26 +38,30 @@
             (host_data.key is match('^ocp.*')) |
             ternary(_ocp_name, host_data.key)
           }}
-        cifmw_dnsmasq_host_network: "{{ _translated_name }}"
-        cifmw_dnsmasq_host_name: "{{ _hostname }}"
-        cifmw_dnsmasq_host_state: 'present'
-        cifmw_dnsmasq_host_mac: "{{ _net_data.mac_addr }}"
-        cifmw_dnsmasq_host_ips: >-
-          {{
-            [
-              _net_data.ip_v4 | default(''),
-              _net_data.ip_v6 | default('')
-            ]
-          }}
-      ansible.builtin.include_role:
-        name: "dnsmasq"
-        tasks_from: "manage_host.yml"
+        _host:
+          network: "{{ _translated_name }}"
+          name: "{{ _hostname }}"
+          state: 'present'
+          mac: "{{ _net_data.mac_addr }}"
+          ips: >-
+            {{
+              [
+                _net_data.ip_v4 | default(''),
+                _net_data.ip_v6 | default('')
+              ]
+            }}
+      ansible.builtin.set_fact:
+        _lm_dhcp_entries: "{{ _lm_dhcp_entries + [_host] }}"
       loop: "{{ cifmw_networking_env_definition.instances | dict2items }}"
       loop_control:
         label: "{{ host_data.key }} - {{ net_name }}"
         loop_var: "host_data"
 
   rescue:
+    - name: Debug built entries
+      ansible.builtin.debug:
+        var: _lm_dhcp_entries
+
     - name: Debug _rev_translate
       ansible.builtin.debug:
         var: _rev_translate

--- a/roles/reproducer/tasks/ocp_layout.yml
+++ b/roles/reproducer/tasks/ocp_layout.yml
@@ -289,19 +289,20 @@
 
         - name: Inject bootstrap VM mac and fixed IP
           vars:
-            cifmw_dnsmasq_host_network: "{{ cifmw_libvirt_manager_pub_net }}"
-            cifmw_dnsmasq_host_state: present
-            cifmw_dnsmasq_host_mac: "{{ _bootstrap_mac }}"
-            cifmw_dnsmasq_host_name: "ocp-bootstrap"
-            cifmw_dnsmasq_host_ips: >-
-              {%- set data = [] -%}
-              {%- if _pub_net_data.network_v4 is defined and _pub_net_data.network_v4 | length > 0 -%}
-              {%- set _ = data.append(_pub_net_data.network_v4 | ansible.utils.nthhost(4)) -%}
-              {%- endif -%}
-              {%- if _pub_net_data.network_v6 is defined and _pub_net_data.network_v6 | length > 0 -%}
-              {%- set _ = data.append(_pub_net_data.network_v6 | ansible.utils.nthhost(4)) -%}
-              {%- endif -%}
-              {{ data }}
+            cifmw_dnsmasq_dhcp_entries:
+              - network: "{{ cifmw_libvirt_manager_pub_net }}"
+                state: present
+                mac: "{{ _bootstrap_mac }}"
+                name: "ocp-bootstrap"
+                ips: >-
+                  {%- set data = [] -%}
+                  {%- if _pub_net_data.network_v4 is defined and _pub_net_data.network_v4 | length > 0 -%}
+                  {%- set _ = data.append(_pub_net_data.network_v4 | ansible.utils.nthhost(4)) -%}
+                  {%- endif -%}
+                  {%- if _pub_net_data.network_v6 is defined and _pub_net_data.network_v6 | length > 0 -%}
+                  {%- set _ = data.append(_pub_net_data.network_v6 | ansible.utils.nthhost(4)) -%}
+                  {%- endif -%}
+                  {{ data }}
           ansible.builtin.include_role:
             name: "dnsmasq"
             tasks_from: "manage_host.yml"

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -451,6 +451,7 @@
     - ^roles/networking_mapper/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
     name: cifmw-molecule-libvirt_manager
     parent: cifmw-molecule-base
+    timeout: 3600
     vars:
       TEST_RUN: libvirt_manager
 - job:


### PR DESCRIPTION
Until now, we were doing far too many things far too many times for
nothing: check if the networks exists, check dataset consistency, etc,
etc.

All of that takes time, far too much time for little added value.

This patch switches to "batch": we can pass a list with all the
requested DHCP entries, and the tasks will loop on that data set.

This allows to check networks only once per set, and leverage faster
treatment, making a bigger difference as we add more nodes to the
layout.

We also bump the libvirt_manager molecule timeout to 1h, the
initial/default 30 minutes seems to be a little bit too tight with the
amount of new checks added lately.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
