### PR TITLE
Add tobiko_cleanup in cifmw

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -106,6 +106,7 @@ Default value: {}
 * `cifmw_test_operator_tobiko_name`: (String) Value used in the `Tobiko.Metadata.Name` field. The value specifies the name of some resources spawned by the test-operator role. Default value: `tobiko-tests`
 * `cifmw_test_operator_tobiko_registry`: (String) The registry where to pull tobiko container. Default value: `{{ cifmw_test_operator_default_registry }}`
 * `cifmw_test_operator_tobiko_namespace`: (String) Registry's namespace where to pull tobiko container. Default value: `{{ cifmw_test_operator_default_namespace }}`
+* `cifmw_test_operator_tobiko_cleanup`: (Boolean) Cleanup all resources created by tobiko. Default value: `false`
 * `cifmw_test_operator_tobiko_container`: (String) Name of the tobiko container. Default value: `openstack-tobiko`
 * `cifmw_test_operator_tobiko_image`: (String) Tobiko image to be used. Default value: `{{ cifmw_test_operator_tobiko_registry }}/{{ cifmw_test_operator_tobiko_namespace }}/{{ cifmw_test_operator_tobiko_container }}`
 * `cifmw_test_operator_tobiko_image_tag`: (String) Tag for the `cifmw_test_operator_tobiko_image`. Default value: `{{ cifmw_test_operator_default_image_tag }}`
@@ -116,6 +117,7 @@ Default value: {}
 * `cifmw_test_operator_tobiko_num_processes`: (Integer) Sets the value of the env variable `TOX_NUM_PROCESSES` that is used to run pytest with `--numprocesses $TOX_NUM_PROCESSES`. Defaults to `null`. In case of `null` value, `TOX_NUM_PROCESSES` is not set (tobiko internally uses the value `auto`, see pytest documentation about the `--numprocesses` option).
 * `cifmw_test_operator_tobiko_advanced_image_url`: (String) Tobiko will download images from this URL that will be used to create advance VM instances. By default, the provided image will include all the customizations required by the tobiko tests. Defaults to `https://softwarefactory-project.io/ubuntu-minimal-customized-enp3s0`.
 * `cifmw_test_operator_tobiko_kubeconfig_secret`: (String) Name of the Openshift Secret required to use Openshift Client from the Tobiko pod. Default value: `tobiko-secret`
+* `cifmw_test_operator_tobiko_openstack_cmd`: (String) Openstack command is used by tobiko to cleanup resources. Default value: `oc -n openstack exec openstackclient -- openstack`
 * `cifmw_test_operator_tobiko_override_conf`: (Dict) Overrides the default configuration from `cifmw_test_operator_tobiko_default_conf` that is used to generate the tobiko.conf file. Default value: empty dictionary
 * `cifmw_test_operator_tobiko_ssh_keytype`: (String) Type of ssh key that tobiko will use to connect to the VM instances it creates. Defaults to `cifmw_ssh_keytype` which default to `ecdsa`.
 * `cifmw_test_operator_tobiko_ssh_keysize`: (Integer) Size of ssh key that tobiko will use to connect to the VM instances it creates. Defaults to `cifmw_ssh_keysize` which defaults to 521.

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -164,6 +164,8 @@ cifmw_test_operator_tobiko_num_processes: null
 cifmw_test_operator_tobiko_advanced_image_url: "https://softwarefactory-project.io/ubuntu-minimal-customized-enp3s0"
 cifmw_test_operator_tobiko_override_conf: {}
 cifmw_test_operator_tobiko_kubeconfig_secret: tobiko-secret
+cifmw_test_operator_tobiko_openstack_cmd: 'oc -n openstack exec openstackclient -- openstack'
+cifmw_test_operator_tobiko_cleanup: false
 cifmw_test_operator_tobiko_ssh_keytype: "{{ cifmw_ssh_keytype | default('ecdsa') }}"
 cifmw_test_operator_tobiko_ssh_keysize: "{{ cifmw_ssh_keysize | default(521) }}"
 cifmw_test_operator_tobiko_debug: false

--- a/roles/test_operator/tasks/runners/tobiko_runner.yml
+++ b/roles/test_operator/tasks/runners/tobiko_runner.yml
@@ -10,3 +10,60 @@
     test_operator_workflow: "{{ stage_vars_dict.cifmw_test_operator_tobiko_workflow }}"
     test_operator_config_playbook: tobiko-tests.yml
   ansible.builtin.include_tasks: run-test-operator-job.yml
+
+- name: Cleanup tobiko workloads
+  when: cifmw_test_operator_tobiko_cleanup | bool
+  block:
+    - name: Cleanup Loadbalancers created by Tobiko tests
+      ansible.builtin.shell: |
+        set -o pipefail && \
+        for lb in $({{ cifmw_test_operator_tobiko_openstack_cmd }} loadbalancer list | \
+            grep "tobiko" | awk -F '|' '{print $2}')
+        do
+            {{ cifmw_test_operator_tobiko_openstack_cmd }} loadbalancer delete --cascade --wait $lb
+        done
+      failed_when: false
+
+    - name: Cleanup Heat stacks created by Tobiko tests
+      ansible.builtin.shell: |
+        set -o pipefail && \
+        {{ cifmw_test_operator_tobiko_openstack_cmd }} stack list | \
+            grep "tobiko" | awk -F '|' '{print $2}' | \
+            xargs -r timeout 180 {{ cifmw_test_operator_tobiko_openstack_cmd }} stack delete -y --wait
+      register: result
+      retries: 5
+      delay: 5
+      until: result.rc == 0
+      failed_when: false
+
+    - name: Cleanup subnet pools created by Tobiko tests
+      ansible.builtin.shell: |
+        set -o pipefail && \
+        {{ cifmw_test_operator_tobiko_openstack_cmd }} subnet pool list | \
+            grep "tobiko" | awk -F '|' '{print $2}' | \
+            xargs -r {{ cifmw_test_operator_tobiko_openstack_cmd }} subnet pool delete
+      failed_when: false
+
+    - name: Cleanup Security Groups created by Tobiko tests
+      ansible.builtin.shell: |
+        set -o pipefail && \
+        {{ cifmw_test_operator_tobiko_openstack_cmd }} security group list | \
+            grep "tobiko" | awk -F '|' '{print $2}' | \
+            xargs -r {{ cifmw_test_operator_tobiko_openstack_cmd }} security group delete
+      failed_when: false
+
+    - name: Cleanup Glance images created by Tobiko tests
+      ansible.builtin.shell: |
+        set -o pipefail && \
+        {{ cifmw_test_operator_tobiko_openstack_cmd }} image list | \
+            grep "tobiko" | awk -F '|' '{print $2}' | \
+            xargs -r {{ cifmw_test_operator_tobiko_openstack_cmd }} image delete
+      failed_when: false
+
+    - name: Cleanup Manila shares created by Tobiko tests
+      ansible.builtin.shell: |
+        set -o pipefail && \
+        {{ cifmw_test_operator_tobiko_openstack_cmd }} share list | \
+            grep "tobiko" | awk -F '|' '{print $2}' | \
+            xargs -r {{ cifmw_test_operator_tobiko_openstack_cmd }} share delete --force
+      failed_when: false


### PR DESCRIPTION
Add tobiko_cleanup task gives the option to remove all resources created by Tobiko.
Because tobiko doesn't remove the resources/workload by default after running tobiko tests.