### PR TITLE
fix dvr tests regex in whitebox_neutron_tempest_jobs.yaml

### DIFF
--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -114,7 +114,7 @@
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_extra_dhcp_opts.ExtraDhcpOptionsTest.test_extra_dhcp_opts_ipv4_ipv6_stateless
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_router_flavors
-              ^whitebox_neutron_tempest_plugin.tests.scenario.test_dvr_ovn.OvnDvrTest
+              ^whitebox_neutron_tempest_plugin.tests.scenario.test_dvr_ovn
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_multicast.MulticastTestIPv4Common.test_flooding_when_special_groups
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_broadcast.BroadcastTestVlanTransparency.test_broadcast_vlan_transparency
             # https://review.opendev.org/892839
@@ -128,7 +128,7 @@
             # - whitebox_neutron_tempest_plugin.tests.scenario.test_broadcast.BroadcastTestVlanTransparency.test_broadcast_vlan_transparency
             # More Flaky tests mblue is working on fixing it
             # - whitebox_neutron_tempest_plugin.tests.scenario.test_router_flavors
-            # - whitebox_neutron_tempest_plugin.tests.scenario.test_dvr_ovn.OvnDvrTest
+            # - whitebox_neutron_tempest_plugin.tests.scenario.test_dvr_ovn
         - stepName: single-thread-testing
           tempestRun:
             concurrency: 1
@@ -151,7 +151,7 @@
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_router_flavors
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_vlan_transparency.ProviderNetworkVlanTransparencyTest
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_router_flavors
-              ^whitebox_neutron_tempest_plugin.tests.scenario.test_dvr_ovn.OvnDvrTest
+              ^whitebox_neutron_tempest_plugin.tests.scenario.test_dvr_ovn
             # NOTE(mblue): Exclude list has test failures which need further debugging
             # remove when bug OSPRH-7998 resolved
             # - whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging.*test_only_dropped_traffic_logged


### PR DESCRIPTION
Whitebox neutron tempest plugin test_dvr_ovn file contains not only OvnDvrTest class with tests but also OvnDvrAdvancedTest that has a requirement to run without other tests in the background. This patch widens the regex for dvr tests to ensure all dvr tests run in a single thread workflow.