### PR TITLE
crawl_n_mask: Ensure keys of other datatypes are also handled

### DIFF
--- a/plugins/modules/crawl_n_mask.py
+++ b/plugins/modules/crawl_n_mask.py
@@ -245,7 +245,7 @@ def apply_mask(yaml_dict: Dict[str, Any]) -> None:
     of type dict.
     """
     for k, v in yaml_dict.items():
-        if re.findall(key_regex, k):
+        if re.findall(key_regex, str(k)):
             yaml_dict[k] = MASK_STR
 
         elif isinstance(v, str):

--- a/tests/unit/modules/test_crawl_n_mask.py
+++ b/tests/unit/modules/test_crawl_n_mask.py
@@ -61,9 +61,10 @@ class TestCrawlNMask:
         assert result == value
 
     def test_process_list(self):
-        data = [{"password": "secret"}, ["nested", {"token": "value"}]]
+        data = [{"password": "secret"}, ["nested", {"token": "value"}], {True: "test_bool_key"}]
         cnm.process_list(data)
         assert data[0]["password"] == cnm.MASK_STR
+        assert data[2][True] == "test_bool_key"
 
     def test_apply_mask(self):
         data = {"password": "secret", "normal": "data"}

--- a/tests/unit/modules/test_crawl_n_mask.py
+++ b/tests/unit/modules/test_crawl_n_mask.py
@@ -1,3 +1,5 @@
+from xmlrpc.client import Fault
+
 import pytest
 from unittest.mock import patch, MagicMock, mock_open
 
@@ -60,11 +62,22 @@ class TestCrawlNMask:
         result = cnm.apply_regex(value)
         assert result == value
 
-    def test_process_list(self):
-        data = [{"password": "secret"}, ["nested", {"token": "value"}], {True: "test_bool_key"}]
+    @pytest.mark.parametrize(
+        "data, ismasked",
+        [
+            ([{"password": "secret"}], True),
+            ([{"secret": "value"}], True),
+            ([{True: "test_bool_key"}], False),
+            ([{1: "int_key"}], False),
+            ([{1.1: "float_key"}], False),
+        ],
+    )
+    def test_process_list(self, data, ismasked):
         cnm.process_list(data)
-        assert data[0]["password"] == cnm.MASK_STR
-        assert data[2][True] == "test_bool_key"
+        if ismasked:
+            assert cnm.MASK_STR in [list(item.values())[0] for item in data]
+        else:
+            assert cnm.MASK_STR not in [list(item.values())[0] for item in data]
 
     def test_apply_mask(self):
         data = {"password": "secret", "normal": "data"}


### PR DESCRIPTION
In crawl_n_mask, it was assumed that the keys in yaml files will be string. But, it is also possible that we might have keys as bool or int. It's better to typecast the keys to string during regex findall.