### PR TITLE
[test-operator][horizon] Fix Horizon CR name

### DIFF
--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -218,7 +218,7 @@ cifmw_test_operator_horizontest_config:
   apiVersion: test.openstack.org/v1beta1
   kind: HorizonTest
   metadata:
-    name: horizontest
+    name: "{{ cifmw_test_operator_horizontest_name }}"
     namespace: "{{ cifmw_test_operator_namespace }}"
   spec:
     storageClass: "{{ cifmw_test_operator_storage_class }}"


### PR DESCRIPTION
This patch ensures that we are creating Horizon CR instance with name set to a value that we later search for when requesting a status of openshift jobs.

Previously we were creating Horizon CR with name horizontest name but were querying jobs with name horizontest-tests [1].

[1] [test_operator vars](https://github.com/openstack-k8s-operators/ci-framework/blob/ad0110d522dac0a1f3637c4207c45ac36b827ef3/roles/test_operator/vars/main.yml#L20)

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
