### PR TITLE
[kustomize_deploy] use recursive=True to combine user kustomize values

### DIFF
--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -147,7 +147,8 @@
             ) |
             combine(
               _cifmw_kustomize_deploy_user_kustomize[_stage_name][_name] is defined |
-              ternary(_cifmw_kustomize_deploy_user_kustomize[_stage_name][_name], {})
+              ternary(_cifmw_kustomize_deploy_user_kustomize[_stage_name][_name], {}),
+              recursive=True
             )
           }}
         cifmw_ci_gen_kustomize_values_userdata_b64: >-


### PR DESCRIPTION
Currently ci-fmw supports defining user kustomize values for a certain architecture step referring to that step with stage_\<number\> or <stage_name>.
If those values are provided using the both available methods, they should be combined using recursive=True.

[OSPRH-15775](https://issues.redhat.com//browse/OSPRH-15775)