### PR TITLE
Fix tempest container tag for nested-crc-baremetal jobs

### DIFF
--- a/zuul.d/edpm_periodic.yaml
+++ b/zuul.d/edpm_periodic.yaml
@@ -13,7 +13,13 @@
 - job:
     name: periodic-podified-edpm-baremetal-master-ocp-crc
     parent: cifmw-crc-podified-edpm-baremetal
-    vars: *edpm_vars
+    vars:
+      <<: *edpm_vars
+      cifmw_tempest_registry: quay.rdoproject.org
+      cifmw_tempest_namespace: podified-{{ cifmw_repo_setup_branch }}-centos9
+      cifmw_tempest_container: openstack-tempest-all
+      cifmw_tempest_image_tag: "{{ cifmw_repo_setup_full_hash }}"
+
 
 - job:
     name: periodic-podified-multinode-edpm-deployment-master-ocp-crc-cs9
@@ -51,6 +57,7 @@
     vars:
       cifmw_repo_setup_branch: antelope
       cifmw_update_containers_org: podified-{{ cifmw_repo_setup_branch }}-centos9
+      cifmw_tempest_namespace: podified-{{ cifmw_repo_setup_branch }}-centos9
 
 - job:
     name: periodic-podified-multinode-edpm-deployment-antelope-ocp-crc-cs9


### PR DESCRIPTION
This PR sets the correct tag for tempest containers that are using current-podified as default.
More info on [OSPCIX-487](https://issues.redhat.com//browse/OSPCIX-487)