### PR TITLE
Convert trigger action into reusable workflow

### DIFF
--- a/.github/workflows/github-action-trigger-downstream-job-reusable-workflow.yaml
+++ b/.github/workflows/github-action-trigger-downstream-job-reusable-workflow.yaml
@@ -1,7 +1,7 @@
-name: Github Action to trigger downstream job
+name: Github Action reusable workflow to trigger downstream job
+
 on:
-  issue_comment:
-    types: [created, edited]
+  workflow_call
 
 jobs:
   jobs01:

--- a/.github/workflows/trigger-downstream-job.yaml
+++ b/.github/workflows/trigger-downstream-job.yaml
@@ -1,0 +1,8 @@
+name: Github Action to trigger downstream job
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  trigger_workflow:
+    uses: openstack-k8s-operators/framework/.github/workflows/github-action-trigger-downstream-job-reusable-workflow.yaml@main


### PR DESCRIPTION
this pull request:
- Renames github-action-trigger-downstream-job.yaml to github-action-trigger-downstream-job-reusable-workflow.yaml and adds on_workflow call to make it reusable github action workflow. It will allow us to reuse the trigger github action in multiple repos

- It adds trigger-downstream-job.yaml to call trigger github action on pull request.

It is being triggered at https://github.com/openstack-k8s-operators/ci-playground/pull/21#issuecomment-2333068050 and tested here: https://github.com/openstack-k8s-operators/ci-playground/pull/21#issuecomment-2333068143