### PR TITLE
Ensure EPEL is reinstalled

### DIFF
--- a/roles/ci_setup/tasks/epel.yml
+++ b/roles/ci_setup/tasks/epel.yml
@@ -4,6 +4,16 @@
     name: ci_setup
     tasks_from: repos.yml
 
+# Some roles like repo_setup may have altered the RPM installed files
+# without removing the RPM itself. Ensuring it's not installed before
+# enforcing its installation will make the EPEL rpm install consistent
+# with the actul state of the repository files.
+- name: Ensure EPEL is not already installed
+  become: true
+  ansible.builtin.dnf:
+    name: epel-release
+    state: absent
+
 - name: Install EPEL
   become: true
   ansible.builtin.dnf:


### PR DESCRIPTION
Some roles like repo_setup may have altered the state of /etc/yum.repos.d/ without removing the EPEL rpm leading to yum/dnf to think the repos are already installed.
Enforcing its deletion ensures the rpm always deploys the repository files.