### PR TITLE
unialpha adopt: provider-physical-network = ironic

### DIFF
--- a/hooks/playbooks/adoption_ironic_post_oc.yml
+++ b/hooks/playbooks/adoption_ironic_post_oc.yml
@@ -16,6 +16,13 @@
 
 - name: OSP 17 - Ironic post overcloud
   hosts: "{{ cifmw_target_host | default('localhost') }}"
+  vars:
+    _subnet_range: '172.20.1.0/24'
+    _subnet_gateway: '172.20.1.1'
+    _subnet_alloc_pool_start: '172.20.1.150'
+    _subnet_alloc_pool_end: '172.20.1.199'
+    _provider_physical_network: ironic
+    _provider_network_type: flat
   tasks:
     - name: Gather ansible_user_dir from OSP nodes
       delegate_to: "{{ item }}"
@@ -133,8 +140,8 @@
               openstack network show provisioning &>/dev/null || \
                 openstack network create provisioning \
                   --share \
-                  --provider-physical-network baremetal \
-                  --provider-network-type flat
+                  --provider-physical-network {{ _provider_physical_network }} \
+                  --provider-network-type {{ _provider_network_type }}
 
         - name: Create subnet
           ansible.builtin.shell:
@@ -142,9 +149,9 @@
               openstack subnet show provisioning-subnet &>/dev/null || \
                 openstack subnet create provisioning-subnet \
                   --network provisioning \
-                  --subnet-range 172.20.1.0/24 \
-                  --gateway 172.20.1.1 \
-                  --allocation-pool start=172.20.1.100,end=172.20.1.199
+                  --subnet-range {{ _subnet_range }} \
+                  --gateway {{ _subnet_gateway }} \
+                  --allocation-pool start={{ _subnet_alloc_pool_start }},end={{ _subnet_alloc_pool_end }}
 
     - name: Slurp ironic_nodes.yaml from controller-0
       delegate_to: controller-0


### PR DESCRIPTION
To align with the physical network name used elsewhere:
* hooks/playbooks/ironic_network.yml
* reproducer/tasks/generate_bm_info.yml
* openstack-k8s-operators/architecture/examples/dt/uni01alpha/control-plane/service-values.yaml
* scenarios in gitlab ci-framework-jobs ...

Let's set the provider-physical-network to `ironic` in when creating the provider network for the ironic provisioning/cleaning/rescue network.

Also change it to use variables, like already done in:
  hooks/playbooks/ironic_network.yml

I will follow up with changes in data-plane-adoption to align there as well.