### PR TITLE
[kuttl multinode] Disable router with gateways

### DIFF
--- a/zuul.d/kuttl_multinode.yaml
+++ b/zuul.d/kuttl_multinode.yaml
@@ -15,6 +15,7 @@
             range: 192.168.122.0/24
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            router: false
           internal-api:
             vlan: 20
             range: 172.17.0.0/24


### PR DESCRIPTION
With limited public IPs on some clouds we hit quota issues from time to time.
So disabling router with gateway ports creation in kuttl multinode jobs.

Same will be done on other jobs in follow up.

Related-Issue: #[OSPCIX-771](https://issues.redhat.com//browse/OSPCIX-771)