### PR TITLE
Add missing cifmw_architecture_automation_file

### DIFF
--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -128,6 +128,18 @@
                 msg: >-
                   Error detected. Check debugging output above.
 
+    - name: Set cifmw_architecture_automation_file if not set before
+      when: cifmw_architecture_automation_file is not defined
+      ansible.builtin.set_fact:
+        cifmw_architecture_automation_file: >-
+          {{
+            (
+              cifmw_architecture_repo | default(ansible_user_dir+'/src/github.com/openstack-k8s-operators/architecture'),
+              'automation/vars',
+              cifmw_architecture_scenario~'.yaml'
+            ) | ansible.builtin.path_join
+          }}
+
     - name: Load architecture automation file
       tags:
         - edpm_deploy


### PR DESCRIPTION
After a recent change [1] we define the architecture automation to be used in the reproducer, based on the VA used. The HCI VA crc job does not use the reproducer role, so it does not get that parameter defined, thus we need to add it to the job definition.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/2292