### PR TITLE
[DCN] Update network values template

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/dcn/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/dcn/network-values/values.yaml.j2
@@ -183,27 +183,35 @@ data:
       - destination: 192.168.133.0/24
         next-hop-address: 192.168.122.1
         next-hop-interface: ospbr
+        table-id: 254
       - destination: 192.168.144.0/24
         next-hop-address: 192.168.122.1
         next-hop-interface: ospbr
+        table-id: 254
       - destination: 172.17.10.0/24
         next-hop-address: 172.17.0.1
         next-hop-interface: internalapi
+        table-id: 254
       - destination: 172.18.10.0/24
         next-hop-address: 172.18.0.1
         next-hop-interface: storage
+        table-id: 254
       - destination: 172.19.10.0/24
         next-hop-address: 172.19.0.1
         next-hop-interface: tenant
+        table-id: 254
       - destination: 172.17.20.0/24
         next-hop-address: 172.17.0.1
         next-hop-interface: internalapi
+        table-id: 254
       - destination: 172.18.20.0/24
         next-hop-address: 172.18.0.1
         next-hop-interface: storage
+        table-id: 254
       - destination: 172.19.20.0/24
         next-hop-address: 172.19.0.1
         next-hop-interface: tenant
+        table-id: 254
 
 # Hardcoding the last IP bit since we don't have support for endpoint_annotations in the networking_mapper output
   rabbitmq:


### PR DESCRIPTION
Explicitly set the route table ID to prevent random assignment, which can lead to the unexpected re-creation of VLAN interfaces.

Related Issue: [OSPRH-9899](https://issues.redhat.com//browse/OSPRH-9899)