### PR TITLE
Skip provider/edpm jobs on validations role

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -61,6 +61,7 @@
       - roles/nat64_appliance
       - roles/reproducer
       - roles/virtualbmc
+      - roles/validations
       - zuul.d/molecule.*
       # Other openstack operators
       - containers/ci


### PR DESCRIPTION
Validations role is used downstream. It does not make sense to run provider/edpm jobs on this role.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

