### PR TITLE
[BGP] ipv4routes can be defined for netconfig

### DIFF
--- a/plugins/module_utils/net_map/networking_env_definitions.py
+++ b/plugins/module_utils/net_map/networking_env_definitions.py
@@ -171,6 +171,8 @@ class MappedNetconfigNetworkConfig:
 
     ipv4_ranges: typing.List[MappedIpv4NetworkRange]
     ipv6_ranges: typing.List[MappedIpv6NetworkRange]
+    ipv4_routes: typing.List[MappedIpv4NetworkRoute]
+    ipv6_routes: typing.List[MappedIpv6NetworkRoute]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/network-values/values.yaml.j2
@@ -67,6 +67,13 @@ data:
         - end: {{ range.end }}
           start: {{ range.start }}
 {%    endfor %}
+{%    if network.tools.netconfig.ipv4_routes | default([]) | length > 0 %}
+        routes:
+{%      for route in network.tools.netconfig.ipv4_routes %}
+        - destination: {{ route.destination }}
+          nexthop: {{ route.gateway }}
+{%      endfor %}
+{%    endif %}
         cidr: {{ network.network_v4 }}
 {%      if network.gw_v4 is defined %}
         gateway: {{ network.gw_v4 }}


### PR DESCRIPTION
In case of octavia, ipv4routes will be needed to connect to the management network.