### PR TITLE
DNM Moving cifmw-crc-podified-edpm-baremetal job to use just IBM cloud

### DIFF
--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -11,7 +11,7 @@
 # Virtual Baremetal job with CRC and single compute node.
 - job:
     name: cifmw-crc-podified-edpm-baremetal
-    nodeset: centos-9-crc-2-48-0-6xlarge
+    nodeset: centos-9-crc-2-48-0-6xlarge-ibm
     parent: cifmw-base-crc-openstack
     run: ci/playbooks/edpm_baremetal_deployment/run.yml
     vars:

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -618,8 +618,9 @@
       - name: controller
         label: centos-9-stream-crc-2-48-0-3xl-ibm
 
+# EDPM jobs - force to use IBM hosts ###
 - nodeset:
-    name: centos-9-crc-2-39-0-6xlarge-ibm
+    name: centos-9-crc-2-48-0-6xlarge-ibm
     nodes:
       - name: controller
-        label: centos-9-stream-crc-2-39-0-6xlarge-ibm
+        label: centos-9-stream-crc-2-48-0-6xlarge-ibm


### PR DESCRIPTION
From time to time we are out of the resources in one of our cloud providers. The IBM private cloud provider is used rary, especially for that job.
Let's try to use just this provider to unlock other CI jobs that needs to be running on Vexxhost provider.