### PR TITLE
Use separate test_operator artifacts basedir for update test run

### DIFF
--- a/update-edpm.yml
+++ b/update-edpm.yml
@@ -25,6 +25,7 @@
   vars:
     pre_tests: "{{ (lookup('vars', 'pre_tempest', default=[])) }}"
     post_tests: "{{ (lookup('vars', 'post_tempest', default=[])) }}"
+    cifmw_test_operator_artifacts_basedir: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/tests/test_operator_update"
   when:
     - cifmw_run_tests | default('false') | bool
   tags:


### PR DESCRIPTION
Save test_operator test runs to separate test_operator_update dir to prevent overriding test_operators deployment run results with update run.

As a pull request owner and reviewers, I checked that:
- [ ] Appropriate testing is done and actually running
- [ ] Appropriate documentation exists and/or is up-to-date:
  - [ ] README in the role
  - [ ] Content of the docs/source is reflecting the changes
