### PR TITLE
[polarion] Quote the custom_fields parameter to be shell safe

### DIFF
--- a/roles/polarion/tasks/main.yml
+++ b/roles/polarion/tasks/main.yml
@@ -131,7 +131,7 @@
           --testrun-title={{ cifmw_polarion_testrun_title }}-{{ loop_idx }}
           --xml-file={{ item.path }}
           --update_testcases={{ cifmw_polarion_update_testcases | default(false) }}
-          --custom-fields {{ _custom_fields_string }}
+          --custom-fields {{ _custom_fields_string | quote }}
           {{ cifmw_polarion_jump_extra_vars | default ('') }}
       loop: "{{ merged_xml_files.files }}"
       loop_control:


### PR DESCRIPTION
As the polarion allows white space characters in the properties we need to quote it to not fail in the shell task.