### PR TITLE
Trigger libvirt_manager molecule on config_drive changes

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -4,6 +4,7 @@
     files:
       - ^roles/dnsmasq/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
       - ^roles/networking_mapper/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/config_drive/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
     timeout: 3600
 - job:
     name: cifmw-molecule-openshift_login

--- a/roles/config_drive/defaults/main.yml
+++ b/roles/config_drive/defaults/main.yml
@@ -21,11 +21,14 @@ cifmw_config_drive_basedir: >-
   {{
     cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data')
   }}
-cifmw_config_drive_workdir: "{{ cifmw_config_drive_basedir }}/cifmw_config_drive"
+cifmw_config_drive_workdir: >-
+  {{ cifmw_config_drive_basedir }}/artifacts/cifmw_config_drive
 
 cifmw_config_drive_uuid: uuid-test
-cifmw_config_drive_instancedir: "{{ cifmw_config_drive_workdir }}/{{ cifmw_config_drive_uuid }}"
-cifmw_config_drive_iso_image: "{{ cifmw_config_drive_workdir }}/{{ cifmw_config_drive_uuid }}.iso"
+cifmw_config_drive_instancedir: >-
+  {{ cifmw_config_drive_workdir }}/{{ cifmw_config_drive_uuid }}
+cifmw_config_drive_iso_image: >-
+  {{ cifmw_config_drive_workdir }}/{{ cifmw_config_drive_uuid }}.iso
 cifmw_config_drive_name: test
 cifmw_config_drive_hostname: test.example.com
 cifmw_config_drive_userdata:

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -471,6 +471,7 @@
     - ^.config/molecule/.*
     - ^roles/dnsmasq/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
     - ^roles/networking_mapper/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+    - ^roles/config_drive/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
     name: cifmw-molecule-libvirt_manager
     parent: cifmw-molecule-base
     timeout: 3600


### PR DESCRIPTION
Since config_drive is used in the libvirt_manager, we want to ensure
it's still properly working.

Also, moving the config_drove workdir to the standard "artifacts" tree,
ensuring we gather the content from the jobs.
