### PR TITLE
Move Tobiko tests to be performed last.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs/dictionary/tmp
 .vscode
 .venv/*
 .env
+.idea/

--- a/roles/test_operator/tasks/main.yml
+++ b/roles/test_operator/tasks/main.yml
@@ -144,18 +144,6 @@
   ansible.builtin.include_tasks: run-test-operator-job.yml
   when: run_tempest
 
-- name: Run tobiko job
-  vars:
-    run_test_fw: tobiko
-    test_operator_config: "{{ cifmw_test_operator_tobiko_config }}"
-    test_operator_job_name: "{{ cifmw_test_operator_tobiko_name }}"
-    test_operator_kind_name: "{{ cifmw_test_operator_tobiko_kind_name }}"
-    test_operator_crd_name: "{{ cifmw_test_operator_tobiko_crd_name }}"
-    test_operator_workflow: "{{ cifmw_test_operator_tobiko_workflow }}"
-    test_operator_config_playbook: tobiko-tests.yml
-  ansible.builtin.include_tasks: run-test-operator-job.yml
-  when: run_tobiko
-
 - name: Run ansibletest job
   vars:
     run_test_fw: ansibletest
@@ -177,6 +165,19 @@
     test_operator_workflow: []
   ansible.builtin.include_tasks: run-test-operator-job.yml
   when: run_horizontest
+
+# Since Tobiko may include disruptive tests (faults), it is better to execute it at the end
+- name: Run tobiko job
+  vars:
+    run_test_fw: tobiko
+    test_operator_config: "{{ cifmw_test_operator_tobiko_config }}"
+    test_operator_job_name: "{{ cifmw_test_operator_tobiko_name }}"
+    test_operator_kind_name: "{{ cifmw_test_operator_tobiko_kind_name }}"
+    test_operator_crd_name: "{{ cifmw_test_operator_tobiko_crd_name }}"
+    test_operator_workflow: "{{ cifmw_test_operator_tobiko_workflow }}"
+    test_operator_config_playbook: tobiko-tests.yml
+  ansible.builtin.include_tasks: run-test-operator-job.yml
+  when: run_tobiko
 
 - name: Delete all resources created by the role
   ansible.builtin.include_tasks: cleanup.yml


### PR DESCRIPTION
Since Tobico may include disruptive tests (faults), it is better to execute it at the end, after the non-disruptive tests (like Tempest, Horizon, etc).