### PR TITLE
[bop]Donot use dlrn --local for downstream

### DIFF
--- a/roles/build_openstack_packages/templates/run_dlrn.sh.j2
+++ b/roles/build_openstack_packages/templates/run_dlrn.sh.j2
@@ -8,7 +8,10 @@ export REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.cr
 {% endif %}
 
 while true; do
-    dlrn --config-file projects.ini --head-only --package-name $PKG --local \
+    dlrn --config-file projects.ini --head-only --package-name $PKG \
+    {% if cifmw_bop_osp_release is not defined  %}
+        --local \
+    {% endif %}
         --info-repo {{ cifmw_bop_build_repo_dir }}/DLRN/{{ cifmw_bop_rdoinfo_repo_name }} \
 	--dev;
     if [ $? -eq 0 ]; then


### PR DESCRIPTION
When we use dlrn --local, then dlrn will use local git reporegardless of version.csv info.
But for downstream, we need to follow version.csv to build downstream packages properly. that's why this pr is removing --local from dlrn command.