### PR TITLE
Make `^nodes?(_[0-9]+)?$` keys removal configurable

### DIFF
--- a/roles/ci_gen_kustomize_values/README.md
+++ b/roles/ci_gen_kustomize_values/README.md
@@ -35,6 +35,8 @@ with a message.
 * `ci_gen_kustomize_fetch_ocp_state`: (Boolean) If true it enables generating CI templates based on the OCP state. Defaults to `true`.
 * `cifmw_ci_gen_kustomize_values_storage_class_prefix`: (String) Prefix for `storageClass` in generated values.yaml files. Defaults to `"lvms-"` only if `cifmw_use_lvms` is True, otherwise it defaults to `""`. The prefix is prepended to the `cifmw_ci_gen_kustomize_values_storage_class`. It is not recommended to override this value, instead set `cifmw_use_lvms` True or False.
 * `cifmw_ci_gen_kustomize_values_storage_class`: (String) Value for `storageClass` in generated values.yaml files. Defaults to `"lvms-local-storage"` only if `cifmw_use_lvms` is True, otherwise it defaults to `"local-storage"`.
+* `cifmw_ci_gen_kustomize_values_remove_keys_expressions`: (List) Remove keys matching the regular expressions from source ConfigMaps (values.yaml).
+  Defaults to `["^nodes$", "^node(_[0-9]+)?$"]`.
 
 ### Specific parameters for edpm-values
 This configMap needs some more parameters in order to properly override the `architecture` provided one.

--- a/roles/ci_gen_kustomize_values/defaults/main.yml
+++ b/roles/ci_gen_kustomize_values/defaults/main.yml
@@ -71,6 +71,9 @@ cifmw_ci_gen_kustomize_values_storage_class_prefix: "{{ 'lvms-' if cifmw_use_lvm
 cifmw_ci_gen_kustomize_values_storage_class: "{{ cifmw_ci_gen_kustomize_values_storage_class_prefix }}local-storage"
 
 cifmw_ci_gen_kustomize_values_primary_ip_version: 4
+cifmw_ci_gen_kustomize_values_remove_keys_expressions:
+  - ^nodes$
+  - ^node(_[0-9]+)?$
 
 # Those parameter must be set if you want to edit an "edpm-values"
 # cifmw_ci_gen_kustomize_values_ssh_authorizedkeys

--- a/roles/ci_gen_kustomize_values/tasks/generate_snippets.yml
+++ b/roles/ci_gen_kustomize_values/tasks/generate_snippets.yml
@@ -80,8 +80,9 @@
     _cifmw_gen_kustomize_values_base_cm_content: >-
       {{
         _config_map_content |
-        ansible.utils.remove_keys(target=['^nodes?(_[0-9]+)?$'],
-                                  matching_parameter='regex')
+        ansible.utils.remove_keys(
+          target=cifmw_ci_gen_kustomize_values_remove_keys_expressions,
+          matching_parameter='regex')
       }}
     cacheable: false
 


### PR DESCRIPTION
When creating the ConfigMap baseline any keys matching regular expression `^nodes?(_[0-9]+)?$` is removed from architecture source  values.yaml files.
    
This change introduces a new parameter to make this behavior configurable, `cifmw_ci_gen_kustomize_values_remove_keys_expressions` takes a list of regular expressions. 

By default these are:
```
      - "^nodes$"
      - "^node(_[0-9]+)?$"
```    

Disabling the keys removal is useful in the case when the values used in architecture repo example files is a 1-to-1 match with the deployed infrastructure - i.e there is no need to jinja template the values based on the network_mapper data.
