### PR TITLE
Add OpenStack Operator Initialization

### DIFF
--- a/roles/update/defaults/main.yml
+++ b/roles/update/defaults/main.yml
@@ -24,6 +24,7 @@ cifmw_update_openstack_update_run_containers_namespace: "podified-antelope-cento
 cifmw_update_openstack_update_run_containers_target_tag: "current-podified"
 cifmw_update_openstack_update_run_timeout: "600s"
 
+# Avoid certain tasks during molecule run
 cifmw_update_run_dryrun: false
 
 ### Test related variables

--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -44,6 +44,51 @@
     - cifmw_ci_gen_kustomize_values_installplan_approval is defined
     - cifmw_ci_gen_kustomize_values_installplan_approval | lower == 'manual'
 
+- name: Initialize the openstack operator if needed
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    definition: "{{ _openstack_init_resource }}"
+    state: present
+  vars:
+    _openstack_init_resource:
+      apiVersion: operator.openstack.org/v1beta1
+      kind: OpenStack
+      metadata:
+        name: openstack
+        namespace: openstack-operators
+  when:
+    - cifmw_ci_gen_kustomize_values_deployment_version is defined
+    - cifmw_ci_gen_kustomize_values_deployment_version is in ['v1.0.3', 'v1.0.6']
+
+- name: Ensure OpenStack deployment is successful and block until it is done
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    api_version: operator.openstack.org/v1beta1
+    kind: OpenStack
+    namespace: openstack-operators
+  register: _cifmw_update_openstack_info
+  until: >
+    _cifmw_update_openstack_info.resources[0].status.conditions is defined
+    and
+    (
+      _cifmw_update_openstack_info.resources[0].status.conditions |
+      selectattr('type', 'equalto', 'Ready') |
+      map(attribute='status') | first | default('False') == 'True'
+    )
+    and
+    (
+      _cifmw_update_openstack_info.resources[0].status.conditions |
+      selectattr('type', 'equalto', 'OpenStackOperatorReadyCondition') |
+      map(attribute='status') | first | default('False') == 'True'
+    )
+  retries: 20
+  delay: 15
+  when: not (cifmw_update_run_dryrun | bool)
+
 # Get the next available version available when using OLM
 - name: Handle the next version when using OLM
   when:


### PR DESCRIPTION
We have introduced new tasks for initializing the OpenStack operator. This is required for versions prior to v1.0.7, where deployment didn't include the initialization. This action only takes place if we are using an OLM-based update.

Additionally, we block the process until the OpenStack deployment is successful. This applies to all starting versions, as the operator should be ready before proceeding.

Closes: [OSPRH-15799](https://issues.redhat.com/browse/OSPRH-15799)