### PR TITLE
Only consider ocps networks for network-values template

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/bgp/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp/network-values/values.yaml.j2
@@ -5,18 +5,16 @@
                       lb_tools={}) %}
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
-{%   for network in cifmw_networking_env_definition.instances[host]['networks'].values() -%}
+{%   if host is match('^(ocp|crc).*') %}
+  node_{{ ns.ocp_index }}:
+    name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}
+{%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
 {%     set ns.interfaces = ns.interfaces |
                            combine({network.network_name: (network.parent_interface |
                                                            default(network.interface_name)
                                                           )
                                    },
-                                   recursive=true) -%}
-{%   endfor -%}
-{%   if host is match('^(ocp|crc).*') %}
-  node_{{ ns.ocp_index }}:
-    name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}
-{%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
+                                   recursive=true) %}
     {{ network.network_name }}_ip: {{ network.ip_v4 }}
 {%     endfor %}
 {%     set node_net_orig_content = original_content.data.bgp['net-attach-def']['node' ~ ns.ocp_index] %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/network-values/values.yaml.j2
@@ -6,20 +6,16 @@
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
 {%   set hostname = cifmw_networking_env_definition.instances[host]['hostname'] %}
-{%   for network in cifmw_networking_env_definition.instances[host]['networks'].values() -%}
-{%     if 'worker-3' != hostname %}
+{%   if host is match('^(ocp|crc).*') %}
+  node_{{ ns.ocp_index }}:
+    name: {{ hostname }}
+{%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
 {%       set ns.interfaces = ns.interfaces |
                              combine({network.network_name: (network.parent_interface |
                                                              default(network.interface_name)
                                                             )
                                      },
-                                     recursive=true) -%}
-{%     endif %}
-{%   endfor -%}
-{%   if host is match('^(ocp|crc).*') %}
-  node_{{ ns.ocp_index }}:
-    name: {{ hostname }}
-{%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
+                                     recursive=true) %}
     {{ network.network_name }}_ip: {{ network.ip_v4 }}
 {%       if 'worker-3' == hostname and 'ctlplane' == network.network_name %}
     base_if: {{ network.interface_name }}

--- a/roles/ci_gen_kustomize_values/templates/common/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/common/network-values/values.yaml.j2
@@ -6,19 +6,17 @@
                       lb_tools={}) %}
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
-{%   for network in cifmw_networking_env_definition.instances[host]['networks'].values() -%}
-{%     set ns.interfaces = ns.interfaces |
-                           combine({network.network_name: (network.parent_interface |
-                                                           default(network.interface_name)
-                                                          )
-                                   },
-                                   recursive=true) -%}
-{%   endfor -%}
 {%   if host is match('^(ocp|crc).*') %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}
 {%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
+{%     set ns.interfaces = ns.interfaces |
+                           combine({network.network_name: (network.parent_interface |
+                                                           default(network.interface_name)
+                                                          )
+                                   },
+                                   recursive=true) %}
     {{ network.network_name }}_ip: {{ network[_ipv.ip_vX] }}
 {%     endfor %}
 {%   endif %}

--- a/roles/ci_gen_kustomize_values/templates/shiftstack/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/shiftstack/network-values/values.yaml.j2
@@ -4,19 +4,17 @@
 
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
-{%   for network in cifmw_networking_env_definition.instances[host]['networks'].values() -%}
-{%     set ns.interfaces = ns.interfaces |
-                           combine({network.network_name: (network.parent_interface |
-                                                           default(network.interface_name)
-                                                          )
-                                   },
-                                   recursive=true) -%}
-{%   endfor -%}
 {%   if host is match('^(ocp|crc).*') %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}
 {%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
+{%     set ns.interfaces = ns.interfaces |
+                           combine({network.network_name: (network.parent_interface |
+                                                           default(network.interface_name)
+                                                          )
+                                   },
+                                   recursive=true) %}
     {{ network.network_name }}_ip: {{ network.ip_v4 }}
 {%     endfor %}
 {%   endif %}

--- a/roles/ci_gen_kustomize_values/templates/uni01alpha/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni01alpha/network-values/values.yaml.j2
@@ -6,19 +6,17 @@
                       lb_tools={}) %}
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
-{%   for network in cifmw_networking_env_definition.instances[host]['networks'].values() -%}
-{%     set ns.interfaces = ns.interfaces |
-                           combine({network.network_name: (network.parent_interface |
-                                                           default(network.interface_name)
-                                                          )
-                                   },
-                                   recursive=true) -%}
-{%   endfor -%}
 {%   if host is match('^(ocp|crc).*') %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}
 {%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
+{%     set ns.interfaces = ns.interfaces |
+                           combine({network.network_name: (network.parent_interface |
+                                                           default(network.interface_name)
+                                                          )
+                                   },
+                                   recursive=true) %}
     {{ network.network_name }}_ip: {{ network[_ipv.ip_vX] }}
 {%     endfor %}
 {%   endif %}

--- a/roles/ci_gen_kustomize_values/templates/uni04delta-ipv6/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni04delta-ipv6/network-values/values.yaml.j2
@@ -6,14 +6,6 @@
                       lb_tools={}) %}
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
-{%   for network in cifmw_networking_env_definition.instances[host]['networks'].values() -%}
-{%     set ns.interfaces = ns.interfaces |
-                           combine({network.network_name: (network.parent_interface |
-                                                           default(network.interface_name)
-                                                          )
-                                   },
-                                   recursive=true) -%}
-{%   endfor -%}
 {%   if host is match('^(ocp|crc).*') %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
@@ -22,6 +14,12 @@ data:
 {#                    Because devscripts use fqdn for node names when ipv6                     #}
     node_name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}.ocp.openstack.lab
 {%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
+{%     set ns.interfaces = ns.interfaces |
+                           combine({network.network_name: (network.parent_interface |
+                                                           default(network.interface_name)
+                                                          )
+                                   },
+                                   recursive=true) %}
     {{ network.network_name }}_ip: {{ network[_ipv.ip_vX] }}
 {%     endfor %}
 {%   endif %}

--- a/roles/ci_gen_kustomize_values/templates/uni05epsilon/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni05epsilon/network-values/values.yaml.j2
@@ -6,19 +6,17 @@
                       lb_tools={}) %}
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
-{%   for network in cifmw_networking_env_definition.instances[host]['networks'].values() -%}
-{%     set ns.interfaces = ns.interfaces |
-                           combine({network.network_name: (network.parent_interface |
-                                                           default(network.interface_name)
-                                                          )
-                                   },
-                                   recursive=true) -%}
-{%   endfor -%}
 {%   if host is match('^(ocp|crc).*') %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}
 {%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
+{%     set ns.interfaces = ns.interfaces |
+                           combine({network.network_name: (network.parent_interface |
+                                                           default(network.interface_name)
+                                                          )
+                                   },
+                                   recursive=true) %}
     {{ network.network_name }}_ip: {{ network[_ipv.ip_vX] }}
 {%     endfor %}
 {%   endif %}

--- a/roles/ci_gen_kustomize_values/templates/uni06zeta/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni06zeta/network-values/values.yaml.j2
@@ -6,19 +6,17 @@
                       lb_tools={}) %}
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
-{%   for network in cifmw_networking_env_definition.instances[host]['networks'].values() -%}
-{%     set ns.interfaces = ns.interfaces |
-                           combine({network.network_name: (network.parent_interface |
-                                                           default(network.interface_name)
-                                                          )
-                                   },
-                                   recursive=true) -%}
-{%   endfor -%}
 {%   if host is match('^(ocp|crc).*') %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}
 {%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
+{%     set ns.interfaces = ns.interfaces |
+                           combine({network.network_name: (network.parent_interface |
+                                                           default(network.interface_name)
+                                                          )
+                                   },
+                                   recursive=true) %}
     {{ network.network_name }}_ip: {{ network[_ipv.ip_vX] }}
 {%     endfor %}
 {%   endif %}

--- a/roles/ci_gen_kustomize_values/templates/uni07eta/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni07eta/network-values/values.yaml.j2
@@ -6,19 +6,17 @@
                       lb_tools={}) %}
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
-{%   for network in cifmw_networking_env_definition.instances[host]['networks'].values() -%}
-{%     set ns.interfaces = ns.interfaces |
-                           combine({network.network_name: (network.parent_interface |
-                                                           default(network.interface_name)
-                                                          )
-                                   },
-                                   recursive=true) -%}
-{%   endfor -%}
 {%   if host is match('^(ocp|crc).*') %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}
 {%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
+{%     set ns.interfaces = ns.interfaces |
+                           combine({network.network_name: (network.parent_interface |
+                                                           default(network.interface_name)
+                                                          )
+                                   },
+                                   recursive=true) %}
     {{ network.network_name }}_ip: {{ network[_ipv.ip_vX] }}
 {%     endfor %}
 {%   endif %}


### PR DESCRIPTION
The common template for the network-values in ci_gen_kustomize_values
iterates over all the hosts in the cifmw_networking_env_definition and
stores in a map the relationship between a network and the interface.

For this to work, the ocp nodes must be the last ones, since if there
are other nodes after them in the cifmw_networking_env_definition,
for example nodes named osp-*, and they use a different network
interface, the resulting nncp will fail when applied.
