### PR TITLE
Add CI job URL to the polarion report

### DIFF
--- a/roles/polarion/defaults/main.yml
+++ b/roles/polarion/defaults/main.yml
@@ -23,3 +23,5 @@ cifmw_polarion_jump_repo_dir: "{{ cifmw_polarion_basedir }}/polarion-jump"
 cifmw_polarion_jump_result_dir: "{{ cifmw_polarion_basedir }}/tests/{{ cifmw_run_test_role | default('tempest') }}/"
 cifmw_polarion_jump_repo_branch: "master"
 cifmw_polarion_use_stage: false
+cifmw_zuul_project: "tripleo-ci-internal"
+cifmw_zuul_url: "https://sf.hosted.upshift.rdu2.redhat.com/zuul/t/{{ cifmw_zuul_project }}/build"

--- a/roles/polarion/tasks/main.yml
+++ b/roles/polarion/tasks/main.yml
@@ -110,6 +110,7 @@
           --testrun-id={{ cifmw_polarion_testrun_id }}
           --xml-file={{ cifmw_polarion_jump_result_dir }}/results_merged.xml
           --update_testcases={{ cifmw_polarion_update_testcases | default(false) }}
+          --custom-fields cijoburl={{ cifmw_zuul_url }}/{{ zuul.build }}
           {{ cifmw_polarion_jump_extra_vars | default ('') }}
       register: jump_script
 


### PR DESCRIPTION
This sets "CI Job URL" field to the Test Run. Anyone checking out the Test Run in polarion will be able to easily identify the job build and the job itself that ran the tests.