### PR TITLE
Add hooks before running kuttl from operator target

### DIFF
--- a/ci/playbooks/kuttl/deploy-deps.yaml
+++ b/ci/playbooks/kuttl/deploy-deps.yaml
@@ -99,6 +99,12 @@
             name: 'install_yamls_makes'
             tasks_from: 'make_openstack_init'
 
+        - name: Run hooks after installing openstack
+          vars:
+            step: post_install_operators_kuttl_from_operator
+          ansible.builtin.include_role:
+            name: run_hook
+
         - name: install kuttl test_suite dependencies
           vars:
             project_name: "github.com/openstack-k8s-operators/{{ operator_name }}"

--- a/ci/playbooks/kuttl/kuttl-from-operator-run.yaml
+++ b/ci/playbooks/kuttl/kuttl-from-operator-run.yaml
@@ -1,0 +1,18 @@
+- name: "Run ci/playbooks/kuttl/run-kuttl-from-operator-targets.yaml"
+  hosts: controller
+  gather_facts: true
+  tasks:
+    - name: Run kuttl tests from operator playbook
+      ansible.builtin.command:
+        chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
+        cmd: >-
+          ansible-playbook ci/playbooks/kuttl/run-kuttl-from-operator-targets.yaml
+          -i "{{ ansible_user_dir }}/ci-framework-data/artifacts/zuul_inventory.yml"
+          -e @scenarios/centos-9/base.yml
+          -e @scenarios/centos-9/ci.yml
+          {%- if cifmw_extras is defined %}
+          {%-   for extra_vars in cifmw_extras %}
+          -e "{{   extra_vars }}"
+          {%-   endfor %}
+          {%- endif %}
+          -e "@{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml"

--- a/ci/playbooks/kuttl/run-kuttl-from-operator-targets.yaml
+++ b/ci/playbooks/kuttl/run-kuttl-from-operator-targets.yaml
@@ -1,4 +1,4 @@
-- hosts: controller
+- hosts: "{{ cifmw_target_host | default('localhost') }}"
   vars:
     project_name: "github.com/openstack-k8s-operators/{{ operator_name }}"
     operator_basedir: >-
@@ -7,6 +7,12 @@
         }}
     kuttl_log_dir: "{{ local_log_dir | default(ansible_user_dir + '/zuul-output/logs/controller') }}"
   tasks:
+    - name: Run hooks before running kuttl tests
+      vars:
+        step: pre_kuttl_from_operator
+      ansible.builtin.include_role:
+        name: run_hook
+
     - name: run kuttl test suite from operator Makefile
       environment:
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -123,6 +123,9 @@ If you want to list multiple hooks, you have to use the following parameter name
 - `post_admin_setup`: before admin setup
 - `pre_tests`: before running tests
 - `post_tests`: after running tests
+- `post_install_operators_kuttl_from_operator`: after installing openstack operator for kuttl test when calling them from the operator's make target
+- `pre_kuttl_from_operator`: before running kuttl test when calling them from
+    the operator's make target
 
 Since we're already providing hooks as list, you may want to just add one or two hooks
 using your own environment file. Parameter structure is simple: `PREFIX_HOOKNAME: {hook struct}`

--- a/zuul.d/kuttl_multinode.yaml
+++ b/zuul.d/kuttl_multinode.yaml
@@ -82,6 +82,6 @@
     pre-run:
       - ci/playbooks/kuttl/kuttl-from-operator-deps.yaml
     run:
-      - ci/playbooks/kuttl/run-kuttl-from-operator-targets.yaml
+      - ci/playbooks/kuttl/kuttl-from-operator-run.yaml
     vars:
       cifmw_target_host: controller


### PR DESCRIPTION
Add a hook to run before calling the kuttl tests in the job variant that runs them from the operator target (wihtout using install_yamls).