### PR TITLE
[switch_config] Fix pip install

### DIFF
--- a/playbooks/switches_config.yml
+++ b/playbooks/switches_config.yml
@@ -16,7 +16,6 @@
         name:
           - paramiko
           - ncclient
-        extra_args: --user
 
 - name: Switches configuration
   hosts: switches


### PR DESCRIPTION
If the reproducer runs in a venv the pip install will fail as we are passing the --user option to pip.
As we are not usign become: true in the install task enforcing --user is not needed, since pip will install the dependencies inside the user site-packages as the root one is not writable.