### PR TITLE
[hooks] Fixed `edpm_network_config_template` variable in `fetch_compute_facts.yml` playbook

### DIFF
--- a/hooks/playbooks/fetch_compute_facts.yml
+++ b/hooks/playbooks/fetch_compute_facts.yml
@@ -193,10 +193,14 @@
                         ---
                         {% set mtu_list = [ctlplane_mtu] %}
                         {% for network in nodeset_networks %}
-                        {{ mtu_list.append(lookup("vars", networks_lower[network] ~ "_mtu")) }}
+                        {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
                         {%- endfor %}
                         {% set min_viable_mtu = mtu_list | max %}
                         network_config:
+                        - type: interface
+                          name: nic1
+                          use_dhcp: true
+                          mtu: {{ min_viable_mtu }}
                         - type: ovs_bridge
                           name: {{ neutron_physical_bridge_name }}
                           mtu: {{ min_viable_mtu }}
@@ -205,6 +209,7 @@
                           domain: {{ dns_search_domains }}
                           addresses:
                           - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+                          routes: {{ ctlplane_host_routes }}
                           members:
                           - type: interface
                             name: nic2
@@ -213,11 +218,11 @@
                             primary: true
                         {% for network in nodeset_networks %}
                           - type: vlan
-                            mtu: {{ min_viable_mtu - 4 }}
+                            mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
                             vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
                             addresses:
                             - ip_netmask:
-                                {{ lookup("vars", networks_lower[network] ~ "_ip") }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+                                {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
                             routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
                         {% endfor %}
                         {% endraw %}


### PR DESCRIPTION
The `edpm_network_config_template` variable wasn't reflecting the content defined in the architecture repo, so a couple of fields were missing from the defined template resulting (as its most impacting side effect) in the `br-ex` interface losing its default gateway and led to some services failures during the edpm deployment.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
