### PR TITLE
Fix molecule - add swift network

### DIFF
--- a/roles/ci_gen_kustomize_values/molecule/default/files/3-ocp-net-def.yml
+++ b/roles/ci_gen_kustomize_values/molecule/default/files/3-ocp-net-def.yml
@@ -86,6 +86,15 @@ instances:
                 parent_interface: enp6s0
                 skip_nm: false
                 vlan_id: 22
+            swift:
+                interface_name: eth1.25
+                ip_v4: 172.22.0.5
+                mac_addr: '52:54:00:0b:a1:d9'
+                mtu: 1500
+                network_name: swift
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 25
     ocp-master-1:
         hostname: ocp-master-1
         name: ocp-master-1
@@ -124,6 +133,15 @@ instances:
                 parent_interface: enp6s0
                 skip_nm: false
                 vlan_id: 22
+            swift:
+                interface_name: eth1.25
+                ip_v4: 172.22.0.6
+                mac_addr: '52:54:00:0b:a0:d9'
+                mtu: 1500
+                network_name: swift
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 25
     ocp-master-2:
         hostname: ocp-master-2
         name: ocp-master-2
@@ -162,6 +180,15 @@ instances:
                 parent_interface: enp6s0
                 skip_nm: false
                 vlan_id: 22
+            swift:
+                interface_name: eth1.25
+                ip_v4: 172.22.0.7
+                mac_addr: '52:54:00:0b:1c:d9'
+                mtu: 1500
+                network_name: swift
+                parent_interface: eth1
+                skip_nm: false
+                vlan_id: 25
 networks:
     ctlplane:
         dns_v4:
@@ -335,3 +362,35 @@ networks:
                     start_host: 100
                 ipv6_ranges: []
         vlan_id: 22
+    swift:
+        dns_v4: []
+        dns_v6: []
+        mtu: 1496
+        network_name: swift
+        network_v4:  172.22.0.0/24
+        search_domain: swift.example.com
+        tools:
+            metallb:
+                ipv4_ranges:
+                -   end:  172.22.0..90
+                    end_host: 90
+                    length: 11
+                    start:  172.22.0.80
+                    start_host: 80
+                ipv6_ranges: []
+            multus:
+                ipv4_ranges:
+                -   end:  172.22.0.70
+                    end_host: 70
+                    length: 41
+                    start:  172.22.0.30
+                    start_host: 30
+                ipv6_ranges: []
+            netconfig:
+                ipv4_ranges:
+                -   end: 72.22.0.250
+                    end_host: 250
+                    length: 151
+                    start: 172.22.0.100
+                    start_host: 100
+        vlan_id: 25


### PR DESCRIPTION
The swift network was added to the HCI scenario used in the molecule tests here: https://github.com/openstack-k8s-operators/architecture/pull/404