### PR TITLE
Allow setting BM_INSTANCE_MEMORY var

### DIFF
--- a/roles/install_yamls/defaults/main.yml
+++ b/roles/install_yamls/defaults/main.yml
@@ -35,6 +35,7 @@ cifmw_install_yamls_whitelisted_vars:
   - OUTPUT_BASEDIR
   - OUTPUT_DIR
   - SSH_KEY_FILE
+  - BM_INSTANCE_MEMORY
 # Defines in install_yamls when we should clone and checkout based on
 # openstack-operator references.
 cifmw_install_yamls_checkout_openstack_ref: "true"


### PR DESCRIPTION
Without this patch, the CI job will fail with error:

    fatal: [localhost]: FAILED! => changed=false
      assertion: _cifmw_install_yamls_unmatched_vars | length == 0
      evaluated_to: false
      msg: 'cifmw_install_yamls_vars contains a variable that is not
      defined in install_yamls Makefile nor
      cifmw_install_yamls_whitelisted_vars: BM_INSTANCE_MEMORY'