### PR TITLE
Multi-cell adoption support                     

### DIFF
--- a/roles/adoption_osp_deploy/templates/adoption_vars.yaml.j2
+++ b/roles/adoption_osp_deploy/templates/adoption_vars.yaml.j2
@@ -1,13 +1,10 @@
 #jinja2: trim_blocks:True, lstrip_blocks:True
-source_mariadb_ip: {{ _controller_1_internalapi_ip }}
+source_mariadb_ip:
+  default:
+    {{ _controller_1_internalapi_ip }}
 source_ovndb_ip: {{ _controller_1_internalapi_ip }}
 edpm_node_hostname: {{ _compute_1_name }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}
 edpm_node_ip: {{ _compute_1_ip }}
-edpm_computes: |
-  {% for compute in _vm_groups['osp-computes'] %}
-  {% set node_nets = cifmw_networking_env_definition.instances[compute] %}
-  ["{{ compute }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}"]="{{ node_nets.networks.ctlplane.ip_v4 }}"
-  {% endfor %}
 edpm_networkers: |
   {% for networker in _vm_groups['osp-networkers'] | default([]) %}
   {% set node_nets = cifmw_networking_env_definition.instances[networker] %}
@@ -15,41 +12,44 @@ edpm_networkers: |
   {% endfor %}
 
 
-source_galera_members: |
-  {% for controller in _vm_groups['osp-controllers'] %}
-  {% set node_nets = cifmw_networking_env_definition.instances[controller] %}
-  ["{{ controller }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}"]="{{ node_nets.networks.internalapi.ip_v4 }}"
-  {% endfor %}
+source_galera_members:
+  default:
+    {% for controller in _vm_groups['osp-controllers'] %}
+    {% set node_nets = cifmw_networking_env_definition.instances[controller] %}
+    - name: "{{ controller }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}"
+      ip: "{{ node_nets.networks.internalapi.ip_v4 }}"
+    {% endfor %}
 
 edpm_nodes:
-  {% for compute in _vm_groups['osp-computes'] %}
-  {% set node_nets = cifmw_networking_env_definition.instances[compute] %}
-  {{ compute }}:
-    hostName: {{ compute }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}
-    ansible:
-      ansibleHost: {{ node_nets.networks.ctlplane.ip_v4 }}
-    networks:
-    {% for net in node_nets.networks.keys() %}
-      - defaultRoute: true
-        fixedIP: {{ node_nets.networks[net].ip_v4 }}
-        name: {{ net }}
-        subnetName: subnet1
-    {% endfor %}
-    {% endfor %}
-  {% for networker in _vm_groups['osp-networkers'] | default([]) %}
-  {% set node_nets = cifmw_networking_env_definition.instances[networker] %}
-  {{ networker }}:
-    hostName: {{ networker }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}
-    ansible:
-      ansibleHost: {{ node_nets.networks.ctlplane.ip_v4 }}
-    networks:
-    {% for net in node_nets.networks.keys() %}
-      - defaultRoute: true
-        fixedIP: {{ node_nets.networks[net].ip_v4 }}
-        name: {{ net }}
-        subnetName: subnet1
-    {% endfor %}
-    {% endfor %}
+  cell1:
+    {% for compute in _vm_groups['osp-computes'] %}
+    {% set node_nets = cifmw_networking_env_definition.instances[compute] %}
+    {{ compute }}:
+      hostName: {{ compute }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}
+      ansible:
+        ansibleHost: {{ node_nets.networks.ctlplane.ip_v4 }}
+      networks:
+      {% for net in node_nets.networks.keys() %}
+        - defaultRoute: true
+          fixedIP: {{ node_nets.networks[net].ip_v4 }}
+          name: {{ net }}
+          subnetName: subnet1
+      {% endfor %}
+      {% endfor %}
+    {% for networker in _vm_groups['osp-networkers'] | default([]) %}
+    {% set node_nets = cifmw_networking_env_definition.instances[networker] %}
+    {{ networker }}:
+      hostName: {{ networker }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}
+      ansible:
+        ansibleHost: {{ node_nets.networks.ctlplane.ip_v4 }}
+      networks:
+      {% for net in node_nets.networks.keys() %}
+        - defaultRoute: true
+          fixedIP: {{ node_nets.networks[net].ip_v4 }}
+          name: {{ net }}
+          subnetName: subnet1
+      {% endfor %}
+      {% endfor %}
 
 
 upstream_dns: {{ cifmw_networking_env_definition.networks.ctlplane.dns_v4 | first }}


### PR DESCRIPTION
Adapt vars for multi-cell layout.
Remove no longer used edpm_computes.

Assume a single default cell exists only (which becomes cell1
after adoption).

Change data formats to become compliant with multi-cell topology.

Depends-On: https://github.com/openstack-k8s-operators/data-plane-adoption/pull/746
Closes: https://github.com/openstack-k8s-operators/data-plane-adoption/issues/184
Jira: #[OSPRH-6548](https://issues.redhat.com/browse/OSPRH-6548)