### PR TITLE
Pull dlrn hash md5 while populating component repo

### DIFF
--- a/roles/repo_setup/tasks/artifacts.yml
+++ b/roles/repo_setup/tasks/artifacts.yml
@@ -31,12 +31,15 @@
         dest: "{{ cifmw_repo_setup_basedir }}/artifacts/repositories/delorean.repo.md5"
         mode: "0644"
 
-    - name: Dump current-podified hash when using with component repo
+    - name: Dump dlrn hash when using with component repo
       when: cifmw_repo_setup_component_name | length > 0
       block:
-        - name: Dump current-podified hash
+          # Note(Chandan Kumar): It should be either podified-ci-testing and current-podified.
+          # or specific dlrn hash to test component content with current-podified and
+          # podified-ci-testing.
+        - name: Dump dlrn hash hash
           ansible.builtin.get_url:
-            url: "{{ cifmw_repo_setup_dlrn_uri }}/{{ cifmw_repo_setup_os_release }}{{ cifmw_repo_setup_dist_major_version }}-{{ cifmw_repo_setup_branch }}/current-podified/delorean.repo.md5"
+            url: "{{ cifmw_repo_setup_dlrn_uri }}/{{ cifmw_repo_setup_os_release }}{{ cifmw_repo_setup_dist_major_version }}-{{ cifmw_repo_setup_branch }}/{{ cifmw_repo_setup_promotion }}/delorean.repo.md5"
             dest: "{{ cifmw_repo_setup_basedir }}/artifacts/repositories/delorean.repo.md5"
             mode: "0644"
 


### PR DESCRIPTION
Currently in component repo, we pull current-podified dlrn md5 hash. But sometimes promotion lags, Specific DFG wants to test with podified-ci-testing content in component pipeline.

By pulling dlrn hash md5 hash instead of hardcoded current-podified hash allows us to test podified-ci-testing content with component repo.