### PR TITLE
[kustomize_deploy] Include symlinks when user kustomize dir is set

### DIFF
--- a/roles/kustomize_deploy/tasks/generate_base64_patches_from_tree.yml
+++ b/roles/kustomize_deploy/tasks/generate_base64_patches_from_tree.yml
@@ -8,14 +8,22 @@
         paths: "{{ cifmw_architecture_user_kustomize_base_dir }}"
         patterns: "*.yml,*.yaml"
         recurse: true
+        file_type: "{{ item }}"
       register: _cifmw_kustomize_deploy_yaml_patches_find
+      loop:
+        - file
+        - link
       delegate_to: localhost
 
     - name: Fetch the content of the kustomize patches
       ansible.builtin.slurp:
         path: "{{ item.path }}"
       register: _cifmw_kustomize_deploy_yaml_patches_slurp
-      loop: "{{ _cifmw_kustomize_deploy_yaml_patches_find.files | default([]) }}"
+      loop: >-
+        {{
+          _cifmw_kustomize_deploy_yaml_patches_find.results | default([]) |
+          map(attribute='files') | flatten
+        }}
       delegate_to: localhost
       loop_control:
         label: "{{ item.path | ansible.builtin.relpath(cifmw_architecture_user_kustomize_base_dir) }}"


### PR DESCRIPTION
With this patch, not only regular files but also symlinks are taken into account.