### PR TITLE
[DNM] Test adding delay when applying OSV update

### DIFF
--- a/roles/deploy_bmh/tasks/create_templated_resource.yml
+++ b/roles/deploy_bmh/tasks/create_templated_resource.yml
@@ -30,3 +30,5 @@
         state: present
         wait: true
         src: "{{ _manifest_file }}"
+      retries: 10
+      delay: 10

--- a/roles/update_containers/tasks/main.yml
+++ b/roles/update_containers/tasks/main.yml
@@ -33,3 +33,5 @@
     PATH: "{{ cifmw_path }}"
   ansible.builtin.command:
     cmd: "oc apply -f {{ cifmw_update_containers_dest_path }}"
+  retries: 5
+  delay: 10


### PR DESCRIPTION
Currently the openstack-operators are reporting Ready before the underlying services are up resulting in the container update failing e.g.:

```
cmd:
  - oc
  - apply
  - -f
  - /home/zuul/ci-framework-data/artifacts/manifests/update_containers.yml
  delta: '0:00:00.189758'
  end: '2024-08-20 22:37:39.909701'
  msg: non-zero return code
  rc: 1
  start: '2024-08-20 22:37:39.719943'
  stderr: 'Error from server (InternalError): error when creating "/home/zuul/ci-framework-data/artifacts/manifests/update_containers.yml": Internal error occurred: failed calling webhook "mopenstackversion.kb.io": failed to call webhook: Post "https://openstack-operator-controller-manager-service.openstack-operators.svc:443/mutate-core-openstack-org-v1beta1-openstackversion?timeout=10s": no endpoints available for service "openstack-operator-controller-manager-service"'
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
```
  
Potentially we need a ready check that does a liveliness probe on the webhook but for now just testing adding a delay.