### PR TITLE
Remove unused glance backends in ci_dcn_site role

### DIFF
--- a/roles/ci_dcn_site/tasks/main.yml
+++ b/roles/ci_dcn_site/tasks/main.yml
@@ -17,6 +17,7 @@
 - name: Initialize vars
   ansible.builtin.set_fact:
     _ceph_vars_list: []
+    _all_azs: []
 
 - name: Set Network related facts
   ansible.builtin.include_tasks: set_network_facts.yml

--- a/roles/ci_dcn_site/tasks/post-ceph.yml
+++ b/roles/ci_dcn_site/tasks/post-ceph.yml
@@ -39,6 +39,21 @@
   ansible.builtin.set_fact:
     _ceph_vars_list: "{{ _ceph_vars_list | union([item.ansible_facts]) }}"
 
+- name: Define _all_azs list for all Ceph backends
+  loop: "{{ _ceph_vars_list }}"
+  ansible.builtin.set_fact:
+    _all_azs: "{{ _all_azs | default([]) + [ item.cifmw_ceph_client_cluster ] }}"
+
+- name: The map for az0 contains all AZ backends
+  ansible.builtin.set_fact:
+    ci_dcn_site_glance_map: "{{ { 'az0': _all_azs } }}"
+
+- name: The map for AZs other than az0 contains backends for az0 and itself
+  loop: "{{ _all_azs }}"
+  when: item != "az0"
+  ansible.builtin.set_fact:
+    ci_dcn_site_glance_map: "{{ ci_dcn_site_glance_map | combine( { item: ['az0', item ] } ) }}"
+
 - name: Render the post-ceph service-values.yaml
   ansible.builtin.template:
     mode: "0644"

--- a/roles/ci_dcn_site/templates/service-values.yaml.j2
+++ b/roles/ci_dcn_site/templates/service-values.yaml.j2
@@ -26,9 +26,7 @@ data:
       customServiceConfig: |
         [DEFAULT]
         enabled_backends = ceph
-{% if 'az0' not in _ceph.cifmw_ceph_client_cluster %}
         glance_api_servers = https://glance-{{ _ceph.cifmw_ceph_client_cluster }}-internal.openstack.svc:9292
-{% endif %}
         [ceph]
         volume_backend_name = ceph
         volume_driver = cinder.volume.drivers.rbd.RBDDriver
@@ -41,51 +39,23 @@ data:
         backend_availability_zone = {{ _ceph.cifmw_ceph_client_cluster }}
 {% endfor %}
   glance:
-    customServiceConfig: |
-        [DEFAULT]
-        enabled_backends = default_backend:rbd
-        [glance_store]
-        default_backend = default_backend
-        [default_backend]
-        rbd_store_ceph_conf = /etc/ceph/az0.conf
-        store_description = "RBD backend"
-        rbd_store_pool = images
-        rbd_store_user = openstack
-        rbd_thin_provisioning = True
+    keystoneEndpoint: az0
     glanceAPIs:
-{% set backends = [] %}
 {% for _ceph in _ceph_vars_list %}
-{% if _ceph.cifmw_ceph_client_cluster not in backends %}
-{% set _ = backends.append(_ceph.cifmw_ceph_client_cluster + ':rbd') %}
-{% endif %}
-{% endfor %}
-{% for _ceph in _ceph_vars_list %}
-{% if 'az0' in _ceph.cifmw_ceph_client_cluster %}
-      default:
-{% else %}
       {{ _ceph.cifmw_ceph_client_cluster }}:
-{% endif %}
         customServiceConfig: |
           [DEFAULT]
           enabled_import_methods = [web-download,copy-image,glance-direct]
-          enabled_backends = {{ backends | join(',') }}
+          enabled_backends = {{ ci_dcn_site_glance_map[_ceph.cifmw_ceph_client_cluster] | join(':rbd,') + ':rbd'}}
           [glance_store]
           default_backend = {{ _ceph.cifmw_ceph_client_cluster }}
-          [{{ _ceph.cifmw_ceph_client_cluster }}]
-          rbd_store_ceph_conf = /etc/ceph/{{ _ceph.cifmw_ceph_client_cluster }}.conf
-          store_description = "{{ _ceph.cifmw_ceph_client_cluster }} RBD backend"
+{% for _ceph_az in ci_dcn_site_glance_map[_ceph.cifmw_ceph_client_cluster] %}
+          [{{ _ceph_az }}]
+          rbd_store_ceph_conf = /etc/ceph/{{ _ceph_az }}.conf
+          store_description = "{{ _ceph_az }} RBD backend"
           rbd_store_pool = images
           rbd_store_user = openstack
           rbd_thin_provisioning = True
-{% for _ceph_az in _ceph_vars_list %}
-{% if _ceph_az.cifmw_ceph_client_cluster != _ceph.cifmw_ceph_client_cluster %}
-          [{{ _ceph_az.cifmw_ceph_client_cluster }}]
-          rbd_store_ceph_conf = /etc/ceph/{{ _ceph_az.cifmw_ceph_client_cluster }}.conf
-          store_description = "{{ _ceph_az.cifmw_ceph_client_cluster }} RBD backend"
-          rbd_store_pool = images
-          rbd_store_user = openstack
-          rbd_thin_provisioning = True
-{% endif %}
 {% endfor %}
         networkAttachments:
           - storage
@@ -99,10 +69,11 @@ data:
                   metallb.universe.tf/loadBalancerIPs: 172.17.0.8{{ loop.index0 }}
               spec:
                 type: LoadBalancer
-        replicas: 3
 {% if _ceph.cifmw_ceph_client_cluster == 'az0' %}
+        replicas: 3
         type: split
 {% else %}
+        replicas: 1
         type: edge
 {% endif %}
 {% endfor %}

--- a/roles/ci_dcn_site/templates/values.yaml.j2
+++ b/roles/ci_dcn_site/templates/values.yaml.j2
@@ -39,11 +39,7 @@ data:
                 rbd_user=openstack
                 rbd_secret_uuid={{ cifmw_ceph_client_fsid }}
                 [glance]
-{% if 'az0' in cifmw_ceph_client_cluster %}
-                endpoint_override = https://glance-default-internal.openstack.svc:9292
-{% else %}
                 endpoint_override = https://glance-{{ _az }}-internal.openstack.svc:9292
-{% endif %}
                 valid_interfaces = internal
                 [cinder]
                 cross_az_attach = False


### PR DESCRIPTION
The enabled_backends for Glance were wrong. Simplify the jinja to define them by basing their logic on a new `ci_dcn_site_glance_map` fact which maps backend names to a list of enabled backned names such that:

- The map for az0 contains all AZ backends
- The map for AZs other than az0 contains backends for az0 and itself

Two new Ansible tasks named after the above define the new map. In the case of three AZs it looks like this:
```
  map:
    az0: ['az0', 'az1', 'az2']
    az1: ['az0', 'az1']
    az2: ['az0', 'az2']
```
Also, remove the customServiceConfig from the Glance template since it's different for each Glance API pod and rename the default backend to 'az0' by setting the `keystoneEndpoint`.