### PR TITLE
cd_dcn_site: Set the correct hostname

### DIFF
--- a/roles/ci_dcn_site/tasks/az.yml
+++ b/roles/ci_dcn_site/tasks/az.yml
@@ -24,13 +24,11 @@
     command: >-
       openstack aggregate show {{ _az }} -c hosts -f value
 
-- name: Convert az_hosts string to list and remove extra text
+- name: Convert az_hosts string to list
   ansible.builtin.set_fact:
     az_hosts_list: >
       {{ az_hosts.stdout
          | default([])
-         | from_yaml
-         | map('regex_replace', 'edpm-compute-(.*?)\\..*', 'compute-\\1')
          | list }}
 
 - name: Create AZ if it does not exist
@@ -54,4 +52,4 @@
     namespace: openstack
     pod: openstackclient
     command: >-
-      openstack aggregate add host {{ _az }} edpm-{{ item.key }}.ctlplane.example.com
+      openstack aggregate add host {{ _az }} {{ item.key }}.ctlplane.example.com

--- a/roles/ci_dcn_site/templates/edpm-pre-ceph/nodeset/values.yaml.j2
+++ b/roles/ci_dcn_site/templates/edpm-pre-ceph/nodeset/values.yaml.j2
@@ -130,7 +130,7 @@ data:
       edpm-{{ _host_name }}:
         ansible:
           ansibleHost: {{ network_data['ip_v4'] }}
-        hostName: edpm-{{ _host_name }}
+        hostName: {{ _host_name }}
         networks:
           - defaultRoute: true
             fixedIP: {{ network_data['ip_v4'] }}


### PR DESCRIPTION
Set the correct hostname (without the
extra prefix "edpm-"). The hostname of
the compute nodes is set to a name
without the "edpm-" prefix by ci-fmw
when the VMs are provisioned. Once the
dataplane is deployed with a different
hostname which would be configured in the
OCP DNS used by dataplane nodes (after
dataplane deployed) The original hostname
which is still set on the dataplane nodes
would not be recognized by the DNS and
the correct domain would not be used.
Instead the original domain which was set
by DHCP during the VM nodes provisioning
by ci-framework would be set until the
DHCP lease is lost and that eventually
leads to fqdn of dataplane nodes mismatch