### PR TITLE
adoption_osp_deploy : br-baremetal ovs_bridge

### DIFF
--- a/roles/adoption_osp_deploy/templates/os_net_config_overcloud.yml.j2
+++ b/roles/adoption_osp_deploy/templates/os_net_config_overcloud.yml.j2
@@ -43,7 +43,7 @@ network_config:
 {% if 'ironic' in _node_net.networks.keys () %}
 {% set net = _node_net.networks.ironic %}
 # ironic
-- type: linux_bridge
+- type: ovs_bridge
   name: br-baremetal
   addresses:
   - ip_netmask: {{ net.ip_v4 }}/{{ net.prefix_length_v4 }}


### PR DESCRIPTION
Change the NIC config template for OSP 17.1 deployment to use a ovs_bridge for the br-baremetal interface.

Fixes issues in OVS wiring, when using linux bridge the patch to br-int
was not created and tap interfaces (qdhcp) was not correctly wired.

This also aligns the configuration used with the documentation. (docs.redhat.com)