### PR TITLE
[test-operator] Fix volume mounting

### DIFF
--- a/roles/test_operator/tasks/run-test-operator-job.yml
+++ b/roles/test_operator/tasks/run-test-operator-job.yml
@@ -67,6 +67,11 @@
     - not cifmw_test_operator_dry_run | bool
     - not testjob_timed_out
   block:
+    - name: Reset volumes and volume_mounts to an empty list
+      ansible.builtin.set_fact:
+        volumes: []
+        volume_mounts: []
+
     - name: Get information about PVCs that store the logs
       kubernetes.core.k8s_info:
         kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
@@ -140,10 +145,15 @@
       environment:
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
+      vars:
+        pod_path: mnt/logs-{{ test_operator_job_name }}-step-{{ index }}
       ansible.builtin.shell: >
         oc cp -n {{ cifmw_test_operator_namespace }}
-        openstack/test-operator-logs-pod-{{ run_test_fw }}:mnt/
+        openstack/test-operator-logs-pod-{{ run_test_fw }}:{{ pod_path }}
         {{ cifmw_test_operator_artifacts_basedir }}
+      loop: "{{ logsPVCs.resources }}"
+      loop_control:
+        index_var: index
 
 - name: Get list of all pods
   kubernetes.core.k8s_info:


### PR DESCRIPTION
In this patch we introduced a small bug that appears when we run both tempest and tobiko tests in a single job [1]. The issue is that when tobiko is executed both variables volume and volume_mounts contain values from the tempest run.

This PR ensures that both volume and volume_mounts are initialized to an empty list when logs are being collected.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/2124

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
