### PR TITLE
Increase the SSHd ready timeout

### DIFF
--- a/roles/libvirt_manager/tasks/manage_vms.yml
+++ b/roles/libvirt_manager/tasks/manage_vms.yml
@@ -64,7 +64,7 @@
       cat ~/.ssh/authorized_keys |
       ssh -v core@{{ vm_con_name }} "cat >> ~/.ssh/authorized_keys"
   retries: 5
-  delay: 10
+  delay: 60
   register: _ssh_access
   until: _ssh_access.rc == 0
 


### PR DESCRIPTION
In some environments it looks like SSHd is taking a bit longer to be ready and it rejects SSH attempts leading to a failure in the CI run.