### PR TITLE
Enable COO in osasinfra DT

### DIFF
--- a/scenarios/reproducers/dt-osasinfra.yml
+++ b/scenarios/reproducers/dt-osasinfra.yml
@@ -141,3 +141,5 @@ cifmw_ceph_daemons_layout:
   dashboard_enabled: false
   cephfs_enabled: true
   ceph_nfs_enabled: true
+
+cifmw_deploy_obs: true


### PR DESCRIPTION
This is a requirement for telemetry that we're adding to the OSASINFRA DT via a separate architecture PR.