### PR TITLE
Do not print oc completion

### DIFF
--- a/roles/ci_setup/tasks/packages.yml
+++ b/roles/ci_setup/tasks/packages.yml
@@ -73,6 +73,7 @@
           {{ cifmw_ci_setup_oc_install_path }}/oc completion bash |
           tee -a ~/.oc_completion
         creates: "{{ ansible_user_dir }}/.oc_completion"
+      no_log: true
 
     - name: Source completion from within .bashrc
       ansible.builtin.blockinfile:


### PR DESCRIPTION
When Ansible is executed in verbose mode, the oc completion output is not needed to print.