### PR TITLE
Rework inventory generation

### DIFF
--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -81,6 +81,29 @@
     - cifmw_libvirt_manager_mac_map is undefined
   ansible.builtin.include_tasks: generate_networking_data.yml
 
+- name: Create group inventories
+  when:
+    - _cifmw_libvirt_manager_layout.vms[item].manage | default(true)
+    - _cifmw_libvirt_manager_layout.vms[item].amount | default(1) | int > 0
+  vars:
+    hosts: >-
+      {{
+        cifmw_libvirt_manager_all_vms |
+        dict2items |
+        selectattr('value', 'equalto', item)
+      }}
+  ansible.builtin.template:
+    dest: "{{ cifmw_libvirt_manager_basedir }}/reproducer-inventory/{{ item }}-group.yml"
+    src: inventory.yml.j2
+  loop: "{{ _cifmw_libvirt_manager_layout.vms.keys() }}"
+  loop_control:
+    label: "{{ item }}"
+
+- name: Create "all" group inventory file
+  ansible.builtin.template:
+    dest: "{{ cifmw_libvirt_manager_basedir }}/reproducer-inventory/all-group.yml"
+    src: "all-inventory.yml.j2"
+
 - name: Ensure storage pool is present.
   when:
     - (require_extra_disks | int) > 0
@@ -232,29 +255,6 @@
   loop_control:
     index_var: index
     label: "{{ item.key }}"
-
-- name: Create group inventories
-  when:
-    - _cifmw_libvirt_manager_layout.vms[item].manage | default(true)
-    - _cifmw_libvirt_manager_layout.vms[item].amount | default(1) | int > 0
-  vars:
-    hosts: >-
-      {{
-        _libvirt_manager_networking.instances |
-        dict2items |
-        selectattr('key', 'match', item)
-      }}
-  ansible.builtin.template:
-    dest: "{{ cifmw_libvirt_manager_basedir }}/reproducer-inventory/{{ item }}-group.yml"
-    src: inventory.yml.j2
-  loop: "{{ _cifmw_libvirt_manager_layout.vms.keys() }}"
-  loop_control:
-    label: "{{ item }}"
-
-- name: Create "all" group inventory file
-  ansible.builtin.template:
-    dest: "{{ cifmw_libvirt_manager_basedir }}/reproducer-inventory/all-group.yml"
-    src: "all-inventory.yml.j2"
 
 - name: List running virtual machines.
   community.libvirt.virt:


### PR DESCRIPTION
First we move the inventory files generation to a far earlier stage.
While it doesn't change anything on its content, having the inventory
generated earlier helps debugging it without the need to create any
actual workload (hacky approach I used to validate the generated
inventories).

Then, the data used to generate the inventories is updated, in order to
ensure we're still puting the nodes under the right group.
This is especially important for the OCP cluster, when we have workers
in the picture.

Before this change, the workers were nested under the "ocps" group,
leaving the "ocp_workers" empty.

This change corrects the situation, leading the generated inventories to
look like this:
```yaml
ocps:
  hosts:
    ocp-master-0:
      ansible_host: master-0.utility
      ansible_user: core
      ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
      ansible_ssh_private_key_file: ~/.ssh/devscripts_key
ocp_workers:
  hosts:
    ocp-worker-0:
      ansible_host: worker-0.utility
      ansible_user: core
      ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
      ansible_ssh_private_key_file: ~/.ssh/devscripts_key
computes:
  hosts:
    compute-xio2mlri-0:
      ansible_host: compute-xio2mlri-0.utility
      ansible_user: zuul
      ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
      ansible_ssh_private_key_file: ~/.ssh/id_cifw
controllers:
  hosts:
    controller-0:
      ansible_host: controller-0.utility
      ansible_user: zuul
      ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
      ansible_ssh_private_key_file: ~/.ssh/id_cifw
```
