### PR TITLE
Support new OpenStack initialization resource for RHOSO install

### DIFF
--- a/roles/edpm_prepare/tasks/main.yml
+++ b/roles/edpm_prepare/tasks/main.yml
@@ -119,6 +119,34 @@
           --namespace={{ cifmw_install_yamls_defaults['OPERATOR_NAMESPACE'] }}
           --for=jsonpath='{.status.phase}'=Complete --timeout=20m
 
+- name: Check if the OpenStack initialization CRD exists
+  when:
+    - not cifmw_edpm_prepare_dry_run
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    kind: CustomResourceDefinition
+    name: openstacks.operator.openstack.org
+  register: _cifmw_kustomize_deploy_olm_osp_operator_openstack_crd_out
+  tags:
+    - control-plane
+
+- name: OpenStack meta-operator initialization, if necessary
+  when:
+    - not cifmw_edpm_prepare_dry_run
+    - _cifmw_kustomize_deploy_olm_osp_operator_openstack_crd_out is defined
+    - _cifmw_kustomize_deploy_olm_osp_operator_openstack_crd_out.resources is defined
+    - (_cifmw_kustomize_deploy_olm_osp_operator_openstack_crd_out.resources | length) > 0
+  vars:
+    make_openstack_init_env: "{{ cifmw_edpm_prepare_common_env }}"
+    make_openstack_init_dryrun: "{{ cifmw_edpm_prepare_dry_run }}"
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_openstack_init'
+  tags:
+    - control-plane
+
   # Note(chkumar): Keeping set_openstack_containers role
   # till we migrate this task to update_containers role
 - name: Update OpenStack Services containers Env

--- a/roles/kustomize_deploy/defaults/main.yml
+++ b/roles/kustomize_deploy/defaults/main.yml
@@ -108,6 +108,24 @@ cifmw_kustomize_deploy_nmstate_dest_file: >-
     ] | path_join
   }}
 
+# openstack init resource
+cifmw_kustomize_deploy_openstack_source_files: >-
+  {{
+    [
+      cifmw_kustomize_deploy_architecture_repo_dest_dir,
+      cifmw_kustomize_deploy_architecture_examples_common_path,
+      'openstack'
+    ] | path_join
+  }}
+
+cifmw_kustomize_deploy_openstack_dest_file: >-
+  {{
+    [
+      cifmw_kustomize_deploy_kustomizations_dest_dir,
+      'openstack.yaml'
+    ] | path_join
+  }}
+
 # controlsplane resources
 
 cifmw_kustomize_deploy_nncp_source_files: >-

--- a/roles/kustomize_deploy/tasks/install_operators.yml
+++ b/roles/kustomize_deploy/tasks/install_operators.yml
@@ -107,7 +107,7 @@
         - _cifmw_kustomize_deploy_olm_osp_operator_sub_out.resources | length == 1
         - (_cifmw_kustomize_deploy_olm_osp_operator_sub_out.resources | first)['status']['installPlanRef'] is defined
 
-    - name: Wait for the openstack operators InstallPlan to be finish
+    - name: Wait for the openstack operators InstallPlan to be finished
       vars:
         _install_plan: >-
           {{
@@ -319,8 +319,69 @@
           status: "True"
         wait_timeout: 300
 
-- name: Wait until OpenStack operators are deployed and ready
-  when: not cifmw_kustomize_deploy_generate_crs_only
+- name: Check if the OpenStack initialization CRD exists
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    kind: CustomResourceDefinition
+    name: openstacks.operator.openstack.org
+  register: _cifmw_kustomize_deploy_olm_osp_operator_openstack_crd_out
+
+- name: Handle OpenStack initialization, if necessary
+  when: (_cifmw_kustomize_deploy_olm_osp_operator_openstack_crd_out.resources | length) > 0
+  block:
+    - name: Generate OpenStack initialization kustomization file
+      ansible.builtin.copy:
+        content: >-
+          {{
+            lookup(
+              'kubernetes.core.kustomize',
+              dir=cifmw_kustomize_deploy_openstack_source_files
+            )
+          }}
+        dest: "{{ cifmw_kustomize_deploy_openstack_dest_file }}"
+        mode: "0644"
+
+    - name: Openstack initialization resources
+      when: not cifmw_kustomize_deploy_generate_crs_only
+      block:
+        - name: Apply the kustomized OpenStack initialization CRs
+          kubernetes.core.k8s:
+            kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+            api_key: "{{ cifmw_openshift_token | default(omit) }}"
+            context: "{{ cifmw_openshift_context | default(omit) }}"
+            state: present
+            wait: true
+            src: "{{ cifmw_kustomize_deploy_openstack_dest_file }}"
+          check_mode: >-
+            {{
+              cifmw_kustomize_deploy_check_mode |
+              default(false, true)
+            }}
+
+    - name: Wait until OpenStack operators are deployed and ready (new install paradigm)
+      when: not cifmw_kustomize_deploy_generate_crs_only
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        kind: Openstack
+        namespace: openstack-operators
+        name: openstack
+        wait: true
+        wait_condition:
+          type: Ready
+          status: "True"
+        wait_timeout: 600
+      check_mode: >-
+        {{
+          cifmw_kustomize_deploy_check_mode |
+          default(false, true)
+        }}
+
+- name: Wait until OpenStack operators are deployed and ready (old install paradigm)
+  when:
+    - not cifmw_kustomize_deploy_generate_crs_only
+    - (_cifmw_kustomize_deploy_olm_osp_operator_openstack_crd_out.resources | length) == 0
   kubernetes.core.k8s_info:
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
     kind: Deployment


### PR DESCRIPTION
We have a new upcoming way to install and deploy the OSP operators. OLM will only install one CRD for OSP, which is an initialization resource. A CR must be created for that CRD, which then, when created, causes all the remaining OSP CRDs to be installed and also deploys their respective operators.

