### PR TITLE
Multi-cell adoption support for osp-deploy plugin

### DIFF
--- a/roles/adoption_osp_deploy/templates/adoption_vars.yaml.j2
+++ b/roles/adoption_osp_deploy/templates/adoption_vars.yaml.j2
@@ -1,13 +1,14 @@
 #jinja2: trim_blocks:True, lstrip_blocks:True
+{%+ if multi_cell|default(false) +%}
+source_mariadb_ip:
+  default: {{ _controller_1_internalapi_ip }}
+{%+ else +%}
 source_mariadb_ip: {{ _controller_1_internalapi_ip }}
+{%+ endif +%}
+
 source_ovndb_ip: {{ _controller_1_internalapi_ip }}
 edpm_node_hostname: {{ _compute_1_name }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}
 edpm_node_ip: {{ _compute_1_ip }}
-edpm_computes: |
-  {% for compute in _vm_groups['osp-computes'] %}
-  {% set node_nets = cifmw_networking_env_definition.instances[compute] %}
-  ["{{ compute }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}"]="{{ node_nets.networks.ctlplane.ip_v4 }}"
-  {% endfor %}
 edpm_networkers: |
   {% for networker in _vm_groups['osp-networkers'] | default([]) %}
   {% set node_nets = cifmw_networking_env_definition.instances[networker] %}
@@ -15,46 +16,57 @@ edpm_networkers: |
   {% endfor %}
 
 
-source_galera_members: |
+source_galera_members:
+  {%+ if multi_cell|default(false) +%}
+  default:
+    {% for controller in _vm_groups['osp-controllers'] %}
+    {% set node_nets = cifmw_networking_env_definition.instances[controller] %}
+    - name: "{{ controller }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}"
+      ip: "{{ node_nets.networks.internalapi.ip_v4 }}"
+    {% endfor %}
+  {%+ else +%}
   {% for controller in _vm_groups['osp-controllers'] %}
   {% set node_nets = cifmw_networking_env_definition.instances[controller] %}
   ["{{ controller }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}"]="{{ node_nets.networks.internalapi.ip_v4 }}"
   {% endfor %}
+  {%+ endif +%}
 
 edpm_nodes:
-  {% for compute in _vm_groups['osp-computes'] %}
-  {% set node_nets = cifmw_networking_env_definition.instances[compute] %}
-  {{ compute }}:
-    hostName: {{ compute }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}
-    ansible:
-      ansibleHost: {{ node_nets.networks.ctlplane.ip_v4 }}
-    networks:
-    {% for net in node_nets.networks.keys() if net not in cifmw_adoption_osp_deploy_adoption_vars_exclude_nets %}
-      - fixedIP: {{ node_nets.networks[net].ip_v4 }}
-        name: {{ net }}
-        subnetName: subnet1
-{% if net == 'ctlplane' %}
-        defaultRoute: true
-{% endif %}
-    {% endfor %}
-    {% endfor %}
-  {% for networker in _vm_groups['osp-networkers'] | default([]) %}
-  {% set node_nets = cifmw_networking_env_definition.instances[networker] %}
-  {{ networker }}:
-    hostName: {{ networker }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}
-    ansible:
-      ansibleHost: {{ node_nets.networks.ctlplane.ip_v4 }}
-    networks:
-    {% for net in node_nets.networks.keys() if net not in cifmw_adoption_osp_deploy_adoption_vars_exclude_nets %}
-      - fixedIP: {{ node_nets.networks[net].ip_v4 }}
-        name: {{ net }}
-        subnetName: subnet1
-{% if net == 'ctlplane' %}
-        defaultRoute: true
-{% endif %}
-    {% endfor %}
-    {% endfor %}
-
+  {%+ if multi_cell|default(false) +%}
+  cell1:
+  {%+ endif +%}
+    {% for compute in _vm_groups['osp-computes'] %}
+    {% set node_nets = cifmw_networking_env_definition.instances[compute] %}
+    {{ compute }}:
+      hostName: {{ compute }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}
+      ansible:
+        ansibleHost: {{ node_nets.networks.ctlplane.ip_v4 }}
+      networks:
+      {% for net in node_nets.networks.keys() if net not in cifmw_adoption_osp_deploy_adoption_vars_exclude_nets %}
+        - fixedIP: {{ node_nets.networks[net].ip_v4 }}
+          name: {{ net }}
+          subnetName: subnet1
+  {% if net == 'ctlplane' %}
+          defaultRoute: true
+  {% endif %}
+      {% endfor %}
+      {% endfor %}
+    {% for networker in _vm_groups['osp-networkers'] | default([]) %}
+    {% set node_nets = cifmw_networking_env_definition.instances[networker] %}
+    {{ networker }}:
+      hostName: {{ networker }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}
+      ansible:
+        ansibleHost: {{ node_nets.networks.ctlplane.ip_v4 }}
+      networks:
+      {% for net in node_nets.networks.keys() if net not in cifmw_adoption_osp_deploy_adoption_vars_exclude_nets %}
+        - fixedIP: {{ node_nets.networks[net].ip_v4 }}
+          name: {{ net }}
+          subnetName: subnet1
+  {% if net == 'ctlplane' %}
+          defaultRoute: true
+  {% endif %}
+      {% endfor %}
+      {% endfor %}
 
 upstream_dns: {{ cifmw_networking_env_definition.networks.ctlplane.dns_v4 | first }}
 os_cloud_name: {{ cifmw_adoption_osp_deploy_scenario.stacks[0].stackname }}


### PR DESCRIPTION
Adapt templating vars for multi-cell layout, but having only default(cell1) supported yet.

Remove no longer used edpm_computes.

Assume a single default cell exists only (which becomes cell1 after adoption).

Change data formats to become compliant with multi-cell topology.