### PR TITLE
Libvirt manager/dont add blank unmanaged vms to inventory

### DIFF
--- a/roles/libvirt_manager/tasks/generate_networking_data.yml
+++ b/roles/libvirt_manager/tasks/generate_networking_data.yml
@@ -102,11 +102,17 @@
         _cifmw_libvirt_manager_layout.vms[_vm_type].admin_user |
         default('zuul')
       }}
+    _add_ansible_host: >-
+      {{
+        _cifmw_libvirt_manager_layout.vms[_vm_type].manage | default(true) and
+        _cifmw_libvirt_manager_layout.vms[_vm_type].disk_file_name | default(_vm_type is not none) != 'blank'
+      }}
+    _ansible_host: "{{ _hostname }}.{{ inventory_hostname }}"
   ansible.builtin.add_host:
     name: "{{ item.key | replace('_', '-') }}"
     groups: "{{ _group }}s"
     ansible_ssh_user: "{{ _ssh_user }}"
-    ansible_host: "{{ _hostname }}.{{ inventory_hostname }}"
+    ansible_host: "{{ _add_ansible_host | ternary(_ansible_host, omit) }}"
     vm_type: "{{ _group }}"
   loop: "{{ cifmw_libvirt_manager_mac_map | dict2items }}"
   loop_control:


### PR DESCRIPTION
When generating networking data, don't add `ansible_host` for VMs
that have a 'blank' image or is marked as `managed: false` to the
inventory. Adding `ansible_host` for these VMs will cause facts
gathering to be triggered by network_mapper later, which raises
unreachable error.