### PR TITLE
Enable to increase timeout for steps in openstack_update_run target

### DIFF
--- a/roles/update/README.md
+++ b/roles/update/README.md
@@ -5,6 +5,7 @@ Role to run update
 * `cifmw_update_extras`: (hash) Hold job variable that get set when running the update playbook.
 * `cifmw_update_openstack_update_run_operators_updated`: (Boolean) Set if openstack_update_run make target should not modify openstack-operator csv to fake openstack services container change. Default to `True`.
 * `cifmw_update_openstack_update_run_target_version`: (String) Define openstack target version to run update to.
+* `cifmw_update_openstack_update_run_timeout`: (String) Define `oc wait` global timeout passed to each step of update procedure. It should be a value of a longest step of the procedure. Defaults to `600s`.
 * `cifmw_update_run_dryrun`: (Boolean) Do a dry run on make openstack_update_run command. Defaults to `False`.
 * `cifmw_update_ping_test`: (Boolean) Activate the ping test during update. Default to `False`.
 * `cifmw_update_create_volume`: (Boolean) Attach a volume to the test OS instance when set to true.  Default to `False`

--- a/roles/update/defaults/main.yml
+++ b/roles/update/defaults/main.yml
@@ -22,6 +22,7 @@ cifmw_update_openstack_update_run_target_version: "0.0.2"
 cifmw_update_openstack_update_run_operators_updated: true
 cifmw_update_openstack_update_run_containers_namespace: "podified-antelope-centos9"
 cifmw_update_openstack_update_run_containers_target_tag: "current-podified"
+cifmw_update_openstack_update_run_timeout: "600s"
 
 cifmw_update_run_dryrun: false
 

--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -35,6 +35,7 @@
     - always
   ansible.builtin.set_fact:
     _make_openstack_update_run_params: |
+      TIMEOUT: {{ cifmw_update_openstack_update_run_timeout }}
       {% if not cifmw_update_openstack_update_run_operators_updated | bool -%}
       FAKE_UPDATE: true
       CONTAINERS_NAMESPACE: {{ cifmw_update_openstack_update_run_containers_namespace }}


### PR DESCRIPTION
openstack_update_run make target uses globall timeout variable value. To be able to increase timeout when openstack_update_run runs from CI-framework we need set timeout in _make_openstack_update_run_params.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
