### PR TITLE
Specify Ceph configuration file path for Cinder backup

### DIFF
--- a/roles/ci_dcn_site/templates/service-values.yaml.j2
+++ b/roles/ci_dcn_site/templates/service-values.yaml.j2
@@ -18,6 +18,7 @@ data:
     customServiceConfig: |
       [DEFAULT]
       backup_driver = cinder.backup.drivers.ceph.CephBackupDriver
+      backup_ceph_conf = /etc/ceph/az0.conf
       backup_ceph_pool = backups
       backup_ceph_user = openstack
   cinderVolumes:


### PR DESCRIPTION
Adds `backup_ceph_conf` parameter to Cinder backup configuration to explicitly set the Ceph configuration file path.