### PR TITLE
Use libvirt_manager extra_disks for Ceph OSDs

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -364,6 +364,7 @@ operatorgroup
 opn
 orchestrator
 osd
+osds
 osp
 osprh
 otz

--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -98,11 +98,16 @@
   gather_facts: true
   become: true
   pre_tasks:
+    # If ceph is not being deployed, then skip this play
+    # Or if cifmw_ceph_spec_data_devices is overridden, then skip this play
+    # Assume cifmw_ceph_spec_data_devices implies block devices are already present
     # end_play will end this current playbook and go the the next
     # imported play.
     - name: Early stop ceph related work
       when:
-        - not _deploy_ceph | default(true)
+        - not _deploy_ceph | default(true) or
+          (cifmw_ceph_spec_data_devices is defined and
+           cifmw_ceph_spec_data_devices | length > 0)
       ansible.builtin.meta: end_play
   tasks:
     - name: Set cifmw_num_osds_perhost

--- a/scenarios/reproducers/va-hci.yml
+++ b/scenarios/reproducers/va-hci.yml
@@ -76,6 +76,8 @@ cifmw_libvirt_manager_configuration:
       disksize: "{{ [cifmw_libvirt_manager_compute_disksize|int, 50] | max }}"
       memory: "{{ [cifmw_libvirt_manager_compute_memory|int, 8] | max }}"
       cpus: "{{ [cifmw_libvirt_manager_compute_cpus|int, 4] | max }}"
+      extra_disks_num: 3
+      extra_disks_size: 30G
       nets:
         - ocpbm
         - osp_trunk


### PR DESCRIPTION
Update Ceph playbook to not call `cifmw_block_device` role if `cifmw_ceph_spec_data_devices` is set. This parameter should only be overridden if different disks than the ones created by the `cifmw_block_device` role are going to be used.

Document an example of how to use the `libvirt_manager` role extra_disks_ parameter to create EDPM nodes with extra disks and how to override `cifmw_ceph_spec_data_devices` to use those disks.

Following the example provides an alterative to get better storage performance but this option is only available for jobs which use the reproducer and thus the `cifmw_block_device` role cannot be removed.

Also update scenarios/reproducers/va-hci.yml to add extra_disks.

Jira: https://issues.redhat.com/browse/OSPRH-9489

Signed-off-by: John Fulton <fulton@redhat.com>

(cherry-picked from f75fff6dbdb9c46b56857d043aacf5422f2db5ca)