### PR TITLE
Set NNCP_DNS_SERVER in kuttl deploy-deps.yaml playbook

### DIFF
--- a/ci/playbooks/kuttl/deploy-deps.yaml
+++ b/ci/playbooks/kuttl/deploy-deps.yaml
@@ -32,18 +32,28 @@
       loop_control:
         label: "{{ item }}"
 
-    - name: Ensure that the isolated net was configured for crc
-      ansible.builtin.assert:
-        that:
-          - crc_ci_bootstrap_networks_out is defined
-          - "'crc' in crc_ci_bootstrap_networks_out"
-          - "'default' in crc_ci_bootstrap_networks_out['crc']"
+    - name: set facts for further usage within the framework
+      vars:
+        _crc_hostname: "{{ cifmw_crc_hostname | default('crc') }}"
+      block:
+        - name: Ensure that the isolated net was configured for crc
+          ansible.builtin.assert:
+            that:
+              - crc_ci_bootstrap_networks_out is defined
+              - crc_ci_bootstrap_networks_out[_crc_hostname] is defined
+              - crc_ci_bootstrap_networks_out[_crc_hostname]['default'] is defined
 
-    - name: Set facts for further usage within the framework
-      ansible.builtin.set_fact:
-        cifmw_edpm_prepare_extra_vars:
-          NNCP_INTERFACE: "{{ crc_ci_bootstrap_networks_out.crc.default.iface }}"
-          NETWORK_MTU: "{{ crc_ci_bootstrap_networks_out.crc.default.mtu }}"
+        - name: Set facts for further usage within the framework
+          ansible.builtin.set_fact:
+            cifmw_edpm_prepare_extra_vars:
+              NNCP_INTERFACE: "{{ crc_ci_bootstrap_networks_out.crc.default.iface }}"
+              NETWORK_MTU: "{{ crc_ci_bootstrap_networks_out.crc.default.mtu }}"
+              NNCP_DNS_SERVER: >-
+                {{
+                  crc_ci_bootstrap_networks_out[_crc_hostname].default.ip4 |
+                  default(crc_ci_bootstrap_networks_out[_crc_hostname].default.ip) |
+                  split('/') | first
+                }}
 
 - hosts: "{{ cifmw_target_host | default('localhost') }}"
   name: Deploy Openstack Operators


### PR DESCRIPTION
Currently watcher-operator-kuttl tests are failing with nncp_dns error[1]. https://github.com/openstack-k8s-operators/install_yamls/pull/1024/ recently added DNS only NNCP in install_yamls.

In order to make it work, we need to set NNCP_DNS_SERVER var in the kuttl tests to make it work.

Links:
[1]. https://github.com/openstack-k8s-operators/watcher-operator/pull/119#issuecomment-2753365667

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1394