### PR TITLE
Change Ceph Dashboard port to 8443

### DIFF
--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -92,7 +92,7 @@ cifmw_cephadm_cephfs_name: "cephfs"
 cifmw_ceph_dashboard_spec_path: /tmp/ceph_dashboard.yml
 cifmw_cephadm_certificate: ""
 cifmw_cephadm_key: ""
-cifmw_cephadm_dashboard_port: 8444
+cifmw_cephadm_dashboard_port: 8443
 cifmw_cephadm_grafana_admin_user: 'admin'
 cifmw_cephadm_grafana_admin_password: '/home/grafana_password.yml'
 cifmw_cephadm_prometheus_port: 9092


### PR DESCRIPTION
Update edpm_ceph_hci_pre role since the default port for the dashboard was wrong as per the ceph docs.

https://docs.ceph.com/en/latest/mgr/dashboard/#host-name-and-port

If we're going to change this port in the product (see depends-on) then we should update how we test it in ci-framework.

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/888
Jira: https://issues.redhat.com/browse/OSPRH-14300