### PR TITLE
[test-operator] Add wait_timeout for removing CRD instances in test-o…

### DIFF
--- a/roles/test_operator/tasks/run-test-operator-job.yml
+++ b/roles/test_operator/tasks/run-test-operator-job.yml
@@ -228,6 +228,7 @@
         name: "{{ test_operator_job_name }}"
         namespace: "{{ cifmw_test_operator_namespace }}"
         wait: true
+        wait_timeout: 600
 
     - name: Delete CRD for {{ run_test_fw }}
       kubernetes.core.k8s:
@@ -240,6 +241,7 @@
         name: "{{ test_operator_crd_name }}"
         namespace: "{{ cifmw_test_operator_namespace }}"
         wait: true
+        wait_timeout: 600
 
 - name: Delete test-operator-logs-pod
   kubernetes.core.k8s:
@@ -252,6 +254,7 @@
     name: "test-operator-logs-pod-{{ run_test_fw }}"
     namespace: "{{ cifmw_test_operator_namespace }}"
     wait: true
+    wait_timeout: 600
   when:
     - cifmw_test_operator_cleanup | bool and not cifmw_test_operator_dry_run | bool or
       cifmw_test_operator_delete_logs_pod | bool


### PR DESCRIPTION
…perator

Follow-up on PR [1]: Still encountering timeout issues during the deletion of the test-operator.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/2305