### PR TITLE
[test_operator] Avoid overwriting previous changes in tempest workflows

### DIFF
--- a/roles/test_operator/tasks/tempest-tests.yml
+++ b/roles/test_operator/tasks/tempest-tests.yml
@@ -173,6 +173,11 @@
               test_operator_cr |
               combine({'spec': {'workflow': overriden_workflow}}, recursive=true)
           }}
+        stage_vars_dict: >-
+          {{
+              stage_vars_dict |
+              combine({'cifmw_test_operator_tempest_workflow': overriden_workflow})
+          }}
 
 - name: Make sure resources are not set for worklfow step
   when:
@@ -197,4 +202,9 @@
           {{
               test_operator_cr |
               combine({'spec': {'workflow': no_resources_workflow}}, recursive=true)
+          }}
+        stage_vars_dict: >-
+          {{
+              stage_vars_dict |
+              combine({'cifmw_test_operator_tempest_workflow': no_resources_workflow})
           }}


### PR DESCRIPTION
A couple of blocks at the end of the tempest-tests.yml tasks override the originally configured tempest workflows when certain conditions match.
Before this PR, the second block overrode the changes performed in the first block.