### PR TITLE
[DNM] Adjust OCP and compute resources

### DIFF
--- a/scenarios/reproducers/dt-osasinfra.yml
+++ b/scenarios/reproducers/dt-osasinfra.yml
@@ -45,9 +45,9 @@ cifmw_networking_mapper_definition_patches_01:
 
 # HCI requires bigger size to hold OCP on OSP disks
 cifmw_block_device_size: 100G
-cifmw_libvirt_manager_compute_disksize: 200
-cifmw_libvirt_manager_compute_memory: 50
-cifmw_libvirt_manager_compute_cpus: 8
+cifmw_libvirt_manager_compute_disksize: 160
+cifmw_libvirt_manager_compute_memory: 70
+cifmw_libvirt_manager_compute_cpus: 4
 
 cifmw_libvirt_manager_configuration:
   networks:
@@ -86,8 +86,8 @@ cifmw_libvirt_manager_configuration:
       image_local_dir: "{{ cifmw_basedir }}/images/"
       disk_file_name: "ocp_master"
       disksize: "100"
-      cpus: 16
-      memory: 32
+      cpus: 20
+      memory: 70
       root_part_id: 4
       uefi: true
       nets:
@@ -117,7 +117,7 @@ cifmw_libvirt_manager_configuration:
       disk_file_name: "base-os.qcow2"
       disksize: 50
       memory: 8
-      cpus: 4
+      cpus: 2
       nets:
         - ocpbm
         - osp_trunk


### PR DESCRIPTION
The OCP and compute nodes resources are adapted for osasinfra DT running on titan19 (500 GB RAM, 890 GB disk, 40 CPUs).
For testing purposes on titan19.