### PR TITLE
Add a hook that deploys Ceph on BMO nodes

### DIFF
--- a/hooks/playbooks/ceph-bm.yml
+++ b/hooks/playbooks/ceph-bm.yml
@@ -1,0 +1,39 @@
+- name: Deploy ceph on OSP BMO deployed nodes
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Fetch OSP BMO nodesets
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.command:
+        cmd: >-
+          oc get OpenStackBaremetalSet -n "{{ _namespace}}"  -o yaml
+      register: _osp_bmo_nodsets_oc_out
+
+    - name: Add OSP BMO nodesets to Ansible
+      ansible.builtin.add_host:
+        name: "{{ item.name }}"
+        groups: "{{ item.group }}"
+        ansible_ssh_user: "{{ item.user }}"
+        ansible_host: "{{ item.ip }}"
+        ansible_ssh_private_key_file: "{{ ansible_user_dir }}/.ssh/id_cifw"
+        ansible_ssh_extra_args: '-o StrictHostKeyChecking=no'
+      loop: >-
+        {% set hosts = [] -%}
+        {% set nodesets = (_osp_bmo_nodsets_oc_out.stdout | from_yaml)['items'] | default([]) -%}
+        {% for spec in nodesets | map(attribute='spec') -%}
+        {%   for host_key, host_val in spec.baremetalHosts.items() -%}
+        {%     set _ = hosts.append(
+          {
+          'name': host_key,
+          'ip': host_val['ctlPlaneIP'] | ansible.utils.ipaddr('address'),
+          'user': spec.cloudUserName,
+          'group': host_key | split('-') | first + 's'
+        }) -%}
+        {%   endfor -%}
+        {% endfor -%}
+        {{ hosts }}
+
+- name: Deploy Ceph on target nodes
+  ansible.builtin.import_playbook: ../../playbooks/ceph.yml

--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -63,7 +63,13 @@
   become: true
   vars:
     cifmw_admin_user: ceph-admin
-    ansible_ssh_private_key_file: "{{ lookup('env', 'ANSIBLE_SSH_PRIVATE_KEY') }}"
+    _target_group: "{{ cifmw_ceph_target | default('computes') }}"
+    _target: "{{ groups[_target_group] | default([]) | first }}"
+    ansible_ssh_private_key_file: >-
+      {{
+        hostvars[_target]['ansible_ssh_private_key_file'] |
+        default(lookup('env', 'ANSIBLE_SSH_PRIVATE_KEY'))
+      }}
   pre_tasks:
     # end_play will end this current playbook and go the the next
     # imported play.
@@ -119,7 +125,13 @@
           {{ num_osds }}
     - name: Create Block Device on EDPM Nodes
       vars:
-        ansible_ssh_private_key_file: "{{ lookup('env', 'ANSIBLE_SSH_PRIVATE_KEY') }}"
+        _target_group: "{{ cifmw_ceph_target | default('computes') }}"
+        _target: "{{ groups[_target_group] | default([]) | first }}"
+        ansible_ssh_private_key_file: >-
+          {{
+            hostvars[_target]['ansible_ssh_private_key_file'] |
+            default(lookup('env', 'ANSIBLE_SSH_PRIVATE_KEY'))
+          }}
         cifmw_block_device_image_file: /var/lib/ceph-osd-{{ i }}.img
         cifmw_block_device_loop: /dev/loop{{ i + 3 }}
         cifmw_block_lv_name: ceph_lv{{ i }}


### PR DESCRIPTION
This patch is to allow discovering of nodeset computes and adding them to a in memory inventory before calling ceph, this is to enable NFV+HCI job to run.