### PR TITLE
[libvirt_manager] Add retry to vm start

### DIFF
--- a/roles/libvirt_manager/tasks/start_one_vm.yml
+++ b/roles/libvirt_manager/tasks/start_one_vm.yml
@@ -1,0 +1,10 @@
+---
+- name: Start vm
+  community.libvirt.virt:
+    name: "cifmw-{{ vm }}"
+    state: running
+    uri: "qemu:///system"
+  register: _vm_start_result
+  retries: 5
+  delay: 30
+  until: _vm_start_result is not failed

--- a/roles/libvirt_manager/tasks/start_vms.yml
+++ b/roles/libvirt_manager/tasks/start_vms.yml
@@ -20,10 +20,8 @@
       {{
         _cifmw_libvirt_manager_layout.vms[vm_type]
       }}
-  community.libvirt.virt:
-    state: running
-    name: "cifmw-{{ vm }}"
-    uri: "qemu:///system"
+  ansible.builtin.include_tasks:
+    file: start_one_vm.yml
   loop: "{{ cifmw_libvirt_manager_all_vms | dict2items }}"
   loop_control:
     loop_var: _vm


### PR DESCRIPTION
The retry will prevent the role to fail while trying to start the vms:

```2025-02-24 09:59:32.704653 | controller | TASK [libvirt_manager : Start VMs for type {{ vm_type }} state=running, name=cifmw-{{ vm }}, uri=qemu:///system] ***
2025-02-24 09:59:32.704662 | controller | Monday 24 February 2025  09:59:30 -0500 (0:00:00.021)       0:00:16.765 *******
2025-02-24 09:59:32.704676 | controller | An exception occurred during task execution. To see the full traceback, use -vvv. The error was: libvirt.libvirtError: Failed to connect socket to '/var/run/libvirt/virtqemud-sock': No such file or directory
2025-02-24 09:59:32.792688 | controller | failed: [localhost -> hypervisor(xxhypervisorxx)] (item={'key': 'osp-undercloud-nh2jxo9r-0', 'value': 'osp-underclouds'}) => changed=false
2025-02-24 09:59:32.792824 | controller |   _vm:
2025-02-24 09:59:32.792833 | controller |     key: osp-undercloud-nh2jxo9r-0
2025-02-24 09:59:32.792857 | controller |     value: osp-underclouds
2025-02-24 09:59:32.792865 | controller |   ansible_loop_var: _vm
2025-02-24 09:59:32.792872 | controller |   msg: 'Failed to connect socket to ''/var/run/libvirt/virtqemud-sock'': No such file or directory'
```