### PR TITLE
Add "tobiko" namespace to be gathered by the openstack-must-gather

### DIFF
--- a/roles/os_must_gather/defaults/main.yml
+++ b/roles/os_must_gather/defaults/main.yml
@@ -23,7 +23,7 @@ cifmw_os_must_gather_image_registry: "quay.rdoproject.org/openstack-k8s-operator
 cifmw_os_must_gather_output_dir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_os_must_gather_repo_path: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/openstack-must-gather"
 cifmw_os_must_gather_timeout: "10m"
-cifmw_os_must_gather_additional_namespaces: "kuttl,openshift-storage,openshift-marketplace,sushy-emulator"
+cifmw_os_must_gather_additional_namespaces: "kuttl,openshift-storage,openshift-marketplace,sushy-emulator,tobiko"
 cifmw_os_must_gather_namespaces:
   - openstack-operators
   - openstack


### PR DESCRIPTION
This namespace is used by Tobiko to run e.g. background ping POD (and other PODs with background tasks in the future) and it would be nice to have logs from those PODs gathered in the CI job's results.