### PR TITLE
Set Cinder customServiceConfig globally in DCN DT

### DIFF
--- a/roles/ci_dcn_site/templates/service-values.yaml.j2
+++ b/roles/ci_dcn_site/templates/service-values.yaml.j2
@@ -10,11 +10,11 @@ data:
   preserveJobs: false
   cinder:
     uniquePodNames: false
-  cinderAPI:
-    replicas: 3
     customServiceConfig: |
       [DEFAULT]
-      default_availability_zone = az0
+      storage_availability_zone = az0
+  cinderAPI:
+    replicas: 3
   cinderBackup:
     replicas: 3
     customServiceConfig: |
@@ -23,7 +23,6 @@ data:
       backup_ceph_conf = /etc/ceph/az0.conf
       backup_ceph_pool = backups
       backup_ceph_user = openstack
-      storage_availability_zone = az0
   cinderVolumes:
 {% for _ceph in _ceph_vars_list %}
     {{ _ceph.cifmw_ceph_client_cluster }}:


### PR DESCRIPTION
The customServiceConfig for cinder in the DCN DT is used to set the storage_availability_zone. We wish to do this for all Cinder services in the default site (`az0`), not just for cinderAPI or cinderBackup as the AZ was missing from the cinder-scheduler. Thus, we will move it to the global section under the cinder template and out of the cinderAPI and cinderBackup since they will inherit it. The backend_availability_zone is kept inside of the cinderVolumes loop since it needs to be set for other AZs. There's no harm in letting the loop set it for az0 and it's simpler to do that than add a conditional.

Jira: https://issues.redhat.com/browse/OSPRH-11915