### PR TITLE
[nat64_appliance] Check if virtqemud socket exists during the cleanup

### DIFF
--- a/roles/nat64_appliance/tasks/cleanup.yml
+++ b/roles/nat64_appliance/tasks/cleanup.yml
@@ -19,44 +19,52 @@
     state: absent
     path: "{{ cifmw_nat64_appliance_workdir }}/nat64-appliance.qcow2"
 
-- name: List VMs
-  register: _list_vms
-  community.libvirt.virt:
-    command: list_vms
+- name: Get virtqemud socket
+  register: _virtqemud
+  ansible.builtin.stat:
+    path: "/var/run/libvirt/virtqemud-sock"
 
-- name: Stop the nat64_appliance VM
-  when: cifmw_nat64_appliance_name in _list_vms.list_vms
-  community.libvirt.virt:
-    command: destroy
-    name: "{{ cifmw_nat64_appliance_name }}"
-    uri: "{{ cifmw_nat64_libvirt_uri }}"
+- name: Perform the nat64_appliance cleanup in libvirt
+  when: _virtqemud.stat.exists
+  block:
+    - name: List VMs
+      register: _list_vms
+      community.libvirt.virt:
+        command: list_vms
 
-- name: Undefine the nat64_appliance VM
-  when: cifmw_nat64_appliance_name in _list_vms.list_vms
-  community.libvirt.virt:
-    command: undefine
-    name: "{{ cifmw_nat64_appliance_name }}"
-    force: true
-    uri: "{{ cifmw_nat64_libvirt_uri }}"
+    - name: Stop the nat64_appliance VM
+      when: cifmw_nat64_appliance_name in _list_vms.list_vms
+      community.libvirt.virt:
+        command: destroy
+        name: "{{ cifmw_nat64_appliance_name }}"
+        uri: "{{ cifmw_nat64_libvirt_uri }}"
 
-- name: Destroy the nat64 networks
-  register: net_destroy
-  community.libvirt.virt_net:
-    command: destroy
-    name: "{{ item }}"
-    uri: "{{ cifmw_nat64_libvirt_uri }}"
-  loop:
-    - "{{ cifmw_nat64_network_ipv4_name }}"
-    - "{{ cifmw_nat64_network_ipv6_name }}"
-  failed_when:
-    - net_destroy.rc is defined
-    - net_destroy.rc > 1
+    - name: Undefine the nat64_appliance VM
+      when: cifmw_nat64_appliance_name in _list_vms.list_vms
+      community.libvirt.virt:
+        command: undefine
+        name: "{{ cifmw_nat64_appliance_name }}"
+        force: true
+        uri: "{{ cifmw_nat64_libvirt_uri }}"
 
-- name: Undefine the nat64 networks
-  community.libvirt.virt_net:
-    command: undefine
-    name: "{{ item }}"
-    uri: "{{ cifmw_nat64_libvirt_uri }}"
-  loop:
-    - "{{ cifmw_nat64_network_ipv4_name }}"
-    - "{{ cifmw_nat64_network_ipv6_name }}"
+    - name: Destroy the nat64 networks
+      register: net_destroy
+      community.libvirt.virt_net:
+        command: destroy
+        name: "{{ item }}"
+        uri: "{{ cifmw_nat64_libvirt_uri }}"
+      loop:
+        - "{{ cifmw_nat64_network_ipv4_name }}"
+        - "{{ cifmw_nat64_network_ipv6_name }}"
+      failed_when:
+        - net_destroy.rc is defined
+        - net_destroy.rc > 1
+
+    - name: Undefine the nat64 networks
+      community.libvirt.virt_net:
+        command: undefine
+        name: "{{ item }}"
+        uri: "{{ cifmw_nat64_libvirt_uri }}"
+      loop:
+        - "{{ cifmw_nat64_network_ipv4_name }}"
+        - "{{ cifmw_nat64_network_ipv6_name }}"


### PR DESCRIPTION
Since most of the cleanup operations are performed via libvirt, we are going to test if the service is up checking for the existance of the `virtqemud` socket.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

