### PR TITLE
[test-operator][tobiko] Change downloaded images path

### DIFF
--- a/roles/test_operator/vars/main.yml
+++ b/roles/test_operator/vars/main.yml
@@ -35,7 +35,7 @@ cifmw_test_operator_tobiko_default_conf:
     test_runner_timeout: 14400.0
   ubuntu:
     interface_name: enp3s0
-    image_file: ~/.downloaded-images/ubuntu-minimal
+    image_file: /usr/local/share/ubuntu-minimal
   keystone:
     interface: public
   manila:


### PR DESCRIPTION
This patch changes the default path for downloaded images used for
tobiko testing from ~/.downloaded-images/ubuntu-minimal to
/usr/local/share.

This change is needed because we have to free /var/lib/tobiko from any
files that are present prior the container execution. This allows us to
mount ephemeral-storage to /var/lib/tobiko and use this directory as the
only point where write actions are allowed when readOnlyRootFilesystem:
true.
