### PR TITLE
DNM: Use rpm python packages instead of pip packages

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -14,17 +14,22 @@
 gcc
 
 # Base requirements for RPM distros
-gcc-c++           [platform:rpm]
-git               [platform:rpm]
-libffi-devel      [platform:rpm]
-openssl-devel     [platform:rpm]
-podman            [platform:rpm]
-python3-devel     [platform:rpm !platform:rhel-7 !platform:centos-7]
-python3-libvirt   [platform:rpm]
-python3-lxml      [platform:rpm]
-PyYAML            [platform:rpm !platform:rhel-8 !platform:centos-8 !platform:rhel-9 !platform:centos-9 !platform:fedora]
-python3-pyyaml    [platform:rpm !platform:rhel-7 !platform:centos-7]
-python3-dnf       [platform:rpm !platform:rhel-7 !platform:centos-7]
+gcc-c++              [platform:rpm]
+git                  [platform:rpm]
+libffi-devel         [platform:rpm]
+openssl-devel        [platform:rpm]
+podman               [platform:rpm]
+python3-devel        [platform:rpm !platform:rhel-7 !platform:centos-7]
+python3-libvirt      [platform:rpm]
+python3-lxml         [platform:rpm]
+PyYAML               [platform:rpm !platform:rhel-8 !platform:centos-8 !platform:rhel-9 !platform:centos-9 !platform:fedora]
+python3-pyyaml       [platform:rpm !platform:rhel-7 !platform:centos-7]
+python3-dnf          [platform:rpm !platform:rhel-7 !platform:centos-7]
+python3-pyOpenSSL    [platform:rpm]
+python3-jsonschema   [platform:rpm]
+python3-openstacksdk [platform:rpm]
+python3-kubernetes   [platform:rpm]
+python3-oauthlib     [platform:rpm]
 
 # SELinux cent7
 libselinux-python3  [platform:rpm !platform:rhel-8 !platform:centos-8]

--- a/common-requirements.txt
+++ b/common-requirements.txt
@@ -1,7 +1,2 @@
 ansible-core==2.15.13
-oauthlib==3.2.2
-kubernetes==31.0.0
 kubernetes-validate==1.31.0
-openstacksdk==4.1.0
-jsonschema==4.23.0
-pyOpenSSL==24.2.1


### PR DESCRIPTION
Since pip recommends use of venv over system-wide installation. This patch tries to use rpm packages wherever it's possible.