### PR TITLE
Add skip subscription manager patch to devscripts role

### DIFF
--- a/roles/devscripts/files/01_subs_check.patch
+++ b/roles/devscripts/files/01_subs_check.patch
@@ -1,0 +1,21 @@
+diff --git a/01_install_requirements.sh b/01_install_requirements.sh
+index 7024abe..7a2294e 100755
+--- a/01_install_requirements.sh
++++ b/01_install_requirements.sh
+@@ -88,9 +88,13 @@ case $DISTRO in
+       sudo dnf config-manager --set-enabled crb
+       sudo dnf -y install epel-release
+     elif [[ $DISTRO == "rhel9" ]]; then
+-      # NOTE(elfosardo): a valid RHEL subscription is needed to be able to
+-      # enable the CRB repository
+-      sudo subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms
++      # NOTE(raukadah): If a system is subscribed to RHEL subscription then
++      # sudo subscription-manager identity will return exit 0 else 1.
++      if $(sudo subscription-manager identity > /dev/null 2>&1); then
++	# NOTE(elfosardo): a valid RHEL subscription is needed to be able to
++	# enable the CRB repository
++	sudo subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms
++      fi
+       sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+     fi
+     sudo ln -s /usr/bin/python3 /usr/bin/python || true

--- a/roles/devscripts/tasks/135_patch_src.yml
+++ b/roles/devscripts/tasks/135_patch_src.yml
@@ -19,6 +19,13 @@
     src: "{{ cifmw_devscripts_repo_dir }}/vm_setup_vars.yml"
   register: vm_setup_data
 
+# An upstream patch is also proposed
+# https://github.com/openshift-metal3/dev-scripts/pull/1681
+- name: Patch dev-scripts for skip subscription-manager command.
+  ansible.posix.patch:
+    src: 01_subs_check.patch
+    dest: "{{ cifmw_devscripts_repo_dir }}/01_install_requirements.sh"
+
 # Note: Override When external network is being reused.
 - name: Ensure dev-scripts vm_setup_vars reflects external network address
   when:


### PR DESCRIPTION
https://github.com/openshift-metal3/dev-scripts/pull/1674 enables CRB repos on RHEL using subscription-manager to devscript. It breaks downstream baremetal job.

In downstream, we add custom crb repos. The systems are not subscribed to subscription manager. It is blocking the pipelines.

https://github.com/openshift-metal3/dev-scripts/pull/1681 runs subscription-manager command when system is subscribed. Since it is not merged yet. Let's copy the patch in devscripts role to unblock it.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running