### PR TITLE
Add iscsi initiator file to the existing machineConfig template

### DIFF
--- a/roles/devscripts/templates/iscsi.j2
+++ b/roles/devscripts/templates/iscsi.j2
@@ -21,7 +21,31 @@ spec:
             name: root
           contents:
             source: data:,node.session.initial_login_retry_max%20%3D%203%0Anode.conn%5B0%5D.timeo.login_timeout%20%3D%205%0Anode.session.auth.chap_algs%20%3D%20SHA3%2D256%2CSHA256%0A
+        - path: /etc/iscsi/initiatorname.iscsi
+          overwrite: false
+          mode: 420
+          user:
+            name: root
+          group:
+            name: root
+          contents:
+            source: data:,
     systemd:
       units:
         - enabled: true
           name: iscsid.service
+        - name: set-iscsi-initiator.service
+          enabled: true
+          contents: |
+            [Unit]
+            Description=Set iSCSI Initiator Name
+            After=network-online.target
+            Wants=network-online.target
+
+            [Service]
+            Type=oneshot
+            ExecStart=/bin/bash -c 'echo InitiatorName=$(iscsi-iname) > /etc/iscsi/initiatorname.iscsi'
+            RemainAfterExit=true
+
+            [Install]
+            WantedBy=multi-user.target


### PR DESCRIPTION
We recently had an issue related to `CIX-745` which sees `glance` failing to upload an image when `cinder` is the backend. Apparently, it seems that the current failure is related to the missing `iscsi initiator` in the nodes where `cinder-volume` `Pod` is hosted. This patch updates the `machineConfig` template to workaround the issue until [1] is merged and promoted.

Jira: https://issues.redhat.com/browse/OSPCIX-745

[1] https://review.opendev.org/c/openstack/cinder/+/946103