### PR TITLE
BGP controlplane Pure L3 Spine&Leaf

### DIFF
--- a/playbooks/bgp-l3-computes-ready.yml
+++ b/playbooks/bgp-l3-computes-ready.yml
@@ -1,0 +1,19 @@
+---
+- name: Wait until computes are ready
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  tasks:
+    - name: Wait until number of computes is the expected one
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.command: >-
+        oc rsh
+        -n openstack
+        openstackclient
+        openstack compute service list -f value --service nova-compute
+      register: nova_compute_service_list
+      retries: 30
+      delay: 4
+      until:
+        - nova_compute_service_list.rc == 0
+        - nova_compute_service_list.stdout | regex_findall('enabled up') | length == num_computes | int

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2
@@ -1,7 +1,8 @@
 # source: bgp_dt01/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2
 {% set instances_names = []                                                            %}
+{% set rack = 'r' ~ rack_number                                                        %}
 {% for _inst in cifmw_networking_env_definition.instances.keys()                       %}
-{%   if _inst.startswith(node_type)                                                    %}
+{%   if _inst.startswith('-'.join([rack, node_type]))                                  %}
 {%     set _ = instances_names.append(_inst)                                           %}
 {%   endif                                                                             %}
 {% endfor                                                                              %}
@@ -22,34 +23,36 @@ data:
         edpm_fips_mode: "{{ 'enabled' if cifmw_fips_enabled|default(false)|bool else 'check' }}"
         timesync_ntp_servers:
           - hostname: "{{ cifmw_ci_gen_kustomize_values_ntp_srv | default('pool.ntp.org') }}"
-{% if cifmw_ci_gen_kustomize_values_sshd_ranges | default([]) | length > 0             %}
         edpm_sshd_allowed_ranges:
-{%   for range in cifmw_ci_gen_kustomize_values_sshd_ranges                            %}
+{% set sshd_allowed_range = cifmw_ci_gen_kustomize_values_sshd_ranges | default([])    %}
+{% for rack in ['r0', 'r1', 'r2']                                                      %}
+{%   set _ = sshd_allowed_range.append(cifmw_networking_env_definition.networks['ctlplane' + rack].network_v4) %}
+{% endfor                                                                              %}
+{% for range in sshd_allowed_range                                                     %}
           - "{{ range }}"
-{%   endfor                                                                            %}
-{% endif                                                                               %}
+{% endfor                                                                              %}
     nodes:
 {% for instance in instances_names                                                     %}
       {{ instance }}:
         ansible:
-          host: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.ip_v4 }}
+{%   set ctlplane_rack = 'ctlplane' + rack                                             %}
+          host: {{ cifmw_networking_env_definition.instances[instance].networks[ctlplane_rack].ip_v4 }}
 {%   if original_content.data.nodeset.nodes['edpm-' ~ node_type ~ '-' ~ loop.index0].ansible.ansibleVars is defined %}
           ansibleVars: {{ original_content.data.nodeset.nodes['edpm-' ~ node_type ~ '-' ~ loop.index0].ansible.ansibleVars }}
 {%   endif                                                                                                          %}
         hostName: {{ instance }}
         networks:
 {%      for net in cifmw_networking_env_definition.instances[instance].networks.keys() %}
-{%        if net is not match('storagemgmt')                                           %}
-          - name: {{ net }}
-            subnetName: subnet1
-{%          if net is match('ctlplane')                                                %}
+{%        if 'storagemgmt' not in net                                                  %}
+          - name: {{ net if net != ctlplane_rack else 'ctlplane' }}
+            subnetName: {{ 'subnet1' if net != ctlplane_rack else 'subnet' ~ rack_number }}
+{%          if 'ctlplane' in net                                                       %}
             defaultRoute: true
-            fixedIP: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.ip_v4 }}
+            fixedIP: {{ cifmw_networking_env_definition.instances[instance].networks[ctlplane_rack].ip_v4 }}
 {%          endif                                                                      %}
 {%        endif                                                                        %}
 {%      endfor                                                                         %}
-{%        set rack_number = instance.split('-') | last                                 %}
-{%        set peer_suffix = 1 if instance.startswith('compute') else 5                 %}
+{%        set peer_suffix = 1 if 'compute' in instance else 5                          %}
           - name: BgpNet0
             subnetName: subnet{{ rack_number }}
             fixedIP: 100.64.{{ rack_number }}.{{ peer_suffix + 1 }}
@@ -58,8 +61,8 @@ data:
             fixedIP: 100.65.{{ rack_number }}.{{ peer_suffix + 1 }}
           - name: BgpMainNet
             subnetName: subnet{{ rack_number }}
-            fixedIP: 172.30.{{ rack_number }}.{{ peer_suffix + 1 }}
+            fixedIP: 99.99.{{ rack_number }}.{{ peer_suffix + 1 }}
           - name: BgpMainNetV6
             subnetName: subnet{{ rack_number }}
-            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:00{{ (rack_number | int) + 1 }}{{ 2 if instance.startswith('compute') else 3 }}
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:00{{ (rack_number | int) + 1 }}{{ 2 if 'compute' in instance else 3 }}
 {% endfor                                                                              %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-compute-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-compute-nodeset-values/values.yaml.j2
@@ -1,4 +1,0 @@
----
-# source: bgp_dt01/edpm-compute-nodeset-values/values.yaml.j2
-{% set node_type = "compute"                                               %}
-{% include 'templates/bgp_dt01/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-networker-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-networker-nodeset-values/values.yaml.j2
@@ -1,4 +1,0 @@
----
-# source: bgp_dt01/edpm-networker-nodeset-values/values.yaml.j2
-{% set node_type = "networker"                                             %}
-{% include 'templates/bgp_dt01/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-r0-compute-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-r0-compute-nodeset-values/values.yaml.j2
@@ -1,0 +1,5 @@
+---
+# source: bgp_dt01/edpm-r0-compute-nodeset-values/values.yaml.j2
+{% set node_type = "compute"                                                              %}
+{% set rack_number = 0                                                                    %}
+{% include 'templates/bgp_dt01/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-r0-networker-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-r0-networker-nodeset-values/values.yaml.j2
@@ -1,0 +1,5 @@
+---
+# source: bgp_dt01/edpm-r0-networker-nodeset-values/values.yaml.j2
+{% set node_type = "networker"                                                            %}
+{% set rack_number = 0                                                                    %}
+{% include 'templates/bgp_dt01/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-r1-compute-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-r1-compute-nodeset-values/values.yaml.j2
@@ -1,0 +1,5 @@
+---
+# source: bgp_dt01/edpm-r1-compute-nodeset-values/values.yaml.j2
+{% set node_type = "compute"                                                              %}
+{% set rack_number = 1                                                                    %}
+{% include 'templates/bgp_dt01/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-r1-networker-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-r1-networker-nodeset-values/values.yaml.j2
@@ -1,0 +1,5 @@
+---
+# source: bgp_dt01/edpm-r1-networker-nodeset-values/values.yaml.j2
+{% set node_type = "networker"                                                            %}
+{% set rack_number = 1                                                                    %}
+{% include 'templates/bgp_dt01/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-r2-compute-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-r2-compute-nodeset-values/values.yaml.j2
@@ -1,0 +1,5 @@
+---
+# source: bgp_dt01/edpm-r2-compute-nodeset-values/values.yaml.j2
+{% set node_type = "compute"                                                              %}
+{% set rack_number = 2                                                                    %}
+{% include 'templates/bgp_dt01/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-r2-networker-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-r2-networker-nodeset-values/values.yaml.j2
@@ -1,0 +1,5 @@
+---
+# source: bgp_dt01/edpm-r2-networker-nodeset-values/values.yaml.j2
+{% set node_type = "networker"                                                            %}
+{% set rack_number = 2                                                                    %}
+{% include 'templates/bgp_dt01/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/network-values/values.yaml.j2
@@ -52,7 +52,7 @@ data:
 {% endfor %}
 
 {% for network in cifmw_networking_env_definition.networks.values() %}
-{% set ns.lb_tools = {} %}
+{%  set ns.lb_tools = {} %}
   {{ network.network_name }}:
     dnsDomain: {{ network.search_domain }}
 {%  if network.tools is defined and network.tools.keys() | length > 0 %}
@@ -62,19 +62,38 @@ data:
 {%        set _ = ns.lb_tools.update({tool: []}) %}
 {%      endif %}
 {%    endfor %}
+{%    if network.network_name != 'ctlplane' %}
       - allocationRanges:
-{%    for range in network.tools.netconfig.ipv4_ranges %}
+{%      for range in network.tools.netconfig.ipv4_ranges %}
         - end: {{ range.end }}
           start: {{ range.start }}
-{%    endfor %}
+{%      endfor %}
         cidr: {{ network.network_v4 }}
 {%      if network.gw_v4 is defined %}
         gateway: {{ network.gw_v4 }}
 {%      endif %}
         name: subnet1
-{%  if network.vlan_id is defined  %}
+{%      if network.vlan_id is defined  %}
         vlan: {{ network.vlan_id }}
-{%  endif %}
+{%      endif %}
+{%    else %}
+{%      for rack in ['r0', 'r1', 'r2'] %}
+{%        set rack_subnet = cifmw_networking_env_definition.networks[network.network_name + rack] %}
+      - allocationRanges:
+{%        for range in rack_subnet.tools.netconfig.ipv4_ranges %}
+        - end: {{ range.end }}
+          start: {{ range.start }}
+{%        endfor %}
+        cidr: {{ rack_subnet.network_v4 }}
+{%        if rack_subnet.gw_v4 is defined %}
+        gateway: {{ rack_subnet.gw_v4 }}
+{%        endif %}
+        name: {{ 'subnet' ~ loop.index0 }}
+{%        if rack_subnet.vlan_id is defined  %}
+        vlan: {{ rack_subnet.vlan_id }}
+{%        endif %}
+{%      endfor %}
+{%    endif %}
 {%    if ns.lb_tools | length > 0 %}
     lb_addresses:
 {%      for tool in ns.lb_tools.keys() %}
@@ -107,19 +126,18 @@ data:
       {
         "cniVersion": "0.3.1",
         "name": "{{ network.network_name }}",
-{%  if network.network_name == "octavia" %}
         "type": "bridge",
-{%  else %}
-        "type": "macvlan",
-{%  endif %}
+        "isDefaultGateway": true,
+        "isGateway": true,
+        "forceAddress": false,
+        "ipMasq": true,
+        "hairpinMode": true,
 {%  if network.network_name == "octavia" %}
         "bridge": "octbr",
-{%  elif network.vlan_id is defined %}
-        "master": "{{ network.network_name }}",
 {%  elif network.network_name == "ctlplane" %}
-        "master": "ospbr",
+        "bridge": "ospbr",
 {%  else %}
-        "master": "{{ ns.interfaces[network.network_name] }}",
+        "bridge": "{{ network.network_name }}",
 {%  endif %}
         "ipam": {
           "type": "whereabouts",
@@ -135,7 +153,8 @@ data:
            ],
 {%  endif %}
           "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
-          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}"
+          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}",
+          "gateway": "{{ network.network_v4 |ansible.utils.nthhost(1) }}"
         }
       }
 {%  endif %}

--- a/roles/reproducer/tasks/configure_computes.yml
+++ b/roles/reproducer/tasks/configure_computes.yml
@@ -3,6 +3,11 @@
   delegate_to: "{{ _host }}"
   block:
     - name: Ensure we can ping controller-0 from ctlplane
+      when:
+        # do not check connectivity between computes/networkers and
+        # controller-0 in BGP environments via ctlplane until BGP is configured
+        - _host is not match('^r[0-9]-compute-.*')
+        - _host is not match('^r[0-9]-networker-.*')
       ansible.builtin.command:
         cmd: |
           ping -c2 {{ cifmw_reproducer_validate_network_host }}

--- a/roles/reproducer/tasks/libvirt_layout.yml
+++ b/roles/reproducer/tasks/libvirt_layout.yml
@@ -100,7 +100,9 @@
       (compute.key in (groups['cephs'] | default([]))) or
       (compute.key in (groups['networkers'] | default([]))) or
       (compute.key in (groups['dcn1-computes'] | default([]))) or
-      (compute.key in (groups['dcn2-computes'] | default([])))
+      (compute.key in (groups['dcn2-computes'] | default([]))) or
+      (compute.key is match('^r[0-9]-compute-.*')) or
+      (compute.key is match('^r[0-9]-networker-.*'))
   vars:
     _host: "{{ compute.key }}"
     _prefix: >-


### PR DESCRIPTION
With this PR, BGP DT01 configures isolated L2 segments for networkers and computes.
The controlplane communications between RHOSO services running on OCP
nodes and services running on EDPM nodes is routed through the BGP
network. Spines and leaves connect the computes, networkers and OCP
nodes in different racks and route the traffic between them, as well as
the dataplane traffic to/from the Openstack VM instances.

[OSPRH-13820](https://issues.redhat.com//browse/OSPRH-13820)