### PR TITLE
Run ceph update if part of the deployment

### DIFF
--- a/playbooks/update.yml
+++ b/playbooks/update.yml
@@ -49,6 +49,42 @@
         dest: "/etc/yum.repos.d/"
         src: "{{ cifmw_basedir }}/artifacts/repositories/"
 
+- name: Run Ceph update if part of the deployment
+  hosts: "{{ (groups[cifmw_ceph_target | default('computes')] | default([]))[:1] }}"
+  gather_facts: true
+  tasks:
+    - name: Update Ceph
+      when: cifmw_ceph_update | default(false) | bool
+      tags:
+        - update
+        - ceph_update
+      block:
+        - name: Get ceph.conf to inspect
+          become: true
+          ansible.builtin.slurp:
+            src: "{{ cifmw_ceph_conf }}"
+          vars:
+            cifmw_ceph_conf: "/etc/ceph/ceph.conf"
+          register: cephconf
+
+        - name: Save /ceph.conf and inspect content
+          become: true
+          delegate_to: localhost
+          ansible.builtin.copy:
+            content: "{{ cephconf['content'] | b64decode }}"
+            dest: "/tmp/ceph.conf"
+
+        - name: Extract the CephFSID from ceph.conf
+          ansible.builtin.set_fact:
+            ceph_fsid: "{{ lookup('ansible.builtin.ini', 'fsid', section='global', file='/tmp/ceph.conf') }}"
+
+        - name: Perform a Ceph Update
+          ansible.builtin.import_role:
+            name: cifmw_cephadm
+            tasks_from: ceph_upgrade
+          vars:
+            cifmw_cephadm_fsid: "{{ ceph_fsid }}"
+
 - name: Run update role
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false

--- a/roles/cifmw_ceph_spec/defaults/main.yml
+++ b/roles/cifmw_ceph_spec/defaults/main.yml
@@ -39,3 +39,6 @@ cifmw_ceph_spec_private_network: ''
 
 # Enable over-the-wire and on-disk encryption
 cifmw_ceph_spec_encryption: false
+
+# osd pool default size is 1 because of single node HCI jobs
+cifmw_cephadm_single_host_defaults: true

--- a/roles/cifmw_ceph_spec/templates/initial_ceph.conf.j2
+++ b/roles/cifmw_ceph_spec/templates/initial_ceph.conf.j2
@@ -7,7 +7,9 @@ ms_mon_client_mode = secure
 ms_mon_cluster_mode = secure
 ms_mon_service_mode = secure
 {% endif %}
+{% if cifmw_cephadm_single_host_defaults %}
 osd pool default size = 1
+{% endif %}
 {% if cifmw_ceph_spec_public_network %}
 public_network = {{ cifmw_ceph_spec_public_network }}
 {% endif %}

--- a/roles/cifmw_cephadm/tasks/ceph_upgrade.yml
+++ b/roles/cifmw_cephadm/tasks/ceph_upgrade.yml
@@ -20,10 +20,10 @@
 
 - name: Fail if health is HEALTH_WARN || HEALTH_ERR
   ansible.builtin.fail:
-    msg: Ceph is in {{ ceph_health.status }} state.
+    msg: Ceph is in {{ ceph_health.health.status }} state.
   when:
-    - ceph_health.status == 'HEALTH_WARN' or
-      ceph_health.status == 'HEALTH_ERR'
+    - ceph_health.health.status == 'HEALTH_WARN' or
+      ceph_health.health.status == 'HEALTH_ERR'
 
 - name: Build container image target
   ansible.builtin.set_fact:


### PR DESCRIPTION
In case we perform a minor update job where `Ceph` is deployed, as part of the minor update procedure we might want to update `Ceph` (according to a given `container image tag`) to verify the combination between the target Ceph version and the target OpenStack version is still healthy. This patch introduces the tasks that are supposed to call the `Ceph` update before OpenStack:
- it results in a noop in case the ceph container image tag is the <= of the current deployed `Ceph` cluster
- it is skipped by default if no `cifmw_ceph_update` variable is passed or it is set to `false` (which is the default)
- it can be skipped by passing `--skip-tags ceph_update` to the playbook

By doing this we have the ability to trigger a Ceph update and make sure we continue to test the combination between the two projects, but at the same time we are not introducing an hard dependency as it can easily be skipped.

Jira: https://issues.redhat.com/browse/OSPRH-9697