### PR TITLE
Add a flag to disable ci_mirror repos

### DIFF
--- a/roles/repo_setup/defaults/main.yml
+++ b/roles/repo_setup/defaults/main.yml
@@ -33,6 +33,7 @@ cifmw_repo_setup_additional_repos: ''
 cifmw_repo_setup_dlrn_hash_tag: ''
 cifmw_repo_setup_component_name: ''
 cifmw_repo_setup_component_promotion_tag: component-ci-testing
+cimfw_repo_setup_disable_ci_mirror: true
 
 # Variables related to rhos-release tools
 # rhos-release is used in downstream to populate downstream base os repos

--- a/roles/repo_setup/tasks/ci_mirror.yml
+++ b/roles/repo_setup/tasks/ci_mirror.yml
@@ -12,6 +12,8 @@
     set -o pipefail
     source /etc/ci/mirror_info.sh
     sed -i -e "s|https://trunk.rdoproject.org|$NODEPOOL_RDO_PROXY|g" *.repo
+    {% if ansible_distribution | lower == 'centos' and ansible_distribution_major_version is version('10', '==') %}
     sed -i -e "s|http://mirror.stream.centos.org|$NODEPOOL_CENTOS_MIRROR|g" *.repo
+    {% endif %}
   args:
     chdir: "{{ cifmw_repo_setup_output }}"

--- a/roles/repo_setup/tasks/main.yml
+++ b/roles/repo_setup/tasks/main.yml
@@ -29,6 +29,7 @@
   when: cifmw_repo_setup_enable_rhos_release | bool
 - name: Update generated repos with mirror repos
   ansible.builtin.import_tasks: ci_mirror.yml
+  when: cimfw_repo_setup_disable_ci_mirror | bool
 - name: Add gating repo
   ansible.builtin.import_tasks: populate_gating_repo.yml
   when: content_provider_registry_ip is defined


### PR DESCRIPTION
For CentOS Stream 10 repos, these are not available on vexxhost mirror. It will allow us to test centos 10 repos from centos mirror.

It also adds a conditional to skip using ci-mirror for centos-10.