### PR TITLE
Correct how config_drive content is generated

### DIFF
--- a/roles/config_drive/tasks/main.yml
+++ b/roles/config_drive/tasks/main.yml
@@ -49,6 +49,9 @@
 
 - name: Generate user-data
   register: _user_data_change
+  when:
+    - cifmw_config_drive_userdata is defined
+    - cifmw_config_drive_userdata | length > 0
   ansible.builtin.template:
     src: "user-data.j2"
     dest: "{{ cifmw_config_drive_instancedir }}/user-data"
@@ -57,8 +60,8 @@
 - name: Generate network-data
   register: _net_data_change
   when:
-    - "cifmw_config_drive_networkconfig is defined"
-    - "cifmw_config_drive_networkconfig is not none"
+    - cifmw_config_drive_networkconfig is defined
+    - cifmw_config_drive_networkconfig | length > 0
   ansible.builtin.template:
     src: "network-config.j2"
     dest: "{{ cifmw_config_drive_instancedir }}/network-config"
@@ -95,6 +98,6 @@
       -joliet
       -rock user-data meta-data
       {% if cifmw_config_drive_networkconfig is defined and
-            cifmw_config_drive_networkconfig is not none -%}
+            cifmw_config_drive_networkconfig | length > 0 -%}
        network-config
       {%- endif -%}

--- a/roles/config_drive/templates/user-data.j2
+++ b/roles/config_drive/templates/user-data.j2
@@ -1,4 +1,2 @@
 #cloud-config
-{% if cifmw_config_drive_userdata is defined and cifmw_config_drive_userdata is not none -%}
 {{ cifmw_config_drive_userdata | to_nice_yaml(indent=2) }}
-{% endif %}


### PR DESCRIPTION
It seems older cloud-init, as 22.1 exposed in RHEL-9.2, is having issues
with the way some of the content is generated, preventing to apply the
whole configuration.

Namely, in the libvirt_manager, we might have no network configuration;
but in the config_drive, a file was created with `''` as content,
leading to cloud-init to crash (not a valid YAML dict).

This patch changes how configuration snippets are checked and generated.

The error as detected by cloud-init was as follow:
```
[    5.237126] cloud-init[744]: Cloud-init v. 22.1-9.el9 running 'init-local' at Mon, 09 Sep 2024 11:16:09 +0000. Up 5.21 seconds.
[    5.387470] cloud-init[744]: 2024-09-09 11:16:10,072 - util.py[WARNING]: Failed loading yaml blob. Yaml load allows (<class 'dict'>,) root types, but got str instead
[    5.389029] cloud-init[744]: 2024-09-09 11:16:10,072 - util.py[WARNING]: Getting data from <class 'cloudinit.sources.DataSourceNoCloud.DataSourceNoCloud'> failed
```

With newer cloud-init (23.x) as shipped by RHEL-9.4, the error wasn't
fatal and it was still continuing to apply the other files (in this
case, the user-data).
In earlier version, it was a hard stop.

Using `cloud-init devel schema -c <config-file>` also raised the missing
header:
```
[root@builder2 /]# cloud-init devel schema -c config_drive/meta-data
Error:
Cloud config schema errors: format-l1.c1: File config_drive/meta-data needs to begin with "#cloud-config"
```

And adding the header, but without any actual data, lead to:
```
[root@builder2 /]# cloud-init devel schema -c config_drive/network-config
Error:
Cloud-config is not a YAML dict.
```
