### PR TITLE
Set ServerAlive params on ssh_jumper role

### DIFF
--- a/roles/ssh_jumper/molecule/default/converge.yml
+++ b/roles/ssh_jumper/molecule/default/converge.yml
@@ -85,6 +85,8 @@
               User zuul
               StrictHostKeyChecking no
               UserKnownHostsFile /dev/null
+              ServerAliveInterval 60
+              ServerAliveCountMax 10
         _res: "{{ cifmw_minimal_example_com['content'] | b64decode }}"
       ansible.builtin.assert:
         that:
@@ -104,6 +106,8 @@
               User zuul
               StrictHostKeyChecking no
               UserKnownHostsFile /dev/null
+              ServerAliveInterval 60
+              ServerAliveCountMax 10
         _res: "{{ cifmw_ssh_config_d_192_168_250_10['content'] | b64decode }}"
       ansible.builtin.assert:
         that:
@@ -123,6 +127,8 @@
               IdentityFile /opt/basedir/ssh/id_test
               StrictHostKeyChecking no
               UserKnownHostsFile /dev/null
+              ServerAliveInterval 60
+              ServerAliveCountMax 10
         _res: "{{ cifmw_ssh_config_d_192_168_250_11['content'] | b64decode }}"
       ansible.builtin.assert:
         that:

--- a/roles/ssh_jumper/templates/ssh_host.conf.j2
+++ b/roles/ssh_jumper/templates/ssh_host.conf.j2
@@ -9,3 +9,5 @@ Host {{ (_config.patterns | default(cifmw_ssh_jumper_defaults.patterns) + [_conf
 {% endif %}
     StrictHostKeyChecking {{ _config.strict_host_key_checking | default(cifmw_ssh_jumper_defaults.strict_host_key_checking) }}
     UserKnownHostsFile {{ _config.user_known_hosts_file | default (cifmw_ssh_jumper_defaults.user_known_hosts_file) }}
+    ServerAliveInterval 60
+    ServerAliveCountMax 10


### PR DESCRIPTION
the shiftstack testing is getting disconnected transparently. We believe this could help.