### PR TITLE
[tempest] Set dhcp_domain to match nova-operator defaults

### DIFF
--- a/roles/tempest/vars/main.yml
+++ b/roles/tempest/vars/main.yml
@@ -3,3 +3,4 @@ cifmw_tempest_tempestconf_profile_default:
   debug: true
   overrides:
     identity.v3_endpoint_type: public
+    compute-feature-enabled.dhcp_domain: ''

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -79,6 +79,9 @@ cifmw_tempest_tempestconf_config_defaults:
     [identity-feature-enabled]
     enforce_scope = true
 
+    [compute-feature-enabled]
+    dhcp_domain = ''
+
     [load_balancer]
     member_role = load-balancer_member
     admin_role = load-balancer_admin


### PR DESCRIPTION
tempest-40.0.0 included a new test[1] which requires dhcp_domain to be set correctly in order to pass.
Setting defaults to match nova-operator defaults to get this test working.

This is prepartory steps to avoid job failures
when tempest-40.0.0 is promoted.

[1] https://review.opendev.org/c/openstack/tempest/+/922342

Related-Issue: [OSPCIX-489](https://issues.redhat.com//browse/OSPCIX-489)