### PR TITLE
Update CRDs when changing test-operator version

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -5,8 +5,9 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 ## Parameters
 * `cifmw_test_operator_artifacts_basedir`: (String) Directory where we will have all test-operator related files. Default value: `{{ cifmw_basedir }}/tests/test_operator` which defaults to `~/ci-framework-data/tests/test_operator`
 * `cifmw_test_operator_namespace`: (String) Namespace inside which all the resources are created. Default value: `openstack`
-* `cifmw_test_operator_controller_namespace`: (String) Namespace inside which the test-operator-controller-manager is created. Default value: `openstack-opearators`
+* `cifmw_test_operator_controller_namespace`: (String) Namespace inside which the test-operator-controller-manager is created. Default value: `openstack-operators`
 * `cifmw_test_operator_bundle`: (String) Full name of container image with bundle that contains the test-operator. Default value: `""`
+* `cifmw_test_operator_version`: (String) The commit hash corresponding to the version of test-operator the user wants to use. This parameter is only used when `cifmw_test_operator_bundle` is also set.
 * `cifmw_test_operator_timeout`: (Integer) Timeout in seconds for the execution of the tests. Default value: `3600`
 * `cifmw_test_operator_logs_image`: (String) Image that should be used to collect logs from the pods spawned by the test-operator. Default value: `quay.io/quay/busybox`
 * `cifmw_test_operator_concurrency`: (Integer) Tempest concurrency value. Default value: `8`

--- a/roles/test_operator/tasks/main.yml
+++ b/roles/test_operator/tasks/main.yml
@@ -118,6 +118,45 @@
           )
         }}
 
+    - name: Update existing CRDs
+      when: cifmw_test_operator_version is defined
+      block:
+        - name: Delete CRDs created by test-operator
+          kubernetes.core.k8s:
+            kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+            api_key: "{{ cifmw_openshift_token | default(omit)}}"
+            context: "{{ cifmw_openshift_context | default(omit)}}"
+            kind: CustomResourceDefinition
+            state: absent
+            api_version: v1
+            name: "{{ item }}"
+            namespace: "{{ cifmw_test_operator_namespace }}"
+            wait: true
+            wait_timeout: 600
+          loop:
+            - "{{ cifmw_test_operator_tempest_crd_name }}"
+            - "{{ cifmw_test_operator_tobiko_crd_name }}"
+            - "{{ cifmw_test_operator_ansibletest_crd_name }}"
+            - "{{ cifmw_test_operator_horizontest_crd_name }}"
+
+        - name: Clone test-operator repository and checkout into specified version
+          ansible.builtin.git:
+            repo: "https://github.com/openstack-k8s-operators/test-operator.git"
+            dest: /tmp/test-operator
+            refspec: '+refs/pull/*:refs/heads/*'
+            version: "{{ cifmw_test_operator_version }}"
+            force: true
+
+        - name: Run make generate manifests install from /tmp/test-operator dir
+          environment:
+            KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+            PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
+          ansible.builtin.shell: >-
+            set -o pipefail;
+            make generate manifests install
+          args:
+            chdir: /tmp/test-operator
+
 - name: Call test stages loop
   when: not cifmw_test_operator_dry_run | bool
   ansible.builtin.include_tasks: stages.yml


### PR DESCRIPTION
This patch updates the CRDs, if the user wants to patch the test operator version. Until now the CRDs stayed unchanged even after version change, so testing new test-operator parameters was not possible. It is important to point out, that the update will not be triggered in 90% of test-operator use cases. It is primarily used in two situations:
1. When running checks for new PRs in the test-operator repository.    
2. When updating the test-operator version in jobs to prevent failures.

The approach isn’t the cleanest, but alternative solutions are significantly more complex than the benefits they offer.
