### PR TITLE
[OSPCIX-532] Set volume.catalog_type to volumev3

### DIFF
--- a/roles/tempest/vars/main.yml
+++ b/roles/tempest/vars/main.yml
@@ -4,3 +4,4 @@ cifmw_tempest_tempestconf_profile_default:
   overrides:
     identity.v3_endpoint_type: public
     compute-feature-enabled.dhcp_domain: ''
+    volume.catalog_type: volumev3

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -92,6 +92,9 @@ cifmw_tempest_tempestconf_config_defaults:
     enforce_new_defaults = true
     enforce_scope = false
 
+    [volume]
+    catalog_type = volumev3
+
 # Please refer to https://openstack-k8s-operators.github.io/test-operator/guide.html#executing-tempest-tests
 cifmw_test_operator_tempest_debug: false
 cifmw_test_operator_tempest_config:


### PR DESCRIPTION
This patch in tempest changed the default value of the catalog_type for the cinder service to block-storage [1]. In RHOSO however, we seem to be still using volumev3.

This patch ensures that the default value in ci-framework deployed environment is still volumev3.

[1] https://review.opendev.org/c/openstack/tempest/+/930296