### PR TITLE
Integrate set_openstack_containers in validated architecture playbook

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -35,6 +35,7 @@ are shared among multiple roles:
 - `cifmw_deploy_edpm`: (Bool) toggle deploying EDPM. Default to false.
 - `cifmw_use_vbmc`: (Bool) Toggle VirtualBMC usage. Defaults to `false`.
 - `cifmw_use_sushy_emulator`: (Bool) Toggle Sushy Emulator usage. Defaults to `true`.
+- `cifmw_set_openstack_containers`:  (Bool) Run set_openstack_containers role during deployment to update openstack containers. Defaults to `false`.
 - `cifmw_sushy_redfish_bmc_protocol`: (String) The RedFish BMC protocol you would like to use with Sushy Emulator, options are `redfish` or `redfish-virtualmedia`. Defaults to `redfish-virtualmedia`
 - `cifmw_config_nmstate`: (Bool) toggle NMstate networking deployment. Default to false.
 - `cifmw_config_bmh`: (Bool) toggle Metal3 BareMetalHost CRs deployment. Default to false.

--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -227,6 +227,14 @@
         - update_containers
         - edpm_bootstrap
 
+    - name: Update containers in deployed OSP operators using set_openstack_containers role
+      when: cifmw_set_openstack_containers | default(false) | bool
+      ansible.builtin.include_role:
+        name: set_openstack_containers
+      tags:
+        - set_openstack_containers
+        - edpm_bootstrap
+
     - name: Configure LVMS Storage Class
       ansible.builtin.include_role:
         name: ci_lvms_storage


### PR DESCRIPTION
set_openstack_containers role is used to update openstack container images using openstack version cr in update jobs. Let's use the same to update the containers in va.

It will be used in downstream VA jobs to use RHEL openstack services container.