### PR TITLE
Remove rgw default zone and realm

### DIFF
--- a/roles/cifmw_cephadm/templates/ceph_rgw.yml.j2
+++ b/roles/cifmw_cephadm/templates/ceph_rgw.yml.j2
@@ -11,8 +11,6 @@ networks:
 - {{ cifmw_cephadm_rgw_network }}
 spec:
   rgw_frontend_port: 8082
-  rgw_realm: default
-  rgw_zone: default
 {% if rgw_frontend_cert is defined %}
   ssl: true
   rgw_frontend_ssl_certificate: |


### PR DESCRIPTION
We don't test `RGW` `multisite` in `OpenStack`. From `Squid+` a default realm is not deployed anymore, resulting in `RGW` deployment failures. This patch removes both default realm and zone from the `RGW` spec.
