### PR TITLE
Lower the priority of component repo when gating repo is used

### DIFF
--- a/roles/repo_setup/tasks/populate_gating_repo.yml
+++ b/roles/repo_setup/tasks/populate_gating_repo.yml
@@ -31,3 +31,20 @@
         path: "{{ cifmw_repo_setup_output }}/delorean.repo"
         regexp: "priority=1"
         replace: "priority=20"
+
+    - name: Update DLRN component repo priority
+      when: cifmw_repo_setup_component_name | length > 0
+      vars:
+        _comp_repo: "{{ cifmw_repo_setup_component_name }}_component-ci-testing_delorean.repo.repo"
+      block:
+        - name: Check for DLRN component repo
+          ansible.builtin.stat:
+            path: "{{ cifmw_repo_setup_output }}/{{ _comp_repo }}"
+          register: _component_repo
+
+        - name: Lower the priority of componennt repos to allow installation from gating repo
+          when: _component_repo.stat.exists
+          ansible.builtin.replace:
+            path: "{{ cifmw_repo_setup_output }}//{{ _comp_repo }}"
+            regexp: "priority=1"
+            replace: "priority=2"


### PR DESCRIPTION
Currently the prirority of gating and component repo is 1.
If the package is in both repos. The package under test will get installed from any repo. It makes the code.eng or opendev gerrit review depends-on testing faulty as not sure from which repo package is picked up.
    
In order to fix that, when gating and componenet repo is used, lower the prirority of component repo so that package get pulled from gating repo.

Related-Jira: https://issues.redhat.com/browse/OSPRH-11948
