### PR TITLE
Ensure we gather devscripts deployment logs

### DIFF
--- a/roles/devscripts/defaults/main.yml
+++ b/roles/devscripts/defaults/main.yml
@@ -34,8 +34,8 @@ cifmw_devscripts_logs_dir: >-
   {{
     (
       cifmw_devscripts_data_dir,
-      'devscripts',
-      'logs'
+      'logs',
+      'devscripts'
     ) | ansible.builtin.path_join
   }}
 cifmw_devscripts_output_dir: >-

--- a/roles/devscripts/molecule/default/converge.yml
+++ b/roles/devscripts/molecule/default/converge.yml
@@ -31,7 +31,7 @@
     cifmw_devscripts_repo_dir: "{{ (ansible_user_dir, 'src', 'dev-scripts') | path_join }}"
     cifmw_devscripts_data_dir: "{{ (ansible_user_dir, 'ci-framework-data') | path_join }}"
     cifmw_devscripts_artifacts_dir: "{{ (cifmw_devscripts_data_dir, 'devscripts', 'artifacts') | path_join }}"
-    cifmw_devscripts_logs_dir: "{{ (cifmw_devscripts_data_dir, 'devscripts', 'logs') | path_join }}"
+    cifmw_devscripts_logs_dir: "{{ (cifmw_devscripts_data_dir, 'logs', 'devscripts') | path_join }}"
     cifmw_devscripts_output_dir: "{{ (cifmw_devscripts_data_dir, 'devscripts', 'output') | path_join }}"
     cifmw_devscripts_config_overrides:
       num_extra_workers: 2

--- a/roles/devscripts/tasks/main.yml
+++ b/roles/devscripts/tasks/main.yml
@@ -41,22 +41,45 @@
           (cifmw_devscripts_ocp_online | bool)
         )
       )
-  register: _devscripts_deploy
-  community.general.make:
-    chdir: "{{ cifmw_devscripts_repo_dir }}"
-    target: "all"
-  async: "{{ cifmw_devscripts_installer_timeout }}"
-  poll: 0
+  vars:
+    _log_src: >-
+      {{
+        (cifmw_devscripts_repo_dir, 'logs' ) | path_join
+      }}
+  block:
+    - name: Run devscripts make all
+      register: _devscripts_deploy
+      no_log: true
+      community.general.make:
+        chdir: "{{ cifmw_devscripts_repo_dir }}"
+        target: "all"
+      async: "{{ cifmw_devscripts_installer_timeout }}"
+      poll: 0
 
-- name: Check async deploy status
-  when:
-    - not cifmw_devscripts_dry_run | bool
-  ansible.builtin.async_status:
-    jid: "{{ _devscripts_deploy.ansible_job_id }}"
-  register: _deploy_status
-  until: _deploy_status.finished
-  retries: "{{ (cifmw_devscripts_installer_timeout / 15) | int }}"
-  delay: 30
+    - name: Check async deploy status
+      no_log: true
+      ansible.builtin.async_status:
+        jid: "{{ _devscripts_deploy.ansible_job_id }}"
+      register: _deploy_status
+      until: _deploy_status.finished
+      retries: "{{ (cifmw_devscripts_installer_timeout / 15) | int }}"
+      delay: 30
+
+  always:
+    - name: Gather logs
+      register: _deploy_logs
+      ansible.builtin.find:
+        paths: "{{ _log_src }}"
+        patterns: "*.log"
+
+    - name: Copy all generated logs
+      ansible.builtin.copy:
+        dest: "{{ cifmw_devscripts_logs_dir }}/{{ item.path | basename }}"
+        remote_src: true
+        src: "{{ item.path }}"
+      loop: "{{ _deploy_logs.files }}"
+      loop_control:
+        label: "{{ item.path }}"
 
 - name: Executing dev-scripts post-install tasks.
   when:


### PR DESCRIPTION
Until now, the devscripts logs were outside of the standard tree,
meaning we couldn't get them in the zuul output.

This patch corrects the situation, and works even in case of deployment
failure, as shown in the snippet bellow. It also ensures we don't get
the whole devscripts failure output in the ansible log, since we now
have access to the various log files.

We also converge the logs destination to the standard logs location, in
~/ci-framework-data/logs/devscripts.

This also ensures we're gathering it in zuul jobs.

The use of `block/always` ensures the actions nested under the `always`
block are launched, even in case of failure.
Also, contrary to the `block/rescue`, a failure will fail the run right
after the last task of the `always` block:

```
TASK [devscripts : Check async deploy status] *************************************************************************************************************************************************************************************************
Tuesday 06 August 2024  13:52:40 +0200 (0:00:00.616)       0:03:19.695 ********
FAILED - RETRYING: [builder1]: Check async deploy status (480 retries left).
FAILED - RETRYING: [builder1]: Check async deploy status (479 retries left).
FAILED - RETRYING: [builder1]: Check async deploy status (478 retries left).
FAILED - RETRYING: [builder1]: Check async deploy status (477 retries left).
FAILED - RETRYING: [builder1]: Check async deploy status (476 retries left).
FAILED - RETRYING: [builder1]: Check async deploy status (475 retries left).
FAILED - RETRYING: [builder1]: Check async deploy status (474 retries left).
FAILED - RETRYING: [builder1]: Check async deploy status (473 retries left).
FAILED - RETRYING: [builder1]: Check async deploy status (472 retries left).
FAILED - RETRYING: [builder1]: Check async deploy status (471 retries left).
fatal: [builder1]: FAILED! => changed=false
  attempts: 11
  censored: 'the output has been hidden due to the fact that ''no_log: true'' was specified for this result'

TASK [devscripts : Gather logs paths={{ _log_src }}, patterns=*.log] **************************************************************************************************************************************************************************
Tuesday 06 August 2024  13:57:43 +0200 (0:05:03.132)       0:08:22.828 ********
ok: [builder1]

TASK [devscripts : Copy all generated logs dest={{ cifmw_devscripts_logs_dir }}/{{ item.path | basename }}, remote_src=True, src={{ item.path }}] *********************************************************************************************
Tuesday 06 August 2024  13:57:43 +0200 (0:00:00.236)       0:08:23.065 ********
changed: [builder1] => (item=/home/virtuser/src/github.com/openshift-metal3/dev-scripts/logs/01_install_requirements-2024-08-06-135240.log)
changed: [builder1] => (item=/home/virtuser/src/github.com/openshift-metal3/dev-scripts/logs/02_configure_host-2024-08-06-135404.log)
changed: [builder1] => (item=/home/virtuser/src/github.com/openshift-metal3/dev-scripts/logs/03_build_installer-2024-08-06-135448.log)
changed: [builder1] => (item=/home/virtuser/src/github.com/openshift-metal3/dev-scripts/logs/04_setup_ironic-2024-08-06-135512.log)
changed: [builder1] => (item=/home/virtuser/src/github.com/openshift-metal3/dev-scripts/logs/05_create_install_config-2024-08-06-135558.log)
changed: [builder1] => (item=/home/virtuser/src/github.com/openshift-metal3/dev-scripts/logs/06_create_cluster-2024-08-06-135602.log)

PLAY RECAP ************************************************************************************************************************************************************************************************************************************
builder1                   : ok=372  changed=113  unreachable=0    failed=1    skipped=82   rescued=4    ignored=0
```
