### PR TITLE
Change the way how the hooks playbook is executed

### DIFF
--- a/ci/playbooks/kuttl/e2e-kuttl.yml
+++ b/ci/playbooks/kuttl/e2e-kuttl.yml
@@ -33,42 +33,25 @@
         name: "install_yamls_makes"
         tasks_from: "make_crc_attach_default_interface"
 
-- name: Run pre_kuttl hooks
-  vars:
-    hooks: "{{ pre_kuttl | default([]) }}"
-    step: pre_kuttl
-  ansible.builtin.import_playbook: >-
-    {{
-        [
-          ansible_user_dir,
-          zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
-          'playbooks',
-          'hooks.yml'
-        ] | ansible.builtin.path_join
-    }}
+    - name: Run pre_kuttl hooks
+      vars:
+        hooks: "{{ pre_kuttl | default([]) }}"
+        step: pre_kuttl
+      ansible.builtin.import_role:
+        name: run_hook
 
-- name: Run KUTTL operator tests
-  hosts: "{{ cifmw_target_host | default('localhost') }}"
-  tasks:
     - name: Run kuttl tests
       ansible.builtin.include_tasks: run-kuttl-tests.yml
       loop: "{{ cifmw_kuttl_tests_operator_list | default(['cinder' 'keystone']) }}"
       loop_control:
         loop_var: operator
 
-- name: Run post_kuttl hooks
-  vars:
-    hooks: "{{ post_kuttl | default([]) }}"
-    step: post_kuttl
-  ansible.builtin.import_playbook: >-
-    {{
-        [
-          ansible_user_dir,
-          zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir,
-          'playbooks',
-          'hooks.yml'
-        ] | ansible.builtin.path_join
-    }}
+    - name: Run post_kuttl hooks
+      vars:
+        hooks: "{{ post_kuttl | default([]) }}"
+        step: post_kuttl
+      ansible.builtin.import_role:
+        name: run_hook
 
 - name: Run log related tasks
   ansible.builtin.import_playbook: >-

--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -69,14 +69,18 @@
   tags:
     - compliance
 
-- name: Run log related tasks
-  ansible.builtin.import_playbook: playbooks/98-pre-end.yml
-  tags:
-    - pre-end
-
-- name: Inject status flag
+- name: Run hooks and inject status flag
   hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
   tasks:
+    - name: Run pre_end hooks
+      tags:
+        - pre-end
+      vars:
+        step: pre_end
+      ansible.builtin.import_role:
+        name: run_hook
+
     - name: Inject success flag
       ansible.builtin.file:
         path: "{{ ansible_user_dir }}/cifmw-success"

--- a/playbooks/02-infra.yml
+++ b/playbooks/02-infra.yml
@@ -1,7 +1,13 @@
+---
 - name: Run pre_infra hooks
-  vars:
-    step: pre_infra
-  ansible.builtin.import_playbook: ./hooks.yml
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Run pre_infra hooks
+      vars:
+        step: pre_infra
+      ansible.builtin.import_role:
+        name: run_hook
 
 - name: Prepare host virtualization
   hosts: "{{ ('virthosts' in groups) | ternary('virthosts', cifmw_target_host | default('localhost') ) }}"
@@ -129,7 +135,8 @@
       ansible.builtin.include_role:
         name: pkg_build
 
-- name: Run post_infra hooks
-  vars:
-    step: post_infra
-  ansible.builtin.import_playbook: ./hooks.yml
+    - name: Run post_infra hooks
+      vars:
+        step: post_infra
+      ansible.builtin.import_role:
+        name: run_hook

--- a/playbooks/03-build-packages.yml
+++ b/playbooks/03-build-packages.yml
@@ -1,12 +1,14 @@
-- name: Run pre_package_build hooks
-  vars:
-    step: pre_package_build
-  ansible.builtin.import_playbook: ./hooks.yml
-
+---
 - name: Build package playbook
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
+    - name: Run pre_package_build hooks
+      vars:
+        step: pre_package_build
+      ansible.builtin.import_role:
+        name: run_hook
+
     - name: Load parameters files
       ansible.builtin.include_vars:
         dir: "{{ cifmw_basedir }}/artifacts/parameters"
@@ -19,7 +21,8 @@
         name: pkg_build
         tasks_from: build.yml
 
-- name: Run post_package_build hooks
-  vars:
-    step: post_package_build
-  ansible.builtin.import_playbook: ./hooks.yml
+    - name: Run post_package_build hooks
+      vars:
+        step: post_package_build
+      ansible.builtin.import_role:
+        name: run_hook

--- a/playbooks/04-build-containers.yml
+++ b/playbooks/04-build-containers.yml
@@ -1,12 +1,14 @@
-- name: Run pre_container_build hooks
-  vars:
-    step: pre_container_build
-  ansible.builtin.import_playbook: ./hooks.yml
-
+---
 - name: Build container playbook
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
+    - name: Run pre_container_build hooks
+      vars:
+        step: pre_container_build
+      ansible.builtin.import_role:
+        name: run_hook
+
     - name: Load parameters files
       ansible.builtin.include_vars:
         dir: "{{ cifmw_basedir }}/artifacts/parameters"
@@ -15,7 +17,8 @@
       ansible.builtin.debug:
         msg: "No support for that step yet"
 
-- name: Run post_container_build hooks
-  vars:
-    step: post_container_build
-  ansible.builtin.import_playbook: ./hooks.yml
+    - name: Run post_container_build hooks
+      vars:
+        step: post_container_build
+      ansible.builtin.import_role:
+        name: run_hook

--- a/playbooks/05-build-operators.yml
+++ b/playbooks/05-build-operators.yml
@@ -1,14 +1,16 @@
-- name: Run pre_operator_build hooks
-  vars:
-    step: pre_operator_build
-  ansible.builtin.import_playbook: ./hooks.yml
-
+---
 - name: Build operators playbook
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   environment:
     PATH: "{{ cifmw_path }}"
   tasks:
+    - name: Run pre_operator_build hooks
+      vars:
+        step: pre_operator_build
+      ansible.builtin.import_role:
+        name: run_hook
+
     - name: Load parameters files
       ansible.builtin.include_vars:
         dir: "{{ cifmw_basedir }}/artifacts/parameters"
@@ -20,7 +22,8 @@
       ansible.builtin.import_role:
         name: operator_build
 
-- name: Run post_operator_build hooks
-  vars:
-    step: post_operator_build
-  ansible.builtin.import_playbook: ./hooks.yml
+    - name: Run post_operator_build hooks
+      vars:
+        step: post_operator_build
+      ansible.builtin.import_role:
+        name: run_hook

--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -1,14 +1,15 @@
 ---
-- name: Run pre_deploy hooks
-  when:
-    - cifmw_architecture_scenario is defined
-  vars:
-    step: pre_deploy
-  ansible.builtin.import_playbook: ./hooks.yml
-
 - name: Deploy VA
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   tasks:
+    - name: Run pre_deploy hooks
+      when:
+        - cifmw_architecture_scenario is defined
+      vars:
+        step: pre_deploy
+      ansible.builtin.import_role:
+        name: run_hook
+
     # end_play will end only current play, not the main edpm-deploy.yml
     - name: Early end if not architecture deploy
       tags:
@@ -280,12 +281,13 @@
         nova-cell0-conductor-0
         nova-manage cell_v2 discover_hosts --verbose
 
-- name: Run post_deploy hooks
-  when:
-    - cifmw_architecture_scenario is defined
-  vars:
-    step: post_deploy
-  ansible.builtin.import_playbook: ./hooks.yml
+    - name: Run post_deploy hooks
+      when:
+        - cifmw_architecture_scenario is defined
+      vars:
+        step: post_deploy
+      ansible.builtin.import_role:
+        name: run_hook
 
 - name: Validations workflow
   ansible.builtin.import_playbook: validations.yml

--- a/playbooks/06-deploy-edpm.yml
+++ b/playbooks/06-deploy-edpm.yml
@@ -1,15 +1,16 @@
 ---
-- name: Run pre_deploy hooks
-  when:
-    - cifmw_architecture_scenario is not defined
-  vars:
-    step: pre_deploy
-  ansible.builtin.import_playbook: ./hooks.yml
-
 - name: Deploy podified control plane
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
+    - name: Run pre_deploy hooks
+      when:
+        - cifmw_architecture_scenario is not defined
+      vars:
+        step: pre_deploy
+      ansible.builtin.import_role:
+        name: run_hook
+
     # end_play will end only current play, not the main edpm-deploy.yml
     - name: Early end if architecture deploy
       when:
@@ -34,12 +35,13 @@
       ansible.builtin.include_role:
         name: edpm_prepare
 
-- name: Run post_ctlplane_deploy hooks
-  when:
-    - cifmw_architecture_scenario is undefined
-  vars:
-    step: post_ctlplane_deploy
-  ansible.builtin.import_playbook: ./hooks.yml
+    - name: Run post_ctlplane_deploy hooks
+      when:
+        - cifmw_architecture_scenario is undefined
+      vars:
+        step: post_ctlplane_deploy
+      ansible.builtin.import_role:
+        name: run_hook
 
 - name: EDPM deployment on virtual baremetal
   hosts: "{{ cifmw_target_host | default('localhost') }}"
@@ -150,12 +152,13 @@
           vars:
             cifmw_edpm_deploy_prepare_run: false
 
-- name: Run post_deploy hooks
-  when:
-    - cifmw_architecture_scenario is not defined
-  vars:
-    step: post_deploy
-  ansible.builtin.import_playbook: ./hooks.yml
+    - name: Run post_deploy hooks
+      when:
+        - cifmw_architecture_scenario is not defined
+      vars:
+        step: post_deploy
+      ansible.builtin.import_role:
+        name: run_hook
 
 - name: Validations workflow
   # If we're doing an architecture deployment, we need to skip validations here.

--- a/playbooks/07-admin-setup.yml
+++ b/playbooks/07-admin-setup.yml
@@ -1,12 +1,14 @@
-- name: Run pre_admin_setup hooks
-  vars:
-    step: pre_admin_setup
-  ansible.builtin.import_playbook: ./hooks.yml
-
+---
 - name: Post-deployment admin setup steps
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
+    - name: Run pre_admin_setup hooks
+      vars:
+        step: pre_admin_setup
+      ansible.builtin.import_role:
+        name: run_hook
+
     - name: Load parameters files
       ansible.builtin.include_vars:
         dir: "{{ cifmw_basedir }}/artifacts/parameters"
@@ -16,7 +18,8 @@
         name: os_net_setup
       when: not cifmw_skip_os_net_setup | default('false') | bool
 
-- name: Run post_admin_setup hooks
-  vars:
-    step: post_admin_setup
-  ansible.builtin.import_playbook: ./hooks.yml
+    - name: Run post_admin_setup hooks
+      vars:
+        step: post_admin_setup
+      ansible.builtin.import_role:
+        name: run_hook

--- a/playbooks/08-run-tests.yml
+++ b/playbooks/08-run-tests.yml
@@ -1,12 +1,14 @@
-- name: "Run pre_tests hooks"
-  vars:
-    step: pre_tests
-  ansible.builtin.import_playbook: ./hooks.yml
-
+---
 - name: "Test playbook"
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
+    - name: Run pre_tests hooks
+      vars:
+        step: pre_tests
+      ansible.builtin.import_role:
+        name: run_hook
+
     # end_play will end only current play, not the main edpm-deploy.yml
     - name: Early exit if no tests
       when:
@@ -19,7 +21,8 @@
       ansible.builtin.import_role:
         name: "{{ cifmw_run_test_role | default('tempest') }}"
 
-- name: "Run post_tests hooks"
-  vars:
-    step: post_tests
-  ansible.builtin.import_playbook: ./hooks.yml
+    - name: Run post_tests hooks
+      vars:
+        step: post_tests
+      ansible.builtin.import_role:
+        name: run_hook

--- a/playbooks/98-pre-end.yml
+++ b/playbooks/98-pre-end.yml
@@ -1,4 +1,0 @@
-- name: "Run pre_end hooks"
-  vars:
-    step: pre_end
-  ansible.builtin.import_playbook: ./hooks.yml

--- a/playbooks/hooks.yml
+++ b/playbooks/hooks.yml
@@ -1,4 +1,7 @@
 ---
+##### DEPRECATION #####
+# Do not use that playbook. Execute the role directly.
+#######################
 - name: Hook playbook
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false

--- a/playbooks/update.yml
+++ b/playbooks/update.yml
@@ -1,12 +1,14 @@
-- name: Run pre_update hooks
-  vars:
-    step: pre_update
-  ansible.builtin.import_playbook: ./hooks.yml
-
+---
 - name: Add comptatibility support to install_yamls
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
+    - name: Run pre_update hooks
+      vars:
+        step: pre_update
+      ansible.builtin.import_role:
+        name: run_hook
+
     - name: Comptatibility layer with install_yamls
       when:
         - cifmw_architecture_scenario is defined
@@ -99,7 +101,8 @@
       ansible.builtin.import_role:
         name: update
 
-- name: Run post_update hooks
-  vars:
-    step: post_update
-  ansible.builtin.import_playbook: ./hooks.yml
+    - name: Run post_update hooks
+      vars:
+        step: post_update
+      ansible.builtin.import_role:
+        name: run_hook


### PR DESCRIPTION
In many places, it was done that Ansible playbook is importing another ansible playbook, which is importing again another playbook and another. It is too complex and after doing simple improvement as it was done in this change by removing import_playbook: hooks.yml, we see that those tasks can be running in same play.
With that approach we can:

- easy understand playbook/role execution,
- better control variables,
- in some part faster execution due there is no need to make delegation or gather_facts,
- easier to debug