### PR TITLE
Add nodeset2 for scenarios using 2 nodesets

### DIFF
--- a/docs/source/baremetal/01_baremetal_hosts_data.md
+++ b/docs/source/baremetal/01_baremetal_hosts_data.md
@@ -53,6 +53,8 @@ cifmw_baremetal_hosts:
     nmstate:
       # interfaces: # Sample nmstate state snippet
       #   - name: enp6s0f0.161
+    # Optional: (string) app label
+    label: openstack
 
   compute-1:
     # Another BM host

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-2nodesets/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-2nodesets/edpm-nodeset-values/values.yaml.j2
@@ -1,0 +1,58 @@
+---
+# source: ovs-dpdk-sriov-2nodesets/edpm-nodeset-values/values.yaml.j2
+{% set instances_names = []                                                            %}
+{% set _original_nodeset = (original_content.data | default({})).nodeset | default({}) %}
+{% set _original_nodes = _original_nodeset.nodes | default({})                         %}
+{% set _original_services = _original_nodeset['services'] | default([])                %}
+{% if cifmw_baremetal_hosts | default([]) | length > 0                                 %}
+{%   for _inst in cifmw_baremetal_hosts.keys()                                         %}
+{%     if (('label' in cifmw_baremetal_hosts[_inst]) and
+           (cifmw_baremetal_hosts[_inst]['label'] == 'openstack'))                     %}
+{%       set _ = instances_names.append(_inst)                                         %}
+{%     endif                                                                           %}
+{%   endfor                                                                            %}
+{% else                                                                                %}
+# Needed for verification gate
+{%   set _vm_type = (_original_nodes.keys() | first).split('-')[1]                     %}
+{%   for _inst in cifmw_networking_env_definition.instances.keys()                     %}
+{%     if _inst.startswith(_vm_type)                                                   %}
+{%       set _ = instances_names.append(_inst)                                         %}
+{%     endif                                                                           %}
+{%   endfor                                                                            %}
+{% endif                                                                               %}
+data:
+  ssh_keys:
+    authorized: {{ cifmw_ci_gen_kustomize_values_ssh_authorizedkeys | b64encode }}
+    private: {{ cifmw_ci_gen_kustomize_values_ssh_private_key | b64encode }}
+    public: {{ cifmw_ci_gen_kustomize_values_ssh_public_key | b64encode }}
+  nova:
+    migration:
+      ssh_keys:
+        private: {{ cifmw_ci_gen_kustomize_values_migration_priv_key | b64encode }}
+        public: {{ cifmw_ci_gen_kustomize_values_migration_pub_key | b64encode }}
+  nodeset:
+    ansible:
+      ansibleVars:
+        edpm_fips_mode: "{{ 'enabled' if cifmw_fips_enabled|default(false)|bool else 'check' }}"
+        timesync_ntp_servers:
+          - hostname: "{{ cifmw_ci_gen_kustomize_values_ntp_srv | default('pool.ntp.org') }}"
+{% if cifmw_ci_gen_kustomize_values_sshd_ranges | default([]) | length > 0             %}
+        edpm_sshd_allowed_ranges:
+{%   for range in cifmw_ci_gen_kustomize_values_sshd_ranges                            %}
+          - "{{ range }}"
+{%   endfor                                                                            %}
+{% endif                                                                               %}
+    nodes:
+{% for instance in instances_names                                                     %}
+      edpm-{{ instance }}:
+        hostName: {{ instance }}
+{% endfor                                                                              %}
+
+{% if ('repo-setup' not in (_original_nodeset['services'] | default([]))) and
+      ('repo-setup' in ci_gen_kustomize_edpm_nodeset_predeployed_services)             %}
+    services:
+      - "repo-setup"
+{%   for svc in _original_services                                                     %}
+      - "{{ svc }}"
+{%   endfor                                                                            %}
+{% endif                                                                               %}

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-2nodesets/edpm-nodeset2-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-2nodesets/edpm-nodeset2-values/values.yaml.j2
@@ -1,0 +1,58 @@
+---
+# source: ovs-dpdk-sriov-2nodesets/edpm-nodeset2-values/values.yaml.j2
+{% set instances_names = []                                                            %}
+{% set _original_nodeset = (original_content.data | default({})).nodeset | default({}) %}
+{% set _original_nodes = _original_nodeset.nodes | default({})                         %}
+{% set _original_services = _original_nodeset['services'] | default([])                %}
+{% if cifmw_baremetal_hosts | default([]) | length > 0                                 %}
+{%   for _inst in cifmw_baremetal_hosts.keys()                                         %}
+{%     if (('label' in cifmw_baremetal_hosts[_inst]) and
+           (cifmw_baremetal_hosts[_inst]['label'] == 'openstack-2'))                   %}
+{%       set _ = instances_names.append(_inst)                                         %}
+{%     endif                                                                           %}
+{%   endfor                                                                            %}
+{% else                                                                                %}
+# Needed for verification gate
+{%   set _vm_type = (_original_nodes.keys() | first).split('-')[1]                     %}
+{%   for _inst in cifmw_networking_env_definition.instances.keys()                     %}
+{%     if _inst.startswith(_vm_type)                                                   %}
+{%       set _ = instances_names.append(_inst)                                         %}
+{%     endif                                                                           %}
+{%   endfor                                                                            %}
+{% endif                                                                               %}
+data:
+  ssh_keys:
+    authorized: {{ cifmw_ci_gen_kustomize_values_ssh_authorizedkeys | b64encode }}
+    private: {{ cifmw_ci_gen_kustomize_values_ssh_private_key | b64encode }}
+    public: {{ cifmw_ci_gen_kustomize_values_ssh_public_key | b64encode }}
+  nova:
+    migration:
+      ssh_keys:
+        private: {{ cifmw_ci_gen_kustomize_values_migration_priv_key | b64encode }}
+        public: {{ cifmw_ci_gen_kustomize_values_migration_pub_key | b64encode }}
+  nodeset:
+    ansible:
+      ansibleVars:
+        edpm_fips_mode: "{{ 'enabled' if cifmw_fips_enabled|default(false)|bool else 'check' }}"
+        timesync_ntp_servers:
+          - hostname: "{{ cifmw_ci_gen_kustomize_values_ntp_srv | default('pool.ntp.org') }}"
+{% if cifmw_ci_gen_kustomize_values_sshd_ranges | default([]) | length > 0             %}
+        edpm_sshd_allowed_ranges:
+{%   for range in cifmw_ci_gen_kustomize_values_sshd_ranges                            %}
+          - "{{ range }}"
+{%   endfor                                                                            %}
+{% endif                                                                               %}
+    nodes:
+{% for instance in instances_names                                                     %}
+      edpm-{{ instance }}:
+        hostName: {{ instance }}
+{% endfor                                                                              %}
+
+{% if ('repo-setup' not in (_original_nodeset['services'] | default([]))) and
+      ('repo-setup' in ci_gen_kustomize_edpm_nodeset_predeployed_services)             %}
+    services:
+      - "repo-setup"
+{%   for svc in _original_services                                                     %}
+      - "{{ svc }}"
+{%   endfor                                                                            %}
+{% endif                                                                               %}

--- a/roles/deploy_bmh/template/bmh.yml.j2
+++ b/roles/deploy_bmh/template/bmh.yml.j2
@@ -9,7 +9,7 @@ metadata:
     inspect.metal3.io: "disabled"
 {% endif %}
   labels:
-    app: openstack
+    app: {{ node_data['label'] | default("openstack") }}
     workload: {{ node_name.split('-')[0] }}
 spec:
   bmc:

--- a/scenarios/reproducers/dt-nfv-ovs-dpdk-sriov-2nodesets.yml
+++ b/scenarios/reproducers/dt-nfv-ovs-dpdk-sriov-2nodesets.yml
@@ -1,0 +1,117 @@
+---
+cifmw_architecture_scenario: "ovs-dpdk-sriov-2nodesets"
+
+# Automation section. Most of those parameters will be passed to the
+# controller-0 as-is and be consumed by the `deploy-va.sh` script.
+# Please note, all paths are on the controller-0, meaning managed by the
+# Framework. Please do not edit them!
+_arch_repo: "{{ cifmw_architecture_repo | default('/home/zuul/src/github.com/openstack-k8s-operators/architecture') }}"
+
+# HERE if you want to override kustomization, you can uncomment this parameter
+# and push the data structure you want to apply.
+# cifmw_architecture_user_kustomize:
+#   stage_0:
+#     'network-values':
+#       data:
+#         starwars: Obiwan
+
+# HERE, if you want to stop the deployment loop at any stage, you can uncomment
+# the following parameter and update the value to match the stage you want to
+# reach. Known stages are:
+#   pre_kustomize_stage_INDEX
+#   pre_apply_stage_INDEX
+#   post_apply_stage_INDEX
+#
+# cifmw_deploy_architecture_stopper:
+
+cifmw_libvirt_manager_net_prefix_add: false
+cifmw_libvirt_manager_fixed_networks:
+  - ocpbm
+  - ocppr
+  - osp_external
+  - osp_trunk
+
+cifmw_libvirt_manager_configuration:
+  networks:
+    ocpbm: |
+      <network>
+        <name>ocpbm</name>
+        <forward mode='bridge' />
+        <bridge name='ocpbm' />
+      </network>
+    ocppr: |
+      <network>
+        <name>ocppr</name>
+        <forward mode='bridge' />
+        <bridge name='ocppr' />
+      </network>
+    osp_external: |
+      <network>
+        <name>osp_external</name>
+        <forward mode='bridge' />
+        <bridge name='osp_external' />
+      </network>
+    osp_trunk: |
+      <network>
+        <name>osp_trunk</name>
+        <forward mode='bridge' />
+        <bridge name='osp_trunk' />
+      </network>
+  vms:
+    controller:
+      uefi: "{{ cifmw_use_uefi }}"
+      root_part_id: "{{ cifmw_root_partition_id }}"
+      image_url: "{{ cifmw_discovered_image_url }}"
+      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "base-os.qcow2"
+      disksize: 50
+      memory: 8
+      cpus: 4
+      nets:
+        - ocpbm
+        - osp_trunk
+    ocp:
+      amount: 3
+      uefi: true
+      root_part_id: 4
+      admin_user: core
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "ocp_master"
+      disksize: "100"
+      extra_disks_num: 3
+      extra_disks_size: "50G"
+      cpus: 10
+      memory: 32
+      nets:
+        - ocppr
+        - ocpbm
+        - osp_trunk
+        - osp_external
+
+# Note: with that extra_network_names "osp_trunk", we instruct
+# devscripts role to create a new network, and associate it to
+# the OCP nodes. This one is a "private network", and will hold
+# the VLANs used for network isolation.
+
+# Please create a custom env file to provide:
+# cifmw_devscripts_ci_token:
+# cifmw_devscripts_pull_secret:
+
+# Baremetal host configuration
+cifmw_config_bmh: true
+
+# BMH are deployed in a differnt NS than the secret OSP BMO
+# references in each BMH. Metal3 requires the referenced
+# secrets to be in the same NS or be allowed to access them
+cifmw_openshift_setup_metal3_watch_all_ns: true
+
+# Use EDPM image for computes
+cifmw_update_containers_edpm_image_url: "{{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/edpm-hardened-uefi:{{ cifmw_update_containers_tag }}"
+
+# Set Logical Volume Manager Storage by default for local storage
+cifmw_use_lvms: true
+cifmw_lvms_disk_list:
+  - /dev/vda
+  - /dev/vdb
+  - /dev/vdc


### PR DESCRIPTION
In NFV, we have some compute nodes belonging to the same deployment that are different and we need 2 nodesets to be able to deploy