### PR TITLE
Update tempest image via update_containers role

### DIFF
--- a/roles/update_containers/templates/update_containers.j2
+++ b/roles/update_containers/templates/update_containers.j2
@@ -76,6 +76,7 @@ spec:
     swiftContainerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-swift-container:{{ cifmw_update_containers_tag }}
     swiftObjectImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-swift-object:{{ cifmw_update_containers_tag }}
     swiftProxyImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-swift-proxy-server:{{ cifmw_update_containers_tag }}
+    testTempestImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-tempest-all:{{ cifmw_update_containers_tag }}
 {% if cifmw_update_containers_cindervolumes | length > 0     %}
     cinderVolumeImages:
 {% for vol in cifmw_update_containers_cindervolumes          %}


### PR DESCRIPTION
Currently update_containers does not update TestTempestImage. By adding TestTempestImage field in the update_containers role will allow us to update the tempest containers and consume it in job.

Signed-off-by: Chandan Kumar (raukadah) <raukadah@gmail.com>

Related-Jira: https://issues.redhat.com/browse/OSPRH-13660