### PR TITLE
kuttl: fix repo cloning, fetch the locally built operators

### DIFF
--- a/ci/playbooks/kuttl/run-kuttl-tests.yml
+++ b/ci/playbooks/kuttl/run-kuttl-tests.yml
@@ -3,11 +3,23 @@
   ansible.builtin.include_vars:
     dir: "{{ cifmw_basedir }}/artifacts/parameters"
 
+- name: Use the locally built operators if any
+  ansible.builtin.set_fact:
+    _local_operators_indexes:
+      "{{ _local_operators_indexes|default({}) |
+      combine({ item.key.split('-')[0]|upper+'_IMG':
+              cifmw_operator_build_output['operators'][item.key].image_catalog}) }}"
+  loop: "{{ cifmw_operator_build_output['operators'] | dict2items }}"
+  when:
+    - cifmw_operator_build_output is defined
+    - "'operators' in cifmw_operator_build_output"
+
 - name: Set environment vars for kuttl test
   ansible.builtin.set_fact:
     cifmw_kuttl_tests_env: >-
       {{
-        cifmw_install_yamls_environment |
+        _local_operators_indexes | default({}) |
+        combine(cifmw_install_yamls_environment) |
         combine(cifmw_kuttl_tests_env_vars | default({})) |
         combine(cifmw_kuttl_openstack_prep_vars | default({})) |
         combine({'PATH': cifmw_path})

--- a/scenarios/centos-9/kuttl.yml
+++ b/scenarios/centos-9/kuttl.yml
@@ -1,6 +1,5 @@
 ---
 cifmw_install_yamls_vars:
-  OPERATOR_BASE_DIR: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators"
   BMO_SETUP: false
 cifmw_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 


### PR DESCRIPTION
When running kuttl tests using install_yamls, operators code are cloned before running the job.
All credits to Douglas Viroel who investigated and fixed a similar issue downstream.

Also, make sure that locally built operator (for example, thanks to the openstack-k8s-operators-content-provider job, or anything else which populates cifmw_operator_build_output) are used.
This is a bit more complex than what EDPM jobs do (see the edpm_prepare role), where only the openstack-operator-index is overridden, likely because here there may be more operators being built.
