### PR TITLE
Remove retries from ci_dcn_site post-ceph deployment

### DIFF
--- a/roles/ci_dcn_site/tasks/post-ceph.yml
+++ b/roles/ci_dcn_site/tasks/post-ceph.yml
@@ -106,10 +106,6 @@
     src: "{{ ci_dcn_site_arch_path }}/dataplane-nodeset-post-ceph_{{ _az }}.yaml"
 
 - name: Apply post-ceph DataPlaneDeployment CR
-  register: result
-  retries: 5
-  delay: 10
-  until: result is not failed
   kubernetes.core.k8s:
     api_key: "{{ _auth_results.openshift_auth.api_key }}"
     state: present


### PR DESCRIPTION
The `Apply post-ceph DataPlaneDeployment CR` task is using The `kubernetes.core.k8s` module with wait `true` so there is no need to use `retries`. In some deployments I have seen this hang and eventually cause the deployment to fail even though `oc get openstackdataplanedeployment` indicates that it reached `Setup complete`.