### PR TITLE
Ignore non-vars file in fetch_compute_facts

### DIFF
--- a/hooks/playbooks/fetch_compute_facts.yml
+++ b/hooks/playbooks/fetch_compute_facts.yml
@@ -26,6 +26,10 @@
     - name: Load parameters
       ansible.builtin.include_vars:
         dir: "{{ item }}"
+        ignore_unknown_extensions: true
+        extensions:
+          - yaml
+          - yml
       loop:
         - "{{ cifmw_basedir }}/artifacts/parameters"
         - "/etc/ci/env"


### PR DESCRIPTION
Some files may be backups of previous versions, like the networking-environment-definition if the mapper is called twice. To avoid trying to load old backed up content load only the default files (yaml and json).