### PR TITLE
[test_operator] Common default values for container images

### DIFF
--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -38,14 +38,18 @@ cifmw_test_operator_storage_class: "{{ cifmw_test_operator_storage_class_prefix 
 cifmw_test_operator_delete_logs_pod: false
 cifmw_test_operator_privileged: true
 cifmw_test_operator_selinux_level: "s0:c478,c978"
+# default testfw registry, namespace and tag can be overriden per testw (tempest, tobiko, horizontest and ansibletest)
+cifmw_test_operator_default_registry: quay.io
+cifmw_test_operator_default_namespace: podified-antelope-centos9
+cifmw_test_operator_default_image_tag: current-podified
 
 # Section 2: tempest parameters - used when run_test_fw is 'tempest'
 cifmw_test_operator_tempest_name: "tempest-tests"
-cifmw_test_operator_tempest_registry: quay.io
-cifmw_test_operator_tempest_namespace: podified-antelope-centos9
+cifmw_test_operator_tempest_registry: "{{ cifmw_test_operator_default_registry }}"
+cifmw_test_operator_tempest_namespace: "{{ cifmw_test_operator_default_namespace }}"
 cifmw_test_operator_tempest_container: openstack-tempest-all
 cifmw_test_operator_tempest_image: "{{ cifmw_test_operator_tempest_registry }}/{{ cifmw_test_operator_tempest_namespace }}/{{ cifmw_test_operator_tempest_container }}"
-cifmw_test_operator_tempest_image_tag: current-podified
+cifmw_test_operator_tempest_image_tag: "{{ cifmw_test_operator_default_image_tag }}"
 cifmw_test_operator_tempest_network_attachments: []
 cifmw_test_operator_tempest_tests_include_override_scenario: false
 cifmw_test_operator_tempest_tests_exclude_override_scenario: false
@@ -133,11 +137,11 @@ cifmw_test_operator_tempest_config:
 
 # Section 3: tobiko parameters - used when run_test_fw is 'tobiko'
 cifmw_test_operator_tobiko_name: "tobiko-tests"
-cifmw_test_operator_tobiko_registry: quay.io
-cifmw_test_operator_tobiko_namespace: podified-antelope-centos9
+cifmw_test_operator_tobiko_registry: "{{ cifmw_test_operator_default_registry }}"
+cifmw_test_operator_tobiko_namespace: "{{ cifmw_test_operator_default_namespace }}"
 cifmw_test_operator_tobiko_container: openstack-tobiko
 cifmw_test_operator_tobiko_image: "{{ cifmw_test_operator_tobiko_registry }}/{{ cifmw_test_operator_tobiko_namespace }}/{{ cifmw_test_operator_tobiko_container }}"
-cifmw_test_operator_tobiko_image_tag: current-podified
+cifmw_test_operator_tobiko_image_tag: "{{ cifmw_test_operator_default_image_tag }}"
 cifmw_test_operator_tobiko_testenv: scenario
 cifmw_test_operator_tobiko_version: master
 cifmw_test_operator_tobiko_pytest_addopts: null
@@ -178,11 +182,11 @@ cifmw_test_operator_tobiko_config:
 
 # Section 4: ansibletest parameters - used when run_test_fw is 'ansibletest'
 cifmw_test_operator_ansibletest_name: "ansibletest"
-cifmw_test_operator_ansibletest_registry: quay.io
-cifmw_test_operator_ansibletest_namespace: podified-antelope-centos9
+cifmw_test_operator_ansibletest_registry: "{{ cifmw_test_operator_default_registry }}"
+cifmw_test_operator_ansibletest_namespace: "{{ cifmw_test_operator_default_namespace }}"
 cifmw_test_operator_ansibletest_container: openstack-ansible-tests
 cifmw_test_operator_ansibletest_image: "{{ cifmw_test_operator_ansibletest_registry }}/{{ cifmw_test_operator_ansibletest_namespace }}/{{ cifmw_test_operator_ansibletest_container }}"
-cifmw_test_operator_ansibletest_image_tag: current-podified
+cifmw_test_operator_ansibletest_image_tag: "{{ cifmw_test_operator_default_image_tag }}"
 cifmw_test_operator_ansibletest_compute_ssh_key_secret_name: "dataplane-ansible-ssh-private-key-secret"
 cifmw_test_operator_ansibletest_workload_ssh_key_secret_name: ""
 cifmw_test_operator_ansibletest_ansible_git_repo: ""
@@ -223,11 +227,11 @@ cifmw_test_operator_ansibletest_config:
 
 # Section 5: horizontest parameters - used when run_test_fw is 'horizontest'
 cifmw_test_operator_horizontest_name: "horizontest-tests"
-cifmw_test_operator_horizontest_registry: quay.io
-cifmw_test_operator_horizontest_namespace: podified-antelope-centos9
+cifmw_test_operator_horizontest_registry: "{{ cifmw_test_operator_default_registry }}"
+cifmw_test_operator_horizontest_namespace: "{{ cifmw_test_operator_default_namespace }}"
 cifmw_test_operator_horizontest_container: openstack-horizontest
 cifmw_test_operator_horizontest_image: "{{ cifmw_test_operator_horizontest_registry }}/{{ cifmw_test_operator_horizontest_namespace }}/{{ cifmw_test_operator_horizontest_container }}"
-cifmw_test_operator_horizontest_image_tag: current-podified
+cifmw_test_operator_horizontest_image_tag: "{{ cifmw_test_operator_default_image_tag }}"
 cifmw_test_operator_horizontest_admin_username: admin
 cifmw_test_operator_horizontest_admin_password: "12345678"
 cifmw_test_operator_horizontest_dashboard_url: "https://horizon-openstack.apps.ocp.openstack.lab/"


### PR DESCRIPTION
test-operator currently supports 4 test frameworks: tempest, tobiko, horizontests and ansibletests. The relevant variables required to download their corresponding container images had to be configured separately, but usually were configured with common values. With this PR, default values for registry, namespace and tag can be configured and they apply to the 4 test frameworks.