### PR TITLE
Reduce compute resources in osasinfra DT

### DIFF
--- a/scenarios/reproducers/dt-osasinfra.yml
+++ b/scenarios/reproducers/dt-osasinfra.yml
@@ -45,8 +45,8 @@ cifmw_networking_mapper_definition_patches_01:
 
 # HCI requires bigger size to hold OCP on OSP disks
 cifmw_block_device_size: 100G
-cifmw_libvirt_manager_compute_disksize: 200
-cifmw_libvirt_manager_compute_memory: 50
+cifmw_libvirt_manager_compute_disksize: 100
+cifmw_libvirt_manager_compute_memory: 40
 cifmw_libvirt_manager_compute_cpus: 8
 
 cifmw_libvirt_manager_configuration:


### PR DESCRIPTION
Smaller RAM and disk allocation for compute nodes in osasinfra DT is required for running in bare metal with 250 GB of RAM and 890 GB of disk.