### PR TITLE
Update COO sub to stable channel

### DIFF
--- a/roles/openshift_obs/defaults/main.yml
+++ b/roles/openshift_obs/defaults/main.yml
@@ -24,7 +24,7 @@ cifmw_openshift_obs_definition:
     labels:
       operators.coreos.com/observability-operator.openshift-operators: ""
   spec:
-    channel: development
+    channel: stable
     installPlanApproval: Automatic
     name: cluster-observability-operator
     source: redhat-operators


### PR DESCRIPTION
COO released v 1.0.0 and the development channel disappeared. We need to switch to the stable channel.