### PR TITLE
Ensure we get a timeout for node listing

### DIFF
--- a/roles/openshift_adm/README.md
+++ b/roles/openshift_adm/README.md
@@ -14,11 +14,13 @@ requires administrator level privileges for the deployed OpenShift.
 
 This role requires the following parameters to be configured.
 
+* `cifmw_openshift_adm_basedir` (str) Framework base directory, defaults to `cifmw_basedir` or
+  `~/ci-framework-data`.
 * `cifmw_openshift_api` (str) Cluster endpoint to be used for communication.
 * `cifmw_openshift_user` (str) Name of the user to be used for authentication.
 * `cifmw_openshift_password` (str) Password of the provided user.
 * `cifmw_openshift_kubeconfig` (str) Absolute path to the kubeconfig file.
-* `cifmw_base_dir` (str) Absolute path to the base directory
+* `cifmw_openshift_adm_stable_period` (str) Minimal period for cluster stability. Defaults to `3m`.
 * `cifmw_path` (str) containing information for environment.path.
 
 ## Parameters - Role

--- a/roles/openshift_adm/defaults/main.yml
+++ b/roles/openshift_adm/defaults/main.yml
@@ -18,12 +18,14 @@
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_openshift_adm"
 
-
+cifmw_openshift_adm_basedir: >-
+  {{ cifmw_base_dir | default(ansible_user_dir ~ '/ci-framework-data') }}
 cifmw_openshift_adm_cert_expire_date_file: >-
   {{
-    (cifmw_base_dir, 'artifacts', '.ocp_cert_not_after') |
+    (cifmw_openshift_adm_basedir, 'artifacts', '.ocp_cert_not_after') |
     ansible.builtin.path_join
   }}
 cifmw_openshift_adm_op: ""
 cifmw_openshift_adm_dry_run: false
 cifmw_openshift_adm_retry_count: 100
+cifmw_openshift_adm_stable_period: 3m

--- a/roles/openshift_adm/tasks/_get_nodes.yml
+++ b/roles/openshift_adm/tasks/_get_nodes.yml
@@ -1,0 +1,11 @@
+---
+- name: Gather node list
+  register: _nodes
+  kubernetes.core.k8s_info:
+    kind: Node
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    validate_certs: false
+    wait_condition:
+      reason: KubeletReady
+      type: Ready
+    wait: true

--- a/roles/openshift_adm/tasks/api_cert.yml
+++ b/roles/openshift_adm/tasks/api_cert.yml
@@ -48,8 +48,11 @@
   environment:
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
     PATH: "{{ cifmw_path }}"
-  ansible.builtin.command:
-    cmd: "oc adm wait-for-stable-cluster --minimum-stable-period=3m"
+  cifmw.general.ci_script:
+    output_dir: "{{ cifmw_openshift_adm_basedir }}/artifacts"
+    script: >-
+      oc adm wait-for-stable-cluster
+      --minimum-stable-period={{ cifmw_openshift_adm_stable_period }}
 
 - name: Gather the kubelet signer secret.
   kubernetes.core.k8s_info:

--- a/roles/openshift_adm/tasks/main.yml
+++ b/roles/openshift_adm/tasks/main.yml
@@ -25,6 +25,15 @@
       - cifmw_openshift_password is defined
       - cifmw_openshift_kubeconfig is defined
 
+- name: Create needed directories
+  ansible.builtin.file:
+    state: directory
+    mode: "0755"
+    path: "{{ cifmw_openshift_adm_basedir }}/{{ item }}"
+  loop:
+    - artifacts
+    - logs
+
 - name: Prepare and shutdown the OpenShift cluster.
   when:
     - cifmw_openshift_adm_op == 'shutdown'

--- a/roles/openshift_adm/tasks/shutdown.yml
+++ b/roles/openshift_adm/tasks/shutdown.yml
@@ -31,12 +31,8 @@
     - not cifmw_openshift_adm_dry_run
   ansible.builtin.include_tasks: api_cert.yml
 
-- name: Gather the list of nodes
-  kubernetes.core.k8s_info:
-    kind: Node
-    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
-    validate_certs: false
-  register: _nodes
+- name: List nodes to shutdown
+  ansible.builtin.import_tasks: _get_nodes.yml
 
 - name: Shutdown the nodes participating in the cluster.
   when:

--- a/roles/openshift_adm/tasks/wait_for_cluster.yml
+++ b/roles/openshift_adm/tasks/wait_for_cluster.yml
@@ -29,15 +29,8 @@
   retries: "{{ cifmw_openshift_adm_retry_count }}"
   delay: 5
 
-- name: Gather the list of nodes
-  kubernetes.core.k8s_info:
-    kind: Node
-    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
-    validate_certs: false
-  register: _nodes
-  until: _nodes.resources is defined
-  retries: "{{ cifmw_openshift_adm_retry_count }}"
-  delay: 2
+- name: Get nodes list
+  ansible.builtin.import_tasks: _get_nodes.yml
 
 - name: Ensure the nodes are in ready state.
   when:


### PR DESCRIPTION
It seems getting the nodes might hang, and it never ever returns.

This patch ensures we set a wait_condition, meaning we can toggle the
`wait` parameter to `true` and benefit from the default `wait_timeout`
of 120s[1] - which should be more than enough to get the OCP cluster
nodes list.

This PR also extract the node listing into its own tasks file, so that
we can import it instead of copy/pasting the same code.

This PR also adds a debugging capability when we're waiting for the
cluster to stabilize after removing the certificates. Using our
ci_script action, we're able to get logs, meaning we can easily review
the command output. Usually it lists the failing service(s) and provides
data about stability duration.

[1] https://docs.ansible.com/ansible/latest/collections/kubernetes/core/k8s_info_module.html#parameter-wait_timeout
