### PR TITLE
Add hook to enable horizon

### DIFF
--- a/hooks/playbooks/control_plane_horizon.yml
+++ b/hooks/playbooks/control_plane_horizon.yml
@@ -1,0 +1,28 @@
+---
+- name: Kustomize ControlPlane for horizon service
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Ensure the kustomizations dir exists
+      ansible.builtin.file:
+        path: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/controlplane"
+        state: directory
+        mode: "0755"
+
+    - name: Create kustomize yaml to enable Horizon
+      ansible.builtin.copy:
+        dest: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/controlplane/80-horizon-kustomization.yaml"
+        content: |-
+          apiVersion: kustomize.config.k8s.io/v1beta1
+          kind: Kustomization
+          namespace: {{ namespace }}
+          patches:
+          - target:
+                kind: OpenStackControlPlane
+            patch: |-
+              - op: add
+                path: /spec/horizon/enabled
+                value: true
+              - op: add
+                path: /spec/horizon/template/memcachedInstance
+                value: memcached

--- a/scenarios/centos-9/horizon.yml
+++ b/scenarios/centos-9/horizon.yml
@@ -1,0 +1,5 @@
+---
+pre_deploy:
+  - name: 80 Kustomize OpenStack CR
+    type: playbook
+    source: control_plane_horizon.yml

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -316,6 +316,7 @@
     vars:
       cifmw_extras:
         - '@scenarios/centos-9/multinode-ci.yml'
+        - '@scenarios/centos-9/horizon.yml'
     run:
       - ci/playbooks/edpm/run.yml
 


### PR DESCRIPTION
This PR adds hooks to enable horizon service which is not enabled by default in a crc deploy . This is needed as we are trying to extend test-operator zuul gating job to include horizon testing .







