### PR TITLE
Ensure ocp is reachable from ocpbm before deploying

### DIFF
--- a/reproducer.yml
+++ b/reproducer.yml
@@ -68,3 +68,13 @@
       when: cifmw_allow_vms_to_reach_osp_api | default ('false') | bool
       ansible.builtin.command: # noqa: command-instead-of-module
         cmd: iptables -I LIBVIRT_FWI 1 -o ocpbm -j ACCEPT
+
+    - name: Run deployment if instructed to
+      when:
+        - cifmw_deploy_architecture | default(false) | bool
+      no_log: "{{ cifmw_nolog | default(true) | bool }}"
+      async: "{{ 7200 + cifmw_test_operator_timeout | default(3600) }}"  # 2h should be enough to deploy EDPM and rest for tests.
+      poll: 20
+      delegate_to: controller-0
+      ansible.builtin.command:
+        cmd: "/home/zuul/deploy-architecture.sh"

--- a/roles/reproducer/tasks/configure_architecture.yml
+++ b/roles/reproducer/tasks/configure_architecture.yml
@@ -25,12 +25,3 @@
       ansible.builtin.include_tasks: rotate_log.yml
       loop:
         - ansible-deploy-architecture.log
-
-    - name: Run deployment if instructed to
-      when:
-        - cifmw_deploy_architecture | default(false) | bool
-      no_log: "{{ cifmw_nolog | default(true) | bool }}"
-      async: "{{ 7200 + cifmw_test_operator_timeout|default(3600) }}"  # 2h should be enough to deploy EDPM and rest for tests.
-      poll: 20
-      ansible.builtin.command:
-        cmd: "/home/zuul/deploy-architecture.sh"


### PR DESCRIPTION
Since we now run the shifstack deployment using the reproducer by toggling `cifmw_deploy_architecture` we must ensure the iptables change we do is done before reaching the deployment step.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
