### PR TITLE
Remove dataplane-operator references

### DIFF
--- a/roles/build_openstack_packages/defaults/main.yml
+++ b/roles/build_openstack_packages/defaults/main.yml
@@ -77,7 +77,6 @@ cifmw_bop_skipped_projects:
   - opendev.org/zuul/zuul-jobs
   - openstack-k8s-operators/barbican-operator
   - openstack-k8s-operators/cinder-operator
-  - openstack-k8s-operators/dataplane-operator
   - openstack-k8s-operators/designate-operator
   - openstack-k8s-operators/glance-operator
   - openstack-k8s-operators/heat-operator

--- a/roles/edpm_deploy/tasks/main.yml
+++ b/roles/edpm_deploy/tasks/main.yml
@@ -18,7 +18,6 @@
   when:
     - zuul is not defined
     - cifmw_operator_build_output is defined
-    - "'dataplane-operator' in operators_build_output.operators"
   tags:
     - always
   vars:
@@ -27,7 +26,6 @@
     _install_yamls_repos:
       DATAPLANE_BRANCH: ""
       GIT_CLONE_OPTS': "-l"
-      DATAPLANE_REPO': "{{ operators_build_output['dataplane-operator'].git_src_dir }}"
 
 - name: Set EDPM related vars
   when:

--- a/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -32,7 +32,6 @@
         ) |
         combine(
           {
-            'DATAPLANE_REPO': operators_build_output['dataplane-operator'].git_src_dir,
             'DATAPLANE_BRANCH': '',
             'GIT_CLONE_OPTS': '-l',
           } if ('dataplane-operator' in operators_build_output)

--- a/tests/integration/targets/make/files/get_makefiles_env/expected_variables_values.yml
+++ b/tests/integration/targets/make/files/get_makefiles_env/expected_variables_values.yml
@@ -61,8 +61,6 @@ variables:
   DATAPLANE_DEFAULT_GW: "192.168.122.1"
   DATAPLANE_DEPLOY_STRATEGY_DEPLOY: "false"
   DATAPLANE_NETWORK_INTERFACE_NAME: "eth0"
-  DATAPLANE_NODESET_BAREMETAL_CR: "/home/test-user/out/operator/dataplane-operator/config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml"
-  DATAPLANE_NODESET_CR: "/home/test-user/out/operator/dataplane-operator/config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml"
   DATAPLANE_NTP_SERVER: "pool.ntp.org"
   DATAPLANE_OVN_METADATA_AGENT_BIND_HOST: "127.0.0.1"
   DATAPLANE_REGISTRY_URL: "quay.io/podified-antelope-centos9"

--- a/tests/integration/targets/make/files/get_makefiles_env/makefiles/Makefile
+++ b/tests/integration/targets/make/files/get_makefiles_env/makefiles/Makefile
@@ -283,8 +283,6 @@ BMH_NAMESPACE       ?= ${NAMESPACE}
 # Dataplane Operator
 OPENSTACK_DATAPLANENODESET                       ?= config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
 OPENSTACK_DATAPLANENODESET_BAREMETAL             ?= config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
-DATAPLANE_NODESET_CR                             ?= ${OPERATOR_BASE_DIR}/dataplane-operator/${OPENSTACK_DATAPLANENODESET}
-DATAPLANE_NODESET_BAREMETAL_CR                   ?= ${OPERATOR_BASE_DIR}/dataplane-operator/${OPENSTACK_DATAPLANENODESET_BAREMETAL}
 DATAPLANE_ANSIBLE_SECRET                         ?=dataplane-ansible-ssh-private-key-secret
 DATAPLANE_ANSIBLE_USER                           ?=
 DATAPLANE_COMPUTE_IP                             ?=192.168.122.100

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -79,7 +79,6 @@
       - openstack-k8s-operators/barbican-operator
       - openstack-k8s-operators/ci-framework
       - openstack-k8s-operators/cinder-operator
-      - openstack-k8s-operators/dataplane-operator
       - openstack-k8s-operators/designate-operator
       - openstack-k8s-operators/glance-operator
       - openstack-k8s-operators/heat-operator
@@ -130,7 +129,6 @@
     irrelevant-files: *ir_files
     required-projects: &multinode_edpm_rp
       - openstack-k8s-operators/ci-framework
-      - openstack-k8s-operators/dataplane-operator
       - openstack-k8s-operators/install_yamls
       - openstack-k8s-operators/infra-operator
       - openstack-k8s-operators/openstack-baremetal-operator
@@ -271,7 +269,6 @@
     irrelevant-files: *ir_files
     required-projects:
       - openstack-k8s-operators/ci-framework
-      - openstack-k8s-operators/dataplane-operator
       - openstack-k8s-operators/install_yamls
       - openstack-k8s-operators/infra-operator
       - openstack-k8s-operators/openstack-baremetal-operator

--- a/zuul.d/tempest_multinode.yaml
+++ b/zuul.d/tempest_multinode.yaml
@@ -58,7 +58,6 @@
     required-projects:
       - github.com/openstack-k8s-operators/install_yamls
       - openstack-k8s-operators/ci-framework
-      - openstack-k8s-operators/dataplane-operator
       - openstack-k8s-operators/infra-operator
       - openstack-k8s-operators/openstack-baremetal-operator
       - openstack-k8s-operators/openstack-operator


### PR DESCRIPTION
Now that the dataplane-operator is combined and
not installed  through a separate repo.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
