### PR TITLE
Store update related repo_setup repos in update_repository

### DIFF
--- a/playbooks/update.yml
+++ b/playbooks/update.yml
@@ -25,6 +25,12 @@
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
+    - name: Copy repos to before_update_repos directory
+      ansible.builtin.copy:
+        remote_src: true
+        src: "{{ cifmw_basedir }}/artifacts/repositories/"
+        dest: "{{ cifmw_basedir }}/artifacts/before_update_repos/"
+
     - name: Run repo_setup
       ansible.builtin.include_role:
         name: repo_setup


### PR DESCRIPTION
Currently we use repo-setup default repositories location to store repo during pre-update and during update process.

There is no way to find out from what repos update happens. This pr changes the cifmw_repo_setup_output to update_repositories directory. It will help to find out what repos used during update.