### PR TITLE
[polarion] Each result dir equals polarion test run

### DIFF
--- a/roles/polarion/README.md
+++ b/roles/polarion/README.md
@@ -6,7 +6,8 @@ Role to setup jump tool and upload XML test results to Polarion.
 * `cifmw_polarion_jump_repo_dir`: (String) Jump repo directory. Defaults to `~/ci-framework-data/polarion-jump`.
 * `cifmw_polarion_jump_result_dir`: (String) Test results directory. Based on `cifmw_run_test_role` defaults to `~/ci-framework-data/tests/tempest/` or `~/ci-framework-data/tests/test_operator/`.
 * `cifmw_polarion_jump_repo_url`: (String) URL of jump repository.
-* `cifmw_polarion_testrun_id`: (String) A test run identification provided by Polarion test case.
+* `cifmw_polarion_testrun_title`: (String) A name of the test run under which the test results will be uploaded to polarion. The role appends an index number to the name to distinguish multiple test runs apart.
+* `cifmw_polarion_testrun_id`: (String) A test run identification provided by Polarion test case or `create-new-test-run` if polarion should generate a random test run ID. A value other than `create-new-test-run` will force this role to upload all test results found in all directories under `cifmw_polarion_jump_repo_url` to one test run identified by the given ID. The default behavior of this role is to treat the directories in `cifmw_polarion_jump_repo_url` as separate test runs.
 * `cifmw_polarion_update_testcases`: (Boolean) A value of True/False to create missing testcases (which should normally _not_ be enabled).
 * `cifmw_polarion_jump_extra_vars`: (String) A list of extra_vars that are being passed to the jump script. Defaults to empty.
 * `cifmw_polarion_use_stage`: (Bool) Flag for using the staging instance of Polarion. Default is False meaning the production instance gets updated. Don't forget to change for testing on stage instance.

--- a/roles/polarion/defaults/main.yml
+++ b/roles/polarion/defaults/main.yml
@@ -22,6 +22,7 @@ cifmw_polarion_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-fram
 cifmw_polarion_jump_repo_dir: "{{ cifmw_polarion_basedir }}/polarion-jump"
 cifmw_polarion_jump_result_dir: "{{ cifmw_polarion_basedir }}/tests/{{ cifmw_run_test_role | default('tempest') }}/"
 cifmw_polarion_jump_repo_branch: "master"
+cifmw_polarion_testrun_title: "testrun-name"
 cifmw_polarion_use_stage: false
 cifmw_zuul_project: "tripleo-ci-internal"
 cifmw_zuul_url: "https://sf.hosted.upshift.rdu2.redhat.com/zuul/t/{{ cifmw_zuul_project }}/build"

--- a/roles/polarion/tasks/main.yml
+++ b/roles/polarion/tasks/main.yml
@@ -94,12 +94,27 @@
       ansible.builtin.debug:
         var: pylero_output.stdout_lines
 
-    - name: Merge result XML files
+    - name: Look for test result directories in artifacts directory
+      ansible.builtin.find:
+        paths: "{{ cifmw_polarion_jump_result_dir }}"
+        recurse: false
+        file_type: directory
+      register: result_dirs
+
+    - name: Merge result XML files of each directory
       ansible.builtin.shell:
         chdir: "{{ cifmw_polarion_jump_result_dir }}"
         cmd: >-
           source "{{ cifmw_polarion_jump_repo_dir }}/jump-venv/bin/activate" &&
-          junitparser merge {{ xml_files.files | json_query('[*].path') | join(' ') }} ./results_merged.xml
+          junitparser merge {{ item.path }}/*.xml {{item.path }}/results_merged.xml
+      loop: "{{ result_dirs.files }}"
+
+    - name: Look for test result XML files in artifacts directory
+      ansible.builtin.find:
+        paths: "{{ cifmw_polarion_jump_result_dir }}"
+        patterns: "results_merged.xml"
+        recurse: true
+      register: merged_xml_files
 
     - name: Update Test Runs
       ansible.builtin.shell:
@@ -108,10 +123,14 @@
           source "{{ cifmw_polarion_jump_repo_dir }}/jump-venv/bin/activate" &&
           {{ cifmw_polarion_jump_repo_dir }}/jump-venv/bin/python jump.py
           --testrun-id={{ cifmw_polarion_testrun_id }}
-          --xml-file={{ cifmw_polarion_jump_result_dir }}/results_merged.xml
+          --testrun-title={{ cifmw_polarion_testrun_title }}-{{ loop_idx }}
+          --xml-file={{ item.path }}
           --update_testcases={{ cifmw_polarion_update_testcases | default(false) }}
-          --custom-fields cijoburl={{ cifmw_zuul_url }}/{{ zuul.build }}
+          --custom-fields cijoburl={{ cifmw_zuul_url }}/{{ zuul.build }},jobteststage={{ result_dirs.files[ loop_idx ].path | basename }}
           {{ cifmw_polarion_jump_extra_vars | default ('') }}
+      loop: "{{ merged_xml_files.files }}"
+      loop_control:
+        index_var: loop_idx
       register: jump_script
 
     - name: Output of jump


### PR DESCRIPTION
Each of the dirs found under the cifmw_polarion_jump_result_dir will be understood as a new test run in polarion. The polarion role will merge all .xml result files found inside each of the directories. Then it will iterate over all merged files and will upload them to polarion as a test run.

The reason behind this is that the same test can be executed several times within one job, each time with a different configuration or in a different cloud state (e.g. before/after service reboot). However, if polarion receives multiple results of the same test it will take into account only the last one.

The results from the tests that are executed repeatedly need to be in separate result directories so that they are reported as separate test runs.