### PR TITLE
[ci_nmstate] Removed `generateName` property from `OperatorGroup` template

### DIFF
--- a/roles/ci_nmstate/defaults/main.yml
+++ b/roles/ci_nmstate/defaults/main.yml
@@ -28,7 +28,6 @@ cifmw_ci_nmstate_olm_operator_group:
   metadata:
     annotations:
       olm.providedAPIs: NMState.v1.nmstate.io
-    generateName: "{{cifmw_ci_nmstate_namespace}}-"
     name: openshift-nmstate
     namespace: "{{ cifmw_ci_nmstate_namespace }}"
   spec:

--- a/roles/ci_nmstate/tasks/nmstate_k8s_install.yml
+++ b/roles/ci_nmstate/tasks/nmstate_k8s_install.yml
@@ -36,7 +36,7 @@
   loop_control:
     label: "{{ item.metadata.name }}"
 
-- name: Wait for nmstate operator to be intalled
+- name: Wait for nmstate operator to be installed
   environment:
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
     PATH: "{{ cifmw_path }}"


### PR DESCRIPTION
`generateName` property was a leftover from `install_yamls` setup but it
shouldn't be used in the OperatorGroup context because otherwise you'll
run into [this](https://access.redhat.com/solutions/6429681) as with 
multiple deployments, multiple instances of the OperatorGroup will be 
created in the namespace. 

- also, fixed a typo

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes

Closes: https://issues.redhat.com/browse/OSPRH-8919