### PR TITLE
Enable RHCS 7 in 17 TripleO deployment

### DIFF
--- a/hooks/playbooks/adoption_deploy_ceph.yml
+++ b/hooks/playbooks/adoption_deploy_ceph.yml
@@ -143,6 +143,19 @@
             state: present
           loop: "{{ _tripleo_nodes }}"
 
+        # NOTE: TripleO has the hardcoded --yes-i-know option that is not valid anymore
+        # in RHCS 7. TripleO does not receive any new patch both upstream and downstream
+        # (it is a retired project), hence the only option we have is to patch the
+        # current code to not have that line.
+        - name: Patch Ceph bootstrap task
+          become: true
+          delegate_to: "osp-undercloud-0"
+          ansible.builtin.lineinfile:
+            path: "/usr/share/ansible/roles/tripleo_cephadm/tasks/bootstrap.yaml"
+            state: absent
+            regexp: '--yes-i-know'
+            backup: true
+
         - name: Deploy ceph
           delegate_to: "osp-undercloud-0"
           vars:
@@ -152,7 +165,7 @@
               --ntp-server {{ cifmw_adoption_osp_deploy_ntp_server }}
               --ceph-spec ceph_spec.yaml
               --network-data {{ _network_data_file_dest }}
-              --cephadm-default-container
+              --container-image-prepare {{ ansible_user_dir }}/containers-prepare-parameters.yaml
               --output {{ ansible_user_dir }}/deployed_ceph.yaml
           cifmw.general.ci_script:
             chdir: "{{ ansible_user_dir }}"

--- a/roles/adoption_osp_deploy/defaults/main.yml
+++ b/roles/adoption_osp_deploy/defaults/main.yml
@@ -24,4 +24,4 @@ cifmw_adoption_osp_deploy_repos:
   - rhel-9-for-x86_64-highavailability-eus-rpms
   - openstack-17.1-for-rhel-9-x86_64-rpms
   - fast-datapath-for-rhel-9-x86_64-rpms
-  - rhceph-6-tools-for-rhel-9-x86_64-rpms
+  - rhceph-7-tools-for-rhel-9-x86_64-rpms

--- a/roles/adoption_osp_deploy/tasks/prepare_undercloud.yml
+++ b/roles/adoption_osp_deploy/tasks/prepare_undercloud.yml
@@ -67,6 +67,16 @@
         dest: "{{ ansible_user_dir }}/containers-prepare-parameters.yaml"
       when: cifmw_adoption_osp_deploy_scenario.container_prepare_params is defined
 
+    # Adoption requires Ceph 7 (Reef) as a requirement. Instead of performing a Ceph
+    # upgrade from 6 (the default) to 7, let's try to deploy 7 in greenfield
+    - name: Patch containers-prepare-parameters Ceph container images
+      ansible.builtin.lineinfile:
+        path: "{{ ansible_user_dir }}/containers-prepare-parameters.yaml"
+        regexp: '^(\s.*)+: rhceph-6-rhel9'
+        line: '\1: rhceph-7-rhel9'
+        backup: true
+        backrefs: true
+
     - name: Ensure os-net-config folder exists
       become: true
       ansible.builtin.file:


### PR DESCRIPTION
For adoption, we need to align ci-framework to deploy `Ceph 7` with `17.1`

Jira: https://issues.redhat.com/browse/OSPRH-7886