### PR TITLE
adoption_osp_deploy: edpm_nodes_networker section

### DIFF
--- a/roles/adoption_osp_deploy/templates/adoption_vars.yaml.j2
+++ b/roles/adoption_osp_deploy/templates/adoption_vars.yaml.j2
@@ -3,17 +3,22 @@ source_mariadb_ip: {{ _controller_1_internalapi_ip }}
 source_ovndb_ip: {{ _controller_1_internalapi_ip }}
 edpm_node_hostname: {{ _compute_1_name }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}
 edpm_node_ip: {{ _compute_1_ip }}
+
+{% if _vm_groups['osp-computes'] | default([]) | length > 0 %}
 edpm_computes: |
   {% for compute in _vm_groups['osp-computes'] %}
   {% set node_nets = cifmw_networking_env_definition.instances[compute] %}
   ["{{ compute }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}"]="{{ node_nets.networks.ctlplane.ip_v4 }}"
   {% endfor %}
+{% endif %}
+
+{% if _vm_groups['osp-networkers'] | default([]) | length > 0 %}
 edpm_networkers: |
   {% for networker in _vm_groups['osp-networkers'] | default([]) %}
   {% set node_nets = cifmw_networking_env_definition.instances[networker] %}
   ["{{ networker }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}"]="{{ node_nets.networks.ctlplane.ip_v4 }}"
   {% endfor %}
-
+{% endif %}
 
 source_galera_members: |
   {% for controller in _vm_groups['osp-controllers'] %}
@@ -21,6 +26,7 @@ source_galera_members: |
   ["{{ controller }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}"]="{{ node_nets.networks.internalapi.ip_v4 }}"
   {% endfor %}
 
+{% if _vm_groups['osp-computes'] | default([]) | length > 0 %}
 edpm_nodes:
   {% for compute in _vm_groups['osp-computes'] %}
   {% set node_nets = cifmw_networking_env_definition.instances[compute] %}
@@ -38,6 +44,10 @@ edpm_nodes:
 {% endif %}
     {% endfor %}
     {% endfor %}
+{% endif %}
+
+{% if _vm_groups['osp-networkers'] | default([]) | length > 0 %}
+edpm_nodes_networker:
   {% for networker in _vm_groups['osp-networkers'] | default([]) %}
   {% set node_nets = cifmw_networking_env_definition.instances[networker] %}
   {{ networker }}:
@@ -54,7 +64,7 @@ edpm_nodes:
 {% endif %}
     {% endfor %}
     {% endfor %}
-
+{% endif %}
 
 upstream_dns: {{ cifmw_networking_env_definition.networks.ctlplane.dns_v4 | first }}
 os_cloud_name: {{ cifmw_adoption_osp_deploy_scenario.stacks[0].stackname }}


### PR DESCRIPTION
Move _vm_groups['osp-networkers'] nodes into a separate edpm_nodes_networker variable.

Also add if conditions to only include _vm_groups if length > 0 for both computes and networkers.