### PR TITLE
Fix after_kuttl commands so that the output is not truncated

### DIFF
--- a/ci/playbooks/kuttl/run-kuttl-tests.yml
+++ b/ci/playbooks/kuttl/run-kuttl-tests.yml
@@ -60,7 +60,7 @@
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
     PATH: "{{ cifmw_path }}"
   ansible.builtin.shell: |
-    {{ item }} > {{ cifmw_artifacts_basedir }}/logs/cmd_after_{{ operator }}_kuttl.log
+    {{ item }} >> {{ cifmw_artifacts_basedir }}/logs/cmd_after_{{ operator }}_kuttl.log
   loop: "{{ commands_after_kuttl_run }}"
   ignore_errors: true
 


### PR DESCRIPTION
The commands run after kuttl were simply redirecting the output and not
appending to the file, so if there were multiple commmands run, only the
output of the last one was kept. Instead, append to the file so the
output of all commands is visible.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/999