### PR TITLE
[hci_prepare] Ensure generated resources are applied in the proper NS

### DIFF
--- a/roles/hci_prepare/README.md
+++ b/roles/hci_prepare/README.md
@@ -14,6 +14,7 @@ None.
 * `cifmw_hci_prepare_enable_repo_setup_service`: (Boolean) Optionally adds `repo-setup` service to OpenStackDataPlaneNodeSet in both phase1 and phase2. Defaults to `True`.
 * `cifmw_hci_prepare_storage_mgmt_mtu`: (Int) Storage-Management network MTU. Defaults to `1500`.
 * `cifmw_hci_prepare_storage_mgmt_vlan`: (Int) Storage-Management network VLAn. Defaults to `23`.
+* `cifmw_hci_prepare_namespace`: (String) Namespace to use to apply resources if install-yamls is not used. Defaults to `openstack`.
 
 ## Examples
 ### 1 - How to deploy HCI using hci_prepare and edpm_deploy

--- a/roles/hci_prepare/tasks/common.yml
+++ b/roles/hci_prepare/tasks/common.yml
@@ -14,13 +14,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-cifmw_hci_prepare_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
-cifmw_hci_prepare_dataplane_dir: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/dataplane"
-cifmw_hci_prepare_dryrun: false
-cifmw_hci_prepare_skip_load_parameters: false
-cifmw_hci_prepare_ceph_secret_path: "/tmp/k8s_ceph_secret.yml"
-cifmw_hci_prepare_enable_storage_mgmt: true
-cifmw_hci_prepare_enable_repo_setup_service: true
-cifmw_hci_prepare_storage_mgmt_mtu: 1500
-cifmw_hci_prepare_storage_mgmt_vlan: 23
-cifmw_hci_prepare_namespace: openstack
+- name: Set common facts
+  ansible.builtin.set_fact:
+    _cifmw_hci_prepare_namespace: >-
+      {{
+        cifmw_install_yamls_defaults.NAMESPACE | default(cifmw_hci_prepare_namespace)
+      }}

--- a/roles/hci_prepare/tasks/phase1.yml
+++ b/roles/hci_prepare/tasks/phase1.yml
@@ -14,6 +14,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Run HCI common tasks
+  ansible.builtin.import_tasks: common.yml
+
 - name: Load parameters
   ansible.builtin.include_tasks: load_parameters.yml
   when: not cifmw_hci_prepare_skip_load_parameters | bool
@@ -34,7 +37,7 @@
       apiVersion: kustomize.config.k8s.io/v1beta1
       kind: Kustomization
       resources:
-      namespace: {{ cifmw_install_yamls_defaults.NAMESPACE }}
+      namespace: {{ _cifmw_hci_prepare_namespace }}
       patches:
       - target:
           kind: OpenStackDataPlaneNodeSet
@@ -55,7 +58,7 @@
       apiVersion: kustomize.config.k8s.io/v1beta1
       kind: Kustomization
       resources:
-      namespace: {{ cifmw_install_yamls_defaults.NAMESPACE }}
+      namespace: {{ _cifmw_hci_prepare_namespace }}
       patches:
       - target:
           kind: OpenStackDataPlaneNodeSet

--- a/roles/hci_prepare/tasks/phase2.yml
+++ b/roles/hci_prepare/tasks/phase2.yml
@@ -14,6 +14,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Run HCI common tasks
+  ansible.builtin.import_tasks: common.yml
+
 - name: Ensure directories
   ansible.builtin.file:
     path: "{{ item }}"
@@ -64,7 +67,7 @@
     - name: Delete OpenStackDataPlaneDeployment
       cifmw.general.ci_script:
         output_dir: "{{ cifmw_hci_prepare_basedir }}/artifacts"
-        script: "oc delete OpenStackDataPlaneDeployment --all -n {{ cifmw_install_yamls_defaults.NAMESPACE }}"
+        script: "oc delete OpenStackDataPlaneDeployment --all -n {{ _cifmw_hci_prepare_namespace }}"
 
 
 - name: Create configuration to finish HCI deployment
@@ -75,7 +78,7 @@
       apiVersion: kustomize.config.k8s.io/v1beta1
       kind: Kustomization
       resources:
-      namespace: {{ cifmw_install_yamls_defaults.NAMESPACE }}
+      namespace: {{ _cifmw_hci_prepare_namespace }}
       patches:
       - target:
           kind: OpenStackDataPlaneNodeSet

--- a/roles/hci_prepare/templates/configmap-ceph-nova.yml.j2
+++ b/roles/hci_prepare/templates/configmap-ceph-nova.yml.j2
@@ -1,9 +1,9 @@
 ---
 apiVersion: v1
 kind: ConfigMap
-namespace: {{ cifmw_install_yamls_defaults.NAMESPACE }}
 metadata:
   name: ceph-nova
+  namespace: {{ _cifmw_hci_prepare_namespace }}
 data:
   03-ceph-nova.conf: |
     [libvirt]

--- a/roles/hci_prepare/templates/dpservice-nova-custom-ceph.yml.j2
+++ b/roles/hci_prepare/templates/dpservice-nova-custom-ceph.yml.j2
@@ -1,9 +1,9 @@
 ---
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneService
-namespace: {{ cifmw_install_yamls_defaults.NAMESPACE }}
 metadata:
   name: nova-custom-ceph
+  namespace: {{ _cifmw_hci_prepare_namespace }}
 spec:
   label: dataplane-deployment-nova-custom-ceph
   dataSources:


### PR DESCRIPTION
The namespace field in the generated CRs is wronly placed. That, and the fact we call apply without specifying the namespace may lead to the resource to be applied to the wrong namespace.

Jira: https://issues.redhat.com/browse/OSPRH-10332