### PR TITLE
[test-operator] Enable creation of multiple PVCs

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -33,6 +33,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_tempest_external_plugin`: (List) List of dicts describing any external plugin to be installed. The dictionary contains a repository, changeRepository (optional) and changeRefspec (optional). Default value: `[]`
 * `cifmw_test_operator_tempest_tests_include_override_scenario`: (Boolean) Whether to override the scenario `cifmw_test_operator_tempest_include_list` definition. Default value: `false`
 * `cifmw_test_operator_tempest_tests_exclude_override_scenario`: (Boolean) Whether to override the scenario `cifmw_test_operator_tempest_exclude_list` definition. Default value: `false`
+* `cifmw_test_operator_tempest_parallel`: (Boolean) Enable parallel execution of steps in workflow. Default value: `false`
 * `cifmw_test_operator_tempest_ssh_key_secret_name`: (String) Name of a secret that contains ssh-privatekey field with a private key. The private key is mounted to `/var/lib/tempest/.ssh/id_ecdsa`
 * `cifmw_test_operator_tempest_config_overwrite`: (Dict) Dictionary where key is name of a file and value is content of the file. All files mentioned in this field are mounted to `/etc/test_operator/<filename>`
 * `cifmw_test_operator_tempest_workflow`: (List) Definition of a Tempest workflow that consists of multiple steps. Each step can contain all values from Spec section of [Tempest CR](https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource).

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -94,6 +94,7 @@ cifmw_test_operator_tempest_config:
   spec:
     containerImage: "{{ cifmw_test_operator_tempest_image }}:{{ cifmw_test_operator_tempest_image_tag }}"
     storageClass: "{{ cifmw_test_operator_storage_class }}"
+    parallel: "{{ cifmw_test_operator_tempest_parallel | default(omit) }}"
     SSHKeySecretName: "{{ cifmw_test_operator_tempest_ssh_key_secret_name | default(omit) }}"
     configOverwrite: "{{ cifmw_test_operator_tempest_config_overwrite | default(omit) }}"
     networkAttachments: "{{ cifmw_test_operator_tempest_network_attachments }}"

--- a/roles/test_operator/tasks/run-test-operator-job.yml
+++ b/roles/test_operator/tasks/run-test-operator-job.yml
@@ -67,7 +67,7 @@
     - not cifmw_test_operator_dry_run | bool
     - not testjob_timed_out
   block:
-    - name: Get information about PVC that stores the logs
+    - name: Get information about PVCs that store the logs
       kubernetes.core.k8s_info:
         kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
         api_key: "{{ cifmw_openshift_token | default(omit)}}"
@@ -75,7 +75,30 @@
         kind: PersistentVolumeClaim
         label_selectors:
           - "instanceName={{ test_operator_job_name }}"
-      register: logsPVC
+      register: logsPVCs
+
+    - name: Set up volume mounts and volumes for all PVCs
+      ansible.builtin.set_fact:
+        volume_mounts: >
+          {{
+            (volume_mounts | default([])) + [{
+              'name': "logs-volume-" ~ index,
+              'mountPath': "/mnt/logs-{{ test_operator_job_name }}-step-" ~ index
+            }]
+          }}
+        volumes: >
+          {{
+            (volumes | default([])) + [{
+              'name': "logs-volume-" ~ index,
+              'persistentVolumeClaim': {
+                'claimName': pvc.metadata.name
+              }
+            }]
+          }}
+      loop: "{{ logsPVCs.resources }}"
+      loop_control:
+        loop_var: pvc
+        index_var: index
 
     - name: Start test-operator-logs-pod
       kubernetes.core.k8s:
@@ -95,13 +118,8 @@
                 image: "{{ cifmw_test_operator_logs_image }}"
                 command: ["sleep"]
                 args: ["infinity"]
-                volumeMounts:
-                  - name: logs-volume
-                    mountPath: /mnt
-            volumes:
-              - name: logs-volume
-                persistentVolumeClaim:
-                  claimName: "{{ logsPVC.resources[0].metadata.name }}"
+                volumeMounts: "{{ volume_mounts }}"
+            volumes: "{{ volumes }}"
             tolerations: "{{ cifmw_test_operator_tolerations | default(omit) }}"
 
     - name: Ensure that the test-operator-logs-pod is Running


### PR DESCRIPTION
This patch enables the creation of multiple PVCs when there are multiple steps in workflow and parallel option is set to true. This change is needed, because the LVM backed storage does not support the RWX, which causes issues in some cases.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes