### PR TITLE
Improve adoption coverage for openstack-operator

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -107,6 +107,7 @@
         Has ceph, not TLS. Uses a content provider.
     parent: adoption-standalone-to-crc-ceph
     files:
+      # ci-framework
       - ^playbooks/01-bootstrap.yml
       - ^playbooks/02-infra.yml
       - ^playbooks/06-deploy-edpm.yml
@@ -119,8 +120,14 @@
       - ^roles/repo_setup/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
       - ^hooks/playbooks/fetch_compute_facts.yml
       - ^zuul.d/adoption.yaml
+      # openstack-operator
       - go.mod
       - apis/go.mod
+      - ^config/crd/bases/.*
+      - ^controllers/core/.*
+      - ^controllers/dataplane/.*
+      - ^pkg/dataplane/.*
+      - ^pkg/openstack/.*
     required-projects:
       - openstack-k8s-operators/openstack-operator
     irrelevant-files:


### PR DESCRIPTION
This should help prevent breakages like [1].

[1] https://github.com/openstack-k8s-operators/openstack-operator/pull/1103

Until now we ran the adoption job only when bumping the component operators, but we should run it also when we change the interface (CRDs) or the behavior of the openstack-operator itself.

Related: [OSPCIX-504](https://issues.redhat.com//browse/OSPCIX-504)