### PR TITLE
Switch edpm-multinode github-check jobs to OCP - 4.18

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -3,11 +3,11 @@
 # nodeset  and an ansible-controller.
 - job:
     name: cifmw-adoption-base
-    parent: base-extracted-crc
+    parent: base-crc-cloud
     abstract: true
     timeout: 14400
     attempts: 1
-    nodeset: centos-9-rhel-9-2-crc-extracted-2-39-0-3xl
+    nodeset: centos-9-rhel-9-2-crc-cloud-ocp-4-18-1-3xl
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run:
@@ -19,6 +19,7 @@
       - ci/playbooks/collect-logs.yml
       - ci/playbooks/multinode-autohold.yml
     vars: &adoption_vars
+      enable_ramdisk: true
       osp_17_repos:
         - rhel-9-for-x86_64-baseos-eus-rpms
         - rhel-9-for-x86_64-appstream-eus-rpms
@@ -198,7 +199,7 @@
 
 - job:
     name: cifmw-adoption-base-source-multinode
-    parent: base-extracted-crc
+    parent: base-crc-cloud
     abstract: true
     timeout: 14400
     attempts: 1
@@ -214,6 +215,7 @@
       - ci/playbooks/collect-logs.yml
       - ci/playbooks/multinode-autohold.yml
     vars:
+      enable_ramdisk: true
       <<: *adoption_vars
       crc_ci_bootstrap_networking:
         networks: &multinode_networks
@@ -406,7 +408,7 @@
 
 - job:
     name: cifmw-adoption-base-source-multinode-novacells
-    parent: base-extracted-crc
+    parent: base-crc-cloud
     abstract: true
     voting: false
     timeout: 14400
@@ -417,6 +419,7 @@
     pre-run: *multinode-prerun
     post-run: *multinode-postrun
     vars:
+      enable_ramdisk: true
       <<: *adoption_vars
       crc_ci_bootstrap_networking:
         networks: *multinode_networks
@@ -491,13 +494,14 @@
 
 - job:
     name: cifmw-adoption-base-multinode-networker
-    parent: base-extracted-crc
+    parent: base-crc-cloud
     abstract: true
     attempts: 1
     roles: *multinode-roles
     pre-run: *multinode-prerun
     post-run: *multinode-postrun
     vars:
+      enable_ramdisk: true
       <<: *adoption_vars
       crc_ci_bootstrap_networking:
         networks: *multinode_networks

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -121,10 +121,10 @@
 # crc_ci_bootstrap_networking using *extra-vars*.
 - job:
     name: cifmw-podified-multinode-edpm-base-crc
-    parent: base-extracted-crc
+    parent: base-crc-cloud
     timeout: 10800
     attempts: 1
-    nodeset: centos-9-medium-centos-9-crc-extracted-2-39-0-3xl
+    nodeset: centos-9-medium-centos-9-crc-cloud-ocp-4-18-1-3xl
     irrelevant-files: *ir_files
     required-projects: &multinode_edpm_rp
       - openstack-k8s-operators/ci-framework
@@ -146,6 +146,7 @@
       - ci/playbooks/collect-logs.yml
       - ci/playbooks/multinode-autohold.yml
     vars: &multinode_edpm_vars
+      enable_ramdisk: true
       zuul_log_collection: true
       registry_login_enabled: true
       push_registry: quay.rdoproject.org
@@ -210,7 +211,7 @@
     parent: base-extracted-crc-ci-bootstrap
     timeout: 10800
     attempts: 1
-    nodeset: centos-9-medium-centos-9-crc-extracted-2-39-0-3xl
+    nodeset: centos-9-medium-centos-9-crc-cloud-ocp-4-18-1-3xl
     irrelevant-files: *ir_files
     required-projects: *multinode_edpm_rp
     roles: *multinode_edpm_roles
@@ -231,7 +232,7 @@
     parent: base-extracted-crc-ci-bootstrap-staging
     timeout: 10800
     attempts: 1
-    nodeset: centos-9-medium-centos-9-crc-extracted-2-39-0-3xl-vexxhost
+    nodeset: centos-9-medium-centos-9-crc-cloud-ocp-4-18-1-3xl-vexxhost
     irrelevant-files: *ir_files
     required-projects: *multinode_edpm_rp
     roles: *multinode_edpm_roles

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -2,7 +2,7 @@
 - job:
     name: podified-multinode-edpm-deployment-crc-2comp
     parent: podified-multinode-edpm-deployment-crc
-    nodeset: centos-9-medium-2x-centos-9-crc-extracted-2-39-0-xxl
+    nodeset: centos-9-medium-2x-centos-9-crc-cloud-ocp-4-18-1-xxl
     description: |
       A multinode EDPM Zuul job which has one controller, one extracted crc
       and two compute nodes. It is used in whitebox neutron tempest plugin testing.
@@ -68,7 +68,7 @@
 - job:
     name: podified-multinode-edpm-deployment-crc-3comp
     parent: podified-multinode-edpm-deployment-crc
-    nodeset: centos-9-medium-3x-centos-9-crc-extracted-2-39-0-xxl
+    nodeset: centos-9-medium-3x-centos-9-crc-cloud-ocp-4-18-1-xxl
     vars:
       crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"
       crc_ci_bootstrap_networking:
@@ -144,7 +144,7 @@
 - job:
     name: podified-multinode-hci-deployment-crc-3comp
     parent: podified-multinode-edpm-deployment-crc
-    nodeset: centos-9-medium-3x-centos-9-crc-extracted-2-39-0-xxl
+    nodeset: centos-9-medium-3x-centos-9-crc-cloud-ocp-4-18-1-xxl
     vars:
       cifmw_edpm_deploy_hci: true
       crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"
@@ -235,7 +235,7 @@
 - job:
     name: podified-multinode-hci-deployment-crc-1comp
     parent: podified-multinode-edpm-deployment-crc
-    nodeset: centos-9-medium-centos-9-crc-extracted-2-39-0-3xl
+    nodeset: centos-9-medium-centos-9-crc-cloud-ocp-4-18-1-3xl
     vars:
       cifmw_edpm_deploy_hci: true
       cifmw_cephadm_single_host_defaults: true

--- a/zuul.d/kuttl_multinode.yaml
+++ b/zuul.d/kuttl_multinode.yaml
@@ -4,7 +4,7 @@
     parent: cifmw-podified-multinode-edpm-base-crc
     timeout: 7200
     abstract: true
-    nodeset: centos-9-medium-crc-extracted-2-39-0-3xl
+    nodeset: centos-9-medium-crc-cloud-ocp-4-18-1-3xl
     vars:
       zuul_log_collection: true
     extra-vars:

--- a/zuul.d/podified_multinode.yaml
+++ b/zuul.d/podified_multinode.yaml
@@ -12,7 +12,7 @@
     parent: cifmw-podified-multinode-edpm-base-crc
     timeout: 5400
     abstract: true
-    nodeset: centos-9-medium-crc-extracted-2-39-0-3xl
+    nodeset: centos-9-medium-crc-cloud-ocp-4-18-1-3xl
     run:
       - ci/playbooks/edpm/run.yml
     extra-vars:

--- a/zuul.d/tempest_multinode.yaml
+++ b/zuul.d/tempest_multinode.yaml
@@ -4,7 +4,7 @@
     parent: cifmw-podified-multinode-edpm-base-crc
     timeout: 5400
     abstract: true
-    nodeset: centos-9-medium-crc-extracted-2-39-0-3xl
+    nodeset: centos-9-medium-crc-cloud-ocp-4-18-1-3xl
     description: |
       Base multinode job definition for running test-operator.
     vars:


### PR DESCRIPTION
This PR switched the edpm multinode github-check jobs to OCP- 4.18

Jobs:

base, edpm_multinode, kuttl_multinode, podified_multinode and tempest_multinode.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2859
Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1394