### PR TITLE
Switch molecule base job to crc 2.48

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -8,20 +8,20 @@
     timeout: 3600
 - job:
     name: cifmw-molecule-openshift_login
-    nodeset: centos-9-crc-2-39-0-xl
+    nodeset: centos-9-crc-2-48-0-xl
 - job:
     name: cifmw-molecule-openshift_provisioner_node
-    nodeset: centos-9-crc-2-39-0-xl
+    nodeset: centos-9-crc-2-48-0-xl
 - job:
     name: cifmw-molecule-openshift_setup
-    nodeset: centos-9-crc-2-39-0-xl
+    nodeset: centos-9-crc-2-48-0-xl
 - job:
     name: cifmw-molecule-rhol_crc
-    nodeset: centos-9-crc-2-39-0-xxl
+    nodeset: centos-9-crc-2-48-0-xxl
     timeout: 5400
 - job:
     name: cifmw-molecule-operator_deploy
-    nodeset: centos-9-crc-2-39-0-xl
+    nodeset: centos-9-crc-2-48-0-xl
 - job:
     name: cifmw-molecule-set_openstack_containers
     parent: cifmw-molecule-base-crc
@@ -45,13 +45,13 @@
 - job:
     name: cifmw-molecule-install_openstack_ca
     parent: cifmw-molecule-base-crc
-    nodeset: centos-9-crc-2-39-0-3xl
+    nodeset: centos-9-crc-2-48-0-3xl
     timeout: 5400
     extra-vars:
       crc_parameters: "--memory 29000 --disk-size 100 --cpus 8"
 - job:
     name: cifmw-molecule-reproducer
-    nodeset: centos-9-crc-2-39-0-xxl
+    nodeset: centos-9-crc-2-48-0-xxl
     timeout: 5400
     files:
       - ^roles/dnsmasq/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
@@ -62,10 +62,10 @@
       - ^roles/rhol_crc/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
 - job:
     name: cifmw-molecule-cert_manager
-    nodeset: centos-9-crc-2-39-0-xxl
+    nodeset: centos-9-crc-2-48-0-xxl
 - job:
     name: cifmw-molecule-env_op_images
-    nodeset: centos-9-crc-2-39-0-xl
+    nodeset: centos-9-crc-2-48-0-xl
 - job:
     name: cifmw_molecule-pkg_build
     files:
@@ -82,19 +82,19 @@
       - ^roles/repo_setup/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
 - job:
     name: cifmw-molecule-manage_secrets
-    nodeset: centos-9-crc-2-39-0-xl
+    nodeset: centos-9-crc-2-48-0-xl
 - job:
     name: cifmw-molecule-ci_local_storage
-    nodeset: centos-9-crc-2-39-0-xl
+    nodeset: centos-9-crc-2-48-0-xl
 - job:
     name: cifmw-molecule-networking_mapper
     nodeset: 4x-centos-9-medium
 - job:
     name: cifmw-molecule-openshift_obs
-    nodeset: centos-9-crc-2-39-0-xxl
+    nodeset: centos-9-crc-2-48-0-xxl
 - job:
     name: cifmw-molecule-sushy_emulator
-    nodeset: centos-9-crc-2-39-0-xl
+    nodeset: centos-9-crc-2-48-0-xl
 - job:
     name: cifmw-molecule-shiftstack
-    nodeset: centos-9-crc-2-39-0-xl
+    nodeset: centos-9-crc-2-48-0-xl

--- a/ci/playbooks/edpm_baremetal_deployment/run.yml
+++ b/ci/playbooks/edpm_baremetal_deployment/run.yml
@@ -15,10 +15,14 @@
         path: "{{ ansible_user_dir }}/ci-framework-data/artifacts/edpm-ansible.yml"
       register: edpm_file
 
+    - name: Check if new ssh keypair exists
+      ansible.builtin.include_role:
+        name: recognize_ssh_keypair
+
     - name: Add crc node in local inventory
       ansible.builtin.add_host:
         name: crc
-        ansible_ssh_private_key_file: "{{ ansible_user_dir }}/.crc/machines/crc/id_ecdsa"
+        ansible_ssh_private_key_file: "{{ ansible_user_dir }}/.crc/machines/crc/{{ crc_ssh_keypair }}"
         ansible_ssh_user: core
         ansible_host: api.crc.testing
 

--- a/roles/artifacts/README.md
+++ b/roles/artifacts/README.md
@@ -10,6 +10,7 @@ None - writes happen only in the user home.
 * `cifmw_artifacts_crc_host`: (String) Hostname of the CRC instance. Defaults to `api.crc.testing`.
 * `cifmw_artifacts_crc_user`: (String) Username to connect to the CRC instance. Defaults to `core`.
 * `cifmw_artifacts_crc_sshkey`: (String) Path to the private SSH key to connect to CRC. Defaults to `~/.crc/machines/crc/id_ecdsa`.
+* `cifmw_artifacts_crc_sshkey_ed25519`: (String) Path to the private SSH key to connect to CRC (newer CRC images). Defaults to `~/.crc/machines/crc/id_ed25519`.
 * `cifmw_artifacts_gather_logs`: (Boolean) Enables must-gather logs fetching. Defaults to `true`
 
 ## Examples

--- a/roles/artifacts/defaults/main.yml
+++ b/roles/artifacts/defaults/main.yml
@@ -21,4 +21,5 @@ cifmw_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-fra
 cifmw_artifacts_crc_host: "api.crc.testing"
 cifmw_artifacts_crc_user: "core"
 cifmw_artifacts_crc_sshkey: "~/.crc/machines/crc/id_ecdsa"
+cifmw_artifacts_crc_sshkey_ed25519: "~/.crc/machines/crc/id_ed25519"
 cifmw_artifacts_gather_logs: true

--- a/roles/artifacts/tasks/crc.yml
+++ b/roles/artifacts/tasks/crc.yml
@@ -18,12 +18,22 @@
     - crc_host_key.rc is defined
     - crc_host_key.rc == 0
   block:
+    - name: Recognize new keypair
+      ansible.builtin.stat:
+        path: "{{ cifmw_artifacts_crc_sshkey_ed25519 }}"
+      register: _sshkeypair
+
+    - name: Set fact if new keypair exists
+      when: _sshkeypair.stat.exists
+      ansible.builtin.set_fact:
+        new_keypair_path: "{{ cifmw_artifacts_crc_sshkey_ed25519 }}"
+
     - name: Prepare root ssh accesses
       ignore_errors: true  # noqa: ignore-errors
       ci_script:
         output_dir: "{{ cifmw_artifacts_basedir }}/artifacts"
         script: |-
-          ssh -i {{ cifmw_artifacts_crc_sshkey }} {{ cifmw_artifacts_crc_user }}@{{ cifmw_artifacts_crc_host }} <<EOF
+          ssh -i {{ new_keypair_path | default(cifmw_artifacts_crc_sshkey) }} {{ cifmw_artifacts_crc_user }}@{{ cifmw_artifacts_crc_host }} <<EOF
           set -xe;
           test -d /etc/ssh/sshd_config.d/ && sudo sed -ri 's/PermitRootLogin no/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config.d/* || true;
           sudo sed -i 's/PermitRootLogin no/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config;
@@ -36,6 +46,6 @@
       ci_script:
         output_dir: "{{ cifmw_artifacts_basedir }}/artifacts"
         script: >-
-          scp -v -r -i {{ cifmw_artifacts_crc_sshkey }}
+          scp -v -r -i {{ new_keypair_path | default(cifmw_artifacts_crc_sshkey) }}
           root@{{ cifmw_artifacts_crc_host }}:/ostree/deploy/rhcos/var/log/pods
           {{ cifmw_artifacts_basedir }}/logs/crc/

--- a/roles/ci_local_storage/molecule/default/converge.yml
+++ b/roles/ci_local_storage/molecule/default/converge.yml
@@ -26,10 +26,14 @@
     cifmw_cls_storage_capacity: 100Mi
     cifmw_cls_local_storage_name: /mnt/openstack
   tasks:
+    - name: Check if new ssh keypair exists
+      ansible.builtin.include_role:
+        name: recognize_ssh_keypair
+
     - name: Add the crc host dynamically
       ansible.builtin.add_host:
         name: crc
-        ansible_ssh_private_key_file: "{{ ansible_user_dir }}/.crc/machines/crc/id_ecdsa"
+        ansible_ssh_private_key_file: "{{ ansible_user_dir }}/.crc/machines/crc/{{ crc_ssh_keypair }}"
         ansible_ssh_user: core
 
     - name: Run ci_local_storage role

--- a/roles/ci_multus/molecule/default/converge.yml
+++ b/roles/ci_multus/molecule/default/converge.yml
@@ -24,10 +24,14 @@
         path: /etc/hosts
         line: "192.168.130.11 crc"
 
+    - name: Check if new ssh keypair exists
+      ansible.builtin.include_role:
+        name: recognize_ssh_keypair
+
     - name: Add the crc host dynamically
       ansible.builtin.add_host:
         name: crc
-        ansible_ssh_private_key_file: "{{ ansible_user_dir }}/.crc/machines/crc/id_ecdsa"
+        ansible_ssh_private_key_file: "{{ ansible_user_dir }}/.crc/machines/crc/{{ crc_ssh_keypair }}"
         ansible_ssh_user: core
 
     - name: Fetch crc network facts

--- a/roles/ci_nmstate/molecule/default/converge.yml
+++ b/roles/ci_nmstate/molecule/default/converge.yml
@@ -26,10 +26,14 @@
         path: /etc/hosts
         line: "192.168.130.11 crc"
 
+    - name: Check if new ssh keypair exists
+      ansible.builtin.include_role:
+        name: recognize_ssh_keypair
+
     - name: Add the crc host dynamically
       ansible.builtin.add_host:
         name: crc
-        ansible_ssh_private_key_file: "{{ ansible_user_dir }}/.crc/machines/crc/id_ecdsa"
+        ansible_ssh_private_key_file: "{{ ansible_user_dir }}/.crc/machines/crc/{{ crc_ssh_keypair }}"
         ansible_ssh_user: core
         cifmw_molecule_ci_nmstate_crc_mac: "{{ cifmw_molecule_ci_nmstate_crc_mac }}"
 

--- a/roles/env_op_images/tasks/main.yml
+++ b/roles/env_op_images/tasks/main.yml
@@ -54,8 +54,6 @@
           -o yaml
       register: _csvs_out
 
-    # FIXME: why there is no "manager" anymore? Should we parse
-    # all images with *manager* ?
     - name: Get the images name
       ansible.builtin.shell: >
         set -o pipefail;
@@ -69,12 +67,11 @@
         .spec.template.spec.containers[]? |
         .env[]? |
         select(.name? | test("^RELATED_IMAGE")) |
+        select(.name == "*manager*" or .name == "*MANAGER*") |
         {(.name): .value}]'
       register: _sa_images_content
       args:
         executable: /bin/bash
-      environment:
-        KUBECONFIG: "{{ ansible_user_dir }}/.kube/config"
 
     - name: Extract env variable name and images
       ansible.builtin.set_fact:

--- a/roles/env_op_images/tasks/main.yml
+++ b/roles/env_op_images/tasks/main.yml
@@ -54,37 +54,31 @@
           -o yaml
       register: _csvs_out
 
+    # FIXME: why there is no "manager" anymore? Should we parse
+    # all images with *manager* ?
+    - name: Get the images name
+      ansible.builtin.shell: >
+        set -o pipefail;
+        oc get ClusterServiceVersion
+        -l operators.coreos.com/openstack-operator.openstack-operators
+        --all-namespaces
+        -o yaml |
+        yq e '
+        [.items[]? |
+        .spec.install.spec.deployments[]? |
+        .spec.template.spec.containers[]? |
+        .env[]? |
+        select(.name? | test("^RELATED_IMAGE")) |
+        {(.name): .value}]'
+      register: _sa_images_content
+      args:
+        executable: /bin/bash
+      environment:
+        KUBECONFIG: "{{ ansible_user_dir }}/.kube/config"
+
     - name: Extract env variable name and images
       ansible.builtin.set_fact:
-        cifmw_openstack_service_images_content: >-
-          {{
-            cifmw_openstack_service_images_content |
-            default({}) |
-            combine(
-              {
-                item.name: item.value
-              }
-            )
-          }}
-      loop: >-
-        {{
-          (_csvs_out.stdout | from_yaml)['items'] |
-          flatten(levels=1) |
-          selectattr('spec.install.spec.deployments', 'defined') |
-          map(attribute='spec.install.spec.deployments') |
-          flatten(levels=1) |
-          selectattr('spec.template.spec.containers', 'defined') |
-          map(attribute='spec.template.spec.containers') |
-          flatten(levels=1) |
-          selectattr('name', 'defined') |
-          selectattr('name', 'equalto', 'manager') |
-          selectattr('env', 'defined') |
-          map(attribute='env') |
-          flatten(levels=1) |
-          selectattr("name", "match", "^RELATED_IMAGE")
-        }}
-      loop_control:
-        label: "{{ item.name }}"
+        cifmw_openstack_service_images_content: "{{ _sa_images_content.stdout | from_yaml }}"
 
     - name: Get all the pods in openstack-operator namespace
       vars:

--- a/roles/install_openstack_ca/molecule/default/prepare.yml
+++ b/roles/install_openstack_ca/molecule/default/prepare.yml
@@ -56,6 +56,11 @@
           NETWORK_ISOLATION: false
           TIMEOUT: "600s"
 
+    - name: Install openstack operator and wait for openstackversion resource
+      ansible.builtin.include_role:
+        name: 'install_yamls_makes'
+        tasks_from: 'make_openstack_init'
+
     - name: Deploy openstack controlplane
       ansible.builtin.include_role:
         name: 'install_yamls_makes'

--- a/roles/install_yamls/tasks/zuul_set_operators_repo.yml
+++ b/roles/install_yamls/tasks/zuul_set_operators_repo.yml
@@ -15,23 +15,43 @@
 # under the License.
 
 # When using CI (Zuul) to deploy operators and its dependencies with install_yamls,
-#  it may be needed to set operator's repo variable to properly clone PR's
-#  code, instead of getting latest promoted content. This task search for all
-#  modified operators in zuul.items[] and set install_yaml variables.
+# it may be needed to set operator's repo variable to properly clone PR's
+# code, instead of getting latest promoted content. This task search for all
+# modified operators in zuul.items[] and set install_yaml variables.
+
 - name: Create variables with local repos based on Zuul items
   when:
     - zuul is defined
     - "'operator' in zuul_item.project.short_name"
     - "'openstack-k8s-operators' in zuul_item.project.name"
-  vars:
-    _repo_operator_name: "{{ zuul_item.project.short_name | regex_search('(?:openstack-)?(.*)-operator', '\\1') | first }}"
-    _repo_operator_info:
-      - key: "{{ _repo_operator_name | upper }}_REPO"
-        value: "{{ ansible_user_dir }}/{{ zuul_item.project.src_dir }}"
-      - key: "{{ _repo_operator_name | upper }}_BRANCH"
-        value: ""
-  ansible.builtin.set_fact:
-    cifmw_install_yamls_operators_repo: "{{ cifmw_install_yamls_operators_repo | default({}) | combine(_repo_operator_info | items2dict) }}"
-  loop: "{{ zuul['items'] }}"
-  loop_control:
-    loop_var: zuul_item
+  block:
+    - name: Set fact with local repos based on Zuul items
+      vars:
+        _repo_operator_name: "{{ zuul_item.project.short_name | regex_search('(?:openstack-)?(.*)-operator', '\\1') | first }}"
+        _repo_operator_info:
+          - key: "{{ _repo_operator_name | upper }}_REPO"
+            value: "{{ ansible_user_dir }}/{{ zuul_item.project.src_dir }}"
+          - key: "{{ _repo_operator_name | upper }}_BRANCH"
+            value: ""
+      ansible.builtin.set_fact:
+        cifmw_install_yamls_operators_repo: "{{ cifmw_install_yamls_operators_repo | default({}) | combine(_repo_operator_info | items2dict) }}"
+      loop: "{{ zuul['items'] }}"
+      loop_control:
+        loop_var: zuul_item
+
+    - name: Print helpful data for debugging
+      vars:
+        _repo_operator_name: "{{ zuul_item.project.short_name | regex_search('(?:openstack-)?(.*)-operator', '\\1') | first }}"
+        _repo_operator_info:
+          - key: "{{ _repo_operator_name | upper }}_REPO"
+            value: "{{ ansible_user_dir }}/{{ zuul_item.project.src_dir }}"
+          - key: "{{ _repo_operator_name | upper }}_BRANCH"
+            value: ""
+      ansible.builtin.debug:
+        msg: |
+          _repo_operator_name: {{ _repo_operator_name }}
+          _repo_operator_info: {{ _repo_operator_info }}
+          cifmw_install_yamls_operators_repo: {{ cifmw_install_yamls_operators_repo }}
+      loop: "{{ zuul['items'] }}"
+      loop_control:
+        loop_var: zuul_item

--- a/roles/libvirt_manager/tasks/manage_vms.yml
+++ b/roles/libvirt_manager/tasks/manage_vms.yml
@@ -1,4 +1,9 @@
 ---
+- name: Check if new ssh keypair exists
+  when: vm_type == 'crc'
+  ansible.builtin.include_role:
+    name: recognize_ssh_keypair
+
 - name: "Push ssh jumper/configuration for {{ vm }}"
   vars:
     _ocp_name: >-
@@ -40,7 +45,7 @@
       identity_file: >-
         {{
           cifmw_libvirt_manager_basedir ~ '/artifacts/cifmw_ocp_access_key' if vm_type is match('^ocp.*') else
-          ansible_user_dir ~ '/.crc/machines/crc/id_ecdsa' if vm_type == 'crc' else
+          ansible_user_dir ~ '/.crc/machines/crc/' +  crc_ssh_keypair if vm_type == 'crc' else
           ansible_user_dir ~ '/.ssh/cifmw_reproducer_key'
         }}
     config: >-

--- a/roles/openshift_obs/molecule/default/converge.yml
+++ b/roles/openshift_obs/molecule/default/converge.yml
@@ -35,10 +35,14 @@
         path: /etc/hosts
         line: "192.168.130.11 crc"
 
+    - name: Check if new ssh keypair exists
+      ansible.builtin.include_role:
+        name: recognize_ssh_keypair
+
     - name: Add the crc host dynamically
       ansible.builtin.add_host:
         name: crc
-        ansible_ssh_private_key_file: "{{ ansible_user_dir }}/.crc/machines/crc/id_ecdsa"
+        ansible_ssh_private_key_file: "{{ ansible_user_dir }}/.crc/machines/crc/{{ crc_ssh_keypair }}"
         ansible_ssh_user: core
 
     - name: Deploy Cluster observability Operator

--- a/roles/recognize_ssh_keypair/tasks/main.yaml
+++ b/roles/recognize_ssh_keypair/tasks/main.yaml
@@ -1,0 +1,15 @@
+---
+- name: Check if id_ed25519 key exists
+  ansible.builtin.stat:
+    path: "~/.crc/machines/crc/id_ed25519"
+  register: _ed25519_key
+
+- name: Set fact if new keypair exists
+  when: _ed25519_key.stat.exists
+  ansible.builtin.set_fact:
+    crc_ssh_keypair: "id_ed25519"
+
+- name: Set fact if new keypair does not exists
+  when: not _ed25519_key.stat.exists
+  ansible.builtin.set_fact:
+    crc_ssh_keypair: "id_ecdsa"

--- a/roles/reproducer/tasks/crc_layout.yml
+++ b/roles/reproducer/tasks/crc_layout.yml
@@ -25,10 +25,14 @@
     name: rhol_crc
     tasks_from: undefine.yml
 
+- name: Check if new ssh keypair exists
+  ansible.builtin.include_role:
+    name: recognize_ssh_keypair
+
 - name: Slurp ssh key for CRC access
   register: crc_priv_key
   ansible.builtin.slurp:
-    path: "{{ ansible_user_dir}}/.crc/machines/crc/id_ecdsa"
+    path: "{{ ansible_user_dir}}/.crc/machines/crc/{{ crc_ssh_keypair }}"
 
 - name: Get kubeconfig file from crc directory
   register: _crc_kubeconfig

--- a/roles/rhol_crc/tasks/add_crc_creds.yml
+++ b/roles/rhol_crc/tasks/add_crc_creds.yml
@@ -18,7 +18,7 @@
         create: true
         block: |-
           if command -v crc; then
-              eval $(crc oc-env)
+              eval "$(crc oc-env --shell bash)"
           fi
           export KUBECONFIG="{{ cifmw_rhol_crc_kubeconfig }}"
         mode: "0644"
@@ -32,6 +32,8 @@
       changed_when: false
       retries: 30
       delay: 20
+      args:
+        executable: /bin/bash
 
     - name: Check bashrc results
       ansible.builtin.debug:

--- a/roles/rhol_crc/tasks/add_crc_creds.yml
+++ b/roles/rhol_crc/tasks/add_crc_creds.yml
@@ -17,7 +17,9 @@
         dest: ~/.bashrc
         create: true
         block: |-
-          eval $(crc oc-env)
+          if command -v crc; then
+              eval $(crc oc-env)
+          fi
           export KUBECONFIG="{{ cifmw_rhol_crc_kubeconfig }}"
         mode: "0644"
 

--- a/roles/sushy_emulator/molecule/default/converge.yml
+++ b/roles/sushy_emulator/molecule/default/converge.yml
@@ -50,10 +50,14 @@
         file: input.yml
         name: cifmw_networking_definition
 
+    - name: Check if new ssh keypair exists
+      ansible.builtin.include_role:
+        name: recognize_ssh_keypair
+
     - name: Add the crc host dynamically
       ansible.builtin.add_host:
         name: crc
-        ansible_ssh_private_key_file: "{{ ansible_user_dir }}/.crc/machines/crc/id_ecdsa"
+        ansible_ssh_private_key_file: "{{ ansible_user_dir }}/.crc/machines/crc/{{ crc_ssh_keypair }}"
         ansible_ssh_user: core
 
     - name: Add ansible_host entry to "{{ cifmw_sushy_emulator_hypervisor_target }}"

--- a/zuul.d/molecule-base.yaml
+++ b/zuul.d/molecule-base.yaml
@@ -23,7 +23,7 @@
 
 - job:
     name: cifmw-molecule-base-crc
-    nodeset: centos-9-crc-2-39-0-xxl
+    nodeset: centos-9-crc-2-48-0-xxl
     parent: base-simple-crc
     provides:
       - cifmw-molecule

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -877,6 +877,15 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/federation/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-federation
+    parent: cifmw-molecule-noop
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/krb_request/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
@@ -908,6 +917,15 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-polarion
+    parent: cifmw-molecule-noop
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
+    - ^roles/recognize_ssh_keypair/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-recognize_ssh_keypair
     parent: cifmw-molecule-noop
 - job:
     files:

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -52,7 +52,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cert_manager
-    nodeset: centos-9-crc-2-39-0-xxl
+    nodeset: centos-9-crc-2-48-0-xxl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: cert_manager
@@ -77,7 +77,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_local_storage
-    nodeset: centos-9-crc-2-39-0-xl
+    nodeset: centos-9-crc-2-48-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: ci_local_storage
@@ -364,7 +364,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-env_op_images
-    nodeset: centos-9-crc-2-39-0-xl
+    nodeset: centos-9-crc-2-48-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: env_op_images
@@ -422,7 +422,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-install_openstack_ca
-    nodeset: centos-9-crc-2-39-0-3xl
+    nodeset: centos-9-crc-2-48-0-3xl
     parent: cifmw-molecule-base-crc
     timeout: 5400
     vars:
@@ -474,7 +474,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-manage_secrets
-    nodeset: centos-9-crc-2-39-0-xl
+    nodeset: centos-9-crc-2-48-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: manage_secrets
@@ -520,7 +520,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_login
-    nodeset: centos-9-crc-2-39-0-xl
+    nodeset: centos-9-crc-2-48-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: openshift_login
@@ -532,7 +532,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_obs
-    nodeset: centos-9-crc-2-39-0-xxl
+    nodeset: centos-9-crc-2-48-0-xxl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: openshift_obs
@@ -544,7 +544,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_provisioner_node
-    nodeset: centos-9-crc-2-39-0-xl
+    nodeset: centos-9-crc-2-48-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: openshift_provisioner_node
@@ -556,7 +556,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_setup
-    nodeset: centos-9-crc-2-39-0-xl
+    nodeset: centos-9-crc-2-48-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: openshift_setup
@@ -579,7 +579,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-operator_deploy
-    nodeset: centos-9-crc-2-39-0-xl
+    nodeset: centos-9-crc-2-48-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: operator_deploy
@@ -674,7 +674,7 @@
     - ^roles/sushy_emulator/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
     - ^roles/rhol_crc/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
     name: cifmw-molecule-reproducer
-    nodeset: centos-9-crc-2-39-0-xxl
+    nodeset: centos-9-crc-2-48-0-xxl
     parent: cifmw-molecule-base
     timeout: 5400
     vars:
@@ -687,7 +687,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-rhol_crc
-    nodeset: centos-9-crc-2-39-0-xxl
+    nodeset: centos-9-crc-2-48-0-xxl
     parent: cifmw-molecule-base
     timeout: 5400
     vars:
@@ -722,7 +722,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-shiftstack
-    nodeset: centos-9-crc-2-39-0-xl
+    nodeset: centos-9-crc-2-48-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: shiftstack
@@ -745,7 +745,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-sushy_emulator
-    nodeset: centos-9-crc-2-39-0-xl
+    nodeset: centos-9-crc-2-48-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: sushy_emulator

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -326,3 +326,275 @@
     nodes:
       - name: controller
         label: centos-9-stream-crc-2-39-0-xl
+
+
+#
+# CRC-2.48 (OCP4.18) nodesets
+#
+
+- nodeset:
+    name: centos-9-medium-crc-extracted-2-48-0-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: crc
+        label: crc-cloud-ocp-4-18-1-3xl
+    groups:
+      - name: computes
+        nodes: []
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-crc-2-48-0-xxl
+    nodes:
+      - name: controller
+        label: centos-9-stream-crc-2-48-0-xxl
+
+- nodeset:
+    name: centos-9-rhel-9-2-crc-extracted-2-48-0-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: crc-cloud-ocp-4-18-1-3xl
+      - name: standalone
+        label: cloud-rhel-9-2-tripleo
+    groups:
+      - name: computes
+        nodes: []
+      - name: ocps
+        nodes:
+          - crc
+      - name: rh-subscription
+        nodes:
+          - standalone
+
+- nodeset:
+    name: centos-9-multinode-rhel-9-2-crc-extracted-2-48-0-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: crc-cloud-ocp-4-18-1-3xl
+      - name: undercloud
+        label: cloud-rhel-9-2-tripleo
+      - name: overcloud-controller-0
+        label: cloud-rhel-9-2-tripleo
+      - name: overcloud-controller-1
+        label: cloud-rhel-9-2-tripleo
+      - name: overcloud-controller-2
+        label: cloud-rhel-9-2-tripleo
+      - name: overcloud-novacompute-0
+        label: cloud-rhel-9-2-tripleo
+      - name: overcloud-novacompute-1
+        label: cloud-rhel-9-2-tripleo
+      - name: overcloud-novacompute-2
+        label: cloud-rhel-9-2-tripleo
+    groups:
+      - name: computes
+        nodes: []
+      - name: ocps
+        nodes:
+          - crc
+      - name: rh-subscription
+        nodes:
+          - undercloud
+          - overcloud-controller-0
+          - overcloud-controller-1
+          - overcloud-controller-2
+          - overcloud-novacompute-0
+          - overcloud-novacompute-1
+          - overcloud-novacompute-2
+      - name: tripleo_controllers
+        nodes:
+          - overcloud-controller-0
+          - overcloud-controller-1
+          - overcloud-controller-2
+      - name: tripleo_computes
+        nodes:
+          - overcloud-novacompute-0
+          - overcloud-novacompute-1
+          - overcloud-novacompute-2
+
+- nodeset:
+    name: centos-9-multinode-rhel-9-2-crc-extracted-2-48-0-3xl-novacells
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: crc-cloud-ocp-4-18-1-3xl
+      - name: undercloud
+        label: cloud-rhel-9-2-tripleo
+      - name: overcloud-controller-0
+        label: cloud-rhel-9-2-tripleo
+      - name: cell1-controller-0
+        label: cloud-rhel-9-2-tripleo
+      - name: cell1-compute-0
+        label: cloud-rhel-9-2-tripleo
+      - name: cell2-controller-compute-0
+        label: cloud-rhel-9-2-tripleo
+    groups:
+      - name: computes
+        nodes: []
+      - name: ocps
+        nodes:
+          - crc
+      - name: rh-subscription
+        nodes:
+          - undercloud
+          - overcloud-controller-0
+          - cell1-controller-0
+          - cell2-controller-compute-0
+          - cell1-compute-0
+      - name: tripleo_controllers
+        nodes:
+          - overcloud-controller-0
+          - cell1-controller-0
+          - cell2-controller-compute-0
+      - name: tripleo_computes
+        nodes:
+          - cell1-compute-0
+          - cell2-controller-compute-0
+
+- nodeset:
+    name: centos-9-medium-centos-9-crc-extracted-2-48-0-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: crc-cloud-ocp-4-18-1-3xl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-crc-2-48-0-3xl
+    nodes:
+      - name: controller
+        label: centos-9-stream-crc-2-48-0-3xl
+
+- nodeset:
+    name: centos-9-medium-2x-centos-9-crc-extracted-2-48-0-xxl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+        # Note(Chandan Kumar): Switch to xxl nodeset once RHOSZUUL-1940 resolves
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: crc-cloud-ocp-4-18-1-xxl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-2x-centos-9-xxl-crc-extracted-2-48-0-xxl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo-xxl
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo-xxl
+      - name: crc
+        label: crc-cloud-ocp-4-18-1-xxl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-medium-3x-centos-9-crc-extracted-2-48-0-xxl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-2
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: crc-cloud-ocp-4-18-1-xxl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+          - compute-2
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-medium-3x-centos-9-crc-extracted-2-48-0-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-2
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: crc-cloud-ocp-4-18-1-3xl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+          - compute-2
+      - name: ocps
+        nodes:
+          - crc
+
+
+# todo: Remove. Temporal. Needed as the credentials used in ci-bootstrap jobs for IBM don't work
+- nodeset:
+    name: centos-9-medium-centos-9-crc-extracted-2-48-0-3xl-vexxhost
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-vexxhost-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo-vexxhost
+      - name: crc
+        label: crc-cloud-ocp-4-18-1-3xl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-crc-2-48-0-6xlarge
+    nodes:
+      - name: controller
+        label: centos-9-stream-crc-2-48-0-6xlarge
+
+- nodeset:
+    name: centos-9-crc-2-48-0-xl
+    nodes:
+      - name: controller
+        label: centos-9-stream-crc-2-48-0-xl

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -50,6 +50,7 @@
       - cifmw-molecule-edpm_kustomize
       - cifmw-molecule-edpm_prepare
       - cifmw-molecule-env_op_images
+      - cifmw-molecule-federation
       - cifmw-molecule-hci_prepare
       - cifmw-molecule-hive
       - cifmw-molecule-idrac_configuration
@@ -76,6 +77,7 @@
       - cifmw-molecule-pkg_build
       - cifmw-molecule-podman
       - cifmw-molecule-polarion
+      - cifmw-molecule-recognize_ssh_keypair
       - cifmw-molecule-registry_deploy
       - cifmw-molecule-repo_setup
       - cifmw-molecule-reportportal


### PR DESCRIPTION
After merging change https://github.com/openstack-k8s-operators/ci-framework/pull/2795, it would be good to switch other molecule jobs to use newer image.