### PR TITLE
Change order of if-elif conditionals in set_openstack_containers template

### DIFF
--- a/roles/set_openstack_containers/templates/update_env_vars.sh.j2
+++ b/roles/set_openstack_containers/templates/update_env_vars.sh.j2
@@ -19,14 +19,9 @@ export PATH="{{ cifmw_path }}"
 {%   set container_data = container.split('=') -%}
 {%   set _container_env = container_data[0] -%}
 {%   set _container = container_data[1] -%}
-{#   This section overrides the non openstack services containers #}
-{%   if cifmw_set_openstack_containers_overrides.keys()|length > 0 -%}
-{%     if _container_env in cifmw_set_openstack_containers_overrides.keys() -%}
-{%       set _ = containers_dict.update({_container_env: cifmw_set_openstack_containers_overrides[_container_env]}) -%}
-{%     endif -%}
 {#   All the openstack services containers contain /openstack- prefix #}
 {#   It filters out the same and update the container address with new url #}
-{%   elif (_container_prefix in _container) and ('operator' not in _container) -%}
+{%   if (_container_prefix in _container) and ('operator' not in _container) -%}
 {%     set _container_data = _container.split(_container_prefix)[-1] -%}
 {#   There is sha256 tag initially for container tags, but in some jobs we switch to dlrn tag #}
 {%     if '@sha256' in _container_data  -%}
@@ -36,6 +31,11 @@ export PATH="{{ cifmw_path }}"
 {%     endif                                                             -%}
 {%     set _container_address = _container_registry + '/' + _container_prefix + _container_name + ':' + cifmw_set_openstack_containers_tag -%}
 {%     set _ = containers_dict.update({_container_env: _container_address}) -%}
+{#   This section overrides the non openstack services containers #}
+{%   elif cifmw_set_openstack_containers_overrides.keys() | length > 0 -%}
+{%     if _container_env in cifmw_set_openstack_containers_overrides.keys() -%}
+{%       set _ = containers_dict.update({_container_env: cifmw_set_openstack_containers_overrides[_container_env]}) -%}
+{%     endif -%}
 {%   endif -%}
 {% endfor -%}
 


### PR DESCRIPTION
To update both container tags and ansiblee RELATED_VARS of openstack-operator in the same set_openstack_containers role run both cifmw_set_openstack_containers_tag and cifmw_set_openstack_containers_overrides are defined. cifmw_set_openstack_containers_overrides if conditional must be checked later, because otherwise container_tags modifications are all skipped.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
