### PR TITLE
[install_openstack_ca] Refactor main.yml

### DIFF
--- a/roles/install_openstack_ca/README.md
+++ b/roles/install_openstack_ca/README.md
@@ -8,6 +8,8 @@ Note that this role assumes that an OpenstackControlPlane is deployed.
 OpenstackControlPlane CA. Defaults to `~/ci-framework/artifacts/manifests`.
 * `cifmw_install_openstack_ca_file`: (String) File name to the extracted CA file
 that will be installed. Defaults to `tls-ca-bundle.pem`.
+* `cifmw_install_openstack_ca_file_full_path`: (String) Full path to the extracted CA file
+that will be installed. Defaults to `(cifmw_install_openstack_ca_dest_path, cifmw_install_openstack_ca_file) | path_join`.
 
 ## Examples
 ```YAML

--- a/roles/install_openstack_ca/defaults/main.yml
+++ b/roles/install_openstack_ca/defaults/main.yml
@@ -14,9 +14,15 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of
 # "cifmw_install_openstack_ca"
 cifmw_install_openstack_ca_dest_path: "{{ cifmw_basedir }}/artifacts/manifests"
 cifmw_install_openstack_ca_file: "tls-ca-bundle.pem"
+cifmw_install_openstack_ca_file_full_path: >-
+  {{
+    (
+    cifmw_install_openstack_ca_dest_path,
+    cifmw_install_openstack_ca_file
+    ) | path_join
+  }}

--- a/roles/install_openstack_ca/tasks/main.yml
+++ b/roles/install_openstack_ca/tasks/main.yml
@@ -16,7 +16,7 @@
 
 # Here we rescue and not force error to preseve
 # the ignore_errors: true
-- name: Try/catch block
+- name: Try to get CA bundle from OCP and generate tls-ca-bundle.pem
   block:
     - name: Get CA bundle data with retries
       environment:
@@ -27,38 +27,57 @@
       retries: 10
       no_log: true
       delay: 3
-      until: ca_bundle_data.rc == 0
-      register: ca_bundle_data
+      until: _ca_bundle_data.rc == 0
+      register: _ca_bundle_data
+
+    - name: Set _ca_bundle fact if CA returned from OCP
+      when:
+        - _ca_bundle_data.rc == 0
+      no_log: true
+      ansible.builtin.set_fact:
+        _ca_bundle: >-
+          {{ _ca_bundle_data.stdout | ansible.builtin.b64decode }}
+
+    - name: Creating tls-ca-bundle.pem from CA bundle
+      when: _ca_bundle | default('') | length > 0
+      ansible.builtin.copy:
+        dest: "{{ cifmw_install_openstack_ca_file_full_path }}"
+        content: "{{ _ca_bundle }}"
   rescue:
-    - name: Dump ca_bundle_data var
+    - name: Dump _ca_bundle vars
       ansible.builtin.debug:
-        var: ca_bundle_data
+        var:
+          - _ca_bundle_data
+          - _ca_bundle
+        msg: >-
+          Error detected, please check assertions and
+          debugging output above.
 
-- name: Get CA bundle
-  when: ca_bundle_data.rc == 0
-  no_log: true
-  ansible.builtin.set_fact:
-    ca_bundle: >-
-      {{ ca_bundle_data.stdout | ansible.builtin.b64decode }}
+- name: Inject OpenStackControlplane CA file if present
+  block:
+    - name: Check if OpenStackControlplane CA file is present
+      register: _ca_bundle_file
+      ansible.builtin.stat:
+        path: "{{ cifmw_install_openstack_ca_file_full_path }}"
+        get_attributes: false
+        get_checksum: false
+        get_mime: false
 
-- name: Creating tls-ca-bundle.pem
-  when: (ca_bundle is defined) and (ca_bundle | length > 0)
-  ansible.builtin.copy:
-    dest: "{{ cifmw_install_openstack_ca_dest_path }}/{{ cifmw_install_openstack_ca_file }}"
-    content: "{{ ca_bundle }}"
-  register: ca_bundle_file
+    - name: Call install_ca role to inject OpenStackControlplane CA file if present
+      when: _ca_bundle_file.stat.exists
+      vars:
+        cifmw_install_ca_bundle_src: "{{ cifmw_install_openstack_ca_file_full_path }}"
+      ansible.builtin.include_role:
+        role: install_ca
+  rescue:
+    - name: Dump _ca_bundle vars
+      ansible.builtin.debug:
+        var:
+          - _ca_bundle_file
+          - cifmw_install_openstack_ca_file_full_path
 
-- name: Check if OpenStackControlplane CA file is present
-  register: _ca_bundle_file
-  ansible.builtin.stat:
-    path: "{{ cifmw_install_openstack_ca_dest_path }}/{{ cifmw_install_openstack_ca_file }}"
-    get_attributes: false
-    get_checksum: false
-    get_mime: false
-
-- name: Inject OpenStackControlplane CA bundle # noqa: no-handler
-  when: _ca_bundle_file.stat.exists
-  vars:
-    cifmw_install_ca_bundle_src: "{{ _ca_bundle_file.stat.path }}"
-  ansible.builtin.include_role:
-    role: install_ca
+    - name: Fail for good
+      ansible.builtin.fail:
+        msg: >-
+          Error detected, please check assertions and
+          debugging output above.


### PR DESCRIPTION
This patch cleans up the main.yml file of the install_openstack_ca role by:
- Making task names more clear
- Adding rescue blocks to print debug info when needed
- Adding a new default to ease reading `cifmw_install_openstack_ca_file_full_path`
- prepend internal vars with `_`

This patch is a result of a review on https://github.com/openstack-k8s-operators/ci-framework/pull/2155

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2155