### PR TITLE
Removing some WNTP tests from excludelist

### DIFF
--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -135,15 +135,8 @@
               ^neutron_.*plugin..*scenario.test_.*macvtap
             # NOTE(mblue): If test skipped - please add related ticket to remove skip when issue resolved
             excludeList: |
-              # TODO(ralonsoh): enable "test_ovn_fdb" tests once [1] is merged and released.
-              # [1]https://review.opendev.org/c/x/whitebox-neutron-tempest-plugin/+/929410
-              ^whitebox_neutron_tempest_plugin.tests.scenario.test_ovn_fdb.*
               # remove when bug OSPRH-9569 resolved
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_metadata_rate_limiting
-              # remove when bug OSPRH-7998 resolved
-              ^whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging.*test_only_dropped_traffic_logged
-              # remove when issue OSPCIX-457 resolved
-              ^whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging.*test_.*accepted_traffic_logged
               # neutron whitebox multi-thread tests (executed on different workflow step)
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_basic.NetworkBasicTest
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_broadcast.BroadcastTestIPv4Common


### PR DESCRIPTION
This patch only applies to the
`whitebox-neutron-tempest-plugin-podified-multinode-edpm-deployment-crc-2comp` job.
Some tests were skipped due to related bugs. They are removed from excludelist because those bugs have been fixed.