### PR TITLE
Add support to deploy sushy in extracted jobs

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -72,6 +72,7 @@ are shared among multiple roles:
 - `cifmw_run_id`: (String) CI Framework run identifier. This is used in libvirt_manager, to add some uniqueness to some types of virtual machines (anything that's not OCP, CRC nor controller).
   If not set, the Framework will generate a random string for you, and store it on the target host, in `{{ cifmw_basedir }}/artifacts/run-id`
 - `cifmw_deploy_architecture_args`: (String) additional args and parameters to pass to the deploy-architecture script. Default is `''`.
+- `cifmw_enable_virtual_baremetal_support`: (Bool) Toggle the deployment and configuration of virtual baremetal services. If enabled Sushy Emulator will be deployed to OCP and Libvirt will be configured on the CI-Framework Ansible controller node. Defaults to `false`
 
 ```{admonition} Words of caution
 :class: danger

--- a/playbooks/02-infra.yml
+++ b/playbooks/02-infra.yml
@@ -86,6 +86,22 @@
       ansible.builtin.include_role:
         name: cert_manager
 
+    - name: Deploy Sushy Emulator and configure controller as hypervisor
+      when:
+        - cifmw_enable_virtual_baremetal_support | default(false) | bool
+      block:
+        - name: Deploy Sushy Emulator service pod
+          vars:
+            cifmw_sushy_emulator_hypervisor_address: "{{ hostvars['controller'].ansible_host }}"
+            cifmw_sushy_emulator_hypervisor_target: controller
+            cifmw_sushy_emulator_install_type: ocp
+          ansible.builtin.include_role:
+            name: sushy_emulator
+
+        - name: Setup Libvirt on controller
+          ansible.builtin.include_role:
+            name: libvirt_manager
+
     - name: Configure hosts networking using nmstate
       when:
         - cifmw_config_nmstate is defined

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -444,6 +444,7 @@
     name: podified-multinode-edpm-deployment-crc-bootstrap-staging-ironic
     parent: podified-multinode-edpm-deployment-crc-bootstrap-staging
     vars:
+      cifmw_enable_virtual_baremetal_support: true
       cifmw_networking_mapper_definition_patch_02_bmaas_net:
         networks:
           baremetal:


### PR DESCRIPTION
- Add support for deploying Sushy Emulator in non reproducer jobs
- Add support for configuring the controller node as a hypervisor
- Add new var `cifmw_enable_virtual_baremetal_support` to toggle feature
- Enable `cifmw_enable_virtual_baremetal_support` in
  `podified-multinode-edpm-deployment-crc-bootstrap-staging-ironic` for
  testing.