### PR TITLE
Ignore validation errors

### DIFF
--- a/roles/validations/defaults/main.yml
+++ b/roles/validations/defaults/main.yml
@@ -49,3 +49,7 @@ cifmw_validations_custom_nova_service: "nova-custom-ceph"
 cifmw_validations_edpm_scale_down_hostname: compute-2.ctlplane.example.com
 cifmw_validations_edpm_scale_down_nodename: edpm-compute-2
 cifmw_validations_timeout: 100
+
+cifmw_validations_polarion_reporting:
+  failureCount: 0
+  tests: 0

--- a/roles/validations/tasks/main.yml
+++ b/roles/validations/tasks/main.yml
@@ -14,6 +14,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Set error_count for polarion reporting
+  ansible.builtin.set_fact:
+    error_count: 0
 
 # Create data collection directories
 - name: Ensure directories exist
@@ -39,15 +42,11 @@
         recurse: true
         # We need to exclude this file from the list of found validations to avoid an infinite loop.
         excludes: "{{ cifmw_validations_default_path }}/main.yml"
-
-    - name: Run all found validations
-      ansible.builtin.include_tasks:
-        file: "{{ item.path }}"
-      loop: "{{ found_validations.files }}"
-      # We can ignore errors that come from each validation, as we will collate them
-      # and report on the overall status at the end.
-      ignore_errors: true
-
+    
+    - name: Set required validations list
+      ansible.builtin.set_fact:
+        required_validations: found_validations
+    
 - name: Run selected validations
   when: not cifmw_validations_run_all | bool
   block:
@@ -58,9 +57,26 @@
       register: validation_exists
       failed_when: not validation_exists.stat.exists
 
-    - name: Run validations
-      ansible.builtin.include_tasks: "{{ item }}"
-      loop: "{{ cifmw_validations_list }}"
-      # We can ignore errors that come from each validation, as we will collate them
-      # and report on the overall status at the end.
+    - name: Set required validations list
+      ansible.builtin.set_fact:
+        required_validations: cifmw_validations_list
+
+- name: Run validations
+  block:
+    - name: Update validations count
+      ansible.builtin.set_fact:
+        cifmw_validations_polarion_reporting:
+          tests: "{{ found_validations | length }}"
+    
+    - name: Run required validations
+      ansible.builtin.include_tasks: "{{ itme }}"
       ignore_errors: true
+      register: validation_result
+
+    - name: Increment error count as required
+      ansible.builtin.set_fact:
+        cifmw_validations_polarion_reporting:
+          failureCount: " {{ error_count | int +1 }}"
+      when: validation_result is failed
+    
+  loop: required_validations

--- a/roles/validations/tasks/main.yml
+++ b/roles/validations/tasks/main.yml
@@ -44,6 +44,9 @@
       ansible.builtin.include_tasks:
         file: "{{ item.path }}"
       loop: "{{ found_validations.files }}"
+      # We can ignore errors that come from each validation, as we will collate them
+      # and report on the overall status at the end.
+      ignore_errors: true
 
 - name: Run selected validations
   when: not cifmw_validations_run_all | bool
@@ -58,3 +61,6 @@
     - name: Run validations
       ansible.builtin.include_tasks: "{{ item }}"
       loop: "{{ cifmw_validations_list }}"
+      # We can ignore errors that come from each validation, as we will collate them
+      # and report on the overall status at the end.
+      ignore_errors: true


### PR DESCRIPTION
We will ignore validation errors coming from the validations role and instead report on each failure in the validation itself. This allows us to run all validations even if one is failing, and then report effectively on the failures.