### PR TITLE
Use rdo-jobs mirror-info-fork role to use rdo package mirror

### DIFF
--- a/ci/playbooks/molecule-prepare.yml
+++ b/ci/playbooks/molecule-prepare.yml
@@ -3,6 +3,12 @@
   hosts: "{{ cifmw_zuul_target_host | default('controller') }}"
   gather_facts: true
   tasks:
+    - name: Execute mirror info role to configure /etc/ci/mirror_info.sh
+      vars:
+        mirror_fqdn: "mirror.{{ nodepool.region | lower }}.{{ nodepool.cloud | lower }}.rdoproject.org"
+      ansible.builtin.include_role:
+        name: mirror-info-fork
+
     - name: Prepare workspace
       ansible.builtin.include_role:
         name: prepare-workspace

--- a/zuul.d/molecule-base.yaml
+++ b/zuul.d/molecule-base.yaml
@@ -11,8 +11,12 @@
       - ci/playbooks/molecule-prepare.yml
     run: ci/playbooks/molecule-test.yml
     post-run: ci/playbooks/collect-logs.yml
+    roles:
+      - zuul: rdo-jobs
     required-projects:
       - github.com/openstack-k8s-operators/install_yamls
+      - name: rdo-jobs
+        override-checkout: master
     vars:
       roles_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/roles/{{ TEST_RUN }}"
       mol_config_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/.config/molecule/config_local.yml"


### PR DESCRIPTION
While running molecule jobs, we populate repos using repo-setup. It contains centos mirror url. Whenever there is an update going on centos mirror, it causes metadata failure issue.

RDO infra have their proxy mirror. Let use mirror-info-fork role to configure the same via /etc/ci/mirror_info.sh script.

repo-setup ci_mirror.yml[1] will take care of using those mirrors.

[1]. https://github.com/openstack-k8s-operators/ci-framework/blob/main/roles/repo_setup/tasks/ci_mirror.yml

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

