### PR TITLE
Add fqdn to the list of host patterns in ssh config

### DIFF
--- a/roles/libvirt_manager/tasks/manage_vms.yml
+++ b/roles/libvirt_manager/tasks/manage_vms.yml
@@ -26,6 +26,7 @@
         - "{{ vm }}"
         - "{{ _type_id }}"
         - "{{ _type_id }}.utility"
+        - "{{ _hostname }}.localdomain"
         - "{{ _type_id }}.{{ inventory_hostname }}"
         - "{{ _hostname }}"
         - "{{ vm_con_name }}"


### PR DESCRIPTION
Ceph orchestrator hosts are configured with fqdn names, ceph adoption tasks try to access the fqdn and fails with ssh issues.

Good to have the fqdn (hostname + .localdomain) in the ssh config to avoid ssh issues.