### PR TITLE
Update OWNERS file to be more granular

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,22 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases
+
+aliases:
+  cifmw-approvers:
+    - pablintino
+    - lewisdenny
+    - frenzyfriday
+    - cescgina
+    - rlandy
+    - viroel
+  cifmw-reviewers:
+    - pablintino
+    - lewisdenny
+    - frenzyfriday
+    - bshewale
+    - cescgina
+    - rlandy
+    - viroel
+    - marios
+  shiftstack-reviewers:
+    - rlobillo
+    - eurijon

--- a/roles/shiftstack/OWNERS
+++ b/roles/shiftstack/OWNERS
@@ -1,6 +1,3 @@
 # See the OWNERS docs at https://go.k8s.io/owners
-approvers:
-  - cifmw-approvers
-
 reviewers:
-  - cifmw-reviewers
+  - shiftstack-reviewers


### PR DESCRIPTION
By using OWNERS_ALIASES we can have teams own there own roles by adding
an OWNERS file into the directory. This patch starts by allowing two
shiftstack members to review patches that are in roles/shiftstack/**

---
Todo: 
- [ ] Find a home for the missing users