### PR TITLE
Skip ironic tests which need to be fixed

### DIFF
--- a/roles/test_operator/files/list_skipped.yml
+++ b/roles/test_operator/files/list_skipped.yml
@@ -1427,3 +1427,48 @@ known_failures:
         lp: https://bugs.launchpad.net/ironic/+bug/2065378
     jobs:
       - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_ports.TestPorts.test_update_port_add
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Test state does not assert a noop network interface, and fails.
+        lp: https://bugs.launchpad.net/ironic/+bug/2087263
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_ports.TestPorts.test_update_mixed_ops
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Test state does not assert a noop network interface, and fails.
+        lp: https://bugs.launchpad.net/ironic/+bug/2087263
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_ports.TestPorts.test_update_port_remove
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Test state does not assert a noop network interface, and fails.
+        lp: https://bugs.launchpad.net/ironic/+bug/2087263
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_ports.TestPorts.test_update_port_replace
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Test state does not assert a noop network interface, and fails.
+        lp: https://bugs.launchpad.net/ironic/+bug/2087263
+    jobs:
+      - ironic-operator
+  - test: ironic_tempest_plugin.tests.api.admin.test_ports_negative.TestPortsNegative.test_update_port_replace_mac_with_duplicated
+    deployment:
+      - overcloud
+    releases:
+      - name: master
+        reason: Test state does not assert a noop network interface, and fails.
+        lp: https://bugs.launchpad.net/ironic/+bug/2087263
+    jobs:
+      - ironic-operator


### PR DESCRIPTION
A bug in the operator experienced by users is a default state of the "noop" network interface. Unfortunately the api contract tests which we exercise were developed to run with this being the default network interface, but the tests themselves are not a fan of the correct but different behavior when you don't have, for example a full network configuraiton behind ironic.

While we work to fix these tests upstream, disable the tests from impacting the test results.

https://bugs.launchpad.net/ironic/+bug/2087263