### PR TITLE
Add the Ironic baremetal net in a dedicated ci-bootstrap job

### DIFF
--- a/ci/playbooks/bootstrap-networking-mapper.yml
+++ b/ci/playbooks/bootstrap-networking-mapper.yml
@@ -22,5 +22,8 @@
           ~/test-python/bin/ansible-playbook {{ ansible_user_dir }}/networking_mapper.yml
           -i {{ ansible_user_dir }}/ci-framework-data/artifacts/zuul_inventory.yml
           -e @scenarios/centos-9/base.yml
-          -e cifmw_networking_mapper_ifaces_info_path=/etc/ci/env/interfaces-info.yml
           -e "@{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml"
+          -e cifmw_networking_mapper_ifaces_info_path=/etc/ci/env/interfaces-info.yml
+          {% if nodepool is defined %}
+          -e "@{{ ansible_user_dir }}/ci-framework-data/artifacts/nodepool_params.yml"
+          {% endif %}

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -233,7 +233,7 @@
     parent: base-extracted-crc-ci-bootstrap-staging
     timeout: 10800
     attempts: 1
-    nodeset: centos-9-medium-centos-9-crc-extracted-2-39-0-3xl
+    nodeset: centos-9-medium-centos-9-crc-extracted-2-39-0-3xl-vexxhost
     irrelevant-files: *ir_files
     required-projects: *multinode_edpm_rp
     roles: *multinode_edpm_roles

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -385,64 +385,6 @@
             network: "172.19.0.0/24"
             gateway: "172.19.0.1"
             vlan: 22
-        instances:
-          controller:
-            networks:
-              default:
-                ip: "192.168.122.11"
-          crc:
-            networks:
-              default:
-                ip: "192.168.122.10"
-              internal-api:
-                ip: "172.17.0.5"
-              storage:
-                ip: "172.18.0.5"
-              tenant:
-                ip: "172.19.0.5"
-          compute-0:
-            skip-nm-configuration: true
-            networks:
-              default:
-                ip: "192.168.122.100"
-              internal-api:
-                ip: "172.17.0.100"
-                trunk_parent: default
-              storage:
-                ip: "172.18.0.100"
-                trunk_parent: default
-              tenant:
-                ip: "172.19.0.100"
-                trunk_parent: default
-      cifmw_extras:
-        - '@scenarios/centos-9/multinode-ci.yml'
-    run:
-      - ci/playbooks/edpm/run.yml
-
-# Job with ci-bootstrap staging branch job - to be used to test ci-bootstrap
-- job:
-    name: podified-multinode-edpm-deployment-crc-bootstrap-staging
-    parent: cifmw-podified-multinode-edpm-ci-bootstrap-staging
-    extra-vars: *edpm_bootstrap_extra_vars
-    vars:
-      cifmw_networking_definition:
-        networks:
-          default:
-            network: "192.168.122.0/24"
-            gateway: "192.168.122.1"
-            mtu: 1500
-          internal-api:
-            network: "172.17.0.0/24"
-            gateway: "172.17.0.1"
-            vlan: 20
-          storage:
-            network: "172.18.0.0/24"
-            gateway: "172.18.0.1"
-            vlan: 21
-          tenant:
-            network: "172.19.0.0/24"
-            gateway: "172.19.0.1"
-            vlan: 22
         routers:
           ci-router:
             external_network: public
@@ -457,13 +399,13 @@
             networks:
               default: {}
               internal-api:
-                trunk_parent: default
+                trunk-parent: default
                 skip-nm-configuration: true
               tenant:
-                trunk_parent: default
+                trunk-parent: default
                 skip-nm-configuration: true
               storage:
-                trunk_parent: default
+                trunk-parent: default
                 skip-nm-configuration: true
         instances:
           controller:
@@ -476,14 +418,49 @@
                 ip: "192.168.122.10"
               internal-api:
                 ip: "172.17.0.5"
-                trunk_parent: default
+                trunk-parent: default
               storage:
                 ip: "172.18.0.5"
-                trunk_parent: default
+                trunk-parent: default
               tenant:
                 ip: "172.19.0.5"
-                trunk_parent: default
+                trunk-parent: default
       cifmw_extras:
         - '@scenarios/centos-9/multinode-ci.yml'
     run:
       - ci/playbooks/edpm/run.yml
+
+# Job with ci-bootstrap staging branch job - to be used to test ci-bootstrap
+- job:
+    name: podified-multinode-edpm-deployment-crc-bootstrap-staging
+    parent: cifmw-podified-multinode-edpm-ci-bootstrap-staging
+    extra-vars: *edpm_bootstrap_extra_vars
+    vars: *edpm_bootstrap_vars
+    run:
+      - ci/playbooks/edpm/run.yml
+
+# TODO: Testing Ironic jobs definition
+- job:
+    name: podified-multinode-edpm-deployment-crc-bootstrap-staging-ironic
+    parent: podified-multinode-edpm-deployment-crc-bootstrap-staging
+    vars:
+      cifmw_networking_mapper_definition_patch_02_bmaas_net:
+        networks:
+          baremetal:
+            network: "172.20.1.0/24"
+            gateway: "172.20.1.1"
+            mtu: 1500
+        instances:
+          controller:
+            networks:
+              baremetal:
+                ip: "172.20.1.11"
+                skip-nm-configuration: true
+          crc:
+            networks:
+              baremetal:
+                ip: "172.20.1.5"
+                skip-nm-configuration: true
+    run:
+      - ci/playbooks/edpm/run.yml
+      - ci/playbooks/edpm/fail.yml

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -288,6 +288,24 @@
         nodes:
           - crc
 
+# todo: Remove. Temporal. Needed as the credentials used in ci-bootstrap jobs for IBM don't work
+- nodeset:
+    name: centos-9-medium-centos-9-crc-extracted-2-39-0-3xl-vexxhost
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-vexxhost-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo-vexxhost
+      - name: crc
+        label: coreos-crc-extracted-2-39-0-3xl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+      - name: ocps
+        nodes:
+          - crc
+
 - nodeset:
     name: centos-9-crc-2-39-0-6xlarge
     nodes:


### PR DESCRIPTION
- Add debugging playbook to manually fail job
- Add new node set locked to Vexxhost as currently ci-bootstrap won't
  work on IBM cloud
- Add new job to test Ironic