### PR TITLE
Rename nodesets to include crc-cloud in the name

### DIFF
--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -339,13 +339,82 @@
       - name: controller
         label: centos-9-stream-crc-2-39-0-xl
 
-
 #
-# CRC-2.48 (OCP4.18) nodesets
+# CRC CLOUD (OCP 4.18) (CRC 2.48.0) nodesets
 #
 
 - nodeset:
-    name: centos-9-medium-crc-extracted-2-48-0-3xl
+    name: centos-9-crc-2-48-0-xxl
+    nodes:
+      - name: controller
+        label: centos-9-stream-crc-2-48-0-xxl
+
+- nodeset:
+    name: centos-9-medium-2x-centos-9-crc-cloud-ocp-4-18-1-xxl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+        # Note(Chandan Kumar): Switch to xxl nodeset once RHOSZUUL-1940 resolves
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: crc-cloud-ocp-4-18-1-xxl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-2x-centos-9-xxl-crc-cloud-ocp-4-18-1-xxl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo-xxl
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo-xxl
+      - name: crc
+        label: crc-cloud-ocp-4-18-1-xxl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-medium-3x-centos-9-crc-cloud-ocp-4-18-1-xxl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-2
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: crc-cloud-ocp-4-18-1-xxl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+          - compute-2
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-medium-crc-cloud-ocp-4-18-1-3xl
     nodes:
       - name: controller
         label: cloud-centos-9-stream-tripleo-medium
@@ -359,13 +428,7 @@
           - crc
 
 - nodeset:
-    name: centos-9-crc-2-48-0-xxl
-    nodes:
-      - name: controller
-        label: centos-9-stream-crc-2-48-0-xxl
-
-- nodeset:
-    name: centos-9-rhel-9-2-crc-extracted-2-48-0-3xl
+    name: centos-9-rhel-9-2-crc-cloud-ocp-4-18-1-3xl
     nodes:
       - name: controller
         label: cloud-centos-9-stream-tripleo
@@ -384,7 +447,7 @@
           - standalone
 
 - nodeset:
-    name: centos-9-multinode-rhel-9-2-crc-extracted-2-48-0-3xl
+    name: centos-9-multinode-rhel-9-2-crc-cloud-ocp-4-18-1-3xl
     nodes:
       - name: controller
         label: cloud-centos-9-stream-tripleo
@@ -431,7 +494,7 @@
           - overcloud-novacompute-2
 
 - nodeset:
-    name: centos-9-multinode-rhel-9-2-crc-extracted-2-48-0-3xl-novacells
+    name: centos-9-multinode-rhel-9-2-crc-cloud-ocp-4-18-1-3xl-novacells
     nodes:
       - name: controller
         label: cloud-centos-9-stream-tripleo
@@ -471,7 +534,7 @@
           - cell2-controller-compute-0
 
 - nodeset:
-    name: centos-9-medium-centos-9-crc-extracted-2-48-0-3xl
+    name: centos-9-medium-centos-9-crc-cloud-ocp-4-18-1-3xl
     nodes:
       - name: controller
         label: cloud-centos-9-stream-tripleo-medium
@@ -494,71 +557,7 @@
         label: centos-9-stream-crc-2-48-0-3xl
 
 - nodeset:
-    name: centos-9-medium-2x-centos-9-crc-extracted-2-48-0-xxl
-    nodes:
-      - name: controller
-        label: cloud-centos-9-stream-tripleo-medium
-        # Note(Chandan Kumar): Switch to xxl nodeset once RHOSZUUL-1940 resolves
-      - name: compute-0
-        label: cloud-centos-9-stream-tripleo
-      - name: compute-1
-        label: cloud-centos-9-stream-tripleo
-      - name: crc
-        label: crc-cloud-ocp-4-18-1-xxl
-    groups:
-      - name: computes
-        nodes:
-          - compute-0
-          - compute-1
-      - name: ocps
-        nodes:
-          - crc
-
-- nodeset:
-    name: centos-9-2x-centos-9-xxl-crc-extracted-2-48-0-xxl
-    nodes:
-      - name: controller
-        label: cloud-centos-9-stream-tripleo
-      - name: compute-0
-        label: cloud-centos-9-stream-tripleo-xxl
-      - name: compute-1
-        label: cloud-centos-9-stream-tripleo-xxl
-      - name: crc
-        label: crc-cloud-ocp-4-18-1-xxl
-    groups:
-      - name: computes
-        nodes:
-          - compute-0
-          - compute-1
-      - name: ocps
-        nodes:
-          - crc
-
-- nodeset:
-    name: centos-9-medium-3x-centos-9-crc-extracted-2-48-0-xxl
-    nodes:
-      - name: controller
-        label: cloud-centos-9-stream-tripleo-medium
-      - name: compute-0
-        label: cloud-centos-9-stream-tripleo
-      - name: compute-1
-        label: cloud-centos-9-stream-tripleo
-      - name: compute-2
-        label: cloud-centos-9-stream-tripleo
-      - name: crc
-        label: crc-cloud-ocp-4-18-1-xxl
-    groups:
-      - name: computes
-        nodes:
-          - compute-0
-          - compute-1
-          - compute-2
-      - name: ocps
-        nodes:
-          - crc
-
-- nodeset:
-    name: centos-9-medium-3x-centos-9-crc-extracted-2-48-0-3xl
+    name: centos-9-medium-3x-centos-9-crc-cloud-ocp-4-18-1-3xl
     nodes:
       - name: controller
         label: cloud-centos-9-stream-tripleo-medium
@@ -583,7 +582,7 @@
 
 # todo: Remove. Temporal. Needed as the credentials used in ci-bootstrap jobs for IBM don't work
 - nodeset:
-    name: centos-9-medium-centos-9-crc-extracted-2-48-0-3xl-vexxhost
+    name: centos-9-medium-centos-9-crc-cloud-ocp-4-18-1-3xl-vexxhost
     nodes:
       - name: controller
         label: cloud-centos-9-stream-tripleo-vexxhost-medium


### PR DESCRIPTION
Since OCP 4.18, CI jobs would be using CRC cloud, not CRC extracted, that might be confusing for people outside the project.