### PR TITLE
[18.0.0-proposed] Add trigger_branch_name to the trigger job

### DIFF
--- a/zuul.d/trigger_jobs.yaml
+++ b/zuul.d/trigger_jobs.yaml
@@ -32,6 +32,10 @@
       # It will create a file trigger_va_hci
       trigger_job_name: "va_hci"
       trigger_commit_msg: "Triggering VA HCI job"
+      # trigger file name will be trigger_va_hci_18.0.0-proposed
+      # It will be created by combining trigger_job_name
+      # and trigger_branch_name.
+      trigger_branch_name: "18.0.0-proposed"
 
 - job:
     name: trigger-job-base


### PR DESCRIPTION
In order to run branch specific VA trigger jobs, we need to create different file to run branch specific VA jobs.

https://review.rdoproject.org/r/c/config/+/54375 provides a way to pass the branch name. By using above review, we can create branch named file on which we can trigger the job.