### PR TITLE
Use zuul clonned repos for upstream in build_openstack_packages role

### DIFF
--- a/roles/build_openstack_packages/tasks/parse_and_build_pkgs.yml
+++ b/roles/build_openstack_packages/tasks/parse_and_build_pkgs.yml
@@ -19,6 +19,7 @@
             'project': item.project.name,
             'branch': item.branch,
             'change': item.change,
+            'src_dir': item.project.src_dir,
             'refspec': '/'.join(['refs', 'changes',
                                   item.change[-2:],
                                   item.change,

--- a/roles/build_openstack_packages/tasks/run_dlrn.yml
+++ b/roles/build_openstack_packages/tasks/run_dlrn.yml
@@ -114,29 +114,15 @@
         dest: '{{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}'
         version: '{{ _change.branch }}'
 
-    - name: "Clone {{ project_name_mapped.stdout }} from Github" # noqa: name[template]
+    - name: "Symlink {{ project_name_mapped.stdout }} from Zuul clonned repos for upstream" # noqa: name[template]
       when:
         - cifmw_bop_openstack_project_path | length == 0
         - not repo_status.stat.exists
-        - "'host' in _change"
-        - "'github.com' in _change.host"
-      ansible.builtin.git:
-        repo: '{{ _change.host }}/{{ _change.project }}'
-        dest: '{{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}'
-        refspec: "+refs/pull/*:refs/remotes/origin/pr/*"
-        version: 'origin/pr/{{ _change.change }}/head'
-
-    - name: "Clone Openstack {{ project_name_mapped.stdout }}" # noqa: name[template]
-      when:
-        - cifmw_bop_openstack_project_path | length == 0
-        - not repo_status.stat.exists
-        - "'host' in _change"
-        - "'opendev' in _change.host"
-      ansible.builtin.git:
-        repo: '{{ _change.host }}/{{ _change.project }}'
-        dest: '{{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}'
-        refspec: "{{ _change.refspec }}"
-        version: 'FETCH_HEAD'
+        - cifmw_bop_osp_release is not defined
+      ansible.builtin.file:
+        src: '{{ ansible_user_dir }}/{{ _change.src_dir }}'
+        path: '{{ cifmw_bop_build_repo_dir }}/DLRN/data/{{ project_name_mapped.stdout }}'
+        state: link
 
     - name: "Update packages.yml to use zuul repo for {{ project_name_mapped.stdout }}" # noqa: name[template], command-instead-of-module
       vars:


### PR DESCRIPTION
In build_openstack_packages role for building rpms from gerrit and github, we are clonning the repo and checking out specific change.

With these tasks, we are not able to build dlrn rpms if we have multiple prs/crs from same project.

But we want to build rpms from all changes.
In order to fix, Zuul knows how to checkout proper repos with changes under test and from Depends-on.

DLRN always looks for clonned repos in DLRN data directory. In order to use zuul clonned sources with DLRN, We are creating symlink to dlrn data project directory and let's dlrn do the job for upstream repos only.

Note: we reverted the similar pr[1] here as original change was lacking proper condition[2] leading to breaking downstream build openstack packages role.

By adding proper conditional for upstream, it fixes the issue.

Links:
[1]. https://github.com/openstack-k8s-operators/ci-framework/pull/2818 
[2]. https://github.com/openstack-k8s-operators/ci-framework/commit/f79ca6f89ae08948f74e34fdd32a691a7cef9f06#diff-fedeaff036de20345e170c4f65374926975f17139c058369f2e909565054e1adR118-L134