### PR TITLE
[reproducer] Enable configuration of NTP service on controller-0

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -71,6 +71,7 @@ are shared among multiple roles:
 - `cifmw_run_compute_compliance_scans`: (Bool) Specifies whether to run compliance scans on the first compute.  Defaults to `false`.
 - `cifmw_run_id`: (String) CI Framework run identifier. This is used in libvirt_manager, to add some uniqueness to some types of virtual machines (anything that's not OCP, CRC nor controller).
   If not set, the Framework will generate a random string for you, and store it on the target host, in `{{ cifmw_basedir }}/artifacts/run-id`
+- `cifmw_ntp_server`: (String) Specifies an ntp server to use. Now it's only used in `controller-0` environment. Defaults to `pool.ntp.org`.
 
 ```{admonition} Words of caution
 :class: danger

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -85,6 +85,7 @@ dependencies:
   'git+https://github.com/ansible-collections/mellanox.onyx': 'master'
   'git+https://github.com/openshift/community.okd': 'main'
   'git+https://github.com/ovirt/ovirt-ansible-collection': 'master'
+  'fedora.linux_system_roles': '1.87.1'
 
 # The URL of the originating SCM repository
 repository: https://github.com/openstack-k8s-operators/ci-framework

--- a/requirements.yml
+++ b/requirements.yml
@@ -13,6 +13,9 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+roles:
+  - name: https://github.com/linux-system-roles/timesync.git
+    version: 1.9.0
 
 collections:
   - name: https://github.com/ansible-collections/ansible.posix

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -9,6 +9,11 @@
          ) | path_join
       }}
 
+- name: Install linux-system-roles.timesync role
+  community.general.ansible_galaxy_install:
+    type: role
+    name: linux-system-roles.timesync
+
 # The dynamic inventory sets the ansible_ssh_user to zuul once we get the proper
 # ssh configuration accesses set.
 - name: Configure controller-0
@@ -472,3 +477,14 @@
       register: _sync_dep_install_result
       until: _sync_dep_install_result.finished
       retries: 20
+
+    - name: Configure the NTP service
+      become: true
+      vars:
+        timesync_dhcp_ntp_servers: true
+        timesync_ntp_servers:
+          - hostname: "{{ cifmw_ntp_server | default('pool.ntp.org') }}"
+      block:
+        - name: Include timesync role
+          ansible.builtin.include_role:
+            name: linux-system-roles.timesync


### PR DESCRIPTION
`controller-0` was the only vm deployed by the framework where the NTP service wasn't enabled and that led to some issues while parsing log files.

We are going to use the `timesync` role from the `linux-system-roles` collection just like we do in EDPM compute nodes in the `edpm-ansible` collection.

By default the configuration will enable all the NTP servers provided by the dhcp server, plus `pool.ntp.org` server that can be overridden declaring the `cifmw_ntp_server` variable.

Closes: https://issues.redhat.com/browse/OSPRH-9299