### PR TITLE
Log overcloud installation to log

### DIFF
--- a/roles/adoption_osp_deploy/tasks/deploy_overcloud.yml
+++ b/roles/adoption_osp_deploy/tasks/deploy_overcloud.yml
@@ -68,6 +68,7 @@
           -e {{ ansible_user_dir }}/config_download_{{ _overcloud_name }}.yaml
           -e {{ ansible_user_dir }}/{{ _vips_provision_output }}
           -e {{ ansible_user_dir }}/{{ _network_provision_output }}
+          | tee -a overcloud_install.log
         _source_cmd: "source {{ ansible_user_dir }}/stackrc"
         _default_overcloud_deploy_cmd: "{{ _source_cmd }}; {{ _overcloud_deploy_cmd }}"
       cifmw.general.ci_script:
@@ -78,3 +79,6 @@
             _stack.deploy_command |
             default(_default_overcloud_deploy_cmd)
           }}
+
+    - name: Print the last few lines of the output to spot failures
+      ansible.builtin.command: tail -n60 overcloud_install.log


### PR DESCRIPTION
In case of failure it would be nice to have a separate log for overcloud deployment in order to be able to analyze it in case of failure. This patch saves overcloud deployment to the log and spot a few last lines to console.