### PR TITLE
Move test-operator to openstack-operators namespace

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -5,7 +5,8 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 ## Parameters
 
 * `cifmw_test_operator_artifacts_basedir`: (String) Directory where we will have all test-operator related files. Default value: `{{ cifmw_basedir }}/tests/test_operator` which defaults to `~/ci-framework-data/tests/test_operator`
-* `cifmw_test_operator_namespace`: (String) Namespace inside which all the resources are created. Default value: `openstack`
+* `cifmw_test_operator_namespace`: (String) Namespace inside which all the resources related to the test-operator controller pod are created. Default value: `openstack-operators`
+* `cifmw_test_operator_test_namespace`: (String) Namespace inside which all the test related resources (e.g., test pods) are created. Default value: `openstack`
 * `cifmw_test_operator_index`: (String) Full name of container image with index that contains the test-operator. Default value: `quay.io/openstack-k8s-operators/test-operator-index:latest`
 * `cifmw_test_operator_timeout`: (Integer) Timeout in seconds for the execution of the tests. Default value: `3600`
 * `cifmw_test_operator_logs_image`: (String) Image that should be used to collect logs from the pods spawned by the test-operator. Default value: `quay.io/quay/busybox`
@@ -54,7 +55,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
   kind: Tempest
   metadata:
     name: "{{ cifmw_test_operator_tempest_name }}"
-    namespace: "{{ cifmw_test_operator_namespace }}"
+    namespace: "{{ cifmw_test_operator_test_namespace }}"
   spec:
     containerImage: "{{ cifmw_test_operator_tempest_image }}:{{ cifmw_test_operator_tempest_image_tag }}"
     storageClass: "{{ cifmw_test_operator_storage_class }}"
@@ -99,7 +100,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
   kind: Tobiko
   metadata:
     name: "{{ cifmw_test_operator_tobiko_name }}"
-    namespace: "{{ cifmw_test_operator_namespace }}"
+    namespace: "{{ cifmw_test_operator_test_namespace }}"
   spec:
     kubeconfigSecretName: "{{ cifmw_test_operator_tobiko_kubeconfig_secret }}"
     storageClass: "{{ cifmw_test_operator_storage_class }}"
@@ -145,7 +146,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
   kind: AnsibleTest
   metadata:
     name: "{{ cifmw_test_operator_ansibletest_name }}"
-    namespace: "{{ cifmw_test_operator_namespace }}"
+    namespace: "{{ cifmw_test_operator_test_namespace }}"
   spec:
     containerImage: "{{ cifmw_test_operator_ansibletest_image }}:{{ cifmw_test_operator_ansibletest_image_tag }}"
     extraConfigmapsMounts: "{{ cifmw_test_operator_ansibletest_extra_configmaps_mounts }}"
@@ -190,7 +191,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
   kind: HorizonTest
   metadata:
     name: "{{ cifmw_test_operator_horizontest_name }}"
-    namespace: "{{ cifmw_test_operator_namespace }}"
+    namespace: "{{ cifmw_test_operator_test_namespace }}"
   spec:
     containerImage: "{{ cifmw_test_operator_horizontest_image }}:{{ cifmw_test_operator_horizontest_image_tag }}"
     adminUsername: "{{ cifmw_test_operator_horizontest_admin_username }}"

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -21,7 +21,8 @@
 # Section 1: generic parameters (applied to all supported test frameworks)
 cifmw_test_operator_fail_on_test_failure: true
 cifmw_test_operator_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}/tests/test_operator"
-cifmw_test_operator_namespace: openstack
+cifmw_test_operator_namespace: openstack-operators
+cifmw_test_operator_test_namespace: openstack
 cifmw_test_operator_index: quay.io/openstack-k8s-operators/test-operator-index:latest
 cifmw_test_operator_timeout: 3600
 cifmw_test_operator_logs_image: quay.io/quay/busybox
@@ -102,7 +103,7 @@ cifmw_test_operator_tempest_config:
   kind: Tempest
   metadata:
     name: "{{ test_operator_job_name }}"
-    namespace: "{{ cifmw_test_operator_namespace }}"
+    namespace: "{{ cifmw_test_operator_test_namespace }}"
   spec:
     containerImage: "{{ cifmw_test_operator_tempest_image }}:{{ cifmw_test_operator_tempest_image_tag }}"
     storageClass: "{{ cifmw_test_operator_storage_class }}"
@@ -155,7 +156,7 @@ cifmw_test_operator_tobiko_config:
   kind: Tobiko
   metadata:
     name: tobiko-tests
-    namespace: "{{ cifmw_test_operator_namespace }}"
+    namespace: "{{ cifmw_test_operator_test_namespace }}"
   spec:
     kubeconfigSecretName: "{{ cifmw_test_operator_tobiko_kubeconfig_secret }}"
     storageClass: "{{ cifmw_test_operator_storage_class }}"
@@ -201,7 +202,7 @@ cifmw_test_operator_ansibletest_config:
   kind: AnsibleTest
   metadata:
     name: "{{ test_operator_job_name }}"
-    namespace: "{{ cifmw_test_operator_namespace }}"
+    namespace: "{{ cifmw_test_operator_test_namespace }}"
   spec:
     containerImage: "{{ cifmw_test_operator_ansibletest_image }}:{{ cifmw_test_operator_ansibletest_image_tag }}"
     extraConfigmapsMounts: "{{ cifmw_test_operator_ansibletest_extra_configmaps_mounts }}"
@@ -246,7 +247,7 @@ cifmw_test_operator_horizontest_config:
   kind: HorizonTest
   metadata:
     name: "{{ cifmw_test_operator_horizontest_name }}"
-    namespace: "{{ cifmw_test_operator_namespace }}"
+    namespace: "{{ cifmw_test_operator_test_namespace }}"
   spec:
     storageClass: "{{ cifmw_test_operator_storage_class }}"
     privileged: "{{ cifmw_test_operator_privileged }}"

--- a/roles/test_operator/tasks/cleanup.yml
+++ b/roles/test_operator/tasks/cleanup.yml
@@ -40,19 +40,6 @@
     wait: true
     wait_timeout: 600
 
-- name: Delete OperatorGroup
-  kubernetes.core.k8s:
-    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
-    api_key: "{{ cifmw_openshift_token | default(omit)}}"
-    context: "{{ cifmw_openshift_context | default(omit)}}"
-    kind: OperatorGroup
-    state: absent
-    api_version: operators.coreos.com/v1
-    name: test-operator-operatorgroup
-    namespace: "{{ cifmw_test_operator_namespace }}"
-    wait: true
-    wait_timeout: 600
-
 - name: Delete ClusterServiceVersion
   kubernetes.core.k8s:
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"

--- a/roles/test_operator/tasks/main.yml
+++ b/roles/test_operator/tasks/main.yml
@@ -30,24 +30,6 @@
     run_ansibletest: "{{ cifmw_run_ansibletest | default('false') | bool }}"
     run_horizontest: "{{ cifmw_run_horizontest | default('false') | bool }}"
 
-- name: Ensure OperatorGroup for the test-operator is present
-  kubernetes.core.k8s:
-    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
-    api_key: "{{ cifmw_openshift_token | default(omit) }}"
-    context: "{{ cifmw_openshift_context | default(omit) }}"
-    state: present
-    wait: true
-    definition:
-      apiVersion: operators.coreos.com/v1
-      kind: OperatorGroup
-      metadata:
-        name: test-operator-operatorgroup
-        namespace: "{{ cifmw_test_operator_namespace }}"
-      spec:
-        targetNamespaces:
-          - "{{ cifmw_test_operator_namespace }}"
-  when: not cifmw_test_operator_dry_run | bool
-
 - name: Ensure CatalogSource for the test-operator is present
   kubernetes.core.k8s:
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"

--- a/roles/test_operator/tasks/run-test-operator-job.yml
+++ b/roles/test_operator/tasks/run-test-operator-job.yml
@@ -42,7 +42,7 @@
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
     api_key: "{{ cifmw_openshift_token | default(omit) }}"
     context: "{{ cifmw_openshift_context | default(omit) }}"
-    namespace: "{{ cifmw_test_operator_namespace }}"
+    namespace: "{{ cifmw_test_operator_test_namespace }}"
     kind: Job
     label_selectors:
       - "workflowStep={{ [(test_operator_workflow | length) - 1, 0] | max }}"
@@ -116,7 +116,7 @@
           kind: Pod
           metadata:
             name: "test-operator-logs-pod-{{ run_test_fw }}-{{ test_operator_job_name }}"
-            namespace: "{{ cifmw_test_operator_namespace }}"
+            namespace: "{{ cifmw_test_operator_test_namespace }}"
           spec:
             containers:
               - name: test-operator-logs-container
@@ -132,7 +132,7 @@
         kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
         api_key: "{{ cifmw_openshift_token | default(omit) }}"
         context: "{{ cifmw_openshift_context | default(omit) }}"
-        namespace: "{{ cifmw_test_operator_namespace }}"
+        namespace: "{{ cifmw_test_operator_test_namespace }}"
         kind: Pod
         name: "test-operator-logs-pod-{{ run_test_fw }}-{{ test_operator_job_name }}"
         wait: true
@@ -148,7 +148,7 @@
       vars:
         pod_path: mnt/logs-{{ test_operator_job_name }}-step-{{ index }}
       ansible.builtin.shell: >
-        oc cp -n {{ cifmw_test_operator_namespace }}
+        oc cp -n {{ cifmw_test_operator_test_namespace }}
         openstack/test-operator-logs-pod-{{ run_test_fw }}-{{ test_operator_job_name }}:{{ pod_path }}
         {{ cifmw_test_operator_artifacts_basedir }}
       loop: "{{ logsPVCs.resources }}"
@@ -160,7 +160,7 @@
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
     api_key: "{{ cifmw_openshift_token | default(omit)}}"
     context: "{{ cifmw_openshift_context | default(omit) }}"
-    namespace: "{{ cifmw_test_operator_namespace }}"
+    namespace: "{{ cifmw_test_operator_test_namespace }}"
     kind: Pod
   register: pod_list
   when: not cifmw_test_operator_dry_run | bool
@@ -171,7 +171,7 @@
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
     api_key: "{{ cifmw_openshift_token | default(omit) }}"
     context: "{{ cifmw_openshift_context | default(omit) }}"
-    namespace: "{{ cifmw_test_operator_namespace }}"
+    namespace: "{{ cifmw_test_operator_test_namespace }}"
     kind: Pod
     label_selectors:
       - "instanceName={{ test_operator_job_name }}"
@@ -226,7 +226,7 @@
         state: absent
         api_version: test.openstack.org/v1beta1
         name: "{{ test_operator_job_name }}"
-        namespace: "{{ cifmw_test_operator_namespace }}"
+        namespace: "{{ cifmw_test_operator_test_namespace }}"
         wait: true
         wait_timeout: 600
 
@@ -239,7 +239,7 @@
         state: absent
         api_version: v1
         name: "{{ test_operator_crd_name }}"
-        namespace: "{{ cifmw_test_operator_namespace }}"
+        namespace: "{{ cifmw_test_operator_test_namespace }}"
         wait: true
         wait_timeout: 600
 
@@ -252,7 +252,7 @@
     state: absent
     api_version: v1
     name: "test-operator-logs-pod-{{ run_test_fw }}-{{ test_operator_job_name }}"
-    namespace: "{{ cifmw_test_operator_namespace }}"
+    namespace: "{{ cifmw_test_operator_test_namespace }}"
     wait: true
     wait_timeout: 600
   when:

--- a/roles/test_operator/tasks/tempest-tests.yml
+++ b/roles/test_operator/tasks/tempest-tests.yml
@@ -105,7 +105,7 @@
           type: Opaque
           metadata:
             name: "{{ cifmw_test_operator_controller_priv_key_secret_name }}"
-            namespace: "{{ cifmw_test_operator_namespace }}"
+            namespace: "{{ cifmw_test_operator_test_namespace }}"
           data:
             ssh-privatekey: >-
               {{

--- a/roles/test_operator/tasks/tobiko-tests.yml
+++ b/roles/test_operator/tasks/tobiko-tests.yml
@@ -101,7 +101,7 @@
       type: Opaque
       metadata:
         name: "{{ cifmw_test_operator_tobiko_kubeconfig_secret }}"
-        namespace: "{{ cifmw_test_operator_namespace }}"
+        namespace: "{{ cifmw_test_operator_test_namespace }}"
       data:
         config: "{{ lookup('file', cifmw_openshift_kubeconfig) | b64encode }}"
   when: not cifmw_test_operator_dry_run | bool


### PR DESCRIPTION
The test-operator role was installing test-operator into the openstack
namespace when it should be installed in the openstack-operators
namespace together with all the other namespaces. The installation into
the openstack namespace was needed when in the beginning the
test-operator was not capable of working correctly from other namespace
than openstack. Now the test-operator should be capable of working
correctly from the openstack-operators namespace.
