### PR TITLE
Fix polarion result dir filtering

### DIFF
--- a/roles/polarion/tasks/main.yml
+++ b/roles/polarion/tasks/main.yml
@@ -94,20 +94,13 @@
       ansible.builtin.debug:
         var: pylero_output.stdout_lines
 
-    - name: Look for test result directories in artifacts directory
-      ansible.builtin.find:
-        paths: "{{ cifmw_polarion_jump_result_dir }}"
-        recurse: false
-        file_type: directory
-      register: result_dirs
-
     - name: Merge result XML files of each directory
       ansible.builtin.shell:
         chdir: "{{ cifmw_polarion_jump_result_dir }}"
         cmd: >-
           source "{{ cifmw_polarion_jump_repo_dir }}/jump-venv/bin/activate" &&
-          junitparser merge {{ item.path }}/*.xml {{item.path }}/results_merged.xml
-      loop: "{{ result_dirs.files }}"
+          junitparser merge {{ item.path | dirname }}/*.xml {{item.path | dirname }}/results_merged.xml
+      loop: "{{ xml_files.files }}"
 
     - name: Look for test result XML files in artifacts directory
       ansible.builtin.find:
@@ -126,7 +119,7 @@
           --testrun-title={{ cifmw_polarion_testrun_title }}-{{ loop_idx }}
           --xml-file={{ item.path }}
           --update_testcases={{ cifmw_polarion_update_testcases | default(false) }}
-          --custom-fields cijoburl={{ cifmw_zuul_url }}/{{ zuul.build }},jobteststage={{ result_dirs.files[ loop_idx ].path | basename }}
+          --custom-fields cijoburl={{ cifmw_zuul_url }}/{{ zuul.build }},jobteststage={{ merged_xml_files.files[ loop_idx ].path | dirname | basename }}
           {{ cifmw_polarion_jump_extra_vars | default ('') }}
       loop: "{{ merged_xml_files.files }}"
       loop_control:


### PR DESCRIPTION
Previous code assumed that the cifmw_polarion_jump_result_dir points only to a result directory, meaning it contains only the test results. However, cifmw_polarion_jump_result_dir may point to a tempest location, meaning there are not only directories with test results but also some other directories (etc/, tempest_lock/ etc) that may be empty or not contain any .xml files.

This commit changes the logic of finding the directories with test results from a "give me all directories in this location" to "let's derive the directories from the paths of found .xml files". This way, we will filter only the directories that contain at least one .xml file.