### PR TITLE
Use Ceph monitoring (not RGW) network for Dashboard

### DIFF
--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -471,6 +471,9 @@
       ansible.builtin.import_role:
         name: cifmw_cephadm
         tasks_from: post
+      vars:
+        cifmw_cephadm_dashboard_crt: "{{ cifmw_cephadm_certificate }}"
+        cifmw_cephadm_dashboard_key: "{{ cifmw_cephadm_key }}"
 
 - name: Render Ceph client configuration
   tags: client

--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -138,3 +138,5 @@ cifmw_cephadm_update_log_commands:
   # Get last cephadm logs in case of failure
   - type: "mod_cephadm"
     cmd: "log last cephadm"
+cifmw_cephadm_wait_for_dashboard_retries: 10
+cifmw_cephadm_wait_for_dashboard_delay: 20

--- a/roles/cifmw_cephadm/tasks/dashboard/configure_dashboard_backends.yml
+++ b/roles/cifmw_cephadm/tasks/dashboard/configure_dashboard_backends.yml
@@ -34,5 +34,5 @@
   ansible.builtin.command: |
     {{ cifmw_cephadm_ceph_cli }} config set \
     mgr mgr/dashboard/{{ current_mgr }}/server_addr \
-    {{ hostvars[item][all_addresses] | ansible.utils.ipaddr(cifmw_cephadm_rgw_network) | first }}
+    {{ hostvars[item][all_addresses] | ansible.utils.ipaddr(cifmw_cephadm_monitoring_network) | first }}
   become: true

--- a/roles/cifmw_cephadm/tasks/dashboard/validation.yml
+++ b/roles/cifmw_cephadm/tasks/dashboard/validation.yml
@@ -1,15 +1,47 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Update urischeme based on cert/key
+  ansible.builtin.set_fact:
+    cifmw_cephadm_urischeme_dashboard: "https"
+  when:
+    - cifmw_cephadm_dashboard_crt | default("") | length > 0
+    - cifmw_cephadm_dashboard_key | default("") | length > 0
+
 - name: Validate connection to dashboard service
   ansible.builtin.get_url:
-    url: "http://{{ grafana_server_addr }}:{{ cifmw_cephadm_dashboard_port }}"
+    url: "{{ cifmw_cephadm_urischeme_dashboard | default('http') }}://{{ grafana_server_addr }}:{{ cifmw_cephadm_dashboard_port }}"
     dest: "/tmp/dash_response"
+    validate_certs: false
   register: dashboard_response
   failed_when: dashboard_response.failed == true
+  until: dashboard_response.failed == false
+  retries: "{{ cifmw_cephadm_wait_for_dashboard_retries }}"
+  delay: "{{ cifmw_cephadm_wait_for_dashboard_delay }}"
+
 
 - name: Check http response code from dashboard service with login
   ansible.builtin.get_url:
-    url: "http://{{ grafana_server_addr }}:{{ cifmw_cephadm_dashboard_port }}"
+    url: "{{ cifmw_cephadm_urischeme_dashboard | default('http') }}://{{ grafana_server_addr }}:{{ cifmw_cephadm_dashboard_port }}"
     dest: "/tmp/dash_http_response"
+    validate_certs: false
     username: admin
     password: admin
   register: dashboard_resp
   failed_when: dashboard_resp.status_code != 200
+  until: dashboard_resp.status_code == 200
+  retries: "{{ cifmw_cephadm_wait_for_dashboard_retries }}"
+  delay: "{{ cifmw_cephadm_wait_for_dashboard_delay }}"

--- a/roles/cifmw_cephadm/templates/ceph_monitoring_stack.yml.j2
+++ b/roles/cifmw_cephadm/templates/ceph_monitoring_stack.yml.j2
@@ -11,7 +11,7 @@ placement:
   - {{ _hosts[0] }}
   count: 1
 networks:
-- {{ cifmw_cephadm_rgw_network }}
+- {{ cifmw_cephadm_monitoring_network }}
 ---
 service_type: prometheus
 service_id: prometheus
@@ -21,7 +21,7 @@ placement:
   - {{ _hosts[0] }}
   count: 1
 networks:
-- {{ cifmw_cephadm_rgw_network }}
+- {{ cifmw_cephadm_monitoring_network }}
 ---
 service_type: alertmanager
 service_id: alertmanager
@@ -31,4 +31,4 @@ placement:
   - {{ _hosts[0] }}
   count: 1
 networks:
-- {{ cifmw_cephadm_rgw_network }}
+- {{ cifmw_cephadm_monitoring_network }}


### PR DESCRIPTION
Use Ceph monitoring (not RGW) network for Dashboard

Use the existing `cifmw_cephadm_monitoring_network`
parameter to configure the Ceph dashboard instead of
the `cifmw_cephadm_rgw_network` parameter. This was
not detected earlier because the Ceph playbook set them
both to the Ceph public_network, but we recently added
a feature to run RGW on a separate network [1].
Also, add retries/delay to the dashboard HTTP check.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/2301