### PR TITLE
Don't consider non-ocp vms for deploy-ocp

### DIFF
--- a/deploy-ocp.yml
+++ b/deploy-ocp.yml
@@ -30,25 +30,24 @@
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: true
   tasks:
-    # Inject "start: false" in the layout to not start any VM yet.
-    # Starting the VM will be done later, either by the tool deploying
-    # OSP, or the one deploy RHOSO.
-    # VM initial configuration, when managed, is done using cloud-init.
-    - name: Ensure no VM is started when we create them during this run
+    # Filter out non-ocp vms, that are created, but not started by the
+    # create-infra plabyook.
+    # The rest are created by the create-infra playbook, and managing
+    # them from here can cause problems in some environments, e.g
+    # when running each playbook from a different zuul vm
+    - name: Filter out non ocp vms from libvirt layout
       vars:
-        _no_start: >-
-          {% set _vms = {}                                          -%}
-          {% for _type in _cifmw_libvirt_manager_layout.vms.keys()  -%}
-          {%   if _type is not match('^ocp.*')                      -%}
-          {%     set _ = _vms.update({_type: {'start': false}})     -%}
-          {%   endif                                                -%}
-          {% endfor                                                 -%}
-          {{ _vms }}
+        _non_ocp_vms: >-
+          {{
+            _cifmw_libvirt_manager_layout.vms |
+            list | reject('match', '^ocp.*')
+
+          }}
       ansible.builtin.set_fact:
         _cifmw_libvirt_manager_layout: >-
           {{
             _cifmw_libvirt_manager_layout |
-            combine({'vms': _no_start}, recursive=true)
+            ansible.utils.remove_keys(target=_non_ocp_vms)
           }}
 
 - name: Prepare networking


### PR DESCRIPTION
When running in zuul, if we keep the non-ocp vms in the libvirt layout
when running from different executors, the config_drive crashes because
the user data changes. This change filters out the non-ocp vms from the
libvirt layout to avoid this problem.
