### PR TITLE
Unskip no valid host whitebox neutron tempest plugin tests

### DIFF
--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -5,6 +5,7 @@
 - job:
     name: whitebox-neutron-tempest-plugin-podified-multinode-edpm-deployment-crc-2comp
     parent: podified-multinode-edpm-deployment-crc-2comp
+    nodeset: centos-9-2x-centos-9-xxl-crc-extracted-2-39-0-xxl
     timeout: 12600
     override-checkout: main
     description: |
@@ -110,20 +111,12 @@
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_ovn_dbs.OvnDbsMonitoringTest.*
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_qos.*external
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging
-              ^whitebox_neutron_tempest_plugin.tests.scenario.test_extra_dhcp_opts.ExtraDhcpOptionsTest.test_extra_dhcp_opts_ipv4_ipv6_stateless
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_router_flavors
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_dvr_ovn
-              ^whitebox_neutron_tempest_plugin.tests.scenario.test_multicast.MulticastTestIPv4Common.test_flooding_when_special_groups
-              ^whitebox_neutron_tempest_plugin.tests.scenario.test_broadcast.BroadcastTestVlanTransparency.test_broadcast_vlan_transparency
             # https://review.opendev.org/892839
             # - neutron_tempest_plugin.scenario.test_mtu.NetworkWritableMtuTest
             # It's in Blacklist before, FWaaS tests are not executed in any of our setups so there is no need to keep them whitelisted
             #   ^neutron_tempest_plugin.fwaas.*
-            # Note(chandankumar): Skipping due to https://issues.redhat.com/browse/OSPRH-9091/RHOSZUUL-1940
-            # and It require xl node to fix no valid host.
-            # - whitebox_neutron_tempest_plugin.tests.scenario.test_extra_dhcp_opts.ExtraDhcpOptionsTest.test_extra_dhcp_opts_ipv4_ipv6_stateless
-            # - whitebox_neutron_tempest_plugin.tests.scenario.test_multicast.MulticastTestIPv4Common.test_flooding_when_special_groups
-            # - whitebox_neutron_tempest_plugin.tests.scenario.test_broadcast.BroadcastTestVlanTransparency.test_broadcast_vlan_transparency
             # More Flaky tests mblue is working on fixing it
             # - whitebox_neutron_tempest_plugin.tests.scenario.test_router_flavors
             # - whitebox_neutron_tempest_plugin.tests.scenario.test_dvr_ovn


### PR DESCRIPTION
In order to fix no valid host whitebox neutron tempest plugin tests, https://github.com/openstack-k8s-operators/ci-framework/pull/2308 adds new nodeset with bigger label cloud-centos-9-stream-tripleo-xxl.
    
This fixes all the usnkipped tests and results are here: https://github.com/openstack-k8s-operators/ci-framework/pull/2308#issuecomment-2331143848
    
tested here: https://review.rdoproject.org/r/c/testproject/+/54009/15#message-db6853ac3a3a1d941aea45f6d02b3c77889b6aeb
    
and Tempest results: https://logserver.rdoproject.org/09/54009/15/check/periodic-whitebox-neutron-tempest-plugin-podified-multinode-edpm-deployment-crc-2comp/9aa7925/controller/ci-framework-data/tests/test_operator/tempest-tests-multi-thread-testing-workflow-step-0/stestr_results.html

 ```
    whitebox_neutron_tempest_plugin.tests.scenario.test_extra_dhcp_opts.ExtraDhcpOptionsTest passed
    whitebox_neutron_tempest_plugin.tests.scenario.test_multicast.MulticastTestIPv4Common passed
    whitebox_neutron_tempest_plugin.tests.scenario.test_broadcast.BroadcastTestVlanTransparency passed
```

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2308