### PR TITLE
[DNM] Testing extracing network info from controller

### DIFF
--- a/roles/reproducer/tasks/ci_deploy_data.yml
+++ b/roles/reproducer/tasks/ci_deploy_data.yml
@@ -29,7 +29,7 @@
       }}
   ansible.builtin.set_fact:
     cacheable: true
-    ci_job_networking: "{{ zuul_inventory.all.hosts.crc.crc_ci_bootstrap_networking }}"
+    ci_job_networking: "{{ zuul_inventory.all.hosts.controller.crc_ci_bootstrap_networking }}"
     operator_content_provider: >-
       {{
         zuul_params.content_provider_registry_ip is defined


### PR DESCRIPTION
When executing reproducer with cifmw_job_uri, crc_ci_bootstrap_networking is being stored in controller instead of crc.  Updating to point to controller when populating bootstrap network info.