### PR TITLE
libvirt_manager/extra_net_config - nmstate format

### DIFF
--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -44,6 +44,7 @@ Used for checking if:
 * `cifmw_libvirt_manager_attach_dummy_interface_on_bridges`: (Bool) Attach dummy interface on bridges. Defaults to `true`.
 * `cifmw_libvirt_manager_default_gw_nets`: (List[String]) List of networks used as default gateway. If not set, defaults to the `cifmw_libvirt_manager_pub_net`. Read bellow for more information about that parameter.
 * `cifmw_libvirt_manager_vm_users`: (List[Dict]) Used to override the default list of users enabled in the vm. For its format, refers to cloud-init [documentation](https://cloudinit.readthedocs.io/en/latest/reference/modules.html#users-and-groups) about `users`. Defaults to `[]`.
+* `cifmw_libvirt_manager_extra_network_configuration`: (Dict) Extra network configuration in nmstate format for the hypervisor. This configuration is applied after creating the libvirt networks, so it can be used to create VLAN interfaces on the libvirt bridges. Defaults to: `{}`.
 
 ### `cifmw_libvirt_manager_default_gw_nets` parameter usage
 
@@ -109,6 +110,22 @@ _networks:
     default: true
     range: "192.168.122.0/24"
     mtu: 9000
+
+cifmw_libvirt_manager_extra_network_configuration:
+  interfaces:
+    - name: vlan10
+      type: vlan
+      state: up
+      vlan:
+        base-iface: cifmw-osp_trunk
+        id: 10
+        protocol: 802.1q
+      ipv4:
+        enabled: true
+        dhcp: false
+        address:
+          - ip: 172.20.0.1
+            prefix-length: 24
 
 cifmw_libvirt_manager_configuration:
   vms:

--- a/roles/libvirt_manager/defaults/main.yml
+++ b/roles/libvirt_manager/defaults/main.yml
@@ -85,5 +85,6 @@ cifmw_libvirt_manager_firewalld_zone_libvirt_forward: true
 cifmw_libvirt_manager_firewalld_default_zone: public
 cifmw_libvirt_manager_firewalld_default_zone_masquerade: true
 cifmw_libvirt_manager_attach_dummy_interface_on_bridges: true
+cifmw_libvirt_manager_extra_network_configuration: {}
 
 cifmw_libvirt_manager_vm_users: []

--- a/roles/libvirt_manager/molecule/ocp_layout/converge.yml
+++ b/roles/libvirt_manager/molecule/ocp_layout/converge.yml
@@ -66,6 +66,35 @@
         file: net-def.yml
 
     - name: Generate networking data
+      vars:
+        cifmw_libvirt_manager_extra_network_configuration:
+          interfaces:
+            - name: "vlan{{ cifmw_networking_definition.networks.internalapi.vlan }}"
+              type: vlan
+              state: up
+              vlan:
+                base-iface: cifmw-public
+                id: "{{ cifmw_networking_definition.networks.internalapi.vlan }}"
+                protocol: 802.1q
+              ipv4:
+                enabled: true
+                dhcp: false
+                address:
+                  - ip: "{{ cifmw_networking_definition.networks.internalapi.gateway }}"
+                    prefix-length: "{{ cifmw_networking_definition.networks.internalapi.network | ansible.utils.ipaddr('prefix') }}"
+            - name: "vlan{{ cifmw_networking_definition.networks.storage.vlan }}"
+              type: vlan
+              state: up
+              vlan:
+                base-iface: cifmw-public
+                id: "{{ cifmw_networking_definition.networks.storage.vlan }}"
+                protocol: 802.1q
+              ipv4:
+                enabled: true
+                dhcp: false
+                address:
+                  - ip: "{{ cifmw_networking_definition.networks.storage.gateway }}"
+                    prefix-length: "{{ cifmw_networking_definition.networks.storage.network | ansible.utils.ipaddr('prefix') }}"
       ansible.builtin.import_role:
         name: libvirt_manager
         tasks_from: generate_networking_data
@@ -163,3 +192,20 @@
             msg: >-
               Expected {{ _expected_imgs }} while found
               {{ _existing_imgs }}
+
+        - name: List all interfaces
+          register: _ip_link_show
+          ansible.builtin.command: ip -json link show
+
+        - name: Ensure the VLAN interfaces was created
+          vars:
+            _vlan_interfaces:
+              - "vlan{{ cifmw_networking_definition.networks.internalapi.vlan }}"
+              - "vlan{{ cifmw_networking_definition.networks.storage.vlan }}"
+          ansible.builtin.assert:
+            quiet: true
+            that:
+              - _ip_link_show.stdout | from_json | selectattr('ifname', 'eq', item) | length > 0
+            msg: >-
+              Expected vlan {{ item }} not found
+          loop: "{{ _vlan_interfaces }}"

--- a/roles/libvirt_manager/molecule/ocp_layout/vars/net-def.yml
+++ b/roles/libvirt_manager/molecule/ocp_layout/vars/net-def.yml
@@ -24,6 +24,7 @@ cifmw_networking_definition:
               end: 90
     internalapi:
       network: "172.17.0.0/24"
+      gateway: "172.17.0.1"
       vlan: 20
       mtu: 1496
       tools:
@@ -41,6 +42,7 @@ cifmw_networking_definition:
               end: 70
     storage:
       network: "172.18.0.0/24"
+      gateway: "172.18.0.1"
       vlan: 21
       mtu: 1496
       tools:
@@ -58,6 +60,7 @@ cifmw_networking_definition:
               end: 70
     tenant:
       network: "172.19.0.0/24"
+      gateway: "172.19.0.1"
       tools:
         metallb:
           ranges:
@@ -84,6 +87,7 @@ cifmw_networking_definition:
       mtu: 1500
     storagemgmt:
       network: "172.20.0.0/24"
+      gateway: "172.20.0.1"
       tools:
         netconfig:
           ranges:

--- a/roles/libvirt_manager/tasks/create_networks.yml
+++ b/roles/libvirt_manager/tasks/create_networks.yml
@@ -86,6 +86,15 @@
   when: cifmw_libvirt_manager_attach_dummy_interface_on_bridges | bool
   ansible.builtin.include_tasks: create_networks_dummy_interfaces.yml
 
+- name: Create extra network configuration
+  when: cifmw_libvirt_manager_extra_network_configuration | default({}) | length > 0
+  vars:
+    cifmw_ci_nmstate_unmanaged_host: "{{ inventory_hostname }}"
+    cifmw_ci_nmstate_unmanaged_node_config: "{{ cifmw_libvirt_manager_extra_network_configuration }}"
+  ansible.builtin.include_role:
+    name: "ci_nmstate"
+    tasks_from: "nmstate_unmanaged_provision_node.yml"
+
 ## Ensure we get dnsmasq DHCP service for all created networks
 # Refreshing network facts will ensure we get the new interfaces.
 # They (usually?) have the same name as the network itself.


### PR DESCRIPTION
Add a new parameter to libvirt_manager role:
  cifmw_libvirt_manager_extra_network_configuration

When set the raw nmstate configuration defined in the parameter is added using the `ci_nmstate` after creating the libvirt bridges. One usecase is to add VLAN interfaces on the hypervisor.

For example:
```
cifmw_libvirt_manager_extra_network_configuration:
  interfaces:
    - name: "vlan{{ cifmw_networking_definition.networks.internalapi.vlan }}"
      type: vlan
      state: up
      vlan:
        base-iface: cifmw-osp_trunk
        id: "{{ cifmw_networking_definition.networks.internalapi.vlan }}"
        protocol: 802.1q
      ipv4:
        enabled: true
        dhcp: false
        address:
          - ip: "{{ cifmw_networking_definition.networks.internalapi.gateway }}"
            prefix-length: "{{ cifmw_networking_definition.networks.internalapi.network | ansible.utils.ipaddr('prefix') }}"
    - name: "vlan{{ cifmw_networking_definition.networks.internalapi1.vlan }}"
      type: vlan
      state: up
      vlan:
        base-iface: cifmw-trunk1
        id: "{{ cifmw_networking_definition.networks.internalapi1.vlan }}"
        protocol: 802.1q
      ipv4:
        enabled: true
        dhcp: false
        address:
          - ip: "{{ cifmw_networking_definition.networks.internalapi1.gateway }}"
            prefix-length: "{{ cifmw_networking_definition.networks.internalapi1.network | ansible.utils.ipaddr('prefix') }}"
```