### PR TITLE
Introduce cifmw_reproducer_default_repositories_override_checkout var

### DIFF
--- a/roles/reproducer/README.md
+++ b/roles/reproducer/README.md
@@ -21,6 +21,7 @@ None
 * `cifmw_reproducer_skip_fetch_repositories`: (Bool) Skip fetching repositories from zuul var and simply copy the code from the ansible controller. Defaults to `false`.
 * `cifmw_reproducer_supported_hypervisor_os`: (List) List of supported hypervisor operating systems and their minimum version.
 * `cifmw_reproducer_minimum_hardware_requirements`: (Dict) Define minimum hardware requirements for specific scenarios. Example below
+* `cifmw_reproducer_default_repositories_override_checkout`: (String) Default branch name to checkout for default repositories. Defaults to `main`
 
 ### Advanced parameters
 Those parameters shouldn't be used, unless the user is able to understand potential issues in their environment.

--- a/roles/reproducer/defaults/main.yml
+++ b/roles/reproducer/defaults/main.yml
@@ -50,3 +50,4 @@ cifmw_reproducer_controller_basedir: >-
 # own risks!
 cifmw_reproducer_validate_network: true
 cifmw_reproducer_validate_ocp_layout: true
+cifmw_reproducer_default_repositories_override_checkout: main

--- a/roles/reproducer/vars/main.yml
+++ b/roles/reproducer/vars/main.yml
@@ -3,10 +3,13 @@
 cifmw_reproducer_default_repositories:
   - src: "https://github.com/openstack-k8s-operators/ci-framework"
     dest: "/home/zuul/src/github.com/openstack-k8s-operators/ci-framework"
+    override-checkout: "{{ cifmw_reproducer_default_repositories_override_checkout }}"
   - src: "https://github.com/openstack-k8s-operators/install_yamls"
     dest: "/home/zuul/src/github.com/openstack-k8s-operators/install_yamls"
+    override-checkout: "{{ cifmw_reproducer_default_repositories_override_checkout }}"
   - src: "https://github.com/openstack-k8s-operators/architecture"
     dest: "/home/zuul/src/github.com/openstack-k8s-operators/architecture"
+    override-checkout: "{{ cifmw_reproducer_default_repositories_override_checkout }}"
 
 # one place to rule them all
 cifmw_reproducer_nm_dnsmasq: "/etc/NetworkManager/conf.d/zz-dnsmasq.conf"


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/ci-framework/pull/1791 already supports passing override-checkout to
cifmw_reproducer_default_repositories vars.

Let's expand this functionality to pass override_checkout to all the repo. It assumes that all the repos have same default branch name.