### PR TITLE
[shiftstack]Switch incluster-kubeconfig to admin context

### DIFF
--- a/roles/shiftstack/tasks/deploy_shiftstackclient_pod.yml
+++ b/roles/shiftstack/tasks/deploy_shiftstackclient_pod.yml
@@ -14,6 +14,10 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Switch context to admin on {{ cifmw_openshift_kubeconfig }}
+  ansible.builtin.command: oc config use-context admin --kubeconfig={{ cifmw_openshift_kubeconfig }}
+  changed_when: true
+
 - name: Encode kubeconfig file to Base64
   ansible.builtin.set_fact:
     incluster_kubeconfig_base64: "{{ lookup('ansible.builtin.file', cifmw_openshift_kubeconfig ) | b64encode }}"


### PR DESCRIPTION
By switching to the admin context we facilitate the usage of the kubeconfig in the shiftstackclient pod.