### PR TITLE
multinode: Add adoption vars for osp repos

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -19,6 +19,14 @@
       - ci/playbooks/collect-logs.yml
       - ci/playbooks/multinode-autohold.yml
     vars: &adoption_vars
+      osp_17_repos:
+        - rhel-9-for-x86_64-baseos-eus-rpms
+        - rhel-9-for-x86_64-appstream-eus-rpms
+        - rhel-9-for-x86_64-highavailability-eus-rpms
+        - openstack-17.1-for-rhel-9-x86_64-rpms
+        - fast-datapath-for-rhel-9-x86_64-rpms
+      osp_17_ceph_repos:
+        - rhceph-7-tools-for-rhel-9-x86_64-rpms
       zuul_log_collection: true
       registry_login_enabled: true
       push_registry: quay.rdoproject.org


### PR DESCRIPTION
Add vars for osp 17 repos into the base multinode CI job for adoption testing. Those become shared by the multinode single-stack and multinode multi-stack (novacells) jobs.

Required-by: https://review.rdoproject.org/r/c/rdo-jobs/+/55528
Jira: #[OSPRH-6548](https://issues.redhat.com/browse/OSPRH-6548)