### PR TITLE
Enable sushy-emulator in create-infra.yml

### DIFF
--- a/create-infra.yml
+++ b/create-infra.yml
@@ -75,3 +75,66 @@
       ansible.builtin.import_role:
         name: "libvirt_manager"
         tasks_from: "deploy_layout.yml"
+
+    - name: Gather ansible_user_id
+      ansible.builtin.setup:
+        gather_subset:
+          - user_id
+          - user_dir
+
+    - name: Ensure controllers vms are started and reachable
+      when: groups.controllers | default([]) | length > 0
+      vars:
+        _cifmw_libvirt_manager_layout:
+          vms:
+            controllers:
+              start: true
+              disk_file_name: "dummy"
+        cifmw_libvirt_manager_all_vms: >-
+          {%- set vms = {} -%}
+          {%- for vm in groups.controllers | default([]) -%}
+            {%- set _ = vms.update({vm: 'controllers'}) -%}
+          {%- endfor -%}
+          {{ vms }}
+        ansible_libvirt_pools: {}
+      ansible.builtin.include_role:
+        name: "libvirt_manager"
+        tasks_from: "start_vms.yml"
+        apply:
+          delegate_to: "{{ cifmw_target_host | default('localhost') }}"
+
+    # This bootstraps the controller-0 node, and RedFish virtual BMC is
+    # spawned if cifmw_use_sushy_emulator is enabled.
+    - name: Bootstrap sushy-emulator (RedFish Virtual BMC) on controller-0
+      when:
+        - "'controllers' in groups"
+        - "'controllers' in group_names"
+        - cifmw_use_sushy_emulator | default(false) | bool
+      delegate_to: controller-0
+      become: true
+      vars:
+        cifmw_sushy_emulator_hypervisor_target: "{{ cifmw_target_host }}"
+        cifmw_sushy_emulator_hypervisor_address: "{{ cifmw_target_host }}.utility"
+        cifmw_sushy_emulator_install_type: podman
+        cifmw_podman_user_linger: "zuul"
+      block:
+        - name: Run reproducer roles rhos_release tasks on controller-0
+          ansible.builtin.include_role:
+            name: reproducer
+            tasks_from: rhos_release.yml
+
+        - name: Include role sushy_emulator
+          ansible.builtin.include_role:
+            name: sushy_emulator
+
+        - name: Generate baremetal-info fact
+          vars:
+            cifmw_sushy_emulator_uri: 'http://sushy.utility:8000'
+          ansible.builtin.include_role:
+            name: reproducer
+            tasks_from: generate_bm_info.yml
+
+        - name: Verify connection to baremetal VMs via Sushy Emulator
+          ansible.builtin.include_role:
+            name: sushy_emulator
+            tasks_from: verify.yml

--- a/roles/adoption_osp_deploy/tasks/main.yml
+++ b/roles/adoption_osp_deploy/tasks/main.yml
@@ -17,13 +17,10 @@
 - name: Validate 17.1 scenario definition
   ansible.builtin.import_tasks: validate_scenario.yml
 
-- name: Ensure controller and undercloud vms are started and reachable
+- name: Ensure undercloud vms are started and reachable
   vars:
     _cifmw_libvirt_manager_layout:
       vms:
-        controllers:
-          start: true
-          disk_file_name: "dummy"
         osp-underclouds:
           start: true
           disk_file_name: "dummy"
@@ -31,9 +28,6 @@
       {%- set vms = {} -%}
       {%- for vm in _vm_groups['osp-underclouds'] -%}
         {%- set _ = vms.update({vm: 'osp-underclouds'}) -%}
-      {%- endfor -%}
-      {%- for vm in _vm_groups['controllers'] -%}
-        {%- set _ = vms.update({vm: 'controllers'}) -%}
       {%- endfor -%}
       {{ vms }}
     ansible_libvirt_pools: {}

--- a/roles/podman/tasks/main.yml
+++ b/roles/podman/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: Ensure podman is installed
   become: true
-  ansible.builtin.package:
+  ansible.builtin.dnf:
     name: "{{ cifmw_podman_packages }}"
     state: present
 

--- a/roles/sushy_emulator/tasks/main.yml
+++ b/roles/sushy_emulator/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: Install required packages
   become: true
-  ansible.builtin.package:
+  ansible.builtin.dnf:
     name: httpd-tools
     state: present
 


### PR DESCRIPTION
For adoption of the ironic service we need a Virtual BMC for spinning up test workloads on the OSP 17.x cloud, and to validate workload operations after adoption.

This change ensure the controller is started at the end of create-infra, and does the neccecary steps to apply and validate the sushy-emulator running as a POD on the controller node.

I have switched the use of `ansible.builtin.package` to `ansible.builtin.dnf` in some places to avoid issues with hostvars lookups raising undefined variable errors.