### PR TITLE
Convert pre-run/post-run to lists

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -15,7 +15,8 @@
     pre-run:
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
-    post-run: ci/playbooks/collect-logs.yml
+    post-run:
+      - ci/playbooks/collect-logs.yml
 
 #
 #  CONTENT PROVIDER

--- a/zuul.d/edpm_build_images.yaml
+++ b/zuul.d/edpm_build_images.yaml
@@ -12,7 +12,8 @@
     run:
       - ci/playbooks/dump_zuul_data.yml
       - ci/playbooks/edpm_build_images/run.yml
-    post-run: ci/playbooks/collect-logs.yml
+    post-run:
+      - ci/playbooks/collect-logs.yml
     vars:
       cifmw_zuul_target_host: controller
       cifmw_repo_setup_branch: antelope

--- a/zuul.d/edpm_build_images_content_provider.yaml
+++ b/zuul.d/edpm_build_images_content_provider.yaml
@@ -14,7 +14,8 @@
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
       - ci/playbooks/edpm_build_images/edpm_build_images_content_provider_run.yaml
-    post-run: ci/playbooks/collect-logs.yml
+    post-run:
+      - ci/playbooks/collect-logs.yml
     vars:
       cifmw_artifacts_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
       cifmw_repo_setup_branch: antelope

--- a/zuul.d/molecule-base.yaml
+++ b/zuul.d/molecule-base.yaml
@@ -10,7 +10,8 @@
       - ci/playbooks/dump_zuul_data.yml
       - ci/playbooks/molecule-prepare.yml
     run: ci/playbooks/molecule-test.yml
-    post-run: ci/playbooks/collect-logs.yml
+    post-run:
+      - ci/playbooks/collect-logs.yml
     roles:
       - zuul: rdo-jobs
     required-projects:
@@ -31,7 +32,8 @@
       - ci/playbooks/dump_zuul_data.yml
       - ci/playbooks/molecule-prepare.yml
     run: ci/playbooks/molecule-test.yml
-    post-run: ci/playbooks/collect-logs.yml
+    post-run:
+      - ci/playbooks/collect-logs.yml
     required-projects:
       - github.com/openstack-k8s-operators/install_yamls
     vars:


### PR DESCRIPTION
Zuul accept list or string as a value for pre-run and post-run. During a process of building jobs, Zuul combines pre/post-runs into lists. To avoid confusions, convert values into lists.

https://zuul-ci.org/docs/zuul/latest/config/job.html#attr-job.pre-run https://zuul-ci.org/docs/zuul/latest/config/job.html#attr-job.post-run