### PR TITLE
Add a tag to the "fix marketplace" imported tasks

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -167,6 +167,7 @@ or `--skip-tags`:
 - `bootstrap_libvirt`: Run the [reproducer](../reproducers/01-considerations.md) libvirt bootstrap only.
 - `bootstrap_repositories`: Run the [reproducer](../reproducers/01-considerations.md) repositories bootstrap steps only.
 - `devscripts_layout`: Run the [reproducer](../reproducers/01-considerations.md) devscripts bootstrap only.
+- `fix_marketplace`: When skipped, allows to not re-run the `openshift_setup/fix_openshift_marketplace.yml` tasks.
 - `infra`: Denotes tasks to prepare host virtualization and Openshift Container Platform when deploy-edpm.yml playbook is run.
 - `build-packages`: Denotes tasks to call the role [pkg_build](../roles/pkg_build.md) when deploy-edpm.yml playbook is run.
 - `build-containers`: Denotes tasks to call the role [build_containers](../roles/build_containers.md) when deploy-edpm.yml playbook is run.

--- a/roles/openshift_setup/tasks/main.yml
+++ b/roles/openshift_setup/tasks/main.yml
@@ -191,4 +191,6 @@
   ansible.builtin.import_tasks: patch_network_operator.yml
 
 - name: Fix openshift-marketplace pods
+  tags:
+    - fix_marketplace
   ansible.builtin.import_tasks: fix_openshift_marketplace.yml


### PR DESCRIPTION
Adding this tag will allow people to get a better re-run experience:
when running multiple time the role, it may happen the marketplace is
broken "for good".

This tag allows now to get a first run up to whatever stage you want,
the re-run with `--skip-tags fix_marketplace` to avoid "unfixing" it.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] Content of the docs/source is reflecting the changes
