### PR TITLE
Add missing molecule jobs for roles

### DIFF
--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -863,6 +863,24 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/adoption_osp_deploy/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-adoption_osp_deploy
+    parent: cifmw-molecule-noop
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
+    - ^roles/ci_dcn_site/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-ci_dcn_site
+    parent: cifmw-molecule-noop
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/ci_lvms_storage/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -13,11 +13,13 @@
       - cifmw-architecture-validate-hci
       - ci-framework-openstack-meta-content-provider
       - build-push-container-cifmw-client
+      - cifmw-molecule-adoption_osp_deploy
       - cifmw-molecule-artifacts
       - cifmw-molecule-build_containers
       - cifmw-molecule-build_openstack_packages
       - cifmw-molecule-build_push_container
       - cifmw-molecule-cert_manager
+      - cifmw-molecule-ci_dcn_site
       - cifmw-molecule-ci_gen_kustomize_values
       - cifmw-molecule-ci_local_storage
       - cifmw-molecule-ci_lvms_storage


### PR DESCRIPTION
The adoption_osp_deploy and ci_dcn_sites roles are missing molecule jobs, which makes the cifmw-pod-zuul-files check fail in another PR[1]. This change adds the output of `make role_molecule` so the molecule job list is up-to-date.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/2485