### PR TITLE
Ensures we can use FQDN in ceph.yml playbook

### DIFF
--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -168,6 +168,22 @@
         - storage
         - edpm_bootstrap
 
+    # The ceph_spec_fqdn parameter is set to true in the
+    # 06-deploy-edpm.yml play already. This will instruct
+    # ceph.yml playbook to use FQDN instead of short names,
+    # allowing to set actual FQDN to the virtual machines and
+    # ensuring they do match the inventory.
+    # This file is loaded from the run_hook/playbook.yml.
+    - name: Ensure ceph will use FQDN instead of shortnames
+      ansible.builtin.copy:
+        dest: "{{ cifmw_basedir }}/artifacts/parameters/ceph-spec-fqdn.yml"
+        mode: "0644"
+        content: |
+          # Used for ceph.yml playbook, called as a hook
+          # from the architecture automation. Ensures we can use
+          # proper FQDN instead of shortnames in inventory + machines.
+          ceph_spec_fqdn: true
+
     - name: Execute deployment steps
       tags:
         - edpm_deploy


### PR DESCRIPTION
Until now, there was an inconsistency between the 06-deploy-edpm.yml and
06-deploy-architecture.yml playbooks when it comes to ceph
configuration:
in the first one, ceph.yml play was instructed to use FQDN (via
ansible_fqdn fact), while the latter was using shortnames (via
ansible_hostname).

This leads to issues whenever we want to set FQDN on the various nodes
and in the inventory, since some stages of the ceph configuration is
checking for name consistency.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
