### PR TITLE
Adds gh actions to sync branches

### DIFF
--- a/.github/workflows/sync_branches_periodically.yml
+++ b/.github/workflows/sync_branches_periodically.yml
@@ -3,11 +3,11 @@ name: Olive Branch sync
 
 on:
   schedule:
-    - cron: '0 21 * * 1'
+    - cron: '0 19 * * *'
 
 jobs:
   trigger-sync:
     uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/release-branch-sync.yaml@main
     with:
       source_branch: main
-      target_branch: olive
+      target_branch: ananya-do-not-use-tmp # Hardcoded till testing finishes

--- a/.github/workflows/sync_branches_reusable_workflow.yml
+++ b/.github/workflows/sync_branches_reusable_workflow.yml
@@ -1,0 +1,33 @@
+---
+name: Sync a follower branch with Main
+on:
+  workflow_call:
+    inputs:
+      main-branch:
+        required: true
+        type: string
+      follower-branch:
+        required: true
+        type: string
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout, rebase and push to target branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref:
+            ${{ inputs.target-branch }}
+      - run: |
+          # Details about the GH action bot comes from
+          # https://api.github.com/users/openshift-merge-robot
+          git config user.name "openshift-merge-robot"
+          git config user.email "30189218+openshift-merge-robot@users.noreply.github.com"
+          git fetch
+          git rebase origin/${{ inputs.source-branch }}
+          git push origin ${{ inputs.target-branch }}

--- a/.github/workflows/sync_branches_with_ext_trigger.yml
+++ b/.github/workflows/sync_branches_with_ext_trigger.yml
@@ -1,0 +1,18 @@
+name: Sync branches with external trigger
+
+on:
+  workflow_dispatch:
+    inputs:
+      source-branch:
+        required: false
+        default: 'main'
+      target-branch:
+        required: false
+        default: 'ananya-do-not-use-tmp'
+
+jobs:
+  trigger-sync:
+    uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/release-branch-sync.yaml@main
+    with:
+      source_branch: ${{ inputs.source-branch }}
+      target_branch: ananya-do-not-use-tmp # Hardcoded till testing finishes


### PR DESCRIPTION
- Reusable workflow
- A periodic trigger
- A manual/API trigger
- Trying to use "openshift-merge-robot" instead of creating a new bot

I will test this on a dummy branch. The branch has same rules as olive/stable will have

![image](https://github.com/user-attachments/assets/bdaadf3c-ffaa-4437-bb3f-33c135f60274)
