### PR TITLE
Elevating privileges for key addition

### DIFF
--- a/docs/source/files/bootstrap-hypervisor.yml
+++ b/docs/source/files/bootstrap-hypervisor.yml
@@ -43,6 +43,7 @@
 
     - name: Add ed25519 pub key to authorized keys
       when: ed_pub_key.stat.exists
+      become: true
       ansible.posix.authorized_key:
         user: "{{ _user }}"
         state: present


### PR DESCRIPTION
When running the bootstrap playbook the key addition would fail due to insufficient privileges.

This way we run commands with effective root, as we do in other cases. 