### PR TITLE
Skip vlan transparent tests until there is a fix

### DIFF
--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -123,6 +123,10 @@
               test_multicast.*ext*
               test_multicast.*restart
               ^neutron_.*plugin..*scenario.test_.*macvtap
+              # remove when bug OSPRH-11751 resolved
+              vlan_transparent_allowed_address_pairs
+              vlan_transparent_port_sec_disabled
+              vlan_transparent_packet_length_greater_mtu
             # https://review.opendev.org/892839
             # - neutron_tempest_plugin.scenario.test_mtu.NetworkWritableMtuTest
             # It's in Blacklist before, FWaaS tests are not executed in any of our setups so there is no need to keep them whitelisted


### PR DESCRIPTION
These tests randomly failing when conflict with
ctlplane network, until we have a fix skipping these tests.
Related-Issue: [OSPRH-11751](https://issues.redhat.com//browse/OSPRH-11751)
Related-Issue: [OSPCIX-442](https://issues.redhat.com//browse/OSPCIX-442)