### PR TITLE
[DNM] Check zuul jobs without router setup

### DIFF
--- a/roles/os_net_setup/defaults/main.yml
+++ b/roles/os_net_setup/defaults/main.yml
@@ -19,7 +19,7 @@ cifmw_os_net_setup_config:
         cidr: 192.168.122.0/24
         allocation_pool_start: 192.168.122.171
         allocation_pool_end: 192.168.122.250
-        gateway_ip: 192.168.122.1
+        gateway_ip: 192.168.122.10
         enable_dhcp: true
 
 cifmw_os_net_subnetpool_config:

--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -47,6 +47,7 @@
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            router: "{{ ('ibm' in nodepool.cloud) | ternary(true, false) }}"
             range: 192.168.122.0/24
           internal-api:
             vlan: 20
@@ -220,6 +221,7 @@
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            router: "{{ ('ibm' in nodepool.cloud) | ternary(true, false) }}"
             range: 192.168.122.0/24
           internal-api:
             vlan: 20

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -164,6 +164,7 @@
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            router: "{{ ('ibm' in nodepool.cloud) | ternary(true, false) }}"
             range: 192.168.122.0/24
           internal-api:
             vlan: 20

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -13,6 +13,7 @@
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            router: "{{ ('ibm' in nodepool.cloud) | ternary(true, false) }}"
             range: 192.168.122.0/24
           internal-api:
             vlan: 20
@@ -76,6 +77,7 @@
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            router: "{{ ('ibm' in nodepool.cloud) | ternary(true, false) }}"
             range: 192.168.122.0/24
           internal-api:
             vlan: 20
@@ -153,6 +155,7 @@
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            router: "{{ ('ibm' in nodepool.cloud) | ternary(true, false) }}"
             range: 192.168.122.0/24
           internal-api:
             vlan: 20
@@ -245,6 +248,7 @@
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            router: "{{ ('ibm' in nodepool.cloud) | ternary(true, false) }}"
             range: 192.168.122.0/24
           internal-api:
             vlan: 20

--- a/zuul.d/kuttl_multinode.yaml
+++ b/zuul.d/kuttl_multinode.yaml
@@ -15,6 +15,7 @@
             range: 192.168.122.0/24
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            router: "{{ ('ibm' in nodepool.cloud) | ternary(true, false) }}"
           internal-api:
             vlan: 20
             range: 172.17.0.0/24

--- a/zuul.d/podified_multinode.yaml
+++ b/zuul.d/podified_multinode.yaml
@@ -23,6 +23,7 @@
             range: 192.168.122.0/24
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            router: "{{ ('ibm' in nodepool.cloud) | ternary(true, false) }}"
           internal-api:
             vlan: 20
             range: 172.17.0.0/24

--- a/zuul.d/tempest_multinode.yaml
+++ b/zuul.d/tempest_multinode.yaml
@@ -23,6 +23,7 @@
             range: 192.168.122.0/24
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            router: "{{ ('ibm' in nodepool.cloud) | ternary(true, false) }}"
           internal-api:
             vlan: 20
             range: 172.17.0.0/24


### PR DESCRIPTION
For clouds where instances directly attached to public network, having a router with default gateway is unnecessary. This to test if we can avoid this and save some quoto on resources.

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1379