### PR TITLE
Add more Ceph OSDs for adoption context

### DIFF
--- a/scenarios/adoption/hci.yml
+++ b/scenarios/adoption/hci.yml
@@ -50,7 +50,7 @@ libvirt_manager_patch_layout:
       memory: 4
       cpus: 4
       disksize: 20
-      extra_disks_num: 1
+      extra_disks_num: 3
       extra_disks_size: 30G
       nets:
         - ocpbm


### PR DESCRIPTION
In adoption, we need to run scenario tempest tests when ceph is configured as a backend for manila/glance/cinder. This patch increases the number of OSDs to not fail because of not having enough space or something related.

Jira: https://issues.redhat.com/browse/OSPRH-11223