### PR TITLE
trivial: fix ironic test name

### DIFF
--- a/roles/test_operator/files/list_skipped.yml
+++ b/roles/test_operator/files/list_skipped.yml
@@ -1436,7 +1436,7 @@ known_failures:
         lp: https://bugs.launchpad.net/ironic/+bug/2087263
     jobs:
       - ironic-operator
-  - test: ironic_tempest_plugin.tests.api.admin.test_ports.TestPorts.test_update_mixed_ops
+  - test: ironic_tempest_plugin.tests.api.admin.test_ports.TestPorts.test_update_port_mixed_ops
     deployment:
       - overcloud
     releases:


### PR DESCRIPTION
I accidently put in the wrong test name, test_update_mixed_ops originally, when the actual test name is test_update_port_mixed_ops.