### PR TITLE
Filter out rhos branches when setting openstack_k8s_branch

### DIFF
--- a/roles/install_yamls/tasks/main.yml
+++ b/roles/install_yamls/tasks/main.yml
@@ -71,7 +71,7 @@
           'OUT': cifmw_install_yamls_manifests_dir,
           'OUTPUT_DIR': cifmw_install_yamls_edpm_dir,
           'CHECKOUT_FROM_OPENSTACK_REF': cifmw_install_yamls_checkout_openstack_ref,
-          'OPENSTACK_K8S_BRANCH': (zuul is defined and zuul.branch != 'master') | ternary(zuul.branch, 'main')
+          'OPENSTACK_K8S_BRANCH': (zuul is defined and not zuul.branch |regex_search('master|rhos')) | ternary(zuul.branch, 'main')
         }) |
         combine(install_yamls_operators_repos)
       }}


### PR DESCRIPTION
In order to run jobs against rhos branches have to filter those branches and fallback to main.

Related-Issue: [OSPRH-10539](https://issues.redhat.com//browse/OSPRH-10539)