### PR TITLE
Fix wait condition for OpenStack initialization resource

### DIFF
--- a/roles/kustomize_deploy/tasks/install_operators.yml
+++ b/roles/kustomize_deploy/tasks/install_operators.yml
@@ -373,7 +373,8 @@
       when: not cifmw_kustomize_deploy_generate_crs_only
       kubernetes.core.k8s_info:
         kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
-        kind: Openstack
+        api_version: "operator.openstack.org/v1beta1"
+        kind: OpenStack
         namespace: openstack-operators
         name: openstack
         wait: true


### PR DESCRIPTION
Api version was not set and kind was wrong and due to this it do not wait for the ready state as there is no such resouce in the default api_version v1. This leads to failure of later tasks as operators are not ready.