### PR TITLE
Change hardcoded eth0 value in multinode-customizations play

### DIFF
--- a/ci/playbooks/multinode-customizations.yml
+++ b/ci/playbooks/multinode-customizations.yml
@@ -279,7 +279,9 @@
     - name: Get the default iface connection
       register: controller_default_connection_out
       ansible.builtin.command:
-        cmd: "nmcli -g general.connection device show eth0"
+        cmd: >-
+          nmcli -g general.connection
+          device show {{ cifmw_controller_interface_name | default('eth0') }}
 
     - name: Prepend CRC DNS server in the controllers default Network Manager connection configuation
       vars:


### PR DESCRIPTION
The hardcoded value for controller default network interface is making problems on local deployment of kuttl job.
With that patch, few steps would be less to execute.