### PR TITLE
Add new role - build_push_container

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -474,6 +474,7 @@ subnet
 subnets
 sudo
 sudoers
+supercedent
 sushy
 svc
 svg

--- a/roles/build_push_container/README.md
+++ b/roles/build_push_container/README.md
@@ -1,0 +1,143 @@
+# build_push_container
+
+`build_push_container` aims to be a generic role that can build multi-arch containers and push them to remote registry.
+
+## Privilege escalation
+
+- Installing packages
+- Installing qemu-user-static
+
+### Tagging
+
+A single image or manifest can have multiple tags moving independently. By default each push can have a tag, each PR and branch can have a latest tag.
+Care should be taken with the latest tag, when running in a Zuul job, the latest tag should only be moved by a [Supercedent Pipeline](https://zuul-ci.org/docs/zuul/latest/config/pipeline.html#value-pipeline.manager.supercedent) which runs after check and gate jobs have passed.
+
+### Multi-arch Builds
+
+Multi-arch builds are made possible by using QEMU emulation via `qemu-user-static`.
+When the non native arch is build a `binfmt_misc` rule is triggered instructing the process to be emulated transparently.
+
+The `binfmt_misc` rules live in `/proc/sys/fs/binfmt_misc/` and can be queried like so:
+
+```shell
+cat /proc/sys/fs/binfmt_misc/qemu-arm64
+enabled
+interpreter /usr/bin/qemu-arm64-static
+flags: F
+offset 0
+magic 7f454c460201010000000000000000000200b700
+mask ffffffffffffff00fffffffffffffffffeffffff
+```
+
+When a multi-arch build is requested, a manifest is first created to hold the container images. This manifest is allows clients to call the same image reference and get a different base architecture image.
+
+For example:
+
+```shell
+# On ARM based MacBook
+$ podman run -t --rm quay.rdoproject.org/openstack-k8s-operators/cifmw-client:latest uname -m
+aarch64
+
+# On X86 based server
+$ podman run -t --rm quay.rdoproject.org/openstack-k8s-operators/cifmw-client:latest uname -m
+x86_64
+```
+
+## Testing
+
+Molecule tests are ran to build single and multi-arch images, these are pushed to a local registry deployed via our `registry_deploy` role.
+
+## Parameters
+
+*`cifmw_build_push_container_basedir`: (String) Base directory. Defaults to `cifmw_basedir` which  defaults to `~/ci-framework`.
+*`cifmw_build_push_container_artifacts`: (String) Role artifacts directory. Defaults to `{{ cifmw_build_push_container_basedir }}/artifacts/build_push_container`
+*`cifmw_build_push_container_name`: (String) Name of container to be build and/or pushed, this is mandatory. Defaults to `Null`
+*`cifmw_build_push_container_build_context_path`: (String) Directory that will be used for the container build context. Defaults to Zuul project src_dir.
+*`cifmw_build_push_container_containerfile_name`: (String) Filename of Containerfile. Defaults to `Containerfile`
+*`cifmw_build_push_container_containerfile_path`: (String) Path to Containerfile. Defaults to {{ zuul.project.src_dir }}/Containerfile
+*`cifmw_build_push_container_local_build_tag`: (String) Local tag used when building container. Defaults to `"{{ (cifmw_build_push_container_name,'latest') | join(':') }}"`
+*`cifmw_build_push_container_supported_platform`: (List) List of architectures to build, supported architectures can be found [here](https://github.com/multiarch/qemu-user-static) Defaults to `[linux/amd64]`
+*`cifmw_build_push_container_qemu_user_static_image`: (String) Container to pull when QEMU is required. Defaults to `quay.rdoproject.org/ci-framework/qemu-user-static:latest`
+*`cifmw_build_push_container_git_sha`: (String) Git SHA that can be provided to tag container image on registry. Defaults to `"{{ zuul.commit_id }}"`
+*`cifmw_build_push_container_patch_number`: (Int) Patch number that can be provided to tag container image on registry. Defaults to `"{{ zuul.change }}"`
+*`cifmw_build_push_container_tag_override`: (List) Variable to add additional tags for container on registry. Defaults to `[]`
+*`cifmw_build_push_container_push`: (Boolean) Enables pushing to remote registry. Defaults to `false`
+*`cifmw_build_push_container_registry_name`: (String) Name of remote registry like `<domain>/<org>/<container_name>`. Defaults to `Null`
+*`cifmw_build_push_container_registry_username`: (String) Username to authenticate to registry. Defaults to `Null`
+*`cifmw_build_push_container_registry_password`: (String) Password to authenticate to registry. Defaults to `Null`
+*`cifmw_build_push_container_registry_tls_verify`: (Boolean) Defaults to `true`
+
+## Examples
+
+Build container locally:
+
+```yaml
+---
+- name: Build container
+  hosts: localhost
+  tasks:
+    - name: Call build_push_container role
+      vars:
+        cifmw_build_push_container_name: test_container
+        cifmw_build_push_container_build_context_path: /home/user/cool_project
+        cifmw_build_push_container_tag_override: [super, cool, tags]
+      ansible.builtin.include_role
+        name: build_push_container
+```
+
+Build container locally and push to remote registry with multi-arch build:
+
+```yaml
+---
+- name: Build container
+  hosts: localhost
+  tasks:
+    - name: Call build_push_container role
+      vars:
+        cifmw_build_push_container_name: Test container
+        cifmw_build_push_container_build_context_path: /home/user/cool_project
+        cifmw_build_push_container_tag_override: [super, cool, tags]
+        cifmw_build_push_container_supported_platform: [linux/amd64, linux/arm64]
+        cifmw_build_push_container_push: true
+        cifmw_build_push_container_registry_name: quay.rdoproject.org/cool_project/test_container
+        cifmw_build_push_container_registry_username: username
+        cifmw_build_push_container_registry_password: Passw0rd
+      ansible.builtin.include_role
+        name: build_push_container
+```
+
+Building a container from a Zuul job:
+
+```yaml
+- job:
+    name: build-push-container-cifmw-client
+    description: |
+      Build and push cifmw-client container to
+        quay.rdoproject.com registry.
+      vars:
+        cifmw_build_push_container_push - Used by build_push_container role to trigger pushing to registry.
+        cifmw_build_push_container_name - Name of container being build and pushed.
+        cifmw_build_push_container_containerfile_path - Path to containerfile.
+        cifmw_build_push_container_registry_name - Registry built containers will be pushed too.
+      Runtime: ~30mins.
+    parent: build-push-container-build
+    vars:
+      ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+      cifmw_ci_framework_src: >-
+        {{
+          (ansible_user_dir,
+          zuul.project.src_dir) | ansible.builtin.path_join
+        }}
+      cifmw_build_push_container_push: true
+      cifmw_build_push_container_name: cifmw-client
+      cifmw_build_push_container_containerfile_path: >-
+        {{
+          (cifmw_ci_framework_src,
+          'containerfiles',
+          'Containerfile.client') | ansible.builtin.path_join
+        }}
+      cifmw_build_push_container_registry_name: >-
+        quay.rdoproject.org/openstack-k8s-operators/cifmw-client
+      cifmw_build_push_container_supported_platform: [linux/arm64, linux/amd64]
+    timeout: 5400
+```

--- a/roles/build_push_container/defaults/main.yml
+++ b/roles/build_push_container/defaults/main.yml
@@ -1,0 +1,48 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_build_push_container"
+
+# Meta vars
+cifmw_build_push_container_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+cifmw_build_push_container_artifacts: "{{ (cifmw_build_push_container_basedir, 'artifacts', 'build_push_container')| ansible.builtin.path_join }}"
+
+# Build vars
+cifmw_build_push_container_name:
+cifmw_build_push_container_build_context_path: "{{ (ansible_user_dir, zuul.project.src_dir) | ansible.builtin.path_join }}"
+cifmw_build_push_container_containerfile_name: Containerfile
+cifmw_build_push_container_containerfile_path: >-
+  {{
+    (ansible_user_dir,
+    zuul.project.src_dir,
+    cifmw_build_push_container_containerfile_name
+    ) | ansible.builtin.path_join
+  }}
+cifmw_build_push_container_local_build_tag: "{{ (cifmw_build_push_container_name,'latest') | join(':') }}"
+cifmw_build_push_container_supported_platform: [linux/amd64]
+cifmw_build_push_container_qemu_user_static_image: quay.rdoproject.org/ci-framework/qemu-user-static:latest
+
+# Tagging vars
+cifmw_build_push_container_git_sha: "{{ zuul.commit_id }}"
+cifmw_build_push_container_patch_number: "{{ zuul.change }}"
+cifmw_build_push_container_tag_override: []
+# Push vars
+cifmw_build_push_container_push: false
+cifmw_build_push_container_registry_name:
+cifmw_build_push_container_registry_username:
+cifmw_build_push_container_registry_password:
+cifmw_build_push_container_registry_tls_verify: true

--- a/roles/build_push_container/meta/main.yml
+++ b/roles/build_push_container/meta/main.yml
@@ -1,0 +1,30 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- build_push_container
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: cifmw
+  galaxy_tags:
+    - cifmw
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/build_push_container/molecule/default/converge.yml
+++ b/roles/build_push_container/molecule/default/converge.yml
@@ -1,0 +1,104 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Deploy Local Registry
+      ansible.builtin.include_role:
+        name: registry_deploy
+
+    - name: Call and test cifmw_build_push_container with multi-arch scenario
+      block:
+        - name: Run cifmw_build_push_container multi-arch
+          vars:
+            cifmw_build_push_container_push: true
+            cifmw_build_push_container_build_context_path: ./
+            cifmw_build_push_container_git_sha: c4ee373c848aa16d1f0767117f61426f17f2a9f3
+            cifmw_build_push_container_patch_number: 123
+            cifmw_build_push_container_name: test_container_multi_arch
+            cifmw_build_push_container_containerfile_path: >-
+              /home/zuul/src/github.com/openstack-k8s-operators/ci-framework/roles/build_push_container/molecule/default/files/containerfile
+            cifmw_build_push_container_registry_name: 127.0.0.1:5001/cifmw-client/test_container_multi_arch
+            cifmw_build_push_container_registry_tls_verify: false
+            cifmw_build_push_container_supported_platform: [linux/amd64, linux/arm64]
+          ansible.builtin.include_role:
+            name: build_push_container
+
+        - name: Request tags from local registry
+          ansible.builtin.uri:
+            headers:
+              Accept: application/vnd.oci.image.index.v1+json
+            url: http://localhost:5001/v2/cifmw-client/test_container_multi_arch/tags/list
+          register: _registry_tag_output
+
+        - name: Check all tags exist
+          ansible.builtin.assert:
+            that: item is in _registry_tag_output.json.tags
+          loop:
+            - c4ee373c848aa16d1f0767117f61426f17f2a9f3
+            - 123-latest
+
+        - name: Request manifest from local registry
+          ansible.builtin.uri:
+            headers:
+              Accept: application/vnd.oci.image.index.v1+json
+            url: http://localhost:5001/v2/cifmw-client/test_container_multi_arch/manifests/123-latest
+          register: _registry_manifests_output
+
+        - name: Check manifest for multi-arch image
+          vars:
+            architectures: "{{ _registry_manifests_output.json.manifests | json_query('[].platform.architecture') }}"
+          ansible.builtin.assert:
+            that:
+              - "'arm64' in architectures"
+              - "'amd64' in architectures"
+
+    - name: Call and test cifmw_build_push_container with single-arch scenario
+      block:
+        - name: Run cifmw_build_push_container single-arch
+          vars:
+            cifmw_build_push_container_push: true
+            cifmw_build_push_container_build_context_path: ./
+            cifmw_build_push_container_git_sha: c4ee373c848aa16d1f0767117f61426f17f2a9f3
+            cifmw_build_push_container_patch_number: 123
+            cifmw_build_push_container_name: test_container_single_arch
+            cifmw_build_push_container_containerfile_path: >-
+              /home/zuul/src/github.com/openstack-k8s-operators/ci-framework/roles/build_push_container/molecule/default/files/containerfile
+            cifmw_build_push_container_registry_name: 127.0.0.1:5001/cifmw-client/test_container_single_arch
+            cifmw_build_push_container_registry_tls_verify: false
+          ansible.builtin.include_role:
+            name: build_push_container
+
+        - name: Request tags from local registry
+          ansible.builtin.uri:
+            headers:
+              Accept: application/vnd.oci.image.index.v1+json
+            url: http://localhost:5001/v2/cifmw-client/test_container_single_arch/tags/list
+          register: _registry_tag_output
+
+        - name: Check all tags exist
+          ansible.builtin.assert:
+            that: item is in _registry_tag_output.json.tags
+          loop:
+            - c4ee373c848aa16d1f0767117f61426f17f2a9f3
+            - 123-latest
+
+    - name: Call cleanup
+      ansible.builtin.include_role:
+        name: build_push_container
+        tasks_from: cleanup.yml

--- a/roles/build_push_container/molecule/default/files/containerfile
+++ b/roles/build_push_container/molecule/default/files/containerfile
@@ -1,0 +1,2 @@
+FROM quay.io/centos/centos:stream9-minimal
+RUN echo test > test.txt

--- a/roles/build_push_container/molecule/default/molecule.yml
+++ b/roles/build_push_container/molecule/default/molecule.yml
@@ -1,0 +1,17 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true
+  env:
+    ANSIBLE_STDOUT_CALLBACK: yaml
+
+prerun: false
+
+scenario:
+  test_sequence:
+    - converge

--- a/roles/build_push_container/tasks/cleanup.yml
+++ b/roles/build_push_container/tasks/cleanup.yml
@@ -1,0 +1,33 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Stop and remove registry container
+  containers.podman.podman_container:
+    name: registry
+    state: absent
+
+- name: List images created and used by role
+  ansible.builtin.command:
+    cmd: >-
+      podman images -q
+      --filter=label=build_push_role=true
+      --filter=reference=docker.io/library/registry:2
+  register: podman_images_output
+
+- name: Remove images created and used by role
+  ansible.builtin.command:
+    cmd: podman rmi -f {{ item }}
+  loop: "{{ podman_images_output.stdout_lines }}"

--- a/roles/build_push_container/tasks/main.yml
+++ b/roles/build_push_container/tasks/main.yml
@@ -1,0 +1,164 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure directories are present
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: "0755"
+    recurse: true
+  loop:
+    - "{{ (cifmw_build_push_container_artifacts, 'scripts') | ansible.builtin.path_join }}"
+    - "{{ (cifmw_build_push_container_artifacts, 'logs') | ansible.builtin.path_join }}"
+
+- name: Install podman and configure session linger
+  ansible.builtin.import_role:
+    name: podman
+
+# Note(Lewis): Using Podman command over podman module:
+#   Can't do multi-arch builds.
+#   Module output is lacking.
+#   Very slow when pushing multiple tags
+- name: Render varibles and optionally print
+  vars:
+    _rendered_tags: >-
+      {% set out = [] -%}
+      {% if cifmw_build_push_container_git_sha is defined -%}
+        {% set _ = out.append(cifmw_build_push_container_git_sha) -%}
+      {% endif -%}
+      {% if cifmw_build_push_container_patch_number is defined -%}
+        {% set _ = out.append(cifmw_build_push_container_patch_number ~ '-latest') -%}
+      {% endif -%}
+      {{ out }}
+    _rendered_tags_with_overrides: >
+      {{
+        _rendered_tags +
+        (
+          cifmw_build_push_container_tag_override
+          if cifmw_build_push_container_tag_override
+          is not none else []
+        )
+      }}
+    _multi_arch_build: "{{ cifmw_build_push_container_supported_platform | length > 1 }}"
+    _container_manifest_name: "{{ 'localhost/' ~ cifmw_build_push_container_name ~ '-manifest' }}"
+    _podman_qemu_user_static_cmd: >-
+      sudo podman run
+      --rm
+      --privileged
+      {{ cifmw_build_push_container_qemu_user_static_image }}
+      --reset
+      -c yes
+      -p yes
+    _podman_build_cmd: >-
+      podman build
+      --security-opt="label=disable"
+      --platform={{ cifmw_build_push_container_supported_platform | join(',') }}
+      {% if _multi_arch_build -%}
+      --manifest={{ _container_manifest_name }}
+      {% endif -%}
+      --tag={{ cifmw_build_push_container_local_build_tag }}
+      --label="build_push_role=true"
+      --file={{ cifmw_build_push_container_containerfile_path }}
+      {{ cifmw_build_push_container_build_context_path }}
+    _podman_push_container_cmd: >-
+      podman push
+      {% if cifmw_build_push_container_registry_username is not none -%}
+      {% if cifmw_build_push_container_registry_password is not none -%}
+      --creds {{ cifmw_build_push_container_registry_username }}:{{ cifmw_build_push_container_registry_password }}
+      {% endif -%}
+      {% endif -%}
+      {% if not cifmw_build_push_container_registry_tls_verify -%}
+      --tls-verify=false
+      {% endif -%}
+      {{ cifmw_build_push_container_local_build_tag }}
+      {{ cifmw_build_push_container_registry_name }}
+    _podman_push_manifest_cmd: >-
+      podman manifest push
+      {% if cifmw_build_push_container_registry_username is not none -%}
+      {% if cifmw_build_push_container_registry_password is not none -%}
+      --creds {{ cifmw_build_push_container_registry_username }}:{{ cifmw_build_push_container_registry_password }}
+      {% endif -%}
+      {% endif -%}
+      {% if not cifmw_build_push_container_registry_tls_verify -%}
+      --tls-verify=false
+      {% endif -%}
+      {{ _container_manifest_name }}
+      {{ cifmw_build_push_container_registry_name }}
+  block:
+    - name: Create manifest if multi-arch requested
+      when: _multi_arch_build
+      block:
+        - name: Install qemu-user-static for multi arch builds
+          cifmw.general.ci_script:
+            output_dir: "{{ (cifmw_build_push_container_artifacts, 'scripts') | ansible.builtin.path_join }}"
+            script: "{{ _podman_qemu_user_static_cmd }}"
+
+        - name: Ensure manifest doesn't exist
+          ansible.builtin.command:
+            cmd: podman manifest rm {{ _container_manifest_name }}
+          register: _podman_manifest_create_output
+          changed_when: _podman_manifest_create_output.rc == 0
+          failed_when:
+            - (_podman_manifest_create_output.rc != 0 and 'image not known' not in _podman_manifest_create_output.stderr)
+
+        - name: Create manifest
+          ansible.builtin.command:
+            cmd: podman manifest create {{ _container_manifest_name }}
+          register: _podman_manifest_create_output
+          changed_when: _podman_manifest_create_output.rc == 0
+
+    - name: Build container
+      block:
+        - name: Build container
+          cifmw.general.ci_script:
+            output_dir: "{{ (cifmw_build_push_container_artifacts, 'scripts') | ansible.builtin.path_join }}"
+            script: "{{ _podman_build_cmd }}"
+
+    - name: Push manifest
+      when:
+        - cifmw_build_push_container_push
+        - _multi_arch_build
+      cifmw.general.ci_script:
+        output_dir: "{{ (cifmw_build_push_container_artifacts, 'scripts') | ansible.builtin.path_join }}"
+        script: "{{ (_podman_push_manifest_cmd, item) | join(':') }}"
+      loop: "{{ _rendered_tags_with_overrides }}"
+
+    - name: Push container
+      when:
+        - cifmw_build_push_container_push
+        - not _multi_arch_build
+      cifmw.general.ci_script:
+        output_dir: "{{ (cifmw_build_push_container_artifacts, 'scripts') | ansible.builtin.path_join }}"
+        script: "{{ (_podman_push_container_cmd, item) | join(':') }}"
+      loop: "{{ _rendered_tags_with_overrides }}"
+
+  rescue:
+    - name: Failure detected, output varibles
+      ansible.builtin.debug:
+        msg:
+          - "_rendered_tags: {{ _rendered_tags }}"
+          - "_rendered_tags_with_overrides: {{ _rendered_tags_with_overrides }}"
+          - "_container_manifest_name: {{ _container_manifest_name }}"
+          - "_multi_arch_build: {{ _multi_arch_build }}"
+          - "{{ _podman_build_cmd }}"
+          - "{{ _podman_push_container_cmd }}"
+          - "{{ _podman_push_manifest_cmd }}"
+          - "{{ _podman_qemu_user_static_cmd }}"
+
+    - name: Re-trigger failure
+      ansible.builtin.fail:
+        msg: >-
+          Failure detected. Check the debug outputs above

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -37,6 +37,17 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/build_push_container/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-build_push_container
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: build_push_container
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/cert_manager/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -15,6 +15,7 @@
       - cifmw-molecule-artifacts
       - cifmw-molecule-build_containers
       - cifmw-molecule-build_openstack_packages
+      - cifmw-molecule-build_push_container
       - cifmw-molecule-cert_manager
       - cifmw-molecule-ci_gen_kustomize_values
       - cifmw-molecule-ci_local_storage


### PR DESCRIPTION
`build_push_container` aims to be a generic role that can build multi-arch containers and push them to remote registry.

JIRA: [OSPRH-9713](https://issues.redhat.com//browse/OSPRH-9713)