### PR TITLE
dump more ceph cluster info during deployment

### DIFF
--- a/roles/cifmw_cephadm/tasks/post.yml
+++ b/roles/cifmw_cephadm/tasks/post.yml
@@ -42,6 +42,32 @@
       ansible.builtin.debug:
         msg: "{{ ceph_orch_ls.stdout_lines }}"
       when: cifmw_cephadm_verbose | bool
+
+    - name: Get ceph config dump
+      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config dump"
+      become: true
+      register: ceph_config_dump
+    - name: Show config dump
+      ansible.builtin.debug:
+        msg: "{{ ceph_config_dump.stdout_lines }}"
+      when: cifmw_cephadm_verbose | bool
+
+    - name: Get ceph require-min-compat-client
+      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} osd get-require-min-compat-client"
+      become: true
+      register: ceph_min_compat_client
+    - name: Show ceph require-min-compat-client
+      ansible.builtin.debug:
+        msg: "{{ ceph_min_compat_client.stdout_lines }}"
+
+    - name: Get ceph version
+      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} -v"
+      become: true
+      register: ceph_version
+    - name: Ceph version
+      ansible.builtin.debug:
+        msg: "{{ ceph_version.stdout_lines }}"
+
     - name: Print the status of the deployed Ceph cluster
       ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} -s"
       become: true


### PR DESCRIPTION
post ceph deployment, this patch will display more cluster details as part of cifmw_cephadm role.

JIRA: https://issues.redhat.com/browse/OSPRH-6286

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
