### PR TITLE
Re add traffic logging tests to skiplist

### DIFF
--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -137,6 +137,10 @@
             excludeList: |
               # remove when bug OSPRH-9569 resolved
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_metadata_rate_limiting
+              # remove when bug OSPRH-7998 resolved
+              ^whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging.*test_only_dropped_traffic_logged
+              # remove when issue OSPCIX-457 resolved
+              ^whitebox_neutron_tempest_plugin.tests.scenario.test_security_group_logging.*test_.*accepted_traffic_logged
               # neutron whitebox multi-thread tests (executed on different workflow step)
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_basic.NetworkBasicTest
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_broadcast.BroadcastTestIPv4Common


### PR DESCRIPTION
This partial revert of [1], the tests are still failing. original change was merged without validating.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/2431

Related-Issue: [OSPRH-7998](https://issues.redhat.com//browse/OSPRH-7998)
Related-Issue: [OSPCIX-457](https://issues.redhat.com//browse/OSPCIX-457)