### PR TITLE
Set `ignore_errors` to true for crawl_n_mask

### DIFF
--- a/roles/artifacts/tasks/main.yml
+++ b/roles/artifacts/tasks/main.yml
@@ -89,6 +89,7 @@
       find {{ cifmw_artifacts_basedir }}/artifacts -type d -exec chmod 0755 '{}' \;
 
 - name: Mask secrets in yaml log files
+  ignore_errors: true  # noqa: ignore-errors
   crawl_n_mask:
     path: "{{ item }}"
     isdir: true


### PR DESCRIPTION
We do not want to fail the entire job if our crawl_n_mask module faces any error.