### PR TITLE
Ensure we deepscrube between tests

### DIFF
--- a/roles/libvirt_manager/molecule/deploy_layout/cleanup.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/cleanup.yml
@@ -53,6 +53,8 @@
         - "/etc/cifmw-dnsmasq.d"
 
     - name: Clean layout
+      vars:
+        deepscrub: true
       ansible.builtin.import_role:
         name: libvirt_manager
         tasks_from: clean_layout.yml

--- a/roles/libvirt_manager/molecule/deploy_layout/prepare.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/prepare.yml
@@ -33,6 +33,8 @@
     - role: "ci_setup"
   tasks:
     - name: Cleanup layout before anything
+      vars:
+        deepscrub: true
       ansible.builtin.import_role:
         name: libvirt_manager
         tasks_from: clean_layout.yml

--- a/roles/libvirt_manager/molecule/generate_network_data/tasks/test.yml
+++ b/roles/libvirt_manager/molecule/generate_network_data/tasks/test.yml
@@ -167,6 +167,8 @@
             - /etc/cifmw-dnsmasq.d
 
     - name: Clean environment
+      vars:
+        deepscrub: true
       ansible.builtin.include_role:
         name: "libvirt_manager"
         tasks_from: "clean_layout.yml"

--- a/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/roles/libvirt_manager/tasks/clean_layout.yml
@@ -7,6 +7,14 @@
   ansible.builtin.stat:
     path: "/var/run/libvirt/virtqemud-sock"
 
+- name: Set _is_deepscrub internal fact
+  ansible.builtin.set_fact:
+    _is_deepscrub: >-
+      {{
+        'deepscrub' in ansible_run_tags or
+        (deepscrub is defined and deepscrub | bool)
+      }}
+
 - name: Perform the libvirt cleanup
   when:
     - ansible_facts.packages is defined
@@ -173,12 +181,13 @@
         cmd: >-
           firewall-cmd --permanent --zone libvirt --remove-forward
 
+    # Pool management
     - name: Remove cifmw storage pool
       vars:
         action: "delete"
       ansible.builtin.include_tasks: storage_pool.yml
 
-    - name: Remove overlay images from ocp_volume pool if exists
+    - name: Remove overlay images from ocp_volume pools if exists
       when:
         - item is not match('^base-.*$')
       ansible.builtin.command:
@@ -192,22 +201,16 @@
            default([])
         }}
 
-    - name: Remove OCP volumes storage pool
-      tags:
-        - never
-        - deepscrub
+    - name: Remove ocp_volumes storage pool
+      when:
+        - _is_deepscrub | bool
       vars:
         action: "delete"
-        cifmw_libvirt_manager_pool: >-
+        cifmw_libvirt_manager_storage_pool: >-
           {{ cifmw_libvirt_manager_ocp_pool }}
         cifmw_libvirt_manager_pool_dir: >-
           {{ cifmw_libvirt_manager_ocp_pool_dir }}
       ansible.builtin.include_tasks: storage_pool.yml
-
-    - name: Refresh pools list
-      community.libvirt.virt_pool:
-        command: facts
-        uri: "qemu:///system"
 
     - name: Refresh all pools after actions
       when:
@@ -225,11 +228,9 @@
     path: "{{ ansible_user_dir }}/.ssh/cifmw_reproducer_key.pub"
 
 - name: Remove temporary ssh key from authorized_keys
-  tags:
-    - never
-    - deepscrub
   when:
     - _tmp_key.stat.exists
+    - _is_deepscrub | bool
   block:
     - name: Get public key
       register: _pub_key
@@ -281,9 +282,8 @@
     - artifacts/net-map-def-patch.yml
 
 - name: Deepscrub data
-  tags:
-    - never
-    - deepscrub
+  when:
+    - _is_deepscrub | bool
   ansible.builtin.file:
     path: "{{ cifmw_libvirt_manager_basedir }}/{{ item }}"
     state: absent

--- a/roles/libvirt_manager/tasks/storage_pool.yml
+++ b/roles/libvirt_manager/tasks/storage_pool.yml
@@ -14,7 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Ensure we have a know action
+- name: Ensure we have a known action
   ansible.builtin.assert:
     that:
       - action is defined
@@ -57,7 +57,7 @@
     - action == "delete"
     - pool_exists.rc == 0
   block:
-    - name: Gather all the volumes in the pool.
+    - name: Gather all the volumes in the pool to delete
       register: _volumes
       ansible.builtin.shell:
         cmd: |
@@ -68,7 +68,7 @@
           awk 'NF'
       failed_when: _volumes.rc != 0 and _volumes.rc != 1
 
-    - name: Remove the volumes
+    - name: Remove the volumes from pool to delete
       when:
         - _volumes.stdout_lines is defined
         - _volumes.stdout_lines | length > 0
@@ -79,7 +79,7 @@
           --pool {{ cifmw_libvirt_manager_storage_pool }}
       loop: "{{ _volumes.stdout_lines }}"
 
-    - name: Remove the storage pool
+    - name: Delete storage pool
       ansible.builtin.command:
         cmd: >-
           virsh -c qemu:///system
@@ -89,7 +89,7 @@
         - "pool-destroy"
         - "pool-undefine"
 
-- name: Get all pools
+- name: Refresh pools facts
   community.libvirt.virt_pool:
     command: facts
     uri: "qemu:///system"


### PR DESCRIPTION
There are a couple of tasks that aren't triggered over standard
cleaning. Ensuring the "always" tag is set should ensure we have a
really clean environment before each stage.

This allowed to find and fix an issue in the way pools were cleaned. Due
to a wrong parameter name, the `ocp_volumes` was dangling after a
deepscrub. This is now properly fixed.
