### PR TITLE
Adding toolbelt catalog metadata file

### DIFF
--- a/docs/toolbelt-catalog.yaml
+++ b/docs/toolbelt-catalog.yaml
@@ -1,0 +1,41 @@
+# Catalog entry for Backstage [backstage.io]
+
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+    name: ci-framework
+    title: ci-framework
+    description: |
+        CI Framework - used for CI, QE and Devs to run OSP 18+ jobs in a converged way
+    annotations:
+        github.com/project-slug: openstack-k8s-operators/ci-framework
+        feedback/type: JIRA
+        feedback/host: https://issues.redhat.com
+        jira/project-key: OSPRH
+    links:
+      - title: docs
+        url: https://ci-framework.readthedocs.io/en/latest/
+        icon: docs
+      - title: code
+        url: https://github.com/openstack-k8s-operators/ci-framework
+        icon: github
+      - title: #osp-podified-ci-support
+        url: https://app.slack.com/client/E030G10V24F/C03MD4LG22Z
+        icon: chat
+    tags:
+        - testing
+        - test-execution
+        - test-framework
+        - test-management
+        - test-reporting
+        - provisioning
+        - python
+        - openstack
+        - openshift
+        - cloud
+        - continuous-integration
+    namespace: quality-community
+spec:
+    type: tool
+    owner: group:redhat/openstack-k8s-operators-ci
+    lifecycle: production


### PR DESCRIPTION
Including this file in our documentation will enable us to list ci-framework in the catalog of tools for QE. 