### PR TITLE
Optimize Ceph log collection and optionally dump to file

### DIFF
--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -105,3 +105,25 @@ cifmw_cephadm_prometheus_container_image: "{{ cifmw_cephadm_prometheus_container
 cifmw_cephadm_ns: openstack
 cifmw_cephadm_urischeme: "http"
 cifmw_cephadm_config_key_set_ssl_option: no_sslv2:sslv3:no_tlsv1:no_tlsv1_1
+# Deployment logs variables
+cifmw_cephadm_log_dump: true
+cifmw_cephadm_log_path: "{{ ansible_user_dir ~ '/ci-framework-data/logs/ceph' }}"
+cifmw_cephadm_log_commands:
+  # Get deployed Ceph daemons
+  - type: "daemons"
+    cmd: "orch ls --export -f json"
+  # Get all the Ceph containers
+  - type: "processes"
+    cmd: "orch ps -f json"
+  # Get health status
+  - type: "health"
+    cmd: "-s -f json"
+  # Get Ceph Config stored in the mgr
+  - type: "config"
+    cmd: "config dump -f json"
+  # Get osd min-compat-client
+  - type: "min-compat-client"
+    cmd: "osd get-require-min-compat-client"
+  # Get the version of each component
+  - type: "version"
+    cmd: "versions -f json"

--- a/roles/cifmw_cephadm/tasks/logs.yml
+++ b/roles/cifmw_cephadm/tasks/logs.yml
@@ -1,0 +1,21 @@
+- name: Get ceph_cli
+  ansible.builtin.include_tasks: ceph_cli.yml
+
+- name: Show the status of the resulting deployed Ceph cluster
+  become: true
+  block:
+    - name: Get Ceph {{ cmd_type }}
+      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} {{ cur_cmd }}"
+      register: out
+    - name: Show the output of the command  {{ cmd_type }}
+      when: cifmw_cephadm_verbose | bool
+      ansible.builtin.debug:
+        msg: "{{ out.stdout_lines }}"
+    # Dump logs on the ci-framework controller node
+    - name: Dump log command output to log file
+      when: cifmw_cephadm_log_dump | default(false)
+      delegate_to: localhost
+      ansible.builtin.copy:
+        content: "{{ out.stdout_lines }}"
+        dest: "{{ cifmw_cephadm_log_path }}/ceph_{{ cmd_type }}.log"
+        mode: "0644"

--- a/roles/cifmw_cephadm/tasks/post.yml
+++ b/roles/cifmw_cephadm/tasks/post.yml
@@ -17,64 +17,37 @@
 - name: Get ceph_cli
   ansible.builtin.include_tasks: ceph_cli.yml
 
+- name: Show and optionally dump Ceph logs
+  block:
+    - name: Get the ceph orchestrator status
+      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} orch status --format json"
+      register: ceph_orch_status
+      become: true
+    - name: Fail if ceph orchestrator is not available
+      ansible.builtin.fail:
+        msg: |
+          'ceph orch status' returned
+          {{ ceph_orch_status.stdout | from_json }}
+      when:
+        - not (ceph_orch_status.stdout | from_json).available
+    # create the log directory on ci-framework controller node
+    - name: Create ceph-logs directory
+      delegate_to: localhost
+      when: cifmw_cephadm_log_dump | default(false)
+      ansible.builtin.file:
+        path: "{{ cifmw_cephadm_log_path }}"
+        state: directory
+        mode: "0755"
+    - name: Dump Ceph logs
+      ansible.builtin.include_tasks: logs.yml
+      vars:
+        cmd_type: "{{ item.type }}"
+        cur_cmd: "{{ item.cmd }}"
+      loop: "{{ cifmw_cephadm_log_commands }}"
+
 - name: Configure ceph object store to use external ceph object gateway
   ansible.builtin.include_tasks: configure_object.yml
   when: cifmw_ceph_daemons_layout.rgw_enabled | default(true) | bool
-
-- name: Get the ceph orchestrator status
-  ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} orch status --format json"
-  register: ceph_orch_status
-  become: true
-
-- name: Fail if ceph orchestrator is not available
-  ansible.builtin.fail:
-    msg: "'ceph orch status' returned {{ ceph_orch_status.stdout | from_json }}"
-  when:
-    - not (ceph_orch_status.stdout | from_json).available
-
-- name: Show the status of the resulting deployed Ceph cluster
-  block:
-    - name: Show the deployed daemons
-      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} orch ls --export"
-      become: true
-      register: ceph_orch_ls
-    - name: Deployed daemons
-      ansible.builtin.debug:
-        msg: "{{ ceph_orch_ls.stdout_lines }}"
-      when: cifmw_cephadm_verbose | bool
-
-    - name: Get ceph config dump
-      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} config dump"
-      become: true
-      register: ceph_config_dump
-    - name: Show config dump
-      ansible.builtin.debug:
-        msg: "{{ ceph_config_dump.stdout_lines }}"
-      when: cifmw_cephadm_verbose | bool
-
-    - name: Get ceph require-min-compat-client
-      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} osd get-require-min-compat-client"
-      become: true
-      register: ceph_min_compat_client
-    - name: Show ceph require-min-compat-client
-      ansible.builtin.debug:
-        msg: "{{ ceph_min_compat_client.stdout_lines }}"
-
-    - name: Get ceph version
-      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} -v"
-      become: true
-      register: ceph_version
-    - name: Ceph version
-      ansible.builtin.debug:
-        msg: "{{ ceph_version.stdout_lines }}"
-
-    - name: Print the status of the deployed Ceph cluster
-      ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} -s"
-      become: true
-      register: ceph_health
-    - name: Ceph cluster status
-      ansible.builtin.debug:
-        msg: "{{ ceph_health.stdout_lines }}"
 
 - name: Dashboard service validation
   ansible.builtin.include_tasks: dashboard/validation.yml


### PR DESCRIPTION
Instead of running several commands to get the required Ceph logs, this patch improves the way the log tasks are executed. It's now based on a struct that can be iterated.
In addition, it might be a good idea to dump logs, at deployment time, in files, other then (optionally) printing them in the playbook log file.