### PR TITLE
Do not add the unique ID to VM names in specific case

### DIFF
--- a/roles/libvirt_manager/molecule/check_dns/converge.yml
+++ b/roles/libvirt_manager/molecule/check_dns/converge.yml
@@ -18,7 +18,6 @@
   hosts: instance
   gather_facts: true
   vars:
-    cifmw_run_id: aabbcc11
     ansible_user_dir: "{{ lookup('env', 'HOME') }}"
     cifmw_basedir: "/opt/basedir"
     _cifmw_libvirt_manager_layout:

--- a/roles/libvirt_manager/molecule/deploy_layout/converge.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/converge.yml
@@ -18,7 +18,6 @@
   hosts: instance
   gather_facts: true
   vars:
-    cifmw_run_id: aabbcc11
     ansible_user_dir: "{{ lookup('env', 'HOME') }}"
     cifmw_basedir: "/opt/basedir"
     cifmw_libvirt_manager_vm_net_ip_set:
@@ -161,9 +160,9 @@
             sorted_vms: "{{ vms.list_vms | sort }}"
             compare_vms: >-
               {{
-                ["cifmw-compute-" ~ cifmw_run_id ~ "-0",
-                 "cifmw-compute-" ~ cifmw_run_id ~ "-1",
-                 "cifmw-baremetal-" ~ cifmw_run_id ~ "-0"] | sort
+                ["cifmw-compute-0",
+                 "cifmw-compute-1",
+                 "cifmw-baremetal-0"] | sort
               }}
           ansible.builtin.assert:
             that:
@@ -178,14 +177,14 @@
           ansible.builtin.command:
             cmd: >-
               virsh -c qemu:///system -q
-              domiflist cifmw-compute-{{ cifmw_run_id }}-0
+              domiflist cifmw-compute-0
 
         - name: Ensure compute-0 connections
           vars:
             _vals: >-
               {{
                 cmp_nics.stdout_lines |
-                product([" compute-" ~ cifmw_run_id ~ "-0"]) |
+                product([" compute--0"]) |
                 map('join') |
                 map('split')
               }}

--- a/roles/libvirt_manager/molecule/generate_network_data/vars/scenarios.yml
+++ b/roles/libvirt_manager/molecule/generate_network_data/vars/scenarios.yml
@@ -11,11 +11,11 @@
 scenarios:
   - name: Standard osp_trunk with extended translation
     check_dns:
-      - rec: "compute-aabbcc11-0.utility"
+      - rec: "compute-0.utility"
         ip: "192.168.140.10"
-      - rec: "compute-aabbcc11-0.ctlplane.local"
+      - rec: "compute-0.ctlplane.local"
         ip: "192.168.140.10"
-      - rec: "compute-aabbcc11-0.public.local"
+      - rec: "compute-0.public.local"
         ip: "192.168.110.10"
       # Ensure we have the short, "old" non-random name in DNS as
       # well
@@ -26,8 +26,8 @@ scenarios:
       - rec: "compute-0.public.local"
         ip: "192.168.110.10"
     check_dhcp:
-      - osp_trunk_compute-aabbcc11-0
-      - public_compute-aabbcc11-0
+      - osp_trunk_compute-0
+      - public_compute-0
     lm_config_patch:
       networks:
         osp_trunk: |
@@ -40,19 +40,19 @@ scenarios:
 
   - name: Baremetal integration
     check_dns:
-      - rec: "compute-aabbcc11-0.utility"
+      - rec: "compute-0.utility"
         ip: "192.168.140.10"
-      - rec: "compute-aabbcc11-0.ctlplane.local"
+      - rec: "compute-0.ctlplane.local"
         ip: "192.168.140.10"
-      - rec: "compute-aabbcc11-0.public.local"
+      - rec: "compute-0.public.local"
         ip: "192.168.110.10"
       - rec: "bm-0.utility"
         ip: "192.168.140.20"
       - rec: "bm-0.ctlplane.local"
         ip: "192.168.140.20"
     check_dhcp:
-      - osp_trunk_compute-aabbcc11-0
-      - public_compute-aabbcc11-0
+      - osp_trunk_compute-0
+      - public_compute-0
       - public_bm-0
     bm_hosts:
       bm-0:
@@ -90,39 +90,39 @@ scenarios:
       dcn2_tr:
         - ctlplanedcn2
     check_dns:
-      - rec: "compute-aabbcc11-0.utility"
+      - rec: "compute-0.utility"
         ip: "192.168.140.10"
-      - rec: "compute-aabbcc11-0.ctlplane.local"
+      - rec: "compute-0.ctlplane.local"
         ip: "192.168.140.10"
       # Ensure we don't have IP here: compute is NOT connected to ocpbm
-      - rec: "compute-aabbcc11-0.ocpbm.local"
+      - rec: "compute-0.ocpbm.local"
         ip: ""
       - rec: "bm-0.utility"
         ip: "192.168.140.20"
       - rec: "bm-0.ctlplane.local"
         ip: "192.168.140.20"
-      - rec: "dcn1-compute-aabbcc11-0.utility"
+      - rec: "dcn1-compute-0.utility"
         ip: "192.168.133.150"
-      - rec: "dcn1-compute-aabbcc11-0.ctlplanedcn1.local"
+      - rec: "dcn1-compute-0.ctlplanedcn1.local"
         ip: "192.168.133.150"
-      - rec: "dcn1-compute-aabbcc11-0.ocpbm.local"
+      - rec: "dcn1-compute-0.ocpbm.local"
         ip: "192.168.111.150"
-      - rec: "dcn1-compute-aabbcc11-1.utility"
+      - rec: "dcn1-compute-1.utility"
         ip: "192.168.133.151"
-      - rec: "dcn2-compute-aabbcc11-0.utility"
+      - rec: "dcn2-compute-0.utility"
         ip: "192.168.144.160"
     check_dhcp:
-      - dcn1_tr_dcn1-compute-aabbcc11-0
-      - dcn1_tr_dcn1-compute-aabbcc11-1
-      - dcn2_tr_dcn2-compute-aabbcc11-0
+      - dcn1_tr_dcn1-compute-0
+      - dcn1_tr_dcn1-compute-1
+      - dcn2_tr_dcn2-compute-0
       - ocpbm_bm-0
-      - ocpbm_dcn1-compute-aabbcc11-0
-      - ocpbm_dcn1-compute-aabbcc11-1
-      - ocpbm_dcn2-compute-aabbcc11-0
+      - ocpbm_dcn1-compute-0
+      - ocpbm_dcn1-compute-1
+      - ocpbm_dcn2-compute-0
       - osp_trunk_bm-0
-      - osp_trunk_compute-aabbcc11-0
+      - osp_trunk_compute-0
       - public_bm-0
-      - public_compute-aabbcc11-0
+      - public_compute-0
     bm_hosts:
       bm-0:
         address: 10.10.1.12

--- a/roles/libvirt_manager/molecule/spine_leaf/converge.yml
+++ b/roles/libvirt_manager/molecule/spine_leaf/converge.yml
@@ -18,7 +18,6 @@
   hosts: instance
   gather_facts: true
   vars:
-    cifmw_run_id: aabbcc11
     ansible_user_dir: "{{ lookup('env', 'HOME') }}"
     cifmw_basedir: "/opt/basedir"
     cifmw_libvirt_manager_spineleaf_setup: true

--- a/roles/libvirt_manager/molecule/spine_leaf/verify.yml
+++ b/roles/libvirt_manager/molecule/spine_leaf/verify.yml
@@ -4,7 +4,6 @@
   gather_facts: true
   vars:
     ansible_user_dir: "{{ lookup('env', 'HOME') }}"
-    cifmw_run_id: aabbcc11
     cifmw_basedir: "/opt/basedir"
     compare_nets: >-
       {{
@@ -14,9 +13,9 @@
       }}
     compare_vms: >-
       {{
-        ['cifmw-sl-compute-aabbcc11-0',
-         'cifmw-sl-compute-aabbcc11-1',
-         'cifmw-router-aabbcc11-0'] | sort
+        ['cifmw-sl-compute-0',
+         'cifmw-sl-compute-1',
+         'cifmw-router-0'] | sort
       }}
   tasks:
     - name: Get wanted files
@@ -64,7 +63,7 @@
       ansible.builtin.command:
         cmd: >-
           virsh -c qemu:///system -q
-          domiflist cifmw-sl-compute-{{ cifmw_run_id }}-0
+          domiflist cifmw-sl-compute-0
 
     - name: Ensure sl-compute-0 connections
       vars:
@@ -93,14 +92,14 @@
       ansible.builtin.command:
         cmd: >-
           virsh -c qemu:///system -q
-          domiflist cifmw-sl-compute-{{ cifmw_run_id }}-1
+          domiflist cifmw-sl-compute-1
 
     - name: Ensure sl-compute-1 connections
       vars:
         _vals: >-
           {{
             cmp_nics_cmp_1.stdout_lines |
-            product([' sl-compute-aabbcc11-1']) |
+            product([' sl-compute-1']) |
             map('join') |
             map('split')
           }}

--- a/roles/libvirt_manager/tasks/generate_networking_data.yml
+++ b/roles/libvirt_manager/tasks/generate_networking_data.yml
@@ -37,29 +37,33 @@
 
     - name: Generate VM list
       vars:
-        _run_id: "{{ cifmw_run_id | lower }}"
+        _run_id: >-
+          {%- if cifmw_architecture_scenario is defined and
+                 cifmw_architecture_scenario | length > 0   -%}
+          -{{ cifmw_run_id | lower }}
+          {%- endif                                         -%}
         vm_list: >-
-          {% set _vm_list = {} -%}
-          {% set _range = [] -%}
-          {% for _type in _cifmw_libvirt_manager_layout.vms.keys() -%}
+          {% set _vm_list = {}                                      -%}
+          {% set _range = []                                        -%}
+          {% for _type in _cifmw_libvirt_manager_layout.vms.keys()  -%}
           {%   set _amount = _cifmw_libvirt_manager_layout.vms[_type].amount |
-                             default(1) | int -%}
-          {%   set _range = range(0, _amount) -%}
-          {%     if _type is not match('^(controller|ocp|crc).*') -%}
-          {%       set _name = _type ~ '-' ~ _run_id          -%}
-          {%     else                                         -%}
-          {%       if _type == 'ocp'                          -%}
-          {%         set _name = 'ocp-master'                 -%}
-          {%       else                                       -%}
-          {%         set _name = _type                        -%}
-          {%       endif                                      -%}
-          {%     endif                                        -%}
+                             default(1) | int                       -%}
+          {%   set _range = range(0, _amount)                       -%}
+          {%     if _type is not match('^(controller|ocp|crc).*')   -%}
+          {%       set _name = _type ~ _run_id                      -%}
+          {%     else                                               -%}
+          {%       if _type == 'ocp'                                -%}
+          {%         set _name = 'ocp-master'                       -%}
+          {%       else                                             -%}
+          {%         set _name = _type                              -%}
+          {%       endif                                            -%}
+          {%     endif                                              -%}
           {%   set _vms = [_name | replace('_', '-')] |
                           product(_range) |
-                          map('join', '-')                    -%}
-          {%   set _map = dict(_vms | zip([_type] * _amount)) -%}
-          {%   set _ = _vm_list.update(_map)                  -%}
-          {% endfor -%}
+                          map('join', '-')                          -%}
+          {%   set _map = dict(_vms | zip([_type] * _amount))       -%}
+          {%   set _ = _vm_list.update(_map)                        -%}
+          {% endfor                                                 -%}
           {{ _vm_list }}
       ansible.builtin.set_fact:
         cifmw_libvirt_manager_all_vms: "{{ vm_list }}"

--- a/roles/reproducer/molecule/crc_layout/converge.yml
+++ b/roles/reproducer/molecule/crc_layout/converge.yml
@@ -146,7 +146,7 @@
               register: _cmp0_ping
               failed_when: false
               vars:
-                _cmpt: "compute-{{ cifmw_run_id }}-0"
+                _cmpt: "compute-0"
                 _inv: >-
                   {{
                     _compute_inv.content | b64decode | from_yaml


### PR DESCRIPTION
The unique hostname is needed for architecture driven deployment. When a
run is using install_yamls, it can't properly kustomize the data since
the names are all hard-coded in that external project.

In order to avoid issues, this patch limits the unique hostname to
scenarios that are 100% handled by the Framework, while keeping the old,
non-unique names for install_yamls usage.
