### PR TITLE
Change how tempest is configured in test_operator role

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -43,30 +43,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_tempest_network_attachments`: (List) List of network attachment definitions to attach to the tempest pods spawned by test-operator. Default value: `[]`.
 * `cifmw_test_operator_tempest_extra_rpms`: (List) . A list of URLs that point to RPMs that should be installed before the execution of tempest. Note that this parameter has no effect when `cifmw_test_operator_tempest_external_plugin` is used. Default value: `[]`
 * `cifmw_test_operator_tempest_extra_configmaps_mounts`: (List) A list of configmaps that should be mounted into the tempest test pods. Default value: `[]`
-* `cifmw_test_operator_tempest_config`: (Object) Definition of Tempest CRD instance that is passed to the test-operator (see [the test-operator documentation](https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource)). Default value:
-```
-  apiVersion: test.openstack.org/v1beta1
-  kind: Tempest
-  metadata:
-    name: tempest-tests
-    namespace: "{{ cifmw_test_operator_namespace }}"
-  spec:
-    containerImage: "{{ cifmw_test_operator_tempest_image }}:{{ cifmw_test_operator_tempest_image_tag }}"
-    storageClass: "{{ cifmw_test_operator_storage_class }}"
-    tolerations: "{{ cifmw_test_operator_tolerations | default(omit) }}"
-    nodeSelector: "{{ cifmw_test_operator_node_selector | default(omit) }}"
-    networkAttachments: "{{ cifmw_test_operator_tempest_network_attachments }}"
-    tempestRun:
-      includeList: |
-        {{ cifmw_test_operator_tempest_include_list | default('') }}
-      excludeList: |
-        {{ cifmw_test_operator_tempest_exclude_list | default('') }}
-      concurrency: "{{ cifmw_test_operator_concurrency }}"
-      externalPlugin: "{{ cifmw_test_operator_tempest_external_plugin | default([]) }}"
-      extraRPMs: "{{ cifmw_test_operator_tempest_extra_rpms | default([]) }}"
-      extraImages: "{{ cifmw_test_operator_tempest_extra_images | default([]) }}"
-    tempestconfRun: "{{ cifmw_tempest_tempestconf_config | default(omit) }}"
-```
+* `cifmw_test_operator_tempest_config`: (Object) Definition of Tempest CRD instance that is passed to the test-operator (see [the test-operator documentation](https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource)). Extends `cifmw_test_operator_tempest_default_conf` (check `vars/main.yml` for its value).
 
 ## Tobiko specific parameters
 * `cifmw_test_operator_tobiko_registry`: (String) The registry where to pull tobiko container. Default value: `quay.io`

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -90,34 +90,7 @@ cifmw_tempest_tempestconf_config_defaults:
     enforce_scope = false
 
 # Please refer to https://openstack-k8s-operators.github.io/test-operator/guide.html#executing-tempest-tests
-cifmw_test_operator_tempest_config:
-  apiVersion: test.openstack.org/v1beta1
-  kind: Tempest
-  metadata:
-    name: "{{ test_operator_job_name }}"
-    namespace: "{{ cifmw_test_operator_namespace }}"
-  spec:
-    containerImage: "{{ cifmw_test_operator_tempest_image }}:{{ cifmw_test_operator_tempest_image_tag }}"
-    storageClass: "{{ cifmw_test_operator_storage_class }}"
-    privileged: "{{ cifmw_test_operator_privileged }}"
-    parallel: "{{ cifmw_test_operator_tempest_parallel | default(omit) }}"
-    SSHKeySecretName: "{{ cifmw_test_operator_tempest_ssh_key_secret_name | default(omit) }}"
-    configOverwrite: "{{ cifmw_test_operator_tempest_config_overwrite | default(omit) }}"
-    networkAttachments: "{{ cifmw_test_operator_tempest_network_attachments }}"
-    tolerations: "{{ cifmw_test_operator_tolerations | default(omit) }}"
-    nodeSelector: "{{ cifmw_test_operator_node_selector | default(omit) }}"
-    extraConfigmapsMounts: "{{ cifmw_test_operator_tempest_extra_configmaps_mounts | default(omit) }}"
-    tempestRun:
-      includeList: |
-        {{ cifmw_test_operator_tempest_include_list | default('') }}
-      excludeList: |
-        {{ cifmw_test_operator_tempest_exclude_list | default('') }}
-      concurrency: "{{ cifmw_test_operator_concurrency }}"
-      externalPlugin: "{{ cifmw_test_operator_tempest_external_plugin | default([]) }}"
-      extraRPMs: "{{ cifmw_test_operator_tempest_extra_rpms | default([]) }}"
-      extraImages: "{{ cifmw_test_operator_tempest_extra_images | default([]) }}"
-    tempestconfRun: "{{ cifmw_tempest_tempestconf_config_defaults | combine(cifmw_tempest_tempestconf_config | default({})) }}"
-    workflow: "{{ cifmw_test_operator_tempest_workflow }}"
+cifmw_test_operator_tempest_config: {}
 
 # Section 3: tobiko parameters - used when run_test_fw is 'tobiko'
 cifmw_test_operator_tobiko_registry: quay.io

--- a/roles/test_operator/tasks/main.yml
+++ b/roles/test_operator/tasks/main.yml
@@ -135,7 +135,11 @@
 - name: Run tempest job
   vars:
     run_test_fw: tempest
-    test_operator_config: "{{ cifmw_test_operator_tempest_config }}"
+    test_operator_config: >-
+      {{
+        cifmw_test_operator_tempest_default_conf |
+        combine(cifmw_test_operator_tempest_config, recursive=true)
+      }}
     test_operator_job_name: "{{ cifmw_test_operator_tempest_name }}"
     test_operator_kind_name: "{{ cifmw_test_operator_tempest_kind_name }}"
     test_operator_crd_name: "{{ cifmw_test_operator_tempest_crd_name }}"

--- a/roles/test_operator/vars/main.yml
+++ b/roles/test_operator/vars/main.yml
@@ -43,3 +43,32 @@ cifmw_test_operator_tobiko_default_conf:
     interface: public
   manila:
     share_protocol: cephfs
+
+cifmw_test_operator_tempest_default_conf:
+  apiVersion: test.openstack.org/v1beta1
+  kind: Tempest
+  metadata:
+    name: "{{ test_operator_job_name }}"
+    namespace: "{{ cifmw_test_operator_namespace }}"
+  spec:
+    containerImage: "{{ cifmw_test_operator_tempest_image }}:{{ cifmw_test_operator_tempest_image_tag }}"
+    storageClass: "{{ cifmw_test_operator_storage_class }}"
+    privileged: "{{ cifmw_test_operator_privileged }}"
+    parallel: "{{ cifmw_test_operator_tempest_parallel | default(omit) }}"
+    SSHKeySecretName: "{{ cifmw_test_operator_tempest_ssh_key_secret_name | default(omit) }}"
+    configOverwrite: "{{ cifmw_test_operator_tempest_config_overwrite | default(omit) }}"
+    networkAttachments: "{{ cifmw_test_operator_tempest_network_attachments }}"
+    tolerations: "{{ cifmw_test_operator_tolerations | default(omit) }}"
+    nodeSelector: "{{ cifmw_test_operator_node_selector | default(omit) }}"
+    extraConfigmapsMounts: "{{ cifmw_test_operator_tempest_extra_configmaps_mounts | default(omit) }}"
+    tempestRun:
+      includeList: |
+        {{ cifmw_test_operator_tempest_include_list | default('') }}
+      excludeList: |
+        {{ cifmw_test_operator_tempest_exclude_list | default('') }}
+      concurrency: "{{ cifmw_test_operator_concurrency }}"
+      externalPlugin: "{{ cifmw_test_operator_tempest_external_plugin | default([]) }}"
+      extraRPMs: "{{ cifmw_test_operator_tempest_extra_rpms | default([]) }}"
+      extraImages: "{{ cifmw_test_operator_tempest_extra_images | default([]) }}"
+    tempestconfRun: "{{ cifmw_tempest_tempestconf_config_defaults | combine(cifmw_tempest_tempestconf_config | default({})) }}"
+    workflow: "{{ cifmw_test_operator_tempest_workflow }}"


### PR DESCRIPTION
Until now, whenever someone wanted to add a new option to their tempest
configuration, they had to add it directly in the `defaults.yml`.

This change proposes another approach, like we have for tobiko
configuration: a default set of configuration entries, and a parameter
allowing to override it.

In order to avoid breaking existing configurations, the default value is
still consuming the various parameters introduced over time - meaning
most of the existing jobs shouldn't be affected.
