### PR TITLE
Pass tcib-extras tcib_package while building containers from source

### DIFF
--- a/roles/build_containers/templates/build_containers.sh.j2
+++ b/roles/build_containers/templates/build_containers.sh.j2
@@ -50,6 +50,9 @@ openstack tcib container image build \
 {%   endif %}
      --tcib-extra tcib_release={{ ansible_distribution_major_version }} \
      --tcib-extra tcib_python_version={{ (ansible_distribution_major_version is version('9', '<')) | ternary ('3.6', '3.9') }} \
+{%   if cifmw_build_containers_install_from_source | bool %}
+     --tcib-extra tcib_package= \
+{%   endif %}
 {%   if (cifmw_build_containers_extra_config is defined) %}
      --extra-config {{ cifmw_build_containers_basedir }}/extra_config.yaml \
 {%   endif %}


### PR DESCRIPTION
We need to pass `--tcib-extras tcib_package=` while [using tcib from source](https://github.com/openstack-k8s-operators/tcib?tab=readme-ov-file#building-images-with-local-changes). This pr updates the same.

Tested it here: https://review.rdoproject.org/r/c/testproject/+/54761/11#message-db813ffd30e270c15753f711d65f2e8079bbb741 and  https://logserver.rdoproject.org/61/54761/11/check/periodic-container-tcib-build-push-centos-9-master/ed662ef/ci-framework-data/artifacts/build_containers.sh 