### PR TITLE
DRAFT: Add support for federation in the horizon UI

### DIFF
--- a/hooks/playbooks/federation-controlplane-config.yml
+++ b/hooks/playbooks/federation-controlplane-config.yml
@@ -2,6 +2,16 @@
 - name: Create kustomization to update Keystone to use Federation
   hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
   tasks:
+    - name: Set urls for install type uni
+      ansible.builtin.set_fact:
+        cifmw_federation_horizon_url: 'https://horizon-openstack.apps.ocp.openstack.lab'
+      when: cifmw_federation_deploy_type == "uni"
+
+    - name: Set urls for install type crc
+      ansible.builtin.set_fact:
+        cifmw_federation_horizon_url: 'https://horizon-openstack.apps-crc.testing'
+      when: cifmw_federation_deploy_type == "crc"
+
     - name: Create file to customize keystone for Federation resources deployed in the control plane
       ansible.builtin.copy:
         dest: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/controlplane/keystone_federation.yaml"
@@ -32,7 +42,7 @@
                   insecure_debug=true
                   debug=true
                   [federation]
-                  trusted_dashboard={{ '{{ .KeystoneEndpointPublic }}' }}/dashboard/auth/websso/
+                  trusted_dashboard={{ cifmw_federation_horizon_url }}/dashboard/auth/websso/
                   [openid]
                   remote_id_attribute=HTTP_OIDC_ISS
                   [auth]

--- a/hooks/playbooks/federation-horizon-controlplane-config.yml
+++ b/hooks/playbooks/federation-horizon-controlplane-config.yml
@@ -1,0 +1,35 @@
+---
+- name: Create kustomization to update Horizon to use Federation
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  tasks:
+    - name: Create file to customize horizon for Federation resources deployed in the control plane
+      ansible.builtin.copy:
+        dest: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/controlplane/horizon_federation.yaml"
+        content: |-
+          apiVersion: kustomize.config.k8s.io/v1beta1
+          kind: Kustomization
+          resources:
+          - namespace: {{ namespace }}
+          patches:
+          - target:
+              kind: OpenStackControlPlane
+              name: .*
+            patch: |-
+              - op: add
+                path: /spec/horizon/enabled
+                value: true
+              - op: add
+                path: /spec/horizon/template/memcachedInstance
+                value: memcached
+              - op: add
+                path: /spec/horizon/template/customServiceConfig
+                value: |
+                  OPENSTACK_KEYSTONE_URL = "{{ '{{ .KeystoneEndpointPublic }}' }}/v3"
+                  WEBSSO_ENABLED = True
+                  WEBSSO_CHOICES = (
+                    ("credentials", _("Keystone Credentials")),
+                    ("OIDC", _("OpenID Connect")),
+                  )
+                  WEBSSO_IDP_MAPPING = {
+                    "OIDC": ("{{ cifmw_keystone_OIDC_provider_name }}", "openid"),
+                  }


### PR DESCRIPTION
This added and openidc dropbox to the horizon login screen so a user can select openidc as a login type the horzion UI will the be redirected to the keycloak server for the user authentication and then be passed back to the horizon dashboard as the federated user.