### PR TITLE
Copy container-prepare file if defined in scenario

### DIFF
--- a/roles/adoption_osp_deploy/tasks/prepare_undercloud.yml
+++ b/roles/adoption_osp_deploy/tasks/prepare_undercloud.yml
@@ -54,6 +54,19 @@
         script: "{{ _container_prepare_cmd }}"
       when: cifmw_adoption_osp_deploy_scenario.container_prepare_params is not defined
 
+    - name: Copy containers-prepare-parameters if needed
+      vars:
+        _container_prapare_path: >-
+          {{
+            [cifmw_adoption_source_scenario_path,
+            cifmw_adoption_osp_deploy_scenario.container_prepare_params
+            ] | path_join
+          }}
+      ansible.builtin.copy:
+        src: "{{ _container_prapare_path }}"
+        dest: "{{ ansible_user_dir }}/containers-prepare-parameters.yaml"
+      when: cifmw_adoption_osp_deploy_scenario.container_prepare_params is defined
+
     - name: Ensure os-net-config folder exists
       become: true
       ansible.builtin.file:


### PR DESCRIPTION
If the adoption source scenario contains a 'container_prepare_params'
file to use, copy to the undercloud instead of generating it.
