### PR TITLE
Ensure crc dnsmasq server entries are not duplicated

### DIFF
--- a/ci/playbooks/multinode-customizations.yml
+++ b/ci/playbooks/multinode-customizations.yml
@@ -89,13 +89,13 @@
           block:
             - name: Configure dns forwarders
               become: true
-              ansible.builtin.blockinfile:
+              ansible.builtin.lineinfile:
                 path: "{{ _dnsmasq_config }}"
-                block: |-
-                  {% for dns_server in _crc_default_net_dns %}
-                  server={{ dns_server }}
-                  {% endfor %}
+                regexp: "^server\\s=\\s{{ item }}"
+                insertafter: "EOF"
+                line: "server={{ item }}"
                 validate: "{{ _validate }}"
+              loop: "{{ _crc_default_net_dns }}"
 
             - name: Configure local DNS for CRC pod
               become: true


### PR DESCRIPTION
Replace the blockinline by lineinfile to avoid injecting multiple times the same server in the dnsmasq config.