### PR TITLE
[kustomize_deploy] Add name field in architecture steps

### DIFF
--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -15,7 +15,15 @@
 - name: Assert all wait conditions are valid
   vars:
     _stage_name_id: "stage_{{ stage_id }}"
-    _stage_name: "stage_{{ stage.build_output | basename | splitext | first }}"
+    _stage_name: >-
+      {{
+        (
+          stage.name |
+          default(
+            'stage_' + (stage.build_output | basename | splitext | first)
+          )
+        ) | regex_replace('[^a-zA-Z\d_-]', '_')
+      }}
     _custom_conditions: >-
       {{
         cifmw_architecture_wait_condition[_stage_name] |
@@ -57,7 +65,15 @@
 - name: Group tasks under the same tags
   vars:
     _stage_name_id: "stage_{{ stage_id }}"
-    _stage_name: "stage_{{ stage.build_output | basename | splitext | first }}"
+    _stage_name: >-
+      {{
+        (
+          stage.name |
+          default(
+            'stage_' + (stage.build_output | basename | splitext | first)
+          )
+        ) | regex_replace('[^a-zA-Z\d_-]', '_')
+      }}
     _tag_name_id: "deploy_architecture_{{ _stage_name_id }}"
     _tag_name: "deploy_architecture_{{ _stage_name }}"
     _skip_tags: >-
@@ -106,9 +122,13 @@
         - not cifmw_kustomize_deploy_generate_crs_only | bool
       vars:
         hooks: "{{ stage.pre_stage_run | default([]) }}"
-        step: "pre_{{ _stage_name_id }}_run"
+        step: "{{ item }}"
       ansible.builtin.include_role:
         name: run_hook
+      loop:
+        - "pre_{{ _stage_name_id }}_run"
+        - "pre_{{ _stage_name }}_run"
+        - "pre_{{ _stage_name | replace( '-', '_') }}_run"
 
     - name: "Generate values.yaml for {{ stage.path }}"
       when:
@@ -299,6 +319,10 @@
         - not cifmw_kustomize_deploy_generate_crs_only | bool
       vars:
         hooks: "{{ stage.post_stage_run | default([]) }}"
-        step: "post_{{ _stage_name_id }}_run"
+        step: "{{ item }}"
       ansible.builtin.include_role:
         name: run_hook
+      loop:
+        - "post_{{ _stage_name_id }}_run"
+        - "post_{{ _stage_name }}_run"
+        - "post_{{ _stage_name | replace('-', '_') }}_run"


### PR DESCRIPTION
Till now, to add a kustomize patch users refered to the step they wanted to patch by a numeric ID or an ID autogenerated based on the output build path. To give users more control, this change allows users to add a name field in each step in the automation field making patching a bit easier.