### PR TITLE
[kustomize_deploy] Make wait conditions optional

### DIFF
--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -5,8 +5,6 @@
       - stage is defined
       - stage_id is defined
       - stage['path'] is defined
-      - stage['wait_conditions'] is defined
-      - stage['wait_conditions'] | length > 0
       - stage['values'] is defined
       - stage['values'] | length > 0
       - stage['build_output'] is defined
@@ -40,7 +38,7 @@
         quiet: true
       ignore_errors: true  # noqa: ignore-errors
       register: _builtin_wait_cond_result
-      loop: "{{ stage.wait_conditions }}"
+      loop: "{{ stage.wait_conditions | default([]) }}"
 
     - name: Check wait_conditions validation result
       when:
@@ -52,7 +50,7 @@
 
     - name: Set stage_wait_conditions fact
       ansible.builtin.set_fact:
-        _wait_conditions: "{{ stage.wait_conditions + _custom_conditions }}"
+        _wait_conditions: "{{ (stage.wait_conditions | default([])) + _custom_conditions }}"
 
 - name: Group tasks under the same tags
   vars:


### PR DESCRIPTION
In some ocassions, like when applying more than one nodesets the user may not want to wait for the first one to be applied and wait for all of them at once when all are applied.
This change is about not forcing the user, for no reason, to run a command to wait for a condition after some `oc apply` has been done.