### PR TITLE
Correct generated OCP domain

### DIFF
--- a/roles/reproducer/tasks/prepare_networking.yml
+++ b/roles/reproducer/tasks/prepare_networking.yml
@@ -141,7 +141,7 @@
       {%- if _use_crc | bool -%}
       crc.testing
       {%- elif _use_ocp | bool -%}
-      {{ cifmw_devscripts_config.base_domain }}
+      {{ cifmw_devscripts_config.cluster_name }}.{{ cifmw_devscripts_config.base_domain }}
       {%- endif -%}
 
 - name: Create the virtual networks


### PR DESCRIPTION
A mistake was introduced when we generate the `cifmw_reproducer_domain`:
the ocp_cluster was missing, leading to "some" issues with the DNS
resolution whenever we wanted to use that domain:
dnsmasq is configured to delegate cluster_name.base_domain to our own
instance, so the "compute-0.base_domain" couldn't resolv.

This patch corrects the issue, allowing to ease the move to FQDN on the
various machines.

Note that, for now, nothing in the Framework is using that specific
domain - all of the accesses are done using the `.utility` domain.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
