### PR TITLE
New OLM Parameter for Managing Deployment of Specific Versions

### DIFF
--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -226,9 +226,12 @@
       tags:
         - update_containers
         - edpm_bootstrap
+      when: cifmw_ci_gen_kustomize_values_deployment_version is not defined
 
     - name: Update containers in deployed OSP operators using set_openstack_containers role
-      when: cifmw_set_openstack_containers | default(false) | bool
+      when:
+        - cifmw_set_openstack_containers | default(false) | bool
+        - cifmw_ci_gen_kustomize_values_deployment_version is not defined
       ansible.builtin.include_role:
         name: set_openstack_containers
       tags:

--- a/playbooks/update.yml
+++ b/playbooks/update.yml
@@ -39,6 +39,7 @@
         cifmw_set_openstack_containers_openstack_final_env: "operator_env_after_update.txt"
       ansible.builtin.include_role:
         name: set_openstack_containers
+      when: cifmw_ci_gen_kustomize_values_deployment_version is not defined
 
 - name: Sync repos for controller to compute
   hosts: computes

--- a/roles/ci_gen_kustomize_values/README.md
+++ b/roles/ci_gen_kustomize_values/README.md
@@ -54,6 +54,18 @@ Optional parameters:
 
 * `cifmw_ci_gen_kustomize_values_edpm_net_template_b64`: (String) The base64 content of `edpm_network_config_template`.
 
+### Specific parameters for olm-values
+This ConfigMap specifies parameters to override those in `architecture/example/common/olm/values.yaml`.
+
+* `cifmw_ci_gen_kustomize_values_ooi_image`: (String) The URI for the image providing the OpenStack operator index. Defaults to `quay.io/openstack-k8s-operators/openstack-operator-index:latest`.
+* `cifmw_ci_gen_kustomize_values_sub_channel`: (String) Specifies the channel to be used.
+
+If the following parameter is set, it overrides the associated parameter in `architecture/example/common/olm-subscriptions/values.yaml`.
+
+* `cifmw_ci_gen_kustomize_values_deployment_version`: (String) The version to be deployed by setting the `startingCSV` of the subscription for the OpenStack operator. Versions `v1.0.3` and `v1.0.6` are unique as they configure the subscription for all operators. The right kustomize overlay is selected by the `ci_gen_kustomize_values/tasks/olm_subscriptions_overlay.yml` file.
+
+Access the remaining parameters in the `olm-subscription/values.yaml` file and override them with the `cifmw_architecture_user_kustomize_<some_string>` variable, which should set the `common.olm-values` hash. The earlier version parameter shouldn't be modified using this method, as it won't activate the additional code required for proper functionality.
+
 ## Adding a new template
 
 The template must have a leading comment staging its source. For example, if your template is located in

--- a/roles/ci_gen_kustomize_values/tasks/olm_subscriptions_overlay.yml
+++ b/roles/ci_gen_kustomize_values/tasks/olm_subscriptions_overlay.yml
@@ -1,0 +1,57 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Description: This playbook generates the kustomize file that
+# retrieves the appropriate overlay based on
+# cifmw_ci_gen_kustomize_values_deployment_version. It allows for
+# specifying the deployment version when multiple versions are
+# available in the OLM catalog. This is particularly useful for
+# testing updates but can also be used to deploy any version from the
+# OLM catalog.
+
+- name: Set the right overlay for the subscriptions
+  ansible.builtin.set_fact:
+    _cifmw_update_deployment_version_dir: >-
+      {{
+      cifmw_ci_gen_kustomize_values_deployment_version
+      if cifmw_ci_gen_kustomize_values_deployment_version in ['v1.0.3', 'v1.0.6']
+      else
+      'default'
+      }}
+
+- name: Point to the right overlay for OLM when deploying old version
+  vars:
+    _kustomization:
+      components:
+        - "../../../lib/olm-deps"
+        - "../../../lib/olm-openstack-subscriptions/overlays/{{ _cifmw_update_deployment_version_dir }}"
+      resources:
+        - "values.yaml"
+  ansible.builtin.copy:
+    content: |
+      ---
+      {{ _kustomization | ansible.builtin.to_nice_yaml(indent=2) }}
+    dest: "{{ cifmw_ci_gen_kustomize_values_architecture_repo }}/examples/common/olm-subscriptions/kustomization.yaml"
+    mode: "0644"
+  when: _cifmw_update_deployment_version_dir != 'default'
+
+# Pass down the new value for `cifmw_kustomize_deploy_olm_source_files`
+- name: Change directory for the customization file when deploying old version
+  ansible.builtin.set_fact:
+    cifmw_kustomize_deploy_olm_source_files: >-
+      {{
+      cifmw_ci_gen_kustomize_values_architecture_repo
+      }}/examples/common/olm-subscriptions

--- a/roles/ci_gen_kustomize_values/templates/common/olm-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/common/olm-values/values.yaml.j2
@@ -4,3 +4,8 @@ data:
 {% if cifmw_ci_gen_kustomize_values_sub_channel is defined %}
     openstack-operator-channel: {{ cifmw_ci_gen_kustomize_values_sub_channel }}
 {% endif %}
+{% if cifmw_ci_gen_kustomize_values_deployment_version is defined %}
+{% if cifmw_ci_gen_kustomize_values_deployment_version not in ['v1.0.3', 'v1.0.6'] %}
+    openstack-operator-version: openstack-operator.{{ cifmw_ci_gen_kustomize_values_deployment_version }}
+{% endif %}
+{% endif %}

--- a/roles/kustomize_deploy/tasks/install_operators.yml
+++ b/roles/kustomize_deploy/tasks/install_operators.yml
@@ -14,9 +14,20 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Install subscriptions
+  ansible.builtin.include_role:
+    name: ci_gen_kustomize_values
+    tasks_from: olm_subscriptions_overlay.yml
+  when: cifmw_ci_gen_kustomize_values_deployment_version is defined
+
 - name: Generate values.yaml for OLM resources
   vars:
-    cifmw_architecture_scenario: 'common/olm'
+    cifmw_architecture_scenario: >-
+      {{
+      'common/olm'
+      if cifmw_ci_gen_kustomize_values_deployment_version is not defined
+      else 'common/olm-subscriptions'
+      }}
     cifmw_ci_gen_kustomize_values_src_file: >-
       {{
         (

--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -36,6 +36,28 @@
   ansible.builtin.shell: |
     {{ cifmw_update_artifacts_basedir }}/control_plane_test_start.sh
 
+# Get the next available version available when using OLM
+- name: Handle the next version when using OLM
+  when:
+    - cifmw_ci_gen_kustomize_values_deployment_version is defined
+  block:
+    - name: Make sure we get a new version available, block until we do.
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit) }}"
+        context: "{{ cifmw_openshift_context | default(omit) }}"
+        api_version: core.openstack.org/v1beta1
+        kind: OpenStackVersion
+        namespace: "{{ cifmw_update_namespace }}"
+      register: openstackversion_info
+      until: openstackversion_info.resources[0].spec.targetVersion != openstackversion_info.resources[0].status.availableVersion
+      retries: 20
+      delay: 15
+
+    - name: Capture the available version in openstackversion
+      ansible.builtin.set_fact:
+        cifmw_update_next_available_version: >-
+          {{ openstackversion_info.resources[0].status.availableVersion }}
 
 - name: Set openstack_update_run Makefile environment variables
   tags:
@@ -43,15 +65,28 @@
   ansible.builtin.set_fact:
     _make_openstack_update_run_params: |
       TIMEOUT: {{ cifmw_update_openstack_update_run_timeout }}
-      {% if not cifmw_update_openstack_update_run_operators_updated | bool -%}
+      {% if _cifmw_update_use_fake_update | bool -%}
       FAKE_UPDATE: true
       CONTAINERS_NAMESPACE: {{ cifmw_update_openstack_update_run_containers_namespace }}
       CONTAINERS_TARGET_TAG: {{ cifmw_update_openstack_update_run_containers_target_tag }}
       OPENSTACK_VERSION: {{ cifmw_update_openstack_update_run_target_version }}
       {% else -%}
-      OPENSTACK_VERSION: {{ cifmw_update_openstack_update_run_target_version }}
+      OPENSTACK_VERSION: {{ _cifmw_update_openstack_version }}
       {% endif -%}
-
+  vars:
+    # When using OLM style of update, or if
+    # cifmw_update_openstack_update_run_operators_updated is true do
+    # not use fake update in openstack-update.sh.
+    _cifmw_update_use_fake_update: >-
+      {{
+      not ( cifmw_ci_gen_kustomize_values_deployment_version is defined ) and
+      not ( cifmw_update_openstack_update_run_operators_updated | bool )
+      }}
+    _cifmw_update_openstack_version: >-
+      {{
+      cifmw_update_next_available_version |
+      default(cifmw_update_openstack_update_run_target_version)
+      }}
 
 - name: Run make openstack_update_run
   vars:


### PR DESCRIPTION
A new parameter, `cifmw_ci_gen_kustomize_values_deployment_version`,
has been introduced for overriding OLM startingCSV values in
kustomize. This also ensures the appropriate architecture directory is
utilized and all necessary subscriptions are deployed based on the
installed version.  This eventually leverages the overlay `kustomize`
feature, hence the new `olm_subscriptions_overlay.yml` that helps set
the right overlay.

When configured, this parameter will stop the update playbook from
executing the `set_openstack_containers` role and the deployment
playbook from executing the `update_container` role. The assumption is
that OLM will be used to update any necessary operators.

New test cases have been added using Molecule for different OpenStack
operator versions: v1.0.3, v1.0.6, and v1.0.7. Note that v1.0.7 is
designed to support all future deployments where only the
openstack-operator subscription is needed.

To assist in testing and verification within a live environment, tasks
for setting up and tearing down OpenShift CRC are provided.

Depends-On: https://github.com/openstack-k8s-operators/architecture/pull/537

Resolves-Part-Of: [OSPRH-15056](https://issues.redhat.com//browse/OSPRH-15056)