### PR TITLE
Switch to OCP 4.18 for periodic-whitebox-neutron-tempest-plugin CI job

### DIFF
--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -5,7 +5,7 @@
 - job:
     name: whitebox-neutron-tempest-plugin-podified-multinode-edpm-deployment-crc-2comp
     parent: podified-multinode-edpm-deployment-crc-2comp
-    nodeset: centos-9-2x-centos-9-xxl-crc-extracted-2-39-0-xxl
+    nodeset: centos-9-2x-centos-9-xxl-crc-cloud-ocp-4-18-1-xxl
     timeout: 12600
     override-checkout: main
     description: |


### PR DESCRIPTION
The job is using parent that is related to crc-cloud, where nodeset is set to use crc-extracted and that's wrong.
Let's switch to CRC cloud (OCP 4.18) also here.