### PR TITLE
Allow to retry adding a host in vbmc

### DIFF
--- a/roles/virtualbmc/tasks/manage_host.yml
+++ b/roles/virtualbmc/tasks/manage_host.yml
@@ -50,6 +50,10 @@
           {{
             cifmw_virtualbmc_ipmi_base_port + _known_hosts
           }}
+      register: _add_host
+      retries: 5
+      delay: 1
+      until: _add_host.rc == 0
       ansible.builtin.command:
         cmd: >-
           podman exec {{ cifmw_virtualbmc_container_name }} vbmc


### PR DESCRIPTION
It seems from time to time vbmcd is slow. Allowing to retry to add the
host might help getting over some temporary issues.
