### PR TITLE
Update adoption-standalone-*-provider irrelevant-files list

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -124,14 +124,47 @@
     required-projects:
       - openstack-k8s-operators/openstack-operator
     irrelevant-files:
-      - .ci-operator.yaml
-      - .ansible-lint
-      - .gitignore
-      - .yamllint
-      - .pre-commit-config.yaml
-      - LICENSE
-      - OWNERS
       - .*/*.md
+      - .ansible-lint
+      - .ci-operator.yaml
+      - .dockerignore
+      - .gitignore
+      - .golangci.yaml
+      - .pre-commit-config.yaml
+      - .readthedocs.yaml
+      - .spellcheck.yml
+      - .yamllint
+      - ^LICENSE$
+      - ^.github/.*$
+      - ^LICENSE$
+      - ^OWNERS$
+      - ^OWNERS_ALIASES$
+      - ^PROJECT$
+      - ^README.md$
+      - ^kuttl-test.yaml$
+      - ^renovate.json$
+      - ci/playbooks/molecule-prepare.yml
+      - ci/playbooks/molecule-test.yml
+      - ci/playbooks/pre-commit.yml
+      - ci/playbooks/pre-doc.yml
+      - ci/playbooks/run-doc.yml
+      - containers/ci
+      - contribute/.*
+      - docs/.*
+      - examples
+      - mkdocs.yml
+      - molecule-requirements.txt
+      - molecule/.*
+      - roles/.*/molecule/.*
+      - roles/dlrn_report
+      - roles/dlrn_promote
+      - roles/devscripts
+      - roles/dnsmasq
+      - roles/nat64_appliance
+      - roles/reproducer
+      - roles/virtualbmc
+      - tests?\/functional
+      - zuul.d/molecule.*
 
 # TODO(marios): remove this once we finish rename OSPRH-8452
 - job:


### PR DESCRIPTION
"adoption-standalone-to-crc-ceph-provider" job depends on a content-provider job to run but since it has a different list of irrelevant-files, Zuul can throw an error like: " adoption-standalone-to-crc-ceph-provider depends on openstack-k8s-operators-content-provider which was not run". This PR copies the missing irrelevant-files from content-provider job to this adoption job.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
