### PR TITLE
Add a new var to override openstack services container prefix

### DIFF
--- a/roles/set_openstack_containers/README.md
+++ b/roles/set_openstack_containers/README.md
@@ -16,6 +16,7 @@ The role will generate two 2 files in ~/ci-framework-data/artifacts/ directory a
 * `cifmw_set_openstack_containers_dlrn_md5_path`: Full path of delorean.repo.md5. Defaults to `/etc/yum.repos.d/delorean.repo.md5`.
 * `cifmw_set_openstack_containers_overrides`: Extra container overrides. Defaults to `{}`
 * `cifmw_set_openstack_containers_prefix`: Update container containing. Defaults to `openstack`
+* `cifmw_set_openstack_containers_new_prefix`: Override existing container prefix name.
 * `cifmw_set_openstack_containers_openstack_version_change`: (Boolean) Set environment variables for openstack services containers for specific OPENSTACK_RELEASE_VERSION defined in cifmw_set_openstack_containers_update_target_version. It should be used only for meta openstack operator in prepare for openstack minor update. Defaults to `false`.
 * `cifmw_set_openstack_containers_update_target_version`: Value of OPENSTACK_RELEASE_VERSION env in openstack operator that should be set. Defaults to `0.0.2`.
 * `cifmw_set_openstack_containers_openstack_final_env`: File name to store the operator env in a file. Default to `operator_env.txt`.

--- a/roles/set_openstack_containers/defaults/main.yml
+++ b/roles/set_openstack_containers/defaults/main.yml
@@ -29,5 +29,9 @@ cifmw_set_openstack_containers_openstack_version_change: false
 cifmw_set_openstack_containers_update_target_version: "0.0.2"
 cifmw_set_openstack_containers_openstack_final_env: "operator_env.txt"
 
+# There are cases where meta operator have openstack services env
+# containers starts with openstack prefix but downstream containers
+# starts with different prefix and we want to use that.
+# cifmw_set_openstack_containers_new_prefix: null
 # Set custom image url for non-openstack images
 cifmw_set_openstack_containers_overrides: {}

--- a/roles/set_openstack_containers/templates/update_env_vars.sh.j2
+++ b/roles/set_openstack_containers/templates/update_env_vars.sh.j2
@@ -29,6 +29,10 @@ export PATH="{{ cifmw_path }}"
 {%     else                                                              -%}
 {%        set _container_name = _container_data.split(':')[0]            -%}
 {%     endif                                                             -%}
+{#   This section overrides existing prefix                               #}
+{%     if cifmw_set_openstack_containers_new_prefix is defined                    -%}
+{%        set _container_prefix = cifmw_set_openstack_containers_new_prefix + '-' -%}
+{%     endif                                                                      -%}
 {%     set _container_address = _container_registry + '/' + _container_prefix + _container_name + ':' + cifmw_set_openstack_containers_tag -%}
 {%     set _ = containers_dict.update({_container_env: _container_address}) -%}
 {#   This section overrides the non openstack services containers #}


### PR DESCRIPTION
In downstream for post_adoption upgrade job. We are using upstream openstack operators. Upstream meta operator openstack services env variables have openstack prefix.

In order to create the post adoption pre update environment, we need to use the downstream openstack services containers. They starts with rhoso-openstack. Since it is a new prefix. We need a way to update the containers prefix to new prefix.

By using set_openstack_containers_new_prefix, we can achieve the same.