### PR TITLE
[autoholds] Use the krb_requests module to fetch holds

### DIFF
--- a/ci/playbooks/multinode-autohold.yml
+++ b/ci/playbooks/multinode-autohold.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Run ci/playbooks/multinode-autohold.yml"
-  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+  hosts: controller, primary
   gather_facts: true
   tasks:
     - name: Verify if "success" flag exists after successful tests execution
@@ -37,38 +37,20 @@
                   'autohold'
                 ] | join('/')
               }}
-          ansible.builtin.uri:
-            url: "{{ zuul_autohold_endpoint | default(_zuul_api_url) }}"
-            method: GET
-            headers:
-              Content-Type: "application/json"
-              Accept: "application/json"
-            return_content: yes
-            status_code: 200
-            body_format: json
-          register: autoholds_response
-          retries: 2
-          delay: 10
-          until:
-            - autoholds_response.status is defined
-            - autoholds_response.content_type is defined
-            - autoholds_response.status == 200
-            - "autoholds_response.content_type.startswith('application/json')"
-          ignore_errors: true
+            cifmw_krb_request_url: "{{ zuul_autohold_endpoint | default(_zuul_api_url)  }}"
+          ansible.builtin.include_role:
+            name: krb_request
+            apply:
+              ignore_errors: true  # noqa: ignore-errors
 
         - name: Check if any autohold matches
           vars:
             autoholds_returned_data: >-
               {{
                 (
-                  autoholds_response.content |
-                  default('[]') |
-                  from_json
-                ) if
-                  (
-                    (not autoholds_response.failed) and
-                    autoholds_response.content_type.startswith('application/json')
-                  )
+                  cifmw_krb_request_out.response_json |
+                  default([])
+                ) if (not cifmw_krb_request_out.failed)
                 else []
               }}
             autohold_candidates: >-

--- a/plugins/modules/krb_request.py
+++ b/plugins/modules/krb_request.py
@@ -201,8 +201,8 @@ def main():
             except ValueError as e:
                 module.fail_json(msg=f"Error with the JSON response: {str(e)}")
 
-        if "dest" in module.params:
-            dest = module.params["dest"]
+        dest = module.params.get("dest", None)
+        if dest:
             if (
                 os.path.exists(dest)
                 and os.path.isdir(dest)


### PR DESCRIPTION
Since the zuul API may be behind a kerberos secured gateway let's consume the endpoint with the module to allow automatic authentication if a kerberos token was already been issued.

JIRA: https://issues.redhat.com/browse/OSPRH-12508