### PR TITLE
Add ``scenario.test_api_server`` to the single thread job

### DIFF
--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -114,6 +114,7 @@
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_router_flavors
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_dvr_ovn
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_ovn_fdb
+              ^whitebox_neutron_tempest_plugin.tests.scenario.test_api_server
             # https://review.opendev.org/892839
             # - neutron_tempest_plugin.scenario.test_mtu.NetworkWritableMtuTest
             # It's in Blacklist before, FWaaS tests are not executed in any of our setups so there is no need to keep them whitelisted
@@ -145,6 +146,7 @@
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_router_flavors
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_dvr_ovn
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_ovn_fdb
+              ^whitebox_neutron_tempest_plugin.tests.scenario.test_api_server
             # NOTE(mblue): Exclude list has test failures which need further debugging
             # remove when bug OSPRH-7998 resolved
             # - whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging.*test_only_dropped_traffic_logged


### PR DESCRIPTION
The tests in ``scenario.test_api_server`` perform a Neutron API restart. This cannot be executed in parallel with other tests.

Patch: https://review.opendev.org/c/x/whitebox-neutron-tempest-plugin/+/927957

Related-Bug: #[OSPRH-2460](https://issues.redhat.com//browse/OSPRH-2460)