### PR TITLE
[ci_gen_kustomize_values][bgp] Change ctlplane default GW

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/network-values/values.yaml.j2
@@ -154,7 +154,11 @@ data:
 {%  endif %}
           "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
           "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}",
+{%  if network.network_name == "ctlplane" %}
+          "gateway": "{{ network.network_v4 |ansible.utils.nthhost(2) }}"
+{%  else %}
           "gateway": "{{ network.network_v4 |ansible.utils.nthhost(1) }}"
+{%  endif %}
         }
       }
 {%  endif %}


### PR DESCRIPTION
Changed from 192.168.125.1 to 192.168.125.2 in order to not collide with dnsmasq