### PR TITLE
[Reproducer] Add support for disabling ocp overlays

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -66,6 +66,7 @@ are shared among multiple roles:
 - `cifmw_nolog`: (Bool) Toggle `no_log` value for selected tasks. Defaults to `true` (hiding those logs by default).
 - `cifmw_parent_scenario`: (String or List(String)) path to existing scenario/parameter file to inherit from.
 - `cifmw_configure_switches`: (Bool) Specifies whether switches should be configured. Computes in `reproducer.yml` playbook. Defaults to `false`.
+- `cifmw_use_ocp_overlay`: (Boolean) Specifies whether OCP nodes deployed via devscripts should use overlay images. Using overlay images speeds up the redeployment when using the reproducer role locally but in CI each job is cleaned up and redeployed. Creating the overlay image takes time so should be disabled when not used. Defaults to `true`.
 - `cifmw_crc_default_network`: (String) name of the untagged network used to address DNS on the crc node. Default is `default`.
 - `cifmw_run_operators_compliance_scans`: (Bool) Specifies whether to run operator compliance scans.  Defaults to `false`.
 - `cifmw_run_compute_compliance_scans`: (Bool) Specifies whether to run compliance scans on the first compute.  Defaults to `false`.

--- a/roles/devscripts/tasks/300_post.yml
+++ b/roles/devscripts/tasks/300_post.yml
@@ -26,42 +26,10 @@
     - not cifmw_devscripts_ocp_online | bool
   ansible.builtin.import_tasks: set_cluster_fact.yml
 
-- name: Prepare for disk overlay configuration.
-  tags:
-    - devscripts_deploy
+- name: Prepare for disk overlay configuration
   when:
     - not cifmw_devscripts_ocp_comply | bool
+    - cifmw_use_ocp_overlay | default(true) | bool
+  tags:
+    - devscripts_deploy
   ansible.builtin.include_tasks: 310_prepare_overlay.yml
-
-- name: Bringing cluster online.
-  when:
-    - not cifmw_use_reproducer | default(false) | bool
-  block:
-    - name: Deploy layout on target host
-      tags:
-        - libvirt_layout
-      when:
-        - not cifmw_devscripts_ocp_comply | bool
-      ansible.builtin.include_role:
-        name: libvirt_manager
-        tasks_from: deploy_layout
-
-    - name: Apply VLAN configuration for vnet interfaces.
-      tags:
-        - devscripts_post
-      when:
-        - cifmw_libvirt_manager_configuration_gen.networks is defined
-      become: true
-      cifmw.general.bridge_vlan:
-        networks: >-
-          {{
-            cifmw_libvirt_manager_configuration_gen.networks.keys() | list
-          }}
-      failed_when: false
-
-    - name: Ensure the OpenShift cluster is accessible.
-      tags:
-        - devscripts_post
-      when:
-        - not cifmw_devscripts_ocp_online | bool
-      ansible.builtin.include_tasks: 330_wait_ocp.yml

--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -29,12 +29,12 @@
     _workload: "{{ cifmw_libvirt_manager_basedir }}/workload"
     _img_dir: "{{ cifmw_libvirt_manager_basedir }}/images"
     _chdir: >-
-      {{ (is_base_img | default(false) | bool) | ternary(_img_dir, _workload) }}
+      {{
+        (_is_base_img | default(false) | bool) |
+        ansible.builtin.ternary(_img_dir, _workload)
+      }}
   block:
     - name: "Create VM image for {{ vm }}"
-      vars:
-        _vm_img: >-
-          {{ vm }}.qcow2
       ansible.builtin.command:
         cmd: >-
           qemu-img create
@@ -48,9 +48,6 @@
         chdir: "{{ _chdir }}"
 
     - name: "Ensure file ownership and rights for {{ vm }}"
-      vars:
-        _vm_img: >-
-          {{ vm }}.qcow2
       ansible.builtin.file:
         path: "{{ (_chdir, _vm_img) | path_join }}"
         group: "qemu"

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -175,6 +175,8 @@
       }}
     pub_key: "{{ pub_ssh_key.content | b64decode }}"
     priv_key: "{{ priv_ssh_key.content | b64decode }}"
+    _vm_img: >-
+      {{ vm }}.qcow2
   ansible.builtin.include_tasks:
     file: create_vms.yml
   loop: "{{ cifmw_libvirt_manager_all_vms | dict2items }}"

--- a/roles/libvirt_manager/tasks/ocp_layout.yml
+++ b/roles/libvirt_manager/tasks/ocp_layout.yml
@@ -6,7 +6,7 @@
   notify: Restart firewalld
   ansible.builtin.command:
     cmd: >-
-       firewall-cmd --permanent --zone libvirt --add-forward
+      firewall-cmd --permanent --zone libvirt --add-forward
 
 - name: Enable masquerading for public traffic
   when: cifmw_libvirt_manager_firewalld_default_zone_masquerade | default(true) | bool
@@ -64,6 +64,7 @@
         state: directory
       loop:
         - "{{ cifmw_libvirt_manager_basedir }}/images"
+        - "{{ cifmw_libvirt_manager_basedir }}/workload"
         - "{{ cifmw_libvirt_manager_ocp_pool_dir }}"
 
     - name: Create pool in libvirt
@@ -79,7 +80,9 @@
           {{
             _ocp_layout.vms[vm_type]
           }}
-        is_base_img: true
+        _vm_img: >-
+          {{ vm }}.qcow2
+        _is_base_img: "{{ cifmw_use_ocp_overlay | default(true) | bool }}"
       ansible.builtin.include_role:
         name: "libvirt_manager"
         tasks_from: "create_vms.yml"

--- a/roles/reproducer/tasks/ocp_layout.yml
+++ b/roles/reproducer/tasks/ocp_layout.yml
@@ -336,8 +336,6 @@
         permanent: true
 
     - name: Run devscripts role
-      vars:
-        cifmw_use_reproducer: true
       ansible.builtin.include_role:
         name: devscripts
 


### PR DESCRIPTION
This patch adds a new top level variable `cifmw_use_ocp_overlay` used to control whether the OCP VMs created by dev_scripts via the reproducer role use image overlays or not.

Prior to this patch the use of image overlays was not configurable, while image overlays are useful for local deployments, in CI they are not used. The downside to image overlays is the process to create them takes a very long time.

The OCP cluster needs come up and stabilize, then we shut the VMs down and copy the images to use as base images, we then need to start the OCP VMs again and wait for it to stabilize, this is all wasted time because in CI environments we start fresh every time.

This patch also removes the undocumented internal variable `cifmw_use_reproducer` and it's use replaced with
`cifmw_use_ocp_overlay`

Jira: https://issues.redhat.com/browse/OSPRH-7771

---

- [x] Test deployment with 3 masters
- [x] Test a uni* job - Testing downstream in TP/501
- [x] Update and verify cleanup

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2320