### PR TITLE
Ensure we don't have shortnames in the DNS

### DIFF
--- a/roles/reproducer/tasks/configure_crc.yml
+++ b/roles/reproducer/tasks/configure_crc.yml
@@ -115,6 +115,7 @@
       expand-hosts
       local=/testing/
       domain=crc.testing
+      dhcp-fqdn
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers

--- a/roles/reproducer/tasks/ocp_layout.yml
+++ b/roles/reproducer/tasks/ocp_layout.yml
@@ -138,6 +138,7 @@
           {% for ip in _api_addr %}
           ptr-record={{ ip | ansible.utils.ipaddr('revdns') }},api-int.{{ _cluster }}.{{ _domain }}
           {% endfor %}
+          dhcp-fqdn
         validate: "/usr/sbin/dnsmasq -C %s --test"
 
 - name: Ensure services are reloaded


### PR DESCRIPTION
Without the dhcp-fqdn option, dnsmasq might push shortnames in the DNS,
leading to some weird situation with the resolution of such names.

Before that change, "dig compute-0" might resolve to the public/ocpbm
network, or, later, on the osp_trunk/ctlplane network.

This is because, in the DHCP configuration, we use only shortnames,
meaning we get "compute-0" twice, with different IP/networks.
Then, it depends on the order of the resolvers in /etc/resolv.conf -
order that might change upon DHCP lease updates.

With this patch, we ensure no shortnames are injected, leading to a more
stable DNS resolution, while it can also lead to slower resolution,
since the request might have to go through multiple resolvers to get an
answer.
