### PR TITLE
[shiftstack]Enable the option to run the role isolated

### DIFF
--- a/roles/shiftstack/README.md
+++ b/roles/shiftstack/README.md
@@ -11,6 +11,7 @@ Role for triggering Openshift on Openstack QA automation (installation and tests
 * `cifmw_shiftstack_client_pod_image`: (*string*) The image for the container running in the `cifmw_shiftstack_client_pod_name` pod. Defaults to `quay.io/shiftstack-qe/shiftstack-client:latest`.
 * `cifmw_shiftstack_client_pvc_manifest`: (*string*) The file name for the shiftstackclient pvc manifest. Defaults to `"{{ cifmw_shiftstack_client_pod_name }}_pvc.yml"`.
 * `cifmw_shiftstack_cluster_name`: (*string*) The Openshift cluster name. Defaults to `ostest`.
+* `cifmw_shiftstack_exclude_artifacts_regex`: (*string*) Regex that will be passed on `oc rsync` command as `--exclude` param, so the role does not gather the artifacts matching it.
 * `cifmw_shiftstack_installation_dir`: (*string*) Directory to place installation files. Defaults to `"{{ cifmw_shiftstack_shiftstackclient_artifacts_dir }}/installation"`.
 * `cifmw_shiftstack_manifests_dir`: (*string*) Directory name for the role generated Openshift manifests. Defaults to `"{{ cifmw_shiftstack_basedir }}/manifests"`.
 * `cifmw_shiftstack_project_name`: (*string*) The Openstack project name. Defaults to `shiftstack`.

--- a/roles/shiftstack/defaults/main.yml
+++ b/roles/shiftstack/defaults/main.yml
@@ -26,6 +26,7 @@ cifmw_shiftstack_client_pod_name: "shiftstackclient-{{ cifmw_shiftstack_project_
 cifmw_shiftstack_client_pod_namespace: "openstack"
 cifmw_shiftstack_client_pvc_manifest: "{{ cifmw_shiftstack_client_pod_name }}_pvc.yml"
 cifmw_shiftstack_cluster_name: "ostest"
+cifmw_shiftstack_exclude_artifacts_regex: "openshift-install"
 cifmw_shiftstack_installation_dir: "{{ cifmw_shiftstack_basedir }}/installation"
 cifmw_shiftstack_manifests_dir: "{{ cifmw_shiftstack_basedir }}/manifests"
 cifmw_shiftstack_project_name: "shiftstack"

--- a/roles/shiftstack/molecule/default/converge.yml
+++ b/roles/shiftstack/molecule/default/converge.yml
@@ -22,6 +22,7 @@
     cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
     cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
     cifmw_shiftstack_run_playbook: cifmw-gate.yaml
+    cifmw_shiftstack_exclude_artifacts_regex: ''
     cifmw_run_test_shiftstack_testconfig:
       - cifmw-gate.yaml
       - cifmw-gate.yaml # The purpose of this repeated test config is to check the test config loop logic

--- a/roles/shiftstack/tasks/pre_test_shiftstack.yml
+++ b/roles/shiftstack/tasks/pre_test_shiftstack.yml
@@ -21,6 +21,7 @@
 
 - name: Remove the shiftstackclient pod if exists
   kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
     state: absent
     api_version: v1
     kind: Pod

--- a/roles/shiftstack/tasks/test_config.yml
+++ b/roles/shiftstack/tasks/test_config.yml
@@ -31,6 +31,7 @@
         namespace: "{{ cifmw_shiftstack_client_pod_namespace }}"
         pod_name: "{{ cifmw_shiftstack_client_pod_name }}"
         command: >-
+          source .bashrc &&
           cd shiftstack-qa &&
           ansible-navigator run playbooks/{{ cifmw_shiftstack_run_playbook }} -e @jobs_definitions/{{ testconfig }} -e ocp_cluster_name={{ cifmw_shiftstack_cluster_name }} -e user_cloud={{ cifmw_shiftstack_project_name }}
       ansible.builtin.include_tasks: exec_command_in_pod.yml
@@ -48,12 +49,19 @@
 
   always:
     - name: "Copy the artifacts from the pod '{{ cifmw_shiftstack_client_pod_name }}'"
+      vars:
+        _exclude_options: >-
+          {{
+            '--exclude=' ~ cifmw_shiftstack_exclude_artifacts_regex
+            if cifmw_shiftstack_exclude_artifacts_regex | default('') != ''
+            else ''
+          }}
       environment:
         PATH: "{{ cifmw_path }}"
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
       ansible.builtin.command:
         cmd: >
-          oc rsync -n {{ cifmw_shiftstack_client_pod_namespace }}
+          oc rsync -n {{ cifmw_shiftstack_client_pod_namespace }} {{ _exclude_options }}
           {{ cifmw_shiftstack_client_pod_name }}:{{ cifmw_shiftstack_shiftstackclient_artifacts_dir }}/
           {{ testconfig_artifacts_dir }}/
       failed_when: false


### PR DESCRIPTION
In order to allow users to run the shiftstack role without being part of
the full reproducer playbook, below changes are needed:

- Add missing kubeconfig param
- Load .bashrc while running the ansible-navigator. That's needed
for reading the envvars that will be used for writting the junit report.
- Enable the option to exclude artifacts to be gathered.