### PR TITLE
Consolidate conditions triggering re-deploy

### DIFF
--- a/roles/devscripts/molecule/check_cluster_status/tasks/test.yml
+++ b/roles/devscripts/molecule/check_cluster_status/tasks/test.yml
@@ -100,10 +100,10 @@
     - name: Assert status
       ansible.builtin.assert:
         that:
-          - _needed_overlays | bool
+          - _needed_base_imgs | bool
           - _needed_volumes | bool
           - (not _openshift_adm_check_cert_approve) | bool
-          - cifmw_devscripts_ocp_exists | bool
+          - cifmw_devscripts_ocp_comply | bool
 
   rescue:
     - name: Clear host errors

--- a/roles/devscripts/tasks/100_pre.yml
+++ b/roles/devscripts/tasks/100_pre.yml
@@ -32,7 +32,7 @@
   when: >-
     (
       not (
-        (cifmw_devscripts_ocp_exists | bool) or
+        (cifmw_devscripts_ocp_comply | bool) or
         (cifmw_devscripts_ocp_online | bool)
       )
     )
@@ -42,7 +42,7 @@
   when: >-
     (
       not (
-        (cifmw_devscripts_ocp_exists | bool) or
+        (cifmw_devscripts_ocp_comply | bool) or
         (cifmw_devscripts_ocp_online | bool)
       )
     )

--- a/roles/devscripts/tasks/110_check_ocp.yml
+++ b/roles/devscripts/tasks/110_check_ocp.yml
@@ -26,7 +26,7 @@
 
 - name: Assign default values to OpenShift cluster check variables.
   ansible.builtin.set_fact:
-    cifmw_devscripts_ocp_exists: false
+    cifmw_devscripts_ocp_comply: false
     cifmw_devscripts_ocp_online: false
     _openshift_adm_check_cert_approve: false
     cifmw_openshift_adm_cert_expire_date_file: >-
@@ -37,13 +37,13 @@
       }}
 
 - name: Check for pre-existences of OpenShift cluster.
+  register: _base_img_results
   ansible.builtin.find:
     file_type: "file"
     path: "{{ cifmw_devscripts_data_dir }}/images"
     patterns: "{{ cifmw_devscripts_config.cluster_name }}_*.qcow2"
-  register: _overlay_results
 
-- name: Ensure we have needed overlays
+- name: Ensure we have needed base images
   vars:
     _cluster_members: >-
       {{
@@ -51,8 +51,8 @@
         cifmw_devscripts_config.num_workers | int
       }}
   ansible.builtin.set_fact:
-    _needed_overlays: >-
-      {{ _cluster_members|int == _overlay_results.matched|int }}
+    _needed_base_imgs: >-
+      {{ _cluster_members|int == _base_img_results.matched|int }}
 
 - name: Get cluster status
   register: _deployed_cluster
@@ -88,10 +88,10 @@
 - name: Verify the node definition match with expected count.
   when:
     - _deployed_cluster.stat.exists | bool
-    - _needed_overlays | bool
+    - _needed_base_imgs | bool
     - _needed_volumes | bool
   ansible.builtin.set_fact:
-    cifmw_devscripts_ocp_exists: true
+    cifmw_devscripts_ocp_comply: true
 
 - name: Gather dev-scripts deployed cluster auth information.
   ansible.builtin.stat:
@@ -115,6 +115,16 @@
 
 - name: Verify the golden image.
   when:
-    - cifmw_devscripts_ocp_exists
+    - cifmw_devscripts_ocp_comply
     - not cifmw_devscripts_ocp_online
   ansible.builtin.include_tasks: 112_verify_golden_image.yml
+
+- name: Cleanup cluster if not complying with wanted layout
+  when:
+    - _deployed_cluster.stat.exists | bool
+    - not cifmw_devscripts_ocp_comply | bool
+  ansible.builtin.include_tasks:
+    file: cleanup.yml
+    apply:
+      tags:
+        - always

--- a/roles/devscripts/tasks/111_verify_cluster.yml
+++ b/roles/devscripts/tasks/111_verify_cluster.yml
@@ -47,8 +47,12 @@
   block:
     - name: Set existences to false
       ansible.builtin.set_fact:
-        cifmw_devscripts_ocp_exists: false
+        cifmw_devscripts_ocp_comply: false
         cifmw_devscripts_force_cleanup: true
 
     - name: Run clean up tasks.
-      ansible.builtin.include_tasks: cleanup.yml
+      ansible.builtin.include_tasks:
+        file: cleanup.yml
+        apply:
+          tags:
+            - always

--- a/roles/devscripts/tasks/112_verify_golden_image.yml
+++ b/roles/devscripts/tasks/112_verify_golden_image.yml
@@ -69,9 +69,13 @@
       block:
         - name: Reset golden image exists flag
           ansible.builtin.set_fact:
-            cifmw_devscripts_ocp_exists: false
+            cifmw_devscripts_ocp_comply: false
             cifmw_devscripts_force_cleanup: true
             _openshift_adm_check_cert_approve: false
 
         - name: Cleanup the golden image if the certificate has expired.
-          ansible.builtin.include_tasks: cleanup.yml
+          ansible.builtin.include_tasks:
+            file: cleanup.yml
+            apply:
+              tags:
+                - always

--- a/roles/devscripts/tasks/300_post.yml
+++ b/roles/devscripts/tasks/300_post.yml
@@ -30,7 +30,7 @@
   tags:
     - devscripts_deploy
   when:
-    - not cifmw_devscripts_ocp_exists | bool
+    - not cifmw_devscripts_ocp_comply | bool
   ansible.builtin.include_tasks: 310_prepare_overlay.yml
 
 - name: Bringing cluster online.
@@ -41,7 +41,7 @@
       tags:
         - libvirt_layout
       when:
-        - not cifmw_devscripts_ocp_exists | bool
+        - not cifmw_devscripts_ocp_comply | bool
       ansible.builtin.include_role:
         name: libvirt_manager
         tasks_from: deploy_layout

--- a/roles/devscripts/tasks/cleanup.yml
+++ b/roles/devscripts/tasks/cleanup.yml
@@ -19,7 +19,8 @@
     - never
     - deepscrub
   when: >-
-    (cifmw_devscripts_ocp_exists is undefined) or
+    (cifmw_devscripts_ocp_comply is undefined) or
+    (not cifmw_devscripts_ocp_comply) or
     (cifmw_devscripts_force_cleanup | default(false) | bool)
   block:
     - name: Gather the configurations to be passed to dev-scripts.
@@ -77,3 +78,19 @@
       ansible.builtin.include_role:
         name: ci_network
         tasks_from: cleanup-dns.yml
+
+    - name: Ensure no dangling qcow2 images
+      block:
+        - name: Get files
+          register: _found_imgs
+          ansible.builtin.find:
+            path: "{{ cifmw_devscripts_data_dir }}/images"
+            patterns: "{{ cifmw_devscripts_config.cluster_name }}_*.qcow2"
+
+        - name: Remove dangling images
+          ansible.builtin.file:
+            path: "{{ item.path }}"
+            state: absent
+          loop: "{{ _found_imgs.files }}"
+          loop_control:
+            label: "{{ item.path }}"

--- a/roles/devscripts/tasks/main.yml
+++ b/roles/devscripts/tasks/main.yml
@@ -37,7 +37,7 @@
     - >-
       (
         not (
-          (cifmw_devscripts_ocp_exists | bool) or
+          (cifmw_devscripts_ocp_comply | bool) or
           (cifmw_devscripts_ocp_online | bool)
         )
       )

--- a/roles/reproducer/tasks/ocp_layout.yml
+++ b/roles/reproducer/tasks/ocp_layout.yml
@@ -150,7 +150,7 @@
 
 - name: Bootstrap devscript using baremetal provisioning
   when:
-    - not cifmw_devscripts_ocp_exists | bool
+    - not cifmw_devscripts_ocp_comply | bool
   vars:
     _bm_ironic_file: >-
       {{


### PR DESCRIPTION
Until now, the role didn't properly detect the need to re-deploy the OCP
cluster, leading to some bad situations.

This patch corrects that situation, and improve the "cleanup.yml" in
order to ensure it also removes any dangling base image - that might be
the case when a fist deploy involved workers, but the next one doesn't:
the dev-scripts configuration wouldn't know about it, since it gets
overridden, and we'd be left with the worker images dangling. Such a
situation would lead in the next runS to re-deploy OCP every single time
if we don't include workers anymore.
