### PR TITLE
[VA HCI]Adds cindervolume and manilashare names for update_containers

### DIFF
--- a/roles/update_containers/defaults/main.yml
+++ b/roles/update_containers/defaults/main.yml
@@ -39,8 +39,10 @@ cifmw_update_containers_org: "podified-antelope-centos9"
 cifmw_update_containers_tag: "current-podified"
 cifmw_update_containers_openstack: false
 cifmw_update_containers_rollback: false
-cifmw_update_containers_cindervolumes: []
-cifmw_update_containers_manilashares: []
+cifmw_update_containers_cindervolumes:
+  - default
+cifmw_update_containers_manilashares:
+  - default
 # cifmw_update_containers_ansibleee_image_url:
 # cifmw_update_containers_edpm_image_url:
 # cifmw_update_containers_ipa_image_url:

--- a/scenarios/reproducers/va-hci.yml
+++ b/scenarios/reproducers/va-hci.yml
@@ -112,3 +112,9 @@ cifmw_ceph_daemons_layout:
   dashboard_enabled: false
   cephfs_enabled: true
   ceph_nfs_enabled: false
+
+# Vars related to update_containers cinder volume and manila share
+cifmw_update_containers_cindervolumes:
+  - ceph
+cifmw_update_containers_manilashares:
+  - share1


### PR DESCRIPTION
HCI job, ceph cinder volume and share1 manila share is used. We need to add the cindervolume and manila share name so that proper containers gets updated by update_containers role.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2231