### PR TITLE
Update build_openstack_packages to support downstream gitlab

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,7 @@ run_ctx_molecule: ci_ctx ## Run molecule check in a container
 	podman run \
 		--rm \
 		--security-opt label=disable \
+		--cap-add=SYS_ADMIN \
 		-v ${PWD}:/opt/sources \
 		--user root \
 		-e MOLECULE_CONFIG=${MOLECULE_CONFIG} \

--- a/roles/build_openstack_packages/tasks/run_dlrn.yml
+++ b/roles/build_openstack_packages/tasks/run_dlrn.yml
@@ -138,45 +138,29 @@
         refspec: "{{ _change.refspec }}"
         version: 'FETCH_HEAD'
 
-    - name: "Clone downstream Openstack {{ project_name_mapped.stdout }}" # noqa: name[template]
+    - name: "Update packages.yml to use zuul repo for {{ project_name_mapped.stdout }}" # noqa: name[template], command-instead-of-module
+      vars:
+        _repo_name: '{{ _change.host | split("://") | last }}/{{ _change.project }}'
+        _old_content: 'osp-patches: git@{{ _change.host | split("//") | last }}:{{ _change.project }}.git'
+        _new_content: 'osp-patches: file://{{ ansible_user_dir }}/{{ zuul.projects[_repo_name].src_dir }}'
       when:
         - cifmw_bop_openstack_project_path | length == 0
         - not repo_status.stat.exists
         - "'host' in _change"
         - "'redhat.com' in _change.host"
-      block:
-        - name: Clone the downstream project
-          ansible.builtin.git:
-            repo: '{{ _change.host }}/gerrit/{{ _change.project }}'
-            dest: '{{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}-tested'
-            refspec: "{{ _change.refspec }}"
-            version: 'FETCH_HEAD'
-
-        - name: Update the branch name for local DLRN clone # noqa: command-instead-of-module
-          ansible.builtin.command:
-            cmd: "git checkout -b {{ item }}"
-          args:
-            chdir: "{{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}-tested"
-          loop:
-            - "{{ cifmw_bop_osp_release }}-rhel-9-trunk"
-            - "{{ cifmw_bop_osp_release }}-trunk-patches"
-
-        - name: Update the project reference in packages.yml # noqa: command-instead-of-module
-          vars:
-            _old_content: 'osp-patches: ssh://{{ _change.host | split("//") | last }}:22/{{ _change.project }}'
-            _new_content: 'osp-patches: file://{{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}-tested'
-          ansible.builtin.command:
-            cmd: >-
-              sed -i -e 's|{{ _old_content }}|{{ _new_content }}|g' packages.yml
-          args:
-            chdir: "{{ cifmw_bop_build_repo_dir }}/DLRN/{{ cifmw_bop_rdoinfo_repo_name }}"
+      ansible.builtin.command:
+        cmd: >-
+          sed -i -e 's|{{ _old_content }}|{{ _new_content }}|g' packages.yml
+      args:
+        chdir: "{{ cifmw_bop_build_repo_dir }}/DLRN/{{ cifmw_bop_rdoinfo_repo_name }}"
 
     - name: Find the last commit from the clonned repo
       register: _commit
       vars:
+        _repo_name: '{{ _change.host | split("://") | last }}/{{ _change.project }}'
         _project_path: >-
           {%- if cifmw_bop_osp_release is defined -%}
-          {{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}-tested
+          {{ ansible_user_dir }}/{{ zuul.projects[_repo_name].src_dir }}
           {%- else -%}
           {{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}
           {%- endif -%}

--- a/roles/build_openstack_packages/templates/projects.ini.j2
+++ b/roles/build_openstack_packages/templates/projects.ini.j2
@@ -40,7 +40,8 @@ custom_preprocess={{ cifmw_bop_build_repo_dir }}/DLRN/scripts/set_nvr.sh,{{ cifm
 info_files=osp.yml
 versions_url=https://trunk.rdoproject.org/centos9-{{ cifmw_bop_openstack_release }}/current-podified/versions.csv
 downstream_source_git_branch={{ cifmw_bop_osp_release }}-trunk-patches
-downstream_distro_branch={{ cifmw_bop_osp_release }}{{ '.0' if '.' not in cifmw_bop_osp_release else '' }}-rhel-9-trunk
+# downstream_distro_branch needs to be rhoso not rhos.
+downstream_distro_branch={{ cifmw_bop_osp_release | replace('rhos-', 'rhoso-') }}{{ '.0' if '.' not in cifmw_bop_osp_release else '' }}-rhel-9-trunk
 downstream_tag=osp-{{ cifmw_bop_osp_release.split('-')[1] }}{{ '.0' if '.' not in cifmw_bop_osp_release else '' }}
 downstream_distgit_key=osp-distgit
 downstream_source_git_key=osp-patches


### PR DESCRIPTION
This pr:
    * Since downstream gerrit repos is moved to gitlab. Zuul works with gitlab and it clones the gitlab repos in 
       job   workspace. Use the zuul clonned content instead of clonning from gerrit or gitlab. As zuul already checks 
       out the source code. Let's reuse it for dlrn purpose by updating packages.yml.
    * Drop branch creation task as it is no longer needed.
    * For RHOS-18, downstream distgit uses rhoso-18 not rhos. It also updates the project.ini to reflect the same.
    
Note: While running build_openstack_packages in containers using make run_ctx_molecule, we are hitting following error in rpmbuild.log in CI and in local environment.
```
DEBUG: unshare(67239936) failed, falling back to unshare(131072)
ERROR: Namespace unshare failed.
 ```
Based on this[ bug](https://bugzilla.redhat.com/show_bug.cgi?id=1336750#c3) , By passing `--cap-add=SYS_ADMIN` fixes the issue.
    
Signed-off-by: Chandan Kumar (raukadah) <raukadah@gmail.com>
    
Related-Jira: https://issues.redhat.com/browse/OSPRH-13660
