### PR TITLE
Change callback plugin to default; format callback result to yaml

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -5,8 +5,11 @@ roles_path = ~/ci-framework-data/artifacts/roles:./roles:/usr/share/ansible/role
 filter_plugins = ./plugins/filter:~/plugins/filter:/usr/share/ansible/plugins/filter
 log_path = ~/ansible.log
 # We may consider ansible.builtin.junit
-callbacks_enabled = ansible.posix.profile_tasks,yaml
-stdout_callback = yaml
+callbacks_enabled = ansible.posix.profile_tasks,ansible.builtin.default
+stdout_callback = ansible.builtin.default
+callback_format_pretty = yaml
+callback_result_format = yaml
+show_task_path_on_failure = true
 display_args_to_stdout = True
 gathering = smart
 fact_caching = jsonfile


### PR DESCRIPTION
The yaml callback plugin is deprecated [1] and it has been
replaced by ansible.builtin.default.
Also enable callback_format_pretty to yaml that is more easy to read
comparing to json.

[1] https://docs.ansible.com/ansible/latest/collections/community/general/yaml_callback.html