### PR TITLE
DNM Set IOPS limitation for CRC host

### DIFF
--- a/ci/playbooks/iops-limitation.yaml
+++ b/ci/playbooks/iops-limitation.yaml
@@ -1,0 +1,42 @@
+---
+- name: Set system-wide IOPS limitation via cgroups v2 on all hosts
+  hosts: all
+  become: true
+  vars:
+    main_blk_name: /dev/vda
+    iops_limit: 25000
+    rw_total_limit: 104857600  # 100mb in bytes
+  tasks:
+    - name: Get block device major:minor
+      become: true
+      ansible.builtin.shell: |
+        lsblk -nd -o MAJ:MIN {{ main_blk_name }}
+      register: _blk_dev
+      changed_when: false
+
+    - name: Set IOPS limit in the root cgroup
+      become: true
+      ansible.builtin.shell: |
+        echo "{{ _blk_dev.stdout }} riops={{ iops_limit }} wiops={{ iops_limit }} rbps={{ rw_total_limit }} wbps={{ rw_total_limit }}" > {{ item }}
+      loop:
+        - /sys/fs/cgroup/init.scope/io.max
+        - /sys/fs/cgroup/machine.slice/io.max
+        - /sys/fs/cgroup/system.slice/io.max
+        - /sys/fs/cgroup/user.slice/io.max
+      ignore_errors: true
+
+    - name: Verify the IOPS limit
+      ansible.builtin.shell: |
+        echo "init";
+        cat /sys/fs/cgroup/init.scope/io.max;
+        echo "machine";
+        cat /sys/fs/cgroup/machine.slice/io.max;
+        echo "syste";
+        cat /sys/fs/cgroup/system.slice/io.max;
+        echo "user"
+        cat /sys/fs/cgroup/user.slice/io.max;
+      register: _current_io_max
+
+    - name: Print the current io.max value
+      ansible.builtin.debug:
+        msg: "{{ _current_io_max.stdout_lines }}"

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -138,6 +138,7 @@
     roles: &multinode_edpm_roles
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run: &multinode_edpm_pre_run
+      - ci/playbooks/iops-limitation.yaml
       - ci/playbooks/multinode-customizations.yml
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
@@ -216,6 +217,7 @@
     required-projects: *multinode_edpm_rp
     roles: *multinode_edpm_roles
     pre-run:
+      - ci/playbooks/iops-limitation.yaml
       - ci/playbooks/bootstrap-networking-mapper.yml
       - ci/playbooks/crc/reconfigure-kubelet.yml
       - ci/playbooks/multinode-customizations.yml
@@ -237,6 +239,7 @@
     required-projects: *multinode_edpm_rp
     roles: *multinode_edpm_roles
     pre-run:
+      - ci/playbooks/iops-limitation.yaml
       - ci/playbooks/bootstrap-networking-mapper.yml
       - ci/playbooks/crc/reconfigure-kubelet.yml
       - ci/playbooks/multinode-customizations.yml
@@ -281,6 +284,7 @@
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run:
+      - ci/playbooks/iops-limitation.yaml
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
     post-run:
@@ -305,6 +309,7 @@
       CRC environment and before running ci-boostrap roles to
       configure networking between nodes.
     pre-run:
+      - ci/playbooks/iops-limitation.yaml
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
       - ci/playbooks/bootstrap-networking-mapper.yml

--- a/zuul.d/kuttl.yaml
+++ b/zuul.d/kuttl.yaml
@@ -7,6 +7,9 @@
     vars:
       crc_parameters: "--memory 20000 --disk-size 120 --cpus 6"
       zuul_log_collection: true
+      # https://review.rdoproject.org/r/c/config/+/57395
+      crc_disk_limitation: true
+
     parent: base-simple-crc
     pre-run:
       - ci/playbooks/e2e-prepare.yml


### PR DESCRIPTION
We are still having issue that OpenShift API is crashing. Set the IOPS limitation. If all is fine, we will revert that change and apply limitations in OpenStack flavor extra specs.