### PR TITLE
Skip building the horizontest container

### DIFF
--- a/roles/build_containers/defaults/main.yml
+++ b/roles/build_containers/defaults/main.yml
@@ -45,6 +45,17 @@ cifmw_build_containers_cleanup: false
 # Install tcib from source
 cifmw_build_containers_install_from_source: false
 
+cifmw_build_containers_exclude_containers:
+  master:
+    centos9:
+      - horizontest
+  antelope:
+    centos9:
+      - horizontest
+  rhos18:
+    rhel9:
+      - horizontest
+
 # Downstream only variables:
 #
 # cifmw_build_containers_rhel_modules

--- a/roles/build_containers/molecule/default/converge.yml
+++ b/roles/build_containers/molecule/default/converge.yml
@@ -19,7 +19,6 @@
   hosts: all
   vars:
     cifmw_build_containers_cleanup: true
-    cifmw_build_containers_install_from_source: true
     cifmw_build_containers_config_file: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/roles/build_containers/files/containers.yaml"
   roles:
     - role: "build_containers"


### PR DESCRIPTION
As we are facing issue [1] to build the horizontest conatiner while building the tcib container.

[1]: https://issues.redhat.com/browse/OSPCIX-378

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
