### PR TITLE
Add _openstack_final_env to set final env filename

### DIFF
--- a/playbooks/update.yml
+++ b/playbooks/update.yml
@@ -35,6 +35,7 @@
         cifmw_set_openstack_containers_tag_from_md5: true
         cifmw_set_openstack_containers_extra_vars: "{{ cifmw_edpm_prepare_extra_vars }}"
         cifmw_set_openstack_containers_openstack_version_change: true
+        cifmw_set_openstack_containers_openstack_final_env: "operator_env_after_update.txt"
       ansible.builtin.include_role:
         name: set_openstack_containers
 

--- a/roles/set_openstack_containers/README.md
+++ b/roles/set_openstack_containers/README.md
@@ -18,6 +18,7 @@ The role will generate two 2 files in ~/ci-framework-data/artifacts/ directory a
 * `cifmw_set_openstack_containers_prefix`: Update container containing. Defaults to `openstack`
 * `cifmw_set_openstack_containers_openstack_version_change`: (Boolean) Set environment variables for openstack services containers for specific OPENSTACK_RELEASE_VERSION defined in cifmw_set_openstack_containers_update_target_version. It should be used only for meta openstack operator in prepare for openstack minor update. Defaults to `false`.
 * `cifmw_set_openstack_containers_update_target_version`: Value of OPENSTACK_RELEASE_VERSION env in openstack operator that should be set. Defaults to `0.0.2`.
+* `cifmw_set_openstack_containers_openstack_final_env`: File name to store the operator env in a file. Default to `operator_env.txt`.
 
 ## Examples
 

--- a/roles/set_openstack_containers/defaults/main.yml
+++ b/roles/set_openstack_containers/defaults/main.yml
@@ -27,6 +27,7 @@ cifmw_set_openstack_containers_tag_from_md5: false
 cifmw_set_openstack_containers_dlrn_md5_path: "/etc/yum.repos.d/delorean.repo.md5"
 cifmw_set_openstack_containers_openstack_version_change: false
 cifmw_set_openstack_containers_update_target_version: "0.0.2"
+cifmw_set_openstack_containers_openstack_final_env: "operator_env.txt"
 
 # Set custom image url for non-openstack images
 cifmw_set_openstack_containers_overrides: {}

--- a/roles/set_openstack_containers/tasks/main.yml
+++ b/roles/set_openstack_containers/tasks/main.yml
@@ -149,6 +149,6 @@
     PATH: "{{ cifmw_path }}"
   cifmw.general.ci_script:
     output_dir: "{{ cifmw_set_openstack_containers_basedir }}/artifacts"
-    script: "oc set env {{ operator_pod_name }} -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} --list > operator_env.txt"
+    script: "oc set env {{ operator_pod_name }} -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} --list > {{ cifmw_set_openstack_containers_openstack_final_env }}"
     chdir: "{{ cifmw_set_openstack_containers_basedir }}/artifacts"
-    creates: operator_env.txt
+    creates: "{{ cifmw_set_openstack_containers_openstack_final_env }}"


### PR DESCRIPTION
Currently we store all the operator env variables in operator_env.txt.

Since this role is used twice in update job. We need a var to store the env variable before update and after update.

cifmw_set_openstack_containers_openstack_final_env will help to achieve the same.

As a pull request owner and reviewers, I checked that:
- [x] Appropriate testing is done and actually running
- [x] Appropriate documentation exists and/or is up-to-date:
  - [x] README in the role
  - [x] Content of the docs/source is reflecting the changes
