### PR TITLE
Set the revision of ansible-podman-collections to 'main'

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -71,7 +71,7 @@ tags:
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
 dependencies:
-  'git+https://github.com/containers/ansible-podman-collections': 'master'
+  'git+https://github.com/containers/ansible-podman-collections': 'main'
   'git+https://github.com/ansible-collections/community.general': 'main'
   'git+https://github.com/ansible-collections/ansible.posix': 'main'
   'git+https://github.com/ansible-collections/ansible.utils': 'main'


### PR DESCRIPTION
Installing ci-framework requirements fails on:
ansible-galaxy collection install --upgrade --force --timeout=120 /home/zuul/src/github.com/openstack-k8s-operators/ci-framework Cloning into '/home/zuul/.ansible/tmp/ansible-local-24798o634gjev/tmpjj8gurw9/ansible-podman-collectionsacd5cco5'... error: pathspec 'master' did not match any file(s) known to git ERROR! Failed to switch a cloned Git repo `https://github .com/containers/ansible-podman-collections` to the requested revision
 `master`.

 It seems that the branch of ansible-podman-collections was renamed
 from 'master' to 'main'.