### PR TITLE
Collect os-must-gather logs from openshift-marketplace namespace

### DIFF
--- a/roles/os_must_gather/defaults/main.yml
+++ b/roles/os_must_gather/defaults/main.yml
@@ -23,7 +23,7 @@ cifmw_os_must_gather_image_registry: "quay.rdoproject.org/openstack-k8s-operator
 cifmw_os_must_gather_output_dir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_os_must_gather_repo_path: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/openstack-must-gather"
 cifmw_os_must_gather_timeout: "10m"
-cifmw_os_must_gather_additional_namespaces: "kuttl,openshift-storage,sushy-emulator"
+cifmw_os_must_gather_additional_namespaces: "kuttl,openshift-storage,openshift-marketplace,sushy-emulator"
 cifmw_os_must_gather_namespaces:
   - openstack-operators
   - openstack


### PR DESCRIPTION
It will help us to debug issues related to openshift-marketplace namespace.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

