### PR TITLE
Remove checking if commit in multiple PRs

### DIFF
--- a/.github/workflows/review-ready-label.yml
+++ b/.github/workflows/review-ready-label.yml
@@ -3,7 +3,6 @@
 #   - There are no failed CI jobs
 #   - There are no Pending CI jobs excluding Tide
 #   - The PR isn't in draft state
-#   - The commit isn't found in more than one PR
 # Removes the label if any of those checks fail.
 
 name: Toggle review ready label
@@ -59,7 +58,7 @@ jobs:
           pr_search_result_length=$(echo "${pr_search_result}" | jq length)
           if [ "$pr_search_result_length" -ne 1 ]; then
               echo "Commit not found or in multiple PRs"
-              exit 1
+              exit 0
           fi
 
           # Define draft_status and set $ready false if PR is in draft state


### PR DESCRIPTION
This check was not requested, I added as it was a side product of the
main check but it doesn't work as I expected and can block good patches