### PR TITLE
Add retries when creating OpenstackVersion

### DIFF
--- a/roles/update_containers/tasks/main.yml
+++ b/roles/update_containers/tasks/main.yml
@@ -33,3 +33,7 @@
     PATH: "{{ cifmw_path }}"
   ansible.builtin.command:
     cmd: "oc apply -f {{ cifmw_update_containers_dest_path }}"
+  register: apply_result
+  retries: 5
+  delay: 10
+  until: apply_result.rc == 0 


### PR DESCRIPTION
Cert-manager is now responsible for creating webhook certs and there a chance for a slightly delay while doing so.  Adding retries when trying to create `OpenStackVersion` in the event the webhook is not available yet.