### PR TITLE
Switch cinder uniquePodNames to true for DCN deployments

### DIFF
--- a/roles/ci_dcn_site/templates/service-values.yaml.j2
+++ b/roles/ci_dcn_site/templates/service-values.yaml.j2
@@ -9,7 +9,6 @@ metadata:
 data:
   preserveJobs: false
   cinder:
-    uniquePodNames: false
     customServiceConfig: |
       [DEFAULT]
       storage_availability_zone = az0
@@ -219,10 +218,8 @@ data:
           extraVolType: Ceph
           volumes:
             - name: ceph
-              projected:
-                sources:
-                  - secret:
-                      name: ceph-conf-files
+              secret:
+                secretName: ceph-conf-files
           mounts:
             - name: ceph
               mountPath: /etc/ceph
@@ -234,10 +231,8 @@ data:
           extraVolType: Ceph
           volumes:
             - name: ceph-{{ _ceph.cifmw_ceph_client_cluster }}
-              projected:
-                sources:
-                  - secret:
-                      name: ceph-conf-files-{{ _ceph.cifmw_ceph_client_cluster }}
+              secret:
+                secretName: ceph-conf-files-{{ _ceph.cifmw_ceph_client_cluster }}
           mounts:
             - name: ceph-{{ _ceph.cifmw_ceph_client_cluster }}
               mountPath: /etc/ceph


### PR DESCRIPTION
This patch removes `uniquePodNames` from the Cinder deployment section and
removes the `projected` keyword that is not required to access the `Ceph` secret.
`uniquePodNames` is set to true by default when the DT is run.

Jira: https://issues.redhat.com/browse/OSPRH-11240