### PR TITLE
Inject FQDN in the DHCP IP reservation

### DIFF
--- a/roles/libvirt_manager/tasks/reserve_dnsmasq_ips.yml
+++ b/roles/libvirt_manager/tasks/reserve_dnsmasq_ips.yml
@@ -39,7 +39,12 @@
           }}
         _host:
           network: "{{ _translated_name }}"
-          name: "{{ _hostname }}"
+          name: >-
+            {{
+              (_hostname,
+               net_name,
+               cifmw_reproducer_domain | default('local')) | join('.')
+            }}
           state: 'present'
           mac: "{{ _net_data.mac_addr }}"
           ips: >-

--- a/roles/reproducer/tasks/configure_crc.yml
+++ b/roles/reproducer/tasks/configure_crc.yml
@@ -115,6 +115,7 @@
       expand-hosts
       local=/testing/
       domain=crc.testing
+      dhcp-fqdn
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers

--- a/roles/reproducer/tasks/ocp_layout.yml
+++ b/roles/reproducer/tasks/ocp_layout.yml
@@ -138,6 +138,7 @@
           {% for ip in _api_addr %}
           ptr-record={{ ip | ansible.utils.ipaddr('revdns') }},api-int.{{ _cluster }}.{{ _domain }}
           {% endfor %}
+          dhcp-fqdn
         validate: "/usr/sbin/dnsmasq -C %s --test"
 
 - name: Ensure services are reloaded


### PR DESCRIPTION
Until now, we could face a clash in the way dnsmasq re-injects its DHCP
nodes into its DNS:
with the previous state of the code, we ended with, for instance,
"compute-0" name associated to two IP, one in the ocpbm/public network,
and one on the osp_trunk (ctlplane) network. DNS resolution was slightly
off and, at least, unreliable.

This change, in addition to the addition of the `dhcp-fqdn` option in
