### PR TITLE
Add wait to prevent race condition

### DIFF
--- a/roles/test_operator/tasks/run-test-operator-job.yml
+++ b/roles/test_operator/tasks/run-test-operator-job.yml
@@ -111,6 +111,7 @@
         api_key: "{{ cifmw_openshift_token | default(omit)}}"
         context: "{{ cifmw_openshift_context | default(omit)}}"
         state: present
+        wait: true
         definition:
           apiVersion: v1
           kind: Pod


### PR DESCRIPTION
Some jobs show an error that could be appearing thanks to a race condition. This patch aims to prevent this case by first waiting for a pod to start before running the next task.