### PR TITLE
Change test-operator-index to openstack-operator-index

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -5,7 +5,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 ## Parameters
 * `cifmw_test_operator_artifacts_basedir`: (String) Directory where we will have all test-operator related files. Default value: `{{ cifmw_basedir }}/tests/test_operator` which defaults to `~/ci-framework-data/tests/test_operator`
 * `cifmw_test_operator_namespace`: (String) Namespace inside which all the resources are created. Default value: `openstack`
-* `cifmw_test_operator_index`: (String) Full name of container image with index that contains the test-operator. Default value: `quay.io/openstack-k8s-operators/test-operator-index:latest`
+* `cifmw_test_operator_index`: (String) Full name of container image with index that contains the test-operator. Default value: `""`
 * `cifmw_test_operator_timeout`: (Integer) Timeout in seconds for the execution of the tests. Default value: `3600`
 * `cifmw_test_operator_logs_image`: (String) Image that should be used to collect logs from the pods spawned by the test-operator. Default value: `quay.io/quay/busybox`
 * `cifmw_test_operator_concurrency`: (Integer) Tempest concurrency value. As of now this value can not be specified inside `test_vars`. Default value: `8`

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -25,7 +25,7 @@ cifmw_test_operator_stages:
 cifmw_test_operator_fail_on_test_failure: true
 cifmw_test_operator_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}/tests/test_operator"
 cifmw_test_operator_namespace: openstack
-cifmw_test_operator_index: quay.io/openstack-k8s-operators/test-operator-index:latest
+cifmw_test_operator_index: ""
 cifmw_test_operator_timeout: 3600
 cifmw_test_operator_logs_image: quay.io/quay/busybox
 cifmw_test_operator_concurrency: 8

--- a/roles/test_operator/tasks/main.yml
+++ b/roles/test_operator/tasks/main.yml
@@ -39,7 +39,9 @@
       spec:
         targetNamespaces:
           - "{{ cifmw_test_operator_namespace }}"
-  when: not cifmw_test_operator_dry_run | bool
+  when:
+    - not cifmw_test_operator_dry_run | bool
+    - cifmw_test_operator_index != ""
 
 - name: Ensure CatalogSource for the test-operator is present
   kubernetes.core.k8s:
@@ -57,7 +59,9 @@
       spec:
         sourceType: grpc
         image: "{{ cifmw_test_operator_index }}"
-  when: not cifmw_test_operator_dry_run | bool
+  when:
+    - not cifmw_test_operator_dry_run | bool
+    - cifmw_test_operator_index != ""
 
 - name: Ensure Subscription for the test-operator is present
   kubernetes.core.k8s:
@@ -74,7 +78,7 @@
         namespace: "{{ cifmw_test_operator_namespace }}"
       spec:
         name: test-operator
-        source: test-operator-catalog
+        source: "{{ 'test-operator-catalog' | default('openstack-operator-index') }}"
         sourceNamespace: "{{ cifmw_test_operator_namespace }}"
         config:
           tolerations: "{{ cifmw_test_operator_tolerations | default(omit) }}"


### PR DESCRIPTION
The test-operator role installs the test-operator from the test-operator-index. To run the test-operator the same way as users, this patch introduces change to the default value to openstack-operator-index. We want the downstream jobs to install test-operator from downstream build and upstream jobs from upstream build.