### PR TITLE
Exclude watcher-operator-index- image in env_op_images role

### DIFF
--- a/roles/env_op_images/tasks/main.yml
+++ b/roles/env_op_images/tasks/main.yml
@@ -119,7 +119,8 @@
           RABBITMQ_OP_IMG: "{{ selected_pod.status.containerStatuses[0].imageID }}"
         selected_pods: "{{ pod_list.resources |
                            rejectattr('metadata.generateName', 'contains', 'openstack-operator-index-') |
-                           rejectattr('metadata.generateName', 'contains', 'rabbitmq-cluster-operator-')
+                           rejectattr('metadata.generateName', 'contains', 'rabbitmq-cluster-operator-') |
+                           rejectattr('metadata.generateName', 'contains', 'watcher-operator-index-')
                         }}"
 
     - name: Add operator images to the dictionary


### PR DESCRIPTION
watcher-operator is going to shipped as a standalone operator. It is going to be installed via olm seperatly from index image in openstack-operators namespace.

when env_ops_images creates operator_images dictionary, it goes over all the pods listed under openstack-operators namespace with label openstack.org/operator-name which does not exists for watcher-operator-index- pod. It fails with following error[1]:
```
The task includes an option with an undefined variable.
The error was: 'dict object' has no attribute 'openstack.org/operator-name'. 'dict object' has no attribute 'openstack.org/operator-name'
```

This pr excluded the watcher-operator-index- pod to fix the issue.

[watcher-operator-validation zuul job is green.](https://github.com/openstack-k8s-operators/watcher-operator/pull/9#issuecomment-2499701046)

Links:
[1]. https://github.com/openstack-k8s-operators/watcher-operator/pull/9#issuecomment-2497462332