### PR TITLE
Introduce cifmw_test_operator_insecure parameter

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -22,6 +22,8 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_storage_class_prefix`: (String) Prefix for `storageClass` in generated Tempest CRD file. Defaults to `"lvms-"` only if `cifmw_use_lvms` is True, otherwise it defaults to `""`. The prefix is prepended to the `cifmw_test_operator_storage_class`. It is not recommended to override this value, instead set `cifmw_use_lvms` True or False.
 * `cifmw_test_operator_storage_class`: (String) Value for `storageClass` in generated Tempest or Tobiko CRD file. Defaults to `"lvms-local-storage"` only if `cifmw_use_lvms` is True, otherwise it defaults to `"local-storage"`.
 * `cifmw_test_operator_delete_logs_pod`: (Boolean) Delete tempest log pod created by the role at the end of the testing. Default value: `false`.
+* `cifmw_test_operator_insecure`: (Boolean) Spawn the test pods with `allowPrivilegedEscalation: true` and default linux capabilities. This is required for certain test-operator functionalities to work properly (e.g.: extraRPMs, certain set of tobiko tests). Default value: `true`
+
 ## Tempest specific parameters
 * `cifmw_test_operator_tempest_registry`: (String) The registry where to pull tempest container. Default value: `quay.io`
 * `cifmw_test_operator_tempest_namespace`: (String) Registry's namespace where to pull tempest container. Default value: `podified-antelope-centos9`

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -36,6 +36,7 @@ cifmw_test_operator_fail_fast: false
 cifmw_test_operator_storage_class_prefix: "{{ 'lvms-' if cifmw_use_lvms | default(false) | bool  else '' }}"
 cifmw_test_operator_storage_class: "{{ cifmw_test_operator_storage_class_prefix }}local-storage"
 cifmw_test_operator_delete_logs_pod: false
+cifmw_test_operator_insecure: true
 
 # Section 2: tempest parameters - used when run_test_fw is 'tempest'
 cifmw_test_operator_tempest_registry: quay.io
@@ -95,6 +96,7 @@ cifmw_test_operator_tempest_config:
   spec:
     containerImage: "{{ cifmw_test_operator_tempest_image }}:{{ cifmw_test_operator_tempest_image_tag }}"
     storageClass: "{{ cifmw_test_operator_storage_class }}"
+    insecure: "{{ cifmw_test_operator_insecure }}"
     parallel: "{{ cifmw_test_operator_tempest_parallel | default(omit) }}"
     SSHKeySecretName: "{{ cifmw_test_operator_tempest_ssh_key_secret_name | default(omit) }}"
     configOverwrite: "{{ cifmw_test_operator_tempest_config_overwrite | default(omit) }}"
@@ -140,6 +142,7 @@ cifmw_test_operator_tobiko_config:
   spec:
     kubeconfigSecretName: "{{ cifmw_test_operator_tobiko_kubeconfig_secret }}"
     storageClass: "{{ cifmw_test_operator_storage_class }}"
+    insecure: "{{ cifmw_test_operator_insecure }}"
     containerImage: "{{ cifmw_test_operator_tobiko_image }}:{{ cifmw_test_operator_tobiko_image_tag }}"
     testenv: "{{ cifmw_test_operator_tobiko_testenv }}"
     version: "{{ cifmw_test_operator_tobiko_version }}"
@@ -183,6 +186,7 @@ cifmw_test_operator_ansibletest_config:
     containerImage: "{{ cifmw_test_operator_ansibletest_image }}:{{ cifmw_test_operator_ansibletest_image_tag }}"
     extraMounts: "{{ cifmw_test_operator_ansibletest_extra_mounts }}"
     storageClass: "{{ cifmw_test_operator_storage_class }}"
+    insecure: "{{ cifmw_test_operator_insecure }}"
     computeSSHKeySecretName: "{{ cifmw_test_operator_ansibletest_compute_ssh_key_secret_name }}"
     workloadSSHKeySecretName: "{{ cifmw_test_operator_ansibletest_workload_ssh_key_secret_name }}"
     ansibleGitRepo: "{{ cifmw_test_operator_ansibletest_ansible_git_repo }}"
@@ -223,6 +227,7 @@ cifmw_test_operator_horizontest_config:
     namespace: "{{ cifmw_test_operator_namespace }}"
   spec:
     storageClass: "{{ cifmw_test_operator_storage_class }}"
+    insecure: "{{ cifmw_test_operator_insecure }}"
     containerImage: "{{ cifmw_test_operator_horizontest_image }}:{{ cifmw_test_operator_horizontest_image_tag }}"
     adminUsername: "{{ cifmw_test_operator_horizontest_admin_username }}"
     adminPassword: "{{ cifmw_test_operator_horizontest_admin_password }}"


### PR DESCRIPTION
In order to be able to consume certain functionalities in the CI the test pods need to be spawned with:

- allowPrivilegedEscalation: true and
- default Linux capabilities.

These parameters are turned off by default on the side of the test-operator. However, in CI we need to use all test-operator functionalities. If this parameter is set to false then the following operations won't work:

- installation of external rpms and
- certain set of tobiko tests