### PR TITLE
Move test-operator CR name variables from vars to defaults folder

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -26,6 +26,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 
 ## Tempest specific parameters
 * `cifmw_test_operator_tempest_registry`: (String) The registry where to pull tempest container. Default value: `quay.io`
+* `cifmw_test_operator_tempest_name`: (String) Name of the tempest CR name. Default value: `tempest-tests`
 * `cifmw_test_operator_tempest_namespace`: (String) Registry's namespace where to pull tempest container. Default value: `podified-antelope-centos9`
 * `cifmw_test_operator_tempest_container`: (String) Name of the tempest container. Default value: `openstack-tempest`
 * `cifmw_test_operator_tempest_image`: (String) Tempest image to be used. Default value: `{{ cifmw_test_operator_tempest_registry }}/{{ cifmw_test_operator_tempest_namespace }}/{{ cifmw_test_operator_tempest_container }}`
@@ -70,6 +71,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 
 ## Tobiko specific parameters
 * `cifmw_test_operator_tobiko_registry`: (String) The registry where to pull tobiko container. Default value: `quay.io`
+* `cifmw_test_operator_tobiko_name`: (String) Name of the tobiko CR name. Default value: `tobiko-tests`
 * `cifmw_test_operator_tobiko_namespace`: (String) Registry's namespace where to pull tobiko container. Default value: `podified-antelope-centos9`
 * `cifmw_test_operator_tobiko_container`: (String) Name of the tobiko container. Default value: `openstack-tobiko`
 * `cifmw_test_operator_tobiko_image`: (String) Tobiko image to be used. Default value: `{{ cifmw_test_operator_tobiko_registry }}/{{ cifmw_test_operator_tobiko_namespace }}/{{ cifmw_test_operator_tobiko_container }}`
@@ -112,6 +114,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 
 ## AnsibleTest specific parameters
 * `cifmw_test_operator_ansibletest_registry`: (String) The registry where to pull ansibletests container. Default value: `quay.io`
+* `cifmw_test_operator_ansibletest_name`: (String) Name of the Ansibletests CR name. Default value: `ansibletest`
 * `cifmw_test_operator_ansibletest_namespace`: (String) Registry's namespace where to pull ansibletests container. Default value:podified-antelope-centos9
 * `cifmw_test_operator_ansibletest_container`: (String) Name of the ansibletests container. Default value: `openstack-ansible-tests`
 * `cifmw_test_operator_ansibletest_image`: (String) Ansibletests image to be used. Default value: `{{ cifmw_test_operator_ansibletest_registry }}/{{ cifmw_test_operator_ansibletest_namespace }}/{{ cifmw_test_operator_ansibletest_container }}`
@@ -156,6 +159,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 
 ## Horizontest specific parameters
 * `cifmw_test_operator_horizontest_registry`: (String) The registry where to pull horizontest container. Default value: `quay.io`
+* `cifmw_test_operator_horizontest_name`: (String) Name of the horizontest CR name. Default value: `horizontest-tests`
 * `cifmw_test_operator_horizontest_namespace`: (String) Registry's namespace where to pull horizontest container. Default value: `podified-antelope-centos9`
 * `cifmw_test_operator_horizontest_container`: (String) Name of the horizontest container. Default value: `openstack-horizontest`
 * `cifmw_test_operator_horizontest_image`: (String) Horizontest image to be used. Default value: `{{ cifmw_test_operator_horizontest_registry }}/{{ cifmw_test_operator_horizontest_namespace }}/{{ cifmw_test_operator_horizontest_container }}`

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -40,6 +40,7 @@ cifmw_test_operator_privileged: true
 
 # Section 2: tempest parameters - used when run_test_fw is 'tempest'
 cifmw_test_operator_tempest_registry: quay.io
+cifmw_test_operator_tempest_name: "tempest-tests"
 cifmw_test_operator_tempest_namespace: podified-antelope-centos9
 cifmw_test_operator_tempest_container: openstack-tempest-all
 cifmw_test_operator_tempest_image: "{{ cifmw_test_operator_tempest_registry }}/{{ cifmw_test_operator_tempest_namespace }}/{{ cifmw_test_operator_tempest_container }}"
@@ -121,6 +122,7 @@ cifmw_test_operator_tempest_config:
 
 # Section 3: tobiko parameters - used when run_test_fw is 'tobiko'
 cifmw_test_operator_tobiko_registry: quay.io
+cifmw_test_operator_tobiko_name: "tobiko-tests"
 cifmw_test_operator_tobiko_namespace: podified-antelope-centos9
 cifmw_test_operator_tobiko_container: openstack-tobiko
 cifmw_test_operator_tobiko_image: "{{ cifmw_test_operator_tobiko_registry }}/{{ cifmw_test_operator_tobiko_namespace }}/{{ cifmw_test_operator_tobiko_container }}"
@@ -162,6 +164,7 @@ cifmw_test_operator_tobiko_config:
 
 # Section 4: ansibletest parameters - used when run_test_fw is 'ansibletest'
 cifmw_test_operator_ansibletest_registry: quay.io
+cifmw_test_operator_ansibletest_name: "ansibletest"
 cifmw_test_operator_ansibletest_namespace: podified-antelope-centos9
 cifmw_test_operator_ansibletest_container: openstack-ansible-tests
 cifmw_test_operator_ansibletest_image: "{{ cifmw_test_operator_ansibletest_registry }}/{{ cifmw_test_operator_ansibletest_namespace }}/{{ cifmw_test_operator_ansibletest_container }}"
@@ -205,6 +208,7 @@ cifmw_test_operator_ansibletest_config:
 
 # Section 5: horizontest parameters - used when run_test_fw is 'horizontest'
 cifmw_test_operator_horizontest_registry: quay.io
+cifmw_test_operator_horizontest_name: "horizontest-tests"
 cifmw_test_operator_horizontest_namespace: podified-antelope-centos9
 cifmw_test_operator_horizontest_container: openstack-horizontest
 cifmw_test_operator_horizontest_image: "{{ cifmw_test_operator_horizontest_registry }}/{{ cifmw_test_operator_horizontest_namespace }}/{{ cifmw_test_operator_horizontest_container }}"

--- a/roles/test_operator/vars/main.yml
+++ b/roles/test_operator/vars/main.yml
@@ -14,10 +14,6 @@
 # under the License.
 
 cifmw_test_operator_controller_priv_key_secret_name: "test-operator-controller-priv-key"
-cifmw_test_operator_tempest_name: "tempest-tests"
-cifmw_test_operator_tobiko_name: "tobiko-tests"
-cifmw_test_operator_ansibletest_name: "ansibletest"
-cifmw_test_operator_horizontest_name: "horizontest-tests"
 cifmw_test_operator_tempest_kind_name: "Tempest"
 cifmw_test_operator_tobiko_kind_name: "Tobiko"
 cifmw_test_operator_ansibletest_kind_name: "AnsibleTest"


### PR DESCRIPTION
Currently the names of the resources created with test-operator role were defined by variables in the vars folder of test-operator role. We want to move those vars to defaults folder to enable their easier customization. The main reason why this name customization might be useful is to be able to run tempest multiple times without doing cleanup of CRs for every tempest run.