### PR TITLE
[ci_nmstate] DNS generation and empty hosts fixes

### DIFF
--- a/roles/ci_nmstate/filter_plugins/ci_nmstate_map_instance_nets.py
+++ b/roles/ci_nmstate/filter_plugins/ci_nmstate_map_instance_nets.py
@@ -199,6 +199,10 @@ class FilterModule:
             net_search_domain = network_data.get("search_domain", None)
             if net_search_domain and net_search_domain not in nmstate_search_domains:
                 nmstate_search_domains.append(net_search_domain)
+
+        # If not DNS servers configured for the instance skip DNS config
+        if not nmstate_nameservers:
+            return {}
         return {
             "search": nmstate_search_domains,
             "server": nmstate_nameservers,
@@ -273,23 +277,22 @@ class FilterModule:
             if not bool(net_data.get("skip_nm", False))
         ]
 
+        result = {}
         interfaces = [
             cls.__map_instance_net_interface(net_data) for net_data in intance_nets_defs
         ]
+        if interfaces:
+            result.update({"interfaces": interfaces})
 
-        if not interfaces:
-            return {}
         routes = cls.__map_instance_net_routes(net_env_def, intance_nets_defs)
+        if routes:
+            result.update({"routes": {"config": routes}})
+
         dns = cls.__map_instance_net_dnss(net_env_def, intance_nets_defs)
-        return {
-            "interfaces": interfaces,
-            "routes": {
-                "config": routes,
-            },
-            "dns-resolver": {
-                "config": dns,
-            },
-        }
+        if dns:
+            result.update({"dns-resolver": {"config": dns}})
+
+        return result
 
     def filters(self):
         return {

--- a/roles/ci_nmstate/tasks/main.yml
+++ b/roles/ci_nmstate/tasks/main.yml
@@ -38,7 +38,7 @@
     _cifmw_ci_nmstate_configs: >-
       {{
         _cifmw_ci_nmstate_configs |
-        combine({ item: _instance_nmstate if _instance_nmstate | length > 0 else omit })
+        combine({ item: _instance_nmstate | default({}) })
       }}
     cacheable: true
   loop: >-
@@ -91,7 +91,12 @@
     cacheable: true
 
 - name: Provision k8s workers with nmstate
-  when: cifmw_openshift_kubeconfig is defined
+  when:
+    - cifmw_openshift_kubeconfig is defined
+    - >-
+      _cifmw_ci_nmstate_configs | dict2items |
+      selectattr('key', 'in', _cifmw_ci_nmstate_k8s_hosts) |
+      map('length') | sum > 0
   ansible.builtin.include_tasks: nmstate_k8s_install.yml
 
 - name: Provision unmanaged nodes with nmstate

--- a/roles/ci_nmstate/tasks/nmstate_k8s_install.yml
+++ b/roles/ci_nmstate/tasks/nmstate_k8s_install.yml
@@ -13,14 +13,54 @@
     kind: Namespace
     state: present
 
+- name: Generate the OperatorGroup final CR
+  vars:
+    _operator_group_patches: >-
+      {{
+        hostvars[inventory_hostname] |
+        dict2items |
+        selectattr("key", "match",
+                   "^cifmw_ci_nmstate_olm_operator_group_patch.*") |
+        sort(attribute='key') |
+        map(attribute='value') |
+        list
+      }}
+  ansible.builtin.set_fact:
+    _cifmw_ci_nmstate_olm_operator_group_patched: >-
+      {{
+        _cifmw_ci_nmstate_olm_operator_group_patched | default({}) |
+        combine(item, recursive=True)
+      }}
+  loop: "{{ [cifmw_ci_nmstate_olm_operator_group] + _operator_group_patches }}"
+
+- name: Generate the Subscription final CR
+  vars:
+    _subscription_patches: >-
+      {{
+        hostvars[inventory_hostname] |
+        dict2items |
+        selectattr("key", "match",
+                   "^cifmw_ci_nmstate_olm_subscription_patch.*") |
+        sort(attribute='key') |
+        map(attribute='value') |
+        list
+      }}
+  ansible.builtin.set_fact:
+    _cifmw_ci_nmstate_olm_subscription_patched: >-
+      {{
+        _cifmw_ci_nmstate_olm_subscription_patched | default({}) |
+        combine(item, recursive=True)
+      }}
+  loop: "{{ [cifmw_ci_nmstate_olm_subscription] + _subscription_patches }}"
+
 - name: Save k8s nmstate OLM manifests as artifacts
   ansible.builtin.copy:
     mode: "0644"
     dest: "{{ cifmw_ci_nmstate_manifests_dir }}/nmstate-{{ item.kind | lower }}-olm.yaml"
     content: "{{ item | to_nice_yaml }}"
   loop:
-    - "{{ cifmw_ci_nmstate_olm_operator_group }}"
-    - "{{ cifmw_ci_nmstate_olm_subscription }}"
+    - "{{ _cifmw_ci_nmstate_olm_operator_group_patched }}"
+    - "{{ _cifmw_ci_nmstate_olm_subscription_patched }}"
   loop_control:
     label: "{{ item.metadata.name }}"
 
@@ -32,8 +72,8 @@
     definition: "{{ item }}"
     state: present
   loop:
-    - "{{ cifmw_ci_nmstate_olm_operator_group }}"
-    - "{{ cifmw_ci_nmstate_olm_subscription }}"
+    - "{{ _cifmw_ci_nmstate_olm_operator_group_patched }}"
+    - "{{ _cifmw_ci_nmstate_olm_subscription_patched }}"
   loop_control:
     label: "{{ item.metadata.name }}"
 


### PR DESCRIPTION
Fixing ci_nmstate to not generate DNS config if not DNS were configured. If an instance that is a k8s one has no configuration we won't try to provision it using raw nmstate.