### PR TITLE
Rename extraMounts to extraConfigmapsMounts

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -126,7 +126,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_ansibletest_openstack_config_secret`: (String) The name of the Secret containing the secure.yaml. Default value: "openstack-config-secret"
 * `cifmw_test_operator_ansibletest_debug`: (Bool) Run ansible playbook with -vvvv. Default value: `false`
 * `cifmw_test_operator_ansibletest_workflow`: (List) A parameter that contains a workflow definition. Default value: `[]`
-* `cifmw_test_operator_ansibletest_extra_mounts`: (List) Extra configmaps for mounting in the pod. Default value: `[]`
+* `cifmw_test_operator_ansibletest_extra_configmaps_mounts`: (List) Extra configmaps for mounting in the pod. Default value: `[]`
 * `cifmw_test_operator_ansibletest_config`: Definition of AnsibleTest CRD instance that is passed to the test-operator (see [the test-operator documentation](https://openstack-k8s-operators.github.io/test-operator/crds.html)). Default value:
 ```
   apiVersion: test.openstack.org/v1beta1
@@ -136,7 +136,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
     namespace: "{{ cifmw_test_operator_namespace }}"
   spec:
     containerImage: "{{ cifmw_test_operator_ansibletest_image }}:{{ cifmw_test_operator_ansibletest_image_tag }}"
-    extraMounts: "{{ cifmw_test_operator_ansibletest_extra_mounts }}"
+    extraConfigmapsMounts: "{{ cifmw_test_operator_ansibletest_extra_configmaps_mounts }}"
     storageClass: "{{ cifmw_test_operator_storage_class }}"
     computeSSHKeySecretName: "{{ cifmw_test_operator_ansibletest_compute_ssh_key_secret_name }}"
     workloadSSHKeySecretName: "{{ cifmw_test_operator_ansibletest_workload_ssh_key_secret_name }}"

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -172,7 +172,7 @@ cifmw_test_operator_ansibletest_openstack_config_map: "openstack-config"
 cifmw_test_operator_ansibletest_openstack_config_secret: "openstack-config-secret"
 cifmw_test_operator_ansibletest_debug: false
 cifmw_test_operator_ansibletest_workflow: []
-cifmw_test_operator_ansibletest_extra_mounts: []
+cifmw_test_operator_ansibletest_extra_configmaps_mounts: []
 cifmw_test_operator_ansibletest_config:
   apiVersion: test.openstack.org/v1beta1
   kind: AnsibleTest
@@ -181,7 +181,7 @@ cifmw_test_operator_ansibletest_config:
     namespace: "{{ cifmw_test_operator_namespace }}"
   spec:
     containerImage: "{{ cifmw_test_operator_ansibletest_image }}:{{ cifmw_test_operator_ansibletest_image_tag }}"
-    extraMounts: "{{ cifmw_test_operator_ansibletest_extra_mounts }}"
+    extraConfigmapsMounts: "{{ cifmw_test_operator_ansibletest_extra_configmaps_mounts }}"
     storageClass: "{{ cifmw_test_operator_storage_class }}"
     computeSSHKeySecretName: "{{ cifmw_test_operator_ansibletest_compute_ssh_key_secret_name }}"
     workloadSSHKeySecretName: "{{ cifmw_test_operator_ansibletest_workload_ssh_key_secret_name }}"


### PR DESCRIPTION
We introduced extraConfigmapsMounts parameter for the Tempest CR that has the same behaviour as extraMounts parameter in AnsibleTest CR.

Let's keep the naming consistent and rename the extraMounts to extraConfigmapsMounts in the AnsibleTest CR.

This follows changes from the second commit of
https://github.com/openstack-k8s-operators/test-operator/pull/192/