### PR TITLE
Expose found versions and location for crc binary

### DIFF
--- a/roles/rhol_crc/tasks/get_versions.yml
+++ b/roles/rhol_crc/tasks/get_versions.yml
@@ -16,3 +16,10 @@
         _crc_vers.stdout_lines |
         select ('match', 'OpenShift') | first |
         regex_replace('^OpenShift version: (.*)$', '\1') }}
+
+- name: Output found binary location and versions
+  ansible.builtin.debug:
+    msg: >-
+      Found crc at {{ cifmw_rhol_crc_binary }}, with
+      version {{ crc_version }} (wants: {{ cifmw_rhol_crc_version }})
+      and serving OpenShift version {{ crc_openshift_version }}.

--- a/roles/rhol_crc/tasks/main.yml
+++ b/roles/rhol_crc/tasks/main.yml
@@ -67,7 +67,7 @@
     - name: Retrieve RHOL/CRC if not existing
       when: (cifmw_rhol_crc_force_cleanup|bool) or not crc_present|bool
       block:
-        - name: Get RHOL/CRC binary if does not exist
+        - name: Get wanted RHOL/CRC version binary if needed
           when:
             - (not crc_bin_available | bool) or
               (crc_version is defined and
@@ -81,7 +81,7 @@
           when:
             - crc_present|bool
             - cifmw_rhol_crc_force_cleanup | bool
-          ansible.builtin.import_tasks: cleanup.yml
+          ansible.builtin.include_tasks: cleanup.yml
 
     - name: Configure and start RHOL/CRC
       when: (cifmw_rhol_crc_force_cleanup|bool) or not crc_running|bool


### PR DESCRIPTION
This will make things slightly easier to understand when the role is
wanting to install a new CRC binary/bundle.

It also change a task title to reflect the new behavior, and changes an
import_tasks to include_tasks since there's a `when` condition, to make
it slightly faster/better.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
