### PR TITLE
[neutron-whitebox] Skip test of BZ#2214566/OSPRH-13533 for antelope

### DIFF
--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -139,6 +139,8 @@
               ^neutron_.*plugin..*scenario.test_.*macvtap
             # NOTE(mblue): If test skipped - please add related ticket to remove skip when issue resolved
             excludeList: |
+              # remove when this job use openstackclient version bigger than in antelope branch (no more releases)
+              ^whitebox_neutron_tempest_plugin.tests.scenario.test_ports.PortListLongOptSGsCmd
               # remove when bug OSPRH-9569 resolved
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_metadata_rate_limiting
               # remove traffic logging tests when OSPRH-9203 resolved


### PR DESCRIPTION
No more releases for antelope, openstackclient test of fix should be skipped on `whitebox-neutron-tempest-plugin` job.
941930: Test verifies BZ#2214566/OSPRH-13533 doesn't regress | https://review.opendev.org/c/x/whitebox-neutron-tempest-plugin/+/941930