### PR TITLE
Adds GH action to run branch sync on demand

### DIFF
--- a/.github/workflows/sync_branches_periodically.yml
+++ b/.github/workflows/sync_branches_periodically.yml
@@ -1,5 +1,5 @@
 ---
-name: Olive Branch sync
+name: Sync olive branch with main periodically
 
 on:
   schedule:

--- a/.github/workflows/sync_branches_with_ext_trigger.yml
+++ b/.github/workflows/sync_branches_with_ext_trigger.yml
@@ -1,0 +1,19 @@
+---
+name: Sync branches with external trigger
+
+on:
+  workflow_dispatch:
+    inputs:
+      source-branch:
+        required: false
+        default: 'main'
+      target-branch:
+        required: false
+        default: 'stable'
+
+jobs:
+  trigger-sync:
+    uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/release-branch-sync.yaml@main
+    with:
+      source_branch: main
+      target_branch: olive


### PR DESCRIPTION
- Adds GH action workflow with trigger `workflow_dispatch` This can be triggered manually through `Run action` or through an API call like this
```
curl -L \
  -X POST \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer <TOKEN_WITH_REPOSITORY_WRITE_PERMISSIONS>" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/openstack-k8s-operators/ci-framework/actions/workflows/sync_branches_with_ext_trigger.yml/dispatches \
  -d '{"ref":"main","inputs":{"source-branch":"main","target-branch":"stable"}}'
```
- Updates the names of the workflows to something more meaningful

Tested here: https://github.com/frenzyfriday/frenzyfriday-testproject/blob/main/.github/workflows/sync_branches_manually.yml 