### PR TITLE
Add DCN compute groups and ctlplane variants for network configuration

### DIFF
--- a/roles/reproducer/README.md
+++ b/roles/reproducer/README.md
@@ -27,6 +27,7 @@ Those parameters shouldn't be used, unless the user is able to understand potent
 
 * `cifmw_reproducer_validate_network`: (Bool) Toggle network validations. Those validations ensure all of listed networks in VMs are defined. Defaults to `true`.
 * `cifmw_reproducer_validate_ocp_layout`: (Bool) Toggle OCP layout validations. Those validations ensure volumes, amounts and resources are properly defined for OCP cluster members (masters and workers). Defaults to `true`.
+* `cifmw_reproducer_validate_network_host`: (String) Specify the hostname that should be pinged in order to validate network connectivity from the ctlplane network. Default value is `controller-0.utility`
 
 ### run_job and run_content_provider booleans and risks.
 

--- a/roles/reproducer/defaults/main.yml
+++ b/roles/reproducer/defaults/main.yml
@@ -49,4 +49,5 @@ cifmw_reproducer_controller_basedir: >-
 # Allow to disable validations - user toggle this at their
 # own risks!
 cifmw_reproducer_validate_network: true
+cifmw_reproducer_validate_network_host: "controller-0.utility"
 cifmw_reproducer_validate_ocp_layout: true

--- a/roles/reproducer/tasks/configure_computes.yml
+++ b/roles/reproducer/tasks/configure_computes.yml
@@ -5,7 +5,7 @@
     - name: Ensure we can ping controller-0 from ctlplane
       ansible.builtin.command:
         cmd: |
-          ping -c2 controller-0.utility
+          ping -c2 {{ cifmw_reproducer_validate_network_host }}
 
     - name: Tweak dnf configuration
       become: true

--- a/roles/reproducer/tasks/libvirt_layout.yml
+++ b/roles/reproducer/tasks/libvirt_layout.yml
@@ -98,10 +98,20 @@
     - >-
       (compute.key in (groups['computes'] | default([]))) or
       (compute.key in (groups['cephs'] | default([]))) or
-      (compute.key in (groups['networkers'] | default([])))
+      (compute.key in (groups['networkers'] | default([]))) or
+      (compute.key in (groups['dcn1-computes'] | default([]))) or
+      (compute.key in (groups['dcn2-computes'] | default([])))
   vars:
     _host: "{{ compute.key }}"
-    _prefix: "{{cifmw_networking_env_definition.networks.ctlplane.network_v4 | ansible.utils.ipaddr('prefix') }}"
+    _prefix: >-
+      {% set ctlplane_variants = ['ctlplane', 'ctlplanedcn1', 'ctlplanedcn2'] %}
+      {{
+        cifmw_networking_env_definition.networks
+        | selectattr('key', 'in', ctlplane_variants)
+        | map(attribute='value.network_v4')
+        | first
+        | ansible.utils.ipaddr('prefix')
+      }}
   ansible.builtin.include_tasks: configure_computes.yml
   loop: >-
     {{ cifmw_networking_env_definition.instances | dict2items }}

--- a/scenarios/reproducers/va-dcn.yml
+++ b/scenarios/reproducers/va-dcn.yml
@@ -15,6 +15,7 @@ cifmw_devscripts_cinder_volume_pvs: []
 cifmw_run_tests: false
 cifmw_arch_automation_file: dcn.yaml
 cifmw_libvirt_manager_pub_net: ocpbm
+cifmw_reproducer_validate_network_host: "192.168.111.9"
 cifmw_libvirt_manager_default_gw_nets:
   - ocpbm
   - dcn1_tr


### PR DESCRIPTION
- Added support for `dcn1-computes` and `dcn2-computes` groups in EDPM-based nodes ctlplane network configuration.
- Defined `ctlplane_variants` to include `ctlplane`, `ctlplanedcn1`, and `ctlplanedcn2`.
- Introduced new variable `cifmw_reproducer_validate_network_host` to specify the hostname for validating network connectivity from the ctlplane network. Default set to `controller-0.utility`.