### PR TITLE
Move from ansible package to ansible-core

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -70,6 +70,7 @@ tags:
 # collection label 'namespace.name'. The value is a version range
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
+# todo(Lewis): Remove ansible-collections-openstack once application_credential.py is removed
 dependencies:
   'git+https://github.com/containers/ansible-podman-collections': 'master'
   'git+https://github.com/ansible-collections/community.general': 'main'
@@ -85,6 +86,7 @@ dependencies:
   'git+https://github.com/ansible-collections/cisco.ios': '3.3.2'
   'git+https://github.com/ansible-collections/mellanox.onyx': 'master'
   'git+https://github.com/openshift/community.okd': 'main'
+  'git+https://github.com/ovirt/ovirt-ansible-collection': 'master'
 
 # The URL of the originating SCM repository
 repository: https://github.com/openstack-k8s-operators/ci-framework

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.16.0'
+requires_ansible: '>=2.14.0'

--- a/requirements.yml
+++ b/requirements.yml
@@ -14,6 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+# todo(Lewis): Remove ansible-collections-openstack once application_credential.py is removed
 collections:
   - name: https://github.com/ansible-collections/ansible.posix
     type: git

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-ansible>=7.0.0
+ansible-core>=2.14.0
 
 # Molecule Deps
 molecule>=5.1.0,<6.0.0


### PR DESCRIPTION
This patch firstly switches us from installing the ansible pip package
to installing the ansible-core pip package.

The ansible package is generally used by ansible users, not by
Ansible collections. The reason the ansible package is useful is it
comes bundled with a curation of the best collections [1] so users can
start using Ansible straight away without having to install many
dependencies, it also installs ansible-core.

We should be using ansible-core as we need finer control of what
dependencies are installed so we can control install size and version.
You can see a list of all dependencies that are installed when using the ansible pip package here [2]. Many of our jobs call the `setup_molecule`
make target which is currently installing the ansible pip package and
all it's dependencies.

One of these dependencies is the fortinet collection coming in at 217M,
for context our repo is only 7M and the `community.general` collection
is only 50M. Worst of all, we never use the fortinet module so it's completely a waste.

This patch puts us in control of what dependencies are installed.

This patch also:
- Updates the `requires_ansible:` metadata field to match our lowest requirement version of `2.14.0`
- Adds the Ovirt module to our documented dependencies

For some data, running `make setup_molecule` in a fresh centos-9 stream
container before and after this patch resulted in a space and download
saving of of 510M:

```
❯ podman images
REPOSITORY                                   TAG         IMAGE ID      CREATED         SIZE
localhost/cifmw-client-before                       latest      5926309f4e21  26 minutes ago  1.7 GB
localhost/cifmw-client-after                       latest      59f865a62210  9 hours ago   1.19 GB
```

[1] https://pypi.org/project/ansible/
[2] https://github.com/ansible-community/ansible-build-data/blob/0c1c2302a32b45871c204f7e873cc9444f174b90/7/ansible-7.0.0.deps

Jira: https://issues.redhat.com/browse/OSPRH-9496