### PR TITLE
Add a role to run compliance scans against the compute nodes and cont…

### DIFF
--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -64,6 +64,11 @@
   tags:
     - run-tests
 
+- name: Run compliance tests
+  ansible.builtin.import_playbook: playbooks/09-compliance.yml
+  tags:
+    - compliance
+
 - name: Run log related tasks
   ansible.builtin.import_playbook: playbooks/98-pre-end.yml
   tags:

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -348,6 +348,7 @@ olm
 oob
 opendev
 openrc
+openscap
 openshift
 openshiftsdn
 openssh
@@ -447,6 +448,8 @@ rpmss
 rsa
 rsync
 runtime
+scansettingbinding
+scap
 scp
 sdk
 selinux

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -68,6 +68,8 @@ are shared among multiple roles:
 - `cifmw_nolog`: (Bool) Toggle `no_log` value for selected tasks. Defaults to `true` (hiding those logs by default).
 - `cifmw_parent_scenario`: (String or List(String)) path to existing scenario/parameter file to inherit from.
 - `cifmw_configure_switches`: (Bool) Specifies whether switches should be configured. Computes in `reproducer.yml` playbook. Defaults to `false`.
+- `cifmw_run_operators_compliance_scans`: (Bool) Specifies whether to run operator compliance scans.  Defaults to `false`.
+- `cifmw_run_compute_compliance_scans`: (Bool) Specifies whether to run compliance scans on the first compute.  Defaults to `false`.
 
 ```{admonition} Words of caution
 :class: danger

--- a/playbooks/09-compliance.yml
+++ b/playbooks/09-compliance.yml
@@ -1,0 +1,23 @@
+---
+- name: Run operators compliance scans
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Run compliance scan for controllers
+      ansible.builtin.import_role:
+        name: compliance
+      vars:
+        cifmw_compliance_podman_username: "{{ cifmw_registry_token.credentials.username }}"
+        cifmw_compliance_podman_password: "{{ cifmw_registry_token.credentials.password }}"
+      when: cifmw_run_operators_compliance_scans | default('false') | bool
+
+- name: Run compliance scan for computes
+  hosts: "{{ groups['computes'] | default ([]) }}"
+  gather_facts: true
+  tasks:
+    - name: Run compliance scan for one compute
+      ansible.builtin.import_role:
+        name: compliance
+        tasks_from: run_compute_node_scans.yml
+      run_once: true
+      when: cifmw_run_compute_compliance_scans | default('false') | bool

--- a/roles/artifacts/tasks/edpm.yml
+++ b/roles/artifacts/tasks/edpm.yml
@@ -74,6 +74,7 @@
           sudo test -d /var/lib/openstack && sudo cp -a /var/lib/openstack /tmp/{{ host_ip }}
           sudo test -d /var/lib/config-data && sudo cp -a /var/lib/config-data /tmp/{{ host_ip }}
           sudo test -d /var/lib/cloud && sudo cp -a /var/lib/cloud /tmp/{{ host_ip }}
+          sudo test -d /home/zuul/compliance-scans && sudo cp -a /home/zuul/compliance-scans /tmp/{{ host_ip }}
           sudo find /tmp/{{ host_ip }} -type d -exec chmod ugoa+rx '{}' \;
           sudo find /tmp/{{ host_ip }} -type f -exec chmod ugoa+r '{}' \;
           command -v ovs-vsctl && sudo ovs-vsctl list Open_vSwitch > /tmp/{{ host_ip }}/ovs_vsctl_list_openvswitch.txt

--- a/roles/compliance/README.md
+++ b/roles/compliance/README.md
@@ -1,0 +1,72 @@
+# Compliance Role
+
+Execute compliance scans on the control plane via the [compliance-operator](https://github.com/openshift/compliance-operator)
+as well as OpenSCAP [scans](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#configuration-compliance-tools-in-rhel_scanning-the-system-for-configuration-compliance-and-vulnerabilities) against the compute nodes.  Retrieve compliance results and generate reports.
+
+The parameter `cifmw_compliance_suites` is used to specify the compliance suites to be scanned.  Each suite is related to specific
+compliance profiles through the `cifmw_compliance_scan_settings` parameter.
+
+When a suite is included, a scansettingbinding is created for each profile (`<suite>-<profile>-binding`).  This triggers
+various compliance scans associated with each profile.  The results are aggregated and are used to generate reports.  The results and
+reports are stored in `cifmw_compliance_artifacts_basedir/<suite>`.
+
+Note that while it is possible to associate more than one profile with a scansettingbinding, this can lead to errors with resource
+contention if too many scans are running at once.  Therefore, we only associate one profile per scansettingbinding - and we wait
+until the compliance scans complete or error out before moving on to the next profile.
+
+## Parameters
+
+* `cifmw_compliance_artifacts_basedir`: (String) Directory where we will have all test-operator related files. Default value: `{{ cifmw_basedir }}/tests/compliance` which defaults to `~/ci-framework-data/tests/compliance`
+* `cifmw_compliance_cleanup`: (Boolean) Delete all resources created by the role at the end of the testing. Default value: `false`
+* `cifmw_compliance_compute_artifacts_basedir`: (String) Directory for the results of compute node scans.  Default value: `~/compliance-scans`
+* `cifmw_compliance_compute_profiles: (List of Strings) Profiles to use when scanning compute nodes. Default value:
+```
+  - pci-dss
+  - e8
+  - stig
+```
+* `cifmw_compliance_dry_run`: (Boolean) Whether the compliance-operator should and OpenSCAP scans should run or not.  Default value: `false`
+* `cifmw_compliance_namespace`: (String) Namespace inside which all the resources are created. Default value: `openshift-compliance`
+* `cifmw_compliance_plugin_image`: (String) Image to use to extract the oc compliance plugin. Default value: `registry.redhat.io/compliance/oc-compliance-rhel8:stable`
+* `cifmw_compliance_podman_password`: (String) password to log into registry to retrieve image for oc compliance plugin
+* `cifmw_compliance_podman_registry`: (String) registry to get image for oc compliance plugin.  Default value: registry.redhat.io
+* `cifmw_compliance_podman_username`: (String) user to log into registry to retrieve image for oc compliance plugin
+* `cifmw_compliance_scan_settings`: (Dictionary) Dictionary that maps compliance suites to compliance profiles.  Default value:
+```
+  cis:
+    - ocp4-cis
+        #- ocp4-cis-node
+  e8:
+    - ocp4-e8
+    - rhcos4-e8
+  high:
+    - ocp4-high
+    - ocp4-high-node
+    - rhcos4-high
+  moderate:
+    - ocp4-moderate
+    - ocp4-moderate-node
+    - rhcos4-moderate
+  nerc-cip:
+    - ocp4-nerc-cip
+    - ocp4-nerc-cip-node
+    - rhcos4-nerc-cip
+  pci-dss:
+    - ocp4-pci-dss
+    - ocp4-pci-dss-node
+  stig:
+    - ocp4-stig
+    - ocp4-stig-node
+    - rhcos4-stig
+```
+* `cifmw_compliance_scap_content_file`: (String) File to get scap profile content in compute scans. Default value: `/usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml`
+* `cifmw_compliance_suites`: (List of Strings) Scan settings to execute.  Default value:
+```
+  - cis
+  - e8
+  - high
+  - moderate
+  - nerc-cip
+  - pci-dss
+  - stig
+```

--- a/roles/compliance/defaults/main.yml
+++ b/roles/compliance/defaults/main.yml
@@ -1,0 +1,69 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# defaults file for compliance role
+
+cifmw_compliance_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}/tests/compliance"
+cifmw_compliance_cleanup: true
+
+# A list of available profiles can be found using "oscap info /usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml"
+# Example profiles are: stig, stig_gui, pci-dss, ospp, ism_o, hipaa, e8, cui, cis_workstation_l2, cis_workstation_l1,
+#   cis_server_l1, cis, ccn_intermediate, ccn_basic, ccn_advanced, anssi_bp28_intermediary, anssi_bp28_high, anssi_bp28_enhanced
+cifmw_compliance_compute_profiles:
+  - pci-dss
+  - e8
+  - stig
+cifmw_compliance_compute_artifacts_basedir: "{{ ansible_user_dir ~ '/compliance-scans' }}"
+cifmw_compliance_dry_run: false
+cifmw_compliance_namespace: openshift-compliance
+cifmw_compliance_plugin_image: registry.redhat.io/compliance/oc-compliance-rhel8:stable
+cifmw_compliance_podman_registry: registry.redhat.io
+cifmw_compliance_scan_settings:
+  cis:
+    - ocp4-cis
+        # - ocp4-cis-node
+  e8:
+    - ocp4-e8
+    - rhcos4-e8
+  high:
+    - ocp4-high
+    - ocp4-high-node
+    - rhcos4-high
+  moderate:
+    - ocp4-moderate
+    - ocp4-moderate-node
+    - rhcos4-moderate
+  nerc-cip:
+    - ocp4-nerc-cip
+    - ocp4-nerc-cip-node
+      # - rhcos4-nerc-cip
+  pci-dss:
+    - ocp4-pci-dss
+    - ocp4-pci-dss-node
+  stig:
+    - ocp4-stig
+    - ocp4-stig-node
+    - rhcos4-stig
+cifmw_compliance_scap_content_file: /usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml
+cifmw_compliance_suites:
+  - cis
+  - e8
+  - high
+  - moderate
+  - nerc-cip
+  - pci-dss
+  - stig

--- a/roles/compliance/meta/main.yml
+++ b/roles/compliance/meta/main.yml
@@ -1,0 +1,36 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- Compliance
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.14
+  namespace: cifmw
+  platforms:
+    - name: CentOS
+      versions:
+        - 9
+
+  galaxy_tags:
+    - cifmw
+    - compliance
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/compliance/molecule/default/converge.yml
+++ b/roles/compliance/molecule/default/converge.yml
@@ -1,0 +1,33 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge test of controller tasks
+  hosts: all
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_compliance_dry_run: true
+  roles:
+    - role: "compliance"
+
+- name: Converge test of compute tasks
+  hosts: all
+  vars:
+    ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+    cifmw_compliance_dry_run: true
+  roles:
+    - role: "compliance"
+      tasks_from: run_compute_node_scans.yml

--- a/roles/compliance/molecule/default/molecule.yml
+++ b/roles/compliance/molecule/default/molecule.yml
@@ -1,0 +1,9 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true

--- a/roles/compliance/tasks/cleanup.yml
+++ b/roles/compliance/tasks/cleanup.yml
@@ -1,0 +1,19 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Log debug tasks
+  ansible.builtin.debug:
+    msg: "Running cleanup tasks here"

--- a/roles/compliance/tasks/create_scap_report.yml
+++ b/roles/compliance/tasks/create_scap_report.yml
@@ -1,0 +1,43 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# This could be a loop over a map of scans. In fact, has to be include_tasks
+# Also extract the results and create the report.
+
+- name: Set base name
+  ansible.builtin.set_fact:
+    base_name: >-
+      {{
+        (
+          bzip_file.path | dirname,
+          bzip_file.path | basename | splitext | first | splitext | first
+        ) | path_join
+      }} # we expect files to end in ".xml.bzip2"
+
+- name: Copy the file to a file with a known extension
+  ansible.builtin.copy:
+    src: "{{ bzip_file.path }}"
+    dest: "{{ base_name }}.xml.bz2"
+
+- name: Unzip the file
+  ansible.builtin.command: "bunzip2 {{ base_name }}.xml.bz2"
+  args:
+    creates: "{{ base_name }}.xml"
+
+- name: Create the report
+  ansible.builtin.command: "oscap xccdf generate report --output {{ base_name }}.html {{ base_name }}.xml"
+  args:
+    creates: "{{ base_name }}.html"

--- a/roles/compliance/tasks/install.yml
+++ b/roles/compliance/tasks/install.yml
@@ -1,0 +1,140 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Install the compliance operator
+- name: Create the compliance namespace
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    api_version: v1
+    kind: Namespace
+    state: present
+    definition:
+      kind: Namespace
+      metadata:
+        name: "{{ cifmw_compliance_namespace }}"
+        labels:
+          openshift.io/cluster-monitoring: "true"
+          pod-security.kubernetes.io/enforce: privileged
+  when: not cifmw_compliance_dry_run | bool
+
+- name: Ensure OperatorGroup for the compliance-operator is present
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        name: compliance-operator
+        namespace: "{{ cifmw_compliance_namespace }}"
+      spec:
+        targetNamespaces:
+          - "{{ cifmw_compliance_namespace }}"
+  when: not cifmw_compliance_dry_run | bool
+
+- name: Ensure Subscription for the compliance-operator is present
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: compliance-operator-sub
+        namespace: "{{ cifmw_compliance_namespace }}"
+      spec:
+        name: compliance-operator
+        source: redhat-operators
+        sourceNamespace: openshift-marketplace
+        channel: "stable"
+        installPlanApproval: Automatic
+  when: not cifmw_compliance_dry_run | bool
+
+- name: Wait until the compliance-operator csv is present
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    namespace: "{{ cifmw_compliance_namespace }}"
+    kind: ClusterServiceVersion
+    api_version: operators.coreos.com/v1alpha1
+  register: csv_list
+  delay: 10
+  retries: 20
+  until: >-
+    {{
+      csv_list.resources |
+      map(attribute='metadata.name') |
+      select('match', 'compliance-operator')
+    }}
+  when: not cifmw_compliance_dry_run | bool
+
+- name: Get full name of the compliance-operator csv
+  ansible.builtin.set_fact:
+    compliance_operator_csv_name: >-
+      {{
+        csv_list.resources |
+        map(attribute='metadata.name') |
+        select('match', 'compliance-operator') | first
+      }}
+  when: not cifmw_compliance_dry_run | bool
+
+- name: Wait for the compliance-operator csv to Succeed
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    namespace: "{{ cifmw_compliance_namespace }}"
+    kind: ClusterServiceVersion
+    api_version: operators.coreos.com/v1alpha1
+    name: "{{ compliance_operator_csv_name }}"
+  register: csv
+  retries: 20
+  delay: 10
+  until: csv.resources[0].status.phase | default(omit) == "Succeeded"
+  when: not cifmw_compliance_dry_run | bool
+
+# Install the compliance plugin
+- name: Install podman
+  ansible.builtin.import_role:
+    name: podman
+
+- name: Log into registry
+  ansible.builtin.command:
+    cmd: "podman login -u {{ cifmw_compliance_podman_username }} -p {{ cifmw_compliance_podman_password }} {{ cifmw_compliance_podman_registry }}"
+  when: not cifmw_compliance_dry_run | bool
+
+- name: Copy out the compliance plugin from the oc-compliance image
+  ansible.builtin.command:
+    cmd: "podman run --rm -v ~/.local/bin:/mnt/out:Z {{ cifmw_compliance_plugin_image }} /bin/cp /usr/bin/oc-compliance /mnt/out/"
+  when: not cifmw_compliance_dry_run | bool
+
+# Install packages to process results
+# bzip2 comes from @rhosp-rhel-9.4-baseos
+# openscap-utils from rhosp-rhel-9.4-appstream
+- name: Install packages to process results
+  become: true
+  ansible.builtin.dnf:
+    name:
+      - bzip2
+      - openscap-utils
+    state: present

--- a/roles/compliance/tasks/main.yml
+++ b/roles/compliance/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure compliance folder exists
+  ansible.builtin.file:
+    path: "{{ cifmw_compliance_artifacts_basedir }}"
+    state: directory
+    recurse: true
+    owner: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+    group: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+    mode: '755'
+
+- name: Install the compliance operator and plugin
+  ansible.builtin.include_tasks: install.yml
+
+# Run compliance scans on the control plane
+- name: Run compliance scans and extract results
+  ansible.builtin.include_tasks: run_suite_scan.yml
+  loop: "{{ cifmw_compliance_suites }}"
+  loop_control:
+    loop_var: suite
+
+- name: Delete all resources created by the role
+  ansible.builtin.include_tasks: cleanup.yml
+  when: cifmw_compliance_cleanup | bool and not cifmw_compliance_dry_run | bool

--- a/roles/compliance/tasks/run_compute_node_scans.yml
+++ b/roles/compliance/tasks/run_compute_node_scans.yml
@@ -1,0 +1,54 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Install needed packages
+# These packages come from @rhosp-rhel-9.4-appstream
+- name: Install openscap-scanner and security guide
+  become: true
+  ansible.builtin.dnf:
+    name:
+      - openscap-scanner
+      - scap-security-guide
+    state: present
+
+- name: Create folder to hold scan results
+  ansible.builtin.file:
+    path: "{{ cifmw_compliance_compute_artifacts_basedir }}"
+    state: directory
+    recurse: true
+    owner: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+    group: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+    mode: '755'
+
+- name: Do compliance scans
+  ansible.builtin.command: >
+    oscap xccdf eval --report {{ cifmw_compliance_compute_artifacts_basedir }}/{{ profile }}.html \
+    --profile {{ profile}}  /usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml
+  become: true
+  failed_when: false
+  loop: "{{ cifmw_compliance_compute_profiles }}"
+  loop_control:
+    loop_var: profile
+  when: not cifmw_compliance_dry_run | bool
+
+- name: Set ownership on report files
+  ansible.builtin.file:
+    path: "{{ cifmw_compliance_compute_artifacts_basedir }}"
+    owner: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+    group: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+    recurse: true
+  become: true
+  when: not cifmw_compliance_dry_run | bool

--- a/roles/compliance/tasks/run_operator_scan.yml
+++ b/roles/compliance/tasks/run_operator_scan.yml
@@ -1,0 +1,71 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Set output directory
+  ansible.builtin.set_fact:
+    scan_binding: "{{ scan_suite }}-{{ scan_profile }}-binding"
+    out_dir: "{{ cifmw_compliance_artifacts_basedir }}/{{ scan_suite }}/{{ scan_profile }}"
+
+- name: Create scan binding
+  ansible.builtin.shell: |
+    oc get scansettingbinding -n {{ cifmw_compliance_namespace }} {{ scan_binding }} || \
+    oc compliance bind -n {{ cifmw_compliance_namespace }} -N {{ scan_binding }} profile/{{ scan_profile }}
+  when: not cifmw_compliance_dry_run | bool
+
+- name: Wait for the scan to complete
+  ansible.builtin.command: >
+    oc get compliancescan -n {{ cifmw_compliance_namespace }} --no-headers -l "compliance.openshift.io/suite={{ scan_binding }}"
+  register: scan_result
+  retries: 120
+  delay: 10
+  until:
+    - scan_result.stdout_lines| list | count > 0
+    - scan_result.stdout_lines| reject('search', 'DONE') | reject('search', 'ERROR') | list | count == 0
+  when: not cifmw_compliance_dry_run | bool
+
+- name: Delete directory for scan results if it exists
+  ansible.builtin.file:
+    path: "{{ out_dir }}"
+    state: absent
+
+- name: Create directory for scan results
+  ansible.builtin.file:
+    path: "{{ out_dir }}"
+    state: directory
+    recurse: true
+    owner: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+    group: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+    mode: '755'
+
+- name: Retrieve scan results
+  ansible.builtin.command: >
+    oc compliance fetch-raw scansettingbindings {{ scan_binding }} \
+    -o {{ out_dir }} -n {{ cifmw_compliance_namespace }}
+  when: not cifmw_compliance_dry_run | bool
+
+- name: Find all the compressed scan results
+  ansible.builtin.find:
+    paths: "{{ out_dir }}"
+    patterns: '.*bzip2$'
+    recurse: true
+    use_regex: true
+  register: scan_result_files
+
+- name: Process scan result files
+  ansible.builtin.include_tasks: create_scap_report.yml
+  loop: "{{ scan_result_files.files }}"
+  loop_control:
+    loop_var: bzip_file

--- a/roles/compliance/tasks/run_suite_scan.yml
+++ b/roles/compliance/tasks/run_suite_scan.yml
@@ -1,0 +1,27 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Log start of scans
+  ansible.builtin.debug:
+    msg: "Starting scans for {{ suite }}"
+
+- name: Run scans and extract results
+  ansible.builtin.include_tasks: run_operator_scan.yml
+  loop: "{{ cifmw_compliance_scan_settings[suite] }}"
+  loop_control:
+    loop_var: scan_profile
+  vars:
+    scan_suite: "{{ suite }}"

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -206,6 +206,17 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/compliance/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-compliance
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: compliance
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/config_drive/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -32,6 +32,7 @@
       - cifmw-molecule-cifmw_create_admin
       - cifmw-molecule-cifmw_external_dns
       - cifmw-molecule-cifmw_test_role
+      - cifmw-molecule-compliance
       - cifmw-molecule-config_drive
       - cifmw-molecule-copy_container
       - cifmw-molecule-deploy_bmh


### PR DESCRIPTION
…rol plane (#2228)

* Add compliance role

* Add code to run scans on compute nodes

* Add playbook to run compliance scans

* Fix pre-commit errors

* Add molecule test files

* Add login credentials for registry.redhat.io

* Fix various errors

* Add check to ensure compliance-operator is ready

Also make sure that the scans has started and are complete. And set to ignore errors on compute compliance scans.

* Fix the target directory for compute scan results

* Modify the script to pass compute scans correctly

* Avoid using shell when unzipping files

We make a couple modifications to the scan logic to avoid the use of shell and add a zuul job for the molecule tests.  Also added some changes to variables to make them more specific.

* Fix issues from code review

Cherry-picked from: 48a1cfe45aa1933a9d8b48f2b74cb0c13325df5d