### PR TITLE
Dynamically rename Tempest resource post-update

### DIFF
--- a/update-edpm.yml
+++ b/update-edpm.yml
@@ -26,6 +26,7 @@
     pre_tests: "{{ (lookup('vars', 'pre_tempest', default=[])) }}"
     post_tests: "{{ (lookup('vars', 'post_tempest', default=[])) }}"
     cifmw_test_operator_artifacts_basedir: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/tests/test_operator_update"
+    cifmw_test_operator_tempest_name: "post-update-tempest-tests"
   when:
     - cifmw_run_tests | default('false') | bool
   tags:


### PR DESCRIPTION
Renamed the Tempest resource name after updates using the "cifmw_test_operator_tempest_name" parameter.
This change enables the test operator role to run multiple times consecutively without requiring resource cleanup, improving test isolation and efficiency.