### PR TITLE
Fix release_minor value in project.ini

### DIFF
--- a/roles/build_openstack_packages/templates/projects.ini.j2
+++ b/roles/build_openstack_packages/templates/projects.ini.j2
@@ -28,10 +28,11 @@ use_components={{ cifmw_bop_use_components }}
 # There default values are `0.date.hash` and `0` respectively.
 # We are only setting these for downstream case when cifmw_bop_osp_release
 # is defined. For downstream case, we are hardcoding release_numbering=minor.date.hash
-# and then just set the release_minor value based on the OSP version
-# (e.g. 0 for 18/18.0, 1 for 18.1, 2 for 18.2 etc).
+# and then just set the release_minor value based on the OSP version.
+# (e.g. 18.0 for rhos-18.0).
+# The default value is 0.
 release_numbering=minor.date.hash
-release_minor={{ '0' if '.' not in cifmw_bop_osp_release.split('-')[1] else cifmw_bop_osp_release.split('-')[1].split('.')[1] }}
+release_minor={{ cifmw_bop_osp_release.split('-')[1] | default('0') }}
 nonfallback_branches=^master$,^rpm-master$,^rhos-
 custom_preprocess={{ cifmw_bop_build_repo_dir }}/DLRN/scripts/set_nvr.sh,{{ cifmw_bop_build_repo_dir }}/DLRN/scripts/patch_rebaser.sh
 


### PR DESCRIPTION
The correct value for release_minor is the rhos-release version i.e. for RHOS-18.0. it is 18.0.
The default value is 0[1].
    
Links: 
[1]. https://github.com/rdo-infra/ansible-role-dlrn/blob/bd748446b62d42d171d6ace179d3f1f39ff36319/templates/projects.ini.j2#L35

Related-Jira: https://issues.redhat.com/browse/OSPRH-11948