### PR TITLE
Wait until ocp cluster is ready in adoption playbook

### DIFF
--- a/deploy-ocp.yml
+++ b/deploy-ocp.yml
@@ -67,3 +67,21 @@
       ansible.builtin.import_role:
         name: "libvirt_manager"
         tasks_from: "deploy_layout.yml"
+
+    # Run from the hypervisor
+    - name: Ensure OCP cluster is stable
+      vars:
+        _auth_path: >-
+          {{
+            (
+            cifmw_devscripts_repo_dir,
+            'ocp',
+            cifmw_devscripts_config.cluster_name,
+            'auth'
+            ) | ansible.builtin.path_join
+          }}
+        cifmw_openshift_adm_op: "stable"
+        cifmw_openshift_kubeconfig: >-
+          {{ (_auth_path, 'kubeconfig') | ansible.builtin.path_join }}
+      ansible.builtin.include_role:
+        name: openshift_adm


### PR DESCRIPTION
Wait until the ocp is ready and stable in the playbook that deploys ocp
to be used in the new adoption uni jobs.
