### PR TITLE
[rhol_crc] Removed `crc delete -f` command from the cleanup phase

### DIFF
--- a/roles/rhol_crc/tasks/cleanup.yml
+++ b/roles/rhol_crc/tasks/cleanup.yml
@@ -28,10 +28,7 @@
 - name: Delete RHOL/CRC instance and associated configuration
   when:
     - _crc_binary.stat.exists
-  ansible.builtin.command: "{{ cifmw_rhol_crc_binary }} {{ item }}"
-  loop:
-    - "delete -f"
-    - "cleanup"
+  ansible.builtin.command: "{{ cifmw_rhol_crc_binary }} cleanup"
 
 - name: Deepscrub CRC directory
   tags:


### PR DESCRIPTION
During the "deepscrub" cleanup, the command `crc delete -f` fails if there's no running crc vm.

We are now executing only the `crc cleanup` command because:
  - it won't fail if the crc vm isn't running
  - it will take care of deleting the vm, making the removed command useless

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running