### PR TITLE
Use cifmw_architecture_scenario file in set va scenario

### DIFF
--- a/roles/kustomize_deploy/molecule/flexible_loop/converge.yml
+++ b/roles/kustomize_deploy/molecule/flexible_loop/converge.yml
@@ -35,12 +35,14 @@
 
     - name: Load architecture automation
       vars:
+        cifmw_architecture_scenario: hci
         _automation: >-
           {{
             (ansible_user_dir,
              'src/github.com/openstack-k8s-operators',
              'architecture/automation/vars',
-             'default.yaml') | path_join
+             cifmw_architecture_scenario~'.yaml')
+             | path_join
           }}
         _file: "{{ lookup('file', _automation) | from_yaml }}"
       ansible.builtin.set_fact:


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/architecture/pull/383 drops defaults.yaml scenario file in favor of
https://github.com/openstack-k8s-operators/architecture/pull/375.

https://github.com/openstack-k8s-operators/ci-framework/pull/2267 suggests to use  Use cifmw_architecture_scenario to set proper automation file.

Whereever default.yaml is used, the job broke. This pr fixes the same using cifmw_architecture_scenario file.