### PR TITLE
Set UTC timezone on all hosts

### DIFF
--- a/ci/playbooks/e2e-prepare.yml
+++ b/ci/playbooks/e2e-prepare.yml
@@ -56,3 +56,12 @@
     - zuul_change_list is defined
     - "'edpm-ansible' in zuul_change_list"
     - registry_login_enabled | default('false') | bool
+
+- name: Set UTC timezone on all hosts
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Set timezone to UTC
+      become: true
+      community.general.timezone:
+        name: UTC


### PR DESCRIPTION
There are different timezone sets on hosts, so during the CI job execution, logs shows different time, which might be confusing.