### PR TITLE
DT - BMO deploy with preprovisioningNetworkData

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/bmo01/baremetalhost-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bmo01/baremetalhost-values/values.yaml.j2
@@ -1,0 +1,21 @@
+---
+# source: bmo01/baremetalhost-values/values.yaml.j2
+data:
+{% for host in cifmw_networking_env_definition.instances.keys() if host is match('^(leaf0|leaf1).*') %}
+{% if cifmw_run_id is defined %}
+{% set _host = host | replace('-' + cifmw_run_id, '') %}
+{% else %}
+{% set _host = host %}
+{% endif %}
+  {{ _host }}:
+    bmc:
+      address: {{ cifmw_baremetal_hosts[host].connection }}
+      credentialsName: bmc-secret
+    bootMACAddress: {{ cifmw_baremetal_hosts[host].nics[0].mac }}
+    labels:
+      app: openstack
+      nodeset: {{ host | split('-') | first }}
+    name: {{ host }}
+    rootDeviceHints:
+      deviceName: /dev/sda
+{% endfor %}

--- a/roles/ci_gen_kustomize_values/templates/bmo01/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bmo01/network-values/values.yaml.j2
@@ -1,0 +1,15 @@
+---
+# source: bmo01/network-values/values.yaml.j2
+{% set _ipv = cifmw_ci_gen_kustomize_values_ip_version_var_mapping %}
+{% set ns = namespace(ocp_index=0) %}
+data:
+{% for host in cifmw_networking_env_definition.instances.keys() -%}
+{%   if host is match('^(ocp|crc).*') %}
+  node_{{ ns.ocp_index }}:
+{%     set ns.ocp_index = ns.ocp_index+1 %}
+    name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}
+{%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
+    {{ network.network_name }}_ip: {{ network[_ipv.ip_vX] }}
+{%     endfor %}
+{%   endif %}
+{% endfor %}

--- a/roles/ci_gen_kustomize_values/templates/bmo01/nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bmo01/nodeset-values/values.yaml.j2
@@ -1,0 +1,29 @@
+---
+# source: bmo01/nodeset-values/values.yaml.j2
+data:
+  nodeset0:
+    timesync_ntp_servers:
+      - hostname: "{{ cifmw_ci_gen_kustomize_values_ntp_srv | default('pool.ntp.org') }}"
+    edpm_bootstrap_command: |
+      # root CA
+      pushd /etc/pki/ca-trust/source/anchors/
+      curl -LOk {{ cifmw_install_ca_url }}
+      update-ca-trust
+      popd
+
+      # install rhos-release repos
+      dnf --nogpgcheck install -y {{ cifmw_repo_setup_rhos_release_rpm }}
+      rhos-release {{ cifmw_repo_setup_rhos_release_args }}
+  nodeset1:
+    timesync_ntp_servers:
+      - hostname: "{{ cifmw_ci_gen_kustomize_values_ntp_srv | default('pool.ntp.org') }}"
+    edpm_bootstrap_command: |
+      # root CA
+      pushd /etc/pki/ca-trust/source/anchors/
+      curl -LOk {{ cifmw_install_ca_url }}
+      update-ca-trust
+      popd
+
+      # install rhos-release repos
+      dnf --nogpgcheck install -y {{ cifmw_repo_setup_rhos_release_rpm }}
+      rhos-release {{ cifmw_repo_setup_rhos_release_args }}

--- a/roles/ci_gen_kustomize_values/templates/bmo01/secret-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bmo01/secret-values/values.yaml.j2
@@ -1,0 +1,12 @@
+---
+# source: bmo01/secret-values/values.yaml.j2
+data:
+  ssh_keys:
+    authorized: {{ cifmw_ci_gen_kustomize_values_ssh_authorizedkeys | b64encode }}
+    private: {{ cifmw_ci_gen_kustomize_values_ssh_private_key | b64encode }}
+    public: {{ cifmw_ci_gen_kustomize_values_ssh_public_key | b64encode }}
+  nova:
+    migration:
+      ssh_keys:
+        private: {{ cifmw_ci_gen_kustomize_values_migration_priv_key | b64encode }}
+        public: {{ cifmw_ci_gen_kustomize_values_migration_pub_key | b64encode }}


### PR DESCRIPTION
This adds ci_gen_kustomize_values for the proposed `bmo01` deployment
topology in openstack-k8s-operators/architecture PR:
https://github.com/openstack-k8s-operators/architecture/pull/413

This DT ...
* Uses OCP Metal3 to provision the compute nodes over redfish-virtualmedia.
* Deploys the two pairs of compute nodes in separate networks -
  routed/spine-and-leaf architecture.