### PR TITLE
Update comment redundant data plane adoption 'old' job names

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -95,7 +95,7 @@
                 ip: 172.20.0.100
                 config_nm: false
 
-# TODO(marios): remove this once we finish rename OSPRH-8452
+# NOTE(marios): need to keep this old job because of zuul branches, see comments at OSPRH-8452
 - job:
     name: cifmw-data-plane-adoption-osp-17-to-extracted-crc
     parent: adoption-standalone-to-crc-ceph-provider
@@ -166,7 +166,7 @@
       - tests?\/functional
       - zuul.d/molecule.*
 
-# TODO(marios): remove this once we finish rename OSPRH-8452
+# NOTE(marios): need to keep this old job because of zuul branches, see comments at OSPRH-8452
 - job:
     name: cifmw-data-plane-adoption-osp-17-to-extracted-crc-minimal-no-ceph
     parent: adoption-standalone-to-crc-no-ceph-provider


### PR DESCRIPTION
We cannot remove the the 'old' data plane adoption jobs after the job rename [1] because zuul checks all branches (e.g. ci-framework has multiple branches referencing these jobs). This just updates the comment to clarify that we will not be removing them.

[1] https://review.rdoproject.org/r/c/rdo-jobs/+/53788

Related: https://issues.redhat.com/browse/OSPRH-8452

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
