### PR TITLE
Enable unique names for certain types of VMs

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -71,6 +71,8 @@ are shared among multiple roles:
 - `cifmw_crc_default_network`: (String) name of the untagged network used to address DNS on the crc node. Default is `default`.
 - `cifmw_run_operators_compliance_scans`: (Bool) Specifies whether to run operator compliance scans.  Defaults to `false`.
 - `cifmw_run_compute_compliance_scans`: (Bool) Specifies whether to run compliance scans on the first compute.  Defaults to `false`.
+- `cifmw_run_id`: (String) CI Framework run identifier. This is used in libvirt_manager, to add some uniqueness to some types of virtual machines (anything that's not OCP, CRC nor controller).
+  If not set, the Framework will generate a random string for you, and store it on the target host, in `{{ cifmw_basedir }}/artifacts/run-id`
 
 ```{admonition} Words of caution
 :class: danger

--- a/reproducer-clean.yml
+++ b/reproducer-clean.yml
@@ -33,7 +33,7 @@
         name: nat64_appliance
         tasks_from: cleanup.yml
 
-    - name: Remove remote selected data directories
+    - name: Remove remote selected data
       tags:
         - deepscrub
       ansible.builtin.file:
@@ -42,6 +42,7 @@
       loop:
         - reproducer-inventory
         - reproducer-network-env
+        - artifacts/run-id
 
     - name: Remove /etc/ci/ directory
       tags:

--- a/reproducer.yml
+++ b/reproducer.yml
@@ -1,4 +1,57 @@
 ---
+- name: Manage/generate unique ID
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: true
+  vars:
+    _unique_id_file: >-
+      {{ ansible_user_dir }}/ci-framework-data/artifacts/run-id
+  tasks:
+    - name: Ensure needed directory tree is present on local node
+      ansible.builtin.file:
+        mode: "0755"
+        path: "{{ _unique_id_file | dirname }}"
+        state: directory
+
+    - name: Check if we have a unique ID already
+      register: _unique_id_stat
+      ansible.builtin.stat:
+        path: "{{ _unique_id_file }}"
+
+    # Here, we want to allow the user to provide their own run ID,
+    # or to fallback on a generated one.
+    # In any cases, we want to get the file in place with the correct value.
+    # The jinja[invalid] is triggered because ansible-lint doesn't seem to find
+    # the community.general.random_string lookup, and doesn't mock it...
+    - name: Generate current job unique ID if needed  # noqa: jinja[invalid]
+      when:
+        - (not _unique_id_stat.stat.exists and cifmw_run_id is undefined)
+          or cifmw_run_id is defined
+      vars:
+        _unique_id: >-
+          {{
+            lookup('community.general.random_string',
+                   special=false, upper=false)
+           }}
+      ansible.builtin.copy:
+        dest: "{{ _unique_id_file }}"
+        content: "{{ cifmw_run_id | default(_unique_id) | lower }}"
+
+    # Since the user might pass their own run ID, we can just consume it.
+    # If, for a subsequent run, the user doesn't pass the run ID, we will
+    # just get it from the file and consume it.
+    - name: Load existing run ID
+      when:
+        - cifmw_run_id is undefined
+      block:
+        - name: Slurp unique id file if needed
+          register: _unique_id_content
+          ansible.builtin.slurp:
+            path: "{{ _unique_id_file }}"
+
+        - name: Expose cifmw_run_id if needed
+          ansible.builtin.set_fact:
+            cifmw_run_id: "{{ _unique_id_content.content | b64decode }}"
+
 - name: Reproducer prepare play
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: true
@@ -57,6 +110,7 @@
       ansible.builtin.import_role:
         name: repo_setup
         tasks_from: rhos_release.yml
+
   roles:
     - role: ci_setup
 

--- a/roles/ci_gen_kustomize_values/templates/bgp/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp/edpm-nodeset-values/values.yaml.j2
@@ -36,7 +36,7 @@ data:
 {% for instance in instances_names                                                     %}
       {{ instance }}:
         ansibleVars:
-{%        set rack_number = instance.split('-')[1]                                     %}
+{%        set rack_number = instance.split('-') | last                                 %}
           edpm_ovn_bgp_agent_local_ovn_peer_ips:
             - 100.64.{{ rack_number }}.1
             - 100.65.{{ rack_number }}.1

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2
@@ -1,7 +1,7 @@
 # source: bgp_dt01/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2
 {% set instances_names = []                                                            %}
 {% for _inst in cifmw_networking_env_definition.instances.keys()                       %}
-{%   if node_type in _inst                                                             %}
+{%   if _inst.startswith(node_type)                                                    %}
 {%     set _ = instances_names.append(_inst)                                           %}
 {%   endif                                                                             %}
 {% endfor                                                                              %}
@@ -48,8 +48,8 @@ data:
 {%          endif                                                                      %}
 {%        endif                                                                        %}
 {%      endfor                                                                         %}
-{%        set rack_number = instance.split('-')[1]                                     %}
-{%        set peer_suffix = 1 if 'compute' in instance else 5                          %}
+{%        set rack_number = instance.split('-') | last                                 %}
+{%        set peer_suffix = 1 if instance.startswith('compute') else 5                 %}
           - name: BgpNet0
             subnetName: subnet{{ rack_number }}
             fixedIP: 100.64.{{ rack_number }}.{{ peer_suffix + 1 }}
@@ -61,5 +61,5 @@ data:
             fixedIP: 172.30.{{ rack_number }}.{{ peer_suffix + 1 }}
           - name: BgpMainNetV6
             subnetName: subnet{{ rack_number }}
-            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:00{{ (rack_number | int) + 1 }}{{ 2 if 'compute' in instance else 3 }}
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:00{{ (rack_number | int) + 1 }}{{ 2 if instance.startswith('compute') else 3 }}
 {% endfor                                                                              %}

--- a/roles/ci_gen_kustomize_values/templates/common/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/common/edpm-nodeset-values/values.yaml.j2
@@ -62,7 +62,7 @@ data:
 {%   endfor                                                                            %}
 {% endif                                                                               %}
 
-{% if 'compute' in _vm_type                                                            %}
+{% if _vm_type.startswith('compute')                                                   %}
   nova:
     migration:
       ssh_keys:

--- a/roles/ci_gen_kustomize_values/templates/common/edpm-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/common/edpm-values/values.yaml.j2
@@ -16,7 +16,7 @@ data:
     authorized: {{ cifmw_ci_gen_kustomize_values_ssh_authorizedkeys | b64encode }}
     private: {{ cifmw_ci_gen_kustomize_values_ssh_private_key | b64encode }}
     public: {{ cifmw_ci_gen_kustomize_values_ssh_public_key | b64encode }}
-{% if 'compute' in _vm_type                                                            %}
+{% if _vm_type.startswith('compute')                                                   %}
   nova:
     migration:
       ssh_keys:

--- a/roles/ci_gen_kustomize_values/templates/shiftstack/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/shiftstack/edpm-nodeset-values/values.yaml.j2
@@ -5,7 +5,7 @@
 {% set _original_nodes = _original_nodeset.nodes | default({})                         %}
 {% set _original_services = _original_nodeset['services'] | default([])                %}
 {% set _vm_type = (_original_nodes.keys() | first).split('-')[1]                       %}
-{% if 'ceph' in _vm_type                                                               %}
+{% if _vm_type.startswith('ceph')                                                      %}
 {%     set _vm_names = cifmw_networking_env_definition.instances.keys()                %}
 {% else                                                                                %}
 {%     set _vm_names = cifmw_baremetal_hosts.keys()                                    %}
@@ -21,7 +21,7 @@ data:
     private: {{ cifmw_ci_gen_kustomize_values_ssh_private_key | b64encode }}
     public: {{ cifmw_ci_gen_kustomize_values_ssh_public_key | b64encode }}
 
-{% if 'compute' in _vm_type                                                            %}
+{% if _vm_type.startswith('compute')                                                   %}
   nova:
     migration:
       ssh_keys:
@@ -37,7 +37,7 @@ data:
         timesync_ntp_servers:
           - hostname: "{{ cifmw_ci_gen_kustomize_values_ntp_srv | default('pool.ntp.org') }}"
         edpm_network_config_os_net_config_mappings:
-{% if 'ceph' in _vm_type                                                               %}
+{% if _vm_type.startswith('ceph')                                                      %}
 {%   for instance in instances_names                                                   %}
           edpm-{{ instance }}:
 {%     if hostvars[instance] is defined                                                %}
@@ -73,7 +73,7 @@ data:
 {% for instance in instances_names                                                     %}
       edpm-{{ instance }}:
         hostName: {{ instance }}
-{%   if 'ceph' in _vm_type                                                             %}
+{%   if _vm_type.startswith('ceph')                                                    %}
         ansible:
           host: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.ip_v4 }}
         networks:

--- a/roles/devscripts/molecule/check_cluster_status/prepare.yml
+++ b/roles/devscripts/molecule/check_cluster_status/prepare.yml
@@ -44,6 +44,6 @@
         path: "{{ ansible_user_dir }}/ci-framework-data/images/{{ item }}"
         state: "touch"
       loop:
-        - "ocp_master-0.qcow2"
-        - "ocp_master-1.qcow2"
-        - "ocp_master-2.qcow2"
+        - "ocp-master-0.qcow2"
+        - "ocp-master-1.qcow2"
+        - "ocp-master-2.qcow2"

--- a/roles/devscripts/molecule/check_cluster_status/tasks/test.yml
+++ b/roles/devscripts/molecule/check_cluster_status/tasks/test.yml
@@ -1,4 +1,13 @@
 ---
+- name: Ensure directories are present
+  become: true
+  ansible.builtin.file:
+    path: "/home/dev-scripts"
+    state: directory
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_id }}"
+    mode: "0755"
+
 - name: Mark run status
   ansible.builtin.set_fact:
     _run_fail: false
@@ -20,12 +29,12 @@
       {{ _cifmw_libvirt_manager_layout.vms.ocp_worker.amount  | default(0) }}
     vols: >-
       {{
-        [['base-cifmw-ocp_master'] |
+        [['base-cifmw-ocp-master'] |
         product(range(0, ocp_num|int)) |
         map('join', '-') |
         product(range(0, create_vols|int)) |
         map('join', '-vol-') | flatten] +
-        [['base-cifmw-ocp_worker'] |
+        [['base-cifmw-ocp-worker'] |
         product(range(0, worker_num|int)) |
         map('join', '-vol-') |
         product(range(0, create_vols|int)) |

--- a/roles/devscripts/tasks/110_check_ocp.yml
+++ b/roles/devscripts/tasks/110_check_ocp.yml
@@ -41,7 +41,7 @@
   ansible.builtin.find:
     file_type: "file"
     path: "{{ cifmw_devscripts_data_dir }}/images"
-    patterns: "{{ cifmw_devscripts_config.cluster_name }}_*.qcow2"
+    patterns: "{{ cifmw_devscripts_config.cluster_name }}*.qcow2"
 
 - name: Ensure we have needed base images
   vars:
@@ -72,7 +72,7 @@
   ansible.builtin.find:
     file_type: "file"
     path: "{{ cifmw_devscripts_data_dir }}/ocp_volumes"
-    patterns: "base-cifmw-ocp_master-0*"
+    patterns: "base-cifmw-{{ cifmw_devscripts_config.cluster_name }}-master-0*"
     excludes: "*.xml"
 
 - name: Ensure we have needed volumes

--- a/roles/devscripts/tasks/310_prepare_overlay.yml
+++ b/roles/devscripts/tasks/310_prepare_overlay.yml
@@ -37,7 +37,7 @@
   failed_when: false
   vars:
     matcher: >-
-      ^cifmw-{{ cifmw_devscripts_config.cluster_name }}_(master|worker).*
+      ^cifmw-{{ cifmw_devscripts_config.cluster_name }}-(master|worker).*
   community.libvirt.virt:
     command: "destroy"
     name: "{{ item }}"
@@ -47,7 +47,7 @@
 - name: Undefine all nodes part of OpenShift platform
   vars:
     matcher: >-
-      ^cifmw-{{ cifmw_devscripts_config.cluster_name }}_(master|worker).*
+      ^cifmw-{{ cifmw_devscripts_config.cluster_name }}-(master|worker).*
   community.libvirt.virt:
     command: "undefine"
     flags:

--- a/roles/libvirt_manager/molecule/check_dns/converge.yml
+++ b/roles/libvirt_manager/molecule/check_dns/converge.yml
@@ -18,6 +18,7 @@
   hosts: instance
   gather_facts: true
   vars:
+    cifmw_run_id: aabbcc11
     ansible_user_dir: "{{ lookup('env', 'HOME') }}"
     cifmw_basedir: "/opt/basedir"
     _cifmw_libvirt_manager_layout:

--- a/roles/libvirt_manager/molecule/deploy_layout/converge.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/converge.yml
@@ -18,6 +18,7 @@
   hosts: instance
   gather_facts: true
   vars:
+    cifmw_run_id: aabbcc11
     ansible_user_dir: "{{ lookup('env', 'HOME') }}"
     cifmw_basedir: "/opt/basedir"
     cifmw_libvirt_manager_vm_net_ip_set:
@@ -160,28 +161,31 @@
             sorted_vms: "{{ vms.list_vms | sort }}"
             compare_vms: >-
               {{
-                ['cifmw-compute-0',
-                 'cifmw-compute-1',
-                 'cifmw-baremetal-0'] | sort
+                ["cifmw-compute-" ~ cifmw_run_id ~ "-0",
+                 "cifmw-compute-" ~ cifmw_run_id ~ "-1",
+                 "cifmw-baremetal-" ~ cifmw_run_id ~ "-0"] | sort
               }}
           ansible.builtin.assert:
             that:
               - sorted_nets == compare_nets
               - sorted_vms == compare_vms
+            msg: |
+              Got {{ sorted_vms }} and {{ sorted_nets }}
+              Want {{ compare_vms }} and {{ compare_nets }}
 
         - name: Get compute-0 network interfaces
           register: cmp_nics
           ansible.builtin.command:
             cmd: >-
               virsh -c qemu:///system -q
-              domiflist cifmw-compute-0
+              domiflist cifmw-compute-{{ cifmw_run_id }}-0
 
         - name: Ensure compute-0 connections
           vars:
             _vals: >-
               {{
                 cmp_nics.stdout_lines |
-                product([' compute-0']) |
+                product([" compute-" ~ cifmw_run_id ~ "-0"]) |
                 map('join') |
                 map('split')
               }}

--- a/roles/libvirt_manager/molecule/deploy_layout/prepare.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/prepare.yml
@@ -66,9 +66,19 @@
           log-queries
           server=/utility/127.0.0.2
           server=/local/127.0.0.2
+          server=/{{ inventory_hostname }}/127.0.0.2
 
     - name: Restart NetworkManager
       become: true
       ansible.builtin.systemd_service:
         name: NetworkManager
         state: restarted
+
+    # The management of that directory isn't widespread, and some
+    # molecule scenario might call only selected subsets of tasks,
+    # leading to the directory not being present.
+    - name: Ensure ocp_volumes exists
+      ansible.builtin.file:
+        path: "{{ cifmw_basedir }}/ocp_volumes"
+        state: directory
+        mode: "0755"

--- a/roles/libvirt_manager/molecule/generate_network_data/converge.yml
+++ b/roles/libvirt_manager/molecule/generate_network_data/converge.yml
@@ -18,6 +18,7 @@
   hosts: instance
   gather_facts: true
   vars:
+    cifmw_run_id: aabbcc11
     cifmw_basedir: "/opt/basedir"
     _output: >-
       {{

--- a/roles/libvirt_manager/molecule/generate_network_data/vars/input.yml
+++ b/roles/libvirt_manager/molecule/generate_network_data/vars/input.yml
@@ -77,7 +77,7 @@ group-templates:
       ctlplane: {}
       internalapi:
         trunk-parent: ctlplane
-  sl-computes:
+  sl_computes:
     network-template:
       range:
         start: 16
@@ -87,14 +87,14 @@ group-templates:
     networks:
       ctlplane:
         range: "192.168.140.20-192.168.140.24"
-  dcn1-computes:
+  dcn1_computes:
     network-template:
       range:
         start: 150
         length: 10
     networks:
       ctlplanedcn1: {}
-  dcn2-computes:
+  dcn2_computes:
     network-template:
       range:
         start: 160

--- a/roles/libvirt_manager/molecule/generate_network_data/vars/scenarios.yml
+++ b/roles/libvirt_manager/molecule/generate_network_data/vars/scenarios.yml
@@ -11,6 +11,14 @@
 scenarios:
   - name: Standard osp_trunk with extended translation
     check_dns:
+      - rec: "compute-aabbcc11-0.utility"
+        ip: "192.168.140.10"
+      - rec: "compute-aabbcc11-0.ctlplane.local"
+        ip: "192.168.140.10"
+      - rec: "compute-aabbcc11-0.public.local"
+        ip: "192.168.110.10"
+      # Ensure we have the short, "old" non-random name in DNS as
+      # well
       - rec: "compute-0.utility"
         ip: "192.168.140.10"
       - rec: "compute-0.ctlplane.local"
@@ -18,8 +26,8 @@ scenarios:
       - rec: "compute-0.public.local"
         ip: "192.168.110.10"
     check_dhcp:
-      - osp_trunk_compute-0
-      - public_compute-0
+      - osp_trunk_compute-aabbcc11-0
+      - public_compute-aabbcc11-0
     lm_config_patch:
       networks:
         osp_trunk: |
@@ -32,19 +40,19 @@ scenarios:
 
   - name: Baremetal integration
     check_dns:
-      - rec: "compute-0.utility"
+      - rec: "compute-aabbcc11-0.utility"
         ip: "192.168.140.10"
-      - rec: "compute-0.ctlplane.local"
+      - rec: "compute-aabbcc11-0.ctlplane.local"
         ip: "192.168.140.10"
-      - rec: "compute-0.public.local"
+      - rec: "compute-aabbcc11-0.public.local"
         ip: "192.168.110.10"
       - rec: "bm-0.utility"
         ip: "192.168.140.20"
       - rec: "bm-0.ctlplane.local"
         ip: "192.168.140.20"
     check_dhcp:
-      - osp_trunk_compute-0
-      - public_compute-0
+      - osp_trunk_compute-aabbcc11-0
+      - public_compute-aabbcc11-0
       - public_bm-0
     bm_hosts:
       bm-0:
@@ -82,39 +90,39 @@ scenarios:
       dcn2_tr:
         - ctlplanedcn2
     check_dns:
-      - rec: "compute-0.utility"
+      - rec: "compute-aabbcc11-0.utility"
         ip: "192.168.140.10"
-      - rec: "compute-0.ctlplane.local"
+      - rec: "compute-aabbcc11-0.ctlplane.local"
         ip: "192.168.140.10"
-      - rec: "compute-0.ocpbm.local"
+      - rec: "compute-aabbcc11-0.ocpbm.local"
         ip: "192.168.111.10"
       - rec: "bm-0.utility"
         ip: "192.168.140.20"
       - rec: "bm-0.ctlplane.local"
         ip: "192.168.140.20"
-      - rec: "dcn1-compute-0.utility"
+      - rec: "dcn1-compute-aabbcc11-0.utility"
         ip: "192.168.133.150"
-      - rec: "dcn1-compute-0.ctlplanedcn1.local"
+      - rec: "dcn1-compute-aabbcc11-0.ctlplanedcn1.local"
         ip: "192.168.133.150"
-      - rec: "dcn1-compute-0.ocpbm.local"
+      - rec: "dcn1-compute-aabbcc11-0.ocpbm.local"
         ip: "192.168.111.150"
-      - rec: "dcn1-compute-1.utility"
+      - rec: "dcn1-compute-aabbcc11-1.utility"
         ip: "192.168.133.151"
-      - rec: "dcn2-compute-0.utility"
+      - rec: "dcn2-compute-aabbcc11-0.utility"
         ip: "192.168.144.160"
     check_dhcp:
-      - dcn1_tr_dcn1-compute-0
-      - dcn1_tr_dcn1-compute-1
-      - dcn2_tr_dcn2-compute-0
+      - dcn1_tr_dcn1-compute-aabbcc11-0
+      - dcn1_tr_dcn1-compute-aabbcc11-1
+      - dcn2_tr_dcn2-compute-aabbcc11-0
       - ocpbm_bm-0
-      - ocpbm_compute-0
-      - ocpbm_dcn1-compute-0
-      - ocpbm_dcn1-compute-1
-      - ocpbm_dcn2-compute-0
+      - ocpbm_compute-aabbcc11-0
+      - ocpbm_dcn1-compute-aabbcc11-0
+      - ocpbm_dcn1-compute-aabbcc11-1
+      - ocpbm_dcn2-compute-aabbcc11-0
       - osp_trunk_bm-0
-      - osp_trunk_compute-0
+      - osp_trunk_compute-aabbcc11-0
       - public_bm-0
-      - public_compute-0
+      - public_compute-aabbcc11-0
     bm_hosts:
       bm-0:
         address: 10.10.1.12
@@ -165,7 +173,7 @@ scenarios:
                   </ip>
           </network>
       vms:
-        dcn1-compute:
+        dcn1_compute:
           amount: 2
           disk_file_name: "blank"
           disksize: "2"
@@ -174,7 +182,7 @@ scenarios:
           nets:
             - ocpbm
             - dcn1_tr
-        dcn2-compute:
+        dcn2_compute:
           amount: 1
           disk_file_name: "blank"
           disksize: "2"

--- a/roles/libvirt_manager/molecule/ocp_layout/cleanup.yml
+++ b/roles/libvirt_manager/molecule/ocp_layout/cleanup.yml
@@ -1,0 +1,28 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Clean VBMC
+  hosts: instance
+  tasks:
+    - name: Remove VBMC
+      ansible.builtin.include_role:
+        name: "virtualbmc"
+        tasks_from: "cleanup.yml"
+
+- name: Cleanup
+  vars:
+    molecule_scenario: ocp_layout
+  ansible.builtin.import_playbook: ../deploy_layout/cleanup.yml

--- a/roles/libvirt_manager/molecule/ocp_layout/converge.yml
+++ b/roles/libvirt_manager/molecule/ocp_layout/converge.yml
@@ -1,0 +1,165 @@
+---
+# Copyright 2023 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Test ocp_layout.yml tasks
+  hosts: instance
+  gather_facts: true
+  vars:
+    cifmw_run_id: aabbcc11
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_basedir: "/opt/basedir"
+    _cifmw_libvirt_manager_layout:
+      vms:
+        ocp:
+          amount: 3
+          uefi: true
+          root_part_id: 4
+          admin_user: core
+          image_local_dir: "{{ cifmw_basedir }}/images/"
+          disk_file_name: "ocp_master"
+          disksize: 10
+          cpus: 2
+          memory: 2
+          nets:
+            - public
+        ocp_worker:
+          amount: 1
+          uefi: true
+          root_part_id: 4
+          admin_user: core
+          image_local_dir: "{{ cifmw_basedir }}/images/"
+          disk_file_name: "ocp_worker"
+          disksize: 10
+          cpus: 2
+          memory: 2
+          nets:
+            - public
+      networks:
+        public: |-
+          <network>
+            <name>public</name>
+            <forward mode='nat'/>
+            <bridge name='public' stp='on' delay='0'/>
+            <dns enable="no"/>
+            <ip
+             family='ipv4'
+             address='192.168.110.1'
+             prefix='24'>
+            </ip>
+          </network>
+  tasks:
+    - name: Load networking definition
+      ansible.builtin.include_vars:
+        file: net-def.yml
+
+    - name: Generate networking data
+      ansible.builtin.import_role:
+        name: libvirt_manager
+        tasks_from: generate_networking_data
+
+    - name: Inject ipmi.utility
+      become: true
+      ansible.builtin.lineinfile:
+        line: "host-record=ipmi.utility,{{ inventory_hostname }}.utility,192.168.110.1"
+        path: "/etc/cifmw-dnsmasq.d/host_records.conf"
+
+    - name: Restart cifmw-dnsmasq
+      become: true
+      ansible.builtin.systemd_service:
+        name: cifmw-dnsmasq
+        state: restarted
+
+    - name: Prepare OCP layout
+      ansible.builtin.import_role:
+        name: libvirt_manager
+        tasks_from: ocp_layout.yml
+
+    - name: Run some assertions
+      vars:
+        _dns_checks:
+          master-0.utility: 192.168.140.10
+          master-0.instance: 192.168.140.10
+          ocp-0.utility: 192.168.140.10
+          ocp-0.instance: 192.168.140.10
+          master-0.ctlplane.local: 192.168.140.10
+          ocp-0.ctlplane.local: 192.168.140.10
+          master-0.public.local: 192.168.110.10
+          ocp-0.public.local: 192.168.110.10
+          master-0.storage.local: 172.18.0.10
+          ocp-0.storage.local: 172.18.0.10
+          master-0.tenant.local: 172.19.0.10
+          ocp-0.tenant.local: 172.19.0.10
+          master-1.utility: 192.168.140.11
+          master-2.utility: 192.168.140.12
+        _disks_name:
+          - ocp-master-0.qcow2
+          - ocp-master-1.qcow2
+          - ocp-master-2.qcow2
+          - ocp-worker-0.qcow2
+      block:
+        - name: Assert names are correct
+          ansible.builtin.assert:
+            quiet: true
+            that:
+              - item is match('^ocp-(master|worker)-[0-9]+$')
+          loop: "{{ _cifmw_libvirt_manager_ocp_cluster }}"
+
+        - name: Ensure DNS is properly resolving
+          vars:
+            _res: "{{ lookup('community.general.dig', item.key) }}"
+          ansible.builtin.assert:
+            quiet: true
+            that:
+              - _res == item.value
+            msg: >-
+              {{ item.key }} does not resolve to {{ item.value }} but
+              to {{ _res }}
+          loop: "{{ _dns_checks | dict2items }}"
+
+        - name: Ensure we have appropriate MAC data
+          vars:
+            _mac_hosts: "{{ cifmw_libvirt_manager_mac_map.keys() | sort}}"
+            _ocp_hosts: "{{ _cifmw_libvirt_manager_ocp_cluster | sort }}"
+          ansible.builtin.assert:
+            quiet: true
+            that:
+              - _mac_hosts == _ocp_hosts
+            msg: >-
+              OCP node list is {{ _ocp_hosts }} while MAC list is
+              {{ _mac_hosts }}
+
+        - name: Get existing disk images
+          register: _disk_imgs
+          ansible.builtin.find:
+            path: "{{ cifmw_basedir }}/images"
+            pattern: "*.qcow2"
+
+        - name: Ensure we have the expected base images
+          vars:
+            _existing_imgs: >-
+              {{
+                _disk_imgs.files |
+                map(attribute='path') |
+                map('basename') | sort
+              }}
+            _expected_imgs: "{{ _disks_name | sort }}"
+          ansible.builtin.assert:
+            quiet: true
+            that:
+              - _existing_imgs == _expected_imgs
+            msg: >-
+              Expected {{ _expected_imgs }} while found
+              {{ _existing_imgs }}

--- a/roles/libvirt_manager/molecule/ocp_layout/molecule.yml
+++ b/roles/libvirt_manager/molecule/ocp_layout/molecule.yml
@@ -1,0 +1,13 @@
+---
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  inventory:
+    host_vars:
+      instance:
+        cifmw_libvirt_manager_configuration_patch_01_more_computes:
+          vms:
+            compute:
+              amount: 2

--- a/roles/libvirt_manager/molecule/ocp_layout/prepare.yml
+++ b/roles/libvirt_manager/molecule/ocp_layout/prepare.yml
@@ -1,0 +1,39 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  ansible.builtin.import_playbook: ../deploy_layout/prepare.yml
+
+- name: Get VBMC in place
+  hosts: instance
+  gather_facts: true
+  vars:
+    cifmw_basedir: "/opt/basedir"
+  tasks:
+    - name: Ensure extra dir is present
+      become: true
+      ansible.builtin.file:
+        path: "{{ cifmw_basedir }}/ocp_volumes"
+        state: directory
+        owner: "{{ ansible_user_id }}"
+        mode: "0755"
+
+    - name: Ensure VBMC is present
+      vars:
+        cifmw_virtualbmc_daemon_port: 51881
+      ansible.builtin.import_role:
+        name: "virtualbmc"

--- a/roles/libvirt_manager/molecule/ocp_layout/vars/net-def.yml
+++ b/roles/libvirt_manager/molecule/ocp_layout/vars/net-def.yml
@@ -1,0 +1,129 @@
+---
+cifmw_networking_definition:
+  networks:
+    ctlplane:
+      network: "192.168.140.0/24"
+      gateway: "192.168.140.1"
+      dns:
+        - "192.168.140.1"
+      mtu: 1500
+      tools:
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+        netconfig:
+          ranges:
+            - start: 100
+              end: 120
+            - start: 150
+              end: 170
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+    internalapi:
+      network: "172.17.0.0/24"
+      vlan: 20
+      mtu: 1496
+      tools:
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+    storage:
+      network: "172.18.0.0/24"
+      vlan: 21
+      mtu: 1496
+      tools:
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+    tenant:
+      network: "172.19.0.0/24"
+      tools:
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+      vlan: 22
+      mtu: 1496
+    external:
+      network: "10.0.0.0/24"
+      tools:
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+      vlan: 22
+      mtu: 1500
+    storagemgmt:
+      network: "172.20.0.0/24"
+      tools:
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+      vlan: 23
+      mtu: 1500
+
+  group-templates:
+    ocps:
+      network-template:
+        range:
+          start: 10
+          length: 3
+      networks: &ocps_nets
+        ctlplane: {}
+        internalapi:
+          trunk-parent: ctlplane
+        tenant:
+          trunk-parent: ctlplane
+        storage:
+          trunk-parent: ctlplane
+    ocp_workers:
+      network-template:
+        range:
+          start: 15
+          length: 3
+      networks: *ocps_nets
+    computes:
+      network-template:
+        range:
+          start: 100
+          length: 21
+      networks: &computes_nets
+        ctlplane: {}
+        internalapi:
+          trunk-parent: ctlplane
+        tenant:
+          trunk-parent: ctlplane
+        storage:
+          trunk-parent: ctlplane
+        storagemgmt:
+          trunk-parent: ctlplane

--- a/roles/libvirt_manager/molecule/spine_leaf/converge.yml
+++ b/roles/libvirt_manager/molecule/spine_leaf/converge.yml
@@ -18,6 +18,7 @@
   hosts: instance
   gather_facts: true
   vars:
+    cifmw_run_id: aabbcc11
     ansible_user_dir: "{{ lookup('env', 'HOME') }}"
     cifmw_basedir: "/opt/basedir"
     cifmw_libvirt_manager_spineleaf_setup: true

--- a/roles/libvirt_manager/molecule/spine_leaf/verify.yml
+++ b/roles/libvirt_manager/molecule/spine_leaf/verify.yml
@@ -4,6 +4,7 @@
   gather_facts: true
   vars:
     ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_run_id: aabbcc11
     cifmw_basedir: "/opt/basedir"
     compare_nets: >-
       {{
@@ -13,9 +14,9 @@
       }}
     compare_vms: >-
       {{
-        ['cifmw-sl-compute-0',
-         'cifmw-sl-compute-1',
-         'cifmw-router-0'] | sort
+        ['cifmw-sl-compute-aabbcc11-0',
+         'cifmw-sl-compute-aabbcc11-1',
+         'cifmw-router-aabbcc11-0'] | sort
       }}
   tasks:
     - name: Get wanted files
@@ -63,7 +64,7 @@
       ansible.builtin.command:
         cmd: >-
           virsh -c qemu:///system -q
-          domiflist cifmw-sl-compute-0
+          domiflist cifmw-sl-compute-{{ cifmw_run_id }}-0
 
     - name: Ensure sl-compute-0 connections
       vars:
@@ -92,14 +93,14 @@
       ansible.builtin.command:
         cmd: >-
           virsh -c qemu:///system -q
-          domiflist cifmw-sl-compute-1
+          domiflist cifmw-sl-compute-{{ cifmw_run_id }}-1
 
     - name: Ensure sl-compute-1 connections
       vars:
         _vals: >-
           {{
             cmp_nics_cmp_1.stdout_lines |
-            product([' sl-compute-1']) |
+            product([' sl-compute-aabbcc11-1']) |
             map('join') |
             map('split')
           }}

--- a/roles/libvirt_manager/tasks/attach_interface.yml
+++ b/roles/libvirt_manager/tasks/attach_interface.yml
@@ -79,15 +79,10 @@
         selectattr('source.' + _type, 'equalto', _local_bridge_name)
       }}
     _clean_vm: "{{ vm_name | replace('cifmw-', '') }}"
-    _act_name: >-
-      {{
-        (_clean_vm is match('^ocp_master.*')) |
-        ternary(_clean_vm | replace('ocp_master', 'ocp'), _clean_vm)
-      }}
     _mac_seed: "{{ '52:54:%02i' % vm_item|default(0)|int }}"
     _lm_mac_address: >-
-      {% if cifmw_libvirt_manager_mac_map[_act_name] is defined -%}
-      {% set known_mac = cifmw_libvirt_manager_mac_map[_act_name] |
+      {% if cifmw_libvirt_manager_mac_map[_clean_vm] is defined -%}
+      {% set known_mac = cifmw_libvirt_manager_mac_map[_clean_vm] |
                          selectattr('network', 'equalto', network.name) |
                          map(attribute='mac')
       -%}

--- a/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/roles/libvirt_manager/tasks/clean_layout.yml
@@ -276,6 +276,7 @@
     - artifacts/debug_network_data.yml
     - artifacts/debug_pub_net_value.txt
     - artifacts/debug_cifmw_libvirt_manager_layout.yml
+    - artifacts/interfaces-info.yml
     - artifacts/libvirt-uuids.yml
     - artifacts/net-map-def-patch.yml
 
@@ -288,7 +289,6 @@
     state: absent
   loop:
     - images
-    - artifacts/interfaces-info.yml
     - artifacts/virtual-nodes.yml
 
 - name: Clean virtualBMC

--- a/roles/libvirt_manager/tasks/create_dns_records.yml
+++ b/roles/libvirt_manager/tasks/create_dns_records.yml
@@ -45,15 +45,18 @@
           }}
         _ocp_name: >-
           {{
-            vm.key | replace('_', '-') |
-            replace('ocp-worker', 'worker') |
-            replace('ocp', 'master')
+            vm.key |
+            replace('ocp-', '')
           }}
         _hostname: >-
           {{
             (vm.key is match('^ocp.*')) |
             ternary(_ocp_name, vm.key)
           }}
+        _compat_name: >-
+          {%- set _id = vm.key | regex_replace('^.*-([0-9]+)$', '\\1') -%}
+          {%- set _type = hostvars[vm.key].vm_type -%}
+          {{ (_type, _id) | join('-') }}
         _domain: >-
           {{
              cifmw_reproducer_domain | default('local')
@@ -61,6 +64,9 @@
         _utility:
           - names:
               - "{{ _hostname }}.utility"
+              - "{{ _hostname }}.{{ inventory_hostname }}"
+              - "{{ _compat_name }}.utility"
+              - "{{ _compat_name }}.{{ inventory_hostname }}"
             ips:
               - "{{ _utility_net.0.value.ip_v4 | default('') }}"
               - "{{ _utility_net.0.value.ip_v6 | default('') }}"
@@ -68,9 +74,12 @@
         _entry: >-
           {%- for network in vm.value.networks | dict2items -%}
           {%- set _fqdn = [_hostname, network.key, _domain] | join('.') -%}
+          {%- set _compat_fqdn = [_compat_name, network.key, _domain] |
+                                 join('.')                              -%}
+          {%- set _fqdns = [_fqdn, _compat_fqdn] -%}
           {%- set _ips = [network.value.ip_v4 | default(''),
                           network.value.ip_v6 | default('') ]-%}
-          {%- set _rec = {'names': [_fqdn], 'ips': _ips, 'state': 'present'} -%}
+          {%- set _rec = {'names': _fqdns, 'ips': _ips, 'state': 'present'} -%}
           {%- set _ = _utility.append(_rec) -%}
           {%- endfor -%}
           {{ _utility }}

--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -2,10 +2,18 @@
 - name: "Create VM overlays or images for {{ vm_type }}"
   become: true
   vars:
+    _ocp_basename: >-
+      {{
+        vm_data.disk_file_name | replace('_', '-')
+      }}
+    _diskfilename: >-
+      {{
+        vm is match('.*ocp.*') | ternary(_ocp_basename, vm_data.disk_file_name)
+      }}
     _base_img_name: >-
       {{
         (vm_data.image_local_dir | default(ansible_user_dir),
-         vm_data.disk_file_name) |
+         _diskfilename) |
          path_join
       }}
     _vm_id: >-
@@ -88,7 +96,7 @@
       }}
     _vname: >-
       {{
-        vm | regex_replace('ocp-([0-9]+)', 'ocp_master-\1')
+        vm | regex_replace('ocp-([0-9]+)', 'ocp-master-\1')
       }}
     vol_prefix: >-
       {{

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -167,12 +167,8 @@
        (vm_data.value.amount | int) > 0) or
       vm_data.value.amount is undefined
   vars:
-    _matcher: >-
-      {{
-        '(cifmw-)?' ~
-        '([a-z0-9]+)-[0-9]+'
-      }}
-    vm_type: "{{ vm | regex_replace(_matcher, '\\2') }}"
+    vm_type: "{{ _vm.value }}"
+    vm: "{{ _vm.key }}"
     vm_data: >-
       {{
         _cifmw_libvirt_manager_layout.vms[vm_type]
@@ -181,9 +177,9 @@
     priv_key: "{{ priv_ssh_key.content | b64decode }}"
   ansible.builtin.include_tasks:
     file: create_vms.yml
-  loop: "{{ cifmw_libvirt_manager_all_vms }}"
+  loop: "{{ cifmw_libvirt_manager_all_vms | dict2items }}"
   loop_control:
-    loop_var: vm
+    loop_var: _vm
     index_var: vm_idx
 
 - name: "Start (power-on) VMs"
@@ -195,12 +191,8 @@
     - vm_data.start | default(true) | bool
     - vm_data.disk_file_name != 'blank'
   vars:
-    _matcher: >-
-      {{
-        '(cifmw-)?' ~
-        '([a-z0-9]+)-[0-9]+'
-      }}
-    vm_type: "{{ vm | regex_replace(_matcher, '\\2') }}"
+    vm_type: "{{ _vm.value }}"
+    vm: "{{ _vm.key }}"
     vm_data: >-
       {{
         _cifmw_libvirt_manager_layout.vms[vm_type]
@@ -208,10 +200,11 @@
     _init_admin_user: "{{ vm_data.value.admin_user | default('root') }}"
     pub_key: "{{ pub_ssh_key.content | b64decode }}"
     priv_key: "{{ priv_ssh_key.content | b64decode }}"
+    vm_con_name: "{{ vm | replace('ocp-', '') }}.{{ inventory_hostname }}"
   ansible.builtin.include_tasks: manage_vms.yml
-  loop: "{{ cifmw_libvirt_manager_all_vms }}"
+  loop: "{{ cifmw_libvirt_manager_all_vms | dict2items }}"
   loop_control:
-    loop_var: vm
+    loop_var: _vm
 
 - name: Create VBMC entity
   when:

--- a/roles/libvirt_manager/tasks/generate_macs.yml
+++ b/roles/libvirt_manager/tasks/generate_macs.yml
@@ -8,14 +8,10 @@
 # The bellow code does all the magic.
 - name: Generate/update mapping all nodes
   vars:
+    vm: "{{ _vm.key }}"
+    _vm_type: "{{ _vm.value }}"
     _mac_seed: "{{ '52:54:%02i' % vm_id }}"
     _fixed_mac: "{{ _mac_seed | community.general.random_mac }}"
-    _matcher: >-
-      {{
-        '(cifmw-)?' ~
-        '([a-z0-9]+)-[0-9]+'
-      }}
-    _vm_type: "{{ vm | regex_replace(_matcher, '\\2') }}"
     # We don't generate MAC for spineleafnets - if that one is set
     # we won't get "nets" entry. Just use an empty list in that case.
     _nets_list: >-
@@ -49,10 +45,10 @@
         cifmw_libvirt_manager_mac_map |
         combine(_generated, recursive=true)
       }}
-  loop: "{{ cifmw_libvirt_manager_all_vms }}"
+  loop: "{{ cifmw_libvirt_manager_all_vms | dict2items }}"
   loop_control:
     index_var: vm_id
-    loop_var: vm
+    loop_var: _vm
 
 - name: Append baremetal nodes if needed
   when:

--- a/roles/libvirt_manager/tasks/generate_networking_data.yml
+++ b/roles/libvirt_manager/tasks/generate_networking_data.yml
@@ -37,15 +37,30 @@
 
     - name: Generate VM list
       vars:
+        _run_id: "{{ cifmw_run_id | lower }}"
         vm_list: >-
-          {% set _vm_list = [] -%}
+          {% set _vm_list = {} -%}
           {% set _range = [] -%}
           {% for _type in _cifmw_libvirt_manager_layout.vms.keys() -%}
-          {%   set _range = range(0, _cifmw_libvirt_manager_layout.vms[_type].amount | default(1) | int) -%}
-          {%   set _vms = [_type] | product(_range) | map('join', '-') -%}
-          {%   set _ = _vm_list.append(_vms) -%}
+          {%   set _amount = _cifmw_libvirt_manager_layout.vms[_type].amount |
+                             default(1) | int -%}
+          {%   set _range = range(0, _amount) -%}
+          {%     if _type is not match('^(controller|ocp|crc).*') -%}
+          {%       set _name = _type ~ '-' ~ _run_id          -%}
+          {%     else                                         -%}
+          {%       if _type == 'ocp'                          -%}
+          {%         set _name = 'ocp-master'                 -%}
+          {%       else                                       -%}
+          {%         set _name = _type                        -%}
+          {%       endif                                      -%}
+          {%     endif                                        -%}
+          {%   set _vms = [_name | replace('_', '-')] |
+                          product(_range) |
+                          map('join', '-')                    -%}
+          {%   set _map = dict(_vms | zip([_type] * _amount)) -%}
+          {%   set _ = _vm_list.update(_map)                  -%}
           {% endfor -%}
-          {{ _vm_list | list | flatten }}
+          {{ _vm_list }}
       ansible.builtin.set_fact:
         cifmw_libvirt_manager_all_vms: "{{ vm_list }}"
 
@@ -63,7 +78,7 @@
   when:
     - (_cifmw_libvirt_manager_layout.vms[_vm_type].amount | default(1) | int) > 0
   vars:
-    _vm_type: "{{ item.key | regex_replace('(cifmw\\-)?([a-z]+)\\-[0-9]+', '\\2') }}"
+    _vm_type: "{{ cifmw_libvirt_manager_all_vms[item.key] | default('none') }}"
     _std_group: "{{ (_vm_type == 'crc') | ternary('ocp', _vm_type) }}"
     _group: >-
       {{
@@ -74,13 +89,13 @@
     _ocp_name: >-
       {{
         item.key | replace('_', '-') |
-        replace('ocp-worker', 'worker') |
-        replace('ocp', 'master')
+        replace('ocp-', '')
       }}
     _hostname: >-
       {{
         (item.key is match('^ocp.*')) |
-        ternary(_ocp_name, item.key)
+        ternary(_ocp_name, item.key) |
+        replace('_', '-')
       }}
     _ssh_user: >-
       {{
@@ -88,10 +103,11 @@
         default('zuul')
       }}
   ansible.builtin.add_host:
-    name: "{{ item.key }}"
+    name: "{{ item.key | replace('_', '-') }}"
     groups: "{{ _group }}s"
     ansible_ssh_user: "{{ _ssh_user }}"
     ansible_host: "{{ _hostname }}.{{ inventory_hostname }}"
+    vm_type: "{{ _group }}"
   loop: "{{ cifmw_libvirt_manager_mac_map | dict2items }}"
   loop_control:
     label: "Adding {{ item.key }} to {{ _group }}s"
@@ -271,10 +287,11 @@
 
 # This task might also be done via the reproducer/prepare_networking.yml
 # but, depending on how we call the libvirt_manager, we might not have it.
-# Using the same filename/permissions/content, we can ensure it's there without
-# re-doing the same tasks.
-# For the record, `local` ensures dnsmasq won't try to resolve names from other places.
-- name: Ensure .utility is local
+# Using the same filename/permissions/content, we can ensure it's there
+# without re-doing the same tasks.
+# For the record, `local` ensures dnsmasq won't try to resolve names from
+# other places.
+- name: Ensure some domains are local
   become: true
   notify: "Restart dnsmasq"
   ansible.builtin.copy:
@@ -282,6 +299,7 @@
     mode: "0644"
     content: |
       local=/utility/
+      local=/{{ inventory_hostname }}/
     validate: "/usr/sbin/dnsmasq -C %s --test"
 
 - name: Ensure dnsmasq is reloaded now

--- a/roles/libvirt_manager/tasks/manage_vms.yml
+++ b/roles/libvirt_manager/tasks/manage_vms.yml
@@ -3,14 +3,19 @@
   vars:
     _ocp_name: >-
       {{
-        vm | replace('_', '-') |
-        replace('ocp-worker', 'worker') |
-        replace('ocp', 'master')
+        vm |
+        replace('ocp-', '')
       }}
     _hostname: >-
       {{
         (vm is match('^ocp.*')) |
         ternary(_ocp_name, vm)
+      }}
+    _type_id: >-
+      {{
+        vm |
+        regex_replace('^.*-([0-9]+)$',
+                      vm_type ~ '-\1')
       }}
     _user: "{{ 'core' if vm is match('^(crc|ocp).*') else 'zuul' }}"
     dataset:
@@ -19,12 +24,12 @@
       hostname: "{{ _hostname }}.utility"
       patterns:
         - "{{ vm }}"
+        - "{{ _type_id }}"
+        - "{{ _type_id }}.utility"
+        - "{{ _type_id }}.{{ inventory_hostname }}"
         - "{{ _hostname }}"
-        - "{{ _hostname }}.utility"
-        - "{{ vm }}.{{ inventory_hostname }}"
+        - "{{ vm_con_name }}"
         - "{{ _hostname }}.{{ inventory_hostname }}"
-        - "cifmw-{{ vm }}"
-        - "cifmw-{{ _hostname }}"
     proxy_data:
       target: localhost
       proxy_host: "{{ ansible_host | default(inventory_hostname) }}"
@@ -59,7 +64,7 @@
     cmd: >-
       set -o pipefail;
       cat ~/.ssh/authorized_keys |
-      ssh -v {{ _user }}@{{ vm }}.{{ inventory_hostname }} "cat >> ~/.ssh/authorized_keys"
+      ssh -v {{ _user }}@{{ vm_con_name }} "cat >> ~/.ssh/authorized_keys"
   retries: 5
   delay: 10
   register: _ssh_access
@@ -73,13 +78,13 @@
     _root_part: "{{ vm_data.root_part_id | default('1') }}"
   ansible.builtin.shell:
     cmd: >-
-      ssh core@{{ vm }}.{{ inventory_hostname }}
+      ssh core@{{ vm_con_name }}
       "sudo growpart /dev/sda {{ _root_part }}; sudo xfs_growfs /;"
 
 - name: "Inject private key on hosts {{ vm }}"
   when:
     - vm_type is match('^controller.*$')
-  delegate_to: "{{ vm }}.{{ inventory_hostname }}"
+  delegate_to: "{{ vm_con_name }}"
   remote_user: "{{ _init_admin_user }}"
   ansible.builtin.copy:
     dest: "/home/zuul/.ssh/id_cifw"
@@ -91,7 +96,7 @@
 - name: "Inject public key on hosts {{ vm }}"
   when:
     - vm_type is match('^controller.*$')
-  delegate_to: "{{ vm }}.{{ inventory_hostname }}"
+  delegate_to: "{{ vm_con_name }}"
   remote_user: "{{ _init_admin_user }}"
   ansible.builtin.copy:
     dest: "/home/zuul/.ssh/id_cifw.pub"

--- a/roles/libvirt_manager/tasks/ocp_layout.yml
+++ b/roles/libvirt_manager/tasks/ocp_layout.yml
@@ -44,15 +44,18 @@
             ansible.utils.remove_keys(target="xml_paths")
           }}
     _vm_list: >-
-      {% set _vm_list = [] -%}
-      {% set _range = [] -%}
-      {% for _type in _ocp_layout.vms.keys() -%}
-      {%   set _range = range(0, _ocp_layout.vms[_type].amount |
-                              default(1) | int) -%}
-      {%   set _vms = [_type] | product(_range) | map('join', '-') -%}
-      {%   set _ = _vm_list.append(_vms) -%}
+      {% set _vm_list = {} -%}
+      {% set _range = []   -%}
+      {% for _type in _ocp_layout.vms.keys()                -%}
+      {%   set _amount = _ocp_layout.vms[_type].amount |
+                         default(1) | int                   -%}
+      {%   set _range = range(0, _amount)                   -%}
+      {%   set _vms = [_type | replace('_', '-')] |
+                      product(_range) | map('join', '-')    -%}
+      {%   set _map = dict(_vms | zip([_type] * _amount))   -%}
+      {%   set _ = _vm_list.update(_map)                    -%}
       {% endfor -%}
-      {{ _vm_list | list | flatten }}
+      {{ _vm_list }}
   block:
     - name: Ensure needed directories exist
       ansible.builtin.file:
@@ -70,12 +73,8 @@
 
     - name: Create blank images for OCP cluster resources
       vars:
-        _matcher: >-
-          {{
-            '(cifmw-)?' ~
-            '([a-z0-9]+)-[0-9]+'
-          }}
-        vm_type: "{{ vm | regex_replace(_matcher, '\\2') }}"
+        vm: "{{ _vm.key }}"
+        vm_type: "{{ _vm.value }}"
         vm_data: >-
           {{
             _ocp_layout.vms[vm_type]
@@ -84,9 +83,9 @@
       ansible.builtin.include_role:
         name: "libvirt_manager"
         tasks_from: "create_vms.yml"
-      loop: "{{ _vm_list }}"
+      loop: "{{ _vm_list | dict2items }}"
       loop_control:
-        loop_var: vm
+        loop_var: _vm
 
     # vBMC is started in reproducer/ocp_layout.yml tasks file.
     - name: Verify vBMC status
@@ -96,18 +95,19 @@
 
     - name: Create VBMC entities for OCP
       vars:
-        cifmw_virtualbmc_machine: "cifmw-{{ item }}"
+        cifmw_virtualbmc_machine: "cifmw-{{ item.key }}"
         cifmw_virtualbmc_ipmi_port: "{{ 51881 + index }}"
         cifmw_virtualbmc_action: "add"
         cifmw_virtualbmc_ipmi_address: "ipmi.utility"
       ansible.builtin.include_role:
         name: "virtualbmc"
         tasks_from: "manage_host.yml"
-      loop: "{{ _vm_list }}"
+      loop: "{{ _vm_list | dict2items }}"
       loop_control:
         index_var: index
-        label: "{{ item }}"
+        label: "{{ item.key }}"
 
     - name: Expose OCP cluster members
       ansible.builtin.set_fact:
-        _cifmw_libvirt_manager_ocp_cluster: "{{ _vm_list }}"
+        _cifmw_libvirt_manager_ocp_cluster: >-
+          {{ _vm_list | dict2items | map(attribute='key') }}

--- a/roles/libvirt_manager/tasks/reserve_dnsmasq_ips.yml
+++ b/roles/libvirt_manager/tasks/reserve_dnsmasq_ips.yml
@@ -29,9 +29,8 @@
         _net_data: "{{ host_data.value.networks[net_name] }}"
         _ocp_name: >-
           {{
-            host_data.key | replace('_', '-') |
-            replace('ocp-worker', 'worker') |
-            replace('ocp', 'master')
+            host_data.key |
+            replace('ocp-', '')
           }}
         _hostname: >-
           {{

--- a/roles/libvirt_manager/tasks/start_vms.yml
+++ b/roles/libvirt_manager/tasks/start_vms.yml
@@ -14,12 +14,8 @@
     - vm_data.start | default(true) | bool
     - vm_data.disk_file_name != 'blank'
   vars:
-    _matcher: >-
-      {{
-        '(cifmw-)?' ~
-        '([a-z0-9]+)-[0-9]+'
-      }}
-    vm_type: "{{ vm | regex_replace(_matcher, '\\2') }}"
+    vm: "{{ _vm.key }}"
+    vm_type: "{{ _vm.value }}"
     vm_data: >-
       {{
         _cifmw_libvirt_manager_layout.vms[vm_type]
@@ -28,9 +24,9 @@
     state: running
     name: "cifmw-{{ vm }}"
     uri: "qemu:///system"
-  loop: "{{ cifmw_libvirt_manager_all_vms }}"
+  loop: "{{ cifmw_libvirt_manager_all_vms | dict2items }}"
   loop_control:
-    loop_var: vm
+    loop_var: _vm
     pause: 1
 
 - name: "Wait for SSH on started VMs"
@@ -39,21 +35,16 @@
     - vm_data.start | default(true) | bool
     - vm_data.disk_file_name != 'blank'
   vars:
-    _matcher: >-
-      {{
-        '(cifmw-)?' ~
-        '([a-z0-9]+)-[0-9]+'
-      }}
-    vm_type: "{{ vm | regex_replace(_matcher, '\\2') }}"
+    vm: "{{ _vm.key }}"
+    vm_type: "{{ _vm.value }}"
     vm_data: >-
       {{
         _cifmw_libvirt_manager_layout.vms[vm_type]
       }}
     _ocp_name: >-
       {{
-        vm | replace('_', '-') |
-        replace('ocp-worker', 'worker') |
-        replace('ocp', 'master')
+        vm |
+        replace('ocp-', '')
       }}
     _hostname: >-
       {{
@@ -64,9 +55,10 @@
     host: "{{ _hostname }}.utility"
     port: 22
     delay: 2
-  loop: "{{ cifmw_libvirt_manager_all_vms }}"
+  loop: "{{ cifmw_libvirt_manager_all_vms | dict2items}}"
   loop_control:
-    loop_var: vm
+    loop_var: _vm
+    label: "{{ _hostname }}.utility"
   async: 120
   poll: 0
 

--- a/roles/libvirt_manager/templates/inventory.yml.j2
+++ b/roles/libvirt_manager/templates/inventory.yml.j2
@@ -1,7 +1,7 @@
 {{ (item == 'crc') | ternary('ocp', item) }}s:
   hosts:
 {% for host in hosts %}
-{% set ocp_name = host.key | replace('_', '-') | replace('ocp-worker', 'worker') | replace('ocp', 'master') -%}
+{% set ocp_name = host.key | replace('_', '-') | replace('ocp-', '') -%}
 {% set hostname = (host.key is match('^ocp.*')) | ternary(ocp_name, host.key) %}
     {{ host.key }}:
       ansible_host: {{ hostname }}.utility

--- a/roles/reproducer/molecule/crc_layout/converge.yml
+++ b/roles/reproducer/molecule/crc_layout/converge.yml
@@ -19,6 +19,7 @@
   hosts: instance
   gather_facts: true
   vars:
+    cifmw_run_id: aabbcc11
     cifmw_manage_secrets_reproducer_secrets:
       - content: "my-default-location-place"
         dest: "default.txt"
@@ -145,12 +146,13 @@
               register: _cmp0_ping
               failed_when: false
               vars:
+                _cmpt: "compute-{{ cifmw_run_id }}-0"
                 _inv: >-
                   {{
                     _compute_inv.content | b64decode | from_yaml
                   }}
                 _ip: >-
-                  {{ _inv.computes.hosts['compute-0'].ansible_host }}
+                  {{ _inv.computes.hosts[_cmpt].ansible_host }}
               ansible.builtin.command:
                 cmd: "ping -c1 -w1 {{ _ip }}"
 

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -199,7 +199,7 @@
           {{
             host | replace('_', '-') |
             replace('ocp-worker', 'worker') |
-            replace('ocp', 'master')
+            replace('ocp-master', 'master')
           }}
         _hostname: >-
           {{

--- a/roles/reproducer/tasks/ocp_layout.yml
+++ b/roles/reproducer/tasks/ocp_layout.yml
@@ -199,8 +199,8 @@
         _name: >-
           {{
             item |
-            regex_replace('^ocp_master-([0-9]+)$', 'openshift-master-\1') |
-            regex_replace('^ocp_worker-([0-9]+)$', 'openshift-worker-\1')
+            regex_replace('^.*master-([0-9]+)$', 'openshift-master-\1') |
+            regex_replace('^.*worker-([0-9]+)$', 'openshift-worker-\1')
           }}
         _node:
           name: "{{ _name }}"

--- a/roles/reproducer/tasks/prepare_networking.yml
+++ b/roles/reproducer/tasks/prepare_networking.yml
@@ -165,6 +165,7 @@
       server=/apps-crc.testing/127.0.0.2
       server=/crc.testing/127.0.0.2
       server=/utility/127.0.0.2
+      server=/{{ inventory_hostname }}/127.0.0.2
 
 - name: Feed utility records
   block:


### PR DESCRIPTION
Unique names are needed for some specific usecases, but not for all VMs.

This patch ensures anything that's not OCP/CRC nor controller VM gets a
unique, random string in their hostname.

We also converge names, ensuring no underscore (`_`) are present in the VM
names - we replace them with dashes (`-`) to ensure it's a valid hostname.
This leads to a modification in the way we build the VM listing, it's
now a dict associating the name to the type, in order to make things
"slightly" easier to handle later.

This patch introduces a new top-level parameter, `cifmw_run_id`, that
can be either passed down by the user, or generated using the
random_string lookup from the community.general collection.

Allowing to set the custom ID would allow, for instance, to use the Zuul
job ID as the identifier, making things slightly easier to follow
across the various runs.

#### Testing (not in commit message)
- [X] va-hci (local testing)
- [x] uni01alpha (via ds tp 609)
- [x] uni02beta (via ds tp 609)
- [ ] ~~uni04delta (via ds tp 609)~~ (failed due to unrelated issues, need a fix at dev-scripts level)
- [ ] BGP/spine-leaf (via ds tp 608) ("should" work - but TP was using midstream in the controller-0, leading to issues)
- [x] NFV (via ds tp 611)