### PR TITLE
use ceph ingress service vars

### DIFF
--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -149,3 +149,5 @@ cifmw_cephadm_version: "squid"
 cifmw_cephadm_prepare_host: false
 cifmw_cephadm_wait_install_retries: 8
 cifmw_cephadm_wait_install_delay: 15
+cifmw_cephadm_rgw_ingress_service_name: "ingress.rgw.default"
+cifmw_cephadm_rgw_ingress_service_id: "rgw.default"

--- a/roles/cifmw_cephadm/templates/ceph_rgw.yml.j2
+++ b/roles/cifmw_cephadm/templates/ceph_rgw.yml.j2
@@ -21,10 +21,8 @@ spec:
 ---
 {% if _hosts|length > 1 %}
   service_type: ingress
-  service_id: rgw.default
-  service_name: ingress.rgw.default
-  placement:
-    count: 1
+  service_id: {{ cifmw_cephadm_rgw_ingress_service_id }}
+  service_name: {{ cifmw_cephadm_rgw_ingress_service_name }}
   spec:
     backend_service: rgw.rgw
     frontend_port: 8080


### PR DESCRIPTION
Using vars will help in overriding the spec during adoptoin.
Also count:1 will create issues as ingress handles both haproxy and keepalived