### PR TITLE
Use the VM UUID instead of some other randomly value

### DIFF
--- a/roles/libvirt_manager/tasks/create_cloud_init_iso.yml
+++ b/roles/libvirt_manager/tasks/create_cloud_init_iso.yml
@@ -59,7 +59,8 @@
 - name: "Call the config_drive role"
   vars:
     cifmw_config_drive_iso_image: "{{ _iso_path }}"
-    cifmw_config_drive_uuid: "{{ 99999999 | random(seed=vm) | to_uuid | lower }}"
+    _default_uuid: "{{ 99999999 | random(seed=vm) | to_uuid | lower }}"
+    cifmw_config_drive_uuid: "{{ _uuid.stdout | default(_default_uuid) | trim}}"
     cifmw_config_drive_hostname: "{{ vm }}"
     cifmw_config_drive_networkconfig: "{{ _network_config | default(None) }}"
     cifmw_config_drive_userdata: "{{ _user_data }}"

--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -131,6 +131,28 @@
           --config --persistent;
           {% endfor -%}
 
+- name: Extract UUID
+  block:
+    - name: Get VM UUID
+      register: _uuid
+      vars:
+        _vm_name: "cifmw-{{ vm }}"
+      ansible.builtin.command:
+        cmd: >-
+          virsh -c qemu:///system
+          domuuid {{ _vm_name }}
+
+    - name: Inject UUID in dataset
+      vars:
+        _vm_name: "cifmw-{{ vm }}"
+      ansible.builtin.set_fact:
+        cifmw_libvirt_manager_uuids: >-
+          {{
+            cifmw_libvirt_manager_uuids |
+            default({}) |
+            combine({_vm_name: _uuid.stdout | trim})
+          }}
+
 - name: Create and attach ISO
   when:
     - vm_data.disk_file_name != 'blank'

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -263,51 +263,17 @@
     uri: "qemu:///system"
   register: _vms
 
-- name: Extract VM UUIDs from libvirt
-  block:
-    - name: Get all XMLs
-      register: _all_xmls
-      community.libvirt.virt:
-        command: get_xml
-        name: "{{ item }}"
-      loop: "{{ _vms.list_vms }}"
-
-    - name: Extract UUIDs from all XMLs
-      register: _extracted_uuids
-      community.general.xml:
-        xmlstring: "{{ vm.get_xml }}"
-        xpath: "/domain/uuid"
-        content: text
-      loop: "{{ _all_xmls.results }}"
-      loop_control:
-        label: "{{ vm.item }}"
-        loop_var: vm
-
-    - name: Build UUIDs fact
-      vars:
-        vm_uuid: "{{ xml.matches | first }}"
-      ansible.builtin.set_fact:
-        cifmw_libvirt_manager_uuids: >-
-          {{
-            cifmw_libvirt_manager_uuids | default({}) |
-            combine({xml.vm.item: vm_uuid.uuid})
-          }}
-      loop: "{{ _extracted_uuids.results }}"
-      loop_control:
-        label: "{{ xml.vm.item }}"
-        loop_var: xml
-
-    - name: Dump UUIDs
-      when:
-        - cifmw_libvirt_manager_uuids is defined
-        - cifmw_libvirt_manager_uuids | length > 0
-      vars:
-        _content:
-          libvirt_uuid: "{{ cifmw_libvirt_manager_uuids }}"
-      ansible.builtin.copy:
-        dest: "{{ cifmw_libvirt_manager_basedir }}/artifacts/libvirt-uuids.yml"
-        content: "{{ _content | to_nice_yaml }}"
-        mode: "0644"
+- name: Dump UUIDs
+  when:
+    - cifmw_libvirt_manager_uuids is defined
+    - cifmw_libvirt_manager_uuids | length > 0
+  vars:
+    _content:
+      libvirt_uuid: "{{ cifmw_libvirt_manager_uuids }}"
+  ansible.builtin.copy:
+    dest: "{{ cifmw_libvirt_manager_basedir }}/artifacts/libvirt-uuids.yml"
+    content: "{{ _content | to_nice_yaml }}"
+    mode: "0644"
 
 - name: Refresh and dump vbmc hosts
   when:


### PR DESCRIPTION
Until now, config_drive was using a random UUID built using the vm name.
It makes tracking slightly more difficult.

This PR reorganize some tasks so that we get the VM UUID earlier. It
also removes the XML parsing to rely on `virsh domuuid` instead, making
it stronger and safer.

The UUID is then injected in the config_drive role directly.
