### PR TITLE
roles/ci_dcn_site: Add multicell to DCN DT

### DIFF
--- a/roles/ci_dcn_site/tasks/post-ceph.yml
+++ b/roles/ci_dcn_site/tasks/post-ceph.yml
@@ -14,13 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Render the post-ceph values.yaml
-  ansible.builtin.template:
-    mode: "0644"
-    backup: true
-    src: "templates/values.yaml.j2"
-    dest: "{{ ci_dcn_site_arch_path }}/values.yaml"
-
 - name: Find all ceph variable files
   register: _ceph_vars_files
   ansible.builtin.find:
@@ -53,6 +46,13 @@
   when: item != "az0"
   ansible.builtin.set_fact:
     ci_dcn_site_glance_map: "{{ ci_dcn_site_glance_map | combine( { item: ['az0', item ] } ) }}"
+
+- name: Render the post-ceph values.yaml
+  ansible.builtin.template:
+    mode: "0644"
+    backup: true
+    src: "templates/values.yaml.j2"
+    dest: "{{ ci_dcn_site_arch_path }}/values.yaml"
 
 - name: Render ceph secret for this _az
   when: _az != "az0"

--- a/roles/ci_dcn_site/templates/deployment/values.yaml.j2
+++ b/roles/ci_dcn_site/templates/deployment/values.yaml.j2
@@ -15,6 +15,6 @@ data:
     - install-certs
     - ceph-client
     - ovn
-    - neutron-metadata
+    - neutron-metadata-cell{{ _all_azs | length }}
     - libvirt
     - nova-custom-ceph-{{ _az }}

--- a/roles/ci_dcn_site/templates/service-values.yaml.j2
+++ b/roles/ci_dcn_site/templates/service-values.yaml.j2
@@ -41,6 +41,18 @@ data:
         rbd_cluster_name = {{ _ceph.cifmw_ceph_client_cluster }}
         backend_availability_zone = {{ _ceph.cifmw_ceph_client_cluster }}
 {% endfor %}
+  galera:
+    templates:
+      openstack:
+        replicas: 1
+        secret: osp-secret
+        storageRequest: 5G
+{% for index in range(1, _all_azs | length + 1) %}
+      openstack-cell{{ index }}:
+        replicas: 1
+        secret: osp-secret
+        storageRequest: 5G
+{% endfor %}
   glance:
     keystoneEndpoint: az0
     glanceAPIs:
@@ -112,6 +124,57 @@ data:
       customServiceConfig: |
         [DEFAULT]
         default_schedule_zone=az0
+      metadataServiceTemplate:
+        enabled: false
+      cellTemplates:
+        cell0:
+          cellDatabaseAccount: nova-cell0
+          hasAPIAccess: true
+{% for index in range(1, _all_azs | length + 1) %}
+        cell{{ index }}:
+          cellDatabaseInstance: openstack-cell{{ index }}
+          cellDatabaseAccount: nova-cell{{ index }}
+          cellMessageBusInstance: rabbitmq-cell{{ index }}
+          conductorServiceTemplate:
+            replicas: 1
+          hasAPIAccess: true
+          metadataServiceTemplate:
+            enabled: true
+            override:
+              service:
+                metadata:
+                  annotations:
+                    metallb.universe.tf/address-pool: internalapi
+                    metallb.universe.tf/allow-shared-ip: internalapi
+                    metallb.universe.tf/loadBalancerIPs: 172.17.0.8{{ index }}
+                spec:
+                  type: LoadBalancer
+            replicas: 3
+{% endfor %}
+  rabbitmq:
+    templates:
+      rabbitmq:
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.85
+            spec:
+              type: LoadBalancer
+        replicas: 3
+{% for index in range(1, _all_azs | length + 1) %}
+      rabbitmq-cell{{ index }}:
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.universe.tf/address-pool: internalapi
+                metallb.universe.tf/loadBalancerIPs: 172.17.0.8{{ 5 + index }}
+            spec:
+              type: LoadBalancer
+        replicas: 3
+{% endfor %}
   extraMounts:
     - name: v1
       region: r1

--- a/roles/ci_dcn_site/templates/values.yaml.j2
+++ b/roles/ci_dcn_site/templates/values.yaml.j2
@@ -2,8 +2,6 @@
 # source: dcn/values.yaml.j2
 apiVersion: v1
 data:
-    customDataplanService:
-      name: nova-custom-ceph-{{ _az }}
     nodeset_name: {{ _group_name }}-edpm
     ceph_conf:
 {% for _file in _ceph_files %}
@@ -23,10 +21,12 @@ data:
             - install-certs
             - ceph-client
             - ovn
-            - neutron-metadata
+            - neutron-metadata-cell{{ _all_azs | length }}
             - libvirt
             - nova-custom-ceph-{{ _az }}
     nova:
+        customDataplaneService:
+          name: nova-custom-ceph-{{ _az }}
         ceph:
             conf: |
                 [libvirt]
@@ -49,9 +49,17 @@ data:
             - configMapRef:
                 name: ceph-nova-{{ _az }}
             - secretRef:
-                name: nova-cell1-compute-config
+                name: nova-cell{{ _all_azs | length }}-compute-config
             - secretRef:
                 name: nova-migration-ssh-key
+    neutron-metadata:
+        customDataplaneService:
+          name: neutron-metadata-cell{{ _all_azs | length }}
+        dataSources:
+            - secretRef:
+                name: neutron-ovn-metadata-agent-neutron-config
+            - secretRef:
+                name: nova-cell{{ _all_azs | length }}-metadata-neutron-config
 kind: ConfigMap
 metadata:
     annotations:


### PR DESCRIPTION
One dedicated cell per site is being deployed with dedicated rabbitmw, Galera and nova services. The nova service and neutron-metadata service are pointed to their dedicated cell per DCN site.