### PR TITLE
Fix interface aggregation in switch_config

### DIFF
--- a/roles/switch_config/tasks/junos_config.yml
+++ b/roles/switch_config/tasks/junos_config.yml
@@ -41,7 +41,7 @@
       vars:
         interface_config: |
           {% for interface in switch_vars['interfaces'] %}
-          - delete interfaces "{{ interface.iface }}" ether-options
+          - delete interfaces {{ interface.iface }} ether-options
           {% endfor %}
       junipernetworks.junos.junos_config:
         lines: '{{ interface_config | from_yaml }}'
@@ -113,8 +113,8 @@
               {% for interface in switch_vars['interfaces'] %}
               {% if interface.aggr_members is defined %}
               {% for member in interface.aggr_members %}
-              - delete interfaces "{{ member }}" mtu
-              - delete interfaces "{{ member }}" unit 0
+              - delete interfaces {{ member }} mtu
+              - delete interfaces {{ member }} unit 0
               {% endfor %}
               {% endif %}
               {% endfor %}
@@ -129,7 +129,7 @@
               - name: "{{ interface.iface }}"
                 members:
               {% for member in interface.aggr_members %}
-                  - member: "{{ member }}"
+                  - member: {{ member }}
               {% endfor %}
                 mode: active
               {% endif %}


### PR DESCRIPTION
Before the fix when we had and interface already configured like this:
```
description tigon13-enp130s0f2;
enable;
mtu 9192;
unit 0 {
    family ethernet-switching {
        interface-mode trunk;
        vlan {
            members [ vlan130 vlan131 vlan132 vlan133 vlan134 vlan135 vlan136 vlan137 vlan138 vlan139 ];
        }
    }
}
```

And we try to configure aggregation like this:
```
    - description: "aggregation"
      iface: "ae1323"
      iface_mode: "trunk"
      vlan: "130-139"
      mtu: "9192"
      aggr_members:
        - "xe-0/0/2"
        - "xe-0/0/3"
```

An error like this error was raised:
```
TASK [switch_config : Clear interfaces MTU before adding to ae lines={{ interface_config | from_yaml }}] ****
task path: /home/zuul/src/gitlab.cee.redhat.com/openstack-midstream/podified/source/ci-framework/roles/switch_config/tasks/junos_config.yml:111
ok: [nfv_private_sw04] => changed=false
  invocation:
    module_args:                                                                                                                                                                                                                                                                                                                   backup: false
      backup_options: null
      check_commit: false
      comment: configured by junos_config                                                                                                                                                                                                                                                                                          confirm: 0
      confirm_commit: false
      lines:
      - delete interfaces "xe-0/0/2" mtu
      - delete interfaces "xe-0/0/2" unit 0
      - delete interfaces "xe-0/0/3" mtu
      - delete interfaces "xe-0/0/3" unit 0
...

TASK [switch_config : Set aggregation for the interface config={{ interface_config | from_yaml }}, state=replaced] ****
task path: /home/zuul/src/gitlab.cee.redhat.com/openstack-midstream/podified/source/ci-framework/roles/switch_config/tasks/junos_config.yml:125
Tuesday 19 November 2024  10:37:40 -0500 (0:00:02.114)       0:00:50.687 ******
redirecting (type: connection) ansible.builtin.netconf to ansible.netcommon.netconf
redirecting (type: netconf) ansible.builtin.junos to junipernetworks.junos.junos
fatal: [nfv_private_sw04]: FAILED! => changed=false
  module_stderr: 'b''error: Setting mtu on ae child device is not allowed\nerror: Setting mtu on ae child device is not allowed\nerror: configuration check-out failed: (statements constraint check failed)'''
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
```

The error was due to the quotation marks were added to the actual switch config to be loaded.

After the fix, with the quoation marks removed, we don't hit the error:
```
TASK [switch_config : Clear interfaces MTU before adding to ae lines={{ interface_config | from_yaml }}] ***
task path: /home/zuul/src/gitlab.cee.redhat.com/openstack-midstream/podified/source/ci-framework/roles/switch_config/tasks/junos_config.yml:111
changed: [nfv_private_sw04] => changed=true                                                                                                                                                                                                                                                                                    invocation:
    module_args:                                                                                                                                                                                                                                                                                                                   backup: false
      backup_options: null
      check_commit: false
      comment: configured by junos_config                                                                                                                                                                                                                                                                                          confirm: 0
      confirm_commit: false
      lines:
      - delete interfaces xe-0/0/2 mtu
      - delete interfaces xe-0/0/2 unit 0
      - delete interfaces xe-0/0/3 mtu
      - delete interfaces xe-0/0/3 unit 0
...
```

And the switch config is properly loaded:
```
description tigon13-enp130s0f2;
enable;
ether-options {
    802.3ad ae1323;
}

description tigon13-enp130s0f3;
enable;
ether-options {
    802.3ad ae1323;
}

description aggregation;
enable;
mtu 9192;
aggregated-ether-options {
    lacp {
        active;
    }
}
unit 0 {
    family ethernet-switching {
        interface-mode trunk;
        vlan {
            members [ vlan130 vlan131 vlan132 vlan133 vlan134 vlan135 vlan136 vlan137 vlan138 vlan139 ];
        }
    }
}
```

A similar thing happened when we tried to remove the aggregation.