### PR TITLE
[BGP] Add octavia routes to network-values template

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/network-values/values.yaml.j2
@@ -124,6 +124,16 @@ data:
         "ipam": {
           "type": "whereabouts",
           "range": "{{ network.network_v4 }}",
+{%  if network.network_name == "octavia" and network.tools.multus.ipv4_routes | default([]) | length > 0 %}
+          "routes": [
+{%  for route in network.tools.multus.ipv4_routes %}
+             {
+               "dst": "{{ route.destination }}",
+               "gw": "{{ route.gateway }}"
+             }{% if not loop.last %},{% endif %}
+{%  endfor %}
+           ],
+{%  endif %}
           "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
           "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}"
         }


### PR DESCRIPTION
Apply the same changes from [1] to bgp_dt01 templates.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/1756

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
