### PR TITLE
Pass {{ job_id }}-params/zuul-params.yml to reproducer play job

### DIFF
--- a/roles/reproducer/templates/play.yml.j2
+++ b/roles/reproducer/templates/play.yml.j2
@@ -43,6 +43,7 @@
 {% if not is_molecule | default(false) %}
       - '@~/{{ job_id }}-params/custom-params.yml'
       - '@~/{{ job_id }}-params/install-yamls-params.yml'
+      - '@~/{{ job_id }}-params/zuul-params.yml'
 {% endif %}
       - '@~/{{ job_id }}-params/reproducer_params.yml'
 {% if (operator_content_provider | bool) or (openstack_content_provider | bool) %}


### PR DESCRIPTION
From a recent reproducer job example:
```
[zuul@controller-0 63ca0e3-params]$ grep -nr update_containers
custom-params.yml:241:cifmw_update_containers: true
custom-params.yml:242:cifmw_update_containers_openstack: true
custom-params.yml:243:cifmw_update_containers_org: podified-rhos18-rhel9
custom-params.yml:244:cifmw_update_containers_registry: 10.0.59.199:5001
custom-params.yml:245:cifmw_update_containers_tag: component-ci-testing
zuul-params.yml:158:cifmw_test_operator_tempest_image_tag: '{{ cifmw_update_containers_tag }}'
zuul-params.yml:159:cifmw_test_operator_tempest_namespace: '{{ cifmw_update_containers_org }}'
zuul-params.yml:162:cifmw_test_operator_tempest_registry: '{{ cifmw_update_containers_registry }}'
zuul-params.yml:219:cifmw_update_containers_openstack: true
zuul-params.yml:220:cifmw_update_containers_org: podified-rhos18-rhel9
zuul-params.yml:221:cifmw_update_containers_registry: '{{ content_provider_registry_ip }}:5001'
zuul-params.yml:222:cifmw_update_containers_tag: component-ci-testing
content-provider.yml:1:cifmw_update_containers_registry: '{{ content_provider_registry_ip }}:5001'
```
cifmw_test_operator_tempest_registry value depends on cifmw_update_containers_registry. Since we are not passing zuul-params.yml file. Then cifmw_update_containers_registry value will be taken from custom-params.yml file. It will fail the test_operator.

In order to fix that, we need to pass zuul-params.yml to the reproducer to take replace proper zuul vars.