### PR TITLE
Ensure we can re-run the deploy_layout multiple times

### DIFF
--- a/roles/libvirt_manager/molecule/deploy_layout/converge.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/converge.yml
@@ -267,3 +267,11 @@
             that:
               - expected_count == found_count
           loop: "{{ volume_count.results }}"
+
+    # Redeploying the exact same layout will ensure we
+    # are able to run the role multiple time over the
+    # same data, without facing any issue.
+    - name: Redeploy layout
+      ansible.builtin.import_role:
+        name: libvirt_manager
+        tasks_from: deploy_layout


### PR DESCRIPTION
Calling the tasks twice will ensure we're able to re-run the whole
deployment more than once without cleaning up in-between.

This should help preventing issues when we add new features, by ensuring
tasks are either properly isolated, or idempotent.
