### PR TITLE
Add scenario unidelta_ipv6 adoption

### DIFF
--- a/scenarios/adoption/uni04delta-ipv6.yml
+++ b/scenarios/adoption/uni04delta-ipv6.yml
@@ -1,0 +1,2 @@
+libvirt_manager_patch_layout: {}
+networking_mapper_definition_patch: {}


### PR DESCRIPTION
It's empty patch, the config will be defined in the config job.
but this file is required for the adoption_osp_deploy
role to run.