### PR TITLE
DNM Add compressed version of all collected logs

### DIFF
--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -136,6 +136,16 @@
             src: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/docs_build"
             dest: "{{ ansible_user_dir }}/zuul-output/logs/docs_build"
 
+        - name: Create tar gz file
+          become: true
+          vars:
+            compressed_file: "{{ inventory_hostname_short }}-all-logs.tar.gz"
+          ansible.builtin.shell: |
+            tar -caf {{ ansible_user_dir }}/{{ compressed_file }} {{ ansible_user_dir }}/zuul-output/
+            mv {{ ansible_user_dir }}/{{ compressed_file }}  {{ ansible_user_dir }}/zuul-output/
+            chown "{{ ansible_user }}" {{ ansible_user_dir }}/zuul-output/{{ compressed_file }}
+          changed_when: false
+
       always:
         - name: Copy files from workspace on node
           vars:


### PR DESCRIPTION
In the post job, there would be create a tar.gz. file that contains all collected logs.
It might be helpful to download whole logs in faster way than iterating on each files.

As a pull request owner and reviewers, I checked that:
- [X] Appropriate testing is done and actually running
