### PR TITLE
Retry nmcli command when timeout reached

### DIFF
--- a/ci/playbooks/multinode-customizations.yml
+++ b/ci/playbooks/multinode-customizations.yml
@@ -55,6 +55,10 @@
                 ip4: "{{ _crc_default_net_ip }}"
                 gw4: "{{ _crc_default_gw }}"
                 state: present
+              register: _nmcli_result
+              until: _nmcli_result is success
+              retries: 5
+              delay: 10
 
             - name: Ensure crc does not get "public" DNS
               become: true


### PR DESCRIPTION
From time to time, Ansible is raising error:

    TASK [Ensure crc knows about its second NIC]
    crc | ERROR
    crc | {
    crc |   "msg": "Error: Failed to modify connection 'ci-private-network': Timeout was reached\n",
    crc |   "name": "ci-private-network",
    crc |   "rc": 1
    crc | }

Add retry parameter to avoid CI job to fail.