### PR TITLE
[ci-boostrap] Add second call to the mapper to ingest interface-info

### DIFF
--- a/ci/playbooks/bootstrap-networking-mapper.yml
+++ b/ci/playbooks/bootstrap-networking-mapper.yml
@@ -31,6 +31,7 @@
           ~/test-python/bin/ansible-playbook {{ ansible_user_dir }}/networking_mapper.yml
           -i {{ ansible_user_dir }}/ci-framework-data/artifacts/zuul_inventory.yml
           -e @scenarios/centos-9/base.yml
+          -e cifmw_networking_mapper_ifaces_info_path=/etc/ci/env/interfaces-info.yml
           -e "@{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml"
           {% if nodepool is defined %}
           -e "@{{ ansible_user_dir }}/ci-framework-data/artifacts/nodepool_params.yml"

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -216,6 +216,7 @@
     required-projects: *multinode_edpm_rp
     roles: *multinode_edpm_roles
     pre-run:
+      - ci/playbooks/bootstrap-networking-mapper.yml
       - ci/playbooks/crc/reconfigure-kubelet.yml
       - ci/playbooks/multinode-customizations.yml
     post-run: *multinode_edpm_post_run
@@ -236,6 +237,7 @@
     required-projects: *multinode_edpm_rp
     roles: *multinode_edpm_roles
     pre-run:
+      - ci/playbooks/bootstrap-networking-mapper.yml
       - ci/playbooks/crc/reconfigure-kubelet.yml
       - ci/playbooks/multinode-customizations.yml
     post-run: *multinode_edpm_post_run
@@ -305,4 +307,4 @@
     pre-run:
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
-      - ci/playbooks/pre-ci-bootstrap.yml
+      - ci/playbooks/bootstrap-networking-mapper.yml


### PR DESCRIPTION
This change is part of the content of https://github.com/openstack-k8s-operators/ci-framework/pull/2371, where the changes applied here are tested all along other related ones.


Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2401