### PR TITLE
[os_net_setup] Add --availability-zone-hint to network creation

### DIFF
--- a/roles/os_net_setup/defaults/main.yml
+++ b/roles/os_net_setup/defaults/main.yml
@@ -8,6 +8,12 @@ cifmw_os_net_setup_config:
     is_default: true
     provider_network_type: flat
     provider_physical_network: datacentre
+    # availability_zone_hints is a list of AZs that should have been configured in neutron controlplane). Example:
+    # availability_zone_hints:
+    #   - zone-1
+    #   - zone-2
+    # availability_zone_hints defaults to empty list
+    availability_zone_hints: []
     subnets:
       - name: public_subnet
         cidr: 192.168.122.0/24

--- a/roles/os_net_setup/templates/network_command.j2
+++ b/roles/os_net_setup/templates/network_command.j2
@@ -35,5 +35,8 @@ oc exec -n openstack openstackclient -- openstack network create \
 {%   if net_args.is_vlan_transparent is defined and net_args.is_vlan_transparent %}
     --transparent-vlan \
 {%   endif %}
+{%   for az in (net_args.availability_zone_hints | default([])) %}
+    --availability-zone-hint {{ az }} \
+{%   endfor %}
     {{ net_args.name }}
 {% endfor %}


### PR DESCRIPTION
This PR adds the option to configure external networks for certain AZs. In order to do this, the list `availability_zone_hints` should be configured as port of `cifmw_os_net_setup_config`.