### PR TITLE
Make sure set_openstack_container is less depedent on instal_yamls

### DIFF
--- a/playbooks/update.yml
+++ b/playbooks/update.yml
@@ -14,12 +14,6 @@
         - name: Prepare install_yamls make targets
           ansible.builtin.include_role:
             name: install_yamls
-        - name: Make a viable cifmw_install_yamls_environment
-          ansible.builtin.set_fact:
-            cifmw_install_yamls_environment: "{{ cifmw_install_yamls_environment | default({}) }}"
-        - name: Add a default value cifmw_install_yamls_defaults
-          ansible.builtin.set_fact:
-            cifmw_install_yamls_defaults: "{{ cifmw_install_yamls_defaults | default({'OPERATOR_NAMESPACE': 'openstack-operators'}) }}"
 
 - name: Update repos and openstack services containers
   hosts: "{{ cifmw_target_host | default('localhost') }}"

--- a/roles/set_openstack_containers/defaults/main.yml
+++ b/roles/set_openstack_containers/defaults/main.yml
@@ -24,6 +24,7 @@ cifmw_set_openstack_containers_tag: current-podified
 cifmw_set_openstack_containers_prefix: openstack
 cifmw_set_openstack_containers_prefix_filter: "{{ cifmw_set_openstack_containers_prefix }}"
 cifmw_set_openstack_containers_operator_name: openstack
+cifmw_set_openstack_containers_operators_namespace: openstack-operators
 cifmw_set_openstack_containers_tag_from_md5: false
 cifmw_set_openstack_containers_excluded_envs: []
 cifmw_set_openstack_containers_dlrn_md5_path: "/etc/yum.repos.d/delorean.repo.md5"

--- a/roles/set_openstack_containers/tasks/main.yml
+++ b/roles/set_openstack_containers/tasks/main.yml
@@ -37,23 +37,27 @@
 - name: Set common facts for the role
   ansible.builtin.set_fact:
     operator_name: "{{ cifmw_set_openstack_containers_operator_name }}"
+    operator_namespace: >-
+      {{
+        cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] |
+        default(cifmw_set_openstack_containers_operators_namespace)
+      }}
     cifmw_set_openstack_containers_common_env: >-
       {{
-        cifmw_install_yamls_environment |
+        ( cifmw_install_yamls_environment |
         combine({'PATH': cifmw_path}) |
         combine(cifmw_set_openstack_containers_extra_vars | default({}))
+        ) if cifmw_install_yamls_environment is defined else omit
       }}
     cacheable: true
 
 - name: Get meta operator environment variable
-  vars:
-    _operator_ns: "{{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }}"
   environment:
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
     PATH: "{{ cifmw_path }}"
   cifmw.general.ci_script:
     output_dir: "{{ cifmw_set_openstack_containers_basedir }}/artifacts"
-    script: "oc set env $(oc get pods -n {{ _operator_ns }} -o name -l openstack.org/operator-name={{ operator_name }}) -n {{ _operator_ns }} --list"
+    script: "oc set env $(oc get pods -n {{ operator_namespace }} -o name -l openstack.org/operator-name={{ operator_name }}) -n {{ operator_namespace }} --list"
   register: containers_env_list
 
 - name: Generate update_env_vars.sh script
@@ -86,7 +90,7 @@
     cmd: |
       set -o pipefail
       oc get csv -l operators.coreos.com/openstack-operator.openstack-operators \
-      --namespace={{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} \
+      --namespace={{ operator_namespace }} \
       --no-headers=true | grep -i "succeeded"
   register: operator_status
   until: operator_status.rc == 0
@@ -105,6 +109,9 @@
   ansible.builtin.include_role:
     name: 'install_yamls_makes'
     tasks_from: 'make_wait'
+  when:
+    - operator_name != 'openstack'
+    - not cifmw_architecture_scenario is defined
 
 - name: Retrieve operator pods
   environment:
@@ -112,7 +119,7 @@
     PATH: "{{ cifmw_path }}"
   cifmw.general.ci_script:
     output_dir: "{{ cifmw_set_openstack_containers_basedir }}/artifacts"
-    script: "oc get pods -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} -o name"
+    script: "oc get pods -n {{ operator_namespace }} -o name"
   register: operator_pod_name
 
 - name: Get the operator pod name
@@ -131,6 +138,6 @@
     PATH: "{{ cifmw_path }}"
   cifmw.general.ci_script:
     output_dir: "{{ cifmw_set_openstack_containers_basedir }}/artifacts"
-    script: "oc set env {{ operator_pod_name }} -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} --list > {{ cifmw_set_openstack_containers_openstack_final_env }}"
+    script: "oc set env {{ operator_pod_name }} -n {{ operator_namespace }} --list > {{ cifmw_set_openstack_containers_openstack_final_env }}"
     chdir: "{{ cifmw_set_openstack_containers_basedir }}/artifacts"
     creates: "{{ cifmw_set_openstack_containers_openstack_final_env }}"

--- a/roles/set_openstack_containers/templates/update_env_vars.sh.j2
+++ b/roles/set_openstack_containers/templates/update_env_vars.sh.j2
@@ -42,7 +42,7 @@ export PATH="{{ cifmw_path }}"
 {% endfor -%}
 
 # patch csv
-oc get csv -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} \
+oc get csv -n {{ operator_namespace }} \
    -l operators.coreos.com/{{ operator_name }}-operator.openstack-operators -o=jsonpath='{.items[0]}' \
    {% for key, value in containers_dict.items() -%}
    | jq '(.spec.install.spec.deployments[]?.spec.template.spec.containers[]?.env[]? | select(.name=={{ '\"' + key + '\"' }}?)) |= (.value={{ '\"' + value + '\"' }})' \
@@ -51,8 +51,8 @@ oc get csv -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} \
 
 
 # Apply patch
-oc patch csv -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} \
-   $(oc get csv -n {{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }} \
+oc patch csv -n {{ operator_namespace }} \
+   $(oc get csv -n {{ operator_namespace }} \
    -l operators.coreos.com/{{ operator_name }}-operator.openstack-operators \
    -o jsonpath='{.items[0].metadata.name}') \
    --type=merge \


### PR DESCRIPTION
Cleanup set_openstack_container role by setting default values and omitting
setting fact if install_yamls was not used during deployment.

This is first atempt of reducing dependency in set_openstack_container role
from install_yamls. The work that is left for later is for updating
ENVs in operators other than openstack-operator. Task that waits
for an operator(other than openstack-operator) update to complete will only work in install_yaml deployed environments and is skipped in architecture_scenario context.

Jira: https://issues.redhat.com/browse/OSPRH-10285
