### PR TITLE
Kuttl multinode: bump the timeout

### DIFF
--- a/zuul.d/kuttl_multinode.yaml
+++ b/zuul.d/kuttl_multinode.yaml
@@ -52,6 +52,7 @@
 - job:
     name: cifmw-multinode-kuttl
     parent: cifmw-base-multinode-kuttl
+    timeout: 9000
     files:
       - ^ci/playbooks/kuttl/.*
       - ^scenarios/centos-9/kuttl.yml


### PR DESCRIPTION
It seems the test is timing out more often then not. Let's try to see if the execution time is the only issue.