### PR TITLE
[polarion] Allow users pass extra custom-fields

### DIFF
--- a/roles/polarion/README.md
+++ b/roles/polarion/README.md
@@ -10,6 +10,7 @@ Role to setup jump tool and upload XML test results to Polarion.
 * `cifmw_polarion_testrun_id`: (String) A test run identification provided by Polarion test case or `create-new-test-run` if polarion should generate a random test run ID. A value other than `create-new-test-run` will force this role to upload all test results found in all directories under `cifmw_polarion_jump_repo_url` to one test run identified by the given ID. The default behavior of this role is to treat the directories in `cifmw_polarion_jump_repo_url` as separate test runs.
 * `cifmw_polarion_update_testcases`: (Boolean) A value of True/False to create missing testcases (which should normally _not_ be enabled).
 * `cifmw_polarion_jump_extra_vars`: (String) A list of extra_vars that are being passed to the jump script. Defaults to empty.
+* `cifmw_polarion_jump_custom_fields`: (Dict) Structure listing the fields for --custom-fields argument of jump tool.
 * `cifmw_polarion_use_stage`: (Bool) Flag for using the staging instance of Polarion. Default is False meaning the production instance gets updated. Don't forget to change for testing on stage instance.
 
 

--- a/roles/polarion/defaults/main.yml
+++ b/roles/polarion/defaults/main.yml
@@ -19,6 +19,7 @@
 # All variables within this role should have a prefix of "cifmw_polarion"
 
 cifmw_polarion_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+cifmw_polarion_jump_custom_fields: {}
 cifmw_polarion_jump_repo_dir: "{{ cifmw_polarion_basedir }}/polarion-jump"
 cifmw_polarion_jump_result_dir: "{{ cifmw_polarion_basedir }}/tests/{{ cifmw_run_test_role | default('tempest') }}/"
 cifmw_polarion_jump_repo_branch: "master"

--- a/roles/polarion/tasks/main.yml
+++ b/roles/polarion/tasks/main.yml
@@ -110,6 +110,18 @@
       register: merged_xml_files
 
     - name: Update Test Runs
+      vars:
+        _opts:
+          cijoburl: "{{ cifmw_zuul_url }}/{{ zuul.build }}"
+          jobteststage: "{{ merged_xml_files.files[ loop_idx ].path | dirname | basename }}"
+        _custom_fields: "{{ _opts | combine(cifmw_polarion_jump_custom_fields) }}"
+        _custom_fields_string: >-
+          {{
+            _custom_fields.keys() |
+            zip(_custom_fields.values()) |
+            map('join', '=') |
+            join(',')
+          }}
       ansible.builtin.shell:
         chdir: "{{ cifmw_polarion_jump_repo_dir }}"
         cmd: >-
@@ -119,7 +131,7 @@
           --testrun-title={{ cifmw_polarion_testrun_title }}-{{ loop_idx }}
           --xml-file={{ item.path }}
           --update_testcases={{ cifmw_polarion_update_testcases | default(false) }}
-          --custom-fields cijoburl={{ cifmw_zuul_url }}/{{ zuul.build }},jobteststage={{ merged_xml_files.files[ loop_idx ].path | dirname | basename }}
+          --custom-fields {{ _custom_fields_string }}
           {{ cifmw_polarion_jump_extra_vars | default ('') }}
       loop: "{{ merged_xml_files.files }}"
       loop_control:


### PR DESCRIPTION
Jump has --custom-fields argument that is set here in the polarion role. This commit allows users pass extra custom fields by introducing cifmw_polarion_jump_extra_custom_fields variable.