### PR TITLE
Add possibility to run HorizonTest in debug mode

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -214,6 +214,7 @@ Default value: {}
 * `cifmw_test_operator_horizontest_logs_directory_name`: (String) The name of the directory to store test logs. Default value: `horizon`
 * `cifmw_test_operator_horizontest_horizon_test_dir`: (String) The directory path for Horizon tests. Default value: `/var/lib/horizontest`
 * `cifmw_test_operator_horizontest_resources`: (Dict) A dictionary that specifies resources (cpu, memory) for the test pods. When kept untouched it defaults to the resource limits specified on the test-operator side. Default value: `{}`
+* `cifmw_test_operator_horizontest_debug`: (Bool) Run HorizonTest in debug mode, it keeps the operator pod sleeping infinitely (it must only set to `true` only for debugging purposes). Default value: `false`
 * `cifmw_test_operator_horizontest_config`: (Dict) Definition of HorizonTest CR instance that is passed to the test-operator (see [the test-operator documentation](https://openstack-k8s-operators.github.io/test-operator/crds.html#horizontest-custom-resource)). Default value:
 ```
   apiVersion: test.openstack.org/v1beta1
@@ -235,6 +236,7 @@ Default value: {}
     password: "{{ cifmw_test_operator_horizontest_password }}"
     flavorName: "{{ cifmw_test_operator_horizontest_flavor_name }}"
     logsDirectoryName: "{{ cifmw_test_operator_horizontest_logs_directory_name }}"
+    debug: "{{ cifmw_test_operator_horizontest_debug }}"
     horizonTestDir: "{{ cifmw_test_operator_horizontest_horizon_test_dir }}"
 ```
 

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -261,6 +261,7 @@ cifmw_test_operator_horizontest_user: "horizontest"
 cifmw_test_operator_horizontest_password: "horizontest"
 cifmw_test_operator_horizontest_flavor_name: "m1.tiny"
 cifmw_test_operator_horizontest_logs_directory_name: "horizon"
+cifmw_test_operator_horizontest_debug: false
 cifmw_test_operator_horizontest_horizon_test_dir: "/var/lib/horizontest"
 cifmw_test_operator_horizontest_resources: {}
 cifmw_test_operator_horizontest_config:
@@ -286,5 +287,6 @@ cifmw_test_operator_horizontest_config:
     password: "{{ stage_vars_dict.cifmw_test_operator_horizontest_password }}"
     flavorName: "{{ stage_vars_dict.cifmw_test_operator_horizontest_flavor_name }}"
     logsDirectoryName: "{{ stage_vars_dict.cifmw_test_operator_horizontest_logs_directory_name }}"
+    debug: "{{ stage_vars_dict.cifmw_test_operator_horizontest_debug }}"
     horizonTestDir: "{{ stage_vars_dict.cifmw_test_operator_horizontest_horizon_test_dir }}"
     resources: "{{ stage_vars_dict.cifmw_test_operator_horizontest_resources }}"


### PR DESCRIPTION
This patch adds support in the test-operator role to run HorizonTest tests in the debug mode (same as already is there for Tempest).