### PR TITLE
Added workaround to fix OSPCIX-487

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -9,6 +9,10 @@
       jobs:
         - openstack-k8s-operators-content-provider
         - podified-multinode-edpm-deployment-crc: &content_provider
+            vars:
+              # Note(Chandan): Drop it once https://issues.redhat.com/browse/OSPCIX-487 fixes
+              cifmw_test_operator_tempest_extra_rpms:
+                - "https://trunk.rdoproject.org/centos9-antelope/deps/latest/noarch/python3-testscenarios-0.5.0-21.el9s.noarch.rpm"
             dependencies:
               - openstack-k8s-operators-content-provider
         - cifmw-crc-podified-edpm-baremetal: *content_provider
@@ -31,9 +35,7 @@
       jobs:
         - noop
         - openstack-k8s-operators-content-provider
-        - podified-multinode-ironic-deployment:
-            dependencies:
-              - openstack-k8s-operators-content-provider
+        - podified-multinode-ironic-deployment: *content_provider
 
 - project-template:
     name: podified-multinode-edpm-ci-framework-pipeline
@@ -62,9 +64,7 @@
             requires:
               - cifmw-pod-pre-commit
               - cifmw-molecule
-        - adoption-standalone-to-crc-ceph-provider:
-            dependencies:
-              - openstack-k8s-operators-content-provider
+        - adoption-standalone-to-crc-ceph-provider: *content_provider
 
 - project-template:
     name: data-plane-adoption-pipeline
@@ -73,6 +73,4 @@
     github-check:
       jobs:
         - openstack-k8s-operators-content-provider
-        - adoption-standalone-to-crc-ceph-provider:
-            dependencies:
-              - openstack-k8s-operators-content-provider
+        - adoption-standalone-to-crc-ceph-provider: *content_provider


### PR DESCRIPTION
Currently tempest run in all jobs are broken due to missing testscenarios dependency[1]. This pr installed python3-testscenarios package using  cifmw_test_operator_tempest_extra_rpms and workaround this issue.

It modifies the project template to include this var to avoid affecting downstream/periodic job.

[1]. https://issues.redhat.com/browse/OSPCIX-487