### PR TITLE
Enable "backup" for config_drive generated files

### DIFF
--- a/roles/config_drive/tasks/main.yml
+++ b/roles/config_drive/tasks/main.yml
@@ -43,6 +43,7 @@
 - name: Generate meta-data
   register: _meta_data_change
   ansible.builtin.template:
+    backup: true
     src: "meta-data.j2"
     dest: "{{ cifmw_config_drive_instancedir }}/meta-data"
     mode: '0644'
@@ -53,6 +54,7 @@
     - cifmw_config_drive_userdata is defined
     - cifmw_config_drive_userdata | length > 0
   ansible.builtin.template:
+    backup: true
     src: "user-data.j2"
     dest: "{{ cifmw_config_drive_instancedir }}/user-data"
     mode: '0644'
@@ -63,6 +65,7 @@
     - cifmw_config_drive_networkconfig is defined
     - cifmw_config_drive_networkconfig | length > 0
   ansible.builtin.template:
+    backup: true
     src: "network-config.j2"
     dest: "{{ cifmw_config_drive_instancedir }}/network-config"
     mode: '0644'


### PR DESCRIPTION
While we keep failing in case of file changes, we might want to know
what changed in those files over a re-run.
Enabling the "backup" feature ensures we are able to spot the
differences and adjust our runs if needed.
