### PR TITLE
Add content-provider variant for FR2

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -109,6 +109,18 @@
     vars:
       cifmw_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 
+# Variant for FR2: some projects do not have 18.0-fr2 branch, so we override...
+# (when preparing a build for matching branch, Zuul will merge the definitions)
+- job:
+    name: openstack-k8s-operators-content-provider
+    parent: cifmw-base-minimal
+    branches: ^18.0-fr2
+    required-projects:
+      - name: openstack-k8s-operators/ci-framework
+        override-checkout: main
+      - name: openstack-k8s-operators/repo-setup
+        override-checkout: main
+
 
 #
 # EDPM MULTINODE CI


### PR DESCRIPTION
Some required projects do not have 18.0-fr2 branch, so we override them to checkout the main branch by default. When preparing a build for a matching branch, Zuul will merge the jobs definitions and the override will happen only for FR2.

It would be still possible to use Depends-On to test specific changes in the projects that are listed as required ones.