### PR TITLE
Use base-extracted-crc when nodeset is based on OCP 4.16

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -199,7 +199,7 @@
 
 - job:
     name: cifmw-adoption-base-source-multinode
-    parent: base-crc-cloud
+    parent: base-extracted-crc
     abstract: true
     timeout: 14400
     attempts: 1
@@ -408,7 +408,7 @@
 
 - job:
     name: cifmw-adoption-base-source-multinode-novacells
-    parent: base-crc-cloud
+    parent: base-extracted-crc
     abstract: true
     voting: false
     timeout: 14400


### PR DESCRIPTION
The base job should not be changed in those jobs in commit [1].

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/2819