### PR TITLE
Use only IBM hosts for some molecule CI jobs

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -8,16 +8,16 @@
     timeout: 3600
 - job:
     name: cifmw-molecule-openshift_login
-    nodeset: centos-9-crc-2-48-0-xl
+    nodeset: centos-9-crc-2-48-0-xl-ibm
 - job:
     name: cifmw-molecule-openshift_provisioner_node
-    nodeset: centos-9-crc-2-48-0-xl
+    nodeset: centos-9-crc-2-48-0-xl-ibm
 - job:
     name: cifmw-molecule-openshift_setup
-    nodeset: centos-9-crc-2-48-0-xl
+    nodeset: centos-9-crc-2-48-0-xl-ibm
 - job:
     name: cifmw-molecule-rhol_crc
-    nodeset: centos-9-crc-2-48-0-xxl
+    nodeset: centos-9-crc-2-48-0-xxl-ibm
     timeout: 5400
 - job:
     name: cifmw-molecule-operator_deploy
@@ -45,13 +45,13 @@
 - job:
     name: cifmw-molecule-install_openstack_ca
     parent: cifmw-molecule-base-crc
-    nodeset: centos-9-crc-2-48-0-3xl
+    nodeset: centos-9-crc-2-48-0-3xl-ibm
     timeout: 5400
     extra-vars:
       crc_parameters: "--memory 29000 --disk-size 100 --cpus 8"
 - job:
     name: cifmw-molecule-reproducer
-    nodeset: centos-9-crc-2-48-0-xxl
+    nodeset: centos-9-crc-2-48-0-xxl-ibm
     timeout: 5400
     files:
       - ^roles/dnsmasq/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
@@ -62,10 +62,10 @@
       - ^roles/rhol_crc/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
 - job:
     name: cifmw-molecule-cert_manager
-    nodeset: centos-9-crc-2-48-0-xxl
+    nodeset: centos-9-crc-2-48-0-xxl-ibm
 - job:
     name: cifmw-molecule-env_op_images
-    nodeset: centos-9-crc-2-48-0-xl
+    nodeset: centos-9-crc-2-48-0-xl-ibm
 - job:
     name: cifmw_molecule-pkg_build
     files:
@@ -82,19 +82,19 @@
       - ^roles/repo_setup/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
 - job:
     name: cifmw-molecule-manage_secrets
-    nodeset: centos-9-crc-2-48-0-xl
+    nodeset: centos-9-crc-2-48-0-xl-ibm
 - job:
     name: cifmw-molecule-ci_local_storage
-    nodeset: centos-9-crc-2-48-0-xl
+    nodeset: centos-9-crc-2-48-0-xl-ibm
 - job:
     name: cifmw-molecule-networking_mapper
     nodeset: 4x-centos-9-medium
 - job:
     name: cifmw-molecule-openshift_obs
-    nodeset: centos-9-crc-2-48-0-xxl
+    nodeset: centos-9-crc-2-48-0-xxl-ibm
 - job:
     name: cifmw-molecule-sushy_emulator
-    nodeset: centos-9-crc-2-48-0-xl
+    nodeset: centos-9-crc-2-48-0-xl-ibm
 - job:
     name: cifmw-molecule-shiftstack
-    nodeset: centos-9-crc-2-48-0-xl
+    nodeset: centos-9-crc-2-48-0-xl-ibm

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -52,7 +52,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cert_manager
-    nodeset: centos-9-crc-2-48-0-xxl
+    nodeset: centos-9-crc-2-48-0-xxl-ibm
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: cert_manager
@@ -77,7 +77,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_local_storage
-    nodeset: centos-9-crc-2-48-0-xl
+    nodeset: centos-9-crc-2-48-0-xl-ibm
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: ci_local_storage
@@ -364,7 +364,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-env_op_images
-    nodeset: centos-9-crc-2-48-0-xl
+    nodeset: centos-9-crc-2-48-0-xl-ibm
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: env_op_images
@@ -422,7 +422,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-install_openstack_ca
-    nodeset: centos-9-crc-2-48-0-3xl
+    nodeset: centos-9-crc-2-48-0-3xl-ibm
     parent: cifmw-molecule-base-crc
     timeout: 5400
     vars:
@@ -474,7 +474,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-manage_secrets
-    nodeset: centos-9-crc-2-48-0-xl
+    nodeset: centos-9-crc-2-48-0-xl-ibm
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: manage_secrets
@@ -520,7 +520,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_login
-    nodeset: centos-9-crc-2-48-0-xl
+    nodeset: centos-9-crc-2-48-0-xl-ibm
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: openshift_login
@@ -532,7 +532,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_obs
-    nodeset: centos-9-crc-2-48-0-xxl
+    nodeset: centos-9-crc-2-48-0-xxl-ibm
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: openshift_obs
@@ -544,7 +544,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_provisioner_node
-    nodeset: centos-9-crc-2-48-0-xl
+    nodeset: centos-9-crc-2-48-0-xl-ibm
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: openshift_provisioner_node
@@ -556,7 +556,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_setup
-    nodeset: centos-9-crc-2-48-0-xl
+    nodeset: centos-9-crc-2-48-0-xl-ibm
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: openshift_setup
@@ -674,7 +674,7 @@
     - ^roles/sushy_emulator/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
     - ^roles/rhol_crc/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
     name: cifmw-molecule-reproducer
-    nodeset: centos-9-crc-2-48-0-xxl
+    nodeset: centos-9-crc-2-48-0-xxl-ibm
     parent: cifmw-molecule-base
     timeout: 5400
     vars:
@@ -687,7 +687,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-rhol_crc
-    nodeset: centos-9-crc-2-48-0-xxl
+    nodeset: centos-9-crc-2-48-0-xxl-ibm
     parent: cifmw-molecule-base
     timeout: 5400
     vars:
@@ -722,7 +722,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-shiftstack
-    nodeset: centos-9-crc-2-48-0-xl
+    nodeset: centos-9-crc-2-48-0-xl-ibm
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: shiftstack
@@ -745,7 +745,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-sushy_emulator
-    nodeset: centos-9-crc-2-48-0-xl
+    nodeset: centos-9-crc-2-48-0-xl-ibm
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: sushy_emulator


### PR DESCRIPTION
The IBM hosts have less usage so some part of jobs might less fail.
Temporary use only IBM hosts for some molecule CI jobs until Zuul
will round robin jobs between all providers.

Needs: https://github.com/openstack-k8s-operators/ci-framework/pull/2812