### PR TITLE
Enable running the test-operator role multiple times

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -25,6 +25,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_privileged`: (Boolean) Spawn the test pods with `allowPrivilegedEscalation: true` and default linux capabilities. This is required for certain test-operator functionalities to work properly (e.g.: `extraRPMs`, certain set of tobiko tests). Default value: `true`
 
 ## Tempest specific parameters
+* `cifmw_test_operator_tempest_name`: (String) Value used in the `Tempest.Metadata.Name` field. The value specifies the name of some resources spawned by the test-operator role. Default value: `tempest-tests`
 * `cifmw_test_operator_tempest_registry`: (String) The registry where to pull tempest container. Default value: `quay.io`
 * `cifmw_test_operator_tempest_namespace`: (String) Registry's namespace where to pull tempest container. Default value: `podified-antelope-centos9`
 * `cifmw_test_operator_tempest_container`: (String) Name of the tempest container. Default value: `openstack-tempest`
@@ -48,7 +49,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
   apiVersion: test.openstack.org/v1beta1
   kind: Tempest
   metadata:
-    name: tempest-tests
+    name: "{{ cifmw_test_operator_tempest_name }}"
     namespace: "{{ cifmw_test_operator_namespace }}"
   spec:
     containerImage: "{{ cifmw_test_operator_tempest_image }}:{{ cifmw_test_operator_tempest_image_tag }}"
@@ -69,6 +70,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 ```
 
 ## Tobiko specific parameters
+* `cifmw_test_operator_tobiko_name`: (String) Value used in the `Tobiko.Metadata.Name` field. The value specifies the name of some resources spawned by the test-operator role. Default value: `tobiko-tests`
 * `cifmw_test_operator_tobiko_registry`: (String) The registry where to pull tobiko container. Default value: `quay.io`
 * `cifmw_test_operator_tobiko_namespace`: (String) Registry's namespace where to pull tobiko container. Default value: `podified-antelope-centos9`
 * `cifmw_test_operator_tobiko_container`: (String) Name of the tobiko container. Default value: `openstack-tobiko`
@@ -90,7 +92,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
   apiVersion: test.openstack.org/v1beta1
   kind: Tobiko
   metadata:
-    name: tobiko-tests
+    name: "{{ cifmw_test_operator_tobiko_name }}"
     namespace: "{{ cifmw_test_operator_namespace }}"
   spec:
     kubeconfigSecretName: "{{ cifmw_test_operator_tobiko_kubeconfig_secret }}"
@@ -111,6 +113,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 ```
 
 ## AnsibleTest specific parameters
+* `cifmw_test_operator_ansibletest_name`: (String) Value used in the `Ansibletest.Metadata.Name` field. The value specifies the name of some resources spawned by the test-operator role. Default value: `ansibletest`
 * `cifmw_test_operator_ansibletest_registry`: (String) The registry where to pull ansibletests container. Default value: `quay.io`
 * `cifmw_test_operator_ansibletest_namespace`: (String) Registry's namespace where to pull ansibletests container. Default value:podified-antelope-centos9
 * `cifmw_test_operator_ansibletest_container`: (String) Name of the ansibletests container. Default value: `openstack-ansible-tests`
@@ -134,7 +137,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
   apiVersion: test.openstack.org/v1beta1
   kind: AnsibleTest
   metadata:
-    name: horizontest-sample
+    name: "{{ cifmw_test_operator_ansibletest_name }}"
     namespace: "{{ cifmw_test_operator_namespace }}"
   spec:
     containerImage: "{{ cifmw_test_operator_ansibletest_image }}:{{ cifmw_test_operator_ansibletest_image_tag }}"
@@ -155,6 +158,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 ```
 
 ## Horizontest specific parameters
+* `cifmw_test_operator_horizontest_name`: (String) Value used in the `Horizontest.Metadata.Name` field. The value specifies the name of some resources spawned by the test-operator role. Default value: `horizontest-tests`
 * `cifmw_test_operator_horizontest_registry`: (String) The registry where to pull horizontest container. Default value: `quay.io`
 * `cifmw_test_operator_horizontest_namespace`: (String) Registry's namespace where to pull horizontest container. Default value: `podified-antelope-centos9`
 * `cifmw_test_operator_horizontest_container`: (String) Name of the horizontest container. Default value: `openstack-horizontest`
@@ -178,7 +182,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
   apiVersion: test.openstack.org/v1beta1
   kind: HorizonTest
   metadata:
-    name: horizontest
+    name: "{{ cifmw_test_operator_horizontest_name }}"
     namespace: "{{ cifmw_test_operator_namespace }}"
   spec:
     containerImage: "{{ cifmw_test_operator_horizontest_image }}:{{ cifmw_test_operator_horizontest_image_tag }}"
@@ -195,4 +199,16 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
     flavorName: "{{ cifmw_test_operator_horizontest_flavor_name }}"
     logsDirectoryName: "{{ cifmw_test_operator_horizontest_logs_directory_name }}"
     horizonTestDir: "{{ cifmw_test_operator_horizontest_horizon_test_dir }}"
+```
+
+## Examples
+
+### Execute the `test-operator` role multiple times within a single job
+
+If you want to run the `test-operator` role twice within a single job, make sure
+that for the second run, you specify a value for the `cifmw_test_operator_*_name`
+other than the default one (e.g., `tempest-tests`, `tobiko-tests`, ...):
+
+```
+cifmw_test_operator_tempest_name: "post-update-tempest-tests"
 ```

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -39,6 +39,7 @@ cifmw_test_operator_delete_logs_pod: false
 cifmw_test_operator_privileged: true
 
 # Section 2: tempest parameters - used when run_test_fw is 'tempest'
+cifmw_test_operator_tempest_name: "tempest-tests"
 cifmw_test_operator_tempest_registry: quay.io
 cifmw_test_operator_tempest_namespace: podified-antelope-centos9
 cifmw_test_operator_tempest_container: openstack-tempest-all
@@ -120,6 +121,7 @@ cifmw_test_operator_tempest_config:
     workflow: "{{ cifmw_test_operator_tempest_workflow }}"
 
 # Section 3: tobiko parameters - used when run_test_fw is 'tobiko'
+cifmw_test_operator_tobiko_name: "tobiko-tests"
 cifmw_test_operator_tobiko_registry: quay.io
 cifmw_test_operator_tobiko_namespace: podified-antelope-centos9
 cifmw_test_operator_tobiko_container: openstack-tobiko
@@ -161,6 +163,7 @@ cifmw_test_operator_tobiko_config:
     workflow: "{{ cifmw_test_operator_tobiko_workflow }}"
 
 # Section 4: ansibletest parameters - used when run_test_fw is 'ansibletest'
+cifmw_test_operator_ansibletest_name: "ansibletest"
 cifmw_test_operator_ansibletest_registry: quay.io
 cifmw_test_operator_ansibletest_namespace: podified-antelope-centos9
 cifmw_test_operator_ansibletest_container: openstack-ansible-tests
@@ -204,6 +207,7 @@ cifmw_test_operator_ansibletest_config:
     debug: "{{ cifmw_test_operator_ansibletest_debug }}"
 
 # Section 5: horizontest parameters - used when run_test_fw is 'horizontest'
+cifmw_test_operator_horizontest_name: "horizontest-tests"
 cifmw_test_operator_horizontest_registry: quay.io
 cifmw_test_operator_horizontest_namespace: podified-antelope-centos9
 cifmw_test_operator_horizontest_container: openstack-horizontest

--- a/roles/test_operator/tasks/run-test-operator-job.yml
+++ b/roles/test_operator/tasks/run-test-operator-job.yml
@@ -115,7 +115,7 @@
           apiVersion: v1
           kind: Pod
           metadata:
-            name: "test-operator-logs-pod-{{ run_test_fw }}"
+            name: "test-operator-logs-pod-{{ run_test_fw }}-{{ test_operator_job_name }}"
             namespace: "{{ cifmw_test_operator_namespace }}"
           spec:
             containers:
@@ -134,7 +134,7 @@
         context: "{{ cifmw_openshift_context | default(omit) }}"
         namespace: "{{ cifmw_test_operator_namespace }}"
         kind: Pod
-        name: "test-operator-logs-pod-{{ run_test_fw }}"
+        name: "test-operator-logs-pod-{{ run_test_fw }}-{{ test_operator_job_name }}"
         wait: true
       register: logs_pod
       until: logs_pod.resources[0].status.phase == "Running"
@@ -149,7 +149,7 @@
         pod_path: mnt/logs-{{ test_operator_job_name }}-step-{{ index }}
       ansible.builtin.shell: >
         oc cp -n {{ cifmw_test_operator_namespace }}
-        openstack/test-operator-logs-pod-{{ run_test_fw }}:{{ pod_path }}
+        openstack/test-operator-logs-pod-{{ run_test_fw }}-{{ test_operator_job_name }}:{{ pod_path }}
         {{ cifmw_test_operator_artifacts_basedir }}
       loop: "{{ logsPVCs.resources }}"
       loop_control:
@@ -249,7 +249,7 @@
     kind: Pod
     state: absent
     api_version: v1
-    name: "test-operator-logs-pod-{{ run_test_fw }}"
+    name: "test-operator-logs-pod-{{ run_test_fw }}-{{ test_operator_job_name }}"
     namespace: "{{ cifmw_test_operator_namespace }}"
     wait: true
   when:

--- a/roles/test_operator/vars/main.yml
+++ b/roles/test_operator/vars/main.yml
@@ -14,10 +14,6 @@
 # under the License.
 
 cifmw_test_operator_controller_priv_key_secret_name: "test-operator-controller-priv-key"
-cifmw_test_operator_tempest_name: "tempest-tests"
-cifmw_test_operator_tobiko_name: "tobiko-tests"
-cifmw_test_operator_ansibletest_name: "ansibletest"
-cifmw_test_operator_horizontest_name: "horizontest-tests"
 cifmw_test_operator_tempest_kind_name: "Tempest"
 cifmw_test_operator_tobiko_kind_name: "Tobiko"
 cifmw_test_operator_ansibletest_kind_name: "AnsibleTest"


### PR DESCRIPTION
It was not possible to run the test-operator role multiple times without cleaning up all resources created by the first role run, such as the logs pod created for the logs collection.

This patch makes it possible to run the test operator role multiple times without cleaning up the resources (e.g., after the update in an update job). It is possible because:

- test-operator-logs pod now has unique name for each job run
- The variable cifmw_test_operator_*_name is now exposed. By specifying a unique name, we can guarantee no name collisions between the test-operator related resources (logs pods, instances of CRs)

If you want to run test-operator role twice within a single job then make sure that for the second run you specify a value for the cifmw_test_operator_*_name. For example:

  cifmw_test_operator_tempest_name: "post-update-tempest-tests"