### PR TITLE
[pre-commit] Remove `bashate` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,20 +12,6 @@ repos:
       - id: check-symlinks
       - id: debug-statements
 
-  - repo: https://github.com/openstack-dev/bashate.git
-    rev: 2.1.1
-    hooks:
-      - id: bashate
-        # Run bashate check for all bash scripts
-        # Ignores the following rules:
-        # E006: Line longer than 79 columns (as many scripts use jinja
-        #       templating, this is very difficult)
-        # E040: Syntax error determined using `bash -n` (as many scripts
-        #       use jinja templating, this will often fail and the syntax
-        #       error will be discovered in execution anyway)
-        entry: bashate --error . --ignore=E006,E040
-        verbose: false
-
   # First execution of shellcheck reports all findings without failing
   # Second execution outputs nothing and fails if any finding meets the
   # defined severity.
@@ -38,13 +24,12 @@ repos:
     hooks:
       - id: shellcheck
         verbose: true
-        # entry: bash -c "shellcheck "$@" || true" --
         entry: >
-         bash -c 'shellcheck "$@" ||
-         shellcheck -f quiet
-         --severity=error
-         --exclude=SC2071
-         "$@"' --
+          bash -c 'shellcheck "$@" ||
+          shellcheck -f quiet
+          --severity=error
+          --exclude=SC2071
+          "$@"' --
 
   # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
   - repo: https://github.com/psf/black-pre-commit-mirror


### PR DESCRIPTION
Since we're now using `shellcheck` to lint and validate shell scripts, we can remove `bashate` which contains only a subsets of checks implemented by shellcheck.