### PR TITLE
Reuse OCP cluster

### DIFF
--- a/clean_openstack_deployment.yaml
+++ b/clean_openstack_deployment.yaml
@@ -1,6 +1,5 @@
 - name: Clean OpenStack deployment
   hosts: "{{ target_host | default('localhost') }}"
-  gather_facts: false
   tasks:
     - name: Clean up OpenStack operators
       vars:
@@ -8,3 +7,11 @@
       ansible.builtin.include_role:
         name: kustomize_deploy
         tasks_from: cleanup
+
+    - name: Remove logs and tests directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "/home/zuul/ci-framework-data/logs"
+        - "/home/zuul/ci-framework-data/tests"

--- a/deploy-edpm-reuse.yaml
+++ b/deploy-edpm-reuse.yaml
@@ -1,0 +1,102 @@
+---
+- name: Manage unique ID
+  ansible.builtin.import_playbook: playbooks/unique-id.yml
+
+- name: Reproducer prepare play
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: true
+  pre_tasks:
+    - name: Prepare cleanup script
+      ansible.builtin.include_role:
+        name: reproducer
+        tasks_from: configure_cleanup.yaml
+
+    - name: Run Openstack cleanup
+      no_log: "{{ cifmw_nolog | default(true) | bool }}"
+      async: "{{ 7200 + cifmw_test_operator_timeout | default(3600) }}"  # 2h should be enough to deploy EDPM and rest for tests.
+      poll: 20
+      delegate_to: controller-0
+      ansible.builtin.command:
+        cmd: "/home/zuul/cleanup-architecture.sh"
+
+    - name: Inherit from parent scenarios if needed
+      ansible.builtin.include_tasks:
+        file: "ci/playbooks/tasks/inherit_parent_scenario.yml"
+
+    - name: Include common architecture parameter file
+      when:
+        - cifmw_architecture_scenario is defined
+        - cifmw_architecture_scenario | length > 0
+      ansible.builtin.include_vars:
+        file: "scenarios/reproducers/va-common.yml"
+
+    - name: Run reproducer validations
+      ansible.builtin.import_role:
+        name: reproducer
+        tasks_from: validations
+
+    - name: Gather OS facts
+      ansible.builtin.setup:
+        gather_subset:
+          - "!all"
+          - "!min"
+          - "distribution"
+
+    - name: Tweak dnf configuration
+      become: true
+      community.general.ini_file:
+        no_extra_spaces: true
+        option: "{{ config.option }}"
+        path: "/etc/dnf/dnf.conf"
+        section: "{{ config.section | default('main') }}"
+        state: "{{ config.state | default(omit) }}"
+        value: "{{ config.value | default(omit) }}"
+        mode: "0644"
+      loop: "{{ cifmw_reproducer_dnf_tweaks }}"
+      loop_control:
+        label: "{{ config.option }}"
+        loop_var: 'config'
+
+    - name: Install custom CA if needed
+      ansible.builtin.import_role:
+        name: install_ca
+
+    - name: Setup repositories via rhos-release if needed
+      tags:
+        - packages
+      when:
+        - ansible_facts['distribution'] == 'RedHat'
+        - cifmw_reproducer_hp_rhos_release | bool
+      vars:
+        cifmw_repo_setup_output: /etc/yum.repos.d
+        cifmw_repo_setup_rhos_release_args: "rhel"
+      ansible.builtin.import_role:
+        name: repo_setup
+        tasks_from: rhos_release
+
+  roles:
+    - role: ci_setup
+
+- name: Prepare switches
+  vars:
+    cifmw_configure_switches: "{{ 'switches' in groups }}"
+  ansible.builtin.import_playbook: playbooks/switches_config.yml
+
+- name: Reproducer reuse run
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Run reproducer reuse playbook
+      ansible.builtin.include_role:
+        name: reproducer
+        tasks_from: reuse_main
+
+    - name: Run deployment if instructed to
+      when:
+        - cifmw_deploy_architecture | default(false) | bool
+      no_log: "{{ cifmw_nolog | default(true) | bool }}"
+      async: "{{ 7200 + cifmw_test_operator_timeout | default(3600) }}"  # 2h should be enough to deploy EDPM and rest for tests.
+      poll: 20
+      delegate_to: controller-0
+      ansible.builtin.command:
+        cmd: "/home/zuul/deploy-architecture.sh {{ cifmw_deploy_architecture_args | default('') }}"

--- a/roles/kustomize_deploy/tasks/cleanup.yml
+++ b/roles/kustomize_deploy/tasks/cleanup.yml
@@ -34,6 +34,7 @@
         reverse |
         selectattr('build_output', 'defined') |
         map(attribute='build_output') |
+        map('basename') |
         list
       }}
     _stages_crs_path: >-
@@ -48,10 +49,14 @@
       - "{{ cifmw_kustomize_deploy_metallb_dest_file }}"
       - "{{ cifmw_kustomize_deploy_kustomizations_dest_dir }}/openstack.yaml"
       - "{{ cifmw_kustomize_deploy_olm_dest_file }}"
+    _external_dns_crs:
+      - /home/zuul/ci-framework-data/artifacts/manifests/cifmw_external_dns/ceph-local-dns.yml
+      - /home/zuul/ci-framework-data/artifacts/manifests/cifmw_external_dns/ceph-local-cert.yml
   register: _cifmw_kustomize_files
   ansible.builtin.set_fact:
     cifmw_kustomize_deploy_crs_to_delete: >-
       {{
+        _external_dns_crs +
         _stages_crs_path +
         _operators_crs
       }}
@@ -72,6 +77,10 @@
     wait: true
     wait_timeout: 600
   loop: "{{ _cifmw_kustomize_files.results }}"
+  register: _cleanup_results
+  until: "_cleanup_results is success"
+  retries: 3
+  delay: 120
   when:
     - item.stat.exists
     - not cifmw_kustomize_deploy_generate_crs_only

--- a/roles/reproducer/tasks/configure_cleanup.yaml
+++ b/roles/reproducer/tasks/configure_cleanup.yaml
@@ -1,0 +1,56 @@
+---
+- name: Configure cleanup
+  delegate_to: controller-0
+  block:
+    - name: Discover and expose CI Framework path on remote node
+      tags:
+        - always
+      vars:
+        default_path: >-
+          {{
+            cifmw_reproducer_default_repositories |
+            selectattr('src', 'match', '^.*/ci[_\-]framework$') |
+            map(attribute='dest') | first
+          }}
+        custom_path: >-
+          {{
+            cifmw_reproducer_repositories |
+            selectattr('src', 'match', '^.*/ci-framework$') |
+            map(attribute='dest')
+          }}
+        _path: >-
+          {{
+            (custom_path | length > 0) |
+            ternary(custom_path | first, default_path)
+          }}
+      ansible.builtin.set_fact:
+        _cifmw_reproducer_framework_location: >-
+          {{
+            (_path is match('.*/ci-framework/?$')) |
+            ternary(_path, [_path, 'ci-framework'] | path_join)
+          }}
+
+    - name: Push cleanup script
+      vars:
+        run_directory: "{{ _cifmw_reproducer_framework_location }}"
+        exports:
+          ANSIBLE_LOG_PATH: "~/ansible-cleanup-architecture.log"
+        default_extravars:
+          - "@~/ci-framework-data/parameters/reproducer-variables.yml"
+          - "@~/ci-framework-data/parameters/openshift-environment.yml"
+          - "@~/ci-framework-data/artifacts/parameters/openshift-login-params.yml"
+        extravars: "{{ cifmw_reproducer_play_extravars }}"
+        playbook: "clean_openstack_deployment.yaml"
+      ansible.builtin.template:
+        dest: "/home/zuul/cleanup-architecture.sh"
+        src: "script.sh.j2"
+        mode: "0755"
+        owner: "zuul"
+        group: "zuul"
+
+    - name: Rotate some logs
+      tags:
+        - always
+      ansible.builtin.include_tasks: rotate_log.yml
+      loop:
+        - ansible-cleanup-architecture.log

--- a/roles/reproducer/tasks/reuse_main.yaml
+++ b/roles/reproducer/tasks/reuse_main.yaml
@@ -1,0 +1,274 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Load CI job environment
+  tags:
+    - bootstrap_layout
+  when:
+    - cifmw_job_uri is defined
+  ansible.builtin.include_tasks:
+    file: ci_data.yml
+    apply:
+      tags:
+        - bootstrap_layout
+
+- name: Discover and expose CI Framework path on remote node
+  tags:
+    - always
+  vars:
+    default_path: >-
+      {{
+        cifmw_reproducer_default_repositories |
+        selectattr('src', 'match', '^.*/ci[_\-]framework$') |
+        map(attribute='dest') | first
+      }}
+    custom_path: >-
+      {{
+        cifmw_reproducer_repositories |
+        selectattr('src', 'match', '^.*/ci-framework$') |
+        map(attribute='dest')
+      }}
+    _path: >-
+      {{
+        (custom_path | length > 0) |
+        ternary(custom_path | first, default_path)
+      }}
+  ansible.builtin.set_fact:
+    _cifmw_reproducer_framework_location: >-
+      {{
+        (_path is match('.*/ci-framework/?$')) |
+        ternary(_path, [_path, 'ci-framework'] | path_join)
+      }}
+
+- name: Set _use_crc based on actual layout
+  tags:
+    - always
+  vars:
+    _use_crc: >-
+      {{
+        _cifmw_libvirt_manager_layout.vms.crc is defined and
+        (
+          (_cifmw_libvirt_manager_layout.vms.crc.amount is defined and
+           _cifmw_libvirt_manager_layout.vms.crc.amount|int > 0) or
+        _cifmw_libvirt_manager_layout.vms.crc.amount is undefined)
+      }}
+    _use_ocp: >-
+      {{
+        _cifmw_libvirt_manager_layout.vms.ocp is defined and
+        (_cifmw_libvirt_manager_layout.vms.ocp.amount is defined and
+         _cifmw_libvirt_manager_layout.vms.ocp.amount|int > 0)
+      }}
+  ansible.builtin.set_fact:
+    _use_crc: "{{ _use_crc }}"
+    _use_ocp: "{{ _use_ocp }}"
+    _has_openshift: "{{ _use_ocp or _use_crc }}"
+
+- name: Ensure directories are present
+  tags:
+    - always
+  ansible.builtin.file:
+    path: "{{ cifmw_reproducer_basedir }}/{{ item }}"
+    state: directory
+    mode: "0755"
+  loop:
+    - artifacts
+    - logs
+
+- name: Load the architecture local kustomize patches
+  when:
+    - cifmw_architecture_scenario is defined
+  ansible.builtin.include_role:
+    name: kustomize_deploy
+    tasks_from: generate_base64_patches_from_tree.yml
+
+- name: Run only on hypervisor with controller-0
+  block:
+    - name: Push local code
+      ansible.builtin.include_tasks: push_code.yml
+
+    - name: Group tasks on controller-0
+      delegate_to: controller-0
+      block:
+        - name: Inject CI Framework motd
+          become: true
+          ansible.builtin.template:
+            dest: "/etc/motd.d/cifmw.motd"
+            src: "motd.j2"
+            mode: "0644"
+
+        - name: Rotate ansible-bootstrap logs
+          tags:
+            - always
+          ansible.builtin.include_tasks: rotate_log.yml
+          loop:
+            - "/home/zuul/ansible-bootstrap.log"
+
+        - name: Bootstrap environment on controller-0
+          environment:
+            ANSIBLE_LOG_PATH: "~/ansible-bootstrap.log"
+          no_log: "{{ cifmw_nolog | default(true) | bool }}"
+          ansible.builtin.command:
+            chdir: "{{ _cifmw_reproducer_framework_location }}"
+            cmd: >-
+              ansible-playbook -i ~/ci-framework-data/artifacts/zuul_inventory.yml
+              -e @~/ci-framework-data/parameters/reproducer-variables.yml
+              -e @scenarios/reproducers/networking-definition.yml
+              playbooks/01-bootstrap.yml
+            creates: "/home/zuul/ansible-bootstrap.log"
+
+        - name: Install dev tools from install_yamls on controller-0
+          environment:
+            ANSIBLE_LOG_PATH: "~/ansible-bootstrap.log"
+          vars:
+            _devsetup_path: >-
+              {{
+                (
+                  cifmw_install_yamls_repo | default('/home/zuul/src/github.com/openstack-k8s-operators/install_yamls'),
+                  'devsetup'
+                ) | ansible.builtin.path_join
+              }}
+          no_log: "{{ cifmw_nolog | default(true) | bool }}"
+          ansible.builtin.command:
+            chdir: "{{ _devsetup_path }}"
+            cmd: >-
+              ansible-playbook -i ~/ci-framework-data/artifacts/zuul_inventory.yml
+              download_tools.yaml --tags kustomize,kubectl
+            creates: "/home/zuul/bin/kubectl"
+
+# Run from the hypervisor
+- name: Ensure OCP cluster is stable
+  when:
+    - _wait_ocp_cluster is defined
+    - _wait_ocp_cluster | bool
+  tags:
+    - bootstrap
+    - bootstrap_layout
+  vars:
+    _auth_path: >-
+      {{
+        (
+          cifmw_devscripts_repo_dir,
+          'ocp',
+          cifmw_devscripts_config.cluster_name,
+          'auth'
+        ) | ansible.builtin.path_join
+      }}
+    cifmw_openshift_adm_op: "stable"
+    cifmw_openshift_kubeconfig: >-
+      {{ (_auth_path, 'kubeconfig') | ansible.builtin.path_join }}
+  ansible.builtin.include_role:
+    name: openshift_adm
+
+- name: Run from controller-0
+  delegate_to: controller-0
+  block:
+    - name: Emulate CI job
+      when:
+        - cifmw_job_uri is defined
+      ansible.builtin.include_tasks: ci_job.yml
+
+    - name: Prepare VA deployment
+      when:
+        - cifmw_architecture_scenario is defined
+        - cifmw_job_uri is undefined
+      tags:
+        - deploy_architecture
+      ansible.builtin.include_tasks:
+        file: configure_architecture.yml
+        apply:
+          tags:
+            - deploy_architecture
+
+    - name: Set facts related to the reproducer
+      ansible.builtin.set_fact:
+        _ctl_reproducer_basedir: >-
+          {{
+            (
+            '/home/zuul',
+            'ci-framework-data',
+            ) | path_join
+          }}
+
+    - name: Ensure directories exist
+      ansible.builtin.file:
+        path: "{{ _ctl_reproducer_basedir }}/{{ item }}"
+        state: directory
+        mode: "0755"
+      loop:
+        - parameters
+        - artifacts
+
+    - name: Inject most of the cifmw_ parameters passed to the reproducer run
+      tags:
+        - bootstrap_env
+      vars:
+        _filtered_vars: >-
+          {{
+            hostvars[inventory_hostname] | default({}) |
+            dict2items |
+            selectattr('key', 'match',
+                       '^(pre|post|cifmw)_(?!install_yamls|devscripts).*') |
+            rejectattr('key', 'equalto', 'cifmw_target_host') |
+            rejectattr('key', 'equalto', 'cifmw_basedir') |
+            rejectattr('key', 'equalto', 'cifmw_path') |
+            rejectattr('key', 'equalto', 'cifmw_extras') |
+            rejectattr('key', 'equalto', 'cifmw_openshift_kubeconfig') |
+            rejectattr('key', 'equalto', 'cifmw_openshift_token') |
+            rejectattr('key', 'equalto', 'cifmw_networking_env_definition') |
+            rejectattr('key', 'match', '^cifmw_use_(?!lvms).*') |
+            rejectattr('key', 'match', '^cifmw_reproducer.*') |
+            rejectattr('key', 'match', '^cifmw_rhol.*') |
+            rejectattr('key', 'match', '^cifmw_discover.*') |
+            rejectattr('key', 'match', '^cifmw_libvirt_manager.*') |
+            rejectattr('key', 'match', '^cifmw_manage_secrets_(pullsecret|citoken).*') |
+            items2dict
+          }}
+      ansible.builtin.copy:
+        mode: "0644"
+        dest: "/home/zuul/ci-framework-data/parameters/reproducer-variables.yml"
+        content: "{{ _filtered_vars | to_nice_yaml }}"
+
+    - name: Create reproducer-variables.yml symlink to old location
+      ansible.builtin.file:
+        dest: "/home/zuul/reproducer-variables.yml"
+        src: "/home/zuul/ci-framework-data/parameters/reproducer-variables.yml"
+        state: link
+
+    - name: Slurp kubeadmin password
+      ansible.builtin.slurp:
+        src: /home/zuul/.kube/kubeadmin-password
+      register: _kubeadmin_password
+
+    - name: Prepare ci-like EDPM deploy
+      when:
+        - cifmw_job_uri is undefined
+      delegate_to: controller-0
+      vars:
+        run_directory: "{{ _cifmw_reproducer_framework_location }}"
+        exports:
+          ANSIBLE_LOG_PATH: "~/ansible-deploy-edpm.log"
+        default_extravars:
+          - "@scenarios/centos-9/base.yml"
+          - "@scenarios/centos-9/edpm_ci.yml"
+          - "cifmw_openshift_password='{{ _kubeadmin_password.content | b64decode }}'"
+        extravars: "{{ cifmw_reproducer_play_extravars }}"
+        playbook: "deploy-edpm.yml"
+      ansible.builtin.template:
+        dest: "/home/zuul/deploy-edpm.sh"
+        src: "script.sh.j2"
+        mode: "0755"
+        owner: "zuul"
+        group: "zuul"


### PR DESCRIPTION
This patch is made to allow re-deploying openstack without having to re-deploy OCP every time.  This patch will allow optimizing CI jobs run time for NFV jobs.