### PR TITLE
Fix create-infra.yml sushy-emulator

### DIFF
--- a/create-infra.yml
+++ b/create-infra.yml
@@ -108,7 +108,6 @@
     - name: Bootstrap sushy-emulator (RedFish Virtual BMC) on controller-0
       when:
         - "'controllers' in groups"
-        - "'controllers' in group_names"
         - cifmw_use_sushy_emulator | default(false) | bool
       delegate_to: controller-0
       become: true


### PR DESCRIPTION
The condition: `controllers'' in group_names` cause it to always skip the tasks to set up sushy-emulator.

  false_condition: '''controllers'' in group_names'
  skip_reason: Conditional result was False

Remove that part of the when condition for the block.