### PR TITLE
Do not edit sensitive data set in machineconfig

### DIFF
--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -117,6 +117,8 @@
               chown -R "{{ ansible_user }}" libvirt
               chown "{{ ansible_user }}" *
               cp /etc/containers/registries.conf {{ ansible_user_dir }}/zuul-output/logs/
+              cp -r /etc/containers/registries.conf.d {{ ansible_user_dir }}/zuul-output/logs/
+              chown -R "{{ ansible_user }}" {{ ansible_user_dir }}/zuul-output/logs/registries.conf.d
 
         - name: Copy generated documentation if available
           when:

--- a/ci/playbooks/tasks/set_crc_insecure_registry.yml
+++ b/ci/playbooks/tasks/set_crc_insecure_registry.yml
@@ -27,12 +27,19 @@
     }
     }' image.config.openshift.io/cluster
 
+- name: Ensure registries.conf.d exists
+  become: true
+  ansible.builtin.file:
+    path: /etc/containers/registries.conf.d
+    state: directory
+
 - name: Set Insecure registry for content provider
   become: true
   ansible.builtin.blockinfile:
     state: present
     insertafter: EOF
-    dest: /etc/containers/registries.conf
+    dest: /etc/containers/registries.conf.d/99-insecure-registry.conf
+    create: true
     content: |-
       [[registry]]
       location = "{{ content_provider_registry_ip }}:5001"

--- a/roles/registry_deploy/tasks/main.yml
+++ b/roles/registry_deploy/tasks/main.yml
@@ -57,6 +57,12 @@
     - "nft insert rule ip filter INPUT tcp dport {{ cifmw_rp_registry_port }} counter accept"
   changed_when: true
 
+- name: Ensure registries.conf.d exists
+  become: true
+  ansible.builtin.file:
+    path: /etc/containers/registries.conf.d
+    state: directory
+
 - name: Add the local registry to unqualified-search-registries
   become: true
   tags:
@@ -64,7 +70,8 @@
   ansible.builtin.blockinfile:
     state: present
     insertafter: EOF
-    dest: /etc/containers/registries.conf
+    dest: /etc/containers/registries.conf.d/99-local-registry.conf
+    create: true
     content: |-
       [[registry]]
       location = "{{ cifmw_rp_registry_ip }}:{{ cifmw_rp_registry_port }}"


### PR DESCRIPTION
By editing the sensitive data for the OpenShift, later the machineconfig daemon will set the node as degraded, so later the operations that we would like to be done via machineconfig manifests, will be not triggered.
Some projects are using the machineconfig manifests to configure the host, not directly by using the Ansible.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running

