### PR TITLE
Revert "Run fdb aging tests in single thread only"

### DIFF
--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -113,7 +113,6 @@
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_router_flavors
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_dvr_ovn
-              ^whitebox_neutron_tempest_plugin.tests.scenario.test_ovn_fdb
             # https://review.opendev.org/892839
             # - neutron_tempest_plugin.scenario.test_mtu.NetworkWritableMtuTest
             # It's in Blacklist before, FWaaS tests are not executed in any of our setups so there is no need to keep them whitelisted
@@ -144,7 +143,6 @@
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_vlan_transparency.ProviderNetworkVlanTransparencyTest
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_router_flavors
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_dvr_ovn
-              ^whitebox_neutron_tempest_plugin.tests.scenario.test_ovn_fdb
             # NOTE(mblue): Exclude list has test failures which need further debugging
             # remove when bug OSPRH-7998 resolved
             # - whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging.*test_only_dropped_traffic_logged


### PR DESCRIPTION
Reverts openstack-k8s-operators/ci-framework#2347

Testing is failing on periodic antelope line.