### PR TITLE
DRAFT: Use the new label cloud-centos-9-stream-tripleo-xxl

### DIFF
--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -205,8 +205,7 @@
     name: centos-9-medium-2x-centos-9-crc-extracted-2-39-0-xxl
     nodes:
       - name: controller
-        label: cloud-centos-9-stream-tripleo-medium
-        # Note(Chandan Kumar): Switch to xxl nodeset once RHOSZUUL-1940 resolves
+        label: cloud-centos-9-stream-tripleo-xxl
       - name: compute-0
         label: cloud-centos-9-stream-tripleo
       - name: compute-1


### PR DESCRIPTION
This test is to verify the availability of the new label. Once confirmed, this change will be abandoned.