### PR TITLE
[BGP] Fix template to properly obtain ansibleVars

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2
@@ -37,8 +37,8 @@ data:
         ansible:
 {%   set ctlplane_rack = 'ctlplane' + rack                                             %}
           host: {{ cifmw_networking_env_definition.instances[instance].networks[ctlplane_rack].ip_v4 }}
-{%   if original_content.data.nodeset.nodes['edpm-' ~ node_type ~ '-' ~ loop.index0].ansible.ansibleVars is defined %}
-          ansibleVars: {{ original_content.data.nodeset.nodes['edpm-' ~ node_type ~ '-' ~ loop.index0].ansible.ansibleVars }}
+{%   if original_content.data.nodeset.nodes['edpm-' ~ instance].ansible.ansibleVars is defined %}
+          ansibleVars: {{ original_content.data.nodeset.nodes['edpm-' ~ instance].ansible.ansibleVars }}
 {%   endif                                                                                                          %}
         hostName: {{ instance }}
         networks:


### PR DESCRIPTION
The ci_gen_kustomize_values templates have to be adapted to the EDPM hostname changes.

OSPRH-13820