### PR TITLE
[OSPRH-12761] Adjust post-deploy image collection for OpenStack init controller pod

### DIFF
--- a/roles/env_op_images/tasks/main.yml
+++ b/roles/env_op_images/tasks/main.yml
@@ -131,7 +131,7 @@
             cifmw_openstack_operator_images_content |
             combine(
               {
-                item.metadata.labels['openstack.org/operator-name'] | upper ~ '_OP_IMG': item.status.containerStatuses[1].imageID
+                item.metadata.labels['openstack.org/operator-name'] | upper ~ '_OP_IMG': (item.status.containerStatuses | last).imageID
               }
             )
           }}


### PR DESCRIPTION
When gathering the environment's operator images in `playersbooks/99_logs.yml`, we need to be mindful of the upcoming new OpenStack install paradigm.  The OpenStack operator's "init" controller manager does not have two containers like all other controller managers, so we need to exclude it from the task that gathers controller manager images and add a special task to handle it instead.