### PR TITLE
Added periodic whitebox neutron tempest plugin job

### DIFF
--- a/zuul.d/edpm_periodic.yaml
+++ b/zuul.d/edpm_periodic.yaml
@@ -66,3 +66,24 @@
       cifmw_repo_setup_branch: antelope
       openstack_release: "{{ cifmw_repo_setup_branch }}"
       cifmw_edpm_build_images_push_registry_namespace: "podified-{{ cifmw_repo_setup_branch }}-centos9"
+
+# Whitebox Neutron tempest plugin job
+- job:
+    name: periodic-whitebox-neutron-tempest-plugin-podified-multinode-edpm-deployment-crc-2comp
+    parent: whitebox-neutron-tempest-plugin-podified-multinode-edpm-deployment-crc-2comp
+    description: |
+      A periodic zuul job for rdo third party
+      whitebox-neutron-tempest-plugin-podified-multinode-edpm-deployment-crc-2comp job. It will
+      make sure check job is always functional.
+    vars:
+      cifmw_repo_setup_promotion: podified-ci-testing
+      cifmw_dlrn_report_result: true
+      cifmw_repo_setup_branch: antelope
+      cifmw_update_containers_org: podified-{{ cifmw_repo_setup_branch }}-centos9
+      cifmw_update_containers_registry: quay.rdoproject.org
+      cifmw_update_containers_tag: "{{ cifmw_repo_setup_full_hash }}"
+      cifmw_update_containers_openstack: true
+      cifmw_run_tests: true
+      cifmw_test_operator_tempest_registry: "{{ cifmw_update_containers_registry }}"
+      cifmw_test_operator_tempest_namespace: "{{ cifmw_update_containers_org }}"
+      cifmw_test_operator_tempest_image_tag: "{{ cifmw_repo_setup_full_hash }}"

--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -5,6 +5,7 @@
 - job:
     name: whitebox-neutron-tempest-plugin-podified-multinode-edpm-deployment-crc-2comp
     parent: podified-multinode-edpm-deployment-crc-2comp
+    timeout: 12600
     override-checkout: main
     description: |
       A multinode EDPM Zuul job which one controller, one extracted crc and
@@ -112,6 +113,10 @@
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_qos.*external
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_extra_dhcp_opts.ExtraDhcpOptionsTest.test_extra_dhcp_opts_ipv4_ipv6_stateless
+              ^whitebox_neutron_tempest_plugin.tests.scenario.test_router_flavors
+              ^whitebox_neutron_tempest_plugin.tests.scenario.test_dvr_ovn.OvnDvrTest
+              ^whitebox_neutron_tempest_plugin.tests.scenario.test_multicast.MulticastTestIPv4Common.test_flooding_when_special_groups
+              ^whitebox_neutron_tempest_plugin.tests.scenario.test_broadcast.BroadcastTestVlanTransparency.test_broadcast_vlan_transparency
             # https://review.opendev.org/892839
             # - neutron_tempest_plugin.scenario.test_mtu.NetworkWritableMtuTest
             # It's in Blacklist before, FWaaS tests are not executed in any of our setups so there is no need to keep them whitelisted
@@ -119,6 +124,11 @@
             # Note(chandankumar): Skipping due to https://issues.redhat.com/browse/OSPRH-9091/RHOSZUUL-1940
             # and It require xl node to fix no valid host.
             # - whitebox_neutron_tempest_plugin.tests.scenario.test_extra_dhcp_opts.ExtraDhcpOptionsTest.test_extra_dhcp_opts_ipv4_ipv6_stateless
+            # - whitebox_neutron_tempest_plugin.tests.scenario.test_multicast.MulticastTestIPv4Common.test_flooding_when_special_groups
+            # - whitebox_neutron_tempest_plugin.tests.scenario.test_broadcast.BroadcastTestVlanTransparency.test_broadcast_vlan_transparency
+            # More Flaky tests mblue is working on fixing it
+            # - whitebox_neutron_tempest_plugin.tests.scenario.test_router_flavors
+            # - whitebox_neutron_tempest_plugin.tests.scenario.test_dvr_ovn.OvnDvrTest
         - stepName: single-thread-testing
           tempestRun:
             concurrency: 1
@@ -140,6 +150,8 @@
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_qos.*external
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_router_flavors
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_vlan_transparency.ProviderNetworkVlanTransparencyTest
+              ^whitebox_neutron_tempest_plugin.tests.scenario.test_router_flavors
+              ^whitebox_neutron_tempest_plugin.tests.scenario.test_dvr_ovn.OvnDvrTest
             # NOTE(mblue): Exclude list has test failures which need further debugging
             # remove when bug OSPRH-7998 resolved
             # - whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging.*test_only_dropped_traffic_logged


### PR DESCRIPTION
This pr adds a periodic version of whitebox-neutron-tempest-plugin-podified-multinode-edpm-deployment-crc-2comp
rdo third party check job. It will help us to monitor the job and keep it working.

It moves following tests to skiplist due to known issue `No valid host` and flakiness.
- ^whitebox_neutron_tempest_plugin.tests.scenario.test_router_flavors
- ^whitebox_neutron_tempest_plugin.tests.scenario.test_dvr_ovn.OvnDvrTest
- ^whitebox_neutron_tempest_plugin.tests.scenario.test_multicast.MulticastTestIPv4Common.test_flooding_when_special_groups.
- ^whitebox_neutron_tempest_plugin.tests.scenario.test_broadcast.BroadcastTestVlanTransparency.test_broadcast_vlan_transparency

Testresults: https://review.rdoproject.org/r/c/testproject/+/54009/13#message-098d12c84a6a2395c89288d8b5399efc426d5a42
```
periodic-whitebox-neutron-tempest-plugin-podified-multinode-edpm-deployment-crc-2comp https://softwarefactory-project.io/zuul/t/rdoproject.org/build/431e9f62b6e24f6ab0c180515aba4368 : SUCCESS in 2h 39m 20s
```