### PR TITLE
Guarantee resources on shiftstackclient pod

### DIFF
--- a/roles/shiftstack/templates/shiftstackclient_pod.yml.j2
+++ b/roles/shiftstack/templates/shiftstackclient_pod.yml.j2
@@ -13,7 +13,17 @@ spec:
     image: {{ cifmw_shiftstack_client_pod_image }}
     imagePullPolicy: Always
     name: {{ cifmw_shiftstack_client_pod_name }}
+{% if 'crc' in cifmw_openshift_kubeconfig %}
     resources: {}
+{% else %}
+    resources:
+      requests:
+        memory: "12Gi"
+        cpu: "4"
+      limits:
+        memory: "12Gi"
+        cpu: "4"
+{% endif %}
     securityContext:
       privileged: true
     terminationMessagePath: /dev/termination-log


### PR DESCRIPTION
It's observed that the rsh session is closed automatically reporting rc=0 which is provoking false success on the zuul job.

This patch guarantees that the pod has enough resources so the rsh session is never killed.

For adapting to the molecule test, the 'resource' section is set to empty if it runs on CRC.