### PR TITLE
Allow set debug mode for Tempest

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -44,6 +44,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_tempest_extra_rpms`: (List) . A list of URLs that point to RPMs that should be installed before the execution of tempest. Note that this parameter has no effect when `cifmw_test_operator_tempest_external_plugin` is used. Default value: `[]`
 * `cifmw_test_operator_tempest_extra_configmaps_mounts`: (List) A list of configmaps that should be mounted into the tempest test pods. Default value: `[]`
 * `cifmw_test_operator_tempest_config`: (Object) Definition of Tempest CRD instance that is passed to the test-operator (see [the test-operator documentation](https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource)). Default value:
+* `cifmw_test_operator_tempest_debug`: (Bool) Run Tempest in debug mode, it keeps the operator pod sleeping infinity (it must only set to `true`only for debugging purposes). Default value: `false`
 ```
   apiVersion: test.openstack.org/v1beta1
   kind: Tempest
@@ -66,6 +67,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
       extraRPMs: "{{ cifmw_test_operator_tempest_extra_rpms | default([]) }}"
       extraImages: "{{ cifmw_test_operator_tempest_extra_images | default([]) }}"
     tempestconfRun: "{{ cifmw_tempest_tempestconf_config | default(omit) }}"
+    debug: "{{ cifmw_test_operator_tempest_debug }}"
 ```
 
 ## Tobiko specific parameters

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -87,6 +87,7 @@ cifmw_tempest_tempestconf_config_defaults:
     enforce_scope = false
 
 # Please refer to https://openstack-k8s-operators.github.io/test-operator/guide.html#executing-tempest-tests
+cifmw_test_operator_tempest_debug: false
 cifmw_test_operator_tempest_config:
   apiVersion: test.openstack.org/v1beta1
   kind: Tempest
@@ -115,6 +116,7 @@ cifmw_test_operator_tempest_config:
       extraImages: "{{ cifmw_test_operator_tempest_extra_images | default([]) }}"
     tempestconfRun: "{{ cifmw_tempest_tempestconf_config_defaults | combine(cifmw_tempest_tempestconf_config | default({})) }}"
     workflow: "{{ cifmw_test_operator_tempest_workflow }}"
+    debug: "{{ cifmw_test_operator_tempest_debug }}"
 
 # Section 3: tobiko parameters - used when run_test_fw is 'tobiko'
 cifmw_test_operator_tobiko_registry: quay.io


### PR DESCRIPTION
This change allows to enable the debug mode for the Tempest test operator by setting `cifmw_test_operator_tempest_debug: true` in spec (false by default). It must only be set to true for debbuging purposes (e.g. when running the operator manually) because it keeps the pod (e.g .Running) sleeping infinity.