### PR TITLE
Add check for NodeSet status

### DIFF
--- a/roles/validations/defaults/main.yml
+++ b/roles/validations/defaults/main.yml
@@ -48,3 +48,4 @@ cifmw_validations_custom_nova_service: "nova-custom-ceph"
 # variables needed for scaledown
 cifmw_validations_edpm_scale_down_hostname: compute-2.ctlplane.example.com
 cifmw_validations_edpm_scale_down_nodename: edpm-compute-2
+cifmw_validations_timeout: 100

--- a/roles/validations/tasks/edpm/hotfix.yml
+++ b/roles/validations/tasks/edpm/hotfix.yml
@@ -26,6 +26,20 @@
     script: >-
       oc patch -n {{ cifmw_validations_namespace }} osdpns/"{{ deployed_nodeset_name.stdout | trim }}" --type=merge -p '{"spec": {"nodeTemplate": {"ansible": {"ansibleVars": {"edpm_nova_compute_image": "{{ cifmw_validations_hotfixed_edpm_nova_compute_image }}"}}}}}'
 
+# loop check the status of the openstackdataplanenodeset until it is either SetupReady,
+# or reaches a defined timeout value.
+- name: Wait for nodeset to be SetupReady again
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  cifmw.general.ci_script:
+    output_dir: "{{ cifmw_validations_basedir }}/artifacts"
+    script: >-
+      oc wait osdpns "{{ deployed_nodeset_name.stdout | trim }}"
+      --namespace={{ cifmw_validations_namespace }}
+      --for=condition=SetupReady
+      --timeout={{ cifmw_validations_timeout }}m
+
 # Create a new OpenStackDataPlaneDeployment to apply the hotfixed image
 - name: Create openstackdataplanedeployment to rollout changes
   environment:
@@ -59,7 +73,7 @@
       oc wait openstackdataplanedeployment edpm-hotfix
       --namespace={{ cifmw_validations_namespace }}
       --for=condition=ready
-      --timeout={{ cifmw_validations_timeout | default(100) }}m
+      --timeout={{ cifmw_validations_timeout }}m
 
 # Collect running image to assert the hotfix was applied
 - name: Collect the image currently used by nova_compute on the edpm node

--- a/roles/validations/tasks/edpm/hugepages_and_reboot.yml
+++ b/roles/validations/tasks/edpm/hugepages_and_reboot.yml
@@ -45,6 +45,20 @@
     script: >-
       oc patch -n {{ cifmw_validations_namespace }} osdpns/"{{ deployed_nodeset_name.stdout | trim }}" --type=merge -p '{"spec": {"nodeTemplate": {"ansible": {"ansibleVars": {"edpm_kernel_args": "default_hugepagesz=1gb hugepagesz=1g hugepages=64 iommu=pt intel_iommu=on tsx=off isolcpus=2-11,14-23"}}}}}'
 
+# loop check the status of the openstackdataplanenodeset until it is either SetupReady,
+# or reaches a defined timeout value.
+- name: Wait for nodeset to be SetupReady again
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  cifmw.general.ci_script:
+    output_dir: "{{ cifmw_validations_basedir }}/artifacts"
+    script: >-
+      oc wait osdpns "{{ deployed_nodeset_name.stdout | trim }}"
+      --namespace={{ cifmw_validations_namespace }}
+      --for=condition=SetupReady
+      --timeout={{ cifmw_validations_timeout }}m
+
 # Define an ad-hoc reboot service for our node reboot
 - name: Create ad-hoc reboot service
   environment:
@@ -104,7 +118,7 @@
       oc wait openstackdataplanedeployment edpm-hugepages-update
       --namespace={{ cifmw_validations_namespace }}
       --for=condition=ready
-      --timeout={{ cifmw_validations_timeout | default(100) }}m
+      --timeout={{ cifmw_validations_timeout }}m
 
 # Collect final confighash from the nodeset
 - name: Collecting final confighash from the nodeset


### PR DESCRIPTION
Before we create the OpenStackDataPlaneDeployment, we need to ensure the NodeSet is in the SetupReady state again.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
