### PR TITLE
Use extra disks on compute nodes for ceph

### DIFF
--- a/scenarios/reproducers/va-dcn.yml
+++ b/scenarios/reproducers/va-dcn.yml
@@ -118,6 +118,8 @@ cifmw_libvirt_manager_configuration:
       disksize: "{{ [cifmw_libvirt_manager_compute_disksize|int, 50] | max }}"
       memory: "{{ [cifmw_libvirt_manager_compute_memory|int, 8] | max }}"
       cpus: "{{ [cifmw_libvirt_manager_compute_cpus|int, 4] | max }}"
+      extra_disks_num: 3
+      extra_disks_size: 30G
       nets:
         - ocpbm
         - osp_trunk


### PR DESCRIPTION
Add `extra_disks_num` and `extra_disks_size` to scenarios/reproducers/va-dcn.yml to be used the same way as they are in va-hci.yml.

The job, which calls the ceph playbook, will need its definition updated to remove the variables `cifmw_block_device_size` and `cifmw_num_osds_perhost` and then add the following in it's place.

```
cifmw_ceph_spec_data_devices: >-
  data_devices:
    all: true
```