### PR TITLE
Update converge test controlplane kustomize directory

### DIFF
--- a/roles/ci_gen_kustomize_values/molecule/default/converge.yml
+++ b/roles/ci_gen_kustomize_values/molecule/default/converge.yml
@@ -29,7 +29,7 @@
     artifacts: "{{ cifmw_ci_gen_kustomize_values_basedir }}/artifacts"
     to_kustomize:
       - name: 'ctlplane'
-        path: 'examples/va/hci/control-plane/nncp'
+        path: 'examples/va/hci/control-plane/networking/nncp'
       - name: 'dataplane'
         path: 'examples/va/hci/edpm-pre-ceph/nodeset'
     ci_gen_kustomize_fetch_ocp_state: false
@@ -90,7 +90,7 @@
         cifmw_ci_gen_kustomize_values_src_file: >-
           {{
             [architecture_repo,
-             "examples/va/hci/control-plane/nncp/values.yaml"] | path_join
+             "examples/va/hci/control-plane/networking/nncp/values.yaml"] | path_join
           }}
       ansible.builtin.include_role:
         name: ci_gen_kustomize_values
@@ -163,7 +163,7 @@
             cifmw_ci_gen_kustomize_values_src_file: >-
               {{
                 [architecture_repo,
-                 "examples/va/hci/control-plane/nncp/values.yaml"] | path_join
+                 "examples/va/hci/control-plane/networking/nncp/values.yaml"] | path_join
               }}
           ansible.builtin.include_role:
             name: ci_gen_kustomize_values
@@ -186,7 +186,7 @@
         dest: "{{ architecture_repo }}/{{ item.value }}"
       loop:
         - key: 'network-values'
-          value: 'examples/va/hci/control-plane/nncp/values.yaml'
+          value: 'examples/va/hci/control-plane/networking/nncp/values.yaml'
         - key: 'edpm-nodeset-values'
           value: 'examples/va/hci/edpm-pre-ceph/nodeset/values.yaml'
 


### PR DESCRIPTION
With VA1's network stage was decoupled from controlplane, need to update kustomize directory to reflect new directory structure in architecture repo [1]


[1] https://github.com/openstack-k8s-operators/architecture/commit/3105c9e549baa340cf2a469951a84185310ce64a