### PR TITLE
Add file and dir mode to enable risky-file-permissions linter

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -41,10 +41,10 @@ enable_list:
   - no-log-password
   - no-same-owner
   - name[play]
+  - risky-file-permissions
 skip_list:
   - jinja[spacing]  # We don't really want to get that one. Too picky
   - no-changed-when  # once we get the oc module we can re-enable it
-  - risky-file-permissions  # Seems to fail on 0644 on files ?!
   - schema[meta]  # Apparently "CentOS 9" isn't known... ?!
   - schema[vars]  # weird issue with some "vars" in playbooks
   - yaml[line-length]  # We have long lines, yes.

--- a/deploy-osp-adoption.yml
+++ b/deploy-osp-adoption.yml
@@ -85,6 +85,7 @@
       ansible.builtin.file:
         path: "{{ cifmw_basedir }}/artifacts/parameters"
         state: "directory"
+        mode: "0755"
 
     - name: Save variables for use with hooks
       vars:
@@ -96,6 +97,7 @@
       ansible.builtin.copy:
         dest: "{{ cifmw_basedir }}/artifacts/parameters/adoption_osp.yml"
         content: "{{ _content | to_nice_yaml }}"
+        mode: "0644"
     - name: Set inventory_file for localhost to use with hooks
       ansible.builtin.set_fact:
         inventory_file: "{{ hostvars[_target_host]['inventory_file'] }}"

--- a/docs/source/files/bootstrap-hypervisor.yml
+++ b/docs/source/files/bootstrap-hypervisor.yml
@@ -56,7 +56,7 @@
         dest: "/etc/sudoers.d/{{ _user }}"
         owner: root
         group: root
-        mode: 0640
+        mode: "0640"
 
     - name: Install basic packages
       become: true

--- a/hooks/playbooks/adoption_ironic_post_oc.yml
+++ b/hooks/playbooks/adoption_ironic_post_oc.yml
@@ -55,6 +55,7 @@
           ansible.builtin.file:
             state: directory
             path: "{{ ansible_user_dir }}/ironic-python-agent"
+            mode: "0755"
           loop:
             - osp-undercloud-0
             - osp-controller-0
@@ -82,6 +83,7 @@
             src: "{{ ansible_user_dir }}/ironic-python-agent/ironic-python-agent.kernel"
             dest: /var/lib/ironic/httpboot/agent.kernel
             remote_src: true
+            mode: "0644"
           loop:
             - osp-controller-0
             - osp-controller-1
@@ -93,6 +95,7 @@
             src: "{{ ansible_user_dir }}/ironic-python-agent/ironic-python-agent.initramfs"
             dest: /var/lib/ironic/httpboot/agent.ramdisk
             remote_src: true
+            mode: "0644"
           loop:
             - osp-controller-0
             - osp-controller-1
@@ -166,11 +169,13 @@
           ansible.builtin.file:
             state: directory
             path: "{{ ansible_user_dir }}/ci-framework-data/parameters"
+            mode: "0755"
 
         - name: Write ironic_nodes.yaml on osp-unercloud-o
           ansible.builtin.copy:
             content: "{{ _ironic_nodes_slurp.content | b64decode }}"
             dest: "{{ ansible_user_dir }}/ci-framework-data/parameters/ironic_nodes.yaml"
+            mode: "0644"
 
         - name: Run baremetal create command to enroll the nodes in the Ironic service
           environment:

--- a/hooks/playbooks/barbican-enable-luna.yml
+++ b/hooks/playbooks/barbican-enable-luna.yml
@@ -46,6 +46,7 @@
         login_secret: "{{ cifmw_hsm_login_secret | default('barbican-luna-login', true) }}"
       ansible.builtin.copy:
         dest: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/controlplane/93-barbican-luna.yaml"
+        mode: "0644"
         content: |-
           apiVersion: kustomize.config.k8s.io/v1beta1
           kind: Kustomization

--- a/hooks/playbooks/control_plane_ceph_backends.yml
+++ b/hooks/playbooks/control_plane_ceph_backends.yml
@@ -25,3 +25,4 @@
       ansible.builtin.template:
         dest: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/controlplane/90-ceph-backends-kustomization.yaml"
         src: "config_ceph_backends.yaml.j2"
+        mode: "0644"

--- a/hooks/playbooks/control_plane_hci_pre_deploy.yml
+++ b/hooks/playbooks/control_plane_hci_pre_deploy.yml
@@ -32,3 +32,4 @@
               - op: add
                 path: /spec/swift/enabled
                 value: {{ cifmw_services_swift_enabled | default('false') }}
+        mode: "0644"

--- a/hooks/playbooks/control_plane_horizon.yml
+++ b/hooks/playbooks/control_plane_horizon.yml
@@ -26,3 +26,4 @@
               - op: add
                 path: /spec/horizon/template/memcachedInstance
                 value: memcached
+        mode: "0644"

--- a/hooks/playbooks/control_plane_ironic.yml
+++ b/hooks/playbooks/control_plane_ironic.yml
@@ -24,3 +24,4 @@
               - op: add
                 path: /spec/ironic/enabled
                 value: {{ cifmw_services_ironic_enabled | default('false') }}
+        mode: "0644"

--- a/hooks/playbooks/federation-controlplane-config.yml
+++ b/hooks/playbooks/federation-controlplane-config.yml
@@ -37,6 +37,7 @@
                   remote_id_attribute=HTTP_OIDC_ISS
                   [auth]
                   methods = password,token,oauth1,mapped,application_credential,openid
+        mode: "0644"
 
     - name: Get ingress operator CA cert
       ansible.builtin.slurp:

--- a/hooks/playbooks/fetch_compute_facts.yml
+++ b/hooks/playbooks/fetch_compute_facts.yml
@@ -17,7 +17,7 @@
       ansible.builtin.copy:
         dest: "/etc/yum.repos.d/"
         src: "{{ cifmw_basedir }}/artifacts/repositories/"
-        mode: "0644"
+        mode: "0755"
 
 - name: Build dataset hook
   hosts: localhost

--- a/hooks/playbooks/fetch_compute_facts.yml
+++ b/hooks/playbooks/fetch_compute_facts.yml
@@ -17,6 +17,7 @@
       ansible.builtin.copy:
         dest: "/etc/yum.repos.d/"
         src: "{{ cifmw_basedir }}/artifacts/repositories/"
+        mode: "0644"
 
 - name: Build dataset hook
   hosts: localhost
@@ -106,6 +107,7 @@
                     "values": []
                   }
                 ]
+        mode: "0644"
 
     - name: Prepare EDPM deploy related facts and keys
       when:
@@ -135,6 +137,7 @@
           vars:
             dns_servers: "{{ ((['192.168.122.10'] + ansible_facts['dns']['nameservers']) | unique)[0:2] }}"
           ansible.builtin.copy:
+            mode: "0644"
             dest: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/dataplane/99-kustomization.yaml"
             content: |-
               apiVersion: kustomize.config.k8s.io/v1beta1
@@ -270,3 +273,4 @@
       ansible.builtin.copy:
         dest: "{{ cifmw_basedir }}/artifacts/{{ step }}_{{ hook_name }}.yml"
         content: "{{ file_content | to_nice_yaml }}"
+        mode: "0644"

--- a/hooks/playbooks/ironic_enroll_nodes.yml
+++ b/hooks/playbooks/ironic_enroll_nodes.yml
@@ -61,6 +61,7 @@
       ansible.builtin.copy:
         dest: "{{ cifmw_basedir }}/parameters/ironic_nodes.yaml"
         content: "{{ ironic_nodes | to_yaml }}"
+        mode: "0644"
 
     - name: Enroll ironic nodes
       ansible.builtin.shell: |

--- a/hooks/playbooks/kustomize_cr.yml
+++ b/hooks/playbooks/kustomize_cr.yml
@@ -27,6 +27,7 @@
       ansible.builtin.copy:
         src: "{{ cifmw_kustomize_cr_file_path }}/{{ cifmw_kustomize_cr_file_name }}"
         dest: "{{ cifmw_kustomize_cr_artifact_dir }}/{{ cifmw_kustomize_cr_file_name }}"
+        mode: "0644"
         remote_src: true
 
     - name: Generate kustomization file
@@ -34,6 +35,7 @@
       ansible.builtin.template:
         src: "{{ playbook_dir }}/{{ cifmw_kustomize_cr_template }}"
         dest: "{{ cifmw_kustomize_cr_artifact_dir }}/kustomization.yaml"
+        mode: "0644"
 
     - name: Run oc kustomize
       environment:
@@ -47,3 +49,4 @@
       ansible.builtin.copy:
         dest: "{{ cifmw_kustomize_cr_artifact_dir }}/kustomized_{{ cifmw_kustomize_cr_file_name }}"
         content: "{{ kustomized_cr.stdout }}"
+        mode: "0644"

--- a/hooks/playbooks/kuttl_openstack_prep.yml
+++ b/hooks/playbooks/kuttl_openstack_prep.yml
@@ -42,3 +42,4 @@
       ansible.builtin.copy:
         dest: "{{ cifmw_basedir }}/artifacts/parameters/{{ step }}_{{ hook_name }}.yml"
         content: "{{ file_content | to_nice_yaml }}"
+        mode: "0644"

--- a/hooks/playbooks/link2file.yml
+++ b/hooks/playbooks/link2file.yml
@@ -58,6 +58,7 @@
       ansible.builtin.copy:
         src: "{{ item.stat.lnk_source }}"
         dest: "{{ _file_path }}"
+        mode: "0644"
       loop: "{{ _file_info.results }}"
       loop_control:
         label: "{{ item.item }}"

--- a/playbooks/dcn.yml
+++ b/playbooks/dcn.yml
@@ -106,5 +106,6 @@
       ansible.builtin.copy:
         src: "{{ item.path }}"
         dest: "/home/zuul/ci-framework-data/artifacts/manifests/openstack/cr"
+        mode: "0644"
       loop: "{{ dcn_crs.files }}"
       when: dcn_crs.matched > 0

--- a/playbooks/nfs.yml
+++ b/playbooks/nfs.yml
@@ -48,6 +48,7 @@
         option: vers3
         value: n
         backup: true
+        mode: "0644"
 
     - name: Disable NFSv3-related services
       ansible.builtin.systemd_service:
@@ -89,6 +90,7 @@
             'cifmw_nfs_network_range': cifmw_nfs_network_out.stdout | from_json | json_query('cidr')
             } | to_nice_yaml
           }}
+        mode: "0644"
 
     # NOTE: This represents a workaround because there's an edpm-nftables role
     #       in edpm-ansible already. That role should contain the implementation
@@ -125,6 +127,7 @@
         option: host
         value: "{{ cifmw_nfs_network_out.stdout | from_json | json_query('address') }}"
         backup: true
+        mode: "0644"
 
     - name: Enable and restart nfs-server service
       ansible.builtin.systemd:

--- a/playbooks/unique-id.yml
+++ b/playbooks/unique-id.yml
@@ -38,6 +38,7 @@
       ansible.builtin.copy:
         dest: "{{ _unique_id_file }}"
         content: "{{ cifmw_run_id | default(_unique_id) | lower }}"
+        mode: "0644"
 
     # Since the user might pass their own run ID, we can just consume it.
     # If, for a subsequent run, the user doesn't pass the run ID, we will

--- a/playbooks/update.yml
+++ b/playbooks/update.yml
@@ -24,7 +24,7 @@
         remote_src: true
         src: "{{ cifmw_basedir }}/artifacts/repositories/"
         dest: "{{ cifmw_basedir }}/artifacts/before_update_repos/"
-        mode: "0644"
+        mode: "0755"
 
     - name: Run repo_setup
       ansible.builtin.include_role:
@@ -49,7 +49,7 @@
       ansible.builtin.copy:
         dest: "/etc/yum.repos.d/"
         src: "{{ cifmw_basedir }}/artifacts/repositories/"
-        mode: "0644"
+        mode: "0755"
 
 - name: Run Ceph update if part of the deployment
   hosts: "{{ (groups[cifmw_ceph_target | default('computes')] | default([]))[:1] }}"

--- a/playbooks/update.yml
+++ b/playbooks/update.yml
@@ -24,6 +24,7 @@
         remote_src: true
         src: "{{ cifmw_basedir }}/artifacts/repositories/"
         dest: "{{ cifmw_basedir }}/artifacts/before_update_repos/"
+        mode: "0644"
 
     - name: Run repo_setup
       ansible.builtin.include_role:
@@ -48,6 +49,7 @@
       ansible.builtin.copy:
         dest: "/etc/yum.repos.d/"
         src: "{{ cifmw_basedir }}/artifacts/repositories/"
+        mode: "0644"
 
 - name: Run Ceph update if part of the deployment
   hosts: "{{ (groups[cifmw_ceph_target | default('computes')] | default([]))[:1] }}"
@@ -73,6 +75,7 @@
           ansible.builtin.copy:
             content: "{{ cephconf['content'] | b64decode }}"
             dest: "/tmp/ceph.conf"
+            mode: "0644"
 
         - name: Extract the CephFSID from ceph.conf
           ansible.builtin.set_fact:

--- a/roles/adoption_osp_deploy/tasks/deploy_overcloud.yml
+++ b/roles/adoption_osp_deploy/tasks/deploy_overcloud.yml
@@ -52,6 +52,7 @@
       ansible.builtin.copy:
         src: "{{ _roles_file }}"
         dest: "{{ _roles_file_dest }}"
+        mode: "0644"
 
     - name: Run overcloud deploy
       delegate_to: "osp-undercloud-0"

--- a/roles/adoption_osp_deploy/tasks/prepare_undercloud.yml
+++ b/roles/adoption_osp_deploy/tasks/prepare_undercloud.yml
@@ -66,6 +66,7 @@
       ansible.builtin.copy:
         src: "{{ _container_prapare_path }}"
         dest: "{{ ansible_user_dir }}/containers-prepare-parameters.yaml"
+        mode: "0644"
       when: cifmw_adoption_osp_deploy_scenario.container_prepare_params is defined
 
     # Adoption requires Ceph 7 (Reef) as a requirement. Instead of performing a Ceph
@@ -239,4 +240,5 @@
     option: "{{ item.option }}"
     value: "{{ item.value }}"
     state: "present"
+    mode: "0644"
   loop: "{{ _undercloud_conf.config }}"

--- a/roles/artifacts/tasks/ansible_logs.yml
+++ b/roles/artifacts/tasks/ansible_logs.yml
@@ -10,4 +10,5 @@
     src: "{{ item.path }}"
     dest: "{{ cifmw_artifacts_basedir }}/logs/"
     remote_src: true
+    mode: "0644"
   loop: "{{ files_to_copy.files }}"

--- a/roles/artifacts/tasks/main.yml
+++ b/roles/artifacts/tasks/main.yml
@@ -33,6 +33,7 @@
   ansible.builtin.file:
     path: "{{ cifmw_artifacts_basedir }}/{{ item }}"
     state: directory
+    mode: "0755"
   loop:
     - artifacts
     - logs

--- a/roles/build_openstack_packages/tasks/create_repo.yml
+++ b/roles/build_openstack_packages/tasks/create_repo.yml
@@ -39,7 +39,7 @@
     remote_src: true
     src: "{{ _repodir.path }}/"
     dest: "{{ cifmw_bop_gating_repo_dest }}"
-    mode: "0644"
+    mode: "0755"
 
 - name: Add gating.repo file to install the required built packages
   ansible.builtin.copy:

--- a/roles/build_openstack_packages/tasks/create_repo.yml
+++ b/roles/build_openstack_packages/tasks/create_repo.yml
@@ -39,6 +39,7 @@
     remote_src: true
     src: "{{ _repodir.path }}/"
     dest: "{{ cifmw_bop_gating_repo_dest }}"
+    mode: "0644"
 
 - name: Add gating.repo file to install the required built packages
   ansible.builtin.copy:
@@ -50,6 +51,7 @@
       gpgcheck=0
       priority=1
     dest: "{{ cifmw_bop_gating_repo_dest }}/gating.repo"
+    mode: "0644"
 
 - name: Serve gating repo
   ansible.builtin.import_tasks: serve_gating_repo.yml

--- a/roles/build_openstack_packages/tasks/downstream.yml
+++ b/roles/build_openstack_packages/tasks/downstream.yml
@@ -26,12 +26,14 @@
     remote_src: true
     src: "{{ ansible_user_dir }}/{{ cifmw_bop_initial_dlrn_config }}.cfg"
     dest: "{{ cifmw_bop_build_repo_dir }}/DLRN/scripts/{{ cifmw_bop_initial_dlrn_config }}.cfg"
+    mode: "0644"
 
 - name: Copy patch_rebaser.ini to patch_rebaser repo
   ansible.builtin.copy:
     remote_src: true
     src: "{{ ansible_user_dir }}/patch_rebaser.ini"
     dest: "{{ cifmw_bop_build_repo_dir }}/patch_rebaser/patch_rebaser/patch_rebaser.ini"
+    mode: "0644"
 
 - name: Copy Downstream scripts to DLRN repo
   ansible.builtin.copy:

--- a/roles/build_openstack_packages/tasks/install_dlrn.yml
+++ b/roles/build_openstack_packages/tasks/install_dlrn.yml
@@ -126,6 +126,7 @@
   ansible.builtin.template:
     src: projects.ini.j2
     dest: '{{ cifmw_bop_build_repo_dir }}/DLRN/projects.ini'
+    mode: "0644"
 
 - name: Copy the DLRN scripts in the virtualenv to the scripts dir
   ansible.posix.synchronize:
@@ -159,6 +160,7 @@
     remote_src: true
     src: "{{ cifmw_bop_build_repo_dir }}/DLRN/scripts/{{ cifmw_bop_initial_dlrn_config }}.cfg"
     dest: "{{ cifmw_bop_build_repo_dir }}/DLRN/scripts/{{ cifmw_bop_initial_dlrn_config }}-local.cfg"
+    mode: "0644"
 
 - name: Remove last """ from local mock config # noqa: command-instead-of-module
   ansible.builtin.command:

--- a/roles/cert_manager/tasks/olm_manifest.yml
+++ b/roles/cert_manager/tasks/olm_manifest.yml
@@ -3,6 +3,7 @@
   ansible.builtin.copy:
     dest: "{{ cifmw_cert_manager_manifests_dir }}/cert-manager-{{ item.kind | lower }}-olm.yaml"
     content: "{{ item | to_nice_yaml }}"
+    mode: "0644"
   loop:
     - "{{ cifmw_cert_manager_olm_operator_group }}"
     - "{{ cifmw_cert_manager_olm_subscription }}"

--- a/roles/ci_dcn_site/tasks/ceph.yml
+++ b/roles/ci_dcn_site/tasks/ceph.yml
@@ -36,6 +36,7 @@
     create: true
     backup: true
     insertbefore: EOF
+    mode: "0644"
 
 - name: Ensure Ceph bootstrap host can ping itself
   register: _cmd_result

--- a/roles/ci_dcn_site/tasks/scaledown_site.yml
+++ b/roles/ci_dcn_site/tasks/scaledown_site.yml
@@ -200,11 +200,13 @@
   ansible.builtin.file:
     path: "/tmp/ceph_conf_files"
     state: directory
+    mode: "0750"
 
 - name: Save secret data to files
   ansible.builtin.copy:
     content: "{{ secret_info.resources[0].data[key] | b64decode | regex_replace('(?m)^\\s*\\n', '') }}"
     dest: "/tmp/ceph_conf_files/{{ key }}"
+    mode: "0640"
   loop: "{{ secret_info.resources[0].data.keys() }}"
   loop_control:
     loop_var: key

--- a/roles/ci_local_storage/tasks/main.yml
+++ b/roles/ci_local_storage/tasks/main.yml
@@ -33,6 +33,7 @@
   ansible.builtin.copy:
     dest: "{{ cifmw_cls_manifests_dir }}/storage-class.yaml"
     content: "{{ cifmw_cls_storage_manifest | to_nice_yaml }}"
+    mode: "0644"
 
 - name: Get k8s nodes
   ansible.builtin.import_tasks: fetch_names.yml

--- a/roles/ci_lvms_storage/tasks/main.yml
+++ b/roles/ci_lvms_storage/tasks/main.yml
@@ -26,6 +26,7 @@
   ansible.builtin.file:
     path: "{{ cifmw_lvms_manifests_dir }}"
     state: directory
+    mode: "0755"
 
 - name: Put the manifest files in place
   ansible.builtin.template:

--- a/roles/ci_multus/molecule/resources/clean.yml
+++ b/roles/ci_multus/molecule/resources/clean.yml
@@ -23,6 +23,7 @@
         src: "{{ cifmw_ci_multus_manifests_dir }}"
         dest: "{{ cifmw_ci_multus_manifests_dir }}.backup"
         remote_src: true
+        mode: "0755"
 
     - name: Call cleanup
       ansible.builtin.import_role:

--- a/roles/ci_multus/tasks/main.yml
+++ b/roles/ci_multus/tasks/main.yml
@@ -18,6 +18,7 @@
   ansible.builtin.file:
     path: "{{ cifmw_ci_multus_manifests_dir }}"
     state: directory
+    mode: "0755"
 
 - name: Build list of networks from cifmw_networking_env_definition
   block:
@@ -117,6 +118,7 @@
   ansible.builtin.template:
     src: "nad.yml.j2"
     dest: "{{ cifmw_ci_multus_manifests_dir }}/ci_multus_nads.yml"
+    mode: "0644"
 
 - name: Create resources in OCP
   when: not cifmw_ci_multus_dryrun

--- a/roles/ci_network/tasks/main.yml
+++ b/roles/ci_network/tasks/main.yml
@@ -42,6 +42,7 @@
     section: "{{ nm_conf.section }}"
     option: "{{ nm_conf.option }}"
     value: "{{ nm_conf.value }}"
+    mode: "0644"
   loop: "{{ cifmw_network_nm_config }}"
   loop_control:
     loop_var: nm_conf

--- a/roles/ci_nmstate/tasks/nmstate_k8s_install.yml
+++ b/roles/ci_nmstate/tasks/nmstate_k8s_install.yml
@@ -3,6 +3,7 @@
   ansible.builtin.file:
     path: "{{ cifmw_ci_nmstate_manifests_dir }}"
     state: directory
+    mode: "0755"
 
 - name: Create the nmstate namespace
   kubernetes.core.k8s:

--- a/roles/ci_nmstate/tasks/nmstate_unmanaged_provision_node.yml
+++ b/roles/ci_nmstate/tasks/nmstate_unmanaged_provision_node.yml
@@ -25,6 +25,7 @@
   ansible.builtin.file:
     path: "{{ cifmw_ci_nmstate_configs_dir }}"
     state: directory
+    mode: "0755"
 
 - name: "Save nmstate state for {{ cifmw_ci_nmstate_unmanaged_host }}"
   ansible.builtin.copy:

--- a/roles/cifmw_cephadm/tasks/dashboard/validation.yml
+++ b/roles/cifmw_cephadm/tasks/dashboard/validation.yml
@@ -25,6 +25,7 @@
   ansible.builtin.get_url:
     url: "{{ cifmw_cephadm_urischeme_dashboard | default('http') }}://{{ grafana_server_addr }}:{{ cifmw_cephadm_dashboard_port }}"
     dest: "/tmp/dash_response"
+    mode: "0644"
     validate_certs: false
   register: dashboard_response
   failed_when: dashboard_response.failed == true
@@ -37,6 +38,7 @@
   ansible.builtin.get_url:
     url: "{{ cifmw_cephadm_urischeme_dashboard | default('http') }}://{{ grafana_server_addr }}:{{ cifmw_cephadm_dashboard_port }}"
     dest: "/tmp/dash_http_response"
+    mode: "0644"
     validate_certs: false
     username: admin
     password: admin

--- a/roles/cifmw_external_dns/tasks/requirements.yml
+++ b/roles/cifmw_external_dns/tasks/requirements.yml
@@ -56,6 +56,7 @@
   ansible.builtin.file:
     path: "{{ cifmw_external_dns_manifests_dir }}"
     state: directory
+    mode: "0755"
 
 - name: Stat cifmw_external_dns_certificate on target hosts
   ansible.builtin.stat:

--- a/roles/compliance/tasks/create_scap_report.yml
+++ b/roles/compliance/tasks/create_scap_report.yml
@@ -31,6 +31,7 @@
   ansible.builtin.copy:
     src: "{{ bzip_file.path }}"
     dest: "{{ base_name }}.xml.bz2"
+    mode: "0644"
 
 - name: Unzip the file
   ansible.builtin.command: "bunzip2 {{ base_name }}.xml.bz2"

--- a/roles/copy_container/molecule/default/converge.yml
+++ b/roles/copy_container/molecule/default/converge.yml
@@ -43,6 +43,7 @@
       ansible.builtin.copy:
         dest: "/tmp/copy-quay-config.yaml"
         content: "{{ _data }}"
+        mode: "0644"
 
     - name: Copy containers from RDO quay to local registry
       ansible.builtin.command:

--- a/roles/copy_container/tasks/main.yml
+++ b/roles/copy_container/tasks/main.yml
@@ -42,6 +42,7 @@
   ansible.builtin.copy:
     src: copy-quay/
     dest: "{{ temporary_copy_container_dir.path }}"
+    mode: "0755"
 
 - name: Build the copy-container
   register: go_build

--- a/roles/devscripts/molecule/check_cluster_status/tasks/test.yml
+++ b/roles/devscripts/molecule/check_cluster_status/tasks/test.yml
@@ -95,6 +95,7 @@
       ansible.builtin.copy:
         dest: "/home/dev-scripts/.ocp_cert_not_after"
         content: "{{ _date }}"
+        mode: "0644"
 
     - name: Ensure freshly built config
       ansible.builtin.include_role:

--- a/roles/devscripts/tasks/139_configs.yml
+++ b/roles/devscripts/tasks/139_configs.yml
@@ -38,3 +38,4 @@
     src: templates/conf_ciuser.j2
     dest: >-
       {{ cifmw_devscripts_repo_dir }}/config_{{ cifmw_devscripts_user }}.sh
+    mode: "0644"

--- a/roles/devscripts/tasks/main.yml
+++ b/roles/devscripts/tasks/main.yml
@@ -64,6 +64,7 @@
         dest: "{{ cifmw_devscripts_logs_dir }}/{{ item.path | basename }}"
         remote_src: true
         src: "{{ item.path }}"
+        mode: "0644"
       loop: "{{ _deploy_logs.files }}"
       loop_control:
         label: "{{ item.path }}"

--- a/roles/dlrn_promote/tasks/get_hash_from_commit.yaml
+++ b/roles/dlrn_promote/tasks/get_hash_from_commit.yaml
@@ -3,6 +3,7 @@
   ansible.builtin.get_url:
     url: "{{ commit_url }}/commit.yaml"
     dest: "{{ cifmw_dlrn_promote_workspace }}/commit.yaml"
+    mode: "0644"
     force: true
   register: result
   until:

--- a/roles/edpm_build_images/tasks/main.yml
+++ b/roles/edpm_build_images/tasks/main.yml
@@ -31,6 +31,7 @@
     url: "{{ cifmw_discovered_image_url }}"
     dest: "{{ cifmw_edpm_build_images_basedir }}"
     timeout: 20
+    mode: "0644"
   register: result
   until: result is success
   retries: 60

--- a/roles/edpm_kustomize/tasks/kustomize.yml
+++ b/roles/edpm_kustomize/tasks/kustomize.yml
@@ -33,6 +33,7 @@
           }
         ) | to_nice_yaml
       }}
+    mode: "0644"
 
 - name: Apply the already existing kustomization if present
   environment:

--- a/roles/edpm_kustomize/tasks/main.yml
+++ b/roles/edpm_kustomize/tasks/main.yml
@@ -55,6 +55,7 @@
         remote_src: true
         src: "{{ cifmw_edpm_kustomize_cr_path | dirname }}/kustomization.yaml"
         dest: "{{ cifmw_edpm_kustomize_cr_path | dirname }}/kustomization.initial.yaml"
+        mode: "0644"
 
     - name: Prepare and load the ci-framework kustomize template file
       vars:

--- a/roles/env_op_images/tasks/main.yml
+++ b/roles/env_op_images/tasks/main.yml
@@ -139,3 +139,4 @@
       ansible.builtin.copy:
         dest: "{{ cifmw_env_op_images_dir }}/artifacts/{{ cifmw_env_op_images_file }}"
         content: "{{ _content | to_nice_yaml }}"
+        mode: "0644"

--- a/roles/federation/tasks/run_keycloak_setup.yml
+++ b/roles/federation/tasks/run_keycloak_setup.yml
@@ -25,6 +25,7 @@
   ansible.builtin.copy:
     src: "{{ [ ansible_user_dir, '.crc', 'machines', 'src', 'kubeconfig' ] | path_join }}"
     dest: "{{ [ ansible_user_dir, '.kube', 'config' ] | path_join }}"
+    mode: "0640"
   when: cifmw_federation_deploy_type == "crc"
 
 - name: Create namespace
@@ -38,6 +39,7 @@
   ansible.builtin.template:
     src: rhsso-operator-olm.yaml.j2
     dest: "{{ [ ansible_user_dir, 'ci-framework-data', 'tmp', 'rhsso-operator-olm.yaml' ] | path_join }}"
+    mode: "0644"
 
 - name: Install federation rhsso operator
   environment:
@@ -89,6 +91,7 @@
   ansible.builtin.template:
     src: sso.yaml.j2
     dest: "{{ [ ansible_user_dir, 'ci-framework-data', 'tmp', 'sso.yaml' ] | path_join }}"
+    mode: "0644"
 
 - name: Install federation sso pod
   environment:
@@ -130,3 +133,4 @@
   ansible.builtin.copy:
     src: "{{ [ ansible_user_dir, 'ci-framework-data', 'tmp', 'tls.crt'] | path_join }}"
     dest: "{{ [ ansible_user_dir, 'ci-framework-data', 'tmp', 'ingress-operator-ca.crt'] | path_join }}"
+    mode: "0644"

--- a/roles/federation/tasks/run_openstack_auth_test.yml
+++ b/roles/federation/tasks/run_openstack_auth_test.yml
@@ -31,6 +31,7 @@
   ansible.builtin.template:
     src: kctestuser1.j2
     dest: "{{ [ ansible_user_dir, 'ci-framework-data', 'tmp', cifmw_federation_keycloak_testuser1_username ] | path_join }}"
+    mode: "0644"
 
 - name: Copy federation test user1 cloudrc file into pod
   kubernetes.core.k8s_cp:
@@ -43,6 +44,7 @@
   ansible.builtin.copy:
     src: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
     dest: "{{ [ ansible_user_dir, 'ci-framework-data', 'tmp', 'full-ca-list.crt' ] | path_join }}"
+    mode: "0444"
 
 - name: Get ingress operator CA cert
   ansible.builtin.slurp:

--- a/roles/federation/tasks/run_openstack_setup.yml
+++ b/roles/federation/tasks/run_openstack_setup.yml
@@ -18,6 +18,7 @@
   ansible.builtin.copy:
     src: /home/zuul/.crc/machines/crc/kubeconfig
     dest: /home/zuul/.kube/config
+    mode: "0640"
   when: cifmw_federation_deploy_type == "crc"
 
 - name: Run federation create domain
@@ -37,6 +38,7 @@
   ansible.builtin.template:
     src: rules.json.j2
     dest: "{{ [ ansible_user_dir, 'ci-framework-data', 'tmp', cifmw_federation_rules_file ] | path_join }}"
+    mode: "0644"
 
 - name: Copy federation rules json file into pod
   kubernetes.core.k8s_cp:

--- a/roles/hive/tasks/main.yml
+++ b/roles/hive/tasks/main.yml
@@ -30,6 +30,7 @@
   ansible.builtin.file:
     path: "{{ cifmw_hive_artifacts_dir }}"
     state: directory
+    mode: "0755"
 
 - name: "Performing {{ cifmw_hive_platform }} {{cifmw_hive_action }}"  # noqa: name[template]
   ansible.builtin.include_tasks: "{{ cifmw_hive_platform }}_{{ cifmw_hive_action }}.yml"

--- a/roles/install_ca/tasks/main.yml
+++ b/roles/install_ca/tasks/main.yml
@@ -29,6 +29,7 @@
         url: "{{ cifmw_install_ca_url }}"
         dest: "{{ cifmw_install_ca_trust_dir }}"
         validate_certs: "{{ cifmw_install_ca_url_validate_certs | default(omit) }}"
+        mode: "0644"
 
     - name: Install custom CA bundle from inline
       register: ca_inline

--- a/roles/install_yamls/tasks/main.yml
+++ b/roles/install_yamls/tasks/main.yml
@@ -120,6 +120,7 @@
           {% for k,v in cifmw_install_yamls_environment.items() %}
           export {{ k }}={{ v }}
           {% endfor %}
+        mode: "0644"
 
 - name: Set install_yamls default values
   tags:
@@ -166,6 +167,7 @@
         'cifmw_install_yamls_defaults': cifmw_install_yamls_defaults
         } | to_nice_yaml
       }}
+    mode: "0644"
 
 - name: Create empty cifmw_install_yamls_environment if needed
   tags:

--- a/roles/kustomize_deploy/tasks/install_operators.yml
+++ b/roles/kustomize_deploy/tasks/install_operators.yml
@@ -51,6 +51,7 @@
           'values.yaml'
         ) | path_join
       }}
+    mode: "0644"
 
 - name: Generate the OLM kustomization file
   ansible.builtin.copy:

--- a/roles/libvirt_manager/molecule/generate_network_data/tasks/test.yml
+++ b/roles/libvirt_manager/molecule/generate_network_data/tasks/test.yml
@@ -151,6 +151,7 @@
             remote_src: true
             src: "{{ cifmw_basedir }}/{{ item }}"
             dest: "{{ _dest }}/"
+            mode: "0755"
           loop:
             - artifacts
             - logs
@@ -160,11 +161,14 @@
           failed_when: false
           ansible.builtin.copy:
             remote_src: true
-            src: "{{ item }}"
+            src: "{{ item.src }}"
             dest: "{{ _dest }}/"
+            mode: "{{ item.mode }}"
           loop:
-            - /etc/cifmw-dnsmasq.conf
-            - /etc/cifmw-dnsmasq.d
+            - { src: "/etc/cifmw-dnsmasq.conf", mode: "0644" }
+            - { src: "/etc/cifmw-dnsmasq.d", mode: "0755" }
+          loop_control:
+            label: "{{ item.src }}"
 
     - name: Clean environment
       vars:

--- a/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/roles/libvirt_manager/tasks/clean_layout.yml
@@ -82,6 +82,7 @@
         marker: "## {mark} {{ vm }} {{ inventory_hostname }}"
         state: absent
         create: true
+        mode: "0600"
       loop: "{{ cleanup_vms }}"
 
     # KEEP this for now to ensure smoother migration
@@ -93,6 +94,7 @@
         marker: "## {mark} {{ vm }}"
         state: absent
         create: true
+        mode: "0600"
       loop: "{{ cleanup_vms }}"
 
     - name: Get network list

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -95,6 +95,7 @@
   ansible.builtin.template:
     dest: "{{ cifmw_libvirt_manager_basedir }}/reproducer-inventory/{{ item }}-group.yml"
     src: inventory.yml.j2
+    mode: "0644"
   loop: "{{ _cifmw_libvirt_manager_layout.vms.keys() }}"
   loop_control:
     label: "{{ item }}"
@@ -103,6 +104,7 @@
   ansible.builtin.template:
     dest: "{{ cifmw_libvirt_manager_basedir }}/reproducer-inventory/all-group.yml"
     src: "all-inventory.yml.j2"
+    mode: "0644"
 
 - name: Ensure storage pool is present.
   when:
@@ -316,6 +318,7 @@
         dest: >-
           {{ cifmw_libvirt_manager_basedir }}/artifacts/virtual-nodes.yml
         content: "{{ content | to_nice_yaml }}"
+        mode: "0644"
 
 - name: Ensure we get proper access to CRC
   when:

--- a/roles/libvirt_manager/tasks/generate_networking_data.yml
+++ b/roles/libvirt_manager/tasks/generate_networking_data.yml
@@ -79,6 +79,7 @@
       ansible.builtin.copy:
         dest: "{{ _nic_info }}"
         content: "{{ cifmw_libvirt_manager_mac_map | to_nice_yaml }}"
+        mode: "0644"
 # END MAC pre-generation management
 #
 # START generate all IPs using networking_mapper role/module

--- a/roles/libvirt_manager/tasks/get_image.yml
+++ b/roles/libvirt_manager/tasks/get_image.yml
@@ -25,6 +25,7 @@
       ansible.builtin.get_url:
         url: "{{ image_data.image_url }}"
         dest: "{{ image_data.image_local_dir }}/{{ image_data.disk_file_name }}"
+        mode: "0644"
         checksum: >-
           {% if image_data.sha256_image_name -%}
           sha256:{{ image_data.sha256_image_name }}

--- a/roles/mirror_registry/tasks/main.yml
+++ b/roles/mirror_registry/tasks/main.yml
@@ -28,6 +28,7 @@
     owner: "{{ ansible_user_id }}"
     group: "{{ ansible_user_id }}"
     state: directory
+    mode: "0755"
 
 - name: Download mirror-registry tools
   ansible.builtin.unarchive:

--- a/roles/nat64_appliance/molecule/default/converge.yml
+++ b/roles/nat64_appliance/molecule/default/converge.yml
@@ -50,6 +50,7 @@
         url: "{{ cifmw_discovered_image_url }}"
         dest: "{{ cifmw_basedir }}"
         timeout: 20
+        mode: "0644"
       register: result
       until: result is success
       retries: 60
@@ -423,26 +424,31 @@
       ansible.builtin.copy:
         dest: "{{ cifmw_basedir }}/logs/test_node_info.log"
         content: "{{ _test_node_debug_info.stdout }}"
+        mode: "0644"
 
     - name: Write nat64-appliance info to file
       ansible.builtin.copy:
         dest: "{{ cifmw_basedir }}/logs/nat64_appliance_node_info.log"
         content: "{{ _nat64_appliance_debug_info.stdout }}"
+        mode: "0644"
 
     - name: Write nat64-appliance journal to file
       ansible.builtin.copy:
         dest: "{{ cifmw_basedir }}/logs/nat64_appliance_journal.log"
         content: "{{ _nat64_appliance_journal.stdout }}"
+        mode: "0644"
 
     - name: Write nat64-appliance DNS64 debug to file
       ansible.builtin.copy:
         dest: "{{ cifmw_basedir }}/logs/nat64_appliance_dns64_debug.log"
         content: "{{ _nat64_appliance_dns64_debug.stdout }}"
+        mode: "0644"
 
     - name: Write hypervisor info to file
       ansible.builtin.copy:
         dest: "{{ cifmw_basedir }}/logs/hypervisor_info.log"
         content: "{{ _hypervisor_info.stdout }}"
+        mode: "0644"
 
     - name: Ping example.com (delegate to test-node)
       delegate_to: test-node

--- a/roles/networking_mapper/tasks/_gather_facts.yml
+++ b/roles/networking_mapper/tasks/_gather_facts.yml
@@ -77,3 +77,4 @@
             items2dict |
             to_nice_yaml
           }}
+        mode: "0644"

--- a/roles/openshift_login/tasks/main.yml
+++ b/roles/openshift_login/tasks/main.yml
@@ -98,7 +98,7 @@
   ansible.builtin.copy:
     dest: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts/parameters/openshift-login-params.yml"
     content: "{{ cifmw_openshift_login_params_content | from_yaml | to_nice_yaml }}"
-
+    mode: "0600"
 - name: Update the install-yamls-params with KUBECONFIG
   when: cifmw_install_yamls_environment is defined
   block:
@@ -120,3 +120,4 @@
               }, recursive=true) | to_nice_yaml
           }}
         dest: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts/parameters/install-yamls-params.yml"
+        mode: "0600"

--- a/roles/pkg_build/tasks/main.yml
+++ b/roles/pkg_build/tasks/main.yml
@@ -20,6 +20,7 @@
   ansible.builtin.file:
     path: "{{ cifmw_pkg_build_basedir }}/{{ item }}"
     state: directory
+    mode: "0755"
   loop:
     - volumes/packages/gating_repo
     - artifacts
@@ -35,6 +36,7 @@
       ansible.builtin.file:
         path: "{{ cifmw_pkg_build_basedir }}/volumes/packages/{{ pkg.name }}"
         state: directory
+        mode: "0755"
       loop: "{{ cifmw_pkg_build_list }}"
       loop_control:
         loop_var: 'pkg'
@@ -44,6 +46,7 @@
       ansible.builtin.file:
         path: "{{ cifmw_pkg_build_basedir }}/logs/build_{{ pkg.name }}"
         state: directory
+        mode: "0755"
       loop: "{{ cifmw_pkg_build_list }}"
       loop_control:
         loop_var: 'pkg'

--- a/roles/reproducer/tasks/generate_bm_info.yml
+++ b/roles/reproducer/tasks/generate_bm_info.yml
@@ -151,3 +151,4 @@
       ) %}
       {% endfor %}
       {{ {'nodes': _ironic_nodes } | to_nice_yaml(indent=2) }}
+    mode: "0644"

--- a/roles/update/tasks/reboot_hypervisor_using_cr.yml
+++ b/roles/update/tasks/reboot_hypervisor_using_cr.yml
@@ -23,6 +23,7 @@
   ansible.builtin.copy:
     dest: "{{ cifmw_update_artifacts_basedir }}/{{ cifmw_reboot_dep_name }}.yaml"
     content: "{{ _content | to_nice_yaml }}"
+    mode: "0644"
   vars:
     _content:
       apiVersion: dataplane.openstack.org/v1beta1


### PR DESCRIPTION
This PR fixes the file permissions that were wrong in [last PR](https://github.com/openstack-k8s-operators/ci-framework/pull/2814)
TP 1178 passed the task where it was failing in the last PR.

This PR is tested against multiple jobs, if it still breaks your job, let me know where, and it will be patched instead of reverting the entire PR again.