### PR TITLE
Add cifmw_set_openstack_containers_prefix_filter variable to set_openstack_cotaniners

### DIFF
--- a/roles/set_openstack_containers/README.md
+++ b/roles/set_openstack_containers/README.md
@@ -15,7 +15,8 @@ The role will generate two 2 files in ~/ci-framework-data/artifacts/ directory a
 * `cifmw_set_openstack_containers_tag_from_md5`: Get the tag from delorean.repo.md5. Defaults to `false`.
 * `cifmw_set_openstack_containers_dlrn_md5_path`: Full path of delorean.repo.md5. Defaults to `/etc/yum.repos.d/delorean.repo.md5`.
 * `cifmw_set_openstack_containers_overrides`: Extra container overrides. Defaults to `{}`
-* `cifmw_set_openstack_containers_prefix`: Update container containing. Defaults to `openstack`
+* `cifmw_set_openstack_containers_prefix`: Container prefix name to set. Defaults to `openstack`
+* `cifmw_set_openstack_containers_prefix_filter`: Include in filter containers containing prefix in the name. Defaults to value of `cifmw_set_openstack_containers_prefix`
 * `cifmw_set_openstack_containers_openstack_version_change`: (Boolean) Set environment variables for openstack services containers for specific OPENSTACK_RELEASE_VERSION defined in cifmw_set_openstack_containers_update_target_version. It should be used only for meta openstack operator in prepare for openstack minor update. Defaults to `false`.
 * `cifmw_set_openstack_containers_update_target_version`: Value of OPENSTACK_RELEASE_VERSION env in openstack operator that should be set. Defaults to `0.0.2`.
 * `cifmw_set_openstack_containers_openstack_final_env`: File name to store the operator env in a file. Default to `operator_env.txt`.

--- a/roles/set_openstack_containers/defaults/main.yml
+++ b/roles/set_openstack_containers/defaults/main.yml
@@ -22,6 +22,7 @@ cifmw_set_openstack_containers_registry: quay.io
 cifmw_set_openstack_containers_namespace: podified-antelope-centos9
 cifmw_set_openstack_containers_tag: current-podified
 cifmw_set_openstack_containers_prefix: openstack
+cifmw_set_openstack_containers_prefix_filter: "{{ cifmw_set_openstack_containers_prefix }}"
 cifmw_set_openstack_containers_operator_name: openstack
 cifmw_set_openstack_containers_tag_from_md5: false
 cifmw_set_openstack_containers_dlrn_md5_path: "/etc/yum.repos.d/delorean.repo.md5"

--- a/roles/set_openstack_containers/templates/update_env_vars.sh.j2
+++ b/roles/set_openstack_containers/templates/update_env_vars.sh.j2
@@ -7,8 +7,9 @@ export PATH="{{ cifmw_path }}"
 {% set containers_dict = {} -%}
 {# Set the container registry url with namespace #}
 {% set _container_registry = cifmw_set_openstack_containers_registry + '/' + cifmw_set_openstack_containers_namespace -%}
-{#   Add `-` to the cifmw_set_openstack_containers_prefix to avoid issues with #}
+{#   Add `-` to the cifmw_set_openstack_containers_prefix/filter to avoid issues with #}
 {#   openstack-openstackclient image name #}
+{% set _container_prefix_filter = cifmw_set_openstack_containers_prefix_filter + '-' -%}
 {% set _container_prefix = cifmw_set_openstack_containers_prefix + '-' -%}
 {# This is required to instruct openstack-operator to place environment variables for openstack services containers entries in openstackversion cr under targeted version #}
 {% if cifmw_set_openstack_containers_openstack_version_change | bool %}
@@ -19,10 +20,10 @@ export PATH="{{ cifmw_path }}"
 {%   set container_data = container.split('=') -%}
 {%   set _container_env = container_data[0] -%}
 {%   set _container = container_data[1] -%}
-{#   All the openstack services containers contain /openstack- prefix #}
+{#   All the openstack services containers contain /openstack- or /rhos18-openstack- prefix #}
 {#   It filters out the same and update the container address with new url #}
-{%   if (_container_prefix in _container) and ('operator' not in _container) -%}
-{%     set _container_data = _container.split(_container_prefix)[-1] -%}
+{%   if (_container_prefix_filter in _container) and ('operator' not in _container) -%}
+{%     set _container_data = _container.split(_container_prefix_filter)[-1] -%}
 {#   There is sha256 tag initially for container tags, but in some jobs we switch to dlrn tag #}
 {%     if '@sha256' in _container_data  -%}
 {%        set _container_name = _container_data.split('@sha256')[0]      -%}


### PR DESCRIPTION
Add cifmw_set_openstack_containers_prefix_filter variable to replace it in update_env_vars template with cifmw_set_openstack_containers_prefix variable. This will enable to replace prefix of openstack containers if prefixes are not following the same convention between container registries.