### PR TITLE
Tempest config  cleanup must be bool

### DIFF
--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -144,7 +144,7 @@ cifmw_test_operator_tempest_config:
       extraRPMs: "{{ stage_vars_dict.cifmw_test_operator_tempest_extra_rpms | default([]) }}"
       extraImages: "{{ stage_vars_dict.cifmw_test_operator_tempest_extra_images | default([]) }}"
     tempestconfRun: "{{ cifmw_tempest_tempestconf_config_defaults | combine(stage_vars_dict.cifmw_test_operator_tempest_tempestconf_config | default({})) }}"
-    cleanup: "{{ stage_vars_dict.cifmw_test_operator_tempest_cleanup }}"
+    cleanup: "{{ stage_vars_dict.cifmw_test_operator_tempest_cleanup | bool }}"
     workflow: "{{ stage_vars_dict.cifmw_test_operator_tempest_workflow }}"
     debug: "{{ stage_vars_dict.cifmw_test_operator_tempest_debug }}"
 


### PR DESCRIPTION
According to object patching failure[1] spec.cleanup in body must be of type boolean. Cast var to bool type.

[1]`fatal: [localhost]: FAILED! => changed=false                                                                                                                                                                       
  msg: 'Failed to patch object: b''{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Tempest.test.openstack.org \\"post-adoption-tempest-tempest\\" is invalid: spec.cleanup: Invalid 
value: \\"string\\": spec.cleanup in body must be of type boolean: \\"string\\"","reason":"Invalid","details":{"name":"post-adoption-tempest-tempest","group":"test.openstack.org","kind":"Tempest","causes":[{"rea
son":"FieldValueTypeInvalid","message":"Invalid value: \\"string\\": spec.cleanup in body must be of type boolean: \\"string\\"","field":"spec.cleanup"}]},"code":422}\n'''
  reason: Unprocessable Entity    `