### PR TITLE
Overiding edpm_podman_auth_file to check only default locations

### DIFF
--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -7,6 +7,7 @@
     vars:
       cifmw_extras:
         - '@scenarios/centos-9/nested_virt.yml'
+      edpm_podman_auth_file: "" # Note: Override of default location "~/.config/containers/auth.json"
 
 # Virtual Baremetal job with CRC and single compute node.
 - job:
@@ -18,6 +19,7 @@
       crc_parameters: "--memory 32000 --disk-size 240 --cpus 12"
       cifmw_manage_secrets_pullsecret_content: '{}'
       cifmw_rhol_crc_binary_folder: "/usr/local/bin"
+      edpm_podman_auth_file: "" # Note: Override of default location "~/.config/containers/auth.json"
 
 # Podified galera job
 - job:

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -316,6 +316,7 @@
     vars:
       cifmw_extras:
         - '@scenarios/centos-9/multinode-ci.yml'
+      edpm_podman_auth_file: "" # Note: Override of default location "~/.config/containers/auth.json"
     run:
       - ci/playbooks/edpm/run.yml
 


### PR DESCRIPTION
The osp.edpm.edpm_download_cache role now explicitly sets path to the authentication file. Defaulting to `~/.config/containers/auth.json`

This prevents roles from accessing registry, in cases when there are no login information recorded, such as in CI.

Needed by: https://github.com/openstack-k8s-operators/edpm-ansible/pull/727 
