### PR TITLE
Override Ceph version

### DIFF
--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -140,3 +140,10 @@ cifmw_cephadm_update_log_commands:
     cmd: "log last cephadm"
 cifmw_cephadm_wait_for_dashboard_retries: 10
 cifmw_cephadm_wait_for_dashboard_delay: 20
+# Repository parameters
+cifmw_cephadm_repository_override: false
+# we usually support N+1 Ceph version: Adding Squid here because Reef is the
+# default version installed in a greenfield scenario
+cifmw_cephadm_version: "squid"
+# bug in cephadm: if you skip "prepare host" it will fail
+cifmw_cephadm_prepare_host: false

--- a/roles/cifmw_cephadm/tasks/bootstrap.yml
+++ b/roles/cifmw_cephadm/tasks/bootstrap.yml
@@ -55,7 +55,9 @@
         {% if not cifmw_cephadm_default_container %}--image {{ cifmw_cephadm_container_ns + '/' + cifmw_cephadm_container_image + ':' + cifmw_cephadm_container_tag|string }} \{% endif %}
         bootstrap \
         --skip-firewalld \
+        {% if not cifmw_cephadm_prepare_host %}
         --skip-prepare-host \
+        {% endif %}
         --ssh-private-key /home/{{ cifmw_cephadm_ssh_user }}/.ssh/id_rsa \
         --ssh-public-key /home/{{ cifmw_cephadm_ssh_user }}/.ssh/id_rsa.pub \
         --ssh-user {{ cifmw_cephadm_ssh_user }} \

--- a/roles/cifmw_cephadm/tasks/install_cephadm.yml
+++ b/roles/cifmw_cephadm/tasks/install_cephadm.yml
@@ -1,0 +1,45 @@
+---
+# Copyright 2024 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Enabled ceph Tools Repository
+  when:
+    - cifmw_cephadm_repository_override | bool
+  become: true
+  ansible.builtin.dnf:
+    name: centos-release-ceph-{{ cifmw_cephadm_version }}
+    state: present
+
+- name: Install cephadm package
+  become: true
+  when:
+    - cifmw_cephadm_predeployed | bool or
+      cifmw_cephadm_repository_override | bool
+  ansible.builtin.dnf:
+    name: cephadm
+    state: present
+
+- name: Stat cephadm file
+  ansible.builtin.stat:
+    path: "{{ cifmw_cephadm_bin }}"
+  register: stat_cephadm
+  become: true
+  ignore_errors: true  # noqa: ignore-errors
+
+- name: Fail if cephadm is not available
+  when:
+    - not stat_cephadm.stat.exists
+  ansible.builtin.fail:
+    msg: "{{ cifmw_cephadm_bin }} does not exist"

--- a/roles/cifmw_cephadm/tasks/pre.yml
+++ b/roles/cifmw_cephadm/tasks/pre.yml
@@ -21,27 +21,8 @@
   tags:
     - always
 
-- name: Install cephadm package  # noqa: package-latest
-  become: true
-  when:
-    - cifmw_cephadm_predeployed | bool
-  ansible.builtin.package:
-    name: cephadm
-    state: latest
-    releasever: "{{ ansible_facts['distribution_major_version'] }}"
-
-- name: Stat cephadm file
-  ansible.builtin.stat:
-    path: "{{ cifmw_cephadm_bin }}"
-  register: stat_cephadm
-  become: true
-  ignore_errors: true  # noqa: ignore-errors
-
-- name: Fail if cephadm is not available
-  when:
-    - not stat_cephadm.stat.exists
-  ansible.builtin.fail:
-    msg: "{{ cifmw_cephadm_bin }} does not exist"
+- name: Install cephadm package
+  ansible.builtin.include_tasks: install_cephadm.yml
 
 - name: List Ceph daemon instances on this host
   ansible.builtin.command:

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -343,6 +343,13 @@
         dashboard_enabled: true
         cephfs_enabled: true
         ceph_nfs_enabled: true
+      # Override the Ceph container tag and deploy Squid
+      cifmw_cephadm_container_tag: "v19"
+      # Override the Ceph Tools repo and install cephadm Squid
+      cifmw_cephadm_repository_override: true
+      cifmw_cephadm_version: "squid"
+      cifmw_cephadm_prepare_host: true
+
     files:
       - ^hooks/playbooks/control_plane_ceph_backends.yml
       - ^hooks/playbooks/control_plane_hci_pre_deploy.yml


### PR DESCRIPTION
We used to support `N+1` server version with external `Ceph`, and this policy is still adopted. 
For this reason we need a way to do early testing in CI.
This patch adds the ability to override the `CentOS` `Ceph` repository and
install the target `cephadm` release passed as input.

Jira: https://issues.redhat.com/browse/OSPRH-10666