### PR TITLE
Ensure we configure any "managed" VM

### DIFF
--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -135,7 +135,6 @@
   when:
     - vm_data.disk_file_name != 'blank'
     - vm is not match('^(crc|ocp).*$')
-    - vm_data.start | default(true) | bool
     - vm_data.manage | default(true) | bool
   vars:
     _img_dir: "{{ cifmw_libvirt_manager_basedir }}/workload"

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -188,7 +188,6 @@
 - name: "Configure managed VMs"
   when:
     - vm_data.manage | default(true) | bool
-    - vm_data.start | default(true) | bool
     - vm_data.disk_file_name != 'blank'
   vars:
     vm_type: "{{ _vm.value }}"

--- a/roles/libvirt_manager/tasks/manage_vms.yml
+++ b/roles/libvirt_manager/tasks/manage_vms.yml
@@ -53,18 +53,16 @@
   ansible.builtin.include_role:
     name: "ssh_jumper"
 
+# TODO: consider ignition/butane instead
 - name: "Configure ssh access on VM {{ vm }}"
-  vars:
-    _user: >-
-      {{
-        (vm_type is match('^(crc|ocp).*$')) |
-        ternary('core', _init_admin_user)
-      }}
+  when:
+    - vm is match('^(ocp|crc).*')
+    - _cifmw_libvirt_manager_layout.vms[vm_type].start | default(true)
   ansible.builtin.shell:
     cmd: >-
       set -o pipefail;
       cat ~/.ssh/authorized_keys |
-      ssh -v {{ _user }}@{{ vm_con_name }} "cat >> ~/.ssh/authorized_keys"
+      ssh -v core@{{ vm_con_name }} "cat >> ~/.ssh/authorized_keys"
   retries: 5
   delay: 10
   register: _ssh_access
@@ -74,6 +72,7 @@
 - name: Ensure we grow volume for OCP cluster members
   when:
     - vm is match('^ocp.*')
+    - _cifmw_libvirt_manager_layout.vms[vm_type].start | default(true)
   vars:
     _root_part: "{{ vm_data.root_part_id | default('1') }}"
   ansible.builtin.shell:
@@ -84,6 +83,7 @@
 - name: "Inject private key on hosts {{ vm }}"
   when:
     - vm_type is match('^controller.*$')
+    - _cifmw_libvirt_manager_layout.vms[vm_type].start | default(true)
   delegate_to: "{{ vm_con_name }}"
   remote_user: "{{ _init_admin_user }}"
   ansible.builtin.copy:
@@ -96,6 +96,7 @@
 - name: "Inject public key on hosts {{ vm }}"
   when:
     - vm_type is match('^controller.*$')
+    - _cifmw_libvirt_manager_layout.vms[vm_type].start | default(true)
   delegate_to: "{{ vm_con_name }}"
   remote_user: "{{ _init_admin_user }}"
   ansible.builtin.copy:


### PR DESCRIPTION
UNtile now, we didn't generate any config drive for VM that weren't
started, even though we wanted them managed.

This patch corrects the issue, and also ensure we don't rely on SSH to
configure anything on the VMs.

We just keep plain SSH accesses for OCP/CRC, since they can't rely on
cloud-init.
