### PR TITLE
Introduce DCN custom playbooks

### DIFF
--- a/playbooks/dcn/deploy-dcn.yml
+++ b/playbooks/dcn/deploy-dcn.yml
@@ -1,0 +1,48 @@
+---
+- name: Deploy DCN environment
+  hosts: localhost
+  vars:
+    _arch_repo_path: /home/zuul/src/github.com/openstack-k8s-operators/architecture
+    _cifmw_repo_path: /home/zuul/src/github.com/openstack-k8s-operators/ci-framework
+    _jinja_template_src: "{{ _cifmw_repo_path }}/roles/ci_gen_kustomize_values/templates/dcn"
+    _arch_deployment_path: "{{ _arch_repo_path }}/examples/dt/dcn"
+  tasks:
+    - name: Load reproducer-variables
+      ansible.builtin.include_vars:
+        file: "~/reproducer-variables.yml"
+
+    - name: Load networking-environment-definition
+      ansible.builtin.include_vars:
+        file: "/etc/ci/env/networking-environment-definition.yml"
+        name: cifmw_networking_env_definition
+
+    - name: Get OpenShift access token
+      kubernetes.core.k8s_auth:
+        host: "{{ cifmw_openshift_api }}"
+        username: "{{ cifmw_openshift_user }}"
+        password: "{{ cifmw_openshift_password }}"
+        validate_certs: no
+      register: _auth_results
+
+    - name: Create a network subnet list
+      ansible.builtin.set_fact:
+        _network_ranges: >-
+          {{
+            cifmw_networking_env_definition.networks
+            | dict2items
+            | selectattr('key', 'search', '^ctlplane')
+            | map(attribute='value.network_v4')
+            | list
+          }}
+
+    - name: Deploy EDPM
+      include_tasks: deploy-edpm.yml
+      with_items: "{{ groups | dict2items | selectattr('key', 'search', 'compute') | list }}"
+      loop_control:
+        index_var: idx
+        loop_var: item
+      vars:
+        _subnet: "subnet{{ idx + 1 }}"
+        _group_name: "{{ item.key }}"
+        _az: "az{{ idx }}"
+        _subnet_network_range: "{{ _network_ranges[idx] }}"

--- a/playbooks/dcn/deploy-edpm.yml
+++ b/playbooks/dcn/deploy-edpm.yml
@@ -1,0 +1,237 @@
+---
+- name: Initialize vars
+  set_fact:
+    _ceph_vars_list: []
+    _group_hosts: "{{ groups[_group_name] }}"
+    _edpm_hosts: "{{ cifmw_baremetal_hosts | dict2items | selectattr('key', 'in', groups[_group_name]) | items2dict }}"
+    search_storage_network_names:
+      - "storage"
+      - "storagedcn1"
+      - "storagedcn2"
+    search_storagemgmt_network_names:
+      - "storagemgmt"
+      - "storagemgmtdcn1"
+      - "storagemgmtdcn2"
+
+- name: Find storage network parameters
+  set_fact:
+    selected_storage_network: >-
+      {{ cifmw_networking_env_definition.instances[_group_hosts | first]['networks']
+      | dict2items
+      | selectattr('key', 'in', search_storage_network_names)
+      | map(attribute='value')
+      | first }}
+
+- name: Find storagemgmt network parameters
+  set_fact:
+    selected_storagemgmt_network: >-
+      {{ cifmw_networking_env_definition.instances[_group_hosts | first]['networks']
+      | dict2items
+      | selectattr('key', 'in', search_storagemgmt_network_names)
+      | map(attribute='value')
+      | first }}
+
+- name: Calculate storage network CIDR
+  set_fact:
+    _storage_network_range: >-
+      {{ selected_storage_network.ip_v4 }}/{{ selected_storage_network.prefix_length_v4 }}
+
+- name: Calculate storagemgmt network CIDR
+  set_fact:
+    _storage_mgmt_network_range: >-
+      {{ selected_storagemgmt_network.ip_v4 }}/{{ selected_storagemgmt_network.prefix_length_v4 }}
+
+- name: Render the pre-ceph NodeSet values.yaml
+  vars:
+    _edpm_instance_dict: "{{ cifmw_networking_env_definition.instances }}"
+    _edpm_network_dict: "{{ cifmw_networking_env_definition.networks }}"
+    _ssh_authorizedkeys: "{{ lookup('file', '~/.ssh/id_cifw.pub', rstrip=False) }}"
+    _ssh_private_key: "{{ lookup('file', '~/.ssh/id_cifw', rstrip=False) }}"
+    _ssh_public_key: "{{ lookup('file', '~/.ssh/id_cifw.pub', rstrip=False) }}"
+    _migration_priv_key: "{{ lookup('file', '~/ci-framework-data/artifacts/nova_migration_key', rstrip=False) }}"
+    _migration_pub_key: "{{ lookup('file', '~/ci-framework-data/artifacts/nova_migration_key.pub', rstrip=False) }}"
+  ansible.builtin.template:
+    backup: true
+    src: "{{ _jinja_template_src }}/edpm-pre-ceph/nodeset/values.yaml.j2"
+    dest: "{{ _arch_deployment_path }}/edpm-pre-ceph/nodeset/values.yaml"
+
+- name: Render the pre-ceph DataPlaneDeployment values.yaml
+  ansible.builtin.template:
+    backup: true
+    src: "{{ _jinja_template_src }}/edpm-pre-ceph/deployment/values.yaml.j2"
+    dest: "{{ _arch_deployment_path }}/edpm-pre-ceph/deployment/values.yaml"
+
+- name: Kustomize pre-ceph {{ _group_name }} NodeSet
+  ansible.builtin.set_fact:
+    nodeset_cr: >-
+      {{ lookup('kubernetes.core.kustomize',
+      dir=_arch_deployment_path + '/edpm-pre-ceph/nodeset') }}
+
+- name: Save the pre-ceph {{ _group_name }} NodeSet CR
+  ansible.builtin.copy:
+    dest: "{{ _arch_deployment_path }}/dataplane-nodeset-pre-ceph_{{ _az }}.yaml"
+    content: "{{ nodeset_cr }}"
+    backup: true
+
+- name: Kustomize pre-ceph {{ _group_name }} DataPlaneDeployment
+  ansible.builtin.set_fact:
+    deployment_cr: >-
+      {{ lookup('kubernetes.core.kustomize',
+      dir=_arch_deployment_path + '/edpm-pre-ceph/deployment') }}
+
+- name: Save the pre-ceph {{ _group_name }} DataPlaneDeployment CR
+  ansible.builtin.copy:
+    dest: "{{ _arch_deployment_path }}/dataplane-deployment-pre-ceph_{{ _az }}.yaml"
+    content: "{{ deployment_cr }}"
+    backup: true
+
+- name: Apply pre-ceph {{ _group_name }} NodeSet CR
+  kubernetes.core.k8s:
+    api_key: "{{ _auth_results.openshift_auth.api_key }}"
+    state: present
+    apply: true
+    src: "{{ _arch_deployment_path }}/dataplane-nodeset-pre-ceph_{{ _az }}.yaml"
+
+- name: Apply pre-ceph {{ _group_name }} DataPlaneDeployment
+  kubernetes.core.k8s:
+    api_key: "{{ _auth_results.openshift_auth.api_key }}"
+    state: present
+    apply: true
+    src: "{{ _arch_deployment_path }}/dataplane-deployment-pre-ceph_{{ _az }}.yaml"
+    wait: yes
+    wait_condition:
+      type: Ready
+      status: "True"
+    wait_timeout: 2400
+
+- name: Deploy Ceph {{ _az }}
+  ansible.builtin.command:
+    chdir: "{{ _cifmw_repo_path }}"
+    cmd: >-
+      ansible-playbook
+      -i ~/ci-framework-data/artifacts/zuul_inventory.yml
+      -e ssh_network_range={{ _subnet_network_range }}
+      -e @~/ci-framework-data/parameters/reproducer-variables.yml
+      -e cifmw_ceph_client_service_values_post_ceph_path_dst=/tmp/edpm_service_values_post_ceph_{{ _az }}.yaml
+      -e cifmw_ceph_client_values_post_ceph_path_dst="{{ _arch_deployment_path }}/values.yaml"
+      -e cifmw_ceph_target={{ _group_name }}
+      -e cifmw_ceph_client_vars=/tmp/ceph_client_{{_az}}.yml
+      -e cifmw_cephadm_cluster={{ _az }}
+      -e storage_network_range={{ _storage_network_range | ansible.utils.ipaddr('network/prefix') }}
+      -e storage_mgmt_network_range={{ _storage_mgmt_network_range |  ansible.utils.ipaddr('network/prefix') }}
+      playbooks/ceph.yml
+
+- name: Load the Ceph cluster variables
+  ansible.builtin.include_vars:
+    file: "/tmp/ceph_client_{{_az}}.yml"
+
+- name: Find all ceph .conf and .keyring files
+  ansible.builtin.find:
+    paths: "/tmp"
+    patterns: "ceph*.conf,ceph*.keyring,az*.conf,az*.keyring"
+    recurse: no
+  register: _ceph_conf_files
+
+- name: Load ceph configuration files
+  ansible.builtin.set_fact:
+    _ceph_files: "{{ _ceph_conf_files.files | map(attribute='path') | list }}"
+
+- name: Render the post-ceph values.yaml
+  ansible.builtin.template:
+    backup: true
+    src: "{{ _jinja_template_src }}/values.yaml.j2"
+    dest: "{{ _arch_deployment_path }}/values.yaml"
+
+- name: Find all ceph vairable files
+  ansible.builtin.find:
+    paths: "/tmp"
+    patterns: "ceph_client_az*.yml"
+    recurse: no
+  register: _ceph_vars_files
+
+- name: Load all ceph vars from files
+  ansible.builtin.include_vars:
+    file: "{{ item }}"
+  with_items: "{{ _ceph_vars_files.files | map(attribute='path') | list }}"
+  register: _ceph_vars
+
+- name: Combine ceph variables into a list of dictionaries
+  set_fact:
+    _ceph_vars_list: "{{ _ceph_vars_list | union([item.ansible_facts]) }}"
+  with_items: "{{ _ceph_vars.results }}"
+
+- name: Render the post-ceph service-values.yaml
+  ansible.builtin.template:
+    backup: true
+    src: "{{ _jinja_template_src }}/service-values.yaml.j2"
+    dest: "{{ _arch_deployment_path }}/service-values.yaml"
+
+- name: Kustomize post-ceph {{ _group_name }} NodeSet
+  ansible.builtin.set_fact:
+    post_ceph_nodeset_cr: >-
+      {{ lookup('kubernetes.core.kustomize',
+      dir=_arch_deployment_path) }}
+
+- name: Save the post-ceph {{ _group_name }} NodeSet CR
+  ansible.builtin.copy:
+    dest: "{{ _arch_deployment_path }}/dataplane-nodeset-post-ceph_{{ _az }}.yaml"
+    content: "{{ post_ceph_nodeset_cr }}"
+    backup: true
+
+- name: Render the post-ceph DataPlaneDeployment values.yaml
+  ansible.builtin.template:
+    backup: true
+    src: "{{ _jinja_template_src }}/deployment/values.yaml.j2"
+    dest: "{{ _arch_deployment_path }}/deployment/values.yaml"
+
+- name: Kustomize post-ceph {{ _group_name }} DataPlaneDeployment
+  ansible.builtin.set_fact:
+    post_ceph_deployment_cr: >-
+      {{ lookup('kubernetes.core.kustomize',
+      dir=_arch_deployment_path + '/deployment') }}
+
+- name: Save the post-ceph {{ _group_name }} DataPlaneDeployment CR
+  ansible.builtin.copy:
+    dest: "{{ _arch_deployment_path }}/dataplane-deployment-post-ceph_{{ _az }}.yaml"
+    content: "{{ post_ceph_deployment_cr }}"
+    backup: true
+
+- name: Apply post-ceph {{ _group_name }} NodeSet CR
+  kubernetes.core.k8s:
+    api_key: "{{ _auth_results.openshift_auth.api_key }}"
+    state: present
+    apply: true
+    src: "{{ _arch_deployment_path }}/dataplane-nodeset-post-ceph_{{ _az }}.yaml"
+
+- name: Apply post-ceph {{ _group_name }} DataPlaneDeployment CR
+  kubernetes.core.k8s:
+    api_key: "{{ _auth_results.openshift_auth.api_key }}"
+    state: present
+    apply: true
+    src: "{{ _arch_deployment_path }}/dataplane-deployment-post-ceph_{{ _az }}.yaml"
+    wait: yes
+    wait_condition:
+      type: Ready
+      status: "True"
+    wait_timeout: 3200
+
+- name: Run nova cell discovery
+  kubernetes.core.k8s_exec:
+    namespace: openstack
+    pod: nova-cell0-conductor-0
+    command: nova-manage cell_v2 discover_hosts --verbose
+
+- name: Create AZ
+  kubernetes.core.k8s_exec:
+    namespace: openstack
+    pod: openstackclient
+    command: >-
+      openstack aggregate create {{ _az }} --zone {{ _az }}
+
+- name: Add hosts to AZ
+  kubernetes.core.k8s_exec:
+    namespace: openstack
+    pod: openstackclient
+    command: >-
+      openstack aggregate add host {{ _az }} edpm-{{ item.key }}.ctlplane.example.com
+  loop: "{{ _edpm_hosts | dict2items }}"

--- a/roles/ci_gen_kustomize_values/templates/dcn/deployment/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/dcn/deployment/values.yaml.j2
@@ -1,0 +1,20 @@
+# local-config: referenced, but not emitted by kustomize
+---
+# source: dcn/deployment/values.yaml.j2
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-deployment-values-post-ceph
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  nodeset_name: {{ _group_name }}-edpm
+  deployment:
+    name: post-ceph-{{ _group_name }}
+  servicesOverride:
+    - install-certs
+    - ceph-client
+    - ovn
+    - neutron-metadata
+    - libvirt
+    - nova-custom-ceph-{{ _az }}

--- a/roles/ci_gen_kustomize_values/templates/dcn/edpm-pre-ceph/deployment/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/dcn/edpm-pre-ceph/deployment/values.yaml.j2
@@ -1,0 +1,22 @@
+---
+# source: dcn/edpm-pre-ceph/deployment/values.yaml.j2
+apiVersion: v1
+data:
+    nodeset_name: {{ _group_name }}-edpm
+    deployment:
+        name: pre-ceph-{{ _group_name }}
+    servicesOverride:
+        - bootstrap
+        - configure-network
+        - validate-network
+        - install-os
+        - ceph-hci-pre
+        - configure-os
+        - ssh-known-hosts
+        - run-os
+        - reboot-os
+kind: ConfigMap
+metadata:
+    annotations:
+        config.kubernetes.io/local-config: 'true'
+    name: edpm-deployment-values

--- a/roles/ci_gen_kustomize_values/templates/dcn/edpm-pre-ceph/nodeset/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/dcn/edpm-pre-ceph/nodeset/values.yaml.j2
@@ -1,0 +1,164 @@
+---
+# source: dcn/edpm-pre-ceph/nodeset/values.yaml.j2
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edpm-nodeset-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  nodeset_name: {{ _group_name }}-edpm
+  ssh_keys:
+    # Authorized keys that will have access to the dataplane computes via SSH
+    authorized: {{ _ssh_authorizedkeys | b64encode }}
+    # The private key that will have access to the dataplane computes via SSH
+    private: {{ _ssh_private_key | b64encode }}
+    # The public key that will have access to the dataplane computes via SSH
+    public: {{ _ssh_public_key | b64encode }}
+  nodeset:
+    ansible:
+      ansibleUser: "zuul"
+      ansiblePort: 22
+      ansibleVars:
+        timesync_ntp_servers:
+          - hostname: clock.redhat.com
+        # CHANGEME -- see https://access.redhat.com/solutions/253273
+        # edpm_bootstrap_command: |
+        #       subscription-manager register --username <subscription_manager_username> \
+        #         --password <subscription_manager_password>
+        #       podman login -u <registry_username> -p <registry_password> registry.redhat.io
+        edpm_network_config_hide_sensitive_logs: false
+        edpm_network_config_os_net_config_mappings:
+{% for _host_name in _edpm_hosts.keys() %}
+          edpm-{{ _host_name }}:
+{% for  nic in _edpm_hosts[_host_name].nics %}
+            nic{{ loop.index }}: "{{ nic.mac }}"
+{% endfor %}
+{% endfor %}
+{% raw %}
+        edpm_network_config_template: |
+          ---
+          {% set mtu_list = [ctlplane_mtu] %}
+          {% for network in nodeset_networks %}
+          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {%- endfor %}
+          {% set min_viable_mtu = mtu_list | max %}
+          network_config:
+          - type: ovs_bridge
+            name: br-ex
+            use_dhcp: false
+            members:
+            - type: interface
+              name: nic1
+              primary: false
+          - type: ovs_bridge
+            name: {{ neutron_physical_bridge_name }}
+            mtu: {{ min_viable_mtu }}
+            use_dhcp: false
+            dns_servers: {{ ctlplane_dns_nameservers }}
+            domain: {{ dns_search_domains }}
+            addresses:
+            - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
+            routes: {{ ctlplane_host_routes }}
+            members:
+            - type: interface
+              name: nic2
+              mtu: {{ min_viable_mtu }}
+              # force the MAC address of the bridge to this interface
+              primary: true
+          {% for network in nodeset_networks %}
+            - type: vlan
+              mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}
+              vlan_id: {{ lookup('vars', networks_lower[network] ~ '_vlan_id') }}
+              addresses:
+              - ip_netmask:
+                  {{ lookup('vars', networks_lower[network] ~ '_ip') }}/{{ lookup('vars', networks_lower[network] ~ '_cidr') }}
+              routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
+          {% endfor %}
+{% endraw %}
+        edpm_bootstrap_release_version_package: []
+        edpm_nodes_validation_validate_controllers_icmp: false
+        edpm_nodes_validation_validate_gateway_icmp: false
+        edpm_sshd_allowed_ranges:
+          - 192.168.111.0/24
+{% for network_name, network_data in _edpm_network_dict.items() %}
+{% if network_name.startswith('ctlplane') %}
+          - {{ network_data.network_v4 }}
+{% endif %}
+{% endfor %}
+        edpm_sshd_configure_firewall: true
+        gather_facts: false
+{% if 'dcn1' in _group_name %}
+        edpm_ovn_bridge_mappings: ["leaf1:br-ex"]
+{% elif 'dcn2'in _group_name %}
+        edpm_ovn_bridge_mappings: ["leaf2:br-ex"]
+{%endif %}
+        neutron_physical_bridge_name: br-ctl
+        neutron_public_interface_name: eth0
+        edpm_ceph_hci_pre_enabled_services:
+          - ceph_mon
+          - ceph_mgr
+          - ceph_osd
+          - ceph_rgw
+          - ceph_nfs
+          - ceph_rgw_frontend
+          - ceph_nfs_frontend
+        storage_mtu: 9000
+        storage_mgmt_mtu: 9000
+        storage_mgmt_vlan_id: 23
+        storage_mgmt_cidr: "24"
+        storage_mgmt_host_routes: []
+    networks:
+      - defaultRoute: true
+        name: ctlplane
+        subnetName: {{ _subnet }}
+      - name: internalapi
+        subnetName: {{ _subnet }}
+      - name: storage
+        subnetName: {{ _subnet }}
+      - name: tenant
+        subnetName: {{ _subnet }}
+    nodes:
+{% for _host_name in _edpm_hosts.keys() %}
+{% for network_name, network_data in _edpm_instance_dict[_host_name].networks.items() %}
+{% if network_name.startswith('ctlplane') %}
+      edpm-{{ _host_name }}:
+        ansible:
+          ansibleHost: {{ network_data['ip_v4'] }}
+        hostName: edpm-{{ _host_name }}
+        networks:
+          - defaultRoute: true
+            fixedIP: {{ network_data['ip_v4'] }}
+            name: ctlplane
+            subnetName: {{ _subnet }}
+          - name: internalapi
+            subnetName: {{ _subnet }}
+          - name: storage
+            subnetName: {{ _subnet }}
+          - name: storagemgmt
+            subnetName: {{ _subnet }}
+          - name: tenant
+            subnetName: {{ _subnet }}
+{% endif %}
+{% endfor %}
+{% endfor %}
+    services:
+      - bootstrap
+      - configure-network
+      - validate-network
+      - install-os
+      - ceph-hci-pre
+      - configure-os
+      - ssh-known-hosts
+      - run-os
+      - reboot-os
+      - install-certs
+      - ceph-client
+      - ovn
+      - neutron-metadata
+      - libvirt
+  nova:
+    migration:
+      ssh_keys:
+        private: {{ _migration_priv_key | b64encode }}
+        public: {{ _migration_pub_key | b64encode }}

--- a/roles/ci_gen_kustomize_values/templates/dcn/service-values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/dcn/service-values.yaml.j2
@@ -1,0 +1,160 @@
+---
+# source: dcn/service-values.yaml.j2
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-values
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  preserveJobs: false
+  cinderAPI:
+    replicas: 3
+    customServiceConfig: |
+      [DEFAULT]
+      default_availability_zone = az0
+  cinderBackup:
+    replicas: 3
+    customServiceConfig: |
+      [DEFAULT]
+      backup_driver = cinder.backup.drivers.ceph.CephBackupDriver
+      backup_ceph_pool = backups
+      backup_ceph_user = openstack
+  cinderVolumes:
+{% for _ceph in _ceph_vars_list %}
+    {{ _ceph.cifmw_ceph_client_cluster }}:
+      customServiceConfig: |
+        [DEFAULT]
+        enabled_backends = ceph
+{% if 'az0' not in _ceph.cifmw_ceph_client_cluster %}
+        glance_api_servers = https://glance-{{ _ceph.cifmw_ceph_client_cluster }}-internal.openstack.svc:9292
+{% endif %}
+        [ceph]
+        volume_backend_name = ceph
+        volume_driver = cinder.volume.drivers.rbd.RBDDriver
+        rbd_ceph_conf = /etc/ceph/{{ _ceph.cifmw_ceph_client_cluster }}.conf
+        rbd_user = openstack
+        rbd_pool = volumes
+        rbd_flatten_volume_from_snapshot = False
+        rbd_secret_uuid = {{ _ceph.cifmw_ceph_client_fsid }}
+        rbd_cluster_name = {{ _ceph.cifmw_ceph_client_cluster }}
+        backend_availability_zone = {{ _ceph.cifmw_ceph_client_cluster }}
+{% endfor %}
+  glance:
+    customServiceConfig: |
+        [DEFAULT]
+        enabled_backends = default_backend:rbd
+        [glance_store]
+        default_backend = default_backend
+        [default_backend]
+        rbd_store_ceph_conf = /etc/ceph/az0.conf
+        store_description = "RBD backend"
+        rbd_store_pool = images
+        rbd_store_user = openstack
+        rbd_thin_provisioning = True
+    glanceAPIs:
+{% set backends = [] %}
+{% for _ceph in _ceph_vars_list %}
+{% if _ceph.cifmw_ceph_client_cluster not in backends %}
+{% set _ = backends.append(_ceph.cifmw_ceph_client_cluster + ':rbd') %}
+{% endif %}
+{% endfor %}
+{% for _ceph in _ceph_vars_list %}
+{% if 'az0' in _ceph.cifmw_ceph_client_cluster %}
+      default:
+{% else %}
+      {{ _ceph.cifmw_ceph_client_cluster }}:
+{% endif %}
+        customServiceConfig: |
+          [DEFAULT]
+          enabled_import_methods = [web-download,copy-image,glance-direct]
+          enabled_backends = {{ backends | join(',') }}
+          [glance_store]
+          default_backend = {{ _ceph.cifmw_ceph_client_cluster }}
+          [{{ _ceph.cifmw_ceph_client_cluster }}]
+          rbd_store_ceph_conf = /etc/ceph/{{ _ceph.cifmw_ceph_client_cluster }}.conf
+          store_description = "{{ _ceph.cifmw_ceph_client_cluster }} RBD backend"
+          rbd_store_pool = images
+          rbd_store_user = openstack
+          rbd_thin_provisioning = True
+{% for _ceph_az in _ceph_vars_list %}
+{% if _ceph_az.cifmw_ceph_client_cluster != _ceph.cifmw_ceph_client_cluster %}
+          [{{ _ceph_az.cifmw_ceph_client_cluster }}]
+          rbd_store_ceph_conf = /etc/ceph/{{ _ceph_az.cifmw_ceph_client_cluster }}.conf
+          store_description = "{{ _ceph_az.cifmw_ceph_client_cluster }} RBD backend"
+          rbd_store_pool = images
+          rbd_store_user = openstack
+          rbd_thin_provisioning = True
+{% endif %}
+{% endfor %}
+        networkAttachments:
+          - storage
+        override:
+          service:
+            internal:
+              metadata:
+                annotations:
+                  metallb.universe.tf/address-pool: internalapi
+                  metallb.universe.tf/allow-shared-ip: internalapi
+                  metallb.universe.tf/loadBalancerIPs: 172.17.0.8{{ loop.index0 }}
+              spec:
+                type: LoadBalancer
+        replicas: 3
+{% if _ceph.cifmw_ceph_client_cluster == 'az0' %}
+        type: split
+{% else %}
+        type: edge
+{% endif %}
+{% endfor %}
+  manila:
+    enabled: false
+    manilaAPI:
+      customServiceConfig: |
+        [DEFAULT]
+        enabled_share_protocols=nfs,cephfs
+    manilaShares:
+      share1:
+        customServiceConfig: |
+          [DEFAULT]
+          enabled_share_backends = cephfs
+          enabled_share_protocols = cephfs
+          [cephfs]
+          driver_handles_share_servers = False
+          share_backend_name = cephfs
+          share_driver = manila.share.drivers.cephfs.driver.CephFSDriver
+          cephfs_conf_path = /etc/ceph/ceph.conf
+          cephfs_cluster_name = ceph
+          cephfs_auth_id=openstack
+          cephfs_volume_mode = 0755
+          cephfs_protocol_helper_type = CEPHFS
+  neutron:
+      template:
+        customServiceConfig: |
+          [ml2_type_vlan]
+          network_vlan_ranges = datacentre:1:1000,leaf1:1:1000,leaf2:1:1000
+          [neutron]
+          physnets = datacentre,leaf1,leaf2
+  nova:
+      customServiceConfig: |
+        [DEFAULT]
+        default_schedule_zone=az0
+  extraMounts:
+    - name: v1
+      region: r1
+      extraVol:
+        - propagation:
+            - CinderVolume
+            - CinderBackup
+            - GlanceAPI
+            - ManilaShare
+          extraVolType: Ceph
+          volumes:
+            - name: ceph
+              projected:
+                sources:
+                  - secret:
+                      name: ceph-conf-files
+          mounts:
+            - name: ceph
+              mountPath: /etc/ceph
+              readOnly: true

--- a/roles/ci_gen_kustomize_values/templates/dcn/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/dcn/values.yaml.j2
@@ -1,0 +1,63 @@
+---
+# source: dcn/values.yaml.j2
+apiVersion: v1
+data:
+    customDataplanService:
+      name: nova-custom-ceph-{{ _az }}
+    nodeset_name: {{ _group_name }}-edpm
+    ceph_conf:
+{% for _file in _ceph_files %}
+        {{ _file | basename }}: {{ lookup('file', _file, rstrip=False) | b64encode }}
+{% endfor %}
+    nodeset:
+        services:
+            - bootstrap
+            - configure-network
+            - validate-network
+            - install-os
+            - ceph-hci-pre
+            - configure-os
+            - ssh-known-hosts
+            - run-os
+            - reboot-os
+            - install-certs
+            - ceph-client
+            - ovn
+            - neutron-metadata
+            - libvirt
+            - nova-custom-ceph-{{ _az }}
+    nova:
+        ceph:
+            conf: |
+                [libvirt]
+                images_type=rbd
+                images_rbd_pool=vms
+                images_rbd_ceph_conf=/etc/ceph/{{ cifmw_ceph_client_cluster }}.conf
+                images_rbd_glance_store_name={{ cifmw_ceph_client_cluster }}
+                images_rbd_glance_copy_poll_interval=15
+                images_rbd_glance_copy_timeout=600
+                rbd_user=openstack
+                rbd_secret_uuid={{ cifmw_ceph_client_fsid }}
+                [glance]
+{% if 'az0' in cifmw_ceph_client_cluster %}
+                endpoint_override = https://glance-default-internal.openstack.svc:9292
+{% else %}
+                endpoint_override = https://glance-{{ _az }}-internal.openstack.svc:9292
+{% endif %}
+                valid_interfaces = internal
+                [cinder]
+                cross_az_attach = False
+                catalog_info = volumev3:cinderv3:internalURL
+        name: ceph-nova-{{ _az }}
+        dataSources:
+            - configMapRef:
+                name: ceph-nova-{{ _az }}
+            - secretRef:
+                name: nova-cell1-compute-config
+            - secretRef:
+                name: nova-migration-ssh-key
+kind: ConfigMap
+metadata:
+    annotations:
+        config.kubernetes.io/local-config: 'true'
+    name: edpm-nodeset-values-post-ceph


### PR DESCRIPTION
Key changes:

- Added DCN-specific playbooks to the `playbook/dcn` folder.
- Moved Jinja templates from the `architecture` repository into the `roles/ci_gen_kustomize_values/templates/dcn` folder.

There are two playbooks. These playbooks will be executed in a hook after the control plane has been deployed.

- `deploy-dcn.yml`: This playbook generates a list of network ranges and sequentially calls deploy-edpm.yml to deploy the EDPM nodesets based on the defined networking environment.

- `deploy-edpm.yml`: This playbook focuses on the deployment of the EDPM nodeset and the Ceph cluster relating to DCN sites. It leverages Jinja templates to dynamically generate the `values.yaml` and `service-values.yaml` files required for Kustomize.
