### PR TITLE
[test_operator][tobiko.conf] ubuntu section replaced with advanced_vm

### DIFF
--- a/roles/test_operator/vars/main.yml
+++ b/roles/test_operator/vars/main.yml
@@ -33,10 +33,9 @@ cifmw_test_operator_tobiko_default_conf:
   testcase:
     timeout: 1800.0
     test_runner_timeout: 14400.0
-  ubuntu:
-    interface_name: enp3s0
-    customized_image_provided: "True"
+  advanced_vm:
     image_url: "{{ cifmw_test_operator_tobiko_advanced_image_url }}"
+    username: ubuntu
   keystone:
     interface: public
   manila:


### PR DESCRIPTION
Section ubuntu from tobiko.conf file has been replaced with advanced_vm. Coming soon: ubuntu images will be replaced with fedora images.