### PR TITLE
Reprocuder: write ironic_nodes.yaml 

### DIFF
--- a/roles/reproducer/defaults/main.yml
+++ b/roles/reproducer/defaults/main.yml
@@ -51,3 +51,5 @@ cifmw_reproducer_controller_basedir: >-
 cifmw_reproducer_validate_network: true
 cifmw_reproducer_validate_network_host: "controller-0.utility"
 cifmw_reproducer_validate_ocp_layout: true
+
+cifmw_reproducer_ironic_node_name_prefix:

--- a/roles/reproducer/tasks/generate_bm_info.yml
+++ b/roles/reproducer/tasks/generate_bm_info.yml
@@ -121,3 +121,33 @@
     dest: "{{ cifmw_reproducer_controller_basedir }}/parameters/baremetal-info.yml"
     content: "{{ _content | to_nice_yaml }}"
     mode: "0644"
+
+- name: Output ironic_nodes to file
+  when: cifmw_reproducer_ironic_node_name_prefix
+  ansible.builtin.copy:
+    dest: "{{ cifmw_basedir }}/parameters/ironic_nodes.yaml"
+    content: |
+      {% set _ironic_nodes = [] %}
+      {% for node in libvirt_manager_bm_info_data.keys() if node.startswith(cifmw_reproducer_ironic_node_name_prefix) %}
+      {% set _node = libvirt_manager_bm_info_data[node] %}
+      {% set _conn = _node.connection | urlsplit %}
+      {% set _ironic_nodes = _ironic_nodes.append(
+        {
+           'name': node,
+           'driver': 'redfish',
+           'driver_info': {
+             'redfish_address': (_conn.scheme | split('+') | last) + '://' + _conn.hostname + ':' + (_conn.port | string),
+             'redfish_system_id': (_node.connection | urlsplit).path,
+             'redfish_username': _node.username,
+             'redfish_password': _node.password,
+            },
+            'ports': [
+              {
+                'address': (_node.nics | first).mac,
+                'physical_network': (_node.nics | first).network,
+              }
+            ]
+        }
+      ) %}
+      {% endfor %}
+      {{ {'nodes': _ironic_nodes } | to_nice_yaml(indent=2) }}


### PR DESCRIPTION
In the reproducer role's `generate_bm_info.yaml` add another task
to write the YAML required to enroll nodes in Openstack ironic. The
ironic file is only written if `cifmw_reproducer_ironic_node_name_prefix`
is set.

The `cifmw_reproducer_ironic_node_name_prefix` is used to filter from
libvirt_manager_bm_info_data so that only the nodes where the name
startswith the value of this option is added to the ironic_nodes.yaml.

Related: [OSPRH-12093](https://issues.redhat.com//browse/OSPRH-12093)