### PR TITLE
adoption_osp_deploy - os-net-config ironic

### DIFF
--- a/roles/adoption_osp_deploy/templates/os_net_config_overcloud.yml.j2
+++ b/roles/adoption_osp_deploy/templates/os_net_config_overcloud.yml.j2
@@ -40,3 +40,15 @@ network_config:
     routes: []
     {% endif %}
   {% endfor %}
+{% if 'ironic' in _node_net.networks.keys () %}
+{% set net = _node_net.networks.ironic %}
+# ironic
+- name: {{ _stack.os_net_config_ironic_iface |
+           default('nic3') }}
+  type: interface
+  mtu: {{ net.mtu }}
+  addresses:
+  - ip_netmask: {{ net.ip_v4 }}/{{ net.prefix_length_v4 }}
+  use_dhcp: false
+  routes: []
+{% endif %}


### PR DESCRIPTION
Set up the ironic network interface on osp controller nodes if the network is defined in the scenario.

By default it will map to `nic3`, but it can be overriden in the adoption scenario by setting `os_net_config_ironic_iface` in the scenario defenition.