### PR TITLE
[openshift_setup] Metal3 watch all NSs

### DIFF
--- a/roles/openshift_setup/README.md
+++ b/roles/openshift_setup/README.md
@@ -26,3 +26,4 @@ effect if `cifmw_openshift_setup_ca_registry_to_add` is set.
             mirrors:
               - mirror.quay.rdoproject.org
         ```
+* `cifmw_openshift_setup_metal3_watch_all_ns`: (Boolean) Tells Metal3 BMO to watch resources out of its namespace. Defaults to `false`.

--- a/roles/openshift_setup/defaults/main.yml
+++ b/roles/openshift_setup/defaults/main.yml
@@ -24,3 +24,4 @@ cifmw_openshift_setup_skip_internal_registry: false
 cifmw_openshift_setup_skip_internal_registry_tls_verify: false
 cifmw_openshift_setup_ca_bundle_path: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
 cifmw_openshift_setup_digest_mirrors: []
+cifmw_openshift_setup_metal3_watch_all_ns: false

--- a/roles/openshift_setup/tasks/main.yml
+++ b/roles/openshift_setup/tasks/main.yml
@@ -183,6 +183,10 @@
       spec:
         repositoryDigestMirrors: "{{ cifmw_openshift_setup_digest_mirrors }}"
 
+- name: Metal3 tweaks
+  when: not cifmw_openshift_setup_dry_run
+  ansible.builtin.include_tasks: metal3_config.yml
+
 - name: Patch network operator when using OVNKubernetes backend
   ansible.builtin.import_tasks: patch_network_operator.yml
 

--- a/roles/openshift_setup/tasks/metal3_config.yml
+++ b/roles/openshift_setup/tasks/metal3_config.yml
@@ -1,0 +1,21 @@
+- name: Make Metal3 watch all namespaces
+  when:
+    - cifmw_openshift_setup_metal3_watch_all_ns | bool
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  block:
+    - name: Fetch Metal3 configuration name
+      ansible.builtin.command:
+        cmd: "oc get Provisioning -o name"
+      register: _cifmw_openshift_setup_provisioning_name
+      changed_when: false
+
+    - name: Apply the patch to Metal3 Provisioning
+      ansible.builtin.command:
+        cmd: >-
+          oc patch {{ _cifmw_openshift_setup_provisioning_name.stdout }}
+          --type='json'
+          -p='[{"op": "replace", "path": "/spec/watchAllNamespaces", "value": true}]'
+      register: _cifmw_openshift_setup_provisioning_ns_patch_out
+      changed_when: "'no change' not in _cifmw_openshift_setup_provisioning_ns_patch_out.stdout"

--- a/scenarios/reproducers/va-nfv-ovs-dpdk-sriov.yml
+++ b/scenarios/reproducers/va-nfv-ovs-dpdk-sriov.yml
@@ -101,6 +101,11 @@ cifmw_libvirt_manager_configuration:
 # Baremetal host configuration
 cifmw_config_bmh: true
 
+# BMH are deployed in a differnt NS than the secret OSP BMO
+# references in each BMH. Metal3 requires the referenced
+# secrets to be in the same NS or be allowed to access them
+cifmw_openshift_setup_metal3_watch_all_ns: true
+
 # Use EDPM image for computes
 cifmw_update_containers_edpm_image_url: "{{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/edpm-hardened-uefi:{{ cifmw_update_containers_tag }}"
 

--- a/scenarios/reproducers/va-nfv-ovs-sriov.yml
+++ b/scenarios/reproducers/va-nfv-ovs-sriov.yml
@@ -99,5 +99,10 @@ cifmw_libvirt_manager_configuration:
 # Baremetal host configuration
 cifmw_config_bmh: true
 
+# BMH are deployed in a differnt NS than the secret OSP BMO
+# references in each BMH. Metal3 requires the referenced
+# secrets to be in the same NS or be allowed to access them
+cifmw_openshift_setup_metal3_watch_all_ns: true
+
 # Use EDPM image for computes
 cifmw_update_containers_edpm_image_url: "{{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/edpm-hardened-uefi:{{ cifmw_update_containers_tag }}"


### PR DESCRIPTION
Under some circumstances, like when deploying BMH resources and its associated secrets in different namespaces, it may be necessary to allow Metal3's BMO access those resources out of its NS.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
