### PR TITLE
[cifmw_external_dns] Check better for the secret

### DIFF
--- a/roles/cifmw_external_dns/tasks/cert.yml
+++ b/roles/cifmw_external_dns/tasks/cert.yml
@@ -54,7 +54,10 @@
       register: cert_info
       retries: "{{ cifmw_external_dns_retries }}"
       delay: "{{ cifmw_external_dns_delay }}"
-      until: cert_info.failed == false
+      until:
+        - cert_info.failed == false
+        - cert_info.resources[0].data['tls.crt'] is defined
+        - cert_info.resources[0].data['tls.key'] is defined
 
     - name: Ensure key and certificate directories exist on target host
       become: true


### PR DESCRIPTION
We see often the task exits the retry loop but we don't have the secrets and the subsequent Populate key task fails.