### PR TITLE
Bootstrap libvirt in adoption infra playbook

### DIFF
--- a/playbooks/adoption/infra.yml
+++ b/playbooks/adoption/infra.yml
@@ -10,6 +10,13 @@
     - role: discover_latest_image
 
   tasks:
+    - name: Bootstrap libvirt
+      ansible.builtin.include_role:
+        name: libvirt_manager
+        apply:
+          tags:
+            - bootstrap_libvirt
+
     - name: Generate libvirt layout
       ansible.builtin.include_role:
         name: "libvirt_manager"


### PR DESCRIPTION
When creating infra for adoption uni jobs in a freshly provision
machine, we need to make use libvirt is ready to be used by calling the
'boostrap_libvirt' tasks of the libvirt_manager role.
