### PR TITLE
[test-operator] Expose SELinuxLevel parameter

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -23,6 +23,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_storage_class`: (String) Value for `storageClass` in generated Tempest or Tobiko CRD file. Defaults to `"lvms-local-storage"` only if `cifmw_use_lvms` is True, otherwise it defaults to `"local-storage"`.
 * `cifmw_test_operator_delete_logs_pod`: (Boolean) Delete tempest log pod created by the role at the end of the testing. Default value: `false`.
 * `cifmw_test_operator_privileged`: (Boolean) Spawn the test pods with `allowPrivilegedEscalation: true` and default linux capabilities. This is required for certain test-operator functionalities to work properly (e.g.: `extraRPMs`, certain set of tobiko tests). Default value: `true`
+* `cifmw_test_operator_selinux_level`: (String) Specify SELinux level that should be used for pods spawned with the test-operator. Note, that `cifmw_test_operator_privileged: true` must be set when this parameter has non-empty value. Default value: `s0:c478,c978`
 
 ## Tempest specific parameters
 * `cifmw_test_operator_tempest_registry`: (String) The registry where to pull tempest container. Default value: `quay.io`

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -37,6 +37,7 @@ cifmw_test_operator_storage_class_prefix: "{{ 'lvms-' if cifmw_use_lvms | defaul
 cifmw_test_operator_storage_class: "{{ cifmw_test_operator_storage_class_prefix }}local-storage"
 cifmw_test_operator_delete_logs_pod: false
 cifmw_test_operator_privileged: true
+cifmw_test_operator_selinux_level: "s0:c478,c978"
 
 # Section 2: tempest parameters - used when run_test_fw is 'tempest'
 cifmw_test_operator_tempest_registry: quay.io
@@ -100,6 +101,7 @@ cifmw_test_operator_tempest_config:
     containerImage: "{{ cifmw_test_operator_tempest_image }}:{{ cifmw_test_operator_tempest_image_tag }}"
     storageClass: "{{ cifmw_test_operator_storage_class }}"
     privileged: "{{ cifmw_test_operator_privileged }}"
+    SELinuxLevel: "{{ cifmw_test_operator_selinux_level }}"
     parallel: "{{ cifmw_test_operator_tempest_parallel | default(omit) }}"
     SSHKeySecretName: "{{ cifmw_test_operator_tempest_ssh_key_secret_name | default(omit) }}"
     configOverwrite: "{{ cifmw_test_operator_tempest_config_overwrite | default(omit) }}"
@@ -146,6 +148,7 @@ cifmw_test_operator_tobiko_config:
     kubeconfigSecretName: "{{ cifmw_test_operator_tobiko_kubeconfig_secret }}"
     storageClass: "{{ cifmw_test_operator_storage_class }}"
     privileged: "{{ cifmw_test_operator_privileged }}"
+    SELinuxLevel: "{{ cifmw_test_operator_selinux_level }}"
     containerImage: "{{ cifmw_test_operator_tobiko_image }}:{{ cifmw_test_operator_tobiko_image_tag }}"
     testenv: "{{ cifmw_test_operator_tobiko_testenv }}"
     version: "{{ cifmw_test_operator_tobiko_version }}"
@@ -190,6 +193,7 @@ cifmw_test_operator_ansibletest_config:
     extraConfigmapsMounts: "{{ cifmw_test_operator_ansibletest_extra_configmaps_mounts }}"
     storageClass: "{{ cifmw_test_operator_storage_class }}"
     privileged: "{{ cifmw_test_operator_privileged }}"
+    SELinuxLevel: "{{ cifmw_test_operator_selinux_level }}"
     computeSSHKeySecretName: "{{ cifmw_test_operator_ansibletest_compute_ssh_key_secret_name }}"
     workloadSSHKeySecretName: "{{ cifmw_test_operator_ansibletest_workload_ssh_key_secret_name }}"
     ansibleGitRepo: "{{ cifmw_test_operator_ansibletest_ansible_git_repo }}"
@@ -231,6 +235,7 @@ cifmw_test_operator_horizontest_config:
   spec:
     storageClass: "{{ cifmw_test_operator_storage_class }}"
     privileged: "{{ cifmw_test_operator_privileged }}"
+    SELinuxLevel: "{{ cifmw_test_operator_selinux_level }}"
     containerImage: "{{ cifmw_test_operator_horizontest_image }}:{{ cifmw_test_operator_horizontest_image_tag }}"
     adminUsername: "{{ cifmw_test_operator_horizontest_admin_username }}"
     adminPassword: "{{ cifmw_test_operator_horizontest_admin_password }}"


### PR DESCRIPTION
This commit exposes SELinuxLevel parameter for the test-operator CRs.
This parameter is required for the RWX PVCs to work properly.
