### PR TITLE
[Shiftstack]Support proxy

### DIFF
--- a/roles/shiftstack/README.md
+++ b/roles/shiftstack/README.md
@@ -19,6 +19,7 @@ Role for triggering Openshift on Openstack QA automation (installation and tests
 * `cifmw_shiftstack_run_playbook`: (*string*) The playbook to be run from the `cifmw_shiftstack_qa_repo` repository. Defaults to `ocp_testing.yaml`.
 * `cifmw_shiftstack_sc`: (*string*) The storage class to be used for PVC for the shiftstackclient pod. Defaults to `local-storage`.
 * `cifmw_shiftstack_shiftstackclient_artifacts_dir`: (*string*) The artifacts directory path for the shiftstackclient pod. Defaults to `/home/cloud-admin/artifacts`.
+* `cifmw_shiftstack_proxy`: (*string*) The proxy url that should be used to reach the underlying OCP. Defaults to omit.
 
 ## Examples
 The role is imported in the test playbook, i.e. when:

--- a/roles/shiftstack/tasks/cleanup.yml
+++ b/roles/shiftstack/tasks/cleanup.yml
@@ -27,3 +27,4 @@
     namespace: "{{ cifmw_shiftstack_client_pod_namespace }}"
     name: "{{ cifmw_shiftstack_client_pod_name }}"
     wait: true
+    proxy: "{{ cifmw_shiftstack_proxy | default(omit) }}"

--- a/roles/shiftstack/tasks/deploy_shiftstackclient_pod.yml
+++ b/roles/shiftstack/tasks/deploy_shiftstackclient_pod.yml
@@ -25,6 +25,7 @@
     state: present
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
     src: "{{ (cifmw_shiftstack_manifests_dir, cifmw_shiftstack_client_pvc_manifest) | path_join }}"
+    proxy: "{{ cifmw_shiftstack_proxy | default(omit) }}"
 
 - name: Render the pod manifest from a template
   ansible.builtin.template:
@@ -41,3 +42,4 @@
     wait_condition:
       type: Ready
       status: "True"
+    proxy: "{{ cifmw_shiftstack_proxy | default(omit) }}"

--- a/roles/shiftstack/tasks/pre_test_shiftstack.yml
+++ b/roles/shiftstack/tasks/pre_test_shiftstack.yml
@@ -26,6 +26,7 @@
     kind: Pod
     namespace: "{{ cifmw_shiftstack_client_pod_namespace }}"
     name: "{{ cifmw_shiftstack_client_pod_name }}"
+    proxy: "{{ cifmw_shiftstack_proxy | default(omit) }}"
 
 - name: Remove the shiftstack role data directory (if exists)
   ansible.builtin.file:


### PR DESCRIPTION
We want to run the shiftstack role inside the cifmw.general collection for shiftstack validation in an already deployed RHOSO.

For accessing it from the outside, we'll require to interact with the underlying OCP through the kubernetes.core modules using a proxy. That is currently supported in that collection and we just need to set the proxy parameter. That is what this PR enables.

If the variable cifmw_shiftstack_proxy is not set, the variable is then omitted, so backward compatibility is guaranteed.