### PR TITLE
Only gather required ansible facts

### DIFF
--- a/ci/playbooks/molecule-test.yml
+++ b/ci/playbooks/molecule-test.yml
@@ -1,8 +1,16 @@
 ---
 - name: "Run ci/playbooks/molecule-test.yml"
   hosts: "{{ cifmw_zuul_target_host | default('controller') }}"
-  gather_facts: true
+  gather_facts: false
   tasks:
+    - name: Gather required facts
+      ansible.builtin.setup:
+        gather_subset:
+          - "!all"
+          - "!min"
+          - "user_dir"
+          - "env"
+
     - name: Load environment var if instructed to
       when:
         - cifmw_reproducer_molecule_env_file is defined


### PR DESCRIPTION
This would ensure we can test the roles as expected with `gather_facts: false`.