### PR TITLE
Update precommit hooks and add shellcheck

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -26,12 +26,33 @@ repos:
         entry: bashate --error . --ignore=E006,E040
         verbose: false
 
+  # First execution of shellcheck reports all findings without failing
+  # Second execution outputs nothing and fails if any finding meets the
+  # defined severity.
+  # The outcome is all findings are reported but only ones meeting the severity
+  # will fail the check.
+  # Ignores the following rules:
+  # SC2071: todo(Lewis): Will fix in a follow up patch
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        verbose: true
+        # entry: bash -c "shellcheck "$@" || true" --
+        entry: >
+         bash -c 'shellcheck "$@" ||
+         shellcheck -f quiet
+         --severity=error
+         --exclude=SC2071
+         "$@"' --
+
   # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.1.0
+    rev: 24.8.0
     hooks:
       - id: black
 
+  # todo(Lewis): Update version when we bump to python>=3.10
   - repo: https://github.com/ansible/ansible-lint
     rev: v6.22.2
     hooks:


### PR DESCRIPTION
This patch adds a new precommit hook that calls shellcheck [1]

The hook is written in a way that all findings are reported but only
errors cause failure.

In follow up patches the excluded rule will be removed and the severity
lowered, for now this will protect us from new patches with erroneous shell scripts.

[1] https://github.com/koalaman/shellcheck