### PR TITLE
Add missing kubeconfig file name to shiftstack test

### DIFF
--- a/roles/shiftstack/tasks/test_config.yml
+++ b/roles/shiftstack/tasks/test_config.yml
@@ -38,7 +38,7 @@
           -e ocp_cluster_name={{ cifmw_shiftstack_cluster_name }}
           -e user_cloud={{ cifmw_shiftstack_project_name }}
           -e hypervisor={{ cifmw_shiftstack_hypervisor }}
-          -e rhoso_kubeconfig={{ cifmw_shiftstack_shiftstackclient_incluster_kubeconfig_dir }}
+          -e rhoso_kubeconfig={{ cifmw_shiftstack_shiftstackclient_incluster_kubeconfig_dir }}/kubeconfig
       ansible.builtin.include_tasks: exec_command_in_pod.yml
 
   rescue:


### PR DESCRIPTION
The kubeconfig file name was missing in the extra var rhoso_kubeconfig when running the shiftstack playbook inside the shiftstackclient pod.