### PR TITLE
Adjust ironic provision net allocation pool

### DIFF
--- a/hooks/playbooks/adoption_ironic_post_oc.yml
+++ b/hooks/playbooks/adoption_ironic_post_oc.yml
@@ -144,7 +144,7 @@
                   --network provisioning \
                   --subnet-range 172.20.1.0/24 \
                   --gateway 172.20.1.1 \
-                  --allocation-pool start=172.20.1.100,end=172.20.1.199
+                  --allocation-pool start=172.20.1.150,end=172.20.1.199
 
     - name: Slurp ironic_nodes.yaml from controller-0
       delegate_to: controller-0


### PR DESCRIPTION
Make the allocation pool for the ironic net smaller for adoption. The OSP nodes are using addresses starting at 100 ... 120 ish, so let's place the "workloads" starting at 150 and end 199.