### PR TITLE
Add empty list as default for adoption scenarios without networker nodes

### DIFF
--- a/roles/adoption_osp_deploy/templates/adoption_vars.yaml.j2
+++ b/roles/adoption_osp_deploy/templates/adoption_vars.yaml.j2
@@ -9,7 +9,7 @@ edpm_computes: |
   ["{{ compute }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}"]="{{ node_nets.networks.ctlplane.ip_v4 }}"
   {% endfor %}
 edpm_networkers: |
-  {% for networker in _vm_groups['osp-networkers'] %}
+  {% for networker in _vm_groups['osp-networkers'] | default([]) %}
   {% set node_nets = cifmw_networking_env_definition.instances[networker] %}
   ["{{ networker }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}"]="{{ node_nets.networks.ctlplane.ip_v4 }}"
   {% endfor %}


### PR DESCRIPTION
Networker nodes are not required in all adoption topologies.
We need to provide default filter to be able to generate adoption_vars
template if osp-networkers are not defined in _vm_groups.

Fixes: https://github.com/openstack-k8s-operators/ci-framework/pull/2548