### PR TITLE
Add IBM nodesets that will enforce spawning CI on IBM hosts

### DIFF
--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -598,3 +598,28 @@
     nodes:
       - name: controller
         label: centos-9-stream-crc-2-48-0-xl
+
+### Molecule jobs - force use IBM hosts ###
+- nodeset:
+    name: centos-9-crc-2-48-0-xl-ibm
+    nodes:
+      - name: controller
+        label: centos-9-stream-crc-2-48-0-xl-ibm
+
+- nodeset:
+    name: centos-9-crc-2-48-0-xxl-ibm
+    nodes:
+      - name: controller
+        label: centos-9-stream-crc-2-48-0-xxl-ibm
+
+- nodeset:
+    name: centos-9-crc-2-48-0-3xl-ibm
+    nodes:
+      - name: controller
+        label: centos-9-stream-crc-2-48-0-3xl-ibm
+
+- nodeset:
+    name: centos-9-crc-2-39-0-6xlarge-ibm
+    nodes:
+      - name: controller
+        label: centos-9-stream-crc-2-39-0-6xlarge-ibm


### PR DESCRIPTION
Some CI jobs would be executed directly on the IBM private cloud until Zuul CI will not make round robin between all providers.