### PR TITLE
Add retry to the cephadm installation

### DIFF
--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -140,3 +140,5 @@ cifmw_cephadm_update_log_commands:
     cmd: "log last cephadm"
 cifmw_cephadm_wait_for_dashboard_retries: 10
 cifmw_cephadm_wait_for_dashboard_delay: 20
+cifmw_cephadm_wait_install_retries: 8
+cifmw_cephadm_wait_install_delay: 15

--- a/roles/cifmw_cephadm/tasks/pre.yml
+++ b/roles/cifmw_cephadm/tasks/pre.yml
@@ -29,6 +29,10 @@
     name: cephadm
     state: latest
     releasever: "{{ ansible_facts['distribution_major_version'] }}"
+  register: task_result
+  retries: "{{ cifmw_cephadm_wait_install_retries }}"
+  delay: "{{ cifmw_cephadm_wait_install_delay }}"
+  until: task_result is success
 
 - name: Stat cephadm file
   ansible.builtin.stat:


### PR DESCRIPTION
The cephadm package install is failing occasionally because of repo temporary issues. Let's add retries.