### PR TITLE
Create VMs with proper FQDN instead of shortname only

### DIFF
--- a/roles/libvirt_manager/tasks/manage_vms.yml
+++ b/roles/libvirt_manager/tasks/manage_vms.yml
@@ -70,13 +70,14 @@
     - vm_type is not match('^(crc|ocp).*$')
   delegate_to: "{{ vm }}.{{ inventory_hostname }}"
   remote_user: "{{ _init_admin_user }}"
+  vars:
+    _fqdn: "{{ vm }}.{{ cifmw_reproducer_domain | default('local') }}"
   ansible.builtin.shell:
     executable: /bin/bash
     cmd: |-
       test -d /home/zuul && exit 0;
       set -xe -o pipefail;
-      echo "{{ vm }}" | sudo tee /etc/hostname;
-      sudo hostname -F /etc/hostname;
+      sudo hostnamectl hostname "{{ _fqdn }}"
       sudo useradd -m -d /home/zuul zuul;
       echo "zuul ALL=(ALL)  NOPASSWD: ALL" | sudo tee /etc/sudoers.d/zuul;
       sudo -u zuul mkdir -p /home/zuul/.ssh /home/zuul/src/github.com/openstack-k8s-operators;

--- a/roles/libvirt_manager/templates/inventory.yml.j2
+++ b/roles/libvirt_manager/templates/inventory.yml.j2
@@ -3,7 +3,7 @@
 {% for host in hosts %}
 {% set ocp_name = host.key | replace('_', '-') | replace('ocp-worker', 'worker') | replace('ocp', 'master') -%}
 {% set hostname = (host.key is match('^ocp.*')) | ternary(ocp_name, host.key) %}
-    {{ host.key }}:
+    {{ host.key }}.{{ cifmw_reproducer_domain | default('local') }}:
       ansible_host: {{ hostname }}.utility
       ansible_user: {{ _cifmw_libvirt_manager_layout.vms[item].admin_user | default('zuul') }}
       ansible_ssh_common_args: '-o StrictHostKeyChecking=no'

--- a/roles/reproducer/molecule/crc_layout/converge.yml
+++ b/roles/reproducer/molecule/crc_layout/converge.yml
@@ -131,41 +131,17 @@
               ansible.builtin.stat:
                 path: "{{ ansible_user_dir }}/ci-framework-data/parameters/interfaces-info.yml"
 
-            - name: Load crc inventory
-              register: _crc_inv
-              ansible.builtin.slurp:
-                src: "{{ ansible_user_dir }}/reproducer-inventory/crc-group.yml"
-
-            - name: Load compute inventory
-              register: _compute_inv
-              ansible.builtin.slurp:
-                src: "{{ ansible_user_dir }}/reproducer-inventory/compute-group.yml"
-
             - name: Ensure we can ping compute-0 on osp_trunk net
               register: _cmp0_ping
               failed_when: false
-              vars:
-                _inv: >-
-                  {{
-                    _compute_inv.content | b64decode | from_yaml
-                  }}
-                _ip: >-
-                  {{ _inv.computes.hosts['compute-0'].ansible_host }}
               ansible.builtin.command:
-                cmd: "ping -c1 -w1 {{ _ip }}"
+                cmd: "ping -c1 -w1 compute-0.utility"
 
             - name: Ensure we can ping crc-0 on osp_trunk net
               register: _crc_ping
               failed_when: false
-              vars:
-                _inv: >-
-                  {{
-                    _crc_inv.content | b64decode | from_yaml
-                  }}
-                _ip: >-
-                  {{ _inv.ocps.hosts['crc-0'].ansible_host }}
               ansible.builtin.command:
-                cmd: "ping -c1 -w1 {{ _ip }}"
+                cmd: "ping -c1 -w1 crc-0.utility"
 
             - name: Check secret files
               block:


### PR DESCRIPTION
There is a need to get unique hostnames for the VM that will be mounting
some shared volumes in some infrastructure.

Allowing to get FQDN instead of shortnames allows to change the domain
of the VMs, making FQDN actually unique for each run.

The way we will leverage that feature is still unknown, but the support
will be in place whenever we need it.

A possibility would be to set the cifmw_devscripts_config.base_domain to
a unique value, or directly set the cifmw_reproducer_domain to whatever
value the user wants.

#### Testing (not in commit message)
- [x] delta-v6 (downstream TP)
- [x] va-hci