### PR TITLE
Use python from user's environment

### DIFF
--- a/scripts/create_role_molecule.py
+++ b/scripts/create_role_molecule.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright Red Hat, Inc.
 # All Rights Reserved.


### PR DESCRIPTION
To allow for virtualenv usage, force the script to search for python set in an environment variable. By avoiding hard-coding, we don't need to modify system-wide requirements.