### PR TITLE
Enhance test_operator role for flexible test workflows

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -53,8 +53,6 @@ are shared among multiple roles:
 - `cifmw_run_tests`: (Bool) Specifies whether tests should be executed.
   Defaults to false.
 - `cifmw_run_test_role`: (String) Specifies which ci-framework role will be used to run tests. Allowed options are `test_operator`, `tempest` and `shiftstack`. Defaults to `tempest`.
-- `cifmw_run_tempest`: (Bool) Specifies whether tempest tests should be run.  Notice tempest tests can be executed with either `test_operator` or `tempest` roles. Defaults to true.
-- `cifmw_run_tobiko`: (Bool) Specifies whether tobiko tests should be run. Notice tobiko tests can only be executed with the `test_operator` role. Defaults to false.
 - `cifmw_edpm_deploy_nfs`: (Bool) Specifies whether an nfs server should be deployed.
 - `cifmw_nfs_target`: (String) The Ansible inventory group where the nfs server is deployed. Defaults to `computes`. Only has an effect if `cifmw_edpm_deploy_nfs` is set to `true`.
 - `cifmw_nfs_network`: (String) The network the deployed nfs server will be accessible from. Defaults to `storage`. Only has an effect if `cifmw_edpm_deploy_nfs` is set to `true`.

--- a/roles/shiftstack/README.md
+++ b/roles/shiftstack/README.md
@@ -30,12 +30,12 @@ Role for triggering Openshift on Openstack QA automation (installation and tests
 The role is imported in the test playbook, i.e. when:
 ```
 cifmw_run_tests: true
-cifmw_run_tempest: false
+cifmw_test_operator_stages: []
 cifmw_run_test_role: shiftstack
 cifmw_run_test_shiftstack_testconfig:
   - 4.17_ovnkubernetes_ipi.yaml
   - 4.17_ovnkubernetes_upi.yaml
 cifmw_shiftstack_qa_gerrithub_change: refs/changes/29/1188429/50 #optional
 
-$ ansible-playbook deploy-edpm.yml -e 'cifmw_run_tests=true cifmw_run_tempest=false cifmw_run_test_role=shiftstack cifmw_openshift_kubeconfig={{ ansible_user_dir }}/.kube/config cifmw_shiftstack_qa_gerrithub_change=refs/changes/29/1188429/50' -e 'cifmw_run_test_shiftstack_testconfig=["4.17_ovnkubernetes_ipi.yaml","4.17_ovnkubernetes_upi.yaml"]'
+$ ansible-playbook deploy-edpm.yml --extra-vars "cifmw_run_tests=true cifmw_run_test_role=shiftstack cifmw_test_operator_stages=[] cifmw_openshift_kubeconfig={{ ansible_user_dir }}/.kube/config cifmw_run_test_shiftstack_testconfig=4.15_ovnkubernetes_ipi_va1.yaml cifmw_shiftstack_qa_gerrithub_change=refs/changes/29/1188429/50"
 ```

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -19,6 +19,9 @@
 # All variables within this role should have a prefix of "cifmw_test_operator"
 
 # Section 1: generic parameters (applied to all supported test frameworks)
+cifmw_test_operator_stages:
+  - name: tempest
+    type: tempest
 cifmw_test_operator_fail_on_test_failure: true
 cifmw_test_operator_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}/tests/test_operator"
 cifmw_test_operator_namespace: openstack
@@ -44,13 +47,14 @@ cifmw_test_operator_tempest_name: "tempest-tests"
 cifmw_test_operator_tempest_registry: quay.io
 cifmw_test_operator_tempest_namespace: podified-antelope-centos9
 cifmw_test_operator_tempest_container: openstack-tempest-all
-cifmw_test_operator_tempest_image: "{{ cifmw_test_operator_tempest_registry }}/{{ cifmw_test_operator_tempest_namespace }}/{{ cifmw_test_operator_tempest_container }}"
+cifmw_test_operator_tempest_image: "{{ stage_vars_dict.cifmw_test_operator_tempest_registry }}/{{ stage_vars_dict.cifmw_test_operator_tempest_namespace }}/{{ stage_vars_dict.cifmw_test_operator_tempest_container }}"
 cifmw_test_operator_tempest_image_tag: current-podified
 cifmw_test_operator_tempest_network_attachments: []
 cifmw_test_operator_tempest_tests_include_override_scenario: false
 cifmw_test_operator_tempest_tests_exclude_override_scenario: false
 cifmw_test_operator_tempest_workflow: []
 cifmw_test_operator_tempest_cleanup: false
+cifmw_test_operator_tempest_tempestconf_config: "{{ cifmw_tempest_tempestconf_config }}"
 
 # Enabling SRBAC by default, in jobs where this does not make sense should be turned off explicitly
 #
@@ -98,40 +102,42 @@ cifmw_test_operator_tempest_config:
   apiVersion: test.openstack.org/v1beta1
   kind: Tempest
   metadata:
-    name: "{{ test_operator_job_name }}"
+    name: "{{ stage_vars_dict.cifmw_test_operator_tempest_name }}-{{ _stage_vars.name }}"
     namespace: "{{ cifmw_test_operator_namespace }}"
   spec:
-    containerImage: "{{ cifmw_test_operator_tempest_image }}:{{ cifmw_test_operator_tempest_image_tag }}"
+    SELinuxLevel: "{{ cifmw_test_operator_selinux_level }}"
+    containerImage: "{{ stage_vars_dict.cifmw_test_operator_tempest_image }}:{{ stage_vars_dict.cifmw_test_operator_tempest_image_tag }}"
     storageClass: "{{ cifmw_test_operator_storage_class }}"
     privileged: "{{ cifmw_test_operator_privileged }}"
-    SELinuxLevel: "{{ cifmw_test_operator_selinux_level }}"
-    parallel: "{{ cifmw_test_operator_tempest_parallel | default(omit) }}"
-    SSHKeySecretName: "{{ cifmw_test_operator_tempest_ssh_key_secret_name | default(omit) }}"
-    configOverwrite: "{{ cifmw_test_operator_tempest_config_overwrite | default(omit) }}"
-    networkAttachments: "{{ cifmw_test_operator_tempest_network_attachments }}"
+    parallel: "{{ stage_vars_dict.cifmw_test_operator_tempest_parallel | default(omit) }}"
+    SSHKeySecretName: "{{ stage_vars_dict.cifmw_test_operator_tempest_ssh_key_secret_name | default(omit) }}"
+    configOverwrite: "{{ stage_vars_dict.cifmw_test_operator_tempest_config_overwrite | default(omit) }}"
+    networkAttachments: "{{ stage_vars_dict.cifmw_test_operator_tempest_network_attachments }}"
     tolerations: "{{ cifmw_test_operator_tolerations | default(omit) }}"
     nodeSelector: "{{ cifmw_test_operator_node_selector | default(omit) }}"
-    extraConfigmapsMounts: "{{ cifmw_test_operator_tempest_extra_configmaps_mounts | default(omit) }}"
+    extraConfigmapsMounts: "{{ stage_vars_dict.cifmw_test_operator_tempest_extra_configmaps_mounts | default(omit) }}"
     tempestRun:
       includeList: |
-        {{ cifmw_test_operator_tempest_include_list | default('') }}
+        {{ stage_vars_dict.cifmw_test_operator_tempest_include_list | default('') }}
       excludeList: |
-        {{ cifmw_test_operator_tempest_exclude_list | default('') }}
+        {{ stage_vars_dict.cifmw_test_operator_tempest_exclude_list | default('') }}
+      expectedFailuresList: |
+        {{ stage_vars_dict.cifmw_test_operator_tempest_expected_failures_list | default('') }}
       concurrency: "{{ cifmw_test_operator_concurrency }}"
-      externalPlugin: "{{ cifmw_test_operator_tempest_external_plugin | default([]) }}"
-      extraRPMs: "{{ cifmw_test_operator_tempest_extra_rpms | default([]) }}"
-      extraImages: "{{ cifmw_test_operator_tempest_extra_images | default([]) }}"
-    tempestconfRun: "{{ cifmw_tempest_tempestconf_config_defaults | combine(cifmw_tempest_tempestconf_config | default({})) }}"
-    cleanup: "{{ cifmw_test_operator_tempest_cleanup }}"
-    workflow: "{{ cifmw_test_operator_tempest_workflow }}"
-    debug: "{{ cifmw_test_operator_tempest_debug }}"
+      externalPlugin: "{{ stage_vars_dict.cifmw_test_operator_tempest_external_plugin | default([]) }}"
+      extraRPMs: "{{ stage_vars_dict.cifmw_test_operator_tempest_extra_rpms | default([]) }}"
+      extraImages: "{{ stage_vars_dict.cifmw_test_operator_tempest_extra_images | default([]) }}"
+    tempestconfRun: "{{ cifmw_tempest_tempestconf_config_defaults | combine(stage_vars_dict.cifmw_test_operator_tempest_tempestconf_config | default({})) }}"
+    cleanup: "{{ stage_vars_dict.cifmw_test_operator_tempest_cleanup }}"
+    workflow: "{{ stage_vars_dict.cifmw_test_operator_tempest_workflow }}"
+    debug: "{{ stage_vars_dict.cifmw_test_operator_tempest_debug }}"
 
 # Section 3: tobiko parameters - used when run_test_fw is 'tobiko'
 cifmw_test_operator_tobiko_name: "tobiko-tests"
 cifmw_test_operator_tobiko_registry: quay.io
 cifmw_test_operator_tobiko_namespace: podified-antelope-centos9
 cifmw_test_operator_tobiko_container: openstack-tobiko
-cifmw_test_operator_tobiko_image: "{{ cifmw_test_operator_tobiko_registry }}/{{ cifmw_test_operator_tobiko_namespace }}/{{ cifmw_test_operator_tobiko_container }}"
+cifmw_test_operator_tobiko_image: "{{ stage_vars_dict.cifmw_test_operator_tobiko_registry }}/{{ stage_vars_dict.cifmw_test_operator_tobiko_namespace }}/{{ stage_vars_dict.cifmw_test_operator_tobiko_container }}"
 cifmw_test_operator_tobiko_image_tag: current-podified
 cifmw_test_operator_tobiko_testenv: scenario
 cifmw_test_operator_tobiko_version: master
@@ -148,33 +154,34 @@ cifmw_test_operator_tobiko_config:
   apiVersion: test.openstack.org/v1beta1
   kind: Tobiko
   metadata:
-    name: tobiko-tests
+    name: "{{ stage_vars_dict.cifmw_test_operator_tobiko_name }}-{{ _stage_vars.name }}"
     namespace: "{{ cifmw_test_operator_namespace }}"
   spec:
-    kubeconfigSecretName: "{{ cifmw_test_operator_tobiko_kubeconfig_secret }}"
+    SELinuxLevel: "{{ cifmw_test_operator_selinux_level }}"
+    kubeconfigSecretName: "{{ stage_vars_dict.cifmw_test_operator_tobiko_kubeconfig_secret }}"
     storageClass: "{{ cifmw_test_operator_storage_class }}"
     privileged: "{{ cifmw_test_operator_privileged }}"
-    SELinuxLevel: "{{ cifmw_test_operator_selinux_level }}"
-    containerImage: "{{ cifmw_test_operator_tobiko_image }}:{{ cifmw_test_operator_tobiko_image_tag }}"
-    testenv: "{{ cifmw_test_operator_tobiko_testenv }}"
-    version: "{{ cifmw_test_operator_tobiko_version }}"
-    pytestAddopts: "{{ cifmw_test_operator_tobiko_pytest_addopts if cifmw_test_operator_tobiko_pytest_addopts is not none else omit }}"
+    containerImage: "{{ stage_vars_dict.cifmw_test_operator_tobiko_image }}:{{ stage_vars_dict.cifmw_test_operator_tobiko_image_tag }}"
+    testenv: "{{ stage_vars_dict.cifmw_test_operator_tobiko_testenv }}"
+    version: "{{ stage_vars_dict.cifmw_test_operator_tobiko_version }}"
+    pytestAddopts: "{{ stage_vars_dict.cifmw_test_operator_tobiko_pytest_addopts if stage_vars_dict.cifmw_test_operator_tobiko_pytest_addopts is not none else omit }}"
     tolerations: "{{ cifmw_test_operator_tolerations | default(omit) }}"
     nodeSelector: "{{ cifmw_test_operator_node_selector | default(omit) }}"
-    networkAttachments: "{{ cifmw_test_operator_tobiko_network_attachments }}"
-    # preventCreate: preventCreate is generated by the test_operator role based on the value of cifmw_test_operator_tobiko_prevent_create
-    # numProcesses: numProcesses is generated by the test_operator role based on the value of cifmw_test_operator_tobiko_num_processes
+    debug: "{{ stage_vars_dict.cifmw_test_operator_tobiko_debug }}"
+    networkAttachments: "{{ stage_vars_dict.cifmw_test_operator_tobiko_network_attachments }}"
+    # preventCreate: preventCreate is generated by the test_operator role based on the value of stage_vars_dict.cifmw_test_operator_tobiko_prevent_create
+    # numProcesses: numProcesses is generated by the test_operator role based on the value of stage_vars_dict.cifmw_test_operator_tobiko_num_processes
     # privateKey: privateKey is automatically by the test_operator role
     # publicKey: publicKey is automatically generated by the test_operator role
-    # config: config is generated combining cifmw_test_operator_tobiko_default_conf and cifmw_test_operator_tobiko_override_conf
-    workflow: "{{ cifmw_test_operator_tobiko_workflow }}"
+    # config: config is generated combining stage_vars_dict.cifmw_test_operator_tobiko_default_conf and stage_vars_dict.cifmw_test_operator_tobiko_override_conf
+    workflow: "{{ stage_vars_dict.cifmw_test_operator_tobiko_workflow }}"
 
 # Section 4: ansibletest parameters - used when run_test_fw is 'ansibletest'
 cifmw_test_operator_ansibletest_name: "ansibletest"
 cifmw_test_operator_ansibletest_registry: quay.io
 cifmw_test_operator_ansibletest_namespace: podified-antelope-centos9
 cifmw_test_operator_ansibletest_container: openstack-ansible-tests
-cifmw_test_operator_ansibletest_image: "{{ cifmw_test_operator_ansibletest_registry }}/{{ cifmw_test_operator_ansibletest_namespace }}/{{ cifmw_test_operator_ansibletest_container }}"
+cifmw_test_operator_ansibletest_image: "{{ stage_vars_dict.cifmw_test_operator_ansibletest_registry }}/{{ stage_vars_dict.cifmw_test_operator_ansibletest_namespace }}/{{ stage_vars_dict.cifmw_test_operator_ansibletest_container }}"
 cifmw_test_operator_ansibletest_image_tag: current-podified
 cifmw_test_operator_ansibletest_compute_ssh_key_secret_name: "dataplane-ansible-ssh-private-key-secret"
 cifmw_test_operator_ansibletest_workload_ssh_key_secret_name: ""
@@ -193,33 +200,33 @@ cifmw_test_operator_ansibletest_config:
   apiVersion: test.openstack.org/v1beta1
   kind: AnsibleTest
   metadata:
-    name: "{{ test_operator_job_name }}"
+    name: "{{ stage_vars_dict.cifmw_test_operator_ansibletest_name }}-{{ _stage_vars.name }}"
     namespace: "{{ cifmw_test_operator_namespace }}"
   spec:
-    containerImage: "{{ cifmw_test_operator_ansibletest_image }}:{{ cifmw_test_operator_ansibletest_image_tag }}"
-    extraConfigmapsMounts: "{{ cifmw_test_operator_ansibletest_extra_configmaps_mounts }}"
+    SELinuxLevel: "{{ cifmw_test_operator_selinux_level }}"
+    containerImage: "{{ stage_vars_dict.cifmw_test_operator_ansibletest_image }}:{{ stage_vars_dict.cifmw_test_operator_ansibletest_image_tag }}"
+    extraConfigmapsMounts: "{{ stage_vars_dict.cifmw_test_operator_ansibletest_extra_configmaps_mounts }}"
     storageClass: "{{ cifmw_test_operator_storage_class }}"
     privileged: "{{ cifmw_test_operator_privileged }}"
-    SELinuxLevel: "{{ cifmw_test_operator_selinux_level }}"
-    computeSSHKeySecretName: "{{ cifmw_test_operator_ansibletest_compute_ssh_key_secret_name }}"
-    workloadSSHKeySecretName: "{{ cifmw_test_operator_ansibletest_workload_ssh_key_secret_name }}"
-    ansibleGitRepo: "{{ cifmw_test_operator_ansibletest_ansible_git_repo }}"
-    ansiblePlaybookPath: "{{ cifmw_test_operator_ansibletest_ansible_playbook_path }}"
-    ansibleCollections: "{{ cifmw_test_operator_ansibletest_ansible_collection }}"
-    ansibleVarFiles: "{{ cifmw_test_operator_ansibletest_ansible_var_files }}"
-    ansibleExtraVars: "{{ cifmw_test_operator_ansibletest_ansible_extra_vars }}"
-    ansibleInventory: "{{ cifmw_test_operator_ansibletest_ansible_inventory }}"
-    openStackConfigMap: "{{ cifmw_test_operator_ansibletest_openstack_config_map }}"
-    openStackConfigSecret: "{{ cifmw_test_operator_ansibletest_openstack_config_secret }}"
-    workflow: "{{ cifmw_test_operator_ansibletest_workflow }}"
-    debug: "{{ cifmw_test_operator_ansibletest_debug }}"
+    computeSSHKeySecretName: "{{ stage_vars_dict.cifmw_test_operator_ansibletest_compute_ssh_key_secret_name }}"
+    workloadSSHKeySecretName: "{{ stage_vars_dict.cifmw_test_operator_ansibletest_workload_ssh_key_secret_name }}"
+    ansibleGitRepo: "{{ stage_vars_dict.cifmw_test_operator_ansibletest_ansible_git_repo }}"
+    ansiblePlaybookPath: "{{ stage_vars_dict.cifmw_test_operator_ansibletest_ansible_playbook_path }}"
+    ansibleCollections: "{{ stage_vars_dict.cifmw_test_operator_ansibletest_ansible_collection }}"
+    ansibleVarFiles: "{{ stage_vars_dict.cifmw_test_operator_ansibletest_ansible_var_files }}"
+    ansibleExtraVars: "{{ stage_vars_dict.cifmw_test_operator_ansibletest_ansible_extra_vars }}"
+    ansibleInventory: "{{ stage_vars_dict.cifmw_test_operator_ansibletest_ansible_inventory }}"
+    openStackConfigMap: "{{ stage_vars_dict.cifmw_test_operator_ansibletest_openstack_config_map }}"
+    openStackConfigSecret: "{{ stage_vars_dict.cifmw_test_operator_ansibletest_openstack_config_secret }}"
+    workflow: "{{ stage_vars_dict.cifmw_test_operator_ansibletest_workflow }}"
+    debug: "{{ stage_vars_dict.cifmw_test_operator_ansibletest_debug }}"
 
 # Section 5: horizontest parameters - used when run_test_fw is 'horizontest'
 cifmw_test_operator_horizontest_name: "horizontest-tests"
 cifmw_test_operator_horizontest_registry: quay.io
 cifmw_test_operator_horizontest_namespace: podified-antelope-centos9
 cifmw_test_operator_horizontest_container: openstack-horizontest
-cifmw_test_operator_horizontest_image: "{{ cifmw_test_operator_horizontest_registry }}/{{ cifmw_test_operator_horizontest_namespace }}/{{ cifmw_test_operator_horizontest_container }}"
+cifmw_test_operator_horizontest_image: "{{ stage_vars_dict.cifmw_test_operator_horizontest_registry }}/{{ stage_vars_dict.cifmw_test_operator_horizontest_namespace }}/{{ stage_vars_dict.cifmw_test_operator_horizontest_container }}"
 cifmw_test_operator_horizontest_image_tag: current-podified
 cifmw_test_operator_horizontest_admin_username: admin
 cifmw_test_operator_horizontest_admin_password: "12345678"
@@ -238,23 +245,23 @@ cifmw_test_operator_horizontest_config:
   apiVersion: test.openstack.org/v1beta1
   kind: HorizonTest
   metadata:
-    name: "{{ cifmw_test_operator_horizontest_name }}"
+    name: "{{ stage_vars_dict.cifmw_test_operator_horizontest_name }}-{{ _stage_vars.name }}"
     namespace: "{{ cifmw_test_operator_namespace }}"
   spec:
+    SELinuxLevel: "{{ cifmw_test_operator_selinux_level }}"
     storageClass: "{{ cifmw_test_operator_storage_class }}"
     privileged: "{{ cifmw_test_operator_privileged }}"
-    SELinuxLevel: "{{ cifmw_test_operator_selinux_level }}"
-    containerImage: "{{ cifmw_test_operator_horizontest_image }}:{{ cifmw_test_operator_horizontest_image_tag }}"
-    adminUsername: "{{ cifmw_test_operator_horizontest_admin_username }}"
-    adminPassword: "{{ cifmw_test_operator_horizontest_admin_password }}"
-    dashboardUrl: "{{ cifmw_test_operator_horizontest_dashboard_url }}"
-    authUrl: "{{ cifmw_test_operator_horizontest_auth_url }}"
-    repoUrl: "{{ cifmw_test_operator_horizontest_repo_url }}"
-    horizonRepoBranch: "{{ cifmw_test_operator_horizontest_horizon_repo_branch }}"
-    imageUrl: "{{ cifmw_test_operator_horizontest_image_url }}"
-    projectName: "{{ cifmw_test_operator_horizontest_project_name }}"
-    user: "{{ cifmw_test_operator_horizontest_user }}"
-    password: "{{ cifmw_test_operator_horizontest_password }}"
-    flavorName: "{{ cifmw_test_operator_horizontest_flavor_name }}"
-    logsDirectoryName: "{{ cifmw_test_operator_horizontest_logs_directory_name }}"
-    horizonTestDir: "{{ cifmw_test_operator_horizontest_horizon_test_dir }}"
+    containerImage: "{{ stage_vars_dict.cifmw_test_operator_horizontest_image }}:{{ stage_vars_dict.cifmw_test_operator_horizontest_image_tag }}"
+    adminUsername: "{{ stage_vars_dict.cifmw_test_operator_horizontest_admin_username }}"
+    adminPassword: "{{ stage_vars_dict.cifmw_test_operator_horizontest_admin_password }}"
+    dashboardUrl: "{{ stage_vars_dict.cifmw_test_operator_horizontest_dashboard_url }}"
+    authUrl: "{{ stage_vars_dict.cifmw_test_operator_horizontest_auth_url }}"
+    repoUrl: "{{ stage_vars_dict.cifmw_test_operator_horizontest_repo_url }}"
+    horizonRepoBranch: "{{ stage_vars_dict.cifmw_test_operator_horizontest_horizon_repo_branch }}"
+    imageUrl: "{{ stage_vars_dict.cifmw_test_operator_horizontest_image_url }}"
+    projectName: "{{ stage_vars_dict.cifmw_test_operator_horizontest_project_name }}"
+    user: "{{ stage_vars_dict.cifmw_test_operator_horizontest_user }}"
+    password: "{{ stage_vars_dict.cifmw_test_operator_horizontest_password }}"
+    flavorName: "{{ stage_vars_dict.cifmw_test_operator_horizontest_flavor_name }}"
+    logsDirectoryName: "{{ stage_vars_dict.cifmw_test_operator_horizontest_logs_directory_name }}"
+    horizonTestDir: "{{ stage_vars_dict.cifmw_test_operator_horizontest_horizon_test_dir }}"

--- a/roles/test_operator/tasks/main.yml
+++ b/roles/test_operator/tasks/main.yml
@@ -23,13 +23,6 @@
     owner: "{{ ansible_user | default(lookup('env', 'USER')) }}"
     group: "{{ ansible_user | default(lookup('env', 'USER')) }}"
 
-- name: Set run_tempest and run_tobiko bool values
-  ansible.builtin.set_fact:
-    run_tempest: "{{ cifmw_run_tempest | default('true') | bool }}"
-    run_tobiko: "{{ cifmw_run_tobiko | default('false') | bool }}"
-    run_ansibletest: "{{ cifmw_run_ansibletest | default('false') | bool }}"
-    run_horizontest: "{{ cifmw_run_horizontest | default('false') | bool }}"
-
 - name: Ensure OperatorGroup for the test-operator is present
   kubernetes.core.k8s:
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
@@ -132,52 +125,12 @@
   until: csv.resources[0].status.phase | default(omit) == "Succeeded"
   when: not cifmw_test_operator_dry_run | bool
 
-- name: Run tempest job
-  vars:
-    run_test_fw: tempest
-    test_operator_config: "{{ cifmw_test_operator_tempest_config }}"
-    test_operator_job_name: "{{ cifmw_test_operator_tempest_name }}"
-    test_operator_kind_name: "{{ cifmw_test_operator_tempest_kind_name }}"
-    test_operator_crd_name: "{{ cifmw_test_operator_tempest_crd_name }}"
-    test_operator_workflow: "{{ cifmw_test_operator_tempest_workflow }}"
-    test_operator_config_playbook: tempest-tests.yml
-  ansible.builtin.include_tasks: run-test-operator-job.yml
-  when: run_tempest
-
-- name: Run ansibletest job
-  vars:
-    run_test_fw: ansibletest
-    test_operator_config: "{{ cifmw_test_operator_ansibletest_config }}"
-    test_operator_job_name: "{{ cifmw_test_operator_ansibletest_name }}"
-    test_operator_kind_name: "{{ cifmw_test_operator_ansibletest_kind_name }}"
-    test_operator_crd_name: "{{ cifmw_test_operator_ansibletest_crd_name }}"
-    test_operator_workflow: "{{ cifmw_test_operator_ansibletest_workflow }}"
-  ansible.builtin.include_tasks: run-test-operator-job.yml
-  when: run_ansibletest
-
-- name: Run horizontest job
-  vars:
-    run_test_fw: horizontest
-    test_operator_config: "{{ cifmw_test_operator_horizontest_config }}"
-    test_operator_job_name: "{{ cifmw_test_operator_horizontest_name }}"
-    test_operator_kind_name: "{{ cifmw_test_operator_horizontest_kind_name }}"
-    test_operator_crd_name: "{{ cifmw_test_operator_horizontest_crd_name }}"
-    test_operator_workflow: []
-  ansible.builtin.include_tasks: run-test-operator-job.yml
-  when: run_horizontest
-
-# Since Tobiko may include disruptive tests (faults), it is better to execute it at the end
-- name: Run tobiko job
-  vars:
-    run_test_fw: tobiko
-    test_operator_config: "{{ cifmw_test_operator_tobiko_config }}"
-    test_operator_job_name: "{{ cifmw_test_operator_tobiko_name }}"
-    test_operator_kind_name: "{{ cifmw_test_operator_tobiko_kind_name }}"
-    test_operator_crd_name: "{{ cifmw_test_operator_tobiko_crd_name }}"
-    test_operator_workflow: "{{ cifmw_test_operator_tobiko_workflow }}"
-    test_operator_config_playbook: tobiko-tests.yml
-  ansible.builtin.include_tasks: run-test-operator-job.yml
-  when: run_tobiko
+- name: Call test stages loop
+  when: not cifmw_test_operator_dry_run | bool
+  ansible.builtin.include_tasks: stages.yml
+  loop: "{{ cifmw_test_operator_stages }}"
+  loop_control:
+    loop_var: _stage_vars
 
 - name: Delete all resources created by the role
   ansible.builtin.include_tasks: cleanup.yml

--- a/roles/test_operator/tasks/runners/ansibletest_runner.yml
+++ b/roles/test_operator/tasks/runners/ansibletest_runner.yml
@@ -1,0 +1,10 @@
+---
+- name: Run ansibletest job
+  vars:
+    run_test_fw: ansibletest
+    test_operator_config: "{{ stage_vars_dict.cifmw_test_operator_ansibletest_config }}"
+    test_operator_job_name: "{{ stage_vars_dict.cifmw_test_operator_ansibletest_name }}-{{ _stage_vars.name }}"
+    test_operator_kind_name: "{{ stage_vars_dict.cifmw_test_operator_ansibletest_kind_name }}"
+    test_operator_crd_name: "{{ stage_vars_dict.cifmw_test_operator_ansibletest_crd_name }}"
+    test_operator_workflow: "{{ stage_vars_dict.cifmw_test_operator_ansibletest_workflow }}"
+  ansible.builtin.include_tasks: run-test-operator-job.yml

--- a/roles/test_operator/tasks/runners/horizontest_runner.yml
+++ b/roles/test_operator/tasks/runners/horizontest_runner.yml
@@ -1,0 +1,10 @@
+---
+- name: Run horizontest job
+  vars:
+    run_test_fw: horizontest
+    test_operator_config: "{{ stage_vars_dict.cifmw_test_operator_horizontest_config }}"
+    test_operator_job_name: "{{ stage_vars_dict.cifmw_test_operator_horizontest_name }}-{{ _stage_vars.name }}"
+    test_operator_kind_name: "{{ stage_vars_dict.cifmw_test_operator_horizontest_kind_name }}"
+    test_operator_crd_name: "{{ stage_vars_dict.cifmw_test_operator_horizontest_crd_name }}"
+    test_operator_workflow: []
+  ansible.builtin.include_tasks: run-test-operator-job.yml

--- a/roles/test_operator/tasks/runners/tempest_runner.yml
+++ b/roles/test_operator/tasks/runners/tempest_runner.yml
@@ -1,0 +1,11 @@
+---
+- name: Run tempest job
+  vars:
+    run_test_fw: tempest
+    test_operator_config: "{{ stage_vars_dict.cifmw_test_operator_tempest_config }}"
+    test_operator_job_name: "{{ stage_vars_dict.cifmw_test_operator_tempest_name }}-{{ _stage_vars.name }}"
+    test_operator_kind_name: "{{ stage_vars_dict.cifmw_test_operator_tempest_kind_name }}"
+    test_operator_crd_name: "{{ stage_vars_dict.cifmw_test_operator_tempest_crd_name }}"
+    test_operator_workflow: "{{ stage_vars_dict.cifmw_test_operator_tempest_workflow }}"
+    test_operator_config_playbook: tempest-tests.yml
+  ansible.builtin.include_tasks: run-test-operator-job.yml

--- a/roles/test_operator/tasks/runners/tobiko_runner.yml
+++ b/roles/test_operator/tasks/runners/tobiko_runner.yml
@@ -1,0 +1,12 @@
+---
+# Since Tobiko may include disruptive tests (faults), it is better to execute it at the end
+- name: Run tobiko job
+  vars:
+    run_test_fw: tobiko
+    test_operator_config: "{{ stage_vars_dict.cifmw_test_operator_tobiko_config }}"
+    test_operator_job_name: "{{ stage_vars_dict.cifmw_test_operator_tobiko_name }}-{{ _stage_vars.name }}"
+    test_operator_kind_name: "{{ stage_vars_dict.cifmw_test_operator_tobiko_kind_name }}"
+    test_operator_crd_name: "{{ stage_vars_dict.cifmw_test_operator_tobiko_crd_name }}"
+    test_operator_workflow: "{{ stage_vars_dict.cifmw_test_operator_tobiko_workflow }}"
+    test_operator_config_playbook: tobiko-tests.yml
+  ansible.builtin.include_tasks: run-test-operator-job.yml

--- a/roles/test_operator/tasks/stages.yml
+++ b/roles/test_operator/tasks/stages.yml
@@ -1,0 +1,57 @@
+---
+- name: "Run stage {{ _stage_vars.name }}"
+  ansible.builtin.debug:
+    msg: "Run stage {{ _stage_vars.name }}"
+
+- name: "Call pre stage hooks for test operator stage {{ _stage_vars.name }}"
+  when:
+    - not cifmw_test_operator_dry_run | bool
+    - _stage_vars.pre_test_stage_hooks is defined
+  vars:
+    step: pre_test_hooks
+    hooks: "{{ _stage_vars.pre_test_stage_hooks }}"
+  ansible.builtin.import_role:
+    name: run_hook
+
+- name: Set empty stage vars dict
+  ansible.builtin.set_fact:
+    stage_vars_dict: {}
+
+- name: Include stage var file
+  ansible.builtin.include_vars:
+    file: "{{ _stage_vars.test_vars_file | default('/dev/null') }}"
+    name: _stage_var_file
+
+- name: Merge file vars and test vars
+  vars:
+    file_vars: "{{ _stage_var_file }}"
+    test_vars: "{{ _stage_vars.test_vars | default({}) }}"
+  ansible.builtin.set_fact:
+    _stage_test_vars: "{{ file_vars | combine(test_vars) }}"
+
+- name: Overwrite global_vars with stage_vars
+  with_dict: "{{ vars | combine(_stage_test_vars) }}"
+  vars:
+    start_with: cifmw_test_operator_{{ _stage_vars.type }}
+  when: item.key.startswith(start_with)
+  ansible.builtin.set_fact:
+    stage_vars_dict: "{{ stage_vars_dict | combine({item.key: _stage_test_vars[item.key] | default(lookup('vars', item.key, default=omit))} ) }}"
+
+- name: Override specific type config
+  vars:
+    _stage_config: 'cifmw_test_operator_{{ _stage_vars.type }}_config'
+  ansible.builtin.set_fact:
+    stage_vars_dict: "{{ stage_vars_dict | combine({_stage_config: _stage_test_vars[_stage_config] | default(lookup('vars', _stage_config, default=omit))} ) }}"
+
+- name: "Call runner {{ _stage_vars.type }}"
+  ansible.builtin.include_tasks: "runners/{{ _stage_vars.type }}_runner.yml"
+
+- name: "Call post stage hooks for test operator stage {{ _stage_vars.name }}"
+  when:
+    - not cifmw_test_operator_dry_run | bool
+    - _stage_vars.post_test_stage_hooks is defined
+  vars:
+    step: post_test_hooks
+    hooks: "{{ _stage_vars.post_test_stage_hooks }}"
+  ansible.builtin.import_role:
+    name: run_hook

--- a/roles/test_operator/tasks/tempest-tests.yml
+++ b/roles/test_operator/tasks/tempest-tests.yml
@@ -16,8 +16,8 @@
 #
 - name: Configuring tests to be executed via skiplist
   when: >
-   cifmw_test_operator_tempest_include_list is not defined or
-   cifmw_test_operator_tempest_tests_include_override_scenario | bool
+   stage_vars_dict.cifmw_test_operator_tempest_include_list is not defined or
+   stage_vars_dict.cifmw_test_operator_tempest_tests_include_override_scenario | bool
   block:
     - name: Copy list_allowed to artifacts dir
       ansible.builtin.copy:
@@ -50,8 +50,8 @@
 
 - name: Configuring tests to be skipped via skiplist
   when: >
-    cifmw_test_operator_tempest_exclude_list is not defined or
-    cifmw_test_operator_tempest_tests_exclude_override_scenario | bool
+    stage_vars_dict.cifmw_test_operator_tempest_exclude_list is not defined or
+    stage_vars_dict.cifmw_test_operator_tempest_tests_exclude_override_scenario | bool
   block:
     - name: Copy list_skipped to artifacts dir
       ansible.builtin.copy:
@@ -89,7 +89,7 @@
 - name: Create secret with cifmw private key file and set SSHKeySecretName in TempestCR
   when:
     - not cifmw_test_operator_dry_run | bool
-    - cifmw_test_operator_tempest_ssh_key_secret_name is not defined
+    - stage_vars_dict.cifmw_test_operator_tempest_ssh_key_secret_name is not defined
     - private_key_file.stat.exists
   block:
     - name: Ensure a secret for the cifmw private key file exists
@@ -144,7 +144,7 @@
   when:
     - not cifmw_test_operator_dry_run | bool
     - controller_ip != ""
-    - cifmw_test_operator_tempest_workflow | list | length > 0
+    - stage_vars_dict.cifmw_test_operator_tempest_workflow | list | length > 0
   vars:
     controller_ip: >-
       {{ cifmw_test_operator_controller_ip | default(ansible_default_ipv4.address) | default('') }}
@@ -164,7 +164,7 @@
           }}
       ansible.builtin.set_fact:
         overriden_workflow: "{{ overriden_workflow | default([]) + [_overriden_workflow_step] }}"
-      loop: "{{ cifmw_test_operator_tempest_workflow | list }}"
+      loop: "{{ stage_vars_dict.cifmw_test_operator_tempest_workflow | list }}"
 
     - name: Override the Tempest CR workflow
       ansible.builtin.set_fact:

--- a/roles/test_operator/tasks/tobiko-tests.yml
+++ b/roles/test_operator/tasks/tobiko-tests.yml
@@ -19,7 +19,7 @@
     tobikoconf_combined: >-
       {{
           cifmw_test_operator_tobiko_default_conf |
-          combine(cifmw_test_operator_tobiko_override_conf, recursive=True)
+          combine(stage_vars_dict.cifmw_test_operator_tobiko_override_conf, recursive=True)
       }}
   ansible.builtin.include_tasks: create-tobiko-conf.yml
   loop: "{{ tobikoconf_combined | dict2items }}"
@@ -41,20 +41,20 @@
   block:
     - name: Check if the ssh keys already exist
       ansible.builtin.stat:
-        path: "{{ cifmw_test_operator_artifacts_basedir }}/id_{{ cifmw_test_operator_tobiko_ssh_keytype }}"
+        path: "{{ cifmw_test_operator_artifacts_basedir }}/id_{{ stage_vars_dict.cifmw_test_operator_tobiko_ssh_keytype }}"
       register: check_ssh_key
 
     - name: Create the ssh keys
       community.crypto.openssh_keypair:
-        path: "{{ cifmw_test_operator_artifacts_basedir }}/id_{{ cifmw_test_operator_tobiko_ssh_keytype }}"
-        type: "{{ cifmw_test_operator_tobiko_ssh_keytype }}"
-        size: "{{ cifmw_test_operator_tobiko_ssh_keysize }}"
+        path: "{{ cifmw_test_operator_artifacts_basedir }}/id_{{ stage_vars_dict.cifmw_test_operator_tobiko_ssh_keytype  }}"
+        type: "{{ stage_vars_dict.cifmw_test_operator_tobiko_ssh_keytype }}"
+        size: "{{ stage_vars_dict.cifmw_test_operator_tobiko_ssh_keysize }}"
       when: not check_ssh_key.stat.exists
 
     - name: Add private and public keys to tobiko CR
       vars:
         keyname: "{{ item }}Key"
-        keyfilename: "id_{{ cifmw_test_operator_tobiko_ssh_keytype }}{{ '.pub' if item == 'public' else '' }}"
+        keyfilename: "id_{{ stage_vars_dict.cifmw_test_operator_tobiko_ssh_keytype }}{{ '.pub' if item == 'public' else '' }}"
       ansible.builtin.set_fact:
         test_operator_cr: >-
           {{
@@ -73,20 +73,20 @@
     test_operator_cr: >-
       {{
           test_operator_cr |
-          combine({'spec': {'preventCreate': cifmw_test_operator_tobiko_prevent_create | bool}},
+          combine({'spec': {'preventCreate': stage_vars_dict.cifmw_test_operator_tobiko_prevent_create | bool}},
                   recursive=true)
       }}
-  when: cifmw_test_operator_tobiko_prevent_create is not none
+  when: stage_vars_dict.cifmw_test_operator_tobiko_prevent_create is not none
 
 - name: Add numProcesses if it is defined
   ansible.builtin.set_fact:
     test_operator_cr: >-
       {{
           test_operator_cr |
-          combine({'spec': {'numProcesses': cifmw_test_operator_tobiko_num_processes | int}},
+          combine({'spec': {'numProcesses': stage_vars_dict.cifmw_test_operator_tobiko_num_processes | int}},
                   recursive=true)
       }}
-  when: cifmw_test_operator_tobiko_num_processes is not none
+  when: stage_vars_dict.cifmw_test_operator_tobiko_num_processes is not none
 
 - name: Ensure a secret for the kubeconfig file exists
   kubernetes.core.k8s:
@@ -100,7 +100,7 @@
       kind: Secret
       type: Opaque
       metadata:
-        name: "{{ cifmw_test_operator_tobiko_kubeconfig_secret }}"
+        name: "{{ stage_vars_dict.cifmw_test_operator_tobiko_kubeconfig_secret }}"
         namespace: "{{ cifmw_test_operator_namespace }}"
       data:
         config: "{{ lookup('file', cifmw_openshift_kubeconfig) | b64encode }}"

--- a/scenarios/centos-9/ceph_backends.yml
+++ b/scenarios/centos-9/ceph_backends.yml
@@ -37,7 +37,7 @@ cifmw_tempest_default_jobs: *test_operator_list
 
 cifmw_tempest_tests_allowed_override_scenario: true
 
-cifmw_tempest_tempestconf_config:
+cifmw_test_operator_tempest_tempestconf_config:
   overrides: |
     identity.v3_endpoint_type public
     share.run_share_group_tests false

--- a/scenarios/centos-9/hci_ceph_backends.yml
+++ b/scenarios/centos-9/hci_ceph_backends.yml
@@ -33,7 +33,7 @@ cifmw_run_tests: true
 cifmw_tempest_container: openstack-tempest-all
 cifmw_tempest_tests_allowed_override_scenario: true
 
-cifmw_tempest_tempestconf_config:
+cifmw_test_operator_tempest_tempestconf_config:
   overrides: |
     identity.v3_endpoint_type public
     share.run_share_group_tests false

--- a/scenarios/reproducers/bgp-4-racks-3-ocps.yml
+++ b/scenarios/reproducers/bgp-4-racks-3-ocps.yml
@@ -1,6 +1,5 @@
 ---
 cifmw_run_tests: true
-cifmw_run_tempest: true
 cifmw_run_test_role: test_operator
 cifmw_test_operator_timeout: 7200
 cifmw_test_operator_tempest_include_list: |

--- a/scenarios/reproducers/va-common.yml
+++ b/scenarios/reproducers/va-common.yml
@@ -29,7 +29,6 @@ cifmw_libvirt_manager_pub_net: ocpbm
 
 # Run tests
 cifmw_run_tests: true
-cifmw_run_tempest: true
 cifmw_run_test_role: test_operator
 cifmw_test_operator_timeout: 7200
 cifmw_test_operator_tempest_include_list: |

--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -65,7 +65,7 @@
                         igmp_snooping_enable=True
               target:
                 kind: OpenStackControlPlane
-      cifmw_tempest_tempestconf_config:
+      cifmw_test_operator_tempest_tempestconf_config:
         overrides: |
           compute-feature-enabled.vnc_console true
           compute-feature-enabled.cold_migration true


### PR DESCRIPTION
This commit adds key improvements to the test_operator role:

Support for defining test execution order.
Ability to run the same testing controller multiple times. Pre-hooks and post-hooks for stage-specific customization. Per-stage variable overrides via files or test_vars. Refactored pre-set testing stages to enable more dynamic test management and extend hook behavior for complex scenarios.

Jira: [OSPRH-10106](https://issues.redhat.com//browse/OSPRH-10106)