### PR TITLE
susy_emulator - allow 8000/tcp if firewall enabled

### DIFF
--- a/roles/sushy_emulator/tasks/configure_firewalld.yml
+++ b/roles/sushy_emulator/tasks/configure_firewalld.yml
@@ -1,0 +1,31 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Get firewalld.service status
+  ansible.builtin.systemd_service:
+    name: firewalld.service
+  register: firewalld_service_status
+
+- name: Open TCP port 8000 in firewalld if firewalld.service is enabled and active
+  ansible.posix.firewalld:
+    port: "8000/tcp"
+    zone: default
+    state: enabled
+    immediate: true
+    permanent: true
+  when:
+    - "firewalld_service_status.status.UnitFileState | default('disabled') == 'enabled'"
+    - "firewalld_service_status.status.ActiveState | default('inactive') == 'active'"

--- a/roles/sushy_emulator/tasks/main.yml
+++ b/roles/sushy_emulator/tasks/main.yml
@@ -39,3 +39,7 @@
 - name: Deploy Sushy Emulator into Podman container
   ansible.builtin.import_tasks: create_container.yml
   when: cifmw_sushy_emulator_install_type == 'podman'
+
+- name: Deploy Sushy Emulator into Podman container
+  ansible.builtin.import_tasks: configure_firewalld.yml
+  when: cifmw_sushy_emulator_install_type == 'podman'


### PR DESCRIPTION
When deploying sushy_emulator as a pod on, check if the firewalld service is enabled and if it is allow TCP port 8000.

Jira: [OSPRH-15286](https://issues.redhat.com//browse/OSPRH-15286)