### PR TITLE
dnsmasq: Add locahost addresses to lo

### DIFF
--- a/roles/dnsmasq/tasks/configure.yml
+++ b/roles/dnsmasq/tasks/configure.yml
@@ -66,6 +66,15 @@
 - name: Render dns configuration
   ansible.builtin.include_tasks: dns.yml
 
+- name: Add localhost addresses from defined dnsmasq listen addresses to loopback interface
+  become: true
+  loop: "{{ cifmw_dnsmasq_listen_addresses }}"
+  when: item is match("^127\\..*")
+  ansible.builtin.shell: |
+    set -xe -o pipefail
+    ip addr show lo | grep -q "{{ item }}" || ip addr add {{ item }}/8 dev lo
+  changed_when: false
+
 - name: Manage and start dnsmasq instance
   become: true
   when:


### PR DESCRIPTION
The default listener.conf of
cifmw-dnsmasq looks like this:
 except-interface=lo
 bind-dynamic
 listen-address=127.0.0.2
 interface=cifmw-osp_trunk
 interface=ocpbm

Once the cifmw-dnsmasq service is
restarted A race/loop between dnsmasq's
static binding (listen-address
=127.0.0.2) and dynamic behavior
(bind-dynamic). The service constantly
throws an error: "failed to create
listening socket for 127.0.0.2: Address
already in use" and keeps creating
Unnconnected sockets until It reaches
the file descriptors limit and then
stops working properly.
There is no 127.0.0.2 IP assigned to lo
interface so I suspect It may cause
some race condition in the way a new IP
address/interface is dynamically
detected (bind-dynamic option) and the
statis binding (local-address option).