### PR TITLE
fix(ci_setup): restore platform compatibility for CentOS 9 and EL 9

### DIFF
--- a/roles/ci_setup/meta/main.yml
+++ b/roles/ci_setup/meta/main.yml
@@ -21,6 +21,20 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: "2.14"
   namespace: cifmw
+   #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+    - name: EL
+      versions:
+        - 9
+
   galaxy_tags:
     - cifmw
 


### PR DESCRIPTION
- Re-added platform support for CentOS 9 and EL 9 in meta/main.yml
- Ensured the installation of required packages like bash-completion and tmux
Related-Bug: https://issues.redhat.com/browse/OSPCIX-432