### PR TITLE
Create default RGW realm before rendering the spec

### DIFF
--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -69,6 +69,7 @@ cifmw_ceph_mds_spec_path: /tmp/ceph_mds.yml
 cifmw_ceph_rgw_keystone_ep: "https://keystone-internal.openstack.svc:5000"
 cifmw_ceph_rgw_keystone_psw: 12345678
 cifmw_ceph_rgw_keystone_user: "swift"
+cifmw_ceph_rgw_realm: "default"
 cifmw_ceph_rgw_config:
   rgw_keystone_url: "{{ cifmw_ceph_rgw_keystone_ep }}"
   rgw_keystone_verify_ssl: false

--- a/roles/cifmw_cephadm/tasks/rgw.yml
+++ b/roles/cifmw_cephadm/tasks/rgw.yml
@@ -61,6 +61,27 @@
         rgw_frontend_cert: "{{ slurp_cert['content'] | b64decode ~
                                slurp_key['content'] | b64decode }}"
 
+- name: Create default RGW realm
+  block:
+    - name: Get radosgw-admin ceph_cli
+      ansible.builtin.include_tasks: ceph_cli.yml
+      vars:
+        ceph_command: radosgw-admin
+
+    - name: Test if default realm exists
+      become: true
+      ignore_errors: true
+      ansible.builtin.command: |
+        {{ cifmw_cephadm_ceph_cli }} realm get --rgw-realm={{ cifmw_ceph_rgw_realm }}
+      register: rgw_realm
+
+    - name: Create default RGW realm
+      when: rgw_realm.rc > 0
+      ansible.builtin.command: |
+        {{ cifmw_cephadm_ceph_cli }} realm create --rgw-realm={{ cifmw_ceph_rgw_realm }}
+      changed_when: false
+      become: true
+
 - name: Create a Ceph RGW spec
   ansible.builtin.template:
     src: templates/ceph_rgw.yml.j2
@@ -68,7 +89,7 @@
     mode: '0644'
     force: true
 
-- name: Get ceph_cli
+- name: Get ceph orch cli
   ansible.builtin.include_tasks: ceph_cli.yml
   vars:
     mount_spec: true

--- a/roles/cifmw_cephadm/templates/ceph_rgw.yml.j2
+++ b/roles/cifmw_cephadm/templates/ceph_rgw.yml.j2
@@ -11,7 +11,7 @@ networks:
 - {{ cifmw_cephadm_rgw_network }}
 spec:
   rgw_frontend_port: 8082
-  rgw_realm: default
+  rgw_realm: {{ cifmw_ceph_rgw_realm }}
   rgw_zone: default
 {% if rgw_frontend_cert is defined %}
   ssl: true


### PR DESCRIPTION
With Ceph `Squid` `RGW` fails to deploy because the default `realm` is missing [1].
In particular it fails with the following error:

```
0 rgw main: failed to load realm: (2) No such file or directory
 -1 Couldn't init storage provider (RADOS)
```

that is clearly referred to a missing default realm.
This used to work well (probably because of a `Ceph` default) but it started failing from Ceph `Squid+` .
This patch creates a default realm beforehand, and it is valid both for `Squid` and previous releases.

[1] https://tracker.ceph.com/issues/69676

Jira: https://issues.redhat.com/browse/OSPRH-10666