### PR TITLE
Added trigger downstream job github action

### DIFF
--- a/.github/workflows/github-action-trigger-downstream-job.yaml
+++ b/.github/workflows/github-action-trigger-downstream-job.yaml
@@ -1,0 +1,52 @@
+name: Github Action to trigger downstream job
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  jobs01:
+    # Check if comment contains /trigger github-experimental
+    if: contains(github.event.comment.body, '/trigger github-experimental')
+    runs-on: [ubuntu-latest]
+    permissions:
+      pull-requests: write
+    outputs:
+      approvers_check: ${{ steps.approvers_check.outputs.approvers_check }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            OWNERS
+          sparse-checkout-cone-mode: false
+          ref: main
+
+      - name: Get approvers list
+        id: approvers_list
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq -o=csv ".approvers" OWNERS
+
+      - name: Print Approvers list
+        run: echo ${{ steps.approvers_list.outputs.result }}
+
+      - name: Check commenter status
+        id: approvers_check
+        run: |
+          APPROVERS_CHECK=$(python -c "print('${{ github.event.comment.user.login }}' in '${{ steps.approvers_list.outputs.result }}')")
+          echo "approvers_check=$APPROVERS_CHECK" >> "$GITHUB_OUTPUT"
+
+      - name: Add proper labels to trigger workflow
+        if: steps.approvers_check.outputs.approvers_check == 'True'
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: |
+            github-experimental
+
+      - name: Print message for non approvers
+        if: steps.approvers_check.outputs.approvers_check == 'False'
+        uses: mshick/add-pr-comment@v2
+        with:
+          refresh-message-position: true
+          message: |
+            @${{ github.actor }}, You are not listed in project's approvers list. Please check with repo approvers to trigger the downstream job


### PR DESCRIPTION
Since we have limited hardware in downstream. If all developers want to run github-experimental pipeline downstream trigger job, then We may run of resources.

In order to avoid that, This pr adds github-action-trigger-downstream-job to allow approvers to trigger downstream job. Non-approvers will be greeted with message that they are not allowed to run this workflow.

Currently downstream trigger jobs are invoked via 'trigger github-experimental'. Once https://review.rdoproject.org/r/c/config/+/54157 merges, We will trigger it via github-experimental label. There it will be useful.

Testresults:
* [When approver is not in allowed list](https://github.com/raukadah/ci-playground/pull/10#issuecomment-2298751594)
* [When approver is in allowed list](https://github.com/raukadah/ci-playground/pull/12#issuecomment-2298786162)
* [When a new approver is added via pull request and on that pr, approver about to get added run trigger job, they are not allowed to run the trigger job](https://github.com/raukadah/ci-playground/pull/21#issuecomment-2319995489)
  * [Once the PR get merged, they are allowed to run trigger workflow.](https://github.com/raukadah/ci-playground/pull/21#issuecomment-2320004406)