### PR TITLE
Adds GH action to run branch sync

### DIFF
--- a/.github/workflows/sync_branches_reusable_workflow.yml
+++ b/.github/workflows/sync_branches_reusable_workflow.yml
@@ -9,6 +9,10 @@ on:
       target-branch:
         required: true
         type: string
+    secrets:
+      ssh-key:
+        description: 'Deploy token write access'
+        required: true
 
 jobs:
   sync-branches:
@@ -20,6 +24,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.ssh-key }}
+          persist-credentials: true
 
       - name: Git config
         run: |

--- a/.github/workflows/sync_branches_with_ext_trigger.yml
+++ b/.github/workflows/sync_branches_with_ext_trigger.yml
@@ -1,18 +1,14 @@
-name: Sync branches with external trigger
-
+---
+name: Sync a target branch with source branch
 on:
-  workflow_dispatch:
-    inputs:
-      source-branch:
-        required: false
-        default: 'main'
-      target-branch:
-        required: false
-        default: 'ananya-do-not-use-tmp'
+  repository_dispatch:
+    types: [trigger-sync]
 
 jobs:
   trigger-sync:
     uses: openstack-k8s-operators/ci-framework/.github/workflows/sync_branches_reusable_workflow.yml@main
     with:
-      source-branch: ${{ inputs.source-branch }}
-      target-branch: ananya-do-not-use-tmp # Hardcoded till testing finishes
+      source-branch: ${{ github.event.client_payload.source-branch }}
+      target-branch: ${{ github.event.client_payload.target-branch }}
+    secrets:
+      ssh-key: ${{ secrets.DEPLOY_KEY }}


### PR DESCRIPTION
- One reusable workflow
  - You can pass source and target branch and a deploy key to it
  - This can be called from only another gh action workflow that is merged on the main branch
- One trigger workflow
  - This can be triggered with a rest API call with only a PAT generated by someone who owns the repo/organization
  - You can pass source and target branch through the payload. The default is set to main (and a dummy branch for poc)
  - I tried with a[ bad-person branch](https://github.com/frenzyfriday/frenzyfriday-testproject/tree/bad-person) to see if I can trigger this workflow from a non-main branch - I could not
- Tokens:
  - One deploy_token with permission to push to only the target branch
  - One PAT with permission to write on the repo
  - Push to all branches are restricted. The deploy token is added as a bypass to allow push to the target branch (stable/olive whichever we decide)
 ```
curl -L \
  -X POST \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer github_pat_PATPAT" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/frenzyfriday/frenzyfriday-testproject/dispatches \
  -d '{"event_type":"trigger-sync", "client_payload":{"source-branch":"main", "target-branch":"ananya-do-not-use-tmp"}}'
```
Tested on my own repo:
- https://github.com/frenzyfriday/frenzyfriday-testproject/blob/main/.github/workflows/sync_branches_reusable_workflow.yml
- https://github.com/frenzyfriday/frenzyfriday-testproject/blob/main/.github/workflows/sync_branches_with_ext_trigger.yml
- https://github.com/frenzyfriday/frenzyfriday-testproject/actions
