### PR TITLE
Add watcher-operator to the content provider base job

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -102,6 +102,7 @@
       - openstack-k8s-operators/swift-operator
       - openstack-k8s-operators/tcib
       - openstack-k8s-operators/telemetry-operator
+      - openstack-k8s-operators/watcher-operator
     pre-run:
       - ci/playbooks/content_provider/pre.yml
     run:


### PR DESCRIPTION
In order to run meta content provider against watcher-operator[1], We need to add watcher-operator under content provider required projects.

Links:
[1]. https://github.com/openstack-k8s-operators/watcher-operator