### PR TITLE
Force pvcreate in CI

### DIFF
--- a/roles/devscripts/files/lv-cinder-volumes.sh
+++ b/roles/devscripts/files/lv-cinder-volumes.sh
@@ -10,7 +10,7 @@ fi
 
 disk_str=''
 for disk in ${_disks}; do
-    pvcreate ${disk}
+    pvcreate "${disk}" -y -ff
     disk_str="${disk_str} ${disk}"
 done
 


### PR DESCRIPTION
Looks like there are issues with disk wipe in CI [1]. This double force the PV creation, and it overwrites any LVM metadata or partition tables without further warnings.

Jira: https://issues.redhat.com/browse/OSPCIX-540