### PR TITLE
Add retry to cephadm install

### DIFF
--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -147,3 +147,5 @@ cifmw_cephadm_repository_override: false
 cifmw_cephadm_version: "squid"
 # bug in cephadm: if you skip "prepare host" it will fail
 cifmw_cephadm_prepare_host: false
+cifmw_cephadm_wait_install_retries: 8
+cifmw_cephadm_wait_install_delay: 15

--- a/roles/cifmw_cephadm/tasks/install_cephadm.yml
+++ b/roles/cifmw_cephadm/tasks/install_cephadm.yml
@@ -30,6 +30,10 @@
   ansible.builtin.dnf:
     name: cephadm
     state: present
+  register: task_result
+  retries: "{{ cifmw_cephadm_wait_install_retries }}"
+  delay: "{{ cifmw_cephadm_wait_install_delay }}"
+  until: task_result is success
 
 - name: Stat cephadm file
   ansible.builtin.stat:


### PR DESCRIPTION
The cephadm package install is failing occasionally because of repo temporary issues. Let's add retries.