### PR TITLE
Add new cifmw-adoption-base-multinode-networker for adoption CI

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -190,7 +190,7 @@
     timeout: 14400
     attempts: 1
     nodeset: centos-9-multinode-rhel-9-2-crc-extracted-2-39-0-3xl
-    roles:
+    roles: &multinode-roles
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run: &multinode-prerun
       - ci/playbooks/multinode-customizations.yml
@@ -203,7 +203,7 @@
     vars:
       <<: *adoption_vars
       crc_ci_bootstrap_networking:
-        networks:
+        networks: &multinode_networks
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
@@ -290,7 +290,7 @@
               external:
                 ip: 172.21.0.103
                 config_nm: false
-          overcloud-controller-1:
+          overcloud-controller-1: &multinode-controller-1
             networks:
               default:
                 ip: 192.168.122.104
@@ -310,7 +310,7 @@
               external:
                 ip: 172.21.0.104
                 config_nm: false
-          overcloud-controller-2:
+          overcloud-controller-2: &multinode-controller-2
             networks:
               default:
                 ip: 192.168.122.105
@@ -330,7 +330,7 @@
               external:
                 ip: 172.21.0.105
                 config_nm: false
-          overcloud-novacompute-0:
+          overcloud-novacompute-0: &multinode-novacompute-0
             networks:
               default:
                 ip: 192.168.122.106
@@ -350,7 +350,7 @@
               external:
                 ip: 172.21.0.106
                 config_nm: false
-          overcloud-novacompute-1:
+          overcloud-novacompute-1: &multinode-novacompute-1
             networks:
               default:
                 ip: 192.168.122.107
@@ -490,4 +490,66 @@
                 config_nm: false
               external:
                 ip: 172.21.1.106
+                config_nm: false
+
+- job:
+    name: cifmw-adoption-base-multinode-networker
+    parent: base-extracted-crc
+    abstract: true
+    attempts: 1
+    roles: *multinode-roles
+    pre-run: *multinode-prerun
+    post-run: *multinode-postrun
+    vars:
+      <<: *adoption_vars
+      crc_ci_bootstrap_networking:
+        networks: *multinode_networks
+        instances:
+          controller: *multinode-crlr
+          crc: *multinode-crc
+          undercloud: *multinode-uc
+          overcloud-controller-0: *multinode-crlr-leaf0
+          overcloud-controller-1: *multinode-controller-1
+          overcloud-controller-2: *multinode-controller-2
+          overcloud-novacompute-0: *multinode-novacompute-0
+          overcloud-novacompute-1: *multinode-novacompute-1
+          overcloud-networker-0:
+            networks:
+              default:
+                ip: 192.168.122.108
+                config_nm: false
+              internal-api:
+                ip: 172.17.0.108
+                config_nm: false
+              storage:
+                ip: 172.18.0.108
+                config_nm: false
+              tenant:
+                ip: 172.19.0.108
+                config_nm: false
+              storage_mgmt:
+                ip: 172.20.0.108
+                config_nm: false
+              external:
+                ip: 172.21.0.108
+                config_nm: false
+          overcloud-networker-1:
+            networks:
+              default:
+                ip: 192.168.122.109
+                config_nm: false
+              internal-api:
+                ip: 172.17.0.109
+                config_nm: false
+              storage:
+                ip: 172.18.0.109
+                config_nm: false
+              tenant:
+                ip: 172.19.0.109
+                config_nm: false
+              storage_mgmt:
+                ip: 172.20.0.109
+                config_nm: false
+              external:
+                ip: 172.21.0.109
                 config_nm: false


### PR DESCRIPTION
This adds a new cifmw-adoption-base-multinode-networker job to be used as parent in a downstream multinode adoption job with dedicated networker nodes.

Related: https://issues.redhat.com/browse/OSPRH-8810

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
