### PR TITLE
Bump adoption job timeout to 4 hours i.e 14400 sec

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -5,7 +5,7 @@
     name: cifmw-adoption-base
     parent: base-extracted-crc
     abstract: true
-    timeout: 10800
+    timeout: 14400
     attempts: 1
     nodeset: centos-9-rhel-9-2-crc-extracted-2-39-0-3xl
     roles:


### PR DESCRIPTION
Currently periodic-adoption-multinode-to-crc-no-ceph[1] is timing out during tempest run:
```
2024-07-24 09:15:46.782157 | controller | TASK [test_operator : Start tests - tempest kubeconfig={{ cifmw_openshift_kubeconfig }}, api_key={{ cifmw_openshift_token | default(omit)}}, context={{ cifmw_openshift_context | default(omit)}}, state=present, wait=True, definition={{ test_operator_cr }}] ***
2024-07-24 09:15:46.782164 | controller | Wednesday 24 July 2024  09:15:46 -0400 (0:00:00.041)       0:00:53.038 ********
2024-07-24 09:15:46.782176 | controller | changed: [localhost]
2024-07-24 13:20:54.883211 | RUN END RESULT_TIMED_OUT: [untrusted : review.rdoproject.org/rdo-jobs/playbooks/data_plane_adoption/deploy_tripleo_run_repo_tests.yaml@master]
2024-07-24 13:20:54.935353 | POST-RUN START: [untrusted : review.rdoproject.org/rdo-jobs/playbooks/data_plane_adoption/unregister_RH_subscription_standalone.yaml@master]
```

Currently job has 3 hours timeout. Tempest is finishing successfully in os-must-gather logs. We need to bump the timeout to finish tempest.

This pr bumps the same to 4 hrs.

Links:
[1]. https://softwarefactory-project.io/zuul/t/rdoproject.org/builds?job_name=periodic-adoption-multinode-to-crc-no-ceph

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running

