### PR TITLE
Remove duplicated job

### DIFF
--- a/ci/templates/projects.yaml
+++ b/ci/templates/projects.yaml
@@ -15,7 +15,6 @@
         - cifmw-pod-k8s-snippets-source
         - cifmw-pod-pre-commit
         - cifmw-pod-zuul-files
-        - cifmw-baremetal-nested-crc
         - cifmw-content-provider-build-images
         - cifmw-edpm-build-images
         - cifmw-multinode-kuttl

--- a/zuul.d/end-to-end.yaml
+++ b/zuul.d/end-to-end.yaml
@@ -55,19 +55,3 @@
       cifmw_extras:
         - '@scenarios/centos-9/ci.yml'
     run: ci/playbooks/e2e-run.yml
-
-# Run baremetal on rhol_crc modifications only
-- job:
-    name: cifmw-baremetal-nested-crc
-    parent: cifmw-crc-podified-edpm-baremetal
-    files:
-      - ^roles/rhol_crc/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/libvirt_manager/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/cert_manager/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/edpm_deploy_baremetal/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - scenarios/centos-9/edpm_baremetal_deployment_ci.yml
-      - ^plugins/action/ci_script.py
-      - ^plugins/modules/generate_make_tasks.py
-      - ci/playbooks/edpm_baremetal_deployment/run.yml
-
-    run: ci/playbooks/edpm_baremetal_deployment/run.yml

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -6,7 +6,6 @@
       - cifmw-pod-k8s-snippets-source
       - cifmw-pod-pre-commit
       - cifmw-pod-zuul-files
-      - cifmw-baremetal-nested-crc
       - cifmw-content-provider-build-images
       - cifmw-edpm-build-images
       - cifmw-multinode-kuttl


### PR DESCRIPTION
the cifmw-baremetal-nested-crc job was mostly useless, since it was a
duplicate of cifmw-crc-podified-edpm-baremetal.

While the nested-crc one had a `files` entry to limit its triggering,
the other one doesn't have any limitation, probably because it's using
the content-provider.

A potential follow-up would be to limit the triggers in the
project-templates.yml.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
