### PR TITLE
Use inventory_hostname in ceph related roles and play

### DIFF
--- a/ci/playbooks/multinode-customizations.yml
+++ b/ci/playbooks/multinode-customizations.yml
@@ -346,5 +346,5 @@
     - name: Inject hostname in configuration file
       become: true
       ansible.builtin.hostname:
-        name: "{{ inventory_hostname }}.ci-rdo.local"
+        name: "{{ inventory_hostname }}"
         use: "systemd"

--- a/playbooks/06-deploy-edpm.yml
+++ b/playbooks/06-deploy-edpm.yml
@@ -122,7 +122,6 @@
         (cifmw_edpm_deploy_hci | default('false') | bool) and
         cifmw_architecture_scenario is undefined
       }}
-    ceph_spec_fqdn: true
     storage_network_range: 172.18.0.0/24
     storage_mgmt_network_range: 172.20.0.0/24
   ansible.builtin.import_playbook: ceph.yml

--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -143,16 +143,6 @@
         - not _deploy_ceph | default(true)
       ansible.builtin.meta: end_play
 
-    - name: Use ansible_fqdn when ceph_spec_fqdn parameter is true
-      when: ceph_spec_fqdn | default(false)
-      ansible.builtin.set_fact:
-        ceph_hostname_var: 'ansible_fqdn'
-
-    - name: Use ansible_hostname when ceph_spec_fqdn parameter is false
-      when: not (ceph_spec_fqdn | default(false))
-      ansible.builtin.set_fact:
-        ceph_hostname_var: 'ansible_hostname'
-
     - name: Set IPv4 facts
       when: ansible_all_ipv4_addresses | length > 0
       ansible.builtin.set_fact:
@@ -173,27 +163,18 @@
         ms_bind_ipv4: false
         ms_bind_ipv6: true
 
-    - name: Handle IPv6 job configuration
-      when:
-        - ansible_all_ipv4_addresses | length == 0
-        - not (cifmw_cephadm_ceph_spec_fqdn | default(false) | bool)
-      ansible.builtin.set_fact:
-        ceph_hostname_var: 'ansible_hostname'
-
     - name: Build a dict mapping hostname to its IP which is in management network range
       ansible.builtin.set_fact:
         host_to_ip:
           "{{ host_to_ip | default({}) |
             combine(
               {
-                hostvars[item][ceph_hostname_var] :
+                item :
                 hostvars[item][all_addresses] | ansible.utils.ipaddr(ssh_network_range) | first
               }
             )
            }}"
       delegate_to: "{{ item }}"
-      when:
-        - hostvars[item][ceph_hostname_var] is defined
       loop: "{{ groups[cifmw_ceph_target | default('computes')] | default([]) }}"
 
     - name: Load network ranges from Networking Environment Definition if not provided

--- a/roles/cifmw_cephadm/README.md
+++ b/roles/cifmw_cephadm/README.md
@@ -92,10 +92,6 @@ need to be changed for a typical EDPM deployment.
    used as entry point to reach the `ganesha backends` through an `haproxy`
    instance where proxy-protocol is enabled.
 
-* `cifmw_cephadm_ceph_spec_fqdn`: When true, the Ceph spec should use
-  a fully qualified domain name (e.g. server1.bar.com). When false, the
-  Ceph spec should use a short hostname (e.g. server1).
-
 * `cifmw_cephadm_ns`: Name of the OpenStack controlplane namespace
    used in configuring swift objects.
 

--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -89,7 +89,6 @@ cifmw_ceph_rgw_config:
   rgw_max_attrs_num_in_req: 90
   rgw_max_attr_size: 1024
 cifmw_cephadm_cephfs_name: "cephfs"
-cifmw_cephadm_ceph_spec_fqdn: "{{ ceph_spec_fqdn | default(false) | bool }}"
 cifmw_ceph_dashboard_spec_path: /tmp/ceph_dashboard.yml
 cifmw_cephadm_certificate: ""
 cifmw_cephadm_key: ""

--- a/roles/cifmw_cephadm/tasks/cephfs.yml
+++ b/roles/cifmw_cephadm/tasks/cephfs.yml
@@ -14,21 +14,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Use ansible_fqdn when ceph_spec_fqdn parameter is true
-  when: cifmw_cephadm_ceph_spec_fqdn | bool
-  ansible.builtin.set_fact:
-    ceph_hostname_var: 'ansible_fqdn'
-
-- name: Use ansible_hostname when ceph_spec_fqdn parameter is false
-  when: not cifmw_cephadm_ceph_spec_fqdn | bool
-  ansible.builtin.set_fact:
-    ceph_hostname_var: 'ansible_hostname'
-
 - name: Build placement string
   block:
     - name: Collect the host and build the resulting host list
       ansible.builtin.set_fact:
-        _hosts: "{{ _hosts|default([]) + [ hostvars[item][ceph_hostname_var] ] }}"
+        _hosts: "{{ _hosts|default([]) + [ item ] }}"
       with_items: "{{ groups[cifmw_ceph_target | default('computes')] | default([]) }}"
 
     - name: Collect the target hosts

--- a/roles/cifmw_cephadm/tasks/rgw.yml
+++ b/roles/cifmw_cephadm/tasks/rgw.yml
@@ -14,19 +14,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Use ansible_fqdn when ceph_spec_fqdn parameter is true
-  when: cifmw_cephadm_ceph_spec_fqdn | bool
-  ansible.builtin.set_fact:
-    ceph_hostname_var: 'ansible_fqdn'
-
-- name: Use ansible_hostname when ceph_spec_fqdn parameter is false
-  when: not cifmw_cephadm_ceph_spec_fqdn | bool
-  ansible.builtin.set_fact:
-    ceph_hostname_var: 'ansible_hostname'
-
 - name: Collect the host and build the resulting host list
   ansible.builtin.set_fact:
-    _hosts: "{{ _hosts|default([]) + [ hostvars[item][ceph_hostname_var] ] }}"
+    _hosts: "{{ _hosts|default([]) + [ item ] }}"
   loop: "{{ groups[cifmw_ceph_target | default('computes')] | default([]) }}"
 
 - name: Create certificate and DNS for RGW if certificate paths are set


### PR DESCRIPTION
Until now, the ceph playbook and associated roles were trying to be
smart, but it created many other issues, and continues to create weird
situations.

With this patch, we reverse the burden, and base everything on the
inventory.
Since the inventory is generated by the Framework, and the Framework
also sets the virtual machines hostname, we should be able to rely on
the `inventory_hostname` only.

This means the inventory must be consistent, if provided by external
means.

We therefore update/correct the hostname set on the various nodes to
match the inventory.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [X] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role

#### Testing (not in commit message)
- [x] va-hci (locally tested)
- [x] delta-v6 (downstream TP)