### PR TITLE
Add nodeset centos-9-xxl-2x-centos-9-crc-extracted-2-39-0-xxl

### DIFF
--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -223,6 +223,26 @@
           - crc
 
 - nodeset:
+    name: centos-9-2x-centos-9-xxl-crc-extracted-2-39-0-xxl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo-xxl
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo-xxl
+      - name: crc
+        label: coreos-crc-extracted-2-39-0-xxl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
     name: centos-9-medium-3x-centos-9-crc-extracted-2-39-0-xxl
     nodes:
       - name: controller


### PR DESCRIPTION
This nodeset uses the new label `cloud-centos-9-stream-tripleo-xxl` in the compute nodes
