### PR TITLE
Revert adoption_vars.yaml to latest revision working for hci adoption

### DIFF
--- a/roles/adoption_osp_deploy/templates/adoption_vars.yaml.j2
+++ b/roles/adoption_osp_deploy/templates/adoption_vars.yaml.j2
@@ -8,12 +8,6 @@ edpm_computes: |
   {% set node_nets = cifmw_networking_env_definition.instances[compute] %}
   ["{{ compute }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}"]="{{ node_nets.networks.ctlplane.ip_v4 }}"
   {% endfor %}
-edpm_networkers: |
-  {% for networker in _vm_groups['osp-networkers'] | default([]) %}
-  {% set node_nets = cifmw_networking_env_definition.instances[networker] %}
-  ["{{ networker }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}"]="{{ node_nets.networks.ctlplane.ip_v4 }}"
-  {% endfor %}
-
 
 source_galera_members: |
   {% for controller in _vm_groups['osp-controllers'] %}
@@ -29,28 +23,23 @@ edpm_nodes:
     ansible:
       ansibleHost: {{ node_nets.networks.ctlplane.ip_v4 }}
     networks:
-    {% for net in node_nets.networks.keys() %}
       - defaultRoute: true
-        fixedIP: {{ node_nets.networks[net].ip_v4 }}
-        name: {{ net }}
+        fixedIP: {{ node_nets.networks.ctlplane.ip_v4 }}
+        name: ctlplane
+        subnetName: subnet1
+      - name: internalapi
+        fixedIP: {{ node_nets.networks.internalapi.ip_v4 }}
+        subnetName: subnet1
+      - name: storage
+        fixedIP: {{ node_nets.networks.storage.ip_v4 }}
+        subnetName: subnet1
+      - name: storagemgmt
+        fixedIP: {{ node_nets.networks.storagemgmt.ip_v4 }}
+        subnetName: subnet1
+      - name: tenant
+        fixedIP: {{ node_nets.networks.tenant.ip_v4 }}
         subnetName: subnet1
     {% endfor %}
-    {% endfor %}
-  {% for networker in _vm_groups['osp-networkers'] | default([]) %}
-  {% set node_nets = cifmw_networking_env_definition.instances[networker] %}
-  {{ networker }}:
-    hostName: {{ networker }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}
-    ansible:
-      ansibleHost: {{ node_nets.networks.ctlplane.ip_v4 }}
-    networks:
-    {% for net in node_nets.networks.keys() %}
-      - defaultRoute: true
-        fixedIP: {{ node_nets.networks[net].ip_v4 }}
-        name: {{ net }}
-        subnetName: subnet1
-    {% endfor %}
-    {% endfor %}
-
 
 upstream_dns: {{ cifmw_networking_env_definition.networks.ctlplane.dns_v4 | first }}
 os_cloud_name: {{ cifmw_adoption_osp_deploy_scenario.stacks[0].stackname }}


### PR DESCRIPTION
In https://github.com/openstack-k8s-operators/ci-framework/pull/2548/files we loop over networks and as a result all networks have defaultRoute key set to true. 

Revert to temporary fix: [OSPRH-13013](https://issues.redhat.com//browse/OSPRH-13013)