### PR TITLE
Adds gh action to check for DNM labels

### DIFF
--- a/.github/workflows/check-dnm-label.yml
+++ b/.github/workflows/check-dnm-label.yml
@@ -1,0 +1,23 @@
+---
+name: Check for DNM labels
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - labeled
+      - unlabeled
+
+jobs:
+  check-for-DNM:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Fail if PR is DNM
+        if: contains(github.event.pull_request.labels.*.name, 'do-not-merge/hold') || contains(github.event.pull_request.labels.*.name, 'do-not-merge/work-in-progress')
+        run: |
+          echo "This PR has a DNM label."
+          exit 1


### PR DESCRIPTION
This patch should go together with https://github.com/openshift/release/pull/60916 (doesnt matter after or before)

This action checks if the PR has `do-not-merge/hold` or `do-not-merge/work-in-progress`. If yes it fails.
When this action is set as "required" in the repo settings this prevents accidental merge if these labels are set.

The contains() function does not support regexes or arrays - hence the use of "or"