### PR TITLE
compress text artifacts

### DIFF
--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -138,6 +138,19 @@
             src: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/docs_build"
             dest: "{{ ansible_user_dir }}/zuul-output/logs/docs_build"
 
+        - name: Compress artifacts
+          become: true
+          ansible.builtin.shell:
+            chdir: "{{ ansible_user_dir }}/zuul-output/logs/"
+            cmd: |
+              echo "Before compression:"
+              du -sh
+              echo "Start compression"
+              echo "Compressing text files upper to 1MB ..."
+              find {{ ansible_user_dir }}/zuul-output/logs/ -type f -size +1M -exec bash -c 'file --mime-type $1 | grep -E ".*: text/.*" | cut -d: -f1 | xargs -r gzip' sh {} ';'
+              echo "After compression:"
+              du -sh
+
       always:
         - name: Copy files from workspace on node
           vars:


### PR DESCRIPTION
This change proposes to compress text files where size above 1MB.

Toolings/libs/browsers are able to deflate on the fly, thus for fair/substainable use of storage better to compress.

Some investigation shown that this simple step can save hundreds of MB of data for a build. In the case of a CI artifacts storage system and network bandwidth usage that non negligible.