### PR TITLE
Change default of expectedFailuresList parameter

### DIFF
--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -138,8 +138,10 @@ cifmw_test_operator_tempest_config:
         {{ stage_vars_dict.cifmw_test_operator_tempest_include_list | default('') }}
       excludeList: |
         {{ stage_vars_dict.cifmw_test_operator_tempest_exclude_list | default('') }}
+      {%- if stage_vars_dict.cifmw_test_operator_tempest_expected_failures_list is defined %}
       expectedFailuresList: |
-        {{ stage_vars_dict.cifmw_test_operator_tempest_expected_failures_list | default('') }}
+        {{ stage_vars_dict.cifmw_test_operator_tempest_expected_failures_list }}
+      {%- endif %}
       concurrency: "{{ cifmw_test_operator_concurrency }}"
       externalPlugin: "{{ stage_vars_dict.cifmw_test_operator_tempest_external_plugin | default([]) }}"
       extraRPMs: "{{ stage_vars_dict.cifmw_test_operator_tempest_extra_rpms | default([]) }}"


### PR DESCRIPTION
The expectedFailuresList parameter is used to define which tests are expected to fail so that they are not taken into consideration when marking the job's status. It is useful for specific scenarios, such as flaky tests, but we do not want every job to have this parameter by default. It should be used manually to make its intended use more explicit.