### PR TITLE
Pin devscripts repo at working hash

### DIFF
--- a/roles/devscripts/vars/main.yml
+++ b/roles/devscripts/vars/main.yml
@@ -28,7 +28,11 @@ cifmw_devscripts_packages:
   - python3-jmespath
 
 cifmw_devscripts_repo: "https://github.com/openshift-metal3/dev-scripts.git"
-cifmw_devscripts_repo_branch: HEAD
+# Note(Chandan): Pinning devscripts at https://github.com/openshift-metal3/dev-scripts/commit/5756e9cf094d8c4256461b0fd4242cd84dea8c93
+# as https://github.com/openshift-metal3/dev-scripts/pull/1694 broke IPv6 job
+# More details are here: https://issues.redhat.com/browse/OSPCIX-443.
+# We should unpin it as more updates needed from devscript.
+cifmw_devscripts_repo_branch: 5756e9cf094d8c4256461b0fd4242cd84dea8c93
 
 cifmw_devscripts_config_defaults:
   working_dir: "/home/dev-scripts"


### PR DESCRIPTION
https://github.com/openshift-metal3/dev-scripts/pull/1694 broke the IPv6 deployment[1]. Let's ping it at https://github.com/openshift-metal3/dev-scripts/commit/5756e9cf094d8c4256461b0fd4242cd84dea8c93 as it was working.

Jira: https://issues.redhat.com/browse/OSPCIX-443

[Test results with VAHCI](https://review.rdoproject.org/r/c/tripleo-downstream-trigger-nested-virt/+/54231/1#message-d3e69a4ea4204bbdefdaf3edbc24d3997c604ddf)