### PR TITLE
Prevent updating openstackclient pod during openstack update

### DIFF
--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -33,8 +33,14 @@
   when:
     - cifmw_update_control_plane_check | bool
     - not cifmw_update_run_dryrun | bool
-  ansible.builtin.shell: |
-    {{ cifmw_update_artifacts_basedir }}/control_plane_test_start.sh
+
+  block:
+    - name: Prevent updating openstackclient during openstack update
+      ansible.builtin.include_tasks: prevent_openstack_client_update.yml
+
+    - name: Start the continuous control plane test
+      ansible.builtin.shell: |
+        {{ cifmw_update_artifacts_basedir }}/control_plane_test_start.sh
 
 
 - name: Set openstack_update_run Makefile environment variables
@@ -72,8 +78,20 @@
   when:
     - cifmw_update_control_plane_check | bool
     - not cifmw_update_run_dryrun | bool
-  ansible.builtin.command: |
-    {{ cifmw_update_artifacts_basedir }}/control_plane_test_stop.sh
+
+  block:
+    - name: Stop the continuous control plane test
+      ansible.builtin.command: |
+        {{ cifmw_update_artifacts_basedir }}/control_plane_test_stop.sh
+
+    - name: Patch openstackversion to trigger update of openstackclient
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.shell: >
+        oc patch -n {{ cifmw_update_namespace }}
+        openstackversion {{ cifmw_openstack_version_name.stdout }} --type=json
+        --patch '[{ "op": "remove", "path": "/spec/customContainerImages/openstackClientImage" }]'
 
 - name: Reboot the compute nodes
   ansible.builtin.include_tasks: reboot_computes.yml

--- a/roles/update/tasks/prevent_openstack_client_update.yml
+++ b/roles/update/tasks/prevent_openstack_client_update.yml
@@ -1,0 +1,48 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Get current openstackclient image
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.shell: >
+    oc get pod -n {{ cifmw_update_namespace }} openstackclient
+    --output=jsonpath='{.spec.containers[0].image}'
+  register: cifmw_openstack_client_image
+  changed_when: false
+
+- name: Get OpenStackVersion name
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.shell: >
+    oc get openstackversion -n {{ cifmw_update_namespace }}
+    --output=jsonpath='{.items[0].metadata.name}'
+  register: cifmw_openstack_version_name
+  changed_when: false
+
+- name: Patch openstackversion CR to keep old openstackclient pod running
+  kubernetes.core.k8s:
+    state: patched
+    kind: OpenStackVersion
+    api_version: core.openstack.org/v1beta1
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    name: "{{ cifmw_openstack_version_name.stdout }}"
+    namespace: "{{ cifmw_update_namespace }}"
+    definition:
+      spec:
+        customContainerImages:
+          openstackClientImage: "{{ cifmw_openstack_client_image.stdout }}"


### PR DESCRIPTION
Openstackclient pod is used during update to start/stop continues workload tests from it. Openstackclient should not be updated during update to not interfere with this tests. Update of the client should happen at the end of update on request.