### PR TITLE
Increase ControlPersist timeout to 300 seconds

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -16,4 +16,4 @@ inventory = inventory.yml
 pipelining = True
 any_errors_fatal = True
 [ssh_connection]
-ssh_args = -o ControlMaster=auto -o ControlPersist=60s
+ssh_args = -o ControlMaster=auto -o ControlPersist=300


### PR DESCRIPTION
This ControlPersist socket periodically closing seems to be the cause of intermittent MODULE FAULIRE, happening sometimes in downstream CI.
Increase the timeout to make this less likely to happen.

See https://github.com/ansible/ansible/issues/78344

[OSPRH-15947](https://issues.redhat.com//browse/OSPRH-15947)