### PR TITLE
Update the trigger job to use cifms's workflow

### DIFF
--- a/.github/workflows/sync_branches_with_ext_trigger.yml
+++ b/.github/workflows/sync_branches_with_ext_trigger.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   trigger-sync:
-    uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/release-branch-sync.yaml@main
+    uses: openstack-k8s-operators/ci-framework/.github/workflows/sync_branches_reusable_workflow.yml@main
     with:
       source_branch: ${{ inputs.source-branch }}
       target_branch: ananya-do-not-use-tmp # Hardcoded till testing finishes


### PR DESCRIPTION
Update the trigger job to use cifmws's workflow [1] instead of the one from openshift-k8s ci

[1] https://github.com/openstack-k8s-operators/ci-framework/blob/main/.github/workflows/sync_branches_reusable_workflow.yml