### PR TITLE
Allow to NOT connect some VMs to the public network

### DIFF
--- a/roles/libvirt_manager/molecule/generate_network_data/vars/scenarios.yml
+++ b/roles/libvirt_manager/molecule/generate_network_data/vars/scenarios.yml
@@ -94,8 +94,9 @@ scenarios:
         ip: "192.168.140.10"
       - rec: "compute-aabbcc11-0.ctlplane.local"
         ip: "192.168.140.10"
+      # Ensure we don't have IP here: compute is NOT connected to ocpbm
       - rec: "compute-aabbcc11-0.ocpbm.local"
-        ip: "192.168.111.10"
+        ip: ""
       - rec: "bm-0.utility"
         ip: "192.168.140.20"
       - rec: "bm-0.ctlplane.local"
@@ -115,7 +116,6 @@ scenarios:
       - dcn1_tr_dcn1-compute-aabbcc11-1
       - dcn2_tr_dcn2-compute-aabbcc11-0
       - ocpbm_bm-0
-      - ocpbm_compute-aabbcc11-0
       - ocpbm_dcn1-compute-aabbcc11-0
       - ocpbm_dcn1-compute-aabbcc11-1
       - ocpbm_dcn2-compute-aabbcc11-0

--- a/roles/libvirt_manager/tasks/generate_networking_data.yml
+++ b/roles/libvirt_manager/tasks/generate_networking_data.yml
@@ -179,22 +179,24 @@
             (_cifmw_libvirt_manager_layout.vms[group].amount | int) > 0) or
           _cifmw_libvirt_manager_layout.vms[group].amount is undefined) %}
       {% set _gr = (group == 'crc') | ternary('ocp', group)                                                             %}
+      {%   if _lnet_data.name | replace('cifmw_', '') in _cifmw_libvirt_manager_layout.vms[group].nets                  %}
         {{ _gr }}s:
           networks:
             {{ _lnet_data.name | replace('cifmw_', '') }}:
-      {% if cifmw_networking_definition['group-templates'][_gr ~ 's']['network-template'] is undefined %}
-      {%   if net_4 is defined %}
+      {%     if cifmw_networking_definition['group-templates'][_gr ~ 's']['network-template'] is undefined %}
+      {%       if net_4 is defined %}
               range-v4:
                 start: {{  net_4 | ansible.utils.nthhost(ns.ip_start | int ) }}
                 length: {{ _cifmw_libvirt_manager_layout.vms[group].amount | default(1) }}
-      {%   endif %}
-      {%   if net_6 is defined %}
+      {%       endif %}
+      {%       if net_6 is defined %}
               range-v6:
                 start: {{  net_6 | ansible.utils.nthhost(ns.ip_start | int) }}
                 length: {{ _cifmw_libvirt_manager_layout.vms[group].amount | default(1) }}
-      {%   endif %}
+      {%       endif %}
       {%   set ns.ip_start = ns.ip_start|int + (_cifmw_libvirt_manager_layout.vms[group].amount | default(1) | int ) + 1 %}
-      {% endif %}
+      {%     endif %}
+      {%   endif %}
       {% endfor %}
       {% if cifmw_baremetal_hosts is defined and cifmw_baremetal_hosts | length > 0 %}
         baremetals:


### PR DESCRIPTION
Until now, we assumed every VM were connected to the "public network".
This seems to not be right, so we have to prevent patching the
networking-definition for all the nodes.

This patch checks if the VM group/type is connected to the public
network, so that we generate the DHCP configuration only for the ones
that need it.
This should prevent some corner cases.
