### PR TITLE
Change nodeset name and label related to force spawning on IBM

### DIFF
--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -619,7 +619,7 @@
         label: centos-9-stream-crc-2-48-0-3xl-ibm
 
 - nodeset:
-    name: centos-9-crc-2-39-0-6xlarge-ibm
+    name: centos-9-crc-2-48-0-6xlarge-ibm
     nodes:
       - name: controller
-        label: centos-9-stream-crc-2-39-0-6xlarge-ibm
+        label: centos-9-stream-crc-2-48-0-6xlarge-ibm


### PR DESCRIPTION
The nodeset name and label that was used got wrong version set.