### PR TITLE
Set octavia-amphora-image value when octavia is configured

### DIFF
--- a/roles/ci_gen_kustomize_values/README.md
+++ b/roles/ci_gen_kustomize_values/README.md
@@ -35,6 +35,7 @@ with a message.
 * `ci_gen_kustomize_fetch_ocp_state`: (Boolean) If true it enables generating CI templates based on the OCP state. Defaults to `true`.
 * `cifmw_ci_gen_kustomize_values_storage_class_prefix`: (String) Prefix for `storageClass` in generated values.yaml files. Defaults to `"lvms-"` only if `cifmw_use_lvms` is True, otherwise it defaults to `""`. The prefix is prepended to the `cifmw_ci_gen_kustomize_values_storage_class`. It is not recommended to override this value, instead set `cifmw_use_lvms` True or False.
 * `cifmw_ci_gen_kustomize_values_storage_class`: (String) Value for `storageClass` in generated values.yaml files. Defaults to `"lvms-local-storage"` only if `cifmw_use_lvms` is True, otherwise it defaults to `"local-storage"`.
+* `cifmw_ci_gen_kustomize_values_octavia_amphora_image`: (String) Value for `amphoraImageContainerImage` in generated values.yaml files. Defaults to `""`.
 
 ### Specific parameters for edpm-values
 This configMap needs some more parameters in order to properly override the `architecture` provided one.

--- a/roles/ci_gen_kustomize_values/defaults/main.yml
+++ b/roles/ci_gen_kustomize_values/defaults/main.yml
@@ -72,6 +72,8 @@ cifmw_ci_gen_kustomize_values_storage_class: "{{ cifmw_ci_gen_kustomize_values_s
 
 cifmw_ci_gen_kustomize_values_primary_ip_version: 4
 
+cifmw_ci_gen_kustomize_values_octavia_amphora_image: ''
+
 # Those parameter must be set if you want to edit an "edpm-values"
 # cifmw_ci_gen_kustomize_values_ssh_authorizedkeys
 # cifmw_ci_gen_kustomize_values_ssh_private_key

--- a/roles/ci_gen_kustomize_values/templates/common/service-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/common/service-values/values.yaml.j2
@@ -1,0 +1,11 @@
+---
+# source: common/service-values/values.yaml.j2
+{% set amphora_image_data = ({'data':
+                               {'octavia':
+                                 {'amphoraImageContainerImage': cifmw_ci_gen_kustomize_values_octavia_amphora_image}
+                               }
+                             } if (original_content.data is defined and
+                                   original_content.data.octavia is defined)
+                             else {}) -%}
+{% set final_content = original_content | combine(amphora_image_data, recursive=true) -%}
+{{ final_content }}


### PR DESCRIPTION
With this patch, controlplane configuration can be modified with the registry, image name and version of the octavia-amphora-image.