### PR TITLE
Exclude neutron whitebox test_ovn_fdb tests

### DIFF
--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -113,6 +113,7 @@
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_router_flavors
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_dvr_ovn
+              ^whitebox_neutron_tempest_plugin.tests.scenario.test_ovn_fdb
             # https://review.opendev.org/892839
             # - neutron_tempest_plugin.scenario.test_mtu.NetworkWritableMtuTest
             # It's in Blacklist before, FWaaS tests are not executed in any of our setups so there is no need to keep them whitelisted


### PR DESCRIPTION
test_ovn_fdb test is failing and required a fix in the plugin. Moving it to single thread test also didn't work[1], so the best is to remove it from multi-thread test list.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/2347

Related-Bug: #[OSPRH-893](https://issues.redhat.com//browse/OSPRH-893)