### PR TITLE
Allow to leverage tags when running architecture deployment

### DIFF
--- a/playbooks/nfs.yml
+++ b/playbooks/nfs.yml
@@ -21,6 +21,7 @@
     - name: End play early if no NFS is needed
       when:
         - not cifmw_edpm_deploy_nfs | default('false') | bool
+        - cifmw_architecture_scenario is defined
       ansible.builtin.meta: end_play
   vars:
     nftables_path: /etc/nftables


### PR DESCRIPTION
The nfs.yml playbook is imported from the 06-deploy-edpm.yml
sub-playbook. Due to the way ansible imports things, it was leading to
an issue if we wanted to run an architecture driven deployment, with
"--tags deploy_edpm" parameter.
This deploy_edpm tag is shared between 06-deploy-edpm.yml and
06-deploy-architecure.yml playbooks, meaning it would run through both.

The exit condition in the 06-deploy-edpm.yml play was missing the check
on cifmw_architecture_scenario we usually have, leading to issues
because of undefined facts (ansible_user_dir, ansible_env) from the
compute nodes.

This patch should allow to avoid this issue in a clean way.
