### PR TITLE
[test-operator] Add the `wait_timeout` parameter to cleanup tasks

### DIFF
--- a/roles/test_operator/tasks/cleanup.yml
+++ b/roles/test_operator/tasks/cleanup.yml
@@ -25,6 +25,7 @@
     name: test-operator
     namespace: "{{ cifmw_test_operator_namespace }}"
     wait: true
+    wait_timeout: 600
 
 - name: Delete CatalogSource
   kubernetes.core.k8s:
@@ -37,6 +38,7 @@
     name: test-operator-catalog
     namespace: "{{ cifmw_test_operator_namespace }}"
     wait: true
+    wait_timeout: 600
 
 - name: Delete OperatorGroup
   kubernetes.core.k8s:
@@ -49,6 +51,7 @@
     name: test-operator-operatorgroup
     namespace: "{{ cifmw_test_operator_namespace }}"
     wait: true
+    wait_timeout: 600
 
 - name: Delete ClusterServiceVersion
   kubernetes.core.k8s:
@@ -61,6 +64,7 @@
     name: "{{ test_operator_csv_name }}"
     namespace: "{{ cifmw_test_operator_namespace }}"
     wait: true
+    wait_timeout: 600
 
 - name: Delete Operator
   kubernetes.core.k8s:
@@ -73,3 +77,4 @@
     name: test-operator.openstack
     namespace: "{{ cifmw_test_operator_namespace }}"
     wait: true
+    wait_timeout: 600


### PR DESCRIPTION
We recently encountered a timeout issue during the deletion of the test-operator. The default timeout is set to 120 seconds. By adding the `wait_timeout` parameter to the cleanup tasks, we can extend this time frame.