### PR TITLE
Create S3 openstack user when Ceph RGW is deployed

### DIFF
--- a/roles/cifmw_cephadm/tasks/ceph_cli.yml
+++ b/roles/cifmw_cephadm/tasks/ceph_cli.yml
@@ -36,7 +36,10 @@
       {% endif %}
       --entrypoint {{ ceph_command | default('ceph') }}
       {{ cifmw_cephadm_container_ns }}/{{ cifmw_cephadm_container_image }}:{{ cifmw_cephadm_container_tag }}
-      {% if ceph_command|default('ceph') == 'ceph' or ceph_command|default('ceph') == 'rados' or ceph_command|default('ceph') == 'rbd' -%}
+      {% if (ceph_command|default('ceph') == 'ceph') or
+            (ceph_command|default('ceph') == 'rados') or
+            (ceph_command|default('ceph') == 'rbd') or
+            (ceph_command|default('ceph') == 'radosgw-admin') -%}
         {% if not admin_daemon|default(false) -%}
         --fsid {{ cifmw_cephadm_fsid }} -c /etc/ceph/{{ cifmw_cephadm_cluster }}.conf -k /etc/ceph/{{ cifmw_cephadm_cluster }}.client.{{ select_keyring| default('admin') }}.keyring
         {%- endif %}

--- a/roles/cifmw_cephadm/tasks/post.yml
+++ b/roles/cifmw_cephadm/tasks/post.yml
@@ -54,6 +54,20 @@
   vars:
     cifmw_cephadm_rgw_vip: "{{ cifmw_cephadm_vip }}"
 
+- name: Create RGW S3 openstack user
+  when:
+    - cifmw_ceph_daemons_layout.rgw_enabled | default(true) | bool
+  block:
+    - name: Refresh ceph_cli
+      ansible.builtin.include_tasks: ceph_cli.yml
+      vars:
+        ceph_command: "radosgw-admin"
+
+    - name: Ceph rgw - create access/secret key
+      become: true
+      ansible.builtin.command:
+        cmd: >-
+          {{ cifmw_cephadm_ceph_cli }} user create --uid="openstack" --display-name "openstack"
 
 - name: Dashboard service validation
   ansible.builtin.include_tasks: dashboard/validation.yml


### PR DESCRIPTION
When `RGW` is part of the `Ceph` deployment, create an `openstack` `s3` user that can be used to enable `s3 backend` in `Glance`.

Jira: https://issues.redhat.com/browse/OSPRH-11411