### PR TITLE
Use if instead of elif to set container overrides

### DIFF
--- a/roles/set_openstack_containers/templates/update_env_vars.sh.j2
+++ b/roles/set_openstack_containers/templates/update_env_vars.sh.j2
@@ -31,8 +31,9 @@ export PATH="{{ cifmw_path }}"
 {%     endif                                                             -%}
 {%     set _container_address = _container_registry + '/' + _container_prefix + _container_name + ':' + cifmw_set_openstack_containers_tag -%}
 {%     set _ = containers_dict.update({_container_env: _container_address}) -%}
+{%   endif                                                               -%}
 {#   This section overrides the non openstack services containers #}
-{%   elif cifmw_set_openstack_containers_overrides.keys() | length > 0 -%}
+{%   if cifmw_set_openstack_containers_overrides.keys() | length > 0 -%}
 {%     if _container_env in cifmw_set_openstack_containers_overrides.keys() -%}
 {%       set _ = containers_dict.update({_container_env: cifmw_set_openstack_containers_overrides[_container_env]}) -%}
 {%     endif -%}


### PR DESCRIPTION
Currently set_openstack_containers either updates the operator environment variables or apply the overrides. It does not perform both the things together.

In downstream for post-adoption job, we want to update the environment variable as well as overrides. By changing the condition to if, we can achieve the same.