### PR TITLE
Add Networker hosts to edpm_vms for log collection

### DIFF
--- a/roles/artifacts/tasks/edpm.yml
+++ b/roles/artifacts/tasks/edpm.yml
@@ -28,16 +28,18 @@
         path: "{{ ansible_user_dir }}/ci-framework-data/artifacts/zuul_inventory.yml"
       register: _cifmw_artifacs_inventory_slurp
 
-    - name: Extract Compute from zuul mapping if any
+    - name: Extract Compute and Networker from zuul mapping if any
       when:
         - cifmw_edpm_deploy_extra_vars is defined
       vars:
         _inv_data: "{{ _cifmw_artifacs_inventory_slurp['content'] | b64decode | from_yaml }}"
         _edpm_vms_data: >-
-                      {{ _inv_data['computes']['hosts']
-                        if 'computes' in _inv_data
-                        else (_inv_data['all']['hosts'] | default({}))
-                       }}
+                        {{
+                          (_inv_data['computes']['hosts'] | combine(_inv_data['networkers']['hosts']))
+                          if 'computes' in _inv_data and 'networkers' in _inv_data
+                          else ((_inv_data['computes']['hosts']) if 'computes' in _inv_data else
+                          (_inv_data['all']['hosts'] | default({})))
+                        }}
       ansible.builtin.set_fact:
         ssh_key_file: "{{ cifmw_edpm_deploy_extra_vars.SSH_KEY_FILE }}"
         ssh_user: "{{ hostvars['compute-0'].ansible_user | default('zuul') }}"
@@ -45,7 +47,7 @@
               {{
                 _edpm_vms_data | dict2items |
                 selectattr('value.ansible_host', 'defined') |
-                selectattr('key', 'match', '^compute.*$') |
+                selectattr('key', 'match', '^(compute|networker).*$') |
                 map(attribute='value.ansible_host')
               }}
 


### PR DESCRIPTION
This PR aims to solve this issue: https://issues.redhat.com/browse/OSPRH-10205

Currently, logs from networker hosts are not collected, as edpm task in artifacts role focuses only on compute hosts. From now, it will also take care of networker hosts.

Now, it will check for both compute and networker during log collection through artifacts role.
