### PR TITLE
Return proper full hash for component repos

### DIFF
--- a/roles/repo_setup/tasks/artifacts.yml
+++ b/roles/repo_setup/tasks/artifacts.yml
@@ -32,9 +32,22 @@
 
     - name: Dump current-podified hash when using with component repo
       when: cifmw_repo_setup_component_name | length > 0
-      ansible.builtin.get_url:
-        url: "{{ cifmw_repo_setup_dlrn_uri }}/{{ cifmw_repo_setup_os_release }}{{ cifmw_repo_setup_dist_major_version }}-{{ cifmw_repo_setup_branch }}/current-podified/delorean.repo.md5"
-        dest: "{{ cifmw_repo_setup_basedir }}/artifacts/repositories/delorean.repo.md5"
+      block:
+        - name: Dump current-podified hash
+          ansible.builtin.get_url:
+            url: "{{ cifmw_repo_setup_dlrn_uri }}/{{ cifmw_repo_setup_os_release }}{{ cifmw_repo_setup_dist_major_version }}-{{ cifmw_repo_setup_branch }}/current-podified/delorean.repo.md5"
+            dest: "{{ cifmw_repo_setup_basedir }}/artifacts/repositories/delorean.repo.md5"
+
+        - name: Slurp current podified hash
+          ansible.builtin.slurp:
+            src: "{{ cifmw_repo_setup_basedir }}/artifacts/repositories/delorean.repo.md5"
+          register: _current_podified_hash
+
+        - name: Update the value of full_hash
+          vars:
+            _hash: "{{ _current_podified_hash['content'] | b64decode | trim }}"
+          ansible.builtin.set_fact:
+            _repo_setup_json: "{{ _repo_setup_json | combine({'full_hash': _hash}, recursive=true) }}"
 
     - name: Export hashes facts for further use
       ansible.builtin.set_fact:


### PR DESCRIPTION
In Component repos, we dump current-podified hash. We need the same hash needs to be set during hash info set_fact. So the content provider this hash to dependendent job otherwise it will fail.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running

