### PR TITLE
Skip neutron SGL test blocking promotion

### DIFF
--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -146,9 +146,12 @@
             # NOTE(mblue): Exclude list has test failures which need further debugging
             # remove when bug OSPRH-7998 resolved
             # - whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging.*test_only_dropped_traffic_logged
+            # remove when issue OSPCIX-457 resolved
+            # - whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging.*test_dropped_and_accepted_traffic_logged
             excludeList: |
               whitebox_neutron_tempest_plugin.tests.scenario.test_metadata_rate_limiting
               whitebox_neutron_tempest_plugin.tests.scenario.test_mtu.GatewayMtuTestIcmp.test_northbound_pmtud_icmp
               whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging.*test_only_dropped_traffic_logged
               whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging.StatefulSecGroupLoggingTest.test_only_accepted_traffic_logged
               whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging.StatelessSecGroupLoggingTest.test_only_accepted_traffic_logged
+              whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging.*test_dropped_and_accepted_traffic_logged


### PR DESCRIPTION
This issue is most likely automated test race condition, should not block promotion,
more details on OSPCIX-457.