### PR TITLE
Ensure we can re-run the framework without issue on config_drive

### DIFF
--- a/roles/config_drive/tasks/main.yml
+++ b/roles/config_drive/tasks/main.yml
@@ -41,18 +41,21 @@
     mode: "0755"
 
 - name: Generate meta-data
+  register: _meta_data_change
   ansible.builtin.template:
     src: "meta-data.j2"
     dest: "{{ cifmw_config_drive_instancedir }}/meta-data"
     mode: '0644'
 
 - name: Generate user-data
+  register: _user_data_change
   ansible.builtin.template:
     src: "user-data.j2"
     dest: "{{ cifmw_config_drive_instancedir }}/user-data"
     mode: '0644'
 
 - name: Generate network-data
+  register: _net_data_change
   when:
     - "cifmw_config_drive_networkconfig is defined"
     - "cifmw_config_drive_networkconfig is not none"
@@ -61,13 +64,37 @@
     dest: "{{ cifmw_config_drive_instancedir }}/network-config"
     mode: '0644'
 
+- name: Check ISO availability
+  register: _iso_stat
+  ansible.builtin.stat:
+    path: "{{ cifmw_config_drive_iso_image }}"
+    get_attributes: false
+    get_checksum: false
+    get_mime: false
+
+- name: Assert we don't try to change an existing ISO
+  when:
+    - _iso_stat.stat.exists
+  ansible.builtin.assert:
+    that:
+      - _meta_data_change is not changed
+      - _user_data_change is not changed
+      - _net_data_change is not changed
+    msg: >-
+      You're trying to edit an existing ISO. This isn't possible,
+      since the ISO is usually attached to a virtual machine, and
+      you cannot dynamically edit it.
+
 - name: Generate nocloud iso image
   cifmw.general.ci_script:
     chdir: "{{ cifmw_config_drive_instancedir }}"
     output_dir: "{{ cifmw_config_drive_basedir }}/artifacts"
+    creates: "{{ cifmw_config_drive_iso_image }}"
     script: >-
-      genisoimage -output {{ cifmw_config_drive_iso_image }} -volid CIDATA -joliet \
-        -rock user-data meta-data \
-          {% if cifmw_config_drive_networkconfig is defined and cifmw_config_drive_networkconfig is not none -%}
-          network-config
-          {%- endif -%}
+      genisoimage -output {{ cifmw_config_drive_iso_image }} -volid CIDATA
+      -joliet
+      -rock user-data meta-data
+      {% if cifmw_config_drive_networkconfig is defined and
+            cifmw_config_drive_networkconfig is not none -%}
+       network-config
+      {%- endif -%}

--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -146,9 +146,13 @@
     - name: Create cloud-init ISO
       ansible.builtin.include_tasks:
         file: create_cloud_init_iso.yml
+
     - name: Attach cloud-init ISO if exists
-      ansible.builtin.command:
+      ansible.builtin.shell:
         cmd: >-
+          set -o pipefail;
+          virsh -c qemu:///system domblklist {{ _vm_name }} |
+          grep {{ _iso_path }} ||
           virsh -c qemu:///system attach-disk
           --domain {{ _vm_name }}
           --source {{ _iso_path }}
@@ -157,4 +161,3 @@
           --type cdrom
           --mode readonly
           --persistent
-        removes: "{{ _iso_path }}"


### PR DESCRIPTION
Until now, if we were to re-run the same deploy without any cleanup, it
would fail on the geniso from config_drive role because it can't
override the existing ISO.

Adding the "creates" parameter to the ci_script corrects this issue.
The assertions also ensures we don't try to edit an existing ISO - this
wasn't supported before, but since the run crashed, the user would know
there was an issue. The assertion makes it clear now.

The next issue is related to the usage of the ISO from within
libvirt_manager: the ISO isn't removed once it's attached, and
re-running fails since it's already attached to the VM.

Checking for the attached volumes, and removing the useless "removes"
from the command (converted to shell) ensures it's working fine.

This patch also attempts to fix the molecule jobs for libvirt_manager:
from time to time, it might crash due to the incomplet cleanup done in
the common "prepare" stage: the ocp_volumes pool is still present, but
the underneath directory is absent, leading to a crash whenever we want
to refresh the pools:
```
msg: 'cannot open directory ''/opt/basedir/ocp_volumes'': No such file or directory'
```
