### PR TITLE
[repo_setup] Use a role scoped copy of url_request

### DIFF
--- a/roles/repo_setup/library/url_request.py
+++ b/roles/repo_setup/library/url_request.py
@@ -1,0 +1,1 @@
+../../../plugins/modules/url_request.py

--- a/roles/repo_setup/tasks/rhos_release.yml
+++ b/roles/repo_setup/tasks/rhos_release.yml
@@ -9,7 +9,7 @@
         mode: "0755"
 
     - name: Download the RPM
-      cifmw.general.url_request:
+      url_request:
         url: "{{ cifmw_repo_setup_rhos_release_rpm }}"
         dest: "{{ cifmw_repo_setup_rhos_release_path }}/rhos-release.rpm"
         mode: "0644"


### PR DESCRIPTION
Since the role seems to be used from zuul without a nested playbook this role needs to have all of its dependencies self contained and not depending on global modules. To avoid copy/pasting the content of the module a symlink is used.
This change is required for zuul to call this role from its executor.