### PR TITLE
Add option to deploy Ceph with encryption enabled

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -270,6 +270,7 @@ lookups
 loopback
 losetup
 lsblk
+luks
 lv
 lvm
 lvmcluster

--- a/roles/cifmw_ceph_spec/README.md
+++ b/roles/cifmw_ceph_spec/README.md
@@ -28,6 +28,10 @@ None
   which is created by the `cifmw_block_device` role)
 * `cifmw_ceph_spec_path`: path of the rendered spec file (default
   `/tmp/ceph_spec.yml`)
+* `cifmw_ceph_spec_encryption`: Produce an initial Ceph configuration
+  file with both over-the-wire
+  ([msgr2 secure mode](https://docs.ceph.com/en/latest/rados/configuration/msgr2/))
+  and on-disk (LUKS and dm-crypt) encryption enabled (default: `false`).
 
 ## Examples
 

--- a/roles/cifmw_ceph_spec/defaults/main.yml
+++ b/roles/cifmw_ceph_spec/defaults/main.yml
@@ -36,3 +36,6 @@ cifmw_ceph_spec_path_initial_conf: /tmp/initial_ceph.conf
 # Defaults set so role works without network isolation
 cifmw_ceph_spec_public_network: 192.168.122.0/24
 cifmw_ceph_spec_private_network: ''
+
+# Enable over-the-wire and on-disk encryption
+cifmw_ceph_spec_encryption: false

--- a/roles/cifmw_ceph_spec/templates/ceph_spec.yml.j2
+++ b/roles/cifmw_ceph_spec/templates/ceph_spec.yml.j2
@@ -37,6 +37,9 @@ data_devices:
   - /dev/ceph_vg{{ i }}/ceph_lv{{ i }}
 {% endfor %}
 {% endif %}
+{% if cifmw_ceph_spec_encryption %}
+encrypted: true
+{% endif %}
 placement:
   hosts:
 {% for key, value in cifmw_ceph_spec_host_to_ip.items() %}

--- a/roles/cifmw_ceph_spec/templates/initial_ceph.conf.j2
+++ b/roles/cifmw_ceph_spec/templates/initial_ceph.conf.j2
@@ -1,4 +1,12 @@
 [global]
+{% if cifmw_ceph_spec_encryption %}
+ms_client_mode = secure
+ms_cluster_mode = secure
+ms_service_mode = secure
+ms_mon_client_mode = secure
+ms_mon_cluster_mode = secure
+ms_mon_service_mode = secure
+{% endif %}
 osd pool default size = 1
 {% if cifmw_ceph_spec_public_network %}
 public_network = {{ cifmw_ceph_spec_public_network }}


### PR DESCRIPTION
The `cifmw_ceph_spec_encryption` boolean has been added to the `cifmw_ceph_spec` role. When true, the initial Ceph configuration file (which is assimilated on bootstrap) has all six msgr2 options set to `secure` for over-the-wire encryption. At rest encryption is also enabled with LUKS and dm-crypt because the `encrypted: true` option will be set in the Ceph service specification.

Jira: https://issues.redhat.com/browse/OSPRH-8822

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
