### PR TITLE
Use hook to wait for compute service

### DIFF
--- a/roles/edpm_deploy/tasks/main.yml
+++ b/roles/edpm_deploy/tasks/main.yml
@@ -170,14 +170,8 @@
   when:
     - not cifmw_edpm_deploy_dryrun | bool
     - not cifmw_edpm_deploy_skip_nova_discover_hosts | default(false) | bool
-  environment:
-    PATH: "{{ cifmw_path }}"
-    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-  ansible.builtin.command:
-    cmd: >-
-      oc rsh
-      --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
-      nova-cell0-conductor-0 nova-manage cell_v2 discover_hosts --verbose
+  ansible.builtin.include_tasks:
+    file: "../../../hooks/playbooks/nova_wait_for_compute_service.yml"
 
 - name: Validate EDPM
   when: cifmw_edpm_deploy_run_validation | bool


### PR DESCRIPTION
The openstackdataplane deployment can be marked as complete even if nova is not fully running yet. Use hook which insert a wait-and-check for compute services being up before running discover_hosts