### PR TITLE
Revert "Add content-provider variant for FR2"

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -109,18 +109,6 @@
     vars:
       cifmw_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 
-# Variant for FR2: some projects do not have 18.0-fr2 branch, so we override...
-# (when preparing a build for matching branch, Zuul will merge the definitions)
-- job:
-    name: openstack-k8s-operators-content-provider
-    parent: cifmw-base-minimal
-    branches: ^18.0-fr2
-    required-projects:
-      - name: openstack-k8s-operators/ci-framework
-        override-checkout: main
-      - name: openstack-k8s-operators/repo-setup
-        override-checkout: main
-
 
 #
 # EDPM MULTINODE CI


### PR DESCRIPTION
This reverts commit f30dc77a74a3762bf777845bf477832feef273c0 from https://github.com/openstack-k8s-operators/ci-framework/pull/2804

It was merged accidentally and too early, before extensive testing.