### PR TITLE
Retry mechanism for discover hosts

### DIFF
--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -276,6 +276,11 @@
         -n openstack
         nova-cell0-conductor-0
         nova-manage cell_v2 discover_hosts --verbose
+        --strict
+      register: discover_result
+      until: discover_result.rc == 0
+      retries: 3
+      delay: 30
 
 - name: Run post_deploy hooks
   when:

--- a/roles/edpm_deploy/tasks/main.yml
+++ b/roles/edpm_deploy/tasks/main.yml
@@ -178,6 +178,11 @@
       oc rsh
       --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
       nova-cell0-conductor-0 nova-manage cell_v2 discover_hosts --verbose
+      --strict
+    register: discover_result
+    until: discover_result.rc == 0
+    retries: 3
+    delay: 30
 
 - name: Validate EDPM
   when: cifmw_edpm_deploy_run_validation | bool

--- a/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -297,3 +297,8 @@
       oc rsh
       -n {{ cifmw_install_yamls_defaults['NAMESPACE'] }}
       nova-cell0-conductor-0 nova-manage cell_v2 discover_hosts --verbose
+      --strict
+    register: discover_result
+    until: discover_result.rc == 0
+    retries: 3
+    delay: 30


### PR DESCRIPTION
    This retry mechanism is intended to raise an error if no computes are
    found after the dataplane deployment, preventing futher execution of
    tasks (which depend on a successful dataplane deployment)[0].
    Limitation: a discover_hosts execution with --strict option is
    considered successful (exit code 0) when an unmapped host is
    discovered so if for example we have two hosts to discover and only
    one is found no error will be thrown.
    
    [0] https://issues.redhat.com/browse/OSPRH-11052