### PR TITLE
Partial revert commit 4188627

### DIFF
--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -122,13 +122,9 @@
         - not cifmw_kustomize_deploy_generate_crs_only | bool
       vars:
         hooks: "{{ stage.pre_stage_run | default([]) }}"
-        step: "{{ item }}"
+        step: "pre_{{ _stage_name_id }}_run"
       ansible.builtin.include_role:
         name: run_hook
-      loop:
-        - "pre_{{ _stage_name_id }}_run"
-        - "pre_{{ _stage_name }}_run"
-        - "pre_{{ _stage_name | replace( '-', '_') }}_run"
 
     - name: "Generate values.yaml for {{ stage.path }}"
       when:
@@ -319,10 +315,6 @@
         - not cifmw_kustomize_deploy_generate_crs_only | bool
       vars:
         hooks: "{{ stage.post_stage_run | default([]) }}"
-        step: "{{ item }}"
+        step: "post_{{ _stage_name_id }}_run"
       ansible.builtin.include_role:
         name: run_hook
-      loop:
-        - "post_{{ _stage_name_id }}_run"
-        - "post_{{ _stage_name }}_run"
-        - "post_{{ _stage_name | replace('-', '_') }}_run"


### PR DESCRIPTION
PR#2839 introduced an issue where pre and post hooks are executed multiple times. Let's revert the loop on pre/post hook execution to restore the previous behaviour.

I belive a `stage.name` can still be used for `cifmw_architecture_user_kustomize` after this revert.