### PR TITLE
OSPCIX-683 - Fix unbound.service startup error

### DIFF
--- a/roles/nat64_appliance/files/elements/nat64-router/static/etc/unbound/unbound.conf
+++ b/roles/nat64_appliance/files/elements/nat64-router/static/etc/unbound/unbound.conf
@@ -2,6 +2,7 @@ include: "/etc/unbound/conf.d/*.conf"
 server:
   use-systemd: yes
   do-daemonize: no
+  chroot: ""
   do-not-query-localhost: no
   module-config: "dns64 validator iterator"
   interface: ::1


### PR DESCRIPTION
Unbound fails to start, error message:
```
  unbound[1636]: [1636:0] fatal error: sd_notify failed
    /run/systemd/notify: No such file or directory.
    Make sure that unbound has access/permission to use
    the socket presented by systemd.
```

Adding `chroot: ""` in the server section of unbound.conf fixes the issue.

Jira: [OSPCIX-683](https://issues.redhat.com//browse/OSPCIX-683)