### PR TITLE
Limit ncclient version to avoid failures

### DIFF
--- a/hooks/playbooks/switch_config.yml
+++ b/hooks/playbooks/switch_config.yml
@@ -6,7 +6,7 @@
       vars:
         cifmw_switch_config_packages:
           - paramiko
-          - ncclient
+          - ncclient<0.6.18
           - xmltodict
       ansible.builtin.pip:
         name: "{{ cifmw_switch_config_packages }}"

--- a/playbooks/switches_config.yml
+++ b/playbooks/switches_config.yml
@@ -15,7 +15,7 @@
       ansible.builtin.pip:
         name:
           - paramiko
-          - ncclient
+          - ncclient<0.6.18
           - xmltodict
 
 - name: Switches configuration


### PR DESCRIPTION
CI jobs are failing trying to deploy recent version (0.6.18) of ncclient