### PR TITLE
Use provider ifcfg for os-net-config

### DIFF
--- a/roles/adoption_osp_deploy/tasks/prepare_overcloud.yml
+++ b/roles/adoption_osp_deploy/tasks/prepare_overcloud.yml
@@ -237,7 +237,7 @@
       become: true
       delegate_to: "{{ overcloud_vm }}"
       ansible.builtin.command:
-        cmd: "os-net-config -c /etc/os-net-config/tripleo_config.yaml"
+        cmd: "os-net-config -c /etc/os-net-config/tripleo_config.yaml --provider ifcfg"
       loop: "{{ _tripleo_nodes_stack }}"
       loop_control:
         loop_var: overcloud_vm


### PR DESCRIPTION
In the role adoption_osp_deploy use the `ifcfg` provider for os-net-config.

NOTE! This only fixes one of the issue described in Jira.

Jira: [OSPRH-14449](https://issues.redhat.com//browse/OSPRH-14449)