### PR TITLE
[test-operator][horizon] Expose storageClass parameter

### DIFF
--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -220,6 +220,7 @@ cifmw_test_operator_horizontest_config:
     name: horizontest
     namespace: "{{ cifmw_test_operator_namespace }}"
   spec:
+    storageClass: "{{ cifmw_test_operator_storage_class }}"
     containerImage: "{{ cifmw_test_operator_horizontest_image }}:{{ cifmw_test_operator_horizontest_image_tag }}"
     adminUsername: "{{ cifmw_test_operator_horizontest_admin_username }}"
     adminPassword: "{{ cifmw_test_operator_horizontest_admin_password }}"


### PR DESCRIPTION
In order to successfully execute tests in an environment with lvms-locale-storage, we need to ensure that the storageClass parameter is correctly set in the Horizon CR.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
