### PR TITLE
[BGP-L3-XL] Remove ctlplane interface from OCP nodes

### DIFF
--- a/scenarios/reproducers/bgp-l3-xl.yml
+++ b/scenarios/reproducers/bgp-l3-xl.yml
@@ -613,7 +613,6 @@ cifmw_libvirt_manager_configuration:
       nets:  # nets common to all the ocp nodes
         - "ocppr"
         - "ocpbm"
-        - "osp_trunk"
       spineleafnets:
         -  # rack0 - ocp master 0
           - "l00-ocp0"
@@ -639,7 +638,6 @@ cifmw_libvirt_manager_configuration:
       nets:  # nets common to all the ocp_worker nodes
         - "ocppr"
         - "ocpbm"
-        - "osp_trunk"
       spineleafnets:
         -  # rack0 - ocp worker 0
           - "l00-ocp1"
@@ -806,7 +804,9 @@ cifmw_libvirt_manager_configuration:
 cifmw_devscripts_config_overrides:
   fips_mode: "{{ cifmw_fips_enabled | default(false) | bool }}"
   cluster_subnet_v4: "192.172.0.0/16"
-  network_config_folder: "/home/zuul/netconf"
+  network_config_folder: "/home/zuul/src/github.com/openstack-k8s-operators/ci-framework/scenarios/reproducers/bgp/devscripts_netconfig"
+  fips_validate: "{{ cifmw_fips_enabled | default(false) | bool }}"
+  openshift_version: "stable-4.18"
 
 # Required for egress traffic from pods to the osp_trunk network
 cifmw_devscripts_enable_ocp_nodes_host_routing: true
@@ -815,7 +815,7 @@ cifmw_devscripts_enable_ocp_nodes_host_routing: true
 # controller-0 as-is and be consumed by the `deploy-va.sh` script.
 # Please note, all paths are on the controller-0, meaning managed by the
 # Framework. Please do not edit them!
-_arch_repo: "/home/zuul/src/github.com/openstack-k8s-operators/architecture"
+_arch_repo: "{{ cifmw_architecture_repo | default('/home/zuul/src/github.com/openstack-k8s-operators/architecture') }}"
 cifmw_architecture_scenario: bgp-l3-xl
 cifmw_kustomize_deploy_architecture_examples_path: "examples/dt/"
 cifmw_arch_automation_file: "bgp-l3-xl.yaml"

--- a/scenarios/reproducers/bgp/devscripts_netconfig/hosts.yaml
+++ b/scenarios/reproducers/bgp/devscripts_netconfig/hosts.yaml
@@ -1,0 +1,39 @@
+- ip: 192.168.111.10
+  hostnames:
+    - "master-0"
+- ip: 192.168.111.11
+  hostnames:
+    - "master-1"
+- ip: 192.168.111.12
+  hostnames:
+    - "master-2"
+- ip: 192.168.111.13
+  hostnames:
+    - "worker-0"
+- ip: 192.168.111.14
+  hostnames:
+    - "worker-1"
+- ip: 192.168.111.15
+  hostnames:
+    - "worker-2"
+- ip: 192.168.111.16
+  hostnames:
+    - "worker-3"
+- ip: 192.168.111.17
+  hostnames:
+    - "worker-4"
+- ip: 192.168.111.18
+  hostnames:
+    - "worker-5"
+- ip: 192.168.111.19
+  hostnames:
+    - "worker-6"
+- ip: 192.168.111.20
+  hostnames:
+    - "worker-7"
+- ip: 192.168.111.21
+  hostnames:
+    - "worker-8"
+- ip: 192.168.111.22
+  hostnames:
+    - "worker-9"

--- a/scenarios/reproducers/bgp/devscripts_netconfig/ocp-master-0.yaml
+++ b/scenarios/reproducers/bgp/devscripts_netconfig/ocp-master-0.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.10"
+        prefix-length: 24
+      enabled: true
+  - name: enp7s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.0.10"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.0.10"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.0.3"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/scenarios/reproducers/bgp/devscripts_netconfig/ocp-master-1.yaml
+++ b/scenarios/reproducers/bgp/devscripts_netconfig/ocp-master-1.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.11"
+        prefix-length: 24
+      enabled: true
+  - name: enp7s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.1.10"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.1.10"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.0.4"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/scenarios/reproducers/bgp/devscripts_netconfig/ocp-master-2.yaml
+++ b/scenarios/reproducers/bgp/devscripts_netconfig/ocp-master-2.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.12"
+        prefix-length: 24
+      enabled: true
+  - name: enp7s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.2.10"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.2.10"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.0.5"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/scenarios/reproducers/bgp/devscripts_netconfig/ocp-worker-0.yaml
+++ b/scenarios/reproducers/bgp/devscripts_netconfig/ocp-worker-0.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.13"
+        prefix-length: 24
+      enabled: true
+  - name: enp7s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.0.14"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.0.14"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.0.4"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/scenarios/reproducers/bgp/devscripts_netconfig/ocp-worker-1.yaml
+++ b/scenarios/reproducers/bgp/devscripts_netconfig/ocp-worker-1.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.14"
+        prefix-length: 24
+      enabled: true
+  - name: enp7s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.1.14"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.1.14"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.1.4"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/scenarios/reproducers/bgp/devscripts_netconfig/ocp-worker-2.yaml
+++ b/scenarios/reproducers/bgp/devscripts_netconfig/ocp-worker-2.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.15"
+        prefix-length: 24
+      enabled: true
+  - name: enp7s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.2.14"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.2.14"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.2.4"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/scenarios/reproducers/bgp/devscripts_netconfig/ocp-worker-3.yaml
+++ b/scenarios/reproducers/bgp/devscripts_netconfig/ocp-worker-3.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.16"
+        prefix-length: 24
+      enabled: true
+  - name: enp7s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.2.15"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.2.15"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.2.5"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/scenarios/reproducers/bgp/devscripts_netconfig/ocp-worker-4.yaml
+++ b/scenarios/reproducers/bgp/devscripts_netconfig/ocp-worker-4.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.17"
+        prefix-length: 24
+      enabled: true
+  - name: enp7s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.2.16"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.2.16"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.2.6"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/scenarios/reproducers/bgp/devscripts_netconfig/ocp-worker-5.yaml
+++ b/scenarios/reproducers/bgp/devscripts_netconfig/ocp-worker-5.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.18"
+        prefix-length: 24
+      enabled: true
+  - name: enp7s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.2.17"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.2.17"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.2.7"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/scenarios/reproducers/bgp/devscripts_netconfig/ocp-worker-6.yaml
+++ b/scenarios/reproducers/bgp/devscripts_netconfig/ocp-worker-6.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.19"
+        prefix-length: 24
+      enabled: true
+  - name: enp7s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.2.18"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.2.18"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.2.8"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/scenarios/reproducers/bgp/devscripts_netconfig/ocp-worker-7.yaml
+++ b/scenarios/reproducers/bgp/devscripts_netconfig/ocp-worker-7.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.20"
+        prefix-length: 24
+      enabled: true
+  - name: enp7s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.2.19"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.2.19"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.2.9"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/scenarios/reproducers/bgp/devscripts_netconfig/ocp-worker-8.yaml
+++ b/scenarios/reproducers/bgp/devscripts_netconfig/ocp-worker-8.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.21"
+        prefix-length: 24
+      enabled: true
+  - name: enp7s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.2.20"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.2.20"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.2.10"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0

--- a/scenarios/reproducers/bgp/devscripts_netconfig/ocp-worker-9.yaml
+++ b/scenarios/reproducers/bgp/devscripts_netconfig/ocp-worker-9.yaml
@@ -1,0 +1,43 @@
+networkConfig:
+  interfaces:
+  - name: enp6s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "192.168.111.22"
+        prefix-length: 24
+      enabled: true
+  - name: enp7s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.64.10.2"
+        prefix-length: 24
+      enabled: true
+  - name: enp8s0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: "100.65.10.2"
+        prefix-length: 24
+      enabled: true
+  - name: lo
+    type: loopback
+    state: up
+    ipv4:
+      address:
+      - ip: "172.30.10.2"
+        prefix-length: 32
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - 192.168.111.1
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.111.1
+      next-hop-interface: enp2s0


### PR DESCRIPTION
OCP nodes do not need to connect to the ctlplane network, since they connect to EDPM nodes via BGP networks instead.

The devscripts_netconfig files required for the initial installation of the ocp nodes are added to this repo.