### PR TITLE
Create a role for uploading results to Report portal

### DIFF
--- a/roles/reportportal/README.md
+++ b/roles/reportportal/README.md
@@ -1,0 +1,33 @@
+# Report portal
+The `reportportal` role uses Data Router tool for uploading XML test results to Report portal. Access to the specific Report portal instance including URL and credentials has to be specified via Data router web interface.
+
+## Parameters
+* `cifmw_reportportal_basedir`: (String) Base directory. Defaults to `cifmw_basedir` which defaults to `~/ci-framework-data`.
+* `cifmw_reportportal_datarouter_url`: (String) URL with running Data router service (mandatory).
+* `cifmw_reportportal_droute_client_url`: (String) URL of Data router client repository (mandatory).
+* `cifmw_reportportal_datarouter_username`: (String) username for Data router client (mandatory).
+* `cifmw_reportportal_datarouter_password`: (String) password for Data router client (mandatory).
+* `cifmw_reportportal_datarouter_result_dir`: (String) Test results directory. Based on `cifmw_run_test_role` defaults to `~/ci-framework-data/tests/tempest/` or `~/ci-framework-data/tests/test_operator/`. One or more properly formatted xml results files are expected to be found in this directory.
+* `cifmw_reportportal_project`: (String) Report portal project for uploading results (mandatory).
+* `cifmw_reportportal_launch_name`: (String) Name of the Report portal launch defaults to `Dummy launch`.
+* `cifmw_reportportal_launch_description`: (String) Description of the Report portal launch defaults to `Test results sent via Data router`.
+* `cifmw_reportportal_droute_version`: (String) Data router client version defaults to `1.2.1`.
+* `cifmw_reportportal_droute_binary`: (String) Data router binary name defaults to `droute-linux-amd64`.
+
+## Examples
+```YAML
+- name: Play
+  hosts: localhost
+  vars:
+    cifmw_reportportal_droute_client_url: "https://example.com/data_router_client"
+    cifmw_reportportal_datarouter_url: "https://data-router.example.service.com"
+    cifmw_reportportal_datarouter_username: "<username>"
+    cifmw_reportportal_datarouter_password: "<password>"
+    cifmw_reportportal_project: "Example"
+
+  roles:
+    - reportportal
+```
+
+## Note
+This role exclusively relies on the internal Report portal and Data router instances and other internal repositories.

--- a/roles/reportportal/defaults/main.yml
+++ b/roles/reportportal/defaults/main.yml
@@ -1,0 +1,45 @@
+---
+cifmw_reportportal_dry_run: false
+cifmw_reportportal_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+cifmw_reportportal_datarouter_url: ""
+cifmw_reportportal_datarouter_username: ""
+cifmw_reportportal_datarouter_password: ""
+cifmw_reportportal_droute_dir: >-
+  {{
+    (cifmw_reportportal_basedir,
+     'droute') |
+    path_join
+  }}
+cifmw_reportportal_results_dir: >-
+  {{
+    (cifmw_reportportal_basedir,
+     'tests',
+     cifmw_run_test_role | default('tempest')) |
+    path_join
+  }}
+
+cifmw_reportportal_metadata_file: >-
+  {{
+    (cifmw_reportportal_droute_dir,
+     'metadata.json') |
+    path_join
+  }}
+
+cifmw_reportportal_results_pattern: "*.xml"
+cifmw_reportportal_results_search: >-
+  {{
+    (cifmw_reportportal_results_dir,
+     cifmw_reportportal_results_pattern) |
+    path_join
+  }}
+cifmw_reportportal_droute_version: "1.2.1"
+cifmw_reportportal_droute_binary: "droute-linux-amd64"
+cifmw_reportportal_droute_client_url: ""
+cifmw_reportportal_instance: ""
+cifmw_reportportal_project: ""
+cifmw_reportportal_property_filter:
+  - ".*"
+cifmw_reportportal_launch_name: "Dummy launch"
+cifmw_reportportal_launch_description: "Test results sent via Data router"
+cifmw_reportportal_testsuite_name: "results"
+cifmw_reportportal_launch_attributes: []

--- a/roles/reportportal/molecule/default/converge.yml
+++ b/roles/reportportal/molecule/default/converge.yml
@@ -1,0 +1,72 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  roles:
+    - role: "reportportal"
+      cifmw_reportportal_dry_run: true
+      cifmw_reportportal_datarouter_url: "https://data.router.example.com"
+      cifmw_reportportal_datarouter_username: "username"
+      cifmw_reportportal_datarouter_password: "password"
+      cifmw_reportportal_project: "test-project"
+      cifmw_reportportal_droute_client_url: "https://data.router.client.repo example.com"
+
+  tasks:
+    - name: Check directory creation
+      block:
+        - name: Stat directory
+          register: dir_stat
+          ansible.builtin.stat:
+            path: "{{ ansible_user_dir }}/ci-framework-data/droute"
+
+        - name: Validate directory state
+          ansible.builtin.assert:
+            that:
+              - dir_stat.stat.isdir is defined
+              - dir_stat.stat.isdir
+
+    - name: Check the metadata file exists
+      block:
+        - name: Stat metadata file
+          register: metadata_file_stat
+          ansible.builtin.stat:
+            path: "{{ ansible_user_dir }}/ci-framework-data/droute/metadata.json"
+
+        - name: Validate file state
+          ansible.builtin.assert:
+            that:
+              - metadata_file_stat.stat.isreg is defined
+              - metadata_file_stat.stat.isreg
+
+    - name: Check the metadata file content
+      block:
+        - name: Stat metadata golden file
+          register: metadata_golden_file_stat
+          ansible.builtin.stat:
+            path: "files/metadata-golden.json"
+
+        - name: Validate metadata golden file state
+          ansible.builtin.assert:
+            that:
+              - metadata_golden_file_stat.stat.isreg is defined
+              - metadata_golden_file_stat.stat.isreg
+
+        - name: Validate metadata golden is the same as produced metadata
+          ansible.builtin.assert:
+            that:
+              - metadata_golden_file_stat.stat.checksum == metadata_file_stat.stat.checksum

--- a/roles/reportportal/molecule/default/files/metadata-golden.json
+++ b/roles/reportportal/molecule/default/files/metadata-golden.json
@@ -1,0 +1,22 @@
+{
+    "targets": {
+        "reportportal": {
+            "config": {
+                 "hostname": "",
+                 "project": "test-project"
+            },
+            "processing" : {
+                "disable_testitem_updater": "true",
+                "property_filter": [
+                  ".*"
+                ],
+                "launch": {
+                   "name": "Dummy launch",
+                   "description": "Test results sent via Data router",
+                   "attributes": [
+                   ]
+                }
+            }
+        }
+    }
+}

--- a/roles/reportportal/molecule/default/molecule.yml
+++ b/roles/reportportal/molecule/default/molecule.yml
@@ -1,0 +1,9 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true

--- a/roles/reportportal/tasks/main.yaml
+++ b/roles/reportportal/tasks/main.yaml
@@ -1,0 +1,71 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Check if mandatory variables are defined and not empty
+  ansible.builtin.assert:
+    that:
+      - cifmw_reportportal_datarouter_url is defined and cifmw_reportportal_datarouter_url | length > 0
+      - cifmw_reportportal_datarouter_username is defined and cifmw_reportportal_datarouter_username | length > 0
+      - cifmw_reportportal_datarouter_password is defined and cifmw_reportportal_datarouter_password | length > 0
+      - cifmw_reportportal_project is defined and cifmw_reportportal_project | length > 0
+      - cifmw_reportportal_droute_client_url is defined and cifmw_reportportal_droute_client_url | length > 0
+
+- name: Make sure the droute directory exists
+  ansible.builtin.file:
+    path: "{{ cifmw_reportportal_droute_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: Get the Data router client
+  vars:
+    _droute_url: >-
+      {{
+        (cifmw_reportportal_droute_client_url,
+         cifmw_reportportal_droute_version,
+         cifmw_reportportal_droute_binary) |
+        path_join
+      }}
+  ansible.builtin.get_url:
+    url: "{{ _droute_url }}"
+    dest: "{{ cifmw_reportportal_droute_dir }}"
+    backup: true
+    mode: "0755"
+  when: not cifmw_reportportal_dry_run | bool
+
+- name: Create the metadata file
+  ansible.builtin.template:
+    src: metadata.json.j2
+    dest: "{{ cifmw_reportportal_metadata_file }}"
+    mode: "0755"
+
+- name: Send the results via Data router client call
+  ansible.builtin.command:
+    chdir: "{{ cifmw_reportportal_droute_dir }}"
+    cmd: >-
+      {{ cifmw_reportportal_droute_dir }}/{{ cifmw_reportportal_droute_binary }} send
+      --wait
+      --metadata={{ cifmw_reportportal_metadata_file }}
+      --results={{ cifmw_reportportal_results_search }}
+      --username={{ cifmw_reportportal_datarouter_username }}
+      --password={{ cifmw_reportportal_datarouter_password }}
+      --url={{ cifmw_reportportal_datarouter_url }}
+  register: droute_result
+  when: not cifmw_reportportal_dry_run | bool
+
+- name: Log droute result
+  ansible.builtin.debug:
+    var: droute_result.stdout
+  when: not cifmw_reportportal_dry_run | bool

--- a/roles/reportportal/templates/metadata.json.j2
+++ b/roles/reportportal/templates/metadata.json.j2
@@ -1,0 +1,29 @@
+{
+    "targets": {
+        "reportportal": {
+            "config": {
+                 "hostname": "{{ cifmw_reportportal_instance }}",
+                 "project": "{{ cifmw_reportportal_project }}"
+            },
+            "processing" : {
+                "disable_testitem_updater": "true",
+                "property_filter": [
+{% for item in cifmw_reportportal_property_filter %}
+                  "{{ item }}"{{ "" if loop.last else "," }}
+{% endfor %}
+                ],
+                "launch": {
+                   "name": "{{ cifmw_reportportal_launch_name }}",
+                   "description": "{{ cifmw_reportportal_launch_description }}",
+                   "attributes": [
+{% for item in cifmw_reportportal_launch_attributes %}
+                       {
+                         "key": "{{ item.key }}", "value": "{{ item.value }}"
+                       }{{ "" if loop.last else "," }}
+{% endfor %}
+                   ]
+                }
+            }
+        }
+    }
+}

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -641,6 +641,17 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/reportportal/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-reportportal
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: reportportal
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/reproducer/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -73,6 +73,7 @@
       - cifmw-molecule-polarion
       - cifmw-molecule-registry_deploy
       - cifmw-molecule-repo_setup
+      - cifmw-molecule-reportportal
       - cifmw-molecule-reproducer
       - cifmw-molecule-rhol_crc
       - cifmw-molecule-run_hook


### PR DESCRIPTION
The role is using Data router for uploading the test results into an Report portal instance.