### PR TITLE
Add Ansible variable cifmw_openshift_setup_apply_marketplace_fix

### DIFF
--- a/roles/openshift_setup/README.md
+++ b/roles/openshift_setup/README.md
@@ -27,3 +27,4 @@ effect if `cifmw_openshift_setup_ca_registry_to_add` is set.
               - mirror.quay.rdoproject.org
         ```
 * `cifmw_openshift_setup_metal3_watch_all_ns`: (Boolean) Tells Metal3 BMO to watch resources out of its namespace. Defaults to `false`.
+* `cifmw_openshift_setup_apply_marketplace_fix`: (Boolean) Apply openshift-marketplace workaround which is recreating all pods in the namespace. NOTE: same step is done in `base` job.

--- a/roles/openshift_setup/defaults/main.yml
+++ b/roles/openshift_setup/defaults/main.yml
@@ -28,3 +28,4 @@ cifmw_openshift_setup_metal3_watch_all_ns: false
 cifmw_openshift_setup_operator_override_catalog_name: "redhat-operators-4.17"
 cifmw_openshift_setup_operator_override_catalog_namespace: "openshift-marketplace"
 cifmw_openshift_setup_operator_override_catalog_image: "registry.redhat.io/redhat/redhat-operator-index:v4.17"
+cifmw_openshift_setup_apply_marketplace_fix: false

--- a/roles/openshift_setup/tasks/fix_openshift_marketplace.yml
+++ b/roles/openshift_setup/tasks/fix_openshift_marketplace.yml
@@ -3,9 +3,13 @@
 # https://github.com/crc-org/crc/issues/4109#issuecomment-2042497411.
 # It will be removed once https://github.com/crc-org/crc/issues/4109
 # closed.
+# NOTE(dpawlik): similar fix was applied in base job:
+# https://review.rdoproject.org/r/plugins/gitiles/config/+/refs/heads/master/roles/prepare-crc-extracted/tasks/recreate_marketplace.yaml
+# No need to re-apply same thing here.
 - name: Fix OpenShift Marketplace
   when:
     - not cifmw_openshift_setup_dry_run
+    - cifmw_openshift_setup_apply_marketplace_fix
   block:
     - name: Delete the pods from openshift-marketplace namespace
       kubernetes.core.k8s:


### PR DESCRIPTION
On some images (especially on legacy CRC images e.g. 2.30.0), there is no need to run the openshift-marketplace workaround which is removing all the pods from the namespace.
That step might be problematic on old deployments, due the ImagePullPolicy is set to "Always", so after removing the pods when the credentials are vanished, pods would be not recreated.