### PR TITLE
[edpm_deploy_baremetal] Allow passing extra nova-compute config

### DIFF
--- a/roles/edpm_deploy_baremetal/README.md
+++ b/roles/edpm_deploy_baremetal/README.md
@@ -18,6 +18,7 @@ This role doesn't need privilege escalation.
 * `cifmw_edpm_deploy_baremetal_update_os_containers`: (Boolean) Update the uefi image. Default: `false`
 * `cifmw_edpm_deploy_baremetal_repo_setup_override`: (Boolean) Override the repo-setup service in OpenStackDataPlane with repo-setup-downstream. Default: `false`
 * `cifmw_edpm_deploy_baremetal_create_vms`: (Boolean) If enabled, compute nodes are pre-provisioned using Ironic else OpenStackProvisioner. Default: `true`
+* `cifmw_edpm_deploy_baremetal_nova_compute_extra_config`: (String) Oslo config snippet defining extra configuration for the nova-compute services. Defaults to an empty string.
 
 ## Examples
 

--- a/roles/edpm_deploy_baremetal/defaults/main.yml
+++ b/roles/edpm_deploy_baremetal/defaults/main.yml
@@ -28,3 +28,4 @@ cifmw_edpm_deploy_baremetal_wait_dataplane_timeout_mins: 40
 cifmw_edpm_deploy_baremetal_update_os_containers: false
 cifmw_edpm_deploy_baremetal_repo_setup_override: false
 cifmw_edpm_deploy_baremetal_create_vms: true
+cifmw_edpm_deploy_baremetal_nova_compute_extra_config: ""

--- a/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -64,6 +64,30 @@
     name: 'install_yamls_makes'
     tasks_from: 'make_edpm_baremetal_compute'
 
+- name: Pass through extra nova-compute config
+  when:
+    - cifmw_edpm_deploy_baremetal_nova_compute_extra_config is defined
+    - cifmw_edpm_deploy_baremetal_nova_compute_extra_config | length > 0
+  tags:
+    - always
+  vars:
+    _cifmw_edpm_deploy_baremetal_nova_extra_config_file: "{{ cifmw_edpm_deploy_baremetal_basedir }}/nova-extra-config.conf"
+  block:
+    - name: Create the config file
+      ansible.builtin.copy:
+        mode: "0644"
+        content: "{{ cifmw_edpm_deploy_baremetal_nova_compute_extra_config }}"
+        dest: "{{ _cifmw_edpm_deploy_baremetal_nova_extra_config_file }}"
+
+    - name: Define DATAPLANE_EXTRA_NOVA_CONFIG_FILE
+      ansible.builtin.set_fact:
+        cifmw_edpm_deploy_baremetal_common_env: >-
+          {{
+            cifmw_edpm_deploy_baremetal_common_env | default({}) |
+            combine({'DATAPLANE_EXTRA_NOVA_CONFIG_FILE': _cifmw_edpm_deploy_baremetal_nova_extra_config_file })
+          }}
+        cacheable: true
+
 - name: Prepare OpenStack Dataplane NodeSet CR
   vars:
     make_edpm_deploy_baremetal_prep_env: "{{ cifmw_edpm_deploy_baremetal_common_env |


### PR DESCRIPTION
Similar to what done for edpm_deploy[1], required changes on install_yamls side already covered with [2]

Needed by: https://review.rdoproject.org/r/c/testproject/+/54904

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/941
[2] https://github.com/openstack-k8s-operators/install_yamls/pull/729