### PR TITLE
[autohold playbook] Add missing bracket

### DIFF
--- a/ci/playbooks/multinode-autohold.yml
+++ b/ci/playbooks/multinode-autohold.yml
@@ -29,7 +29,7 @@
             _zuul_api_url: >-
               {{
                 [
-                  ('https://'+ _zuul_host,
+                  ('https://'+ _zuul_host),
                   'zuul',
                   'api',
                   'tenant',


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/ci-framework/pull/2607 missed a bracket and that results into an error.

Related-Issue: [OSPRH-12508](https://issues.redhat.com//browse/OSPRH-12508)