### PR TITLE
DNM - Includes optimize.proxy_host_address in tempest override

### DIFF
--- a/roles/test_operator/tasks/tempest-tests.yml
+++ b/roles/test_operator/tasks/tempest-tests.yml
@@ -136,7 +136,8 @@
           test_operator_cr |
           combine({'spec': {'tempestconfRun': {'overrides':
                     (test_operator_cr.spec.tempestconfRun.overrides | default('')) + ' ' +
-                    'whitebox_neutron_plugin_options.proxy_host_address ' + controller_ip
+                    'whitebox_neutron_plugin_options.proxy_host_address ' + controller_ip + ' ' +
+                    'optimize.proxy_host_address ' + controller_ip
                   }}}, recursive=true)
       }}
 
@@ -159,7 +160,8 @@
               item |
               combine({'tempestconfRun': {'overrides':
                 item.tempestconfRun.overrides + ' ' +
-                'whitebox_neutron_plugin_options.proxy_host_address ' + controller_ip
+                'whitebox_neutron_plugin_options.proxy_host_address ' + controller_ip + ' ' +
+                'optimize.proxy_host_address ' + controller_ip
               }}, recursive=true)
           }}
       ansible.builtin.set_fact:


### PR DESCRIPTION
Watcher (optimize) tempest plugin component will now depend on a proxy host to run some additional pre-test commands, as whitebox plugins does, and in order to work it will also need the address from controller to work as proxy host.