### PR TITLE
Add checks for cifmw_devscripts_create_logical_volume is defined

### DIFF
--- a/roles/reproducer/tasks/ocp_layout_assertions.yml
+++ b/roles/reproducer/tasks/ocp_layout_assertions.yml
@@ -84,6 +84,7 @@
 
 - name: Ensure we don't set some parameters when no extra disks
   when:
+    - cifmw_devscripts_create_logical_volume is defined
     - _cifmw_libvirt_manager_layout.vms.ocp.extra_disks_num is undefined or
       _cifmw_libvirt_manager_layout.vms.ocp.extra_disks_num == 0
   ansible.builtin.assert:
@@ -141,7 +142,8 @@
       vars:
         _cinder_vols: >-
           {{
-            (cifmw_devscripts_create_logical_volume | bool) |
+            (cifmw_devscripts_create_logical_volume is defined and
+             cifmw_devscripts_create_logical_volume | bool) |
             ternary(cifmw_devscripts_cinder_volume_pvs, [])
           }}
         _lvms_vols: >-
@@ -178,6 +180,7 @@
   block:
     - name: Ensure no allocation overlap
       when:
+        - cifmw_devscripts_create_logical_volume is defined
         - cifmw_devscripts_create_logical_volume | bool
         - cifmw_use_lvms | default(false) | bool
       ansible.builtin.assert:
@@ -202,6 +205,7 @@
 
     - name: Ensure Cinder PVs allocated disks are available
       when:
+        - cifmw_devscripts_create_logical_volume is defined
         - cifmw_devscripts_create_logical_volume | bool
       ansible.builtin.assert:
         that:


### PR DESCRIPTION
The variable `cifmw_devscripts_create_logical_volume` is defined in the defaults of devscript role and will not be defined outside the role if not defined at the job level. In some places we do a check if `cifmw_devscripts_create_logical_volume` is true/false but there can be scenarios where it is undefined. This patch adds an extra check to make sure the var is defined.