### PR TITLE
Ensure we're talking with boolean

### DIFF
--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -176,7 +176,7 @@
     - name: Handle IPv6 job configuration
       when:
         - ansible_all_ipv4_addresses | length == 0
-        - not (cifmw_cephadm_ceph_spec_fqdn | default(false))
+        - not (cifmw_cephadm_ceph_spec_fqdn | default(false) | bool)
       ansible.builtin.set_fact:
         ceph_hostname_var: 'ansible_hostname'
 

--- a/roles/cifmw_cephadm/tasks/cephfs.yml
+++ b/roles/cifmw_cephadm/tasks/cephfs.yml
@@ -15,12 +15,12 @@
 # under the License.
 
 - name: Use ansible_fqdn when ceph_spec_fqdn parameter is true
-  when: cifmw_cephadm_ceph_spec_fqdn
+  when: cifmw_cephadm_ceph_spec_fqdn | bool
   ansible.builtin.set_fact:
     ceph_hostname_var: 'ansible_fqdn'
 
 - name: Use ansible_hostname when ceph_spec_fqdn parameter is false
-  when: not cifmw_cephadm_ceph_spec_fqdn
+  when: not cifmw_cephadm_ceph_spec_fqdn | bool
   ansible.builtin.set_fact:
     ceph_hostname_var: 'ansible_hostname'
 

--- a/roles/cifmw_cephadm/tasks/rgw.yml
+++ b/roles/cifmw_cephadm/tasks/rgw.yml
@@ -15,12 +15,12 @@
 # under the License.
 
 - name: Use ansible_fqdn when ceph_spec_fqdn parameter is true
-  when: cifmw_cephadm_ceph_spec_fqdn
+  when: cifmw_cephadm_ceph_spec_fqdn | bool
   ansible.builtin.set_fact:
     ceph_hostname_var: 'ansible_fqdn'
 
 - name: Use ansible_hostname when ceph_spec_fqdn parameter is false
-  when: not cifmw_cephadm_ceph_spec_fqdn
+  when: not cifmw_cephadm_ceph_spec_fqdn | bool
   ansible.builtin.set_fact:
     ceph_hostname_var: 'ansible_hostname'
 


### PR DESCRIPTION
Usually we want to cast user provided booleans using the `| bool`
filter, just to be sure we're doing the right thing in the play.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
