### PR TITLE
Add a comment to sushy_driver SSH pub key

### DIFF
--- a/reproducer-clean.yml
+++ b/reproducer-clean.yml
@@ -33,6 +33,13 @@
         name: nat64_appliance
         tasks_from: cleanup.yml
 
+    - name: Cleanup config_drive data
+      tags:
+        - deepscrub
+      ansible.builtin.import_role:
+        name: config_drive
+        tasks_from: cleanup.yml
+
     - name: Remove remote selected data
       tags:
         - deepscrub
@@ -43,6 +50,14 @@
         - reproducer-inventory
         - reproducer-network-env
         - artifacts/run-id
+
+    - name: Ensure sushy_driver key is removed
+      tags:
+        - deepscrub
+      ansible.builtin.lineinfile:
+        path: "{{ ansible_user_dir }}/.ssh/authorized_keys"
+        state: absent
+        regexp: ".*cifmw-sushy_emulator$"
 
     - name: Remove /etc/ci/ directory
       tags:

--- a/roles/libvirt_manager/tasks/create_cloud_init_iso.yml
+++ b/roles/libvirt_manager/tasks/create_cloud_init_iso.yml
@@ -10,12 +10,12 @@
     - cifmw_libvirt_manager_vm_users is not defined or
       cifmw_libvirt_manager_vm_users | length == 0
   vars:
-    _ssh_authorized_keys: |-
-      [
-      {% for ssh_key in (_authorized_keys_b64.content | b64decode).split('\n') | select() %}
-        "{{ ssh_key | trim }}",
-      {% endfor %}
-      ]
+    _ssh_authorized_keys: "{{
+        (_authorized_keys_b64.content | b64decode).split('\n') |
+        select() |
+        reject('match', '^.* cifmw-sushy_emulator$') |
+        map('trim')
+      }}"
   ansible.builtin.set_fact:
     _users:
       - name: root

--- a/roles/sushy_emulator/tasks/collect_details.yml
+++ b/roles/sushy_emulator/tasks/collect_details.yml
@@ -34,6 +34,7 @@
     path: "{{ cifmw_sushy_emulator_sshkey_path }}"
     type: "{{ cifmw_sushy_emulator_sshkey_type }}"
     size: "{{ cifmw_sushy_emulator_sshkey_size }}"
+    comment: "cifmw-sushy_emulator"
     regenerate: full_idempotence
 
 - name: Slurp private ssh key for later use
@@ -46,6 +47,7 @@
     user: "{{ cifmw_sushy_emulator_libvirt_user }}"
     key: "{{ _sushy_emulator_key.public_key }}"
     state: present
+    comment: "cifmw-sushy_emulator"
   delegate_to: "{{ cifmw_sushy_emulator_hypervisor_target }}"
 
 - name: Run ssh-keyscan


### PR DESCRIPTION
Adding this comment, especially when injecting the pub key in the
hypervisor authorized_keys, allows to then filter out that specific key
when we generate the cloud-init "user-data".

This is needed in order to ensure we can re-run the deployment, for
instance when doing a scale-up or scale-down, or just re-running for
whatever reason:
since the sushy_driver key is injected "late" to the hypervisor
authorized_keys via reproducer role, it would then modify the user-data
generated during the libvirt_manager stage, leading to a file change,
leading eventually to a failure since it would re-generate the connfig
drive ISO (and this is prevented).

This patch ensures indempotency of the runs, by ensuring the
"late" sushy_driver ssh key isn't injected.

We also take the opportunity to remove the sushy_driver pub key via the
reproducer-clean.yml, ensuring we don't get an ever-growing file on the
hypervisor.
