### PR TITLE
Added cifmw_update_containers_prefix var to set container prefix

### DIFF
--- a/roles/update_containers/README.md
+++ b/roles/update_containers/README.md
@@ -22,6 +22,7 @@ If apply, please explain the privilege escalation done in this role.
 * `cifmw_update_containers_edpm_image_url`: Full EDPM Image url for updating EDPM OS image.
 * `cifmw_update_containers_ipa_image_url`: Full Ironic Python Agent url needed in Ironic specific podified deployment
 * `cifmw_update_containers_rollback`: Rollback the container update changes. Default to `false`. It will be used with cleanup.
+* `cifmw_update_containers_prefix`: The OpenStack services container name prefix. Default to `openstack`. In downstream release content, we use `rhoso18-openstack`.
 
 ## Examples
 ### 1 - Update OpenStack container
@@ -38,7 +39,22 @@ If apply, please explain the privilege escalation done in this role.
         name: update_containers
 ```
 
-### 2 - Update Ansibleee container image
+### 2 - Update OpenStack containers with different container prefix
+```yaml
+- hosts: all
+  vars:
+    cifmw_update_containers_openstack: true
+    cifmw_update_containers_registry: xxxx
+    cifmw_update_containers_namespace: xxxx
+    cifmw_update_containers_tag: xxxx
+    cifmw_update_containers_prefix: rhoso18-openstack
+  tasks:
+    - name: Generate CR for updating openstack containers
+      ansible.builtin.include_role:
+        name: update_containers
+```
+
+### 3 - Update Ansibleee container image
 ```yaml
 - hosts: all
   vars:
@@ -49,7 +65,7 @@ If apply, please explain the privilege escalation done in this role.
         name: update_containers
 ```
 
-### 3 - Update EDPM OS image
+### 4 - Update EDPM OS image
 ```yaml
 - hosts: all
   vars:

--- a/roles/update_containers/defaults/main.yml
+++ b/roles/update_containers/defaults/main.yml
@@ -41,6 +41,7 @@ cifmw_update_containers_openstack: false
 cifmw_update_containers_rollback: false
 cifmw_update_containers_cindervolumes: []
 cifmw_update_containers_manilashares: []
+cifmw_update_containers_prefix: openstack
 # cifmw_update_containers_ansibleee_image_url:
 # cifmw_update_containers_edpm_image_url:
 # cifmw_update_containers_ipa_image_url:

--- a/roles/update_containers/templates/update_containers.j2
+++ b/roles/update_containers/templates/update_containers.j2
@@ -6,77 +6,79 @@ metadata:
 spec:
   customContainerImages:
 {% if cifmw_update_containers_openstack | bool %}
-    aodhAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-aodh-api:{{ cifmw_update_containers_tag }}
-    aodhEvaluatorImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-aodh-evaluator:{{ cifmw_update_containers_tag }}
-    aodhListenerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-aodh-listener:{{ cifmw_update_containers_tag }}
-    aodhNotifierImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-aodh-notifier:{{ cifmw_update_containers_tag }}
-    barbicanAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-barbican-api:{{ cifmw_update_containers_tag }}
-    barbicanKeystoneListenerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-barbican-keystone-listener:{{ cifmw_update_containers_tag }}
-    barbicanWorkerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-barbican-worker:{{ cifmw_update_containers_tag }}
-    ceilometerCentralImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ceilometer-central:{{ cifmw_update_containers_tag }}
-    ceilometerComputeImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ceilometer-compute:{{ cifmw_update_containers_tag }}
-    ceilometerIpmiImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ceilometer-ipmi:{{ cifmw_update_containers_tag }}
-    ceilometerNotificationImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ceilometer-notification:{{ cifmw_update_containers_tag }}
-    cinderAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-cinder-api:{{ cifmw_update_containers_tag }}
-    cinderBackupImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-cinder-backup:{{ cifmw_update_containers_tag }}
-    cinderSchedulerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-cinder-scheduler:{{ cifmw_update_containers_tag }}
-    cinderVolumeImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-cinder-volume:{{ cifmw_update_containers_tag }}
-    edpmFrrImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-frr:{{ cifmw_update_containers_tag }}
-    edpmIscsidImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-iscsid:{{ cifmw_update_containers_tag }}
-    edpmLogrotateCrondImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-cron:{{ cifmw_update_containers_tag }}
-    edpmMultipathdImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-multipathd:{{ cifmw_update_containers_tag }}
-    edpmNeutronMetadataAgentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-neutron-metadata-agent-ovn:{{ cifmw_update_containers_tag }}
-    edpmNeutronSriovAgentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-neutron-sriov-agent:{{ cifmw_update_containers_tag }}
-    edpmOvnBgpAgentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ovn-bgp-agent:{{ cifmw_update_containers_tag }}
-    glanceAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-glance-api:{{ cifmw_update_containers_tag }}
-    heatAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-heat-api:{{ cifmw_update_containers_tag }}
-    heatCfnapiImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-heat-api-cfn:{{ cifmw_update_containers_tag }}
-    heatEngineImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-heat-engine:{{ cifmw_update_containers_tag }}
-    horizonImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-horizon:{{ cifmw_update_containers_tag }}
-    infraDnsmasqImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-neutron-server:{{ cifmw_update_containers_tag }}
-    infraMemcachedImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-memcached:{{ cifmw_update_containers_tag }}
-    ironicAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ironic-api:{{ cifmw_update_containers_tag }}
-    ironicConductorImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ironic-conductor:{{ cifmw_update_containers_tag }}
-    ironicInspectorImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ironic-inspector:{{ cifmw_update_containers_tag }}
-    ironicNeutronAgentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ironic-neutron-agent:{{ cifmw_update_containers_tag }}
-    ironicPxeImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ironic-pxe:{{ cifmw_update_containers_tag }}
-    keystoneAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-keystone:{{ cifmw_update_containers_tag }}
-    manilaAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-manila-api:{{ cifmw_update_containers_tag }}
-    manilaSchedulerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-manila-scheduler:{{ cifmw_update_containers_tag }}
-    manilaShareImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-manila-share:{{ cifmw_update_containers_tag }}
-    mariadbImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-mariadb:{{ cifmw_update_containers_tag }}
-    neutronAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-neutron-server:{{ cifmw_update_containers_tag }}
-    novaAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-nova-api:{{ cifmw_update_containers_tag }}
-    novaComputeImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-nova-compute:{{ cifmw_update_containers_tag }}
-    novaConductorImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-nova-conductor:{{ cifmw_update_containers_tag }}
-    novaNovncImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-nova-novncproxy:{{ cifmw_update_containers_tag }}
-    novaSchedulerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-nova-scheduler:{{ cifmw_update_containers_tag }}
-    octaviaAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-octavia-api:{{ cifmw_update_containers_tag }}
-    octaviaHealthmanagerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-octavia-health-manager:{{ cifmw_update_containers_tag }}
-    octaviaHousekeepingImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-octavia-housekeeping:{{ cifmw_update_containers_tag }}
-    octaviaWorkerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-octavia-worker:{{ cifmw_update_containers_tag }}
-    openstackClientImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-openstackclient:{{ cifmw_update_containers_tag }}
-    ovnControllerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ovn-controller:{{ cifmw_update_containers_tag }}
-    ovnControllerOvsImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ovn-base:{{ cifmw_update_containers_tag }}
-    ovnNbDbclusterImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ovn-nb-db-server:{{ cifmw_update_containers_tag }}
-    ovnNorthdImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ovn-northd:{{ cifmw_update_containers_tag }}
-    ovnSbDbclusterImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ovn-sb-db-server:{{ cifmw_update_containers_tag }}
-    placementAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-placement-api:{{ cifmw_update_containers_tag }}
-    rabbitmqImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-rabbitmq:{{ cifmw_update_containers_tag }}
-    swiftAccountImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-swift-account:{{ cifmw_update_containers_tag }}
-    swiftContainerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-swift-container:{{ cifmw_update_containers_tag }}
-    swiftObjectImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-swift-object:{{ cifmw_update_containers_tag }}
-    swiftProxyImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-swift-proxy-server:{{ cifmw_update_containers_tag }}
+{# Set the container registry url with container prefix #}
+{% set _container_url_with_prefix = (cifmw_update_containers_registry, cifmw_update_containers_org, cifmw_update_containers_prefix) | path_join %}
+    aodhAPIImage: {{ _container_url_with_prefix }}-aodh-api:{{ cifmw_update_containers_tag }}
+    aodhEvaluatorImage: {{ _container_url_with_prefix }}-aodh-evaluator:{{ cifmw_update_containers_tag }}
+    aodhListenerImage: {{ _container_url_with_prefix }}-aodh-listener:{{ cifmw_update_containers_tag }}
+    aodhNotifierImage: {{ _container_url_with_prefix }}-aodh-notifier:{{ cifmw_update_containers_tag }}
+    barbicanAPIImage: {{ _container_url_with_prefix }}-barbican-api:{{ cifmw_update_containers_tag }}
+    barbicanKeystoneListenerImage: {{ _container_url_with_prefix }}-barbican-keystone-listener:{{ cifmw_update_containers_tag }}
+    barbicanWorkerImage: {{ _container_url_with_prefix }}-barbican-worker:{{ cifmw_update_containers_tag }}
+    ceilometerCentralImage: {{ _container_url_with_prefix }}-ceilometer-central:{{ cifmw_update_containers_tag }}
+    ceilometerComputeImage: {{ _container_url_with_prefix }}-ceilometer-compute:{{ cifmw_update_containers_tag }}
+    ceilometerIpmiImage: {{ _container_url_with_prefix }}-ceilometer-ipmi:{{ cifmw_update_containers_tag }}
+    ceilometerNotificationImage: {{ _container_url_with_prefix }}-ceilometer-notification:{{ cifmw_update_containers_tag }}
+    cinderAPIImage: {{ _container_url_with_prefix }}-cinder-api:{{ cifmw_update_containers_tag }}
+    cinderBackupImage: {{ _container_url_with_prefix }}-cinder-backup:{{ cifmw_update_containers_tag }}
+    cinderSchedulerImage: {{ _container_url_with_prefix }}-cinder-scheduler:{{ cifmw_update_containers_tag }}
+    cinderVolumeImage: {{ _container_url_with_prefix }}-cinder-volume:{{ cifmw_update_containers_tag }}
+    edpmFrrImage: {{ _container_url_with_prefix }}-frr:{{ cifmw_update_containers_tag }}
+    edpmIscsidImage: {{ _container_url_with_prefix }}-iscsid:{{ cifmw_update_containers_tag }}
+    edpmLogrotateCrondImage: {{ _container_url_with_prefix }}-cron:{{ cifmw_update_containers_tag }}
+    edpmMultipathdImage: {{ _container_url_with_prefix }}-multipathd:{{ cifmw_update_containers_tag }}
+    edpmNeutronMetadataAgentImage: {{ _container_url_with_prefix }}-neutron-metadata-agent-ovn:{{ cifmw_update_containers_tag }}
+    edpmNeutronSriovAgentImage: {{ _container_url_with_prefix }}-neutron-sriov-agent:{{ cifmw_update_containers_tag }}
+    edpmOvnBgpAgentImage: {{ _container_url_with_prefix }}-ovn-bgp-agent:{{ cifmw_update_containers_tag }}
+    glanceAPIImage: {{ _container_url_with_prefix }}-glance-api:{{ cifmw_update_containers_tag }}
+    heatAPIImage: {{ _container_url_with_prefix }}-heat-api:{{ cifmw_update_containers_tag }}
+    heatCfnapiImage: {{ _container_url_with_prefix }}-heat-api-cfn:{{ cifmw_update_containers_tag }}
+    heatEngineImage: {{ _container_url_with_prefix }}-heat-engine:{{ cifmw_update_containers_tag }}
+    horizonImage: {{ _container_url_with_prefix }}-horizon:{{ cifmw_update_containers_tag }}
+    infraDnsmasqImage: {{ _container_url_with_prefix }}-neutron-server:{{ cifmw_update_containers_tag }}
+    infraMemcachedImage: {{ _container_url_with_prefix }}-memcached:{{ cifmw_update_containers_tag }}
+    ironicAPIImage: {{ _container_url_with_prefix }}-ironic-api:{{ cifmw_update_containers_tag }}
+    ironicConductorImage: {{ _container_url_with_prefix }}-ironic-conductor:{{ cifmw_update_containers_tag }}
+    ironicInspectorImage: {{ _container_url_with_prefix }}-ironic-inspector:{{ cifmw_update_containers_tag }}
+    ironicNeutronAgentImage: {{ _container_url_with_prefix }}-ironic-neutron-agent:{{ cifmw_update_containers_tag }}
+    ironicPxeImage: {{ _container_url_with_prefix }}-ironic-pxe:{{ cifmw_update_containers_tag }}
+    keystoneAPIImage: {{ _container_url_with_prefix }}-keystone:{{ cifmw_update_containers_tag }}
+    manilaAPIImage: {{ _container_url_with_prefix }}-manila-api:{{ cifmw_update_containers_tag }}
+    manilaSchedulerImage: {{ _container_url_with_prefix }}-manila-scheduler:{{ cifmw_update_containers_tag }}
+    manilaShareImage: {{ _container_url_with_prefix }}-manila-share:{{ cifmw_update_containers_tag }}
+    mariadbImage: {{ _container_url_with_prefix }}-mariadb:{{ cifmw_update_containers_tag }}
+    neutronAPIImage: {{ _container_url_with_prefix }}-neutron-server:{{ cifmw_update_containers_tag }}
+    novaAPIImage: {{ _container_url_with_prefix }}-nova-api:{{ cifmw_update_containers_tag }}
+    novaComputeImage: {{ _container_url_with_prefix }}-nova-compute:{{ cifmw_update_containers_tag }}
+    novaConductorImage: {{ _container_url_with_prefix }}-nova-conductor:{{ cifmw_update_containers_tag }}
+    novaNovncImage: {{ _container_url_with_prefix }}-nova-novncproxy:{{ cifmw_update_containers_tag }}
+    novaSchedulerImage: {{ _container_url_with_prefix }}-nova-scheduler:{{ cifmw_update_containers_tag }}
+    octaviaAPIImage: {{ _container_url_with_prefix }}-octavia-api:{{ cifmw_update_containers_tag }}
+    octaviaHealthmanagerImage: {{ _container_url_with_prefix }}-octavia-health-manager:{{ cifmw_update_containers_tag }}
+    octaviaHousekeepingImage: {{ _container_url_with_prefix }}-octavia-housekeeping:{{ cifmw_update_containers_tag }}
+    octaviaWorkerImage: {{ _container_url_with_prefix }}-octavia-worker:{{ cifmw_update_containers_tag }}
+    openstackClientImage: {{ _container_url_with_prefix }}-openstackclient:{{ cifmw_update_containers_tag }}
+    ovnControllerImage: {{ _container_url_with_prefix }}-ovn-controller:{{ cifmw_update_containers_tag }}
+    ovnControllerOvsImage: {{ _container_url_with_prefix }}-ovn-base:{{ cifmw_update_containers_tag }}
+    ovnNbDbclusterImage: {{ _container_url_with_prefix }}-ovn-nb-db-server:{{ cifmw_update_containers_tag }}
+    ovnNorthdImage: {{ _container_url_with_prefix }}-ovn-northd:{{ cifmw_update_containers_tag }}
+    ovnSbDbclusterImage: {{ _container_url_with_prefix }}-ovn-sb-db-server:{{ cifmw_update_containers_tag }}
+    placementAPIImage: {{ _container_url_with_prefix }}-placement-api:{{ cifmw_update_containers_tag }}
+    rabbitmqImage: {{ _container_url_with_prefix }}-rabbitmq:{{ cifmw_update_containers_tag }}
+    swiftAccountImage: {{ _container_url_with_prefix }}-swift-account:{{ cifmw_update_containers_tag }}
+    swiftContainerImage: {{ _container_url_with_prefix }}-swift-container:{{ cifmw_update_containers_tag }}
+    swiftObjectImage: {{ _container_url_with_prefix }}-swift-object:{{ cifmw_update_containers_tag }}
+    swiftProxyImage: {{ _container_url_with_prefix }}-swift-proxy-server:{{ cifmw_update_containers_tag }}
 {% if cifmw_update_containers_cindervolumes | length > 0     %}
     cinderVolumeImages:
 {% for vol in cifmw_update_containers_cindervolumes          %}
-      {{ vol }}: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-cinder-volume:{{ cifmw_update_containers_tag }}
+      {{ vol }}: {{ _container_url_with_prefix }}-cinder-volume:{{ cifmw_update_containers_tag }}
 {% endfor                                                    %}
 {% endif                                                     %}
 {% if cifmw_update_containers_manilashares | length > 0      %}
     manilaShareImages:
 {% for shares in cifmw_update_containers_manilashares        %}
-      {{ shares }}: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-manila-share:{{ cifmw_update_containers_tag }}
+      {{ shares }}: {{ _container_url_with_prefix }}-manila-share:{{ cifmw_update_containers_tag }}
 {% endfor                                                    %}
 {% endif                                                     %}
 {% endif                                                     %}


### PR DESCRIPTION
In Upstream the openstack-services container name starts with openstack. In downstream released content, the container name starts with rhoso-openstack.

In this case, update_containers role will not work. As container names are different.

Adding cifmw_update_containers_prefix var makes it easier to achieve the same.

This pr also constructs the container url in a temprory var and reuse it across the template to make it more readable.