### PR TITLE
Wait for InstallPlan to complete when installing the OSP operators

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -212,6 +212,7 @@ img
 ingressvips
 ini
 init
+installplan
 installyamls
 ipaddr
 ipam

--- a/roles/kustomize_deploy/README.md
+++ b/roles/kustomize_deploy/README.md
@@ -96,6 +96,13 @@ with a message.
 
 ## Automation specificities
 
+### Timeouts
+
+Some tasks uses timeouts when applying or waiting for resources. Those timeouts can be controlled by:
+
+* `cifmw_kustomize_deploy_delay`: (Int) Ansible `delay` passed to tasks that waits for a resource to reach a target state (default `10`)
+* `cifmw_kustomize_deploy_retries_install_plan`: (Int) Ansible `retries` passed to tasks that wait for the InstallPlan (default `60`)
+
 ### Task tagging
 
 Tags are dynamically associated to each stage of the automated deployment.

--- a/roles/kustomize_deploy/defaults/main.yml
+++ b/roles/kustomize_deploy/defaults/main.yml
@@ -200,3 +200,8 @@ cifmw_kustomize_deploy_dp_dest_file: >-
       'dataplane.yaml'
     ] | path_join
   }}
+
+# timeouts
+
+cifmw_kustomize_deploy_delay: 10
+cifmw_kustomize_deploy_retries_install_plan: 60

--- a/roles/kustomize_deploy/tasks/install_operators.yml
+++ b/roles/kustomize_deploy/tasks/install_operators.yml
@@ -75,6 +75,64 @@
         state: present
         wait: true
         src: "{{ cifmw_kustomize_deploy_olm_dest_file }}"
+      register: _cifmw_kustomize_deploy_olm_apply_out
+
+    - name: Wait for the openstack operators InstallPlan to be created
+      vars:
+        _cifmw_kustomize_deploy_olm_osp_operator_sub: >-
+          {{
+            (
+              _cifmw_kustomize_deploy_olm_apply_out.result.results |
+              selectattr('result.kind', 'defined') |
+              selectattr('result.kind', 'equalto', 'Subscription') |
+              selectattr('result.spec.name', 'defined') |
+              selectattr('result.spec.name', 'equalto', 'openstack-operator') |
+              first
+            ).result
+          }}
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit) }}"
+        context: "{{ cifmw_openshift_context | default(omit) }}"
+        api_version: "{{ _cifmw_kustomize_deploy_olm_osp_operator_sub.apiVersion }}"
+        kind: Subscription
+        namespace: "{{ _cifmw_kustomize_deploy_olm_osp_operator_sub.metadata.namespace }}"
+        name: "{{ _cifmw_kustomize_deploy_olm_osp_operator_sub.metadata.name }}"
+      register: _cifmw_kustomize_deploy_olm_osp_operator_sub_out
+      retries: "{{ cifmw_kustomize_deploy_retries_install_plan }}"
+      delay: "{{ cifmw_kustomize_deploy_delay }}"
+      until:
+        - _cifmw_kustomize_deploy_olm_osp_operator_sub_out.failed is false
+        - _cifmw_kustomize_deploy_olm_osp_operator_sub_out.resources is defined
+        - _cifmw_kustomize_deploy_olm_osp_operator_sub_out.resources | length == 1
+        - (_cifmw_kustomize_deploy_olm_osp_operator_sub_out.resources | first)['status']['installPlanRef'] is defined
+
+    - name: Wait for the openstack operators InstallPlan to be finish
+      vars:
+        _install_plan: >-
+          {{
+            (_cifmw_kustomize_deploy_olm_osp_operator_sub_out.resources | first).status.installPlanRef
+          }}
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit) }}"
+        context: "{{ cifmw_openshift_context | default(omit) }}"
+        api_version: "{{ _install_plan.apiVersion }}"
+        kind: InstallPlan
+        namespace: "{{ _install_plan.namespace }}"
+        name: "{{ _install_plan.name }}"
+      register: _cifmw_kustomize_deploy_olm_osp_operator_install_plan_out
+      retries: "{{ cifmw_kustomize_deploy_retries_install_plan }}"
+      delay: "{{ cifmw_kustomize_deploy_delay }}"
+      until:
+        - _cifmw_kustomize_deploy_olm_osp_operator_install_plan_out.failed is false
+        - _cifmw_kustomize_deploy_olm_osp_operator_install_plan_out.resources is defined
+        - _cifmw_kustomize_deploy_olm_osp_operator_install_plan_out.resources | length == 1
+        - >-
+          (
+            _cifmw_kustomize_deploy_olm_osp_operator_install_plan_out.resources | first
+          ).status.phase | lower == "complete"
+
 
     - name: Wait for cert-manager-operator pods
       kubernetes.core.k8s_info:


### PR DESCRIPTION
Till now we weren't waiting for the OSP operators to be completely installed what may cause some race conditions. This PR ensure the InstallPlan is completed before proceeding consuming the deployed operators.