### PR TITLE
Correct ansible-lint issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
       - id: black
 
   - repo: https://github.com/ansible/ansible-lint
-    rev: v6.22.1
+    rev: v6.22.2
     hooks:
       - id: ansible-lint
         additional_dependencies:

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.13.0'
+requires_ansible: '>=2.16.0'

--- a/roles/libvirt_manager/molecule/check_dns/verify.yml
+++ b/roles/libvirt_manager/molecule/check_dns/verify.yml
@@ -2,7 +2,7 @@
 - name: Verify DNS
   hosts: instance
   tasks:
-    - name: Verify DNS entries
+    - name: Verify DNS entries  # noqa: jinja[invalid]
       vars:
         _lookup: "{{ lookup('community.general.dig', item.rec) }}"
       ansible.builtin.assert:

--- a/roles/libvirt_manager/molecule/generate_network_data/tasks/test.yml
+++ b/roles/libvirt_manager/molecule/generate_network_data/tasks/test.yml
@@ -39,7 +39,7 @@
         - not _run_fail | bool
         - scenario.check_dns is defined
       block:
-        - name: Ensure we have expected records
+        - name: Ensure we have expected records  # noqa: jinja[invalid]
           vars:
             _lookup: "{{ lookup('community.general.dig', dns.rec)  }}"
           ansible.builtin.assert:


### PR DESCRIPTION
It seems ansible-lint didn't bother warning when the new
community.general.dig lookup was introduced in
415c1439185f23f5f90003706e2f904870b439e7 while it does now complain with
a more recent patch.

Let's fix it in a dedicated PR, making things easier to check.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
