### PR TITLE
Add cifmw_bop_versions_url to pass versions.csv url

### DIFF
--- a/roles/build_openstack_packages/README.md
+++ b/roles/build_openstack_packages/README.md
@@ -26,6 +26,8 @@ An Ansible role for generating custom RPMSs of OpenStack Projects using DLRN
 * `cifmw_bop_skipped_projects`: List of projects on which DLRN build needs to be skipped.
 * `cifmw_bop_change_list`: Zuul Change list constructed while using Depends-On in CI to build rpm packages using DLRN.
 * `cifmw_bop_release_mapping`: A list of openstack release names and their respective branch names.
+* `cifmw_bop_versions_url`: A dict with downstream release name (cifmw_bop_osp_release) as key and their value as
+  versions.csv or frozen_versions.csv url.
 
 ## Examples
 

--- a/roles/build_openstack_packages/defaults/main.yml
+++ b/roles/build_openstack_packages/defaults/main.yml
@@ -71,6 +71,9 @@ cifmw_bop_release_mapping:
   master: master
   antelope: unmaintained/2023.1
 
+cifmw_bop_versions_url:
+  rhos-18.0: "https://trunk.rdoproject.org/centos9-antelope/current-podified/versions.csv"
+
 cifmw_bop_skipped_projects:
   - testproject
   - openstack-k8s-operators/ci-framework

--- a/roles/build_openstack_packages/templates/projects.ini.j2
+++ b/roles/build_openstack_packages/templates/projects.ini.j2
@@ -38,7 +38,7 @@ custom_preprocess={{ cifmw_bop_build_repo_dir }}/DLRN/scripts/set_nvr.sh,{{ cifm
 
 [downstream_driver]
 info_files=osp.yml
-versions_url=https://trunk.rdoproject.org/centos9-{{ cifmw_bop_openstack_release }}/current-podified/versions.csv
+versions_url={{ cifmw_bop_versions_url[cifmw_bop_osp_release] }}
 downstream_source_git_branch={{ cifmw_bop_osp_release }}-trunk-patches
 # downstream_distro_branch needs to be rhoso not rhos.
 downstream_distro_branch={{ cifmw_bop_osp_release | replace('rhos-', 'rhoso-') }}{{ '.0' if '.' not in cifmw_bop_osp_release else '' }}-rhel-9-trunk


### PR DESCRIPTION
In Downstream, OSP-18 got released. We are no longer importing content from antelope branches. In order to build DLRN packages in CI, we need to downstream frozen version csv url instead of upstream.

But for OSP-19, we will be using upstream version csv url.

This pr adds cifmw_bop_versions_url as a dict to pass multiple release csv url. So that correct csv file get picked up and packages gets built downstream.

Signed-off-by: Chandan Kumar (raukadah) <raukadah@gmail.com>

Related-Jira: https://issues.redhat.com/browse/OSPRH-13660