### PR TITLE
Remove outdated/wrong definition of cifmw_artifacts_gather_logs

### DIFF
--- a/roles/artifacts/README.md
+++ b/roles/artifacts/README.md
@@ -10,7 +10,6 @@ None - writes happen only in the user home.
 * `cifmw_artifacts_crc_host`: (String) Hostname of the CRC instance. Defaults to `api.crc.testing`.
 * `cifmw_artifacts_crc_user`: (String) Username to connect to the CRC instance. Defaults to `core`.
 * `cifmw_artifacts_crc_sshkey`: (String) Path to the private SSH key to connect to CRC. Defaults to `~/.crc/machines/crc/id_ecdsa`.
-* `cifmw_artifacts_gather_logs`: (Boolean) Force gathering of logs, even in the case of successful test run. Defaults to `false`
 * `cifmw_artifacts_gather_logs`: (Boolean) Enables must-gather logs fetching. Defaults to `true`
 
 ## Examples


### PR DESCRIPTION
This PR aims to improve the README.md documentation for artifacts role where multiple definition of `cifmw_artifacts_gather_logs` existed with different default values.

Now, the outdated/wrong definition has been removed, which will help in closing https://issues.redhat.com/browse/OSPRH-14281