### PR TITLE
Skip watcher containers for downstream

### DIFF
--- a/roles/build_containers/defaults/main.yml
+++ b/roles/build_containers/defaults/main.yml
@@ -55,3 +55,12 @@ cifmw_build_containers_install_from_source: false
 # cifmw_build_containers_dockerfile_labels
 # cifmw_build_containers_extra_config
 # cifmw_build_containers_build_timeout
+
+# Note(Chandankumar): Remove it once watcher related packages are available downstream.
+cifmw_build_containers_exclude_containers:
+  rhos18:
+    rhel9:
+      - watcher-base
+      - watcher-api
+      - watcher-applier
+      - watcher-decision-engine

--- a/roles/build_containers/templates/build_containers.sh.j2
+++ b/roles/build_containers/templates/build_containers.sh.j2
@@ -22,7 +22,7 @@ openstack tcib container image build \
 {%   if cifmw_build_containers_rhel_modules is defined %}
      --rhel-modules {{ cifmw_build_containers_rhel_modules | join(",") }} \
 {%   endif %}
-{%   if cifmw_build_containers_exclude_containers is defined %}
+{%   if cifmw_build_containers_exclude_containers is defined and cifmw_build_containers_openstack_release in cifmw_build_containers_exclude_containers %}
 {%   set distroversion = cifmw_build_containers_distro + cifmw_build_containers_dist_major_version %}
 {%   for item in cifmw_build_containers_exclude_containers[cifmw_build_containers_openstack_release][distroversion] %}
      --exclude {{ item }} \


### PR DESCRIPTION
Watcher related packages got added in RDO antelope but not available in OSP-18 downstream.

https://github.com/openstack-k8s-operators/tcib/pull/215 adds watcher container in tcib. Since downstream tcib jobs install the tcib rpm from main branch so it may break downstream container build and component job.

So in order to avoid breakage, we are skip building watcher related containers.

Note: It also fixes the exclude conditional to check existence of release key in exclude var to avoid following error:
    ```
    ''dict object'' has no attribute ''master'''
    ```


Depends-On: https://github.com/openstack-k8s-operators/tcib/pull/215