### PR TITLE
Do not mount non-existing controller private key

### DIFF
--- a/roles/test_operator/tasks/tempest-tests.yml
+++ b/roles/test_operator/tasks/tempest-tests.yml
@@ -81,38 +81,47 @@
                       }}}, recursive=true)
           }}
 
-- name: Ensure a secret for the cifmw private key file exists
-  when:
-    - not cifmw_test_operator_dry_run | bool
-    - cifmw_test_operator_tempest_ssh_key_secret_name is not defined
-  kubernetes.core.k8s:
-    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
-    api_key: "{{ cifmw_openshift_token | default(omit) }}"
-    context: "{{ cifmw_openshift_context | default(omit) }}"
-    state: present
-    wait: true
-    definition:
-      apiVersion: v1
-      kind: Secret
-      type: Opaque
-      metadata:
-        name: "{{ cifmw_test_operator_controller_priv_key_secret_name }}"
-        namespace: "{{ cifmw_test_operator_namespace }}"
-      data:
-        ssh-privatekey: "{{ lookup('file', '~/.ssh/id_cifw', rstrip=False) | b64encode }}"
+- name: Check that cifmw private key file exists
+  ansible.builtin.stat:
+    path: "{{ cifmw_test_operator_controller_priv_key_file_path }}"
+  register: private_key_file
 
-- name: Add SSHKeySecretName section to Tempest CR
+- name: Create secret with cifmw private key file and set SSHKeySecretName in TempestCR
   when:
     - not cifmw_test_operator_dry_run | bool
     - cifmw_test_operator_tempest_ssh_key_secret_name is not defined
-  ansible.builtin.set_fact:
-    test_operator_cr: >-
-      {{
-          test_operator_cr |
-          combine({'spec': {'SSHKeySecretName':
-                    cifmw_test_operator_controller_priv_key_secret_name
-                  }}, recursive=true)
-      }}
+    - private_key_file.stat.exists
+  block:
+    - name: Ensure a secret for the cifmw private key file exists
+      kubernetes.core.k8s:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit) }}"
+        context: "{{ cifmw_openshift_context | default(omit) }}"
+        state: present
+        wait: true
+        definition:
+          apiVersion: v1
+          kind: Secret
+          type: Opaque
+          metadata:
+            name: "{{ cifmw_test_operator_controller_priv_key_secret_name }}"
+            namespace: "{{ cifmw_test_operator_namespace }}"
+          data:
+            ssh-privatekey: >-
+              {{
+                  lookup('file', cifmw_test_operator_controller_priv_key_file_path, rstrip=False) |
+                  b64encode
+              }}
+
+    - name: Add SSHKeySecretName section to Tempest CR
+      ansible.builtin.set_fact:
+        test_operator_cr: >-
+          {{
+              test_operator_cr |
+              combine({'spec': {'SSHKeySecretName':
+                        cifmw_test_operator_controller_priv_key_secret_name
+                      }}, recursive=true)
+          }}
 
 - name: Add controller IP to the overrides section in Tempest CR
   when:

--- a/roles/test_operator/vars/main.yml
+++ b/roles/test_operator/vars/main.yml
@@ -14,6 +14,7 @@
 # under the License.
 
 cifmw_test_operator_controller_priv_key_secret_name: "test-operator-controller-priv-key"
+cifmw_test_operator_controller_priv_key_file_path: "~/.ssh/id_cifw"
 cifmw_test_operator_tempest_kind_name: "Tempest"
 cifmw_test_operator_tobiko_kind_name: "Tobiko"
 cifmw_test_operator_ansibletest_kind_name: "AnsibleTest"


### PR DESCRIPTION
Some set of tests, for example those in whitebox neutron tempest
plugin, requires a private key that allows them to connect to the
controller node.

This PR ensures that the private key is mounted only when it does
exist.

This change is required because of:
- [OSPCIX-546](https://issues.redhat.com/browse/OSPCIX-546)

[OSPCIX-546](https://issues.redhat.com//browse/OSPCIX-546) further indirectly blocks:
- [OSPCIX-545](https://issues.redhat.com/browse/OSPCIX-545)
- [OSPCIX-532](https://issues.redhat.com/browse/OSPCIX-532)
- [OSPCIX-543](https://issues.redhat.com/browse/OSPCIX-543)