### PR TITLE
Add crc-cloud base job

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -308,3 +308,16 @@
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
       - ci/playbooks/bootstrap-networking-mapper.yml
+
+- job:
+    name: cifmw-crc-cloud-pre-bootstrap
+    parent: base-crc-cloud-wo-networks
+    abstract: true
+    description: |
+      CI-Framework base extracted CRC job which runs after starting
+      CRC environment and before running ci-boostrap roles to
+      configure networking between nodes.
+    pre-run:
+      - ci/playbooks/e2e-prepare.yml
+      - ci/playbooks/dump_zuul_data.yml
+      - ci/playbooks/bootstrap-networking-mapper.yml


### PR DESCRIPTION
The CI jobs require additional base job definition to switch to the CRC cloud.

Related-to: https://review.rdoproject.org/r/c/config/+/57407/