### PR TITLE
Allow to chose which network is the default gateway

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -107,6 +107,7 @@ dataplane
 dataplanedeployments
 dataplanenodeset
 dataplanenodesets
+dcn
 dd'd
 ddr
 ddthh

--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -42,6 +42,28 @@ Used for checking if:
 * `cifmw_libvirt_manager_firewalld_default_zone`: (String) Name of the default firewall zone. Defaults to `public`.
 * `cifmw_libvirt_manager_firewalld_default_zone_masquerade`: (Bool) Enable masquerading on the default firewall zone. Defaults to `true`.
 * `cifmw_libvirt_manager_attach_dummy_interface_on_bridges`: (Bool) Attach dummy interface on bridges. Defaults to `true`.
+* `cifmw_libvirt_manager_default_gw_nets`: (List[String]) List of networks used as default gateway. If not set, defaults to the `cifmw_libvirt_manager_pub_net`. Read bellow for more information about that parameter.
+
+### `cifmw_libvirt_manager_default_gw_nets` parameter usage
+
+By default, the routing is configured so that the default gateway is on the `cifmw_libvirt_manager_pub_net` network (usually `public`). In some cases (DCN for instance), this doesn't scale, leading to
+some hosts not properly reachable.
+
+By using this parameter, the user can instruct the CI Framework to use another network as default gateway. In DCN case, all of the created `ctlplane` can be listed in that parameter and, since the computes
+have only one `ctlplane` network associated, it means they'll use it as default gateway, without any conflict.
+
+#### Example
+
+```YAML
+# Use osp_trunk (ctlplane) as default gateway instead of the public network
+cifmw_libvirt_manager_default_gw_nets: osp_trunk
+
+# List all of the DCN ctlplane as "default gateway"
+cifmw_libvirt_manager_default_gw_nets:
+  - osp_trunk
+  - dcn1_tr
+  - dcn2_tr
+```
 
 ### Structure for `cifmw_libvirt_manager_configuration`
 

--- a/roles/libvirt_manager/tasks/create_networks.yml
+++ b/roles/libvirt_manager/tasks/create_networks.yml
@@ -105,6 +105,17 @@
         ternary(ansible_facts[_name].ipv6 |
                 selectattr('scope', 'equalto', 'global') | first, {})
       }}
+    _default_gw_net: >-
+      {% set out = '' -%}
+      {% if cifmw_libvirt_manager_default_gw_nets is defined -%}
+      {%   set out = cifmw_libvirt_manager_default_gw_nets -%}
+      {% else -%}
+      {%   set out = cifmw_libvirt_manager_pub_net -%}
+      {% endif -%}
+      {% if out is string -%}
+      {%   set out = [out] %}
+      {% endif -%}
+      {{ out }}
     _dns_options: |-
       {% if ansible_facts[_name].ipv4 is defined -%}
       - "option:dns-server,{{ ansible_facts[_name].ipv4.address }}"
@@ -112,7 +123,7 @@
       {% if ansible_facts[_name].ipv6 is defined -%}
       - "option6:dns-server,[{{ _ipv6.address }}]"
       {% endif -%}
-      {% if _no_prefix_name != cifmw_libvirt_manager_pub_net -%}
+      {% if _no_prefix_name not in _default_gw_net -%}
       - "option:router"
       {% endif -%}
     _dns_listener:


### PR DESCRIPTION
The new parameter allows to provide a single network, or a list of nets,
to use as "default gateway".

By default, the Framework uses the "public network" (usually "public" or
"ocpbm"), but it doesn't properly work with DCN layout, where computes
might need some other routing table content.
