### PR TITLE
Update DCN scenario parameters

### DIFF
--- a/scenarios/reproducers/va-dcn.yml
+++ b/scenarios/reproducers/va-dcn.yml
@@ -13,9 +13,10 @@ cifmw_lvms_disk_list:
   - /dev/vdc
 cifmw_devscripts_cinder_volume_pvs: []
 cifmw_run_tests: false
+cifmw_cephadm_log_path: /home/zuul/ci-framework-data/logs
 cifmw_arch_automation_file: dcn.yaml
 cifmw_libvirt_manager_pub_net: ocpbm
-cifmw_reproducer_validate_network_host: "192.168.111.9"
+cifmw_reproducer_validate_network_host: "192.168.122.1"
 cifmw_libvirt_manager_default_gw_nets:
   - ocpbm
   - dcn1_tr
@@ -33,7 +34,7 @@ cifmw_libvirt_manager_configuration:
     osp_trunk: |
       <network>
         <name>osp_trunk</name>
-        <forward mode='nat'/>
+        <forward mode='open'/>
         <bridge name='osp_trunk' stp='on' delay='0'/>
         <dns enable="no"/>
         <ip family='ipv4'
@@ -69,7 +70,7 @@ cifmw_libvirt_manager_configuration:
     dcn1_tr: |
       <network>
         <name>dcn1_tr</name>
-          <forward mode='nat'/>
+          <forward mode='open'/>
             <bridge name='dcn1_tr' stp='on' delay='0'/>
               <ip family='ipv4' address='192.168.133.1' prefix='24'>
               </ip>
@@ -85,7 +86,7 @@ cifmw_libvirt_manager_configuration:
     dcn2_tr: |
       <network>
         <name>dcn2_tr</name>
-          <forward mode='nat'/>
+          <forward mode='open'/>
             <bridge name='dcn2_tr' stp='on' delay='0'/>
               <ip family='ipv4' address='192.168.144.1' prefix='24'>
               </ip>


### PR DESCRIPTION
- Moving the `cifmw_cephadm_log_path` parameter from the job definition to scenario configuration.
- Updated all trunk switch configurations to use the `open` bridge type.