### PR TITLE
Set timezone to UTC in cloud-init user-data

### DIFF
--- a/roles/libvirt_manager/tasks/create_cloud_init_iso.yml
+++ b/roles/libvirt_manager/tasks/create_cloud_init_iso.yml
@@ -39,6 +39,7 @@
         ignore_growroot_disabled: true
         mode: growpart
       resize_rootfs: noblock
+      timezone: UTC
 
 - name: "Define network config"
   when:


### PR DESCRIPTION
`controller-0` was not [syncing time](https://issues.redhat.com/browse/OSPRH-11385) with OC cluster nodes. This patch explicitly sets timezone to UTC in user-data so that timezone is correctly setup during cloud-init.

Timezone on `controller-0` with this patch (Tested Locally):
```
[zuul@controller-0 ~]$ date
Mon Apr  7 07:48:59 UTC 2025
```