### PR TITLE
Retry OCP CSR approval

### DIFF
--- a/roles/openshift_adm/tasks/wait_for_cluster.yml
+++ b/roles/openshift_adm/tasks/wait_for_cluster.yml
@@ -49,8 +49,15 @@
 - name: Check for pending certificate approval.
   when:
     - _openshift_adm_check_cert_approve | default(false) | bool
+  register: _approve_csr
   approve_csr:
     k8s_config: "{{ cifmw_openshift_kubeconfig }}"
+  retries: 30
+  delay: 10
+  until:
+    - _approve_csr is defined
+    - _approve_csr.rc is defined
+    - _approve_csr.rc == 0
 
 - name: Wait until the OpenShift cluster is stable.
   environment:


### PR DESCRIPTION
The `openshift_adm` role's `Check for pending certificate approval` can sometimes fail when the cluster API isn't fully stable yet.  Let's add a retry to avoid failing here unnecessarily.  I'm assuming the actual `Wait until the OpenShift cluster is stable` [1] has to come after CSR approval because, without the approval, the cluster cannot reach full stability.  If I'm wrong about that, perhaps we could just move the CSR task below [1].

[1] https://github.com/openstack-k8s-operators/ci-framework/blob/f8e17fe8789766d409037ec5cbf6e8cac77816e0/roles/openshift_adm/tasks/wait_for_cluster.yml#L63-L73