### PR TITLE
Donot run EDPM/adoption job zuui.d/trigger_jobs.yaml changes

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -165,6 +165,7 @@
       - roles/virtualbmc
       - tests?\/functional
       - zuul.d/molecule.*
+      - zuui.d/trigger_jobs.yaml
 
 # NOTE(marios): need to keep this old job because of zuul branches, see comments at OSPRH-8452
 - job:

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -63,6 +63,7 @@
       - roles/virtualbmc
       - roles/validations
       - zuul.d/molecule.*
+      - zuui.d/trigger_jobs.yaml
       # Other openstack operators
       - containers/ci
       - .ci-operator.yaml


### PR DESCRIPTION
zuui.d/trigger_jobs.yaml file contains downstream trigger jobs. It does not make sense to run EDPM/adoption job on these jobs.

Let's add it to irrelevant files list to fix that.