### PR TITLE
Change base molecule nodeset to use just IBM providers

### DIFF
--- a/zuul.d/molecule-base.yaml
+++ b/zuul.d/molecule-base.yaml
@@ -2,7 +2,7 @@
 # one, and be listed in the "molecule.yaml" file.
 - job:
     name: cifmw-molecule-base
-    nodeset: centos-stream-9
+    nodeset: centos-stream-9-ibm
     parent: base-ci-framework
     provides:
       - cifmw-molecule

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -28,6 +28,18 @@
         nodes: []
 
 - nodeset:
+    name: centos-stream-9-ibm
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-ibm
+    groups:
+      - name: switch
+        nodes:
+          - controller
+      - name: peers
+        nodes: []
+
+- nodeset:
     name: 4x-centos-9-medium
     nodes:
       - name: controller


### PR DESCRIPTION
The other jobs require multi node deployment that mostly will work on Vexxhost. To unlock resources for other job, let's move molecule job to IBM.