### PR TITLE
[polarion] Remove results_merged.xml files

### DIFF
--- a/roles/polarion/tasks/main.yml
+++ b/roles/polarion/tasks/main.yml
@@ -126,6 +126,12 @@
         index_var: loop_idx
       register: jump_script
 
+    - name: Remove merged xml files
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: absent
+      loop: "{{ merged_xml_files.files }}"
+
     - name: Output of jump
       ansible.builtin.debug:
         var: jump_script.stderr_lines


### PR DESCRIPTION
The results_merged.xml files are created only for polarion reporting purposes, they are basically temporary files. Their existance after the polarion report is completed, is irrelevant as the original files that were combined to create these merged files still exist.

For logs gathering purposes it's better if we avoid duplication and remove the merged files after they served their purpose.