### PR TITLE
Revert "Use zuul clonned repos for upstream in build_openstack_packages role" and revers zuul changes list

### DIFF
--- a/roles/build_openstack_packages/tasks/parse_and_build_pkgs.yml
+++ b/roles/build_openstack_packages/tasks/parse_and_build_pkgs.yml
@@ -1,6 +1,6 @@
 ---
 - name: Parse Zuul changes
-  with_items: "{{ zuul['items'] }}"
+  with_items: "{{ zuul['items'] | reverse | list }}"
   when:
     - zuul is defined
     - "'change_url' in item"

--- a/roles/build_openstack_packages/tasks/parse_and_build_pkgs.yml
+++ b/roles/build_openstack_packages/tasks/parse_and_build_pkgs.yml
@@ -19,7 +19,6 @@
             'project': item.project.name,
             'branch': item.branch,
             'change': item.change,
-            'src_dir': item.project.src_dir,
             'refspec': '/'.join(['refs', 'changes',
                                   item.change[-2:],
                                   item.change,

--- a/roles/build_openstack_packages/tasks/run_dlrn.yml
+++ b/roles/build_openstack_packages/tasks/run_dlrn.yml
@@ -114,15 +114,29 @@
         dest: '{{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}'
         version: '{{ _change.branch }}'
 
-    - name: "Symlink {{ project_name_mapped.stdout }} from Zuul clonned repos" # noqa: name[template]
+    - name: "Clone {{ project_name_mapped.stdout }} from Github" # noqa: name[template]
       when:
         - cifmw_bop_openstack_project_path | length == 0
         - not repo_status.stat.exists
-        - "'src_dir' in _change"
-      ansible.builtin.file:
-        src: '{{ ansible_user_dir }}/{{ _change.src_dir }}'
-        path: '{{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}'
-        state: link
+        - "'host' in _change"
+        - "'github.com' in _change.host"
+      ansible.builtin.git:
+        repo: '{{ _change.host }}/{{ _change.project }}'
+        dest: '{{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}'
+        refspec: "+refs/pull/*:refs/remotes/origin/pr/*"
+        version: 'origin/pr/{{ _change.change }}/head'
+
+    - name: "Clone Openstack {{ project_name_mapped.stdout }}" # noqa: name[template]
+      when:
+        - cifmw_bop_openstack_project_path | length == 0
+        - not repo_status.stat.exists
+        - "'host' in _change"
+        - "'opendev' in _change.host"
+      ansible.builtin.git:
+        repo: '{{ _change.host }}/{{ _change.project }}'
+        dest: '{{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}'
+        refspec: "{{ _change.refspec }}"
+        version: 'FETCH_HEAD'
 
     - name: "Update packages.yml to use zuul repo for {{ project_name_mapped.stdout }}" # noqa: name[template], command-instead-of-module
       vars:


### PR DESCRIPTION
This is breaking builds with downstream driver in two ways:

- Not using --local requires the repos to have proper remote definition.
- pre-run scripts as patch_rebaser [1] also require proper remotes.

For the first, we may handle it via change in dlrn [2], but for the second one I'm not sure about the best way.

[1] https://github.com/release-depot/patch_rebaser/
[2] https://softwarefactory-project.io/r/c/DLRN/+/33366

This reverts commit f79ca6f89ae08948f74e34fdd32a691a7cef9f06.

After this revert we still have problems when building multiple in-flight patches in any form:

1. Having multiple depends-on on the same package does not work.
2.  Piling multiple reviews and adding the depends-on to the top one is
   also not working.

This PR is also fixing (2) by reversing the order of the related zuul changes to  find and process the top change for the repo.
