### PR TITLE
Unset resources section in workflows

### DIFF
--- a/roles/test_operator/tasks/tempest-tests.yml
+++ b/roles/test_operator/tasks/tempest-tests.yml
@@ -173,3 +173,28 @@
               test_operator_cr |
               combine({'spec': {'workflow': overriden_workflow}}, recursive=true)
           }}
+
+- name: Make sure resources are not set for worklfow step
+  when:
+    - not cifmw_test_operator_dry_run | bool
+    - stage_vars_dict.cifmw_test_operator_tempest_workflow | list | length > 0
+  block:
+    - name: Remove resources until fix for bug 2088074 reaches openstack-tempest-all image
+      when: item.resources is undefined
+      vars:
+        _no_resources_workflow_step: >-
+          {{
+              item |
+              combine({"resources": {"requests": {}, "limits": {}}}, recursive=true)
+          }}
+      ansible.builtin.set_fact:
+        no_resources_workflow: "{{ no_resources_workflow | default([]) + [_no_resources_workflow_step] }}"
+      loop: "{{ stage_vars_dict.cifmw_test_operator_tempest_workflow | list }}"
+
+    - name: Override the Tempest CR workflow
+      ansible.builtin.set_fact:
+        test_operator_cr: >-
+          {{
+              test_operator_cr |
+              combine({'spec': {'workflow': no_resources_workflow}}, recursive=true)
+          }}


### PR DESCRIPTION
There is a bug in Tempest which prevents us to set a sane upper limit to the amount of memory Tempest can consume [1]. Until the fix reaches the upstream build of the openstack-tempest-all image we should not be setting any resource limits to the tempest pods.

This commit is ensuring that we are unsetting the default values set on the side of the test-operator in the workflow section of Tempest CR.

[1] https://bugs.launchpad.net/tempest/+bug/2088074
Related-Issue: https://issues.redhat.com/browse/OSPCIX-630