### PR TITLE
Use cifmw_architecture_scenario to set proper automation file

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -44,8 +44,6 @@ are shared among multiple roles:
 - `cifmw_ssh_keysize`: (Integer) Size of ssh keys that will be injected into the controller in order to connect to the rest of the nodes. Defaults to 521.
 - `cifmw_architecture_repo`: (String) Path of the architecture repository on the controller node.
   Defaults to `~/src/github.com/openstack-k8s-operators/architecture`
-- `cifmw_arch_automation_file`: (String) Name of the workflow automation file
-  in the architecture repository. Defaults to `default.yaml`
 - `cifmw_architecture_scenario`: (String) The selected VA scenario to deploy.
 - `cifmw_architecture_wait_condition`: (Dict) Structure defining custom wait_conditions for the automation.
 - `cifmw_architecture_user_kustomize.*`: (Dict) Structures defining user provided kustomization for automation. All these variables are combined together.

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -405,7 +405,7 @@
               (
                 cifmw_architecture_repo | default(ansible_user_dir+'/src/github.com/openstack-k8s-operators/architecture'),
                 'automation/vars',
-                cifmw_arch_automation_file | default('default.yaml')
+                cifmw_architecture_scenario~'.yaml'
               ) | ansible.builtin.path_join
             }}
           {% endraw %}

--- a/scenarios/reproducers/bgp-4-racks-3-ocps.yml
+++ b/scenarios/reproducers/bgp-4-racks-3-ocps.yml
@@ -377,12 +377,3 @@ cifmw_devscripts_enable_ocp_nodes_host_routing: true
 _arch_repo: "/home/zuul/src/github.com/openstack-k8s-operators/architecture"
 cifmw_architecture_scenario: bgp
 cifmw_kustomize_deploy_architecture_examples_path: "examples/dt/"
-cifmw_arch_automation_file: "bgp.yaml"
-cifmw_architecture_automation_file: >-
-  {{
-    (ansible_user_dir,
-     'src/github.com/openstack-k8s-operators',
-     'architecture/automation/vars',
-     cifmw_arch_automation_file) |
-     path_join
-  }}

--- a/scenarios/reproducers/dt-osasinfra.yml
+++ b/scenarios/reproducers/dt-osasinfra.yml
@@ -1,6 +1,5 @@
 ---
 cifmw_architecture_scenario: osasinfra
-cifmw_arch_automation_file: osasinfra.yaml
 
 # Automation section. Most of those parameters will be passed to the
 # controller-0 as-is and be consumed by the `deploy-va.sh` script.

--- a/scenarios/reproducers/va-pidone.yml
+++ b/scenarios/reproducers/va-pidone.yml
@@ -5,7 +5,6 @@
 # Framework. Please do not edit them!
 _arch_repo: "/home/zuul/src/github.com/openstack-k8s-operators/architecture"
 cifmw_architecture_scenario: pidone
-cifmw_arch_automation_file: pidone.yaml
 
 # HERE if you want to override kustomization, you can uncomment this parameter
 # and push the data structure you want to apply.


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/architecture/pull/375 splits the default vars into different scenario files. We need to fix the reproducer to adapt this change.

This pull-request uses cifmw_architecture_scenario to set proper automation file. It drops cifmw_arch_automation_file params from scenario files.

Depends-On: https://github.com/openstack-k8s-operators/architecture/pull/394

Note: it excludes zuul.d/architecture-jobs.yaml changes.

Cherry-picked from https://github.com/openstack-k8s-operators/ci-framework/commit/07a61460e9401926c517830dcd74f553140fd19e#diff-693e3f6ce03f7b6994b1195bcced3d58c89f1c286667356f827c3aecd4518ef6