### PR TITLE
[ci_dcn_site] Add support for network availability zones

### DIFF
--- a/roles/ci_dcn_site/defaults/main.yml
+++ b/roles/ci_dcn_site/defaults/main.yml
@@ -25,3 +25,4 @@ ci_dcn_site_search_storagemgmt_network_names:
   - "storagemgmt"
   - "storagemgmtdcn1"
   - "storagemgmtdcn2"
+cifmw_ci_dcn_site_enable_network_az: false

--- a/roles/ci_dcn_site/templates/edpm-pre-ceph/nodeset/values.yaml.j2
+++ b/roles/ci_dcn_site/templates/edpm-pre-ceph/nodeset/values.yaml.j2
@@ -93,6 +93,11 @@ data:
 {% elif 'dcn2'in _group_name %}
         edpm_ovn_bridge_mappings: ["leaf2:br-ex"]
 {%endif %}
+{% if cifmw_ci_dcn_site_enable_network_az is true %}
+        edpm_enable_chassis_gw: true
+        edpm_ovn_availability_zones:
+          - {{ _az }}
+{% endif %}
         neutron_physical_bridge_name: br-ctl
         neutron_public_interface_name: eth0
         edpm_ceph_hci_pre_enabled_services:

--- a/roles/ci_dcn_site/templates/service-values.yaml.j2
+++ b/roles/ci_dcn_site/templates/service-values.yaml.j2
@@ -116,10 +116,30 @@ data:
   neutron:
       template:
         customServiceConfig: |
+{% if cifmw_ci_dcn_site_enable_network_az is true %}
+          [DEFAULT]
+          router_scheduler_driver = neutron.scheduler.l3_agent_scheduler.AZLeastRoutersScheduler
+          network_scheduler_driver =  neutron.scheduler.dhcp_agent_scheduler.AZAwareWeightScheduler
+          default_availability_zones = az0,az1,az2
+{% endif %}
           [ml2_type_vlan]
           network_vlan_ranges = datacentre:1:1000,leaf1:1:1000,leaf2:1:1000
           [neutron]
           physnets = datacentre,leaf1,leaf2
+  ovn:
+    template:
+      ovnController:
+        external-ids:
+          enable-chassis-as-gateway: true
+          ovn-bridge: br-int
+          ovn-encap-type: geneve
+          system-id: random
+{% if cifmw_ci_dcn_site_enable_network_az is true %}
+          availability-zones:
+            - az0
+{% else %}
+          availability-zones: []
+{% endif %}
   nova:
       customServiceConfig: |
         [DEFAULT]


### PR DESCRIPTION
Introduces the `ci_dcn_site_enable_network_az` parameter to enable support for network availability zones. The default value of this parameter is `false`.