### PR TITLE
[edpm_image_builder] Fix virt-customize run after #2673

### DIFF
--- a/roles/edpm_build_images/tasks/add_cert.yml
+++ b/roles/edpm_build_images/tasks/add_cert.yml
@@ -39,8 +39,8 @@
 
     - name: Add cert if it exists
       ansible.builtin.command: >
-        virt-customize -a {{ _cifmw_edpm_build_images_cert_source }}/{{ cifmw_edpm_build_images_cert_dest }}
-        --upload {{ cifmw_edpm_build_images_cert_path }}:{{ cifmw_edpm_build_images_cert_path }}
+        virt-customize -a {{ cifmw_edpm_build_images_basedir }}/{{ cifmw_discovered_image_name }}
+        --upload {{ _cifmw_edpm_build_images_cert_source }}:{{ cifmw_edpm_build_images_cert_dest }}
         --run-command 'update-ca-trust'
       environment:
         LIBGUESTFS_BACKEND: direct


### PR DESCRIPTION
Since [this](https://github.com/openstack-k8s-operators/ci-framework/pull/2673/files#diff-cb0d2ec7ad0b32e1fdf8a6f6cc8c1006f9f65f96692d94f9de3af750993f1d30R42) change the virt-customize command is wrong. The -a argument should be restored to its previous state and the only argument that needs to be changed is --upload, with its first part pointing to the host freshly dumped cert and with the second arg the destination path inside the image.