### PR TITLE
Listallowed telemetry tests

### DIFF
--- a/roles/test_operator/files/list_allowed.yml
+++ b/roles/test_operator/files/list_allowed.yml
@@ -41,6 +41,6 @@ groups:
       - all
   - name: telemetry-operator
     tests:
-      - tempest.api.telemetry.*
+      - telemetry_tempest_plugin.aodh.api
     releases:
       - all

--- a/roles/test_operator/files/list_allowed.yml
+++ b/roles/test_operator/files/list_allowed.yml
@@ -44,3 +44,8 @@ groups:
       - telemetry_tempest_plugin.aodh.api
     releases:
       - all
+  - name: telemetry-operator-scenario
+    tests:
+      - telemetry_tempest_plugin.scenario
+    releases:
+      - all


### PR DESCRIPTION
tempest.api.telemetry.* actually doesn't exist. The only place with telemetry related tempest api tests is in telemetry_tempest_plugin.aodh.api