### PR TITLE
Add swift network to NetConfig for va-hci-base and restore default

### DIFF
--- a/scenarios/reproducers/networking-definition.yml
+++ b/scenarios/reproducers/networking-definition.yml
@@ -91,19 +91,6 @@ cifmw_networking_definition:
               end: 250
       vlan: 23
       mtu: 1500
-    swift:
-      network: "172.22.0.0/24"
-      tools:
-        netconfig:
-          ranges:
-            - start: 100
-              end: 250
-        multus:
-          ranges:
-            - start: 30
-              end: 70
-      vlan: 25
-      mtu: 1500
 
   group-templates:
     ocps:
@@ -118,8 +105,6 @@ cifmw_networking_definition:
         tenant:
           trunk-parent: ctlplane
         storage:
-          trunk-parent: ctlplane
-        swift:
           trunk-parent: ctlplane
     ocp_workers:
       network-template:
@@ -141,8 +126,6 @@ cifmw_networking_definition:
         storage:
           trunk-parent: ctlplane
         storagemgmt:
-          trunk-parent: ctlplane
-        swift:
           trunk-parent: ctlplane
     cephs:
       network-template:

--- a/scenarios/reproducers/va-hci-base.yml
+++ b/scenarios/reproducers/va-hci-base.yml
@@ -15,3 +15,160 @@ cifmw_ceph_client_service_values_post_ceph_path_src: >-
   {{ _arch_repo }}/examples/va/hci/service-values.yaml
 cifmw_ceph_client_service_values_post_ceph_path_dst: >-
   {{ cifmw_ceph_client_service_values_post_ceph_path_src }}
+
+cifmw_networking_definition:
+  networks:
+    ctlplane:
+      network: "192.168.122.0/24"
+      gateway: "192.168.122.1"
+      dns:
+        - "192.168.122.1"
+      mtu: 1500
+      tools:
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+        netconfig:
+          ranges:
+            - start: 100
+              end: 120
+            - start: 150
+              end: 170
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+    internalapi:
+      network: "172.17.0.0/24"
+      vlan: 20
+      mtu: 1496
+      tools:
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+    storage:
+      network: "172.18.0.0/24"
+      vlan: 21
+      mtu: 1496
+      tools:
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+    tenant:
+      network: "172.19.0.0/24"
+      tools:
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+      vlan: 22
+      mtu: 1496
+    external:
+      network: "10.0.0.0/24"
+      tools:
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+      vlan: 22
+      mtu: 1500
+    storagemgmt:
+      network: "172.20.0.0/24"
+      tools:
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+      vlan: 23
+      mtu: 1500
+    swift:
+      network: "172.22.0.0/24"
+      tools:
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+      vlan: 25
+      mtu: 1500
+
+  group-templates:
+    ocps:
+      network-template:
+        range:
+          start: 10
+          length: 10
+      networks: &ocps_nets
+        ctlplane: {}
+        internalapi:
+          trunk-parent: ctlplane
+        tenant:
+          trunk-parent: ctlplane
+        storage:
+          trunk-parent: ctlplane
+        swift:
+          trunk-parent: ctlplane
+    ocp_workers:
+      network-template:
+        range:
+          start: 20
+          length: 10
+      networks: *ocps_nets
+    computes:
+      network-template:
+        range:
+          start: 100
+          length: 21
+      networks: &computes_nets
+        ctlplane: {}
+        internalapi:
+          trunk-parent: ctlplane
+        tenant:
+          trunk-parent: ctlplane
+        storage:
+          trunk-parent: ctlplane
+        storagemgmt:
+          trunk-parent: ctlplane
+        swift:
+          trunk-parent: ctlplane
+    cephs:
+      network-template:
+        range:
+          start: 150
+          length: 21
+      networks: *computes_nets
+  instances:
+    controller-0:
+      networks:
+        ctlplane:
+          ip: "192.168.122.9"


### PR DESCRIPTION
This commit restores networking-definition.yml to its pre-swift state and overrides cifmw_networking_definition in va-hci-base.