### PR TITLE
Correct shellcheck errors

### DIFF
--- a/docs/source/build-docs.sh
+++ b/docs/source/build-docs.sh
@@ -6,8 +6,9 @@ VENV_DIR="${DOCS_DIR}/_venv"
 BUILD_TYPE="${BUILD_TYPE:=static}"
 
 # Create a virtual environment and activate it
-python -m venv ${VENV_DIR} && source ${VENV_DIR}/bin/activate
-pip3 install -r ${DOCS_DIR}/doc-requirements.txt
+# shellcheck disable=SC1091
+python -m venv "${VENV_DIR}" && source "${VENV_DIR}/bin/activate"
+pip3 install -r "${DOCS_DIR}/doc-requirements.txt"
 
 cd ${DOCS_DIR}/source
 

--- a/roles/devscripts/files/lv-cinder-volumes.sh
+++ b/roles/devscripts/files/lv-cinder-volumes.sh
@@ -10,8 +10,8 @@ fi
 
 disk_str=''
 for disk in ${_disks}; do
-    pvcreate ${disk}
+    pvcreate "${disk}"
     disk_str="${disk_str} ${disk}"
 done
 
-vgcreate cinder-volumes ${disk_str}
+vgcreate cinder-volumes "${disk_str}"

--- a/roles/nat64_appliance/files/elements/nat64-router/static/usr/local/sbin/configure-nat64
+++ b/roles/nat64_appliance/files/elements/nat64-router/static/usr/local/sbin/configure-nat64
@@ -23,6 +23,7 @@ if [ -f /etc/nat64/config-complete ]; then
     exit 0
 fi
 
+# shellcheck disable=SC1091
 source /etc/nat64/config-data
 
 if [ -z "${NAT64_IPV6_PREFIX}" ]; then
@@ -42,28 +43,28 @@ NAT64_TAYGA_IPV4=${NAT64_TAYGA_IPV4:-"192.168.255.1"}
 function replace_vars {
 
     pushd /etc/nat64/v6-dnsmasq
-        sed -i s~%%_NAT64_HOST_IPV6_%%~${NAT64_HOST_IPV6%%/*}~g dnsmasq.conf
+        sed -i "s~%%_NAT64_HOST_IPV6_%%~${NAT64_HOST_IPV6%%/*}~g" dnsmasq.conf
     popd
 
     pushd /etc/unbound/
-        sed -i s~%%_NAT64_IPV6_PREFIX_%%~${NAT64_IPV6_PREFIX}~g unbound.conf
-        sed -i s~%%_NAT64_TAYGA_IPV6_PREFIX_%%~${NAT64_TAYGA_IPV6_PREFIX}~g unbound.conf
+        sed -i "s~%%_NAT64_IPV6_PREFIX_%%~${NAT64_IPV6_PREFIX}~g" unbound.conf
+        sed -i "s~%%_NAT64_TAYGA_IPV6_PREFIX_%%~${NAT64_TAYGA_IPV6_PREFIX}~g" unbound.conf
     popd
 
     pushd /etc/tayga
-        sed -i s~%%_NAT64_TAYGA_IPV4_%%~${NAT64_TAYGA_IPV4}~g default.conf
-        sed -i s~%%_NAT64_TAYGA_IPV6_PREFIX_%%~${NAT64_TAYGA_IPV6_PREFIX}~g default.conf
-        sed -i s~%%_NAT64_TAYGA_DYNAMIC_POOL_%%~${NAT64_TAYGA_DYNAMIC_POOL}~g default.conf
+        sed -i "s~%%_NAT64_TAYGA_IPV4_%%~${NAT64_TAYGA_IPV4}~g" default.conf
+        sed -i "s~%%_NAT64_TAYGA_IPV6_PREFIX_%%~${NAT64_TAYGA_IPV6_PREFIX}~g" default.conf
+        sed -i "s~%%_NAT64_TAYGA_DYNAMIC_POOL_%%~${NAT64_TAYGA_DYNAMIC_POOL}~g" default.conf
     popd
 
     pushd /etc/NetworkManager/system-connections
-        sed -i s~%%_NAT64_TAYGA_IPV6_%%~${NAT64_TAYGA_IPV6}~g nat64.nmconnection
-        sed -i s~%%_NAT64_TAYGA_IPV6_PREFIX_%%~${NAT64_TAYGA_IPV6_PREFIX}~g nat64.nmconnection
-        sed -i s~%%_NAT64_TAYGA_DYNAMIC_POOL_%%~${NAT64_TAYGA_DYNAMIC_POOL}~g nat64.nmconnection
+        sed -i "s~%%_NAT64_TAYGA_IPV6_%%~${NAT64_TAYGA_IPV6}~g" nat64.nmconnection
+        sed -i "s~%%_NAT64_TAYGA_IPV6_PREFIX_%%~${NAT64_TAYGA_IPV6_PREFIX}~g" nat64.nmconnection
+        sed -i "s~%%_NAT64_TAYGA_DYNAMIC_POOL_%%~${NAT64_TAYGA_DYNAMIC_POOL}~g" nat64.nmconnection
     popd
 
     pushd /etc/nftables
-        sed -i s~%%_NAT64_TAYGA_DYNAMIC_POOL_%%~${NAT64_TAYGA_DYNAMIC_POOL}~g nat64.nft
+        sed -i "s~%%_NAT64_TAYGA_DYNAMIC_POOL_%%~${NAT64_TAYGA_DYNAMIC_POOL}~g" nat64.nft
     popd
 }
 

--- a/roles/openshift_provisioner_node/files/add_bridge_port.sh
+++ b/roles/openshift_provisioner_node/files/add_bridge_port.sh
@@ -10,19 +10,19 @@ set -euo pipefail
 BRIDGE_NAME=${1}
 IFACE_NAME=${2}
 
-CONN_NAME=$(nmcli -t -f GENERAL.CONNECTION dev show ${IFACE_NAME} | cut -d ':' -f 2)
+CONN_NAME=$(nmcli -t -f GENERAL.CONNECTION dev show "${IFACE_NAME}" | cut -d ':' -f 2)
 PORT_NAME=${BRIDGE_NAME}-p0
 
-check_port=$(nmcli con show | grep -c ${PORT_NAME}) || true
+check_port=$(nmcli con show | grep -c "${PORT_NAME}") || true
 
-if [ ${check_port} -ne 0 ]; then
+if [ "${check_port}" -ne 0 ]; then
     echo "Bridge port available. Nothing to do"
     exit 0
 fi
 
-check_iface=$(nmcli dev status | grep -c ${IFACE_NAME}) || true
+check_iface=$(nmcli dev status | grep -c "${IFACE_NAME}") || true
 
-if [ ${check_iface} -eq 0 ]; then
+if [ "${check_iface}" -eq 0 ]; then
     echo "Invalid device name"
     exit 1
 fi

--- a/scripts/bindep-install
+++ b/scripts/bindep-install
@@ -22,13 +22,14 @@ set -xeuo
 
 
 ## Vars ----------------------------------------------------------------------
-
+# shellcheck disable=SC2046,SC2086
 export BINDEP_FILE="${BINDEP_FILE:-$(dirname $(readlink -f ${BASH_SOURCE[0]}))/../bindep.txt}"
 
 
 ## Main ----------------------------------------------------------------------
 
 # Source distribution information
+# shellcheck disable=SC1091
 source /etc/os-release || source /usr/lib/os-release
 RHT_PKG_MGR=$(command -v dnf || command -v yum)
 
@@ -37,17 +38,17 @@ RHT_PKG_MGR=$(command -v dnf || command -v yum)
 BINDEP_PKGS=''
 case ${USE_VENV:-'yes'} in
     y|yes|true)
-        BINDEP_PKGS=$(${HOME}/test-python/bin/bindep -b -f "${BINDEP_FILE}" test || true)
+        BINDEP_PKGS=$("${HOME}/test-python/bin/bindep" -b -f "${BINDEP_FILE}" test || true)
         ;;
     *)
         BINDEP_PKGS=$(bindep -b -f "${BINDEP_FILE}" test || true)
         ;;
 esac
 
-if [[ ${#BINDEP_PKGS} > 0 ]]; then
+if [[ ${#BINDEP_PKGS} -gt 0 ]]; then
     case "${ID,,}" in
         amzn|rhel|centos|fedora)
-            sudo "${RHT_PKG_MGR}" install -y ${BINDEP_PKGS}
+            sudo "${RHT_PKG_MGR}" install -y "${BINDEP_PKGS}"
             ;;
     esac
 fi

--- a/scripts/check_k8s_snippets_comment.sh
+++ b/scripts/check_k8s_snippets_comment.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -o pipefail
 
 exit_code=0
@@ -10,16 +10,17 @@ if [[ $missing_comment != '' ]]; then
     echo
     echo "${missing_comment}"
     echo
-    let "exit_code+=1"
+    (( exit_code+=1 ))  # bashate: ignore=E043
 fi
 
 set_path=$(grep -r '^# source: ' roles/ci_gen_kustomize_values/templates | sed 's!roles/ci_gen_kustomize_values/templates/!!')
+# shellcheck disable=SC2162
 while read match; do
     tmpl=$(echo -n "${match}" | cut -d ':' -f 1)
     comment=$(echo -n "${match}" | cut -d ':' -f 3 | tr -d '[:space:]')
     if [[ "${tmpl}" != "${comment}" ]]; then
-        let "exit_code+=1"
+        (( exit_code+=1 ))  # bashate: ignore=E043
         echo "${tmpl} doesn't have correct 'source': ${comment}"
     fi
-done <<< ${set_path}
+done <<< "${set_path}"
 exit $exit_code

--- a/scripts/get-stats.sh
+++ b/scripts/get-stats.sh
@@ -28,5 +28,5 @@ if [ -z "$NODE_NAMES" ]; then
 fi
 
 for node in $NODE_NAMES; do
-    /usr/local/bin/oc debug $node -T -- chroot /host /usr/bin/bash -c "crictl stats -a -s $DURATION_TIME |  (sed -u 1q; sort -k 2 -h -r)"
+    /usr/local/bin/oc debug "${node}" -T -- chroot /host /usr/bin/bash -c "crictl stats -a -s ${DURATION_TIME} |  (sed -u 1q; sort -k 2 -h -r)"
 done

--- a/scripts/prepare_doc_build_env.sh
+++ b/scripts/prepare_doc_build_env.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -xe
 
+# shellcheck disable=SC2046,SC2086
 PROJECT_DIR="$(dirname $(readlink -f $0))/../"
 
 # Create a symlink for ansible_collections python package
@@ -12,10 +13,10 @@ ansible-galaxy collection install -U .. -p "${SITE_PACKAGES}"
 
 # Create links for roles' README.md in
 # docs/source/roles
-for i in ${PROJECT_DIR}/roles/*/README.md; do
-    dir_name=$(dirname ${i})
-    role_name=$(basename ${dir_name})
-    test -L docs/source/roles/${role_name}.md || \
-    ln -s ../../../roles/${role_name}/README.md \
-        docs/source/roles/${role_name}.md
+for i in "${PROJECT_DIR}"/roles/*/README.md; do
+    dir_name=$(dirname "${i}")
+    role_name=$(basename "${dir_name}")
+    test -L "docs/source/roles/${role_name}.md" || \
+    ln -s "../../../roles/${role_name}/README.md" \
+        "docs/source/roles/${role_name}.md"
 done

--- a/scripts/run_ansible_test
+++ b/scripts/run_ansible_test
@@ -21,6 +21,7 @@ set -o pipefail
 set -xeuo
 
 ## Vars ----------------------------------------------------------------------
+# shellcheck disable=SC2046,SC2086
 PROJECT_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))/../"
 USE_VENV=${USE_VENV:-yes}
 HOME=${HOME:-/tmp}
@@ -32,7 +33,7 @@ export ANSIBLE_REMOTE_TMP=${HOME}
 
 ansible_test='ansible-test'
 collection_path='/usr/share/ansible/collections/ansible_collections'
-case ${USE_VENV} in
+case "${USE_VENV}" in
     y|yes|true):
         ansible_test="${HOME}/test-python/bin/ansible-test"
         collection_path="${HOME}/.ansible/collections/ansible_collections"
@@ -48,10 +49,10 @@ done
 
 # Create/append the sanity exceptions for the current ansible version
 ansible_version=$(python3 -c "import ansible; print(ansible.__version__)" | sed 's/\.[^.]*$//')
-cat  "${HOME}/.ansible/collections/ansible_collections/cifmw/general/tests/sanity/ignore.txt" >> \
-    "${HOME}/.ansible/collections/ansible_collections/cifmw/general/tests/sanity/ignore-${ansible_version}.txt"
+cat  "${collection_path}/cifmw/general/tests/sanity/ignore.txt" >> \
+    "${collection_path}/cifmw/general/tests/sanity/ignore-${ansible_version}.txt"
 
-pushd ${HOME}/.ansible/collections/ansible_collections/cifmw/general
+pushd "${collection_path}/cifmw/general"
 
 if [ -d tests/unit ]; then
     ${ansible_test} units --color=yes --requirements -vv

--- a/scripts/run_molecule
+++ b/scripts/run_molecule
@@ -21,6 +21,7 @@ set -o pipefail
 set -xeuo
 
 ## Vars ----------------------------------------------------------------------
+# shellcheck disable=SC2046,SC2086
 PROJECT_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))/../"
 ROLE_DIR=$1
 USE_VENV=${USE_VENV:-yes}
@@ -31,7 +32,8 @@ TEST_VERBOSITY=${TEST_VERBOSITY:-'--debug'}
 (test -d "${ROLE_DIR}" || (echo "No such directory: ${ROLE_DIR}" && exit 1) ) || exit 1
 
 pushd "${ROLE_DIR}"
-local_roledir=$(echo $ROLE_DIR | sed 's|\.\?\./||g')
+# shellcheck disable=SC2001,SC2086
+local_roledir="$(echo $ROLE_DIR | sed 's|\.\?\./||g')"
 
 if [[ ${TEST_ALL_ROLES} == 'yes' ]]; then
     ROLES_LIST=$(ls -1)
@@ -41,7 +43,7 @@ elif [[ -n ${TEST_SINGLE_ROLE} ]]; then
 fi
 
 # Find what roles were modified
-if [[ -z ${ROLES_LIST} ]]; then
+if [[ -z "${ROLES_LIST}" ]]; then
     ROLES_LIST=$(git diff --dirstat=files,0,cumulative HEAD^..HEAD | sed "s|^[ 0-9.]\+% \(${local_roledir}\)\?||g" | cut -d/ -f1 | sort -u )
 fi
 
@@ -49,16 +51,16 @@ git clone https://github.com/openstack-k8s-operators/install_yamls /root/src/git
 
 export ANSIBLE_ACTION_PLUGINS=./plugins/action:~/.ansible/plugins/action:/usr/share/ansible/plugins/actions
 for rolepath in ${ROLES_LIST}; do
-    role=$(echo $rolepath|sed "s|${local_roledir}||" | cut -f1 -d /)
-    test -d ${role} || continue
+    role=$(echo "${rolepath}" | sed "s|${local_roledir}||" | cut -f1 -d /)
+    test -d "${role}" || continue
     echo "Running molecule against: ${role}"
-    pushd $role
-    case ${USE_VENV} in
+    pushd "$role"
+    case "${USE_VENV}" in
         y|yes|true)
-            ${HOME}/test-python/bin/molecule -c "${PROJECT_DIR}${MOLECULE_CONFIG}" ${TEST_VERBOSITY} test --all
+            "${HOME}/test-python/bin/molecule" -c "${PROJECT_DIR}${MOLECULE_CONFIG}" "${TEST_VERBOSITY}" test --all
             ;;
         *)
-            molecule -c "${PROJECT_DIR}${MOLECULE_CONFIG}" ${TEST_VERBOSITY} test --all
+            molecule -c "${PROJECT_DIR}${MOLECULE_CONFIG}" "${TEST_VERBOSITY}" test --all
             ;;
     esac
     popd

--- a/scripts/setup_env
+++ b/scripts/setup_env
@@ -20,6 +20,7 @@ set -o pipefail
 set -xeuo
 
 ## Vars ----------------------------------------------------------------------
+# shellcheck disable=SC2155,SC2046,SC2086
 export PROJECT_DIR="$(dirname $(dirname $(readlink -f ${BASH_SOURCE[0]})))"
 # NOTE(cloudnull): Disable ansible compat check, caters to the case where
 #                  system ansible may be installed.
@@ -29,13 +30,14 @@ USE_VENV=${USE_VENV:-'yes'}
 
 ## Main ----------------------------------------------------------------------
 # Source distribution information
+# shellcheck disable=SC1091
 source /etc/os-release || source /usr/lib/os-release
-RHT_PKG_MGR=$(command -v dnf)
+RHT_PKG_MGR=$(command -v dnf || command -v yum)
 PYTHON_EXEC=$(command -v python3)
-SYSTEM_PIP=$(dirname "$PYTHON_EXEC")/pip3
+SYSTEM_PIP=$(dirname "${PYTHON_EXEC}")/pip3
 
 # Install the requirements we need to run local tests
-command -v gcc || sudo dnf -y install gcc
+command -v gcc || sudo "${RHT_PKG_MGR}" -y install gcc
 
 PIP_INSTALL_ARGUMENTS="-U -r ${PROJECT_DIR}/common-requirements.txt"
 case ${USE_VENV} in
@@ -63,12 +65,12 @@ esac
 sudo -k
 
 # Ensure the required ci file is presnet
-mkdir -p ${HOME}/ci/yum.repos.d
-cp /etc/ci/mirror_info.sh ${HOME}/ci || touch ${HOME}/ci/mirror_info.sh
-cp -r /opt/yum.repos.d/* ${HOME}/ci/yum.repos.d || cp -r /etc/yum.repos.d/* ${HOME}/ci/yum.repos.d
+mkdir -p "${HOME}/ci/yum.repos.d"
+cp /etc/ci/mirror_info.sh "${HOME}/ci" || touch "${HOME}/ci/mirror_info.sh"
+cp -r /opt/yum.repos.d/* "${HOME}/ci/yum.repos.d" || cp -r /etc/yum.repos.d/* "${HOME}/ci/yum.repos.d"
 
 
-case ${USE_VENV} in
+case "${USE_VENV}" in
     y|yes|true):
         # Create a virtual env
         "${PYTHON_EXEC}" -m venv --upgrade-deps "${HOME}/test-python"
@@ -82,7 +84,7 @@ esac
 "${PIP}" install pip setuptools bindep --upgrade
 "${PROJECT_DIR}/scripts/bindep-install"
 
-${SYSTEM_PIP} install ${PIP_INSTALL_ARGUMENTS}
+${SYSTEM_PIP} install "${PIP_INSTALL_ARGUMENTS}"
 
 # Display list of installed packages with versions (debugging failures)
 "${SYSTEM_PIP}" freeze

--- a/scripts/setup_molecule
+++ b/scripts/setup_molecule
@@ -20,6 +20,7 @@ set -o pipefail
 set -xeuo
 
 ## Vars ----------------------------------------------------------------------
+# shellcheck disable=SC2155,SC2046,SC2086
 export PROJECT_DIR="$(dirname $(dirname $(readlink -f ${BASH_SOURCE[0]})))"
 # NOTE(cloudnull): Disable ansible compat check, caters to the case where
 #                  system ansible may be installed.
@@ -42,13 +43,13 @@ case ${USE_VENV-'yes'} in
 esac
 
 # Install requirements
-${PIP} install ${PIP_INSTALL_ARGUMENTS}
+${PIP} install "${PIP_INSTALL_ARGUMENTS}"
 
 # append git hash to cifmw collection version (if detected)
 GITVER=$(git -C "${PROJECT_DIR}" rev-parse --short HEAD 2>/dev/null || true)
 [[ "" == "${GITVER}" ]] || sed -ri "s/^(version: [0-9.]+).*/\1+${GITVER}/" "${PROJECT_DIR}/galaxy.yml"
 
-${GALAXY} collection install --upgrade --force --timeout=120 ${PROJECT_DIR}
+${GALAXY} collection install --upgrade --force --timeout=120 "${PROJECT_DIR}"
 
 # remove git hash from version to keep git status clean (not doing checkout to not revert any other manual change)
 [[ "" == "${GITVER}" ]] || sed -ri "s/^(version: [0-9.]+)+${GITVER}/\1/" "${PROJECT_DIR}/galaxy.yml"


### PR DESCRIPTION
Since we're moving to shellcheck instead of bashate, let's get it green.

This patch fixes, but also disables some checks on specific lines. It
also integrate a "bashate" related ignore since the check is still in
place, we can remove it later.
