### PR TITLE
Revert "[bop]Donot use dlrn --local for downstream"

### DIFF
--- a/roles/build_openstack_packages/tasks/parse_and_build_pkgs.yml
+++ b/roles/build_openstack_packages/tasks/parse_and_build_pkgs.yml
@@ -19,7 +19,6 @@
             'project': item.project.name,
             'branch': item.branch,
             'change': item.change,
-            'src_dir': item.project.src_dir,
             'refspec': '/'.join(['refs', 'changes',
                                   item.change[-2:],
                                   item.change,

--- a/roles/build_openstack_packages/tasks/run_dlrn.yml
+++ b/roles/build_openstack_packages/tasks/run_dlrn.yml
@@ -114,15 +114,29 @@
         dest: '{{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}'
         version: '{{ _change.branch }}'
 
-    - name: "Symlink {{ project_name_mapped.stdout }} from Zuul clonned repos" # noqa: name[template]
+    - name: "Clone {{ project_name_mapped.stdout }} from Github" # noqa: name[template]
       when:
         - cifmw_bop_openstack_project_path | length == 0
         - not repo_status.stat.exists
-        - "'src_dir' in _change"
-      ansible.builtin.file:
-        src: '{{ ansible_user_dir }}/{{ _change.src_dir }}'
-        path: '{{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}'
-        state: link
+        - "'host' in _change"
+        - "'github.com' in _change.host"
+      ansible.builtin.git:
+        repo: '{{ _change.host }}/{{ _change.project }}'
+        dest: '{{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}'
+        refspec: "+refs/pull/*:refs/remotes/origin/pr/*"
+        version: 'origin/pr/{{ _change.change }}/head'
+
+    - name: "Clone Openstack {{ project_name_mapped.stdout }}" # noqa: name[template]
+      when:
+        - cifmw_bop_openstack_project_path | length == 0
+        - not repo_status.stat.exists
+        - "'host' in _change"
+        - "'opendev' in _change.host"
+      ansible.builtin.git:
+        repo: '{{ _change.host }}/{{ _change.project }}'
+        dest: '{{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}'
+        refspec: "{{ _change.refspec }}"
+        version: 'FETCH_HEAD'
 
     - name: "Update packages.yml to use zuul repo for {{ project_name_mapped.stdout }}" # noqa: name[template], command-instead-of-module
       vars:

--- a/roles/build_openstack_packages/templates/run_dlrn.sh.j2
+++ b/roles/build_openstack_packages/templates/run_dlrn.sh.j2
@@ -8,10 +8,7 @@ export REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.cr
 {% endif %}
 
 while true; do
-    dlrn --config-file projects.ini --head-only --package-name $PKG \
-    {% if cifmw_bop_osp_release is not defined  %}
-        --local \
-    {% endif %}
+    dlrn --config-file projects.ini --head-only --package-name $PKG --local \
         --info-repo {{ cifmw_bop_build_repo_dir }}/DLRN/{{ cifmw_bop_rdoinfo_repo_name }} \
 	--dev;
     if [ $? -eq 0 ]; then


### PR DESCRIPTION
I am proposing a new approach for this. I have proposed a slight change in the behavior of the dlrn downstream driver [1] which avoids the issue with the versions.csv and gives us the advantadges of using --local (i.e. we don't need to worry about git repos remotes, etc...)

[1] https://softwarefactory-project.io/r/c/DLRN/+/33366

This reverts commit cd2198d97e92e0d696a94c9d269eb4e9ee1ba219.