### PR TITLE
Set nodeexporterimage via cifmw_update_containers_edpmnodeexporterimage

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -143,6 +143,7 @@ ecdsa
 edecb
 edploy
 edpm
+edpmnodeexporter
 ee
 eno
 enp
@@ -325,6 +326,7 @@ nmcli
 nmstate
 nncp
 nobuild
+nodeexporter
 nodenetworkconfigurationpolicy
 nodeps
 nodeset

--- a/roles/update_containers/README.md
+++ b/roles/update_containers/README.md
@@ -19,6 +19,7 @@ If apply, please explain the privilege escalation done in this role.
 * `cifmw_update_containers_manilashares`: The names of the manila shares prefix. Default to `[]`.
 * `cifmw_update_containers_agentimage`: Full Agent Image url for updating Agent Image.
 * `cifmw_update_containers_ceilometersgcoreImage`: Full Ceilometersgcore Image url for updating Ceilometersgcore Image.
+* `cifmw_update_containers_edpmnodeexporterimage`: Fill EdpmNodeExporter Image url for update Nodeexporter Image.
 * `cifmw_update_containers_openstack`: Whether to generate CR for updating openstack containers. Default to `false`.
 * `cifmw_update_containers_ansibleee_image_url`: Full Ansibleee Image url for updating Ansibleee Image.
 * `cifmw_update_containers_edpm_image_url`: Full EDPM Image url for updating EDPM OS image.

--- a/roles/update_containers/defaults/main.yml
+++ b/roles/update_containers/defaults/main.yml
@@ -44,3 +44,4 @@ cifmw_update_containers_manilashares: []
 # cifmw_update_containers_ansibleee_image_url:
 # cifmw_update_containers_edpm_image_url:
 # cifmw_update_containers_ipa_image_url:
+# cifmw_update_containers_edpmnodeexporterimage:

--- a/roles/update_containers/templates/update_containers.j2
+++ b/roles/update_containers/templates/update_containers.j2
@@ -36,7 +36,6 @@ spec:
     edpmNeutronMetadataAgentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-neutron-metadata-agent-ovn:{{ cifmw_update_containers_tag }}
     edpmNeutronOvnAgentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-neutron-ovn-agent:{{ cifmw_update_containers_tag }}
     edpmNeutronSriovAgentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-neutron-sriov-agent:{{ cifmw_update_containers_tag }}
-    edpmNodeExporterImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-telemetry-node:{{ cifmw_update_containers_tag }}
     edpmOvnBgpAgentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ovn-bgp-agent:{{ cifmw_update_containers_tag }}
     glanceAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-glance-api:{{ cifmw_update_containers_tag }}
     heatAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-heat-api:{{ cifmw_update_containers_tag }}
@@ -101,6 +100,9 @@ spec:
 {% endif %}
 {% if cifmw_update_containers_ceilometersgcoreImage is defined %}
     ceilometersgcoreImage: {{ cifmw_update_containers_ceilometersgcoreImage }}
+{% endif %}
+{% if cifmw_update_containers_edpmnodeexporterimage is defined %}
+    edpmNodeExporterImage: {{ cifmw_update_containers_edpmnodeexporterimage }}
 {% endif %}
 {% if cifmw_update_containers_agentimage is defined %}
 	    agentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-baremetal-operator-agent:{{ cifmw_update_containers_tag }}


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/ci-framework/pull/2231 added the missing openstack containers to update_containers role which includes nodeexporterimage also.

nodeexporterimage is not built by tcib tool. It is a different image. It needs to be specified by user while running update_containers role. otherwise deployment will fail saying fail to pull image from container registry as image does not exist on openstack registry namespace.

This pr adds cifmw_update_containers_edpmnodeexporterimage var to update the nodeexperterimage.

Jira: https://issues.redhat.com/browse/OSPCIX-447