### PR TITLE
Switch adoption base job to use OCP 4.18

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -203,7 +203,7 @@
     abstract: true
     timeout: 14400
     attempts: 1
-    nodeset: centos-9-multinode-rhel-9-2-crc-extracted-2-39-0-3xl
+    nodeset: centos-9-multinode-rhel-9-2-crc-cloud-ocp-4-18-1-3xl
     roles: &multinode-roles
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run: &multinode-prerun
@@ -413,7 +413,7 @@
     voting: false
     timeout: 14400
     attempts: 1
-    nodeset: centos-9-multinode-rhel-9-2-crc-extracted-2-39-0-3xl-novacells
+    nodeset: centos-9-multinode-rhel-9-2-crc-cloud-ocp-4-18-1-3xl-novacells
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run: *multinode-prerun


### PR DESCRIPTION
For crc-cloud base job, it should use OCP 4.18 image, not CRC extracted 2.39.