### PR TITLE
Enable the ovn dbs monitoring test

### DIFF
--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -77,8 +77,6 @@
           neutron_plugin_options.ipv6_metadata false
           neutron_plugin_options.advanced_image_ref 11111111-1111-1111-1111-111111111111
           neutron_plugin_options.advanced_image_flavor_ref 22222222-2222-2222-2222-222222222222
-          whitebox_neutron_plugin_options.openstack_type podified
-          whitebox_neutron_plugin_options.run_traffic_flow_tests True
           whitebox_neutron_plugin_options.kubeconfig_path '/home/zuul/.crc/machines/crc/kubeconfig'
           validation.allowed_network_downtime 15
           validation.run_validation true
@@ -158,7 +156,6 @@
             excludeList: |
               whitebox_neutron_tempest_plugin.tests.scenario.test_metadata_rate_limiting
               whitebox_neutron_tempest_plugin.tests.scenario.test_mtu.GatewayMtuTestIcmp.test_northbound_pmtud_icmp
-              whitebox_neutron_tempest_plugin.tests.scenario.test_ovn_dbs.OvnDbsMonitoringTest
               whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging.*test_only_dropped_traffic_logged
               whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging.StatefulSecGroupLoggingTest.test_only_accepted_traffic_logged
               whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging.StatelessSecGroupLoggingTest.test_only_accepted_traffic_logged


### PR DESCRIPTION
After [1] we can enable the ovn_dbs_monitoring test.\
Also removed redundant configs since they set values that are defaults.

[1] https://review.opendev.org/c/x/whitebox-neutron-tempest-plugin/+/927200