### PR TITLE
Add the hypervisors to the inventory

### DIFF
--- a/roles/libvirt_manager/templates/all-inventory.yml.j2
+++ b/roles/libvirt_manager/templates/all-inventory.yml.j2
@@ -20,6 +20,20 @@ virtual machines.
         ansible_ssh_common_args: "-o StrictHostKeyChecking=no -J {{ ansible_user | default(ansible_user_id) }}@{{ _hostname }}"
 {% endif %}
 {% endfor %}
+hypervisors:
+  hosts:
+{% set _hypervisors = (
+      ( _cifmw_libvirt_manager_layout.vms.values() | selectattr('target', 'defined') | map(attribute='target') | list)
+      + [inventory_hostname] ) | unique %}
+{% for _hypervisor in _hypervisors %}
+    {{ _hypervisor }}:
+{% if hostvars[_hypervisor]['ansible_host'] is defined %}
+{% set _hostname = hostvars[_hypervisor]['ansible_host'] %}
+        ansible_host: "{{ _hostname }}"
+        ansible_ssh_private_key_file: "~/.ssh/ssh_{{ _hostname }}"
+        vars:
+{% endif %}
+{% endfor %}
 localhosts:
   hosts:
     localhost:

--- a/roles/libvirt_manager/templates/inventory.yml.j2
+++ b/roles/libvirt_manager/templates/inventory.yml.j2
@@ -14,4 +14,5 @@
 {% else                                                     %}
       ansible_ssh_private_key_file: ~/.ssh/id_cifw
 {% endif                                                    %}
+      cifmw_hypervisor_host: "{{ _cifmw_libvirt_manager_layout.vms[host.key].target | default(inventory_hostname) }}"
 {% endfor %}

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -179,6 +179,7 @@
         marker: "## {mark} {{ _ssh_host }}"
         block: |-
           Host {{ _ssh_host }} {{ hostvars[host]['inventory_hostname'] }}
+            Hostname {{ _ssh_host }}
             IdentityFile ~/.ssh/ssh_{{ _ssh_host }}
             StrictHostKeyChecking no
             UserKnownHostsFile /dev/null


### PR DESCRIPTION
For use cases like ShiftOnStack the deployment may need to tweak the hypervisor.
We did not have a way to tell the deployment how to reach the hypervisor so this commit exposes the hypervisor Ansible instance to each host and creates a hypervisors group in the generated inventory.