### PR TITLE
Set jinja2_native in Ansible to preserve variable types during template operations

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -18,5 +18,6 @@ fact_caching_timeout = 0
 inventory = inventory.yml
 pipelining = True
 any_errors_fatal = True
+jinja2_native = True
 [ssh_connection]
 ssh_args = -o ControlMaster=auto -o ControlPersist=300

--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -9,7 +9,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_bundle`: (String) Full name of container image with bundle that contains the test-operator. Default value: `""`
 * `cifmw_test_operator_timeout`: (Integer) Timeout in seconds for the execution of the tests. Default value: `3600`
 * `cifmw_test_operator_logs_image`: (String) Image that should be used to collect logs from the pods spawned by the test-operator. Default value: `quay.io/quay/busybox`
-* `cifmw_test_operator_concurrency`: (Integer) Tempest concurrency value. As of now this value can not be specified inside `test_vars`. Default value: `8`
+* `cifmw_test_operator_concurrency`: (Integer) Tempest concurrency value. Default value: `8`
 * `cifmw_test_operator_cleanup`: (Bool) Delete all resources created by the role at the end of the testing. Default value: `false`
 * `cifmw_test_operator_tempest_cleanup`: (Bool) Run tempest cleanup after test execution (tempest run) to delete any resources created by tempest that may have been left out.
 * `cifmw_test_operator_default_groups`: (List) List of groups in the include list to search for tests to be executed. Default value: `[ 'default' ]`

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -29,7 +29,6 @@ cifmw_test_operator_controller_namespace: openstack-operators
 cifmw_test_operator_bundle: ""
 cifmw_test_operator_timeout: 3600
 cifmw_test_operator_logs_image: quay.io/quay/busybox
-cifmw_test_operator_concurrency: 8
 cifmw_test_operator_cleanup: false
 cifmw_test_operator_dry_run: false
 cifmw_test_operator_default_groups:
@@ -140,7 +139,7 @@ cifmw_test_operator_tempest_config:
         {{ stage_vars_dict.cifmw_test_operator_tempest_exclude_list | default('') }}
       expectedFailuresList: |
         {{ stage_vars_dict.cifmw_test_operator_tempest_expected_failures_list | default('') }}
-      concurrency: "{{ cifmw_test_operator_concurrency }}"
+      concurrency: "{{ stage_vars_dict.cifmw_test_operator_concurrency | default(8) }}"
       externalPlugin: "{{ stage_vars_dict.cifmw_test_operator_tempest_external_plugin | default([]) }}"
       extraRPMs: "{{ stage_vars_dict.cifmw_test_operator_tempest_extra_rpms | default([]) }}"
       extraImages: "{{ stage_vars_dict.cifmw_test_operator_tempest_extra_images | default([]) }}"

--- a/roles/test_operator/tasks/stages.yml
+++ b/roles/test_operator/tasks/stages.yml
@@ -35,7 +35,11 @@
     start_with: cifmw_test_operator_{{ _stage_vars.type }}
   when: item.key.startswith(start_with)
   ansible.builtin.set_fact:
-    stage_vars_dict: "{{ stage_vars_dict | combine({item.key: _stage_test_vars[item.key] | default(lookup('vars', item.key, default=omit))} ) }}"
+    stage_vars_dict: "{{ stage_vars_dict | combine({item.key: _stage_test_vars[item.key] | default(lookup('vars', item.key, default=omit)) }) }}"
+
+- name: Overwrite concurrency in global_vars
+  ansible.builtin.set_fact:
+    stage_vars_dict: "{{ stage_vars_dict | combine({'cifmw_test_operator_concurrency': _stage_test_vars.cifmw_test_operator_concurrency | default(lookup('vars', 'concurrency', default=omit)) }) }}"
 
 - name: Override specific type config
   vars:


### PR DESCRIPTION
Currently, it is not possible to set concurrency using the 'stages' functionality. It is because the retyping to string is present and concurrency is supposed to be type integer. This patch fixes this bug and lets users to set the value of the parameter.

In other words, on reassignment variable, jinja2 is changing the type to string which raises an issue when running tempest. It raises an error:

```
fatal: [localhost]: FAILED! => 
    changed: false
    msg: 'Failed to create object: b''{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Tempest.test.openstack.org
      \\"tempest-tests-tempest\\" is invalid: spec.tempestRun.concurrency: Invalid value:
      \\"string\\": spec.tempestRun.concurrency in body must be of type integer: \\"string\\"","reason":"Invalid","details":{"name":"tempest-tests-tempest","group":"test.openstack.org","kind":"Tempest","causes":[{"reason":"FieldValueTypeInvalid","message":"Invalid
      value: \\"string\\": spec.tempestRun.concurrency in body must be of type integer:
      \\"string\\"","field":"spec.tempestRun.concurrency"}]},"code":422}\n'''
    reason: Unprocessable Entity
```