### PR TITLE
Fix adoption_vars, only one defaultRoute

### DIFF
--- a/roles/adoption_osp_deploy/README.md
+++ b/roles/adoption_osp_deploy/README.md
@@ -21,6 +21,10 @@ deployment. Defaults to `pool.ntp.org`
 * `cifmw_adoption_osp_deploy_stopper`: (String) Step at which to stop the run.  See `Break point` section below for possible values.
 * `cifmw_adoption_osp_deploy_scenario`: (Dict) Define the parameter to
 configure the OSP17.1 deployment.
+* `cifmw_adoption_osp_deploy_adoption_vars_exclude_nets`: (List) Name of
+  networks in the ci-framework Network Mapper data to exclude when generating
+  the adoption variables. By default it excludes the ci-framework "public"
+  network (`ocpbm`).
 
 ### Break point
 

--- a/roles/adoption_osp_deploy/defaults/main.yml
+++ b/roles/adoption_osp_deploy/defaults/main.yml
@@ -25,3 +25,6 @@ cifmw_adoption_osp_deploy_repos:
   - openstack-17.1-for-rhel-9-x86_64-rpms
   - fast-datapath-for-rhel-9-x86_64-rpms
   - rhceph-7-tools-for-rhel-9-x86_64-rpms
+
+cifmw_adoption_osp_deploy_adoption_vars_exclude_nets:
+  - "{{ cifmw_libvirt_manager_pub_net | default('ocpbm') }}"

--- a/roles/adoption_osp_deploy/templates/adoption_vars.yaml.j2
+++ b/roles/adoption_osp_deploy/templates/adoption_vars.yaml.j2
@@ -29,11 +29,13 @@ edpm_nodes:
     ansible:
       ansibleHost: {{ node_nets.networks.ctlplane.ip_v4 }}
     networks:
-    {% for net in node_nets.networks.keys() %}
-      - defaultRoute: true
-        fixedIP: {{ node_nets.networks[net].ip_v4 }}
+    {% for net in node_nets.networks.keys() if net not in cifmw_adoption_osp_deploy_adoption_vars_exclude_nets %}
+      - fixedIP: {{ node_nets.networks[net].ip_v4 }}
         name: {{ net }}
         subnetName: subnet1
+{% if net == 'ctlplane' %}
+        defaultRoute: true
+{% endif %}
     {% endfor %}
     {% endfor %}
   {% for networker in _vm_groups['osp-networkers'] | default([]) %}
@@ -43,11 +45,13 @@ edpm_nodes:
     ansible:
       ansibleHost: {{ node_nets.networks.ctlplane.ip_v4 }}
     networks:
-    {% for net in node_nets.networks.keys() %}
-      - defaultRoute: true
-        fixedIP: {{ node_nets.networks[net].ip_v4 }}
+    {% for net in node_nets.networks.keys() if net not in cifmw_adoption_osp_deploy_adoption_vars_exclude_nets %}
+      - fixedIP: {{ node_nets.networks[net].ip_v4 }}
         name: {{ net }}
         subnetName: subnet1
+{% if net == 'ctlplane' %}
+        defaultRoute: true
+{% endif %}
     {% endfor %}
     {% endfor %}
 


### PR DESCRIPTION
With [PR#2548](https://github.com/openstack-k8s-operators/ci-framework/pull/2548) support was added for multiple edpm nodesets, these may not have the same networks attached - i.e Compute and Networkere nodes have different network needs. When introducing this support the `networks` was made dynamic, and the `defaultRoute` was set for every network.

Only one network can have the `defaultRoute`, this caused an error when deploying the openstackdataplanenodeset.

Restore the behaviour prior to https://github.com/openstack-k8s-operators/ci-framework/pull/2548 - which would only set `defaultRoute` for the `ctlplane` network.

Also, filter the cifmw_libvirt_manager_pub_net when generating networks
for edpm_nodes. cifmw_libvirt_manager_pub_net (typically named ocpbm) is
a ci-framework "management" network and should not be included in the
EDPM nodeset configs.

Jira: [OSPRH-13013](https://issues.redhat.com//browse/OSPRH-13013)