### PR TITLE
Add bgp-l3-xl dt

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,10 @@ roles/adoption_osp_deploy @openstack-k8s-operators/adoption-core-reviewers
 
 # BGP
 roles/ci_gen_kustomize_values/templates/bgp_dt01 @openstack-k8s-operators/bgp
+roles/ci_gen_kustomize_values/templates/bgp-l3-xl @openstack-k8s-operators/bgp
 playbooks/bgp-l3-computes-ready.yml @openstack-k8s-operators/bgp
+playbooks/bgp @openstack-k8s-operators/bgp
+scenarios/reproducers/bgp-l3-xl.yml @openstack-k8s-operators/bgp
 
 # Compliance
 roles/compliance @openstack-k8s-operators/security

--- a/playbooks/bgp/prepare-bgp-computes.yaml
+++ b/playbooks/bgp/prepare-bgp-computes.yaml
@@ -1,0 +1,71 @@
+---
+- name: Configure computes
+  hosts: "computes{{ networkers_bool | default(false) | bool | ternary(',networkers', '') }}"
+  tasks:
+    - name: Check default route corresponds with BGP
+      ansible.builtin.command:
+        cmd: "ip route show default"
+      register: _initial_default_ip_route_result
+      changed_when: false
+
+    - name: Early end if default route is already based on BGP
+      ansible.builtin.meta: end_play
+      when: "'proto bgp' in _initial_default_ip_route_result.stdout"
+
+    - name: Obtain the device with the DHCP default route
+      ansible.builtin.shell:
+        cmd: >
+          ip r show default |
+          grep "proto dhcp" |
+          grep -o "dev \w*" |
+          cut -d" " -f 2
+      ignore_errors: true
+      register: dhcp_default_route_device
+      changed_when: false
+
+    - name: Remove DHCP default route if it exists
+      when:
+        - dhcp_default_route_device.rc == 0
+        - dhcp_default_route_device.stdout | trim | length > 0
+      vars:
+        default_device: "{{ dhcp_default_route_device.stdout | trim }}"
+      block:
+        - name: Obtain the connection for the DHCP default route device
+          ansible.builtin.command:
+            cmd: >
+              nmcli -g GENERAL.CONNECTION device show {{ default_device }}
+          register: default_connection
+          changed_when: false
+
+        - name: Ignore dhcp default route from ocpbm interfaces
+          become: true
+          community.general.nmcli:
+            conn_name: "{{ default_connection.stdout | trim }}"
+            gw4_ignore_auto: true
+            gw6_ignore_auto: true
+            never_default4: true
+            state: present
+
+    - name: Remove default route obtained via DHCP from leafs in order to apply BGP
+      become: true
+      ansible.builtin.shell:
+        cmd: >
+          set -o pipefail && ip route show default |
+          grep "proto dhcp" |
+          xargs -r ip route del
+      changed_when: false
+
+    - name: Restart NetworkManager
+      become: true
+      ansible.builtin.systemd:
+        name: NetworkManager.service
+        state: restarted
+
+    - name: Check new default route corresponds with BGP
+      ansible.builtin.command:
+        cmd: "ip route show default"
+      register: default_ip_route_result
+      retries: 10
+      delay: 1
+      until: "'proto bgp' in default_ip_route_result.stdout"
+      changed_when: false

--- a/playbooks/bgp/prepare-bgp-hypervisor-from-controller.yaml
+++ b/playbooks/bgp/prepare-bgp-hypervisor-from-controller.yaml
@@ -1,0 +1,23 @@
+---
+- name: Prepare the BGP hypervisor with needed configuration
+  hosts: hypervisor
+  tasks:
+    - name: Set IPv4 forwarding
+      become: true
+      ansible.posix.sysctl:
+        name: net.ipv4.ip_forward
+        value: '1'
+        sysctl_set: true
+        sysctl_file: /etc/sysctl.d/90-network.conf
+        state: present
+        reload: true
+
+    - name: Disable reverse path forwarding validation
+      become: true
+      ansible.posix.sysctl:
+        name: net.ipv4.conf.all.rp_filter
+        value: '0'
+        sysctl_set: true
+        sysctl_file: /etc/sysctl.d/90-network.conf
+        state: present
+        reload: true

--- a/playbooks/bgp/prepare-bgp-spines-leaves.yaml
+++ b/playbooks/bgp/prepare-bgp-spines-leaves.yaml
@@ -1,0 +1,521 @@
+---
+- name: Common spines and leaves configuration
+  hosts: "spines,leafs{{ router_bool | default(false) | ternary(',routers', '') }}"
+  tasks:
+    - name: Workaround router advertisement packets polluting routing tables
+      become: true
+      ansible.builtin.shell:
+        cmd: |
+          for i in $(ls /proc/sys/net/ipv6/conf/*/forwarding); do echo 1 > $i; done
+      changed_when: false
+
+    - name: Register interfaces
+      ansible.builtin.shell:
+        cmd: "set -o pipefail && ls -1 /proc/sys/net/ipv4/conf/*/rp_filter | cut -d/ -f7"
+      register: interfaces
+      changed_when: false
+
+    - name: Disable reverse path forwarding validation
+      become: true
+      ansible.posix.sysctl:
+        name: "net.ipv4.conf.{{ item }}.rp_filter"
+        value: "0"
+        sysctl_set: true
+        sysctl_file: /etc/sysctl.d/sysctl.conf
+        state: present
+        reload: true
+      loop: "{{ interfaces.stdout_lines }}"
+      register: result
+      retries: 3
+      timeout: 60
+      until: result is not failed
+
+    - name: Disable reverse path forwarding validation
+      become: true
+      ansible.posix.sysctl:
+        name: "{{ item.key }}"
+        value: "{{ item.value }}"
+        sysctl_set: true
+        sysctl_file: /etc/sysctl.d/sysctl.conf
+        state: present
+        reload: true
+      loop: "{{ sysctls | dict2items }}"
+      vars:
+        sysctls:
+          net.ipv4.conf.all.rp_filter: '0'
+          net.ipv4.conf.default.rp_filter: '0'
+      register: result
+      retries: 3
+      timeout: 60
+      until: result is not failed
+
+    - name: Set IPv4 forwarding
+      become: true
+      ansible.posix.sysctl:
+        name: net.ipv4.ip_forward
+        value: '1'
+        sysctl_set: true
+        sysctl_file: /etc/sysctl.d/90-network.conf
+        state: present
+        reload: true
+
+    - name: Set IPv6 forwarding
+      become: true
+      ansible.posix.sysctl:
+        name: net.ipv6.conf.all.forwarding
+        value: '1'
+        sysctl_set: true
+        sysctl_file: /etc/sysctl.d/90-network.conf
+        state: present
+        reload: true
+
+    - name: Check installed packages
+      ansible.builtin.package_facts:
+        manager: auto
+
+    - name: Install FRR
+      when: '"frr" not in ansible_facts.packages'
+      block:
+        - name: Install RHOS Release tool
+          become: true
+          ansible.builtin.package:
+            name: "{{ cifmw_repo_setup_rhos_release_rpm }}"
+            state: present
+            disable_gpg_check: true
+
+        - name: Enable RHOS release repos.
+          become: true
+          ansible.builtin.command:
+            cmd: "rhos-release rhel"
+          changed_when: false
+
+        - name: Install frr
+          become: true
+          ansible.builtin.package:
+            name: frr
+            state: present
+
+    - name: Enable FRR BGP daemon
+      become: true
+      ansible.builtin.lineinfile:
+        path: /etc/frr/daemons
+        regexp: "^bgpd="
+        line: "bgpd=yes"
+        owner: frr
+        group: frr
+        mode: '640'
+
+    - name: Enable FRR BFD daemon
+      become: true
+      ansible.builtin.lineinfile:
+        path: /etc/frr/daemons
+        regexp: "^bfdd="
+        line: "bfdd=yes"
+        owner: frr
+        group: frr
+        mode: '640'
+
+    - name: Enable retain option of zebra
+      become: true
+      ansible.builtin.lineinfile:
+        path: /etc/frr/daemons
+        regexp: "^zebra_options="
+        line: "zebra_options=\"  -A 127.0.0.1 -s 90000000 -r \""
+        owner: frr
+        group: frr
+        mode: '640'
+
+# Router play
+- name: Configure router
+  hosts: "{{ router_bool | default(false) | ternary('routers', 'localhost') }}"
+  tasks:
+    - name: Early end if no router defined
+      ansible.builtin.meta: end_play
+      when: not (router_bool | default(false))
+
+    - name: Obtain the connection for the eth0 interface
+      ansible.builtin.command:
+        cmd: >
+          nmcli -g GENERAL.CONNECTION device show eth0
+      register: router_eth0_conn
+      changed_when: false
+
+    # When eth0 connection name is "Wired connection 1", then the rest of the
+    # connection names corresponding to the interfaces will follow this pattern:
+    # eth1 -> "Wired connection 2"
+    # eth2 -> "Wired connection 3"
+    # When eth0 connection name is different from "Wired connection 1", then the
+    # rest of the connection names corresponding to the interfaces will follow
+    # this pattern:
+    # eth1 -> "Wired connection 1"
+    # eth2 -> "Wired connection 2"
+    - name: Set router_conn_name_offset
+      ansible.builtin.set_fact:
+        router_conn_name_offset: >-
+          {{
+            1 if "Wired connection 1" == (router_eth0_conn.stdout | trim)
+            else 0
+          }}
+
+    - name: Build downlink connection list
+      vars:
+        connection_name: "Wired connection {{ (item | int) + (router_conn_name_offset | int) }}"
+        interface_name: "eth{{ item }}"
+      ansible.builtin.set_fact:
+        router_downlink_conns: "{{ router_downlink_conns | default([]) + [connection_name] }}"
+        router_downlink_ifs: "{{ router_downlink_ifs | default([]) + [interface_name] }}"
+      loop: "{{ range(1, 3) | list }}"  # the number of spines is always 2
+
+    - name: Build uplink connection
+      vars:
+        len_router_downlink_conns: "{{ router_downlink_conns | length }}"
+      ansible.builtin.set_fact:
+        router_uplink_conn: "Wired connection {{ 1 + (len_router_downlink_conns | int) + (router_conn_name_offset | int) }}"
+        router_uplink_if: "eth{{ 1 + (len_router_downlink_conns | int) }}"
+
+    - name: Configure downlink router connections with nmcli
+      become: true
+      community.general.nmcli:
+        autoconnect: true
+        conn_name: "{{ item }}"
+        type: ethernet
+        method4: disabled
+        method6: link-local
+        state: present
+      loop: "{{ router_downlink_conns }}"
+
+    - name: Configure uplink router connections with nmcli
+      become: true
+      community.general.nmcli:
+        autoconnect: true
+        conn_name: "{{ router_uplink_conn }}"
+        ip4: "{{ router_uplink_ip }}/30"
+        method4: manual
+        method6: link-local
+        state: present
+
+    - name: Add provider network gateway IP to router loopback
+      become: true
+      community.general.nmcli:
+        autoconnect: true
+        conn_name: lo
+        ip4:
+          - 127.0.0.1/8
+          - 192.168.133.1/32
+        method4: manual
+        ip6: "::1/128"
+        method6: manual
+        state: present
+
+    - name: Configure FRR
+      become: true
+      ansible.builtin.template:
+        src: templates/router-frr.conf.j2
+        dest: /etc/frr/frr.conf
+        owner: frr
+        group: frr
+        mode: '640'
+
+    - name: Enable and start FRR
+      become: true
+      ansible.builtin.service:
+        name: frr
+        enabled: true
+        state: restarted
+
+    - name: Masquerade mortacci
+      block:
+        - name: Install iptables
+          become: true
+          ansible.builtin.package:
+            name: iptables
+            state: present
+
+        - name: Masquerade outgoing traffic
+          vars:
+            router_ext_if: eth0
+          become: true
+          ansible.builtin.shell:
+            cmd: |
+              iptables -t nat -A POSTROUTING -s 99.99.0.0/16 -o {{ router_ext_if }} -j MASQUERADE
+              iptables -t nat -A POSTROUTING -s 192.168.0.0/16 -o {{ router_ext_if }} -j MASQUERADE
+          changed_when: false
+
+    - name: Restart NetworkManager
+      become: true
+      ansible.builtin.systemd:
+        name: NetworkManager.service
+        state: restarted
+
+
+# Spines play
+- name: Configure spines
+  hosts: spines
+  tasks:
+    - name: Obtain the connection for the eth0 interface
+      ansible.builtin.command:
+        cmd: >
+          nmcli -g GENERAL.CONNECTION device show eth0
+      register: spine_eth0_conn
+      changed_when: false
+
+    - name: Set spine_conn_name_offset
+      ansible.builtin.set_fact:
+        spine_conn_name_offset: >-
+          {{
+            1 if "Wired connection 1" == (spine_eth0_conn.stdout | trim)
+            else 0
+          }}
+
+    - name: Build downlink connection list
+      vars:
+        num_conns: "{{ (num_racks | default(4) | int) * 2 }}"
+        connection_name: "Wired connection {{ (item | int) + (spine_conn_name_offset | int) }}"
+        interface_name: "eth{{ item }}"
+      ansible.builtin.set_fact:
+        spine_downlink_conns: "{{ spine_downlink_conns | default([]) + [connection_name] }}"
+        spine_downlink_ifs: "{{ spine_downlink_ifs | default([]) + [interface_name] }}"
+      loop: "{{ range(1, 1 + (num_conns | int)) | list }}"
+
+    - name: Build uplink connection
+      vars:
+        len_spine_downlink_conns: "{{ spine_downlink_conns | length }}"
+      ansible.builtin.set_fact:
+        spine_uplink_conn: "Wired connection {{ 1 + (len_spine_downlink_conns | int) + (spine_conn_name_offset | int) }}"
+        spine_uplink_if: "eth{{ 1 + (len_spine_downlink_conns | int) }}"
+
+    - name: Configure spine connections with nmcli
+      become: true
+      vars:
+        spine_conns: >-
+          {{
+            router_bool | default(false) |
+            ternary(spine_downlink_conns + [spine_uplink_conn],
+                    spine_downlink_conns)
+          }}
+      community.general.nmcli:
+        autoconnect: true
+        conn_name: "{{ item }}"
+        type: ethernet
+        method4: disabled
+        method6: link-local
+        state: present
+      loop: "{{ spine_conns }}"
+
+    - name: Configure FRR
+      become: true
+      ansible.builtin.template:
+        src: templates/spine-frr.conf.j2
+        dest: /etc/frr/frr.conf
+        owner: frr
+        group: frr
+        mode: '640'
+
+    - name: Enable and start FRR
+      become: true
+      ansible.builtin.service:
+        name: frr
+        enabled: true
+        state: restarted
+
+    - name: Masquerade mortacci
+      when: not (router_bool | default(false))
+      block:
+        - name: Install iptables
+          become: true
+          ansible.builtin.package:
+            name: iptables
+            state: present
+
+        - name: Masquerade outgoing traffic
+          become: true
+          ansible.builtin.shell:
+            cmd: |
+              iptables -t nat -A POSTROUTING -s 99.99.0.0/16 -o {{ spine_uplink_if }} -j MASQUERADE
+              iptables -t nat -A POSTROUTING -s 192.168.0.0/16 -o {{ spine_uplink_if }} -j MASQUERADE
+          changed_when: false
+
+# Leaves play
+- name: Configure leaves
+  hosts: leafs
+  vars:
+    leaf_id: "{{ (ansible_hostname.split('-')[-1] | int) % 2 }}"  # always 2 leaves per rack
+    rack_id: "{{ (ansible_hostname.split('-')[-1] | int) // 2 }}"  # always 2 leaves per rack
+  tasks:
+    - name: Obtain the connection for the eth0 interface
+      ansible.builtin.command:
+        cmd: >
+          nmcli -g GENERAL.CONNECTION device show eth0
+      register: leaf_eth0_conn
+      changed_when: false
+
+    - name: Set leaf_conn_name_offset
+      ansible.builtin.set_fact:
+        leaf_conn_name_offset: >-
+          {{
+            1 if "Wired connection 1" == (leaf_eth0_conn.stdout | trim)
+            else 0
+          }}
+
+    - name: Build uplink connection list
+      vars:
+        connection_name: "Wired connection {{ (item | int) + (leaf_conn_name_offset | int) }}"
+        interface_name: "eth{{ item }}"
+      ansible.builtin.set_fact:
+        uplink_conns: "{{ uplink_conns | default([]) + [connection_name] }}"
+        uplink_ifs: "{{ uplink_ifs | default([]) + [interface_name] }}"
+      loop: "{{ range(1, 3) | list }}"  # the number of spines is always 2
+
+    - name: Build downlink connection list
+      vars:
+        num_conns: "{{ (edpm_nodes_per_rack | default(1) | int) + (ocp_nodes_per_rack | default(0) | int) }}"
+        connection_name: "Wired connection {{ (item | int) + (leaf_conn_name_offset | int) }}"
+        interface_name: "eth{{ item }}"
+      ansible.builtin.set_fact:
+        leaf_downlink_conns: "{{ leaf_downlink_conns | default([]) + [connection_name] }}"
+        leaf_downlink_ifs: "{{ leaf_downlink_ifs | default([]) + [interface_name] }}"
+      loop: "{{ range(3, 3 + (num_conns | int)) | list }}"
+
+    - name: Build downlink connection list for rack3
+      vars:
+        connection_name: "Wired connection {{ (item | int) + (leaf_conn_name_offset | int) }}"
+        interface_name: "eth{{ item }}"
+      ansible.builtin.set_fact:
+        downlink_conns_rack3: "{{ downlink_conns_rack3 | default([]) + [connection_name] }}"
+        downlink_ifs_rack3: "{{ downlink_ifs_rack3 | default([]) + [interface_name] }}"
+      loop: "{{ range(3, 6) | list }}"  # number of OCP nodes on rack3 is always 3
+
+    # rack3 is special because only OCP nodes are deployed on it when it exists
+    - name: Configure downlink leaf connections on rack3
+      become: true
+      vars:
+        leaf_ds_ip4: >-
+          100.{{ 64 + (leaf_id | int) }}.{{ rack_id }}.{{ 1 + 4 * (loop_index | int) }}
+      when: (rack_id | int) == 3
+      community.general.nmcli:
+        autoconnect: true
+        conn_name: "{{ item }}"
+        ip4: "{{ leaf_ds_ip4 }}/30"
+        method4: manual
+        method6: link-local
+        state: present
+      loop: "{{ downlink_conns_rack3 }}"
+      loop_control:
+        index_var: loop_index
+
+    - name: Configure downlink leaf connections on racks 0, 1 and 2
+      become: true
+      vars:
+        leaf_ds_ip4: >-
+          100.{{ 64 + (leaf_id | int) }}.{{ rack_id }}.{{ 1 + 4 * (loop_index | int) }}
+      when: (rack_id | int) != 3
+      community.general.nmcli:
+        autoconnect: true
+        conn_name: "{{ item }}"
+        ip4: "{{ leaf_ds_ip4 }}/30"
+        method4: manual
+        method6: link-local
+        state: present
+      loop: "{{ leaf_downlink_conns }}"
+      loop_control:
+        index_var: loop_index
+
+    - name: Configure uplink leaf connections
+      become: true
+      community.general.nmcli:
+        autoconnect: true
+        conn_name: "{{ item }}"
+        method4: disabled
+        method6: link-local
+        state: present
+      loop: "{{ uplink_conns }}"
+
+    - name: Configure FRR
+      become: true
+      vars:
+        downlink_interfaces: "{{ downlink_ifs_rack3 if (rack_id | int) == 3 else leaf_downlink_ifs }}"
+      ansible.builtin.template:
+        src: templates/leaf-frr.conf.j2
+        dest: /etc/frr/frr.conf
+        owner: frr
+        group: frr
+        mode: '640'
+
+    - name: Enable FRR Zebra daemon
+      become: true
+      ansible.builtin.lineinfile:
+        path: /etc/frr/daemons
+        regexp: "^zebra="
+        line: "zebra=yes"
+        owner: frr
+        group: frr
+        mode: '640'
+
+    - name: Enable and start FRR
+      become: true
+      ansible.builtin.service:
+        name: frr
+        enabled: true
+        state: restarted
+
+# Final play to remove DHCP default routes
+- name: Remove DHCP default routes and use BGP instead
+  hosts: "leafs{{ router_bool | default(false) | ternary(',spines', '') }}"
+  tasks:
+    - name: Obtain the device with the DHCP default route
+      ansible.builtin.shell:
+        cmd: >
+          ip r show default |
+          grep "proto dhcp" |
+          grep -o "dev \w*" |
+          cut -d" " -f 2
+      ignore_errors: true
+      register: dhcp_default_route_device
+      changed_when: false
+
+    - name: Remove DHCP default route if it exists
+      when:
+        - dhcp_default_route_device.rc == 0
+        - dhcp_default_route_device.stdout | trim | length > 0
+      vars:
+        default_device: "{{ dhcp_default_route_device.stdout | trim }}"
+      block:
+        - name: Obtain the connection for the DHCP default route device
+          ansible.builtin.command:
+            cmd: >
+              nmcli -g GENERAL.CONNECTION device show {{ default_device }}
+          register: default_connection
+          changed_when: false
+
+        - name: Ignore dhcp default route from ocpbm interfaces
+          become: true
+          community.general.nmcli:
+            conn_name: "{{ default_connection.stdout | trim }}"
+            gw4_ignore_auto: true
+            gw6_ignore_auto: true
+            never_default4: true
+            state: present
+
+    - name: Remove default route obtained via DHCP from leaves in order to apply BGP
+      become: true
+      ansible.builtin.shell:
+        cmd: >
+          set -o pipefail && ip route show default |
+          grep "proto dhcp" |
+          xargs -r ip route del
+      changed_when: false
+
+    - name: Restart NetworkManager
+      become: true
+      ansible.builtin.systemd:
+        name: NetworkManager.service
+        state: restarted
+
+    - name: Check new default route corresponds with BGP
+      ansible.builtin.command:
+        cmd: "ip route show default"
+      register: default_ip_route_result
+      retries: 10
+      delay: 1
+      until: "'proto bgp' in default_ip_route_result.stdout"
+      changed_when: false

--- a/playbooks/bgp/templates/leaf-frr.conf.j2
+++ b/playbooks/bgp/templates/leaf-frr.conf.j2
@@ -1,0 +1,87 @@
+hostname {{ ansible_hostname }}
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+line vty
+frr version 7.0
+
+debug bfd peer
+debug bfd network
+debug bfd zebra
+
+debug bgp graceful-restart
+debug bgp neighbor-events
+debug bgp updates
+debug bgp update-groups
+
+router bgp 64999
+  bgp log-neighbor-changes
+  bgp graceful-shutdown
+
+  bgp graceful-restart
+  bgp graceful-restart notification
+  bgp graceful-restart restart-time 60
+  bgp graceful-restart preserve-fw-state
+  ! bgp long-lived-graceful-restart stale-time 15
+
+  neighbor downlink peer-group
+  neighbor downlink remote-as internal
+  neighbor downlink bfd
+  neighbor downlink bfd profile tripleo
+  neighbor downlink password f00barZ
+  ! neighbor downlink capability extended-nexthop
+{% for iface in downlink_interfaces %}
+  neighbor {{iface}} interface peer-group downlink
+{% endfor %}
+
+  neighbor uplink peer-group
+  neighbor uplink remote-as external
+  neighbor uplink bfd
+  neighbor uplink bfd profile tripleo
+  ! neighbor uplink capability extended-nexthop
+{% for iface in uplink_ifs %}
+  neighbor {{iface}} interface peer-group uplink
+{% endfor %}
+
+  address-family ipv4 unicast
+    redistribute connected
+    neighbor downlink route-reflector-client
+    neighbor downlink default-originate
+    neighbor downlink next-hop-self
+    neighbor downlink prefix-list only-host-prefixes out
+    neighbor uplink allowas-in origin
+    neighbor uplink prefix-list only-default-host-prefixes in
+  exit-address-family
+
+  address-family ipv6 unicast
+    redistribute connected
+    neighbor downlink activate
+    neighbor downlink route-reflector-client
+    neighbor downlink default-originate
+    neighbor downlink next-hop-self
+    neighbor uplink activate
+    neighbor uplink allowas-in origin
+    neighbor uplink prefix-list only-default-host-prefixes in
+  exit-address-family
+
+  address-family l2vpn evpn
+    neighbor uplink activate
+    neighbor uplink allowas-in origin
+    neighbor downlink activate
+    neighbor downlink route-reflector-client
+  exit-address-family
+
+ip prefix-list only-default-host-prefixes permit 0.0.0.0/0
+ip prefix-list only-default-host-prefixes permit 0.0.0.0/0 ge 32
+ip prefix-list only-host-prefixes permit 0.0.0.0/0 ge 32
+
+ipv6 prefix-list only-default-host-prefixes permit ::/0
+ipv6 prefix-list only-default-host-prefixes permit ::/0 ge 128
+ipv6 prefix-list only-host-prefixes permit ::/0 ge 128
+
+ip nht resolve-via-default
+
+bfd
+  profile tripleo
+    detect-multiplier 10
+    transmit-interval 500
+    receive-interval 500

--- a/playbooks/bgp/templates/router-frr.conf.j2
+++ b/playbooks/bgp/templates/router-frr.conf.j2
@@ -1,0 +1,64 @@
+hostname {{ ansible_hostname }}
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+line vty
+frr version 7.0
+
+debug bfd peer
+debug bfd network
+debug bfd zebra
+
+debug bgp graceful-restart
+debug bgp neighbor-events
+debug bgp updates
+debug bgp update-groups
+
+router bgp 65000
+  bgp log-neighbor-changes
+  bgp graceful-shutdown
+
+  neighbor downlink peer-group
+  neighbor downlink remote-as internal
+  neighbor downlink bfd
+  ! neighbor downlink capability extended-nexthop
+{% for iface in router_downlink_ifs %}
+  neighbor {{iface}} interface peer-group downlink
+{% endfor %}
+
+  neighbor uplink peer-group
+  neighbor uplink remote-as external
+  neighbor uplink bfd
+  ! neighbor uplink capability extended-nexthop
+  neighbor {{router_uplink_if}} interface peer-group uplink
+
+  address-family ipv4 unicast
+    redistribute connected
+    neighbor downlink default-originate
+    neighbor downlink prefix-list only-host-prefixes in
+    neighbor uplink prefix-list only-default-host-prefixes in
+  exit-address-family
+
+  address-family ipv6 unicast
+    redistribute connected
+    neighbor downlink activate
+    neighbor downlink default-originate
+    neighbor downlink prefix-list only-host-prefixes in
+    neighbor uplink activate
+    neighbor uplink prefix-list only-default-host-prefixes in
+  exit-address-family
+
+  address-family l2vpn evpn
+    neighbor uplink activate
+    neighbor downlink activate
+    neighbor downlink route-reflector-client
+  exit-address-family
+
+ip prefix-list only-default-host-prefixes permit 0.0.0.0/0
+ip prefix-list only-default-host-prefixes permit 0.0.0.0/0 ge 32
+ip prefix-list only-host-prefixes permit 0.0.0.0/0 ge 32
+
+ipv6 prefix-list only-default-host-prefixes permit ::/0
+ipv6 prefix-list only-default-host-prefixes permit ::/0 ge 128
+ipv6 prefix-list only-host-prefixes permit ::/0 ge 128
+
+ip nht resolve-via-default

--- a/playbooks/bgp/templates/spine-frr.conf.j2
+++ b/playbooks/bgp/templates/spine-frr.conf.j2
@@ -1,0 +1,80 @@
+hostname {{ ansible_hostname }}
+log file /var/log/frr/frr.log
+service integrated-vtysh-config
+line vty
+frr version 7.0
+
+debug bfd peer
+debug bfd network
+debug bfd zebra
+
+debug bgp graceful-restart
+debug bgp neighbor-events
+debug bgp updates
+debug bgp update-groups
+
+router bgp 65000
+  bgp log-neighbor-changes
+  bgp graceful-shutdown
+
+  neighbor downlink peer-group
+  neighbor downlink remote-as external
+  neighbor downlink bfd
+  neighbor downlink bfd profile tripleo
+  ! neighbor downlink capability extended-nexthop
+{% for iface in spine_downlink_ifs %}
+  neighbor {{iface}} interface peer-group downlink
+{% endfor %}
+
+{% if router_bool | default(false) %}
+  neighbor uplink peer-group
+  neighbor uplink remote-as internal
+  neighbor uplink bfd
+  neighbor uplink bfd profile tripleo
+  ! neighbor uplink capability extended-nexthop
+  neighbor {{spine_uplink_if}} interface peer-group uplink
+{% endif %}
+
+  address-family ipv4 unicast
+    redistribute connected
+    neighbor downlink default-originate
+    neighbor downlink prefix-list only-host-prefixes in
+{% if router_bool | default(false) %}
+    neighbor uplink prefix-list only-default-host-prefixes in
+    neighbor uplink next-hop-self
+{% endif %}
+  exit-address-family
+
+  address-family ipv6 unicast
+    redistribute connected
+    neighbor downlink activate
+    neighbor downlink default-originate
+    neighbor downlink prefix-list only-host-prefixes in
+{% if router_bool | default(false) %}
+    neighbor uplink activate
+    neighbor uplink prefix-list only-default-host-prefixes in
+{% endif %}
+  exit-address-family
+
+  address-family l2vpn evpn
+    neighbor downlink activate
+{% if router_bool | default(false) %}
+    neighbor uplink activate
+{% endif %}
+  exit-address-family
+
+ip prefix-list only-default-host-prefixes permit 0.0.0.0/0
+ip prefix-list only-default-host-prefixes permit 0.0.0.0/0 ge 32
+ip prefix-list only-host-prefixes permit 0.0.0.0/0 ge 32
+
+ipv6 prefix-list only-default-host-prefixes permit ::/0
+ipv6 prefix-list only-default-host-prefixes permit ::/0 ge 128
+ipv6 prefix-list only-host-prefixes permit ::/0 ge 128
+
+ip nht resolve-via-default
+
+bfd
+  profile tripleo
+    detect-multiplier 10
+    transmit-interval 500
+    receive-interval 500

--- a/roles/ci_gen_kustomize_values/templates/bgp-l3-xl/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp-l3-xl/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2
@@ -1,0 +1,86 @@
+# source: bgp-l3-xl/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2
+{% set instances_names = [] %}
+{% set rack = 'r' ~ rack_number %}
+{% for _inst in cifmw_networking_env_definition.instances.keys() %}
+{%   if _inst.startswith('-'.join([rack, node_type])) %}
+{%     set _ = instances_names.append(_inst) %}
+{%   endif %}
+{% endfor %}
+data:
+  ssh_keys:
+    authorized: {{ cifmw_ci_gen_kustomize_values_ssh_authorizedkeys | b64encode }}
+    private: {{ cifmw_ci_gen_kustomize_values_ssh_private_key | b64encode }}
+    public: {{ cifmw_ci_gen_kustomize_values_ssh_public_key | b64encode }}
+  nova:
+    migration:
+      ssh_keys:
+        private: {{ cifmw_ci_gen_kustomize_values_migration_priv_key | b64encode }}
+        public: {{ cifmw_ci_gen_kustomize_values_migration_pub_key | b64encode }}
+  nodeset:
+    ansible:
+      ansibleUser: "zuul"
+      ansibleVars:
+        edpm_fips_mode: "{{ 'enabled' if cifmw_fips_enabled|default(false)|bool else 'check' }}"
+        timesync_ntp_servers:
+          - hostname: "{{ cifmw_ci_gen_kustomize_values_ntp_srv | default('pool.ntp.org') }}"
+        edpm_sshd_allowed_ranges:
+{% set sshd_allowed_range = cifmw_ci_gen_kustomize_values_sshd_ranges | default([]) %}
+{% for rack in ['r0', 'r1', 'r2'] %}
+{%   set _ = sshd_allowed_range.append(cifmw_networking_env_definition.networks['ctlplane' + rack].network_v4) %}
+{% endfor %}
+{% for range in sshd_allowed_range %}
+          - "{{ range }}"
+{% endfor %}
+          - 192.168.125.0/24
+          - 192.168.111.0/24
+    nodes:
+{% for instance in instances_names %}
+      {{ instance }}:
+        ansible:
+{%   set ctlplane_rack = 'ctlplane' + rack %}
+          host: {{ cifmw_networking_env_definition.instances[instance].networks[ctlplane_rack].ip_v4 }}
+{%   if original_content.data.nodeset.nodes['edpm-' ~ instance].ansible.ansibleVars is defined %}
+          ansibleVars: {{ original_content.data.nodeset.nodes['edpm-' ~ instance].ansible.ansibleVars }}
+{%   endif %}
+        hostName: {{ instance }}
+        networks:
+{%      for net in cifmw_networking_env_definition.instances[instance].networks.keys() %}
+{%        if 'storagemgmt' not in net %}
+          - name: {{ net if net != ctlplane_rack else 'ctlplane' }}
+            subnetName: {{ 'subnet1' if net != ctlplane_rack else 'subnet' ~ rack_number }}
+{%          if 'ctlplane' in net %}
+            defaultRoute: true
+            fixedIP: {{ cifmw_networking_env_definition.instances[instance].networks[ctlplane_rack].ip_v4 }}
+{%          endif %}
+{%        endif %}
+{%      endfor %}
+{%        if 'compute-0' in instance %}
+{%          set peer_suffix = 1 %}
+{%          set main_suffix = 7 %}
+{%        elif 'compute-1' in instance %}
+{%          set peer_suffix = 5 %}
+{%          set main_suffix = 8 %}
+{%        else %}
+{%          set peer_suffix = 9 %}
+{%          set main_suffix = 9 %}
+{%        endif %}
+          - name: BgpNet0
+            subnetName: subnet{{ rack_number }}
+            fixedIP: 100.64.{{ rack_number }}.{{ peer_suffix + 1 }}
+          - name: BgpNet1
+            subnetName: subnet{{ rack_number }}
+            fixedIP: 100.65.{{ rack_number }}.{{ peer_suffix + 1 }}
+          - name: BgpMainNet
+            subnetName: subnet{{ rack_number }}
+            fixedIP: 99.99.{{ rack_number }}.{{ main_suffix }}
+          - name: BgpMainNetV6
+            subnetName: subnet{{ rack_number }}
+{%        if 'compute-0' in instance %}
+{%          set suffix = 7 %}
+{%        elif 'compute-1' in instance %}
+{%          set suffix = 8 %}
+{%        else %}
+{%          set suffix = 9 %}
+{%        endif %}
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:00{{ (rack_number | int) + 1 }}{{ suffix }}
+{% endfor %}

--- a/roles/ci_gen_kustomize_values/templates/bgp-l3-xl/edpm-r0-compute-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp-l3-xl/edpm-r0-compute-nodeset-values/values.yaml.j2
@@ -1,0 +1,5 @@
+---
+# source: bgp-l3-xl/edpm-r0-compute-nodeset-values/values.yaml.j2
+{% set node_type = "compute"                                                              %}
+{% set rack_number = 0                                                                    %}
+{% include 'templates/bgp-l3-xl/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp-l3-xl/edpm-r0-networker-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp-l3-xl/edpm-r0-networker-nodeset-values/values.yaml.j2
@@ -1,0 +1,5 @@
+---
+# source: bgp-l3-xl/edpm-r0-networker-nodeset-values/values.yaml.j2
+{% set node_type = "networker"                                                            %}
+{% set rack_number = 0                                                                    %}
+{% include 'templates/bgp-l3-xl/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp-l3-xl/edpm-r1-compute-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp-l3-xl/edpm-r1-compute-nodeset-values/values.yaml.j2
@@ -1,0 +1,5 @@
+---
+# source: bgp-l3-xl/edpm-r1-compute-nodeset-values/values.yaml.j2
+{% set node_type = "compute"                                                              %}
+{% set rack_number = 1                                                                    %}
+{% include 'templates/bgp-l3-xl/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp-l3-xl/edpm-r1-networker-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp-l3-xl/edpm-r1-networker-nodeset-values/values.yaml.j2
@@ -1,0 +1,5 @@
+---
+# source: bgp-l3-xl/edpm-r1-networker-nodeset-values/values.yaml.j2
+{% set node_type = "networker"                                                            %}
+{% set rack_number = 1                                                                    %}
+{% include 'templates/bgp-l3-xl/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp-l3-xl/edpm-r2-compute-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp-l3-xl/edpm-r2-compute-nodeset-values/values.yaml.j2
@@ -1,0 +1,5 @@
+---
+# source: bgp-l3-xl/edpm-r2-compute-nodeset-values/values.yaml.j2
+{% set node_type = "compute"                                                              %}
+{% set rack_number = 2                                                                    %}
+{% include 'templates/bgp-l3-xl/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp-l3-xl/edpm-r2-networker-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp-l3-xl/edpm-r2-networker-nodeset-values/values.yaml.j2
@@ -1,0 +1,5 @@
+---
+# source: bgp-l3-xl/edpm-r2-networker-nodeset-values/values.yaml.j2
+{% set node_type = "networker"                                                            %}
+{% set rack_number = 2                                                                    %}
+{% include 'templates/bgp-l3-xl/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp-l3-xl/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp-l3-xl/network-values/values.yaml.j2
@@ -1,0 +1,194 @@
+---
+# source: bgp-l3-xl/network-values/values.yaml.j2
+{% set ns = namespace(interfaces={},
+                      ocp_index=0,
+                      lb_tools={}) %}
+data:
+{% for host in cifmw_networking_env_definition.instances.keys() -%}
+{%   set hostname = cifmw_networking_env_definition.instances[host]['hostname'] %}
+{%   if host is match('^(ocp|crc).*') %}
+  node_{{ ns.ocp_index }}:
+    name: {{ hostname }}
+{%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
+{%       set ns.interfaces = ns.interfaces |
+                             combine({network.network_name: (network.parent_interface |
+                                                             default(network.interface_name)
+                                                            )
+                                     },
+                                     recursive=true) %}
+    {{ network.network_name }}_ip: {{ network.ip_v4 }}
+{%       if 'worker-9' == hostname and 'ctlplane' == network.network_name %}
+    base_if: {{ network.interface_name }}
+{%       endif %}
+{%     endfor %}
+{%     set node_bgp_orig_content = original_content.data.bgp.bgpdefs['node' ~ ns.ocp_index] %}
+{%     set node_bgp_net0 = node_bgp_orig_content.bgpnet0 %}
+{%     if 'worker-9' != hostname %}
+{%       set node_bgp_net1 = node_bgp_orig_content.bgpnet1 %}
+{%     endif %}
+    bgp_peers:
+      - {{ node_bgp_net0.bgp_peer }}
+{%     if 'worker-9' != hostname %}
+      - {{ node_bgp_net1.bgp_peer }}
+{%     endif %}
+    bgp_ip:
+      - {{ node_bgp_net0.bgp_ip }}
+{%     if 'worker-9' != hostname %}
+      - {{ node_bgp_net1.bgp_ip }}
+{%     endif %}
+    loopback_ip: {{ node_bgp_orig_content.loopback_ip }}
+    loopback_ipv6: {{ node_bgp_orig_content.loopback_ipv6 }}
+{%     if node_bgp_orig_content.routes | default(false) %}
+    routes: {{ node_bgp_orig_content.routes }}
+{%     endif %}
+{%     set ns.ocp_index = ns.ocp_index+1 %}
+{%   endif %}
+{% endfor %}
+
+{% for network in cifmw_networking_env_definition.networks.values() %}
+{%  set ns.lb_tools = {} %}
+  {{ network.network_name }}:
+    dnsDomain: {{ network.search_domain }}
+{%  if network.tools is defined and network.tools.keys() | length > 0 %}
+    subnets:
+{%    for tool in network.tools.keys() %}
+{%      if tool is match('.*lb$') %}
+{%        set _ = ns.lb_tools.update({tool: []}) %}
+{%      endif %}
+{%    endfor %}
+{%    if network.network_name != 'ctlplane' %}
+      - allocationRanges:
+{%      for range in network.tools.netconfig.ipv4_ranges %}
+        - end: {{ range.end }}
+          start: {{ range.start }}
+{%      endfor %}
+        cidr: {{ network.network_v4 }}
+{%      if network.gw_v4 is defined %}
+        gateway: {{ network.gw_v4 }}
+{%      endif %}
+        name: subnet1
+{%      if network.vlan_id is defined  %}
+        vlan: {{ network.vlan_id }}
+{%      endif %}
+{%    else %}
+{%      for rack in ['r0', 'r1', 'r2'] %}
+{%        set rack_subnet = cifmw_networking_env_definition.networks[network.network_name + rack] %}
+      - allocationRanges:
+{%        for range in rack_subnet.tools.netconfig.ipv4_ranges %}
+        - end: {{ range.end }}
+          start: {{ range.start }}
+{%        endfor %}
+        cidr: {{ rack_subnet.network_v4 }}
+{%        if rack_subnet.gw_v4 is defined %}
+        gateway: {{ rack_subnet.gw_v4 }}
+{%        endif %}
+        name: {{ 'subnet' ~ loop.index0 }}
+{%        if rack_subnet.vlan_id is defined  %}
+        vlan: {{ rack_subnet.vlan_id }}
+{%        endif %}
+{%      endfor %}
+{%    endif %}
+{%    if ns.lb_tools | length > 0 %}
+    lb_addresses:
+{%      for tool in ns.lb_tools.keys() %}
+{%        for lb_range in network.tools[tool].ipv4_ranges %}
+      - {{ lb_range.start }}-{{ lb_range.end }}
+{%          set _ = ns.lb_tools[tool].append(lb_range.start) %}
+{%        endfor %}
+    endpoint_annotations:
+      {{ tool }}.universe.tf/address-pool: {{ network.network_name }}
+      {{ tool }}.universe.tf/allow-shared-ip: {{ network.network_name }}
+      {{ tool }}.universe.tf/loadBalancerIPs: {{ ','.join(ns.lb_tools[tool]) }}
+{%      endfor %}
+{%    endif %}
+{%  endif %}
+    prefix-length: {{ network.network_v4 | ansible.utils.ipaddr('prefix') }}
+    mtu: {{ network.mtu | default(1500) }}
+{%  if network.vlan_id is defined  %}
+    vlan: {{ network.vlan_id }}
+{%    if ns.interfaces[network.network_name] is defined %}
+    iface: {{ network.network_name }}
+    base_iface: {{ ns.interfaces[network.network_name] }}
+{%    endif %}
+{%  else %}
+{%    if ns.interfaces[network.network_name] is defined %}
+    iface: {{ ns.interfaces[network.network_name] }}
+{%    endif %}
+{%  endif %}
+{%  if network.tools.multus is defined %}
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "{{ network.network_name }}",
+        "type": "bridge",
+        "isDefaultGateway": true,
+        "isGateway": true,
+        "forceAddress": false,
+        "ipMasq": true,
+        "hairpinMode": true,
+{%  if network.network_name == "octavia" %}
+        "bridge": "octbr",
+{%  elif network.network_name == "ctlplane" %}
+        "bridge": "ospbr",
+{%  else %}
+        "bridge": "{{ network.network_name }}",
+{%  endif %}
+        "ipam": {
+          "type": "whereabouts",
+          "range": "{{ network.network_v4 }}",
+{%  if network.network_name == "octavia" and network.tools.multus.ipv4_routes | default([]) | length > 0 %}
+          "routes": [
+{%  for route in network.tools.multus.ipv4_routes %}
+             {
+               "dst": "{{ route.destination }}",
+               "gw": "{{ route.gateway }}"
+             }{% if not loop.last %},{% endif %}
+{%  endfor %}
+           ],
+{%  endif %}
+          "range_start": "{{ network.tools.multus.ipv4_ranges.0.start }}",
+          "range_end": "{{ network.tools.multus.ipv4_ranges.0.end }}",
+{%  if network.network_name == "ctlplane" %}
+          "gateway": "{{ network.network_v4 |ansible.utils.nthhost(2) }}"
+{% else %}
+          "gateway": "{{ network.network_v4 |ansible.utils.nthhost(1) }}"
+{% endif %}
+        }
+      }
+{%  endif %}
+{% endfor %}
+
+  dns-resolver:
+    config:
+      server:
+# We set ctlplane = 192.168.125.0/24 and we rely on this definition to create the nad above.
+# BGP exposes nad ips by advertising a 192.168.125.X address on the worker, and this would break dns
+# because the traffic will not be sent to the right nic if a local ip on the same network is present.
+# To avoid messing with routes etc we hardcode the 122.1 ip here
+        - 192.168.122.1
+      search: []
+    options:
+      - key: server
+        values:
+          - 192.168.122.1
+{% for nameserver in cifmw_ci_gen_kustomize_values_nameservers %}
+      - key: server
+        values:
+          - {{ nameserver }}
+{% endfor %}
+
+  routes:
+    config: []
+
+# Hardcoding the last IP bit since we don't have support for endpoint_annotations in the networking_mapper output
+  rabbitmq:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(85) }}
+  rabbitmq-cell1:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(86) }}
+
+  lbServiceType: LoadBalancer
+  storageClass: local-storage

--- a/roles/reproducer/tasks/ocp_layout.yml
+++ b/roles/reproducer/tasks/ocp_layout.yml
@@ -329,7 +329,7 @@
     - name: Allow libvirt zone on the temporary VBMC port
       become: true
       ansible.posix.firewalld:
-        port: "51881-51890/udp"
+        port: "51881-51899/udp"
         zone: libvirt
         state: enabled
         immediate: true
@@ -347,6 +347,6 @@
     - name: Remove temporary VBMC port from libvirt zone
       become: true
       ansible.posix.firewalld:
-        port: "51881-51890/udp"
+        port: "51881-51899/udp"
         zone: libvirt
         state: disabled

--- a/scenarios/reproducers/bgp-l3-xl.yml
+++ b/scenarios/reproducers/bgp-l3-xl.yml
@@ -1,0 +1,1144 @@
+---
+
+cifmw_os_net_setup_config:
+  - name: public
+    external: true
+    is_default: true
+    provider_network_type: flat
+    provider_physical_network: datacentre
+    shared: true
+    subnets:
+      - name: public_subnet
+        cidr: 192.168.133.0/24
+        allocation_pool_start: 192.168.133.190
+        allocation_pool_end: 192.168.133.250
+        gateway_ip: 192.168.133.1
+        enable_dhcp: true
+
+
+cifmw_run_id: ''
+cifmw_use_devscripts: true
+cifmw_use_libvirt: true
+cifmw_virtualbmc_daemon_port: 50881
+cifmw_use_uefi: >-
+  {{ (cifmw_repo_setup_os_release is defined
+      and cifmw_repo_setup_os_release == 'rhel') | bool }}
+num_racks: 3
+cifmw_libvirt_manager_compute_amount: "{{ num_racks }}"
+cifmw_libvirt_manager_networker_amount: 3
+cifmw_libvirt_manager_pub_net: ocpbm
+cifmw_libvirt_manager_spineleaf_setup: true
+cifmw_libvirt_manager_network_interface_types:
+  rtr-ocp: network
+  s0-rtr: network
+  s1-rtr: network
+  l00-s0: network
+  l01-s0: network
+  l00-s1: network
+  l01-s1: network
+  l10-s0: network
+  l11-s0: network
+  l10-s1: network
+  l11-s1: network
+  l20-s0: network
+  l21-s0: network
+  l20-s1: network
+  l21-s1: network
+  l00-node0: network
+  l00-node1: network
+  l00-node2: network
+  l00-ocp0: network
+  l00-ocp1: network
+  l00-ocp2: network
+  l00-ocp3: network
+  l01-node0: network
+  l01-node1: network
+  l01-node2: network
+  l01-ocp0: network
+  l01-ocp1: network
+  l01-ocp2: network
+  l01-ocp3: network
+  l10-node0: network
+  l10-node1: network
+  l10-node2: network
+  l10-ocp0: network
+  l10-ocp1: network
+  l10-ocp2: network
+  l10-ocp3: network
+  l11-node0: network
+  l11-node1: network
+  l11-node2: network
+  l11-ocp0: network
+  l11-ocp1: network
+  l11-ocp2: network
+  l11-ocp3: network
+  l20-node0: network
+  l20-node1: network
+  l20-node2: network
+  l20-ocp0: network
+  l20-ocp1: network
+  l20-ocp2: network
+  l20-ocp3: network
+  l21-node0: network
+  l21-node1: network
+  l21-node2: network
+  l21-ocp0: network
+  l21-ocp1: network
+  l21-ocp2: network
+  l21-ocp3: network
+
+cifmw_libvirt_manager_configuration:
+  networks:
+    osp_trunk: |
+      <network>
+        <name>osp_trunk</name>
+        <forward mode='nat'/>
+        <bridge name='osp_trunk' stp='on' delay='0'/>
+        <ip family='ipv4'
+        address='{{ cifmw_networking_definition.networks.ctlplane.network |
+                    ansible.utils.nthhost(1) }}'
+        prefix='{{ cifmw_networking_definition.networks.ctlplane.network |
+                   ansible.utils.ipaddr('prefix') }}'>
+        </ip>
+      </network>
+    # router to ocp network
+    rtr-ocp: |
+      <network>
+        <name>rtr-ocp</name>
+        <bridge name='rtr-ocp' stp='on' delay='0'/>
+      </network>
+    # spines to router networks
+    s0-rtr: |
+      <network>
+        <name>s0-rtr</name>
+        <bridge name='s0-rtr' stp='on' delay='0'/>
+      </network>
+    s1-rtr: |
+      <network>
+        <name>s1-rtr</name>
+        <bridge name='s1-rtr' stp='on' delay='0'/>
+      </network>
+    # leafs to spines networks
+    ## rack0
+    l00-s0: |
+      <network>
+        <name>l00-s0</name>
+        <bridge name='l00-s0' stp='on' delay='0'/>
+      </network>
+    l00-s1: |
+      <network>
+        <name>l00-s1</name>
+        <bridge name='l00-s1' stp='on' delay='0'/>
+      </network>
+    l01-s0: |
+      <network>
+        <name>l01-s0</name>
+        <bridge name='l01-s0' stp='on' delay='0'/>
+      </network>
+    l01-s1: |
+      <network>
+        <name>l01-s1</name>
+        <bridge name='l01-s1' stp='on' delay='0'/>
+      </network>
+    ## rack1
+    l10-s0: |
+      <network>
+        <name>l10-s0</name>
+        <bridge name='l10-s0' stp='on' delay='0'/>
+      </network>
+    l10-s1: |
+      <network>
+        <name>l10-s1</name>
+        <bridge name='l10-s1' stp='on' delay='0'/>
+      </network>
+    l11-s0: |
+      <network>
+        <name>l11-s0</name>
+        <bridge name='l11-s0' stp='on' delay='0'/>
+      </network>
+    l11-s1: |
+      <network>
+        <name>l11-s1</name>
+        <bridge name='l11-s1' stp='on' delay='0'/>
+      </network>
+    ## rack2
+    l20-s0: |
+      <network>
+        <name>l20-s0</name>
+        <bridge name='l20-s0' stp='on' delay='0'/>
+      </network>
+    l20-s1: |
+      <network>
+        <name>l20-s1</name>
+        <bridge name='l20-s1' stp='on' delay='0'/>
+      </network>
+    l21-s0: |
+      <network>
+        <name>l21-s0</name>
+        <bridge name='l21-s0' stp='on' delay='0'/>
+      </network>
+    l21-s1: |
+      <network>
+        <name>l21-s1</name>
+        <bridge name='l21-s1' stp='on' delay='0'/>
+      </network>
+    # leafs to nodes and ocps
+    ## rack0
+    l00-node0: |
+      <network>
+        <name>l00-node0</name>
+        <bridge name='l00-node0' stp='on' delay='0'/>
+      </network>
+    l00-node1: |
+      <network>
+        <name>l00-node1</name>
+        <bridge name='l00-node1' stp='on' delay='0'/>
+      </network>
+    l00-node2: |
+      <network>
+        <name>l00-node2</name>
+        <bridge name='l00-node2' stp='on' delay='0'/>
+      </network>
+    l00-ocp0: |
+      <network>
+        <name>l00-ocp0</name>
+        <bridge name='l00-ocp0' stp='on' delay='0'/>
+      </network>
+    l00-ocp1: |
+      <network>
+        <name>l00-ocp1</name>
+        <bridge name='l00-ocp1' stp='on' delay='0'/>
+      </network>
+    l00-ocp2: |
+      <network>
+        <name>l00-ocp2</name>
+        <bridge name='l00-ocp2' stp='on' delay='0'/>
+      </network>
+    l00-ocp3: |
+      <network>
+        <name>l00-ocp3</name>
+        <bridge name='l00-ocp3' stp='on' delay='0'/>
+      </network>
+    l01-node0: |
+      <network>
+        <name>l01-node0</name>
+        <bridge name='l01-node0' stp='on' delay='0'/>
+      </network>
+    l01-node1: |
+      <network>
+        <name>l01-node1</name>
+        <bridge name='l01-node1' stp='on' delay='0'/>
+      </network>
+    l01-node2: |
+      <network>
+        <name>l01-node2</name>
+        <bridge name='l01-node2' stp='on' delay='0'/>
+      </network>
+    l01-ocp0: |
+      <network>
+        <name>l01-ocp0</name>
+        <bridge name='l01-ocp0' stp='on' delay='0'/>
+      </network>
+    l01-ocp1: |
+      <network>
+        <name>l01-ocp1</name>
+        <bridge name='l01-ocp1' stp='on' delay='0'/>
+      </network>
+    l01-ocp2: |
+      <network>
+        <name>l01-ocp2</name>
+        <bridge name='l01-ocp2' stp='on' delay='0'/>
+      </network>
+    l01-ocp3: |
+      <network>
+        <name>l01-ocp3</name>
+        <bridge name='l01-ocp3' stp='on' delay='0'/>
+      </network>
+    ## rack1
+    l10-node0: |
+      <network>
+        <name>l10-node0</name>
+        <bridge name='l10-node0' stp='on' delay='0'/>
+      </network>
+    l10-node1: |
+      <network>
+        <name>l10-node1</name>
+        <bridge name='l10-node1' stp='on' delay='0'/>
+      </network>
+    l10-node2: |
+      <network>
+        <name>l10-node2</name>
+        <bridge name='l10-node2' stp='on' delay='0'/>
+      </network>
+    l10-ocp0: |
+      <network>
+        <name>l10-ocp0</name>
+        <bridge name='l10-ocp0' stp='on' delay='0'/>
+      </network>
+    l10-ocp1: |
+      <network>
+        <name>l10-ocp1</name>
+        <bridge name='l10-ocp1' stp='on' delay='0'/>
+      </network>
+    l10-ocp2: |
+      <network>
+        <name>l10-ocp2</name>
+        <bridge name='l10-ocp2' stp='on' delay='0'/>
+      </network>
+    l10-ocp3: |
+      <network>
+        <name>l10-ocp3</name>
+        <bridge name='l10-ocp3' stp='on' delay='0'/>
+      </network>
+    l11-node0: |
+      <network>
+        <name>l11-node0</name>
+        <bridge name='l11-node0' stp='on' delay='0'/>
+      </network>
+    l11-node1: |
+      <network>
+        <name>l11-node1</name>
+        <bridge name='l11-node1' stp='on' delay='0'/>
+      </network>
+    l11-node2: |
+      <network>
+        <name>l11-node2</name>
+        <bridge name='l11-node2' stp='on' delay='0'/>
+      </network>
+    l11-ocp0: |
+      <network>
+        <name>l11-ocp0</name>
+        <bridge name='l11-ocp0' stp='on' delay='0'/>
+      </network>
+    l11-ocp1: |
+      <network>
+        <name>l11-ocp1</name>
+        <bridge name='l11-ocp1' stp='on' delay='0'/>
+      </network>
+    l11-ocp2: |
+      <network>
+        <name>l11-ocp2</name>
+        <bridge name='l11-ocp2' stp='on' delay='0'/>
+      </network>
+    l11-ocp3: |
+      <network>
+        <name>l11-ocp3</name>
+        <bridge name='l11-ocp3' stp='on' delay='0'/>
+      </network>
+    ## rack2
+    l20-node0: |
+      <network>
+        <name>l20-node0</name>
+        <bridge name='l20-node0' stp='on' delay='0'/>
+      </network>
+    l20-node1: |
+      <network>
+        <name>l20-node1</name>
+        <bridge name='l20-node1' stp='on' delay='0'/>
+      </network>
+    l20-node2: |
+      <network>
+        <name>l20-node2</name>
+        <bridge name='l20-node2' stp='on' delay='0'/>
+      </network>
+    l20-ocp0: |
+      <network>
+        <name>l20-ocp0</name>
+        <bridge name='l20-ocp0' stp='on' delay='0'/>
+      </network>
+    l20-ocp1: |
+      <network>
+        <name>l20-ocp1</name>
+        <bridge name='l20-ocp1' stp='on' delay='0'/>
+      </network>
+    l20-ocp2: |
+      <network>
+        <name>l20-ocp2</name>
+        <bridge name='l20-ocp2' stp='on' delay='0'/>
+      </network>
+    l20-ocp3: |
+      <network>
+        <name>l20-ocp3</name>
+        <bridge name='l20-ocp3' stp='on' delay='0'/>
+      </network>
+    l21-node0: |
+      <network>
+        <name>l21-node0</name>
+        <bridge name='l21-node0' stp='on' delay='0'/>
+      </network>
+    l21-node1: |
+      <network>
+        <name>l21-node1</name>
+        <bridge name='l21-node1' stp='on' delay='0'/>
+      </network>
+    l21-node2: |
+      <network>
+        <name>l21-node2</name>
+        <bridge name='l21-node2' stp='on' delay='0'/>
+      </network>
+    l21-ocp0: |
+      <network>
+        <name>l21-ocp0</name>
+        <bridge name='l21-ocp0' stp='on' delay='0'/>
+      </network>
+    l21-ocp1: |
+      <network>
+        <name>l21-ocp1</name>
+        <bridge name='l21-ocp1' stp='on' delay='0'/>
+      </network>
+    l21-ocp2: |
+      <network>
+        <name>l21-ocp2</name>
+        <bridge name='l21-ocp2' stp='on' delay='0'/>
+      </network>
+    l21-ocp3: |
+      <network>
+        <name>l21-ocp3</name>
+        <bridge name='l21-ocp3' stp='on' delay='0'/>
+      </network>
+    ocpbm: |
+      <network>
+        <name>ocpbm</name>
+        <forward mode='nat'/>
+        <bridge name='ocpbm' stp='on' delay='0'/>
+        <dns enable="no"/>
+        <ip family='ipv4' address='192.168.111.1' prefix='24'>
+        </ip>
+      </network>
+    ocppr: |
+      <network>
+        <name>ocppr</name>
+        <forward mode='bridge'/>
+        <bridge name='ocppr'/>
+      </network>
+    r0_tr: |
+      <network>
+        <name>r0_tr</name>
+        <forward mode='open'/>
+        <bridge name='r0_tr' stp='on' delay='0'/>
+        <ip family='ipv4'
+        address='{{ cifmw_networking_definition.networks.ctlplaner0.network |
+                    ansible.utils.nthhost(1)}}'
+        prefix='{{ cifmw_networking_definition.networks.ctlplaner0.network |
+                    ansible.utils.ipaddr('prefix') }}'>
+        </ip>
+      </network>
+    r1_tr: |
+      <network>
+        <name>r1_tr</name>
+        <forward mode='open'/>
+        <bridge name='r1_tr' stp='on' delay='0'/>
+        <ip family='ipv4'
+        address='{{ cifmw_networking_definition.networks.ctlplaner1.network |
+                    ansible.utils.nthhost(1)}}'
+        prefix='{{ cifmw_networking_definition.networks.ctlplaner1.network |
+                    ansible.utils.ipaddr('prefix') }}'>
+        </ip>
+      </network>
+    r2_tr: |
+      <network>
+        <name>r2_tr</name>
+        <forward mode='open'/>
+        <bridge name='r2_tr' stp='on' delay='0'/>
+        <ip family='ipv4'
+        address='{{ cifmw_networking_definition.networks.ctlplaner2.network |
+                    ansible.utils.nthhost(1)}}'
+        prefix='{{ cifmw_networking_definition.networks.ctlplaner2.network |
+                    ansible.utils.ipaddr('prefix') }}'>
+        </ip>
+      </network>
+
+  vms:
+    controller:
+      root_part_id: >-
+        {{
+          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
+          ternary(4, 1)
+        }}
+      image_url: "{{ cifmw_discovered_image_url }}"
+      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "base-os.qcow2"
+      disksize: 50
+      memory: 8
+      cpus: 4
+      nets:
+        - ocpbm
+        - osp_trunk
+    r0-compute: &r0_compute_def
+      amount: 2
+      root_part_id: >-
+        {{
+          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
+          ternary(4, 1)
+        }}
+      image_url: "{{ cifmw_discovered_image_url }}"
+      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "base-os.qcow2"
+      disksize: 50
+      memory: 8
+      cpus: 4
+      nets:
+        - "ocpbm"
+        - "r0_tr"
+      spineleafnets:
+        -  # rack0 - compute0
+          - "l00-node0"
+          - "l01-node0"
+        -  # rack0 - compute0
+          - "l00-node1"
+          - "l01-node1"
+    r1-compute:
+      amount: 2
+      root_part_id: "{{ cifmw_root_partition_id }}"
+      uefi: "{{ cifmw_use_uefi }}"
+      image_url: "{{ cifmw_discovered_image_url }}"
+      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "centos-stream-9.qcow2"
+      disksize: 50
+      memory: 8
+      cpus: 4
+      nets:
+        - ocpbm
+        - r1_tr
+      spineleafnets:
+        - # rack1 - compute0
+          - "l10-node0"
+          - "l11-node0"
+        - # rack1 - compute1
+          - "l10-node1"
+          - "l11-node1"
+    r2-compute:
+      amount: 2
+      root_part_id: "{{ cifmw_root_partition_id }}"
+      uefi: "{{ cifmw_use_uefi }}"
+      image_url: "{{ cifmw_discovered_image_url }}"
+      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "centos-stream-9.qcow2"
+      disksize: 50
+      memory: 8
+      cpus: 4
+      nets:
+        - ocpbm
+        - r2_tr
+      spineleafnets:
+        - # rack2 - compute0
+          - "l20-node0"
+          - "l21-node0"
+        - # rack2 - compute1
+          - "l20-node1"
+          - "l21-node1"
+
+    r0-networker:
+      amount: 1
+      root_part_id: >-
+        {{
+          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
+          ternary(4, 1)
+        }}
+      image_url: "{{ cifmw_discovered_image_url }}"
+      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "base-os.qcow2"
+      disksize: 40
+      memory: 8
+      cpus: 4
+      # ansible_group: networker
+      nets:
+        - "ocpbm"
+        - "r0_tr"
+      spineleafnets:
+        -  # rack0 - networker0
+          - "l00-node2"
+          - "l01-node2"
+    r1-networker:
+      amount: 1
+      root_part_id: >-
+        {{
+          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
+          ternary(4, 1)
+        }}
+      image_url: "{{ cifmw_discovered_image_url }}"
+      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "base-os.qcow2"
+      disksize: 40
+      memory: 8
+      cpus: 4
+      # ansible_group: networker
+      nets:
+        - "ocpbm"
+        - "r1_tr"
+      spineleafnets:
+        -  # rack1 - networker0
+          - "l10-node2"
+          - "l11-node2"
+    r2-networker:
+      amount: 1
+      root_part_id: >-
+        {{
+          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
+          ternary(4, 1)
+        }}
+      image_url: "{{ cifmw_discovered_image_url }}"
+      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "base-os.qcow2"
+      disksize: 40
+      memory: 8
+      cpus: 4
+      # ansible_group: networker
+      nets:
+        - "ocpbm"
+        - "r2_tr"
+      spineleafnets:
+        -  # rack2 - networker0
+          - "l20-node2"
+          - "l21-node2"
+    ocp:
+      amount: 3
+      uefi: true
+      root_part_id: 4
+      admin_user: core
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "ocp_master"
+      disksize: "105"
+      memory: 16
+      cpus: 10
+      extra_disks_num: 1
+      extra_disks_size: "20G"
+      nets:  # nets common to all the ocp nodes
+        - "ocppr"
+        - "ocpbm"
+        - "osp_trunk"
+      spineleafnets:
+        -  # rack0 - ocp master 0
+          - "l00-ocp0"
+          - "l01-ocp0"
+        -  # rack1 - ocp master 1
+          - "l10-ocp0"
+          - "l11-ocp0"
+        -  # rack2 - ocp master 2
+          - "l20-ocp0"
+          - "l21-ocp0"
+    ocp_worker:
+      amount: 10
+      uefi: true
+      root_part_id: 4
+      admin_user: core
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "ocp_worker"
+      disksize: "105"
+      memory: 16
+      cpus: 10
+      extra_disks_num: 1
+      extra_disks_size: "20G"
+      nets:  # nets common to all the ocp_worker nodes
+        - "ocppr"
+        - "ocpbm"
+        - "osp_trunk"
+      spineleafnets:
+        -  # rack0 - ocp worker 0
+          - "l00-ocp1"
+          - "l01-ocp1"
+        -  # rack0 - ocp worker 1
+          - "l00-ocp2"
+          - "l01-ocp2"
+        -  # rack0 - ocp worker 2
+          - "l00-ocp3"
+          - "l01-ocp3"
+        -  # rack1 - ocp worker 3
+          - "l10-ocp1"
+          - "l11-ocp1"
+        -  # rack1 - ocp worker 4
+          - "l10-ocp2"
+          - "l11-ocp2"
+        -  # rack1 - ocp worker 5
+          - "l10-ocp3"
+          - "l11-ocp3"
+        -  # rack2 - ocp worker 6
+          - "l20-ocp1"
+          - "l21-ocp1"
+        -  # rack2 - ocp worker 7
+          - "l20-ocp2"
+          - "l21-ocp2"
+        -  # rack2 - ocp worker 8
+          - "l20-ocp3"
+          - "l21-ocp3"
+        -  # router - ocp_tester (worker 9)
+          - "rtr-ocp"
+    router:
+      amount: 1
+      root_part_id: >-
+        {{
+          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
+          ternary(4, 1)
+        }}
+      image_url: "{{ cifmw_discovered_image_url }}"
+      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "base-os.qcow2"
+      disksize: 25
+      memory: 4
+      cpus: 2
+      nets:  # nets common to all the router nodes
+        - "ocpbm"
+      spineleafnets:
+        -  # router - ocp_tester
+          - "s0-rtr"
+          - "s1-rtr"
+          - "rtr-ocp"
+    spine:
+      amount: 2
+      root_part_id: >-
+        {{
+          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
+          ternary(4, 1)
+        }}
+      image_url: "{{ cifmw_discovered_image_url }}"
+      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "base-os.qcow2"
+      disksize: 25
+      memory: 4
+      cpus: 2
+      nets:  # nets common to all the spine nodes
+        - "ocpbm"
+      spineleafnets:
+        -  # spine0
+          - "l00-s0"
+          - "l01-s0"
+          - "l10-s0"
+          - "l11-s0"
+          - "l20-s0"
+          - "l21-s0"
+          - "s0-rtr"
+        -  # spine1
+          - "l00-s1"
+          - "l01-s1"
+          - "l10-s1"
+          - "l11-s1"
+          - "l20-s1"
+          - "l21-s1"
+          - "s1-rtr"
+    leaf:
+      amount: 6
+      root_part_id: >-
+        {{
+          (cifmw_repo_setup_os_release is defined and cifmw_repo_setup_os_release == 'rhel') |
+          ternary(4, 1)
+        }}
+      image_url: "{{ cifmw_discovered_image_url }}"
+      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "base-os.qcow2"
+      disksize: 25
+      memory: 4
+      cpus: 2
+      nets:  # nets common to all the leaf nodes
+        - "ocpbm"
+      spineleafnets:
+        -  # rack0 - leaf00
+          - "l00-s0"
+          - "l00-s1"
+          - "l00-node0"
+          - "l00-node1"
+          - "l00-node2"
+          - "l00-ocp0"
+          - "l00-ocp1"
+          - "l00-ocp2"
+          - "l00-ocp3"
+        -  # rack0 - leaf01
+          - "l01-s0"
+          - "l01-s1"
+          - "l01-node0"
+          - "l01-node1"
+          - "l01-node2"
+          - "l01-ocp0"
+          - "l01-ocp1"
+          - "l01-ocp2"
+          - "l01-ocp3"
+        -  # rack1 - leaf10
+          - "l10-s0"
+          - "l10-s1"
+          - "l10-node0"
+          - "l10-node1"
+          - "l10-node2"
+          - "l10-ocp0"
+          - "l10-ocp1"
+          - "l10-ocp2"
+          - "l10-ocp3"
+        -  # rack1 - leaf11
+          - "l11-s0"
+          - "l11-s1"
+          - "l11-node0"
+          - "l11-node1"
+          - "l11-node2"
+          - "l11-ocp0"
+          - "l11-ocp1"
+          - "l11-ocp2"
+          - "l11-ocp3"
+        -  # rack2 - leaf20
+          - "l20-s0"
+          - "l20-s1"
+          - "l20-node0"
+          - "l20-node1"
+          - "l20-node2"
+          - "l20-ocp0"
+          - "l20-ocp1"
+          - "l20-ocp2"
+          - "l20-ocp3"
+        -  # rack2 - leaf21
+          - "l21-s0"
+          - "l21-s1"
+          - "l21-node0"
+          - "l21-node1"
+          - "l21-node2"
+          - "l21-ocp0"
+          - "l21-ocp1"
+          - "l21-ocp2"
+          - "l21-ocp3"
+
+## devscript support for OCP deploy
+cifmw_devscripts_config_overrides:
+  fips_mode: "{{ cifmw_fips_enabled | default(false) | bool }}"
+  cluster_subnet_v4: "192.172.0.0/16"
+  network_config_folder: "/home/zuul/netconf"
+
+# Required for egress traffic from pods to the osp_trunk network
+cifmw_devscripts_enable_ocp_nodes_host_routing: true
+
+# Automation section. Most of those parameters will be passed to the
+# controller-0 as-is and be consumed by the `deploy-va.sh` script.
+# Please note, all paths are on the controller-0, meaning managed by the
+# Framework. Please do not edit them!
+_arch_repo: "/home/zuul/src/github.com/openstack-k8s-operators/architecture"
+cifmw_architecture_scenario: bgp-l3-xl
+cifmw_kustomize_deploy_architecture_examples_path: "examples/dt/"
+cifmw_arch_automation_file: "bgp-l3-xl.yaml"
+cifmw_architecture_automation_file: >-
+  {{
+    (_arch_repo,
+     'automation/vars',
+     cifmw_arch_automation_file) |
+    path_join
+  }}
+
+cifmw_kustomize_deploy_metallb_source_files: >-
+  {{
+    (_arch_repo,
+     'examples/dt/bgp-l3-xl/metallb') |
+    path_join
+  }}
+
+# bgp_spines_leaves_playbook: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ci-framework'].
+#                       src_dir }}/playbooks/bgp/prepare-bgp-spines-leaves.yaml"
+# bgp_computes_playbook: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ci-framework'].
+#                       src_dir }}/playbooks/bgp/prepare-bgp-computes.yaml"
+
+
+pre_deploy:
+  - name: BGP spines and leaves configuration
+    type: playbook
+    source: "/home/zuul/src/github.com/openstack-k8s-operators/ci-framework/playbooks/bgp/prepare-bgp-spines-leaves.yaml"
+    extra_vars:
+      num_racks: "{{ num_racks }}"
+      router_bool: true
+      edpm_nodes_per_rack: 3
+      ocp_nodes_per_rack: 4
+      router_uplink_ip: 100.64.10.1
+
+# post_deploy:
+#   - name: BGP computes configuration
+#     type: playbook
+#     source: "{{ bgp_computes_playbook }}"
+#     extra_vars:
+#       #networkers_bool: true
+#       networkers_bool: false
+
+cifmw_libvirt_manager_default_gw_nets:
+  - ocpbm
+  - r0_tr
+  - r1_tr
+  - r2_tr
+cifmw_networking_mapper_interfaces_info_translations:
+  osp_trunk:
+    - controlplane
+    - ctlplane
+  r0_tr:
+    - ctlplaner0
+  r1_tr:
+    - ctlplaner1
+  r2_tr:
+    - ctlplaner2
+
+
+cifmw_networking_definition:
+  networks:
+    ctlplane:
+      network: "192.168.125.0/24"
+      gateway: "192.168.125.1"
+      dns:
+        - "192.168.122.1"
+      mtu: 1500
+      tools:
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+        netconfig:
+          ranges:
+            - start: 100
+              end: 120
+            - start: 150
+              end: 200
+
+    ctlplaner0:
+      network: "192.168.122.0/24"
+      gateway: "192.168.122.1"
+      dns:
+        - "192.168.122.1"
+      mtu: 1500
+      tools:
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+        netconfig:
+          ranges:
+            - start: 100
+              end: 130
+            - start: 150
+              end: 200
+
+    ctlplaner1:
+      network: "192.168.123.0/24"
+      gateway: "192.168.123.1"
+      dns:
+        - "192.168.123.1"
+      mtu: 1500
+      tools:
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+        netconfig:
+          ranges:
+            - start: 100
+              end: 130
+            - start: 150
+              end: 170
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+    ctlplaner2:
+      network: "192.168.124.0/24"
+      gateway: "192.168.124.1"
+      dns:
+        - "192.168.124.1"
+      mtu: 1500
+      tools:
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+        netconfig:
+          ranges:
+            - start: 100
+              end: 130
+            - start: 150
+              end: 170
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+
+    internalapi:
+      network: "172.17.0.0/24"
+      vlan: 20
+      mtu: 1500
+      tools:
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+
+    storage:
+      network: "172.18.0.0/24"
+      vlan: 21
+      mtu: 1500
+      tools:
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+
+    tenant:
+      network: "172.19.0.0/24"
+      vlan: 22
+      mtu: 1500
+      tools:
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+
+    octavia:
+      vlan: 23
+      mtu: 1500
+      network: "172.23.0.0/24"
+      tools:
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+
+    # Not really used, but required by architecture
+    # https://github.com/openstack-k8s-operators/architecture/blob/main/lib/networking/netconfig/kustomization.yaml#L28-L36
+    external:
+      network: "192.168.32.0/20"
+      vlan: 99
+      mtu: 1500
+      tools:
+        netconfig:
+          ranges:
+            - start: 130
+              end: 250
+
+  group-templates:
+    r0-computes:
+      network-template:
+        range:
+          start: 100
+          length: 5
+      networks:
+        ctlplaner0: {}
+        internalapi:
+          trunk-parent: ctlplaner0
+        tenant:
+          trunk-parent: ctlplaner0
+        storage:
+          trunk-parent: ctlplaner0
+    r1-computes:
+      network-template:
+        range:
+          start: 110
+          length: 5
+      networks:
+        ctlplaner1: {}
+        internalapi:
+          trunk-parent: ctlplaner1
+        tenant:
+          trunk-parent: ctlplaner1
+        storage:
+          trunk-parent: ctlplaner1
+    r2-computes:
+      network-template:
+        range:
+          start: 120
+          length: 5
+      networks:
+        ctlplaner2: {}
+        internalapi:
+          trunk-parent: ctlplaner2
+        tenant:
+          trunk-parent: ctlplaner2
+        storage:
+          trunk-parent: ctlplaner2
+    r0-networkers:
+      network-template:
+        range:
+          start: 200
+          length: 5
+      networks:
+        ctlplaner0: {}
+        internalapi:
+          trunk-parent: ctlplaner0
+        tenant:
+          trunk-parent: ctlplaner0
+        storage:
+          trunk-parent: ctlplaner0
+    r1-networkers:
+      network-template:
+        range:
+          start: 210
+          length: 5
+      networks:
+        ctlplaner1: {}
+        internalapi:
+          trunk-parent: ctlplaner1
+        tenant:
+          trunk-parent: ctlplaner1
+        storage:
+          trunk-parent: ctlplaner1
+    r2-networkers:
+      network-template:
+        range:
+          start: 220
+          length: 5
+      networks:
+        ctlplaner2: {}
+        internalapi:
+          trunk-parent: ctlplaner2
+        tenant:
+          trunk-parent: ctlplaner2
+        storage:
+          trunk-parent: ctlplaner2
+    ocps:
+      network-template:
+        range:
+          start: 10
+          length: 10
+      networks: {}
+    ocp_workers:
+      network-template:
+        range:
+          start: 20
+          length: 10
+      networks: {}
+
+  instances:
+    controller-0:
+      networks:
+        ctlplane:
+          ip: "192.168.125.9"


### PR DESCRIPTION
This commit adds a "bgp-l3-xl" dt where workers/computes/networkers are deployed across three racks over a virtualized spine/leaf fabric using bgp.

The overall footprint consists of 3 masters, 9 workers (3x rack), 6 computes (2x rack), 3 networkers (1x rack) plus 1 router, 2 spines and 6 leaf switches (2x rack).

~~~
$ virsh list
 Id     Name                   State
----------------------------------------
 1292   cifmw-controller-0     running
 1293   cifmw-r0-compute-0     running
 1294   cifmw-r0-compute-1     running
 1295   cifmw-r1-compute-0     running
 1296   cifmw-r1-compute-1     running
 1297   cifmw-r2-compute-0     running
 1298   cifmw-r2-compute-1     running
 1299   cifmw-r0-networker-0   running
 1300   cifmw-r1-networker-0   running
 1301   cifmw-r2-networker-0   running
 1302   cifmw-ocp-master-0     running
 1303   cifmw-ocp-master-1     running
 1304   cifmw-ocp-master-2     running
 1305   cifmw-ocp-worker-0     running
 1306   cifmw-ocp-worker-1     running
 1307   cifmw-ocp-worker-2     running
 1308   cifmw-ocp-worker-3     running
 1309   cifmw-ocp-worker-4     running
 1310   cifmw-ocp-worker-5     running
 1311   cifmw-ocp-worker-6     running
 1312   cifmw-ocp-worker-7     running
 1313   cifmw-ocp-worker-8     running
 1314   cifmw-ocp-worker-9     running
 1315   cifmw-router-0         running
 1316   cifmw-spine-0          running
 1317   cifmw-spine-1          running
 1318   cifmw-leaf-0           running
 1319   cifmw-leaf-1           running
 1320   cifmw-leaf-2           running
 1321   cifmw-leaf-3           running
 1322   cifmw-leaf-4           running
 1323   cifmw-leaf-5           running
~~~