### PR TITLE
Clear ether options for nics

### DIFF
--- a/roles/switch_config/tasks/junos_config.yml
+++ b/roles/switch_config/tasks/junos_config.yml
@@ -36,6 +36,16 @@
         config: "{{ vlans | from_yaml }}"
         state: merged
 
+    - name: Clear interfaces ether-options
+      when: "'interfaces' in switch_vars"
+      vars:
+        interface_config: |
+          {% for interface in switch_vars['interfaces'] %}
+          - delete interfaces "{{ interface.iface }}" ether-options
+          {% endfor %}
+      junipernetworks.junos.junos_config:
+        lines: '{{ interface_config | from_yaml }}'
+
     - name: Configure interfaces - description, mode (access/trunk), vlans
       when: "'interfaces' in switch_vars"
       vars:


### PR DESCRIPTION
This change is to allow setting configuration on nics primaraly used for lacp