### PR TITLE
Enable OvnFdbAgingTest and NeutronAPIServerTest

### DIFF
--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -135,9 +135,6 @@
               ^neutron_.*plugin..*scenario.test_.*macvtap
             # NOTE(mblue): If test skipped - please add related ticket to remove skip when issue resolved
             excludeList: |
-              # TODO(ralonsoh): enable "test_ovn_fdb" tests once [1] is merged and released.
-              # [1]https://review.opendev.org/c/x/whitebox-neutron-tempest-plugin/+/929410
-              ^whitebox_neutron_tempest_plugin.tests.scenario.test_ovn_fdb.*
               # remove when bug OSPRH-9569 resolved
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_metadata_rate_limiting
               # remove when bug OSPRH-7998 resolved
@@ -145,6 +142,7 @@
               # remove when issue OSPCIX-457 resolved
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging.*test_.*accepted_traffic_logged
               # neutron whitebox multi-thread tests (executed on different workflow step)
+              ^whitebox_neutron_tempest_plugin.tests.scenario.test_api_server.NeutronAPIServerTest
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_basic.NetworkBasicTest
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_broadcast.BroadcastTestIPv4Common
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_broadcast.BroadcastTestVlanTransparency
@@ -155,6 +153,7 @@
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_multicast.MulticastTestIPv4Common.test_igmp_snooping_same_network_and_unsubscribe
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_multicast.MulticastTestIPv4Ovn
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_multicast.MulticastTestVlanTransparency
+              ^whitebox_neutron_tempest_plugin.tests.scenario.test_ovn_fdb.OvnFdbAgingTest
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_portsecurity.PortSecurityTest
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_qos.QosTestCommon.test_bw_limit_east_west
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_qos.QosTestCommon.test_bw_limit_tenant_network


### PR DESCRIPTION
Two new testcase classes are enabled:
* scenario.test_ovn_fdb.OvnFdbAgingTest
* scenario.test_api_server.NeutronAPIServerTest

Related-Bug: #[OSPRH-2460](https://issues.redhat.com//browse/OSPRH-2460)
Related-Bug: #[OSPRH-893](https://issues.redhat.com//browse/OSPRH-893)