### PR TITLE
libvirt_manager extra nets - firewall zone

### DIFF
--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -44,7 +44,7 @@ Used for checking if:
 * `cifmw_libvirt_manager_attach_dummy_interface_on_bridges`: (Bool) Attach dummy interface on bridges. Defaults to `true`.
 * `cifmw_libvirt_manager_default_gw_nets`: (List[String]) List of networks used as default gateway. If not set, defaults to the `cifmw_libvirt_manager_pub_net`. Read bellow for more information about that parameter.
 * `cifmw_libvirt_manager_vm_users`: (List[Dict]) Used to override the default list of users enabled in the vm. For its format, refers to cloud-init [documentation](https://cloudinit.readthedocs.io/en/latest/reference/modules.html#users-and-groups) about `users`. Defaults to `[]`.
-* `cifmw_libvirt_manager_extra_network_configuration`: (Dict) Extra network configuration in nmstate format for the hypervisor. This configuration is applied after creating the libvirt networks, so it can be used to create VLAN interfaces on the libvirt bridges. Defaults to: `{}`.
+* `cifmw_libvirt_manager_extra_network_configuration`: (Dict) Extra network configuration in nmstate format for the hypervisor. This configuration is applied after creating the libvirt networks, so it can be used to create VLAN interfaces on the libvirt bridges. In addition to nmstate, it also supports a `cifmw_firewall_zone` hint in nmstate interfaces.  Defaults to: `{}`.
 
 ### `cifmw_libvirt_manager_default_gw_nets` parameter usage
 
@@ -114,6 +114,7 @@ _networks:
 cifmw_libvirt_manager_extra_network_configuration:
   interfaces:
     - name: vlan10
+      cifmw_firewall_zone: libvirt
       type: vlan
       state: up
       vlan:

--- a/roles/libvirt_manager/molecule/ocp_layout/converge.yml
+++ b/roles/libvirt_manager/molecule/ocp_layout/converge.yml
@@ -70,6 +70,7 @@
         cifmw_libvirt_manager_extra_network_configuration:
           interfaces:
             - name: "vlan{{ cifmw_networking_definition.networks.internalapi.vlan }}"
+              cifmw_firewall_zone: libvirt
               type: vlan
               state: up
               vlan:
@@ -83,6 +84,7 @@
                   - ip: "{{ cifmw_networking_definition.networks.internalapi.gateway }}"
                     prefix-length: "{{ cifmw_networking_definition.networks.internalapi.network | ansible.utils.ipaddr('prefix') }}"
             - name: "vlan{{ cifmw_networking_definition.networks.storage.vlan }}"
+              cifmw_firewall_zone: libvirt
               type: vlan
               state: up
               vlan:
@@ -197,6 +199,11 @@
           register: _ip_link_show
           ansible.builtin.command: ip -json link show
 
+        - name: List libvirt firewall zone interfaces
+          become: true
+          register: _libvirt_zone_interfaces
+          ansible.builtin.command: firewall-cmd --zone=libvirt --list-interfaces
+
         - name: Ensure the VLAN interfaces was created
           vars:
             _vlan_interfaces:
@@ -208,4 +215,17 @@
               - _ip_link_show.stdout | from_json | selectattr('ifname', 'eq', item) | length > 0
             msg: >-
               Expected vlan {{ item }} not found
+          loop: "{{ _vlan_interfaces }}"
+
+        - name: Ensure the VLAN interfaces is in the correct firewall zone
+          vars:
+            _vlan_interfaces:
+              - "vlan{{ cifmw_networking_definition.networks.internalapi.vlan }}"
+              - "vlan{{ cifmw_networking_definition.networks.storage.vlan }}"
+          ansible.builtin.assert:
+            quiet: true
+            that:
+              - "item in _libvirt_zone_interfaces.stdout"
+            msg: >-
+              Expected vlan {{ item }} not found in libvirt firewall zone
           loop: "{{ _vlan_interfaces }}"

--- a/roles/libvirt_manager/tasks/create_networks.yml
+++ b/roles/libvirt_manager/tasks/create_networks.yml
@@ -90,10 +90,31 @@
   when: cifmw_libvirt_manager_extra_network_configuration | default({}) | length > 0
   vars:
     cifmw_ci_nmstate_unmanaged_host: "{{ inventory_hostname }}"
-    cifmw_ci_nmstate_unmanaged_node_config: "{{ cifmw_libvirt_manager_extra_network_configuration }}"
+    cifmw_ci_nmstate_unmanaged_node_config: >-
+      {{
+        cifmw_libvirt_manager_extra_network_configuration |
+        ansible.utils.remove_keys(target='cifmw_firewall_zone')
+      }}
   ansible.builtin.include_role:
     name: "ci_nmstate"
     tasks_from: "nmstate_unmanaged_provision_node.yml"
+
+- name: Ensure extra networks is in correct zone
+  when:
+    - cifmw_libvirt_manager_extra_network_configuration | default({}) | length > 0
+    - item.cifmw_firewall_zone is defined
+  become: true
+  notify: Restart firewalld
+  ansible.builtin.shell:
+    cmd: >-
+      firewall-cmd --zone {{ item.cifmw_firewall_zone }}
+      --change-interface={{ item.name }}
+      --permanent;
+  loop: "{{ cifmw_libvirt_manager_extra_network_configuration.interfaces | default([]) }}"
+  loop_control:
+    label: "{{ item.name }}"
+  async: 120
+  poll: 0
 
 ## Ensure we get dnsmasq DHCP service for all created networks
 # Refreshing network facts will ensure we get the new interfaces.


### PR DESCRIPTION
Add support in the libvirt_manager role to overload the nmstate config passed in `cifmw_libvirt_manager_extra_network_configuration` with a firewall zone hint using key name `cifmw_firewall_zone` for an interface in the nmstate interfaces section.

Example:
```
  cifmw_libvirt_manager_extra_network_configuration:
    interfaces:
      - name: vlan10
        cifmw_firewall_zone: libvirt
        type: vlan 
        ...
```
The key is filtered before passing the data to the ci_nmstate role.

When defined a task following the task calling ci_nmstate will run the appropriate firewall-cmd to change the zone for the interfaces.

Jira: [OSPRH-10966](https://issues.redhat.com//browse/OSPRH-10966)