### PR TITLE
Unskip building horizontest container

### DIFF
--- a/roles/build_containers/defaults/main.yml
+++ b/roles/build_containers/defaults/main.yml
@@ -45,17 +45,6 @@ cifmw_build_containers_cleanup: false
 # Install tcib from source
 cifmw_build_containers_install_from_source: false
 
-cifmw_build_containers_exclude_containers:
-  master:
-    centos9:
-      - horizontest
-  antelope:
-    centos9:
-      - horizontest
-  rhos18:
-    rhel9:
-      - horizontest
-
 # Downstream only variables:
 #
 # cifmw_build_containers_rhel_modules


### PR DESCRIPTION
Unskipping building horizontest container as we are no more facing issue seen https://issues.redhat.com/browse/OSPCIX-378 to build the horizontest container while building the tcib containers. Previously the issue was due to https://pypi.org/project/setuptools/71.0.1/ which was yanked 
Resolves [OSPCIX-378](https://issues.redhat.com/browse/OSPCIX-378)

As a pull request owner and reviewers, I checked that:

- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
