### PR TITLE
New OLM parameter for managing deployment of installPlan approval.

### DIFF
--- a/roles/ci_gen_kustomize_values/README.md
+++ b/roles/ci_gen_kustomize_values/README.md
@@ -64,7 +64,9 @@ If the following parameter is set, it overrides the associated parameter in `arc
 
 * `cifmw_ci_gen_kustomize_values_deployment_version`: (String) The version to be deployed by setting the `startingCSV` of the subscription for the OpenStack operator. Versions `v1.0.3` and `v1.0.6` are unique as they configure the subscription for all operators. The right kustomize overlay is selected by the `ci_gen_kustomize_values/tasks/olm_subscriptions_overlay.yml` file.
 
-Access the remaining parameters in the `olm-subscription/values.yaml` file and override them with the `cifmw_architecture_user_kustomize_<some_string>` variable, which should set the `common.olm-values` hash. The earlier version parameter shouldn't be modified using this method, as it won't activate the additional code required for proper functionality.
+* `cifmw_ci_gen_kustomize_values_installplan_approval`: (String) Options are `Manual` or `Automatic`. This determines how the OpenStack operator is installed. In `Manual` mode, the install plan requires approval, which is automatically handled in the `kustomize_deploy/tasks/install_operators.yml` task file.
+
+Access to the other parameters defined in the `olm-subscription/values.yaml` file is doable by overriding them using the `cifmw_architecture_user_kustomize_<some_string>` variable, which should set the `common.olm-values` hash. However, the last two variables should not be modified using this method, as it won't activate the additional code required for them to function correctly.
 
 ## Adding a new template
 

--- a/roles/ci_gen_kustomize_values/tasks/olm_subscriptions_overlay.yml
+++ b/roles/ci_gen_kustomize_values/tasks/olm_subscriptions_overlay.yml
@@ -22,6 +22,16 @@
 # testing updates but can also be used to deploy any version from the
 # OLM catalog.
 
+- name: Fail if installplan_approval is defined without deployment_version
+  ansible.builtin.fail:
+    msg: >
+      You cannot have 'cifmw_ci_gen_kustomize_values_installplan_approval'
+      set to Manual without 'cifmw_ci_gen_kustomize_values_deployment_version'
+  when:
+    - cifmw_ci_gen_kustomize_values_installplan_approval is defined
+    - cifmw_ci_gen_kustomize_values_installplan_approval | lower == 'manual'
+    - cifmw_ci_gen_kustomize_values_deployment_version is not defined
+
 - name: Set the right overlay for the subscriptions
   ansible.builtin.set_fact:
     _cifmw_update_deployment_version_dir: >-

--- a/roles/ci_gen_kustomize_values/templates/common/olm-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/common/olm-values/values.yaml.j2
@@ -9,3 +9,6 @@ data:
     openstack-operator-version: openstack-operator.{{ cifmw_ci_gen_kustomize_values_deployment_version }}
 {% endif %}
 {% endif %}
+{% if cifmw_ci_gen_kustomize_values_installplan_approval is defined %}
+    openstack-operator-installplanapproval: {{ cifmw_ci_gen_kustomize_values_installplan_approval }}
+{% endif %}

--- a/roles/kustomize_deploy/tasks/install_operators.yml
+++ b/roles/kustomize_deploy/tasks/install_operators.yml
@@ -18,7 +18,9 @@
   ansible.builtin.include_role:
     name: ci_gen_kustomize_values
     tasks_from: olm_subscriptions_overlay.yml
-  when: cifmw_ci_gen_kustomize_values_deployment_version is defined
+  when: >
+    cifmw_ci_gen_kustomize_values_deployment_version is defined or
+    cifmw_ci_gen_kustomize_values_installplan_approval is defined
 
 - name: Generate values.yaml for OLM resources
   vars:
@@ -118,6 +120,12 @@
         - _cifmw_kustomize_deploy_olm_osp_operator_sub_out.resources is defined
         - _cifmw_kustomize_deploy_olm_osp_operator_sub_out.resources | length == 1
         - (_cifmw_kustomize_deploy_olm_osp_operator_sub_out.resources | first)['status']['installPlanRef'] is defined
+
+    - name: Install plan
+      ansible.builtin.include_tasks: install_plan.yml
+      when:
+        - cifmw_ci_gen_kustomize_values_installplan_approval is defined
+        - cifmw_ci_gen_kustomize_values_installplan_approval | lower == 'manual'
 
     - name: Wait for the openstack operators InstallPlan to be finished
       vars:

--- a/roles/kustomize_deploy/tasks/install_plan.yml
+++ b/roles/kustomize_deploy/tasks/install_plan.yml
@@ -1,0 +1,90 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# Description:
+# Set of tasks to accept the latest Manual installPlan provided by OLM.
+
+- name: Wait for unapproved InstallPlan creation
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    namespace: openstack-operators
+  register: _cifmw_kustomize_deploy_install_plans
+  until: >
+    _cifmw_kustomize_deploy_install_plans.resources |
+    selectattr('spec.approval', 'equalto', 'Manual') |
+    selectattr('spec.approved', 'equalto', false) | length > 0
+  retries: 30
+  delay: 10
+
+- name: Get InstallPlan name
+  ansible.builtin.set_fact:
+    _cifmw_kustomize_deploy_installplan_name: >-
+      {{
+      (_cifmw_kustomize_deploy_install_plans.resources
+      | selectattr('spec.approval', 'equalto', 'Manual')
+      | selectattr('spec.approved', 'equalto', false)
+      | first)
+      .metadata.name
+      }}
+
+- name: Approve the InstallPlan
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    state: present
+    namespace: openstack-operators
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: InstallPlan
+      metadata:
+        name: "{{ _cifmw_kustomize_deploy_installplan_name }}"
+      spec:
+        approved: true
+
+- name: Display the status of the installPlan found
+  ansible.builtin.debug:
+    msg: "Waiting for InstallPlan {{ _cifmw_kustomize_deploy_installplan_name }}."
+
+- name: Wait for the InstallPlan to complete
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    namespace: openstack-operators
+    name: "{{ _cifmw_kustomize_deploy_installplan_name }}"
+  register: _cifmw_kustomize_deploy_installplan
+  until:
+    - _cifmw_kustomize_deploy_installplan.failed is false
+    - _cifmw_kustomize_deploy_installplan.resources is defined
+    - _cifmw_kustomize_deploy_installplan.resources | length == 1
+    - >-
+      (
+      _cifmw_kustomize_deploy_installplan.resources | first
+      ).status.phase | lower  == 'complete'
+  retries: "{{ cifmw_kustomize_deploy_retries_install_plan }}"
+  delay: "{{ cifmw_kustomize_deploy_delay }}"
+
+- name: Display the status of the installPlan found
+  ansible.builtin.debug:
+    msg: >
+      InstallPlan {{ _cifmw_kustomize_deploy_installplan_name }} deployed.

--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -36,6 +36,14 @@
   ansible.builtin.shell: |
     {{ cifmw_update_artifacts_basedir }}/control_plane_test_start.sh
 
+- name: Install plan
+  ansible.builtin.include_role:
+    name: kustomize_deploy
+    tasks_from: install_plan.yml
+  when:
+    - cifmw_ci_gen_kustomize_values_installplan_approval is defined
+    - cifmw_ci_gen_kustomize_values_installplan_approval | lower == 'manual'
+
 # Get the next available version available when using OLM
 - name: Handle the next version when using OLM
   when:


### PR DESCRIPTION
A new parameter, `cifmw_ci_gen_kustomize_values_installplan_approval`,
is introduced for overriding OLM installPlanApproval values in
kustomize.

It has to be use in conjonction with
`cifmw_ci_gen_kustomize_values_deployment_version` as it won't work if
the the later is not set.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2881

Resolves: [OSPRH-15054](https://issues.redhat.com//browse/OSPRH-15054)