### PR TITLE
Use ansible.utils.ipwrap when configuring DNS forward

### DIFF
--- a/roles/cifmw_external_dns/tasks/dns.yml
+++ b/roles/cifmw_external_dns/tasks/dns.yml
@@ -63,7 +63,7 @@
               forwardPlugin:
                 policy: Random
                 upstreams:
-                  - "{{ cifmw_external_dns_masq_cluster_ip }}:53"
+                  - "{{ cifmw_external_dns_masq_cluster_ip | ansible.utils.ipwrap }}:53"
               name: "{{ cifmw_external_dns_name }}"
               zones:
                 - "{{ cifmw_external_dns_domain }}"


### PR DESCRIPTION
When the cifmw_external_dns role configures a DNS
forward and the DNS server is at an IPv6 address
we get an invalid configuration unless the IPv6
address is correctly wrapped in brackets. This
patch uses ansible.utils.ipwrap to fix that.

Jira: https://issues.redhat.com/browse/OSPRH-8893

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
