### PR TITLE
Fix continuous control plane testing during update

### DIFF
--- a/roles/update/tasks/collect_openstackclient_config.yml
+++ b/roles/update/tasks/collect_openstackclient_config.yml
@@ -1,0 +1,19 @@
+---
+- name: Collect file from openstackclient container
+  kubernetes.core.k8s_exec:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    namespace: "openstack"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    pod: "openstackclient"
+    container: "openstackclient"
+    command: "/usr/bin/cat /home/cloud-admin/.config/openstack/{{ item }}"
+  register: file_content
+  changed_when: false
+
+- name: Save file locally
+  ansible.builtin.copy:
+    content: "{{ file_content.stdout }}"
+    dest: "{{ cifmw_update_artifacts_basedir }}/{{ item }}"
+    mode: '0644'
+  changed_when: false

--- a/roles/update/tasks/create_local_openstackclient.yml
+++ b/roles/update/tasks/create_local_openstackclient.yml
@@ -1,0 +1,109 @@
+---
+- name: Gather NodeSet resource information
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    namespace: "openstack"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    kind: "OpenStackDataPlaneNodeSet"
+    api_version: "dataplane.openstack.org/v1beta1"
+  register: _cifmw_update_osdpns_all_info
+
+- name: Fail if no OSDPNS resources are found
+  ansible.builtin.fail:
+    msg: "No OSDPNS resources found in the 'openstack' namespace!"
+  when: _cifmw_update_osdpns_all_info.resources | length == 0
+
+- name: Choose the first OSDPNS resource
+  ansible.builtin.set_fact:
+    _cifmw_update_osdpns_info: "{{ _cifmw_update_osdpns_all_info.resources[0] }}"
+
+- name: Display which osdpns we're using
+  ansible.builtin.debug:
+    msg: "Found OSDPNS named: '{{ _cifmw_update_osdpns_info.metadata.name }}'"
+
+- name: Determine registry
+  ansible.builtin.set_fact:
+    cifmw_update_local_registry: >-
+      {{
+      (cifmw_ci_gen_kustomize_values_ooi_image.split('/')[0])
+      if cifmw_ci_gen_kustomize_values_ooi_image is defined
+      else 'quay.io'
+      | trim
+      }}
+
+- name: Check if credentials exist
+  ansible.builtin.set_fact:
+    brew_username: "{{ login_username }}"
+    brew_password: "{{ login_dict[login_username] }}"
+  vars:
+    login_dict: >-
+      {{
+      _cifmw_update_osdpns_info.spec.nodeTemplate.ansible.ansibleVars.
+      edpm_container_registry_logins[cifmw_update_local_registry]
+      }}
+    login_username: "{{ login_dict.keys()|list|first }}"
+  when:
+    - _cifmw_update_osdpns_info.spec.nodeTemplate.ansible.ansibleVars.edpm_container_registry_logins is defined
+    - login_dict is defined
+    - login_dict|length > 0
+    - cifmw_update_local_registry != 'quay.io'
+
+- name: Log in to registry when needed
+  containers.podman.podman_login:
+    # Hardcoded for now
+    registry: "registry.redhat.io"
+    username: "{{ brew_username }}"
+    password: "{{ brew_password }}"
+  when:
+    - brew_username is defined
+    - brew_password is defined
+    - cifmw_update_local_registry != 'quay.io'
+
+- name: Retrieve the openstackclient Pod
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    namespace: "openstack"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    kind: "Pod"
+    name: "openstackclient"
+  register: _cifmw_update_openstackclient_pod
+
+- name: Fail if openstackclient Pod is not found
+  ansible.builtin.fail:
+    msg: "No openstackclient Pod found in the openstack namespace!"
+  when: _cifmw_update_openstackclient_pod.resources | length == 0
+
+- name: Set the openstackclient image fact
+  ansible.builtin.set_fact:
+    openstackclient_image: "{{ _cifmw_update_openstackclient_pod.resources[0].spec.containers[0].image }}"
+
+- name: Collect and save OpenStack config files
+  ansible.builtin.include_tasks: collect_openstackclient_config.yml
+  loop:
+    - 'clouds.yaml'
+    - 'secure.yaml'
+  loop_control:
+    label: "{{ item }}"
+
+- name: Create local openstack wrapper script
+  ansible.builtin.copy:
+    dest: "{{ cifmw_update_artifacts_basedir }}/openstack"
+    mode: '0755'
+    content: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      OS_CLOUD=default /usr/bin/openstack --insecure "$@"
+
+- name: Ensure lopenstackclient container is running
+  containers.podman.podman_container:
+    name: lopenstackclient
+    image: "{{ openstackclient_image }}"
+    state: started
+    net: host
+    volumes:
+      - "{{ cifmw_update_artifacts_basedir }}/clouds.yaml:/home/cloud-admin/.config/openstack/clouds.yaml:ro,Z"
+      - "{{ cifmw_update_artifacts_basedir }}/secure.yaml:/home/cloud-admin/.config/openstack/secure.yaml:ro,Z"
+      - "{{ cifmw_update_artifacts_basedir }}/openstack:/home/cloud-admin/.local/bin/openstack:ro,Z"
+    command: ['/usr/bin/sleep', 'infinity']

--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -29,6 +29,12 @@
     - name: Start ping test
       ansible.builtin.include_tasks: l3_agent_connectivity_check_start.yml
 
+- name: Create local openstackclient
+  when:
+    - cifmw_update_control_plane_check | bool
+    - not cifmw_update_run_dryrun | bool
+  ansible.builtin.include_tasks: create_local_openstackclient.yml
+
 - name: Trigger the continuous control plane test
   when:
     - cifmw_update_control_plane_check | bool

--- a/roles/update/templates/workload_launch_k8s.sh.j2
+++ b/roles/update/templates/workload_launch_k8s.sh.j2
@@ -1,53 +1,8 @@
 #!/usr/bin/bash
-set +x
 
-export KUBECONFIG="{{ cifmw_openshift_kubeconfig }}"
-export PATH="{{ cifmw_path }}"
-
-OS_POD_TIMEOUT={{ cifmw_update_openstackclient_pod_timeout }}
-WAIT=0
-
-# Temporary file where to put the error message, if any.
-ERROR_FILE=/tmp/cifmw_update_ctl_testing_current_ouput.txt
-rm -f "${ERROR_FILE}"
-
-while [ $((WAIT++)) -lt ${OS_POD_TIMEOUT} ]; do
-    set -o pipefail             # Make sure we get the failure, as tee
+set -e
+set -o pipefail             # Make sure we get the failure, as tee
                                 # will always succeed.
-    cat "{{ cifmw_update_artifacts_basedir }}/workload_launch.sh" | \
-        oc rsh -n openstack openstackclient env WKL_MODE=sanityfast bash 2>&1 | tee "${ERROR_FILE}"
-    RC=$?
-    set +o pipefail
-    if [ "${RC}" -eq 137 ]; then
-       # When the command is interrupted by the restart of the
-       # OSclient, we have this returns code.  We just retry.
-       sleep 1
-       continue
-    fi
-    # If there's an error and the error file was created we check for
-    # the error message.
-    if [ "${RC}" -ne 0 ]; then
-        if [ ! -e "${ERROR_FILE}" ]; then
-            # no error file, rethrow the error.
-            exit $RC
-        fi
-        # Fragile as it depends on the exact output message.
-        if grep -F 'error: unable to upgrade connection: container not found' \
-                "${ERROR_FILE}"; then
-            # Openstackclient was not able to start as it's being
-            # restarted, retry.
-            sleep 1
-            continue
-        fi
-        # Error is not related to the the openstackclient not being
-        # available. We rethrow it.
-        exit ${RC}
-    fi
-    # No error.
-    exit 0
-done
-
-# We only reach this code if we reach timeout while retrying to
-# trigger the openstackclient.
-echo "OpenstackClient Pod unavalaible, giving up after ${OS_POD_TIMEOUT} seconds" >&2
-exit 127
+cat "{{ cifmw_update_artifacts_basedir }}/workload_launch.sh" | \
+    podman exec -i lopenstackclient \
+           env WKL_MODE=sanityfast bash -i 2>&1


### PR DESCRIPTION
Create a new container run by podman so that the update process won't
interfere with the commands triggered on the OpenStack plateform.

Closes: [OSPRH-16001](https://issues.redhat.com/browse/OSPRH-16001)