### PR TITLE
[OSPRH-15434] Automate deploy of multi-namespace RHOSO

### DIFF
--- a/playbooks/multi-namespace/ns2_osdp_services.yaml
+++ b/playbooks/multi-namespace/ns2_osdp_services.yaml
@@ -1,0 +1,30 @@
+---
+- name: Acquire previously-deployed OpenStackDataPlaneServices for openstack2 namespace
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  tasks:
+    - name: Fetch the already deployed services for further usage
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.command:
+        cmd: >-
+          oc get osdps
+          --namespace openstack2
+          --no-headers
+          -o custom-columns=":metadata.name"
+      changed_when: false
+      register: _ci_gen_kustomize_deployed_services_stdout
+
+    - name: Expose the deployed services as a fact
+      ansible.builtin.set_fact:
+        ci_gen_kustomize_edpm_nodeset_predeployed_services2: >-
+          {{
+            _ci_gen_kustomize_deployed_services_stdout.stdout_lines | default ([])
+          }}
+
+    - name: Feed generated content to main play
+      ansible.builtin.copy:
+        dest: "{{ cifmw_basedir }}/artifacts/pre_stage_8_run_get_openstackdataplaneservices.yml"
+        content: |
+          ci_gen_kustomize_edpm_nodeset_predeployed_services2: {{ ci_gen_kustomize_edpm_nodeset_predeployed_services2 }}
+        mode: "0644"

--- a/playbooks/multi-namespace/ns2_osp_networks.yaml
+++ b/playbooks/multi-namespace/ns2_osp_networks.yaml
@@ -1,0 +1,40 @@
+---
+- name: Post-deployment admin setup steps for namespace {{ cifmw_os_net_setup_namespace }}
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Load parameters files
+      ansible.builtin.include_vars:
+        dir: "{{ cifmw_basedir }}/artifacts/parameters"
+
+    - name: Create openstack network elements
+      vars:
+        cifmw_os_net_setup_config:
+          - name: public
+            external: true
+            shared: false
+            is_default: true
+            provider_network_type: flat
+            provider_physical_network: datacentre
+            availability_zone_hints: []
+            subnets:
+              - name: public_subnet
+                cidr: "{{ cifmw_os_net_setup_public_cidr }}"
+                allocation_pool_start: "{{ cifmw_os_net_setup_public_start }}"
+                allocation_pool_end: "{{ cifmw_os_net_setup_public_end }}"
+                gateway_ip: "{{ cifmw_os_net_setup_public_gateway }}"
+                enable_dhcp: true
+        cifmw_os_net_subnetpool_config:
+          - name: shared-pool-ipv4
+            default_prefix_length: 26
+            prefixes: '10.1.0.0/20'
+            is_default: true
+            is_shared: true
+          - name: shared-pool-ipv6
+            default_prefix_length: 64
+            prefixes: 'fdfe:391f:8400::/56'
+            is_default: true
+            is_shared: true
+      ansible.builtin.import_role:
+        name: os_net_setup
+      when: not cifmw_skip_os_net_setup | default('false') | bool

--- a/playbooks/multi-namespace/ns2_validation.yaml
+++ b/playbooks/multi-namespace/ns2_validation.yaml
@@ -1,0 +1,9 @@
+---
+- name: Validation for namespace {{ cifmw_test_operator_namespace }}
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  tasks:
+    - name: "Run tests for namespace {{ cifmw_test_operator_namespace }}"
+      tags:
+        - tests
+      ansible.builtin.import_role:
+        name: "{{ cifmw_run_test_role | default('tempest') }}"

--- a/roles/ci_gen_kustomize_values/templates/multi-namespace/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/multi-namespace/edpm-nodeset-values/values.yaml.j2
@@ -1,0 +1,71 @@
+---
+# source: multi-namespace/edpm-nodeset-values/values.yaml.j2
+{% set _ipv = cifmw_ci_gen_kustomize_values_ip_version_var_mapping %}
+{% set instances_names = []                                                            %}
+{% set _original_nodeset = (original_content.data | default({})).nodeset | default({}) %}
+{% set _original_nodes = _original_nodeset.nodes | default({})                         %}
+{% set _original_services = _original_nodeset['services'] | default([])                %}
+{% set _vm_type = (_original_nodes.keys() | first).split('-')[1]                       %}
+{% for _inst in cifmw_networking_env_definition.instances.keys()                       %}
+{%   if _inst.startswith(_vm_type ~ "-")                                               %}
+{%     set _ = instances_names.append(_inst)                                           %}
+{%   endif                                                                             %}
+{% endfor                                                                              %}
+data:
+  ssh_keys:
+    authorized: {{ cifmw_ci_gen_kustomize_values_ssh_authorizedkeys | b64encode }}
+    private: {{ cifmw_ci_gen_kustomize_values_ssh_private_key | b64encode }}
+    public: {{ cifmw_ci_gen_kustomize_values_ssh_public_key | b64encode }}
+  nodeset:
+    ansible:
+      ansibleUser: "zuul"
+      ansibleVars:
+        edpm_fips_mode: "{{ 'enabled' if cifmw_fips_enabled|default(false)|bool else 'check' }}"
+        timesync_ntp_servers:
+          - hostname: "{{ cifmw_ci_gen_kustomize_values_ntp_srv | default('pool.ntp.org') }}"
+        edpm_network_config_os_net_config_mappings:
+{% for instance in instances_names                                                     %}
+          edpm-{{ instance }}:
+{%   if hostvars[instance] is defined                                                  %}
+            nic1: "{{ hostvars[instance][_ipv.ansible_default_ipvX].macaddress }}"
+{%   endif                                                                             %}
+            nic2: "{{ cifmw_networking_env_definition.instances[instance].networks.ctlplane.mac_addr }}"
+{% endfor                                                                              %}
+{% if cifmw_ci_gen_kustomize_values_sshd_ranges | default([]) | length > 0             %}
+        edpm_sshd_allowed_ranges:
+{%   for range in cifmw_ci_gen_kustomize_values_sshd_ranges                            %}
+          - "{{ range }}"
+{%   endfor                                                                            %}
+{% endif                                                                               %}
+    nodes:
+{% for instance in instances_names                                                     %}
+      edpm-{{ instance }}:
+        ansible:
+          host: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane[_ipv.ip_vX] }}
+        hostName: {{ instance }}
+        networks:
+{%      for net in cifmw_networking_env_definition.instances[instance].networks.keys() %}
+          - name: {{ net }}
+            subnetName: subnet1
+            fixedIP: {{ cifmw_networking_env_definition.instances[instance].networks[net][_ipv.ip_vX] }}
+{%        if net is match('ctlplane')                                                  %}
+            defaultRoute: true
+{%        endif                                                                        %}
+{%      endfor                                                                         %}
+{% endfor                                                                              %}
+{% if ('repo-setup' not in _original_services) and
+      ('repo-setup' in ci_gen_kustomize_edpm_nodeset_predeployed_services)             %}
+    services:
+      - "repo-setup"
+{%   for svc in _original_services                                                     %}
+      - "{{ svc }}"
+{%   endfor                                                                            %}
+{% endif                                                                               %}
+
+{% if _vm_type.startswith('compute')                                                   %}
+  nova:
+    migration:
+      ssh_keys:
+        private: {{ cifmw_ci_gen_kustomize_values_migration_priv_key | b64encode }}
+        public: {{ cifmw_ci_gen_kustomize_values_migration_pub_key | b64encode }}
+{% endif                                                                               %}

--- a/roles/ci_gen_kustomize_values/templates/multi-namespace/edpm-nodeset2-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/multi-namespace/edpm-nodeset2-values/values.yaml.j2
@@ -1,0 +1,73 @@
+---
+# source: multi-namespace/edpm-nodeset2-values/values.yaml.j2
+{% set _ipv = cifmw_ci_gen_kustomize_values_ip_version_var_mapping                        %}
+{% set instances_names = []                                                               %}
+{% set _original_nodeset = (original_content.data | default({})).nodeset | default({})    %}
+{% set _original_nodes = _original_nodeset.nodes | default({})                            %}
+{% set _original_services = _original_nodeset['services'] | default([])                   %}
+{% set _vm_type = (_original_nodes.keys() | first).split('-')[1]                          %}
+{{ '#vmtype: ' ~ _vm_type }}
+{% for _inst in cifmw_networking_env_definition.instances.keys()                          %}
+{%   if _inst.startswith(_vm_type ~ "2-")                                                 %}
+{%     set _ = instances_names.append(_inst)                                              %}
+{%   endif                                                                                %}
+{{ '#' ~ _inst }}
+{% endfor                                                                                 %}
+data:
+  ssh_keys:
+    authorized: {{ cifmw_ci_gen_kustomize_values_ssh_authorizedkeys | b64encode }}
+    private: {{ cifmw_ci_gen_kustomize_values_ssh_private_key | b64encode }}
+    public: {{ cifmw_ci_gen_kustomize_values_ssh_public_key | b64encode }}
+  nodeset:
+    ansible:
+      ansibleUser: "zuul"
+      ansibleVars:
+        edpm_fips_mode: "{{ 'enabled' if cifmw_fips_enabled|default(false)|bool else 'check' }}"
+        timesync_ntp_servers:
+          - hostname: "{{ cifmw_ci_gen_kustomize_values_ntp_srv | default('pool.ntp.org') }}"
+        edpm_network_config_os_net_config_mappings:
+{% for instance in instances_names                                                        %}
+          edpm-{{ instance }}:
+{%   if hostvars[instance] is defined                                                     %}
+            nic1: "{{ hostvars[instance][_ipv.ansible_default_ipvX].macaddress }}"
+{%   endif                                                                                %}
+            nic2: "{{ cifmw_networking_env_definition.instances[instance].networks.ctlplane2.mac_addr }}"
+{% endfor                                                                                 %}
+{% if cifmw_ci_gen_kustomize_values_sshd_ranges | default([]) | length > 0                %}
+        edpm_sshd_allowed_ranges:
+{%   for range in cifmw_ci_gen_kustomize_values_sshd_ranges                               %}
+          - "{{ range }}"
+{%   endfor                                                                               %}
+{% endif                                                                                  %}
+    nodes:
+{% for instance in instances_names                                                        %}
+      edpm-{{ instance }}:
+        ansible:
+          host: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane2[_ipv.ip_vX] }}
+        hostName: {{ instance }}
+        networks:
+{%      for net in cifmw_networking_env_definition.instances[instance].networks.keys()    %}
+          - name: {{ net | replace('2', '') }}
+            subnetName: subnet1
+            fixedIP: {{ cifmw_networking_env_definition.instances[instance].networks[net][_ipv.ip_vX] }}
+{%        if net is match('ctlplane2')                                                    %}
+            defaultRoute: true
+{%        endif                                                                           %}
+{%      endfor                                                                            %}
+{% endfor                                                                                 %}
+{% if ('repo-setup' not in _original_services) and
+      ('repo-setup' in ci_gen_kustomize_edpm_nodeset_predeployed_services2 | default([])) %}
+    services:
+      - "repo-setup"
+{%   for svc in _original_services                                                        %}
+      - "{{ svc }}"
+{%   endfor                                                                               %}
+{% endif                                                                                  %}
+
+{% if _vm_type.startswith('compute')                                                      %}
+  nova:
+    migration:
+      ssh_keys:
+        private: {{ cifmw_ci_gen_kustomize_values_migration_priv_key | b64encode }}
+        public: {{ cifmw_ci_gen_kustomize_values_migration_pub_key | b64encode }}
+{% endif                                                                                  %}

--- a/roles/ci_gen_kustomize_values/templates/multi-namespace/network-values2/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/multi-namespace/network-values2/values.yaml.j2
@@ -1,0 +1,130 @@
+---
+# source: multi-namespace/network-values2/values.yaml.j2
+{% set _ipv = cifmw_ci_gen_kustomize_values_ip_version_var_mapping %}
+{% set ns = namespace(interfaces={},
+                      ocp_index=0,
+                      lb_tools={}) %}
+data:
+{% for host in cifmw_networking_env_definition.instances.keys() -%}
+{%   if host is match('^(ocp|crc).*') %}
+  node_{{ ns.ocp_index }}:
+{%     set ns.ocp_index = ns.ocp_index+1 %}
+    name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}
+{%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
+{%     set ns.interfaces = ns.interfaces |
+                           combine({network.network_name: (network.parent_interface |
+                                                           default(network.interface_name)
+                                                          )
+                                   },
+                                   recursive=true) %}
+{%     if "2" in network.network_name %}
+    {{ network.network_name | replace("2", "") }}_ip: {{ network[_ipv.ip_vX] }}
+{%     endif %}
+{%     endfor %}
+{%   endif %}
+{% endfor %}
+
+{% for network in cifmw_networking_env_definition.networks.values() if "2" in network %}
+{% set ns.lb_tools = {} %}
+  {{ network.network_name | replace("2", "") }}:
+    dnsDomain: {{ network.search_domain }}
+{%  if network.tools is defined and network.tools.keys() | length > 0 %}
+    subnets:
+{%    for tool in network.tools.keys() %}
+{%      if tool is match('.*lb$') %}
+{%        set _ = ns.lb_tools.update({tool: []}) %}
+{%      endif %}
+{%    endfor %}
+      - allocationRanges:
+{%    for range in network.tools.netconfig[_ipv.ipvX_ranges] %}
+        - end: {{ range.end }}
+          start: {{ range.start }}
+{%    endfor %}
+        cidr: {{ network[_ipv.network_vX] }}
+{%    if network[_ipv.gw_vX] is defined  %}
+        gateway: {{ network[_ipv.gw_vX] }}
+{%    endif %}
+        name: subnet1
+{%    if network.vlan_id is defined  %}
+        vlan: {{ network.vlan_id }}
+{%    endif %}
+{%    if ns.lb_tools | length > 0 %}
+    lb_addresses:
+{%      for tool in ns.lb_tools.keys() %}
+{%        for lb_range in network.tools[tool][_ipv.ipvX_ranges] %}
+      - {{ lb_range.start }}-{{ lb_range.end }}
+{%          set _ = ns.lb_tools[tool].append(lb_range.start) %}
+{%        endfor %}
+    endpoint_annotations:
+      {{ tool }}.universe.tf/address-pool: {{ network.network_name }}
+      {{ tool }}.universe.tf/allow-shared-ip: {{ network.network_name }}
+      {{ tool }}.universe.tf/loadBalancerIPs: {{ ','.join(ns.lb_tools[tool]) }}
+{%      endfor %}
+{%    endif %}
+{%  endif %}
+    prefix-length: {{ network[_ipv.network_vX] | ansible.utils.ipaddr('prefix') }}
+    mtu: {{ network.mtu | default(1500) }}
+{%  if network.vlan_id is defined  %}
+    vlan: {{ network.vlan_id }}
+{%    if ns.interfaces[network.network_name] is defined %}
+    iface: {{ network.network_name }}
+    base_iface: {{ ns.interfaces[network.network_name] }}
+{%    endif %}
+{%  else %}
+{%    if ns.interfaces[network.network_name] is defined %}
+    iface: {{ ns.interfaces[network.network_name] }}
+{%    endif %}
+{%  endif %}
+{%  if network.tools.multus is defined %}
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "{{ network.network_name }}",
+        "type": "macvlan",
+{%  if network.vlan_id is defined%}
+        "master": "{{ network.network_name }}",
+{%  elif network.network_name == "ctlplane" %}
+        "master": "ospbr",
+{%  else %}
+        "master": "{{ ns.interfaces[network.network_name] }}",
+{%  endif %}
+        "ipam": {
+          "type": "whereabouts",
+          "range": "{{ network[_ipv.network_vX] }}",
+          "range_start": "{{ network.tools.multus[_ipv.ipvX_ranges].0.start }}",
+          "range_end": "{{ network.tools.multus[_ipv.ipvX_ranges].0.end }}"
+        }
+      }
+{%  endif %}
+{% endfor %}
+
+  dns-resolver:
+    config:
+      server:
+        - "{{ cifmw_networking_env_definition.networks.ctlplane2[_ipv.gw_vX] }}"
+      search: []
+    options:
+      - key: server
+        values:
+          - {{ cifmw_networking_env_definition.networks.ctlplane2[_ipv.gw_vX] }}
+{% for nameserver in cifmw_ci_gen_kustomize_values_nameservers %}
+      - key: server
+        values:
+          - {{ nameserver }}
+{% endfor %}
+
+  routes:
+    config: []
+
+# Hardcoding the last IP bit since we don't have support for endpoint_annotations in the networking_mapper output
+  rabbitmq:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi2
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi2'][_ipv.network_vX]  | ansible.utils.ipmath(85) }}
+  rabbitmq-cell1:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi2
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi2'][_ipv.network_vX]  | ansible.utils.ipmath(86) }}
+
+  lbServiceType: LoadBalancer
+  storageClass: {{ cifmw_ci_gen_kustomize_values_storage_class }}

--- a/roles/os_net_setup/README.md
+++ b/roles/os_net_setup/README.md
@@ -16,6 +16,7 @@ That is provided by `openshift_login` role.
 * `cifmw_os_net_subnetpool_config`: (list) It contains the definitions for subnet pools.
     See an example in roles/os_net_setup/defaults/main.yml
 * `cifmw_os_net_setup_dry_run`: (bool) Disable the generation of the commands.
+* `cifmw_os_net_setup_namespace`: (str) Namespace in which to access the OSP cloud. Defaults to `openstack`.
 
 ## Molecule
 

--- a/roles/os_net_setup/defaults/main.yml
+++ b/roles/os_net_setup/defaults/main.yml
@@ -35,3 +35,4 @@ cifmw_os_net_subnetpool_config:
     is_shared: true
 
 cifmw_os_net_setup_dry_run: false
+cifmw_os_net_setup_namespace: openstack

--- a/roles/os_net_setup/tasks/main.yml
+++ b/roles/os_net_setup/tasks/main.yml
@@ -9,10 +9,10 @@
     - name: Delete existing subnets
       ansible.builtin.shell: |
         set -euxo pipefail
-        if [ $(oc exec -n openstack openstackclient -- \
+        if [ $(oc exec -n  {{ cifmw_os_net_setup_namespace }} openstackclient -- \
         openstack subnet list --network {{ item.0.name }} -c Name -f value | \
         grep -c {{ item.1.name }}) != 0 ];then
-          oc exec -n openstack openstackclient -- \
+          oc exec -n {{ cifmw_os_net_setup_namespace }} openstackclient -- \
           openstack subnet delete {{ item.1.name }}
         fi
       loop: >-
@@ -23,20 +23,20 @@
     - name: Delete existing subnet pools
       ansible.builtin.shell: |
         set -euxo pipefail
-        if [ $(oc exec -n openstack openstackclient -- \
+        if [ $(oc exec -n {{ cifmw_os_net_setup_namespace }} openstackclient -- \
         openstack subnet pool list -c Name -f value | \
         grep -c {{ item.name }}) != 0 ];then
-          oc exec -n openstack openstackclient -- \
+          oc exec -n {{ cifmw_os_net_setup_namespace }} openstackclient -- \
           openstack subnet pool delete {{ item.name }}
         fi
       loop: "{{ cifmw_os_net_subnetpool_config }}"
     - name: Delete existing networks
       ansible.builtin.shell: |
         set -euxo pipefail
-        if [ $(oc exec -n openstack openstackclient -- \
+        if [ $(oc exec -n {{ cifmw_os_net_setup_namespace }} openstackclient -- \
         openstack network list -c Name -f value | \
         grep -c {{ item.name }}) != 0 ];then
-          oc exec -n openstack openstackclient -- \
+          oc exec -n {{ cifmw_os_net_setup_namespace }} openstackclient -- \
           openstack network delete {{ item.name }}
         fi
       loop: "{{ cifmw_os_net_setup_config }}"

--- a/roles/os_net_setup/templates/network_command.j2
+++ b/roles/os_net_setup/templates/network_command.j2
@@ -1,6 +1,6 @@
 set -euo pipefail
 {% for net_args in cifmw_os_net_setup_config %}
-oc exec -n openstack openstackclient -- openstack network create \
+oc exec -n {{ cifmw_os_net_setup_namespace }} openstackclient -- openstack network create \
 {%   if net_args.dns_domain is defined %}
     --dns-domain {{ keydns_domain }} \
 {%   endif %}

--- a/roles/os_net_setup/templates/subnet_command.j2
+++ b/roles/os_net_setup/templates/subnet_command.j2
@@ -7,7 +7,7 @@ set -euo pipefail
 {% for net_args in cifmw_os_net_setup_config %}
 {%  if net_args.subnets is defined %}
 {%      for subnet_args in net_args.subnets %}
-oc exec -n openstack openstackclient -- openstack subnet create \
+oc exec -n {{ cifmw_os_net_setup_namespace }} openstackclient -- openstack subnet create \
 {%          if subnet_args.allocation_pool_start is defined and
        subnet_args.allocation_pool_end is defined %}
     --allocation-pool start={{ subnet_args.allocation_pool_start }},end={{ subnet_args.allocation_pool_end }} \

--- a/roles/os_net_setup/templates/subnet_pool_command.j2
+++ b/roles/os_net_setup/templates/subnet_pool_command.j2
@@ -1,6 +1,6 @@
 set -euo pipefail
 {% for subnet_pool_args in cifmw_os_net_subnetpool_config %}
-oc exec -n openstack openstackclient -- openstack subnet pool create \
+oc exec -n {{ cifmw_os_net_setup_namespace }} openstackclient -- openstack subnet pool create \
 {%      if subnet_pool_args.default_prefix_length is defined %}
     --default-prefix-length {{ subnet_pool_args.default_prefix_length }} \
 {%      endif %}

--- a/roles/reproducer/tasks/libvirt_layout.yml
+++ b/roles/reproducer/tasks/libvirt_layout.yml
@@ -102,7 +102,8 @@
       (compute.key in (groups['dcn1-computes'] | default([]))) or
       (compute.key in (groups['dcn2-computes'] | default([]))) or
       (compute.key is match('^r[0-9]-compute-.*')) or
-      (compute.key is match('^r[0-9]-networker-.*'))
+      (compute.key is match('^r[0-9]-networker-.*')) or
+      (compute.key is match('^compute2-.*'))
   vars:
     _host: "{{ compute.key }}"
     _prefix: >-

--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -5,7 +5,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 ## Parameters
 * `cifmw_test_operator_artifacts_basedir`: (String) Directory where we will have all test-operator related files. Default value: `{{ cifmw_basedir }}/tests/test_operator` which defaults to `~/ci-framework-data/tests/test_operator`
 * `cifmw_test_operator_namespace`: (String) Namespace inside which all the resources are created. Default value: `openstack`
-* `cifmw_test_operator_controller_namespace`: (String) Namespace inside which the test-operator-controller-manager is created. Default value: `openstack-opearators`
+* `cifmw_test_operator_controller_namespace`: (String) Namespace inside which the test-operator-controller-manager is created. Default value: `openstack-operators`
 * `cifmw_test_operator_bundle`: (String) Full name of container image with bundle that contains the test-operator. Default value: `""`
 * `cifmw_test_operator_timeout`: (Integer) Timeout in seconds for the execution of the tests. Default value: `3600`
 * `cifmw_test_operator_logs_image`: (String) Image that should be used to collect logs from the pods spawned by the test-operator. Default value: `quay.io/quay/busybox`

--- a/roles/test_operator/tasks/run-test-operator-job.yml
+++ b/roles/test_operator/tasks/run-test-operator-job.yml
@@ -77,6 +77,7 @@
         kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
         api_key: "{{ cifmw_openshift_token | default(omit)}}"
         context: "{{ cifmw_openshift_context | default(omit)}}"
+        namespace: "{{ cifmw_test_operator_namespace }}"
         kind: PersistentVolumeClaim
         label_selectors:
           - "instanceName={{ test_operator_instance_name }}"
@@ -150,7 +151,7 @@
         pod_path: mnt/logs-{{ test_operator_instance_name }}-step-{{ index }}
       ansible.builtin.shell: >
         oc cp -n {{ cifmw_test_operator_namespace }}
-        openstack/test-operator-logs-pod-{{ run_test_fw }}-{{ test_operator_instance_name }}:{{ pod_path }}
+        test-operator-logs-pod-{{ run_test_fw }}-{{ test_operator_instance_name }}:{{ pod_path }}
         {{ cifmw_test_operator_artifacts_basedir }}
       loop: "{{ logsPVCs.resources }}"
       loop_control:

--- a/scenarios/reproducers/va-multi.yml
+++ b/scenarios/reproducers/va-multi.yml
@@ -1,0 +1,405 @@
+---
+cifmw_architecture_scenario: multi-namespace
+
+# HERE if you want to override kustomization, you can uncomment this parameter
+# and push the data structure you want to apply.
+# cifmw_architecture_user_kustomize:
+#   stage_0:
+#     'network-values':
+#       data:
+#         starwars: Obiwan
+
+# HERE, if you want to stop the deployment loop at any stage, you can uncomment
+# the following parameter and update the value to match the stage you want to
+# reach. Known stages are:
+#   pre_kustomize_stage_INDEX
+#   pre_apply_stage_INDEX
+#   post_apply_stage_INDEX
+#
+# cifmw_deploy_architecture_stopper:
+
+cifmw_arch_automation_file: multi-namespace.yaml
+cifmw_os_must_gather_additional_namespaces: kuttl,openshift-storage,sushy-emulator,openstack2
+cifmw_reproducer_validate_network_host: "192.168.122.1"
+cifmw_libvirt_manager_default_gw_nets:
+  - ocpbm
+  - osptrunk2
+cifmw_networking_mapper_interfaces_info_translations:
+  osp_trunk:
+    - controlplane
+    - ctlplane
+  osptrunk2:
+    - ctlplane2
+
+cifmw_libvirt_manager_configuration:
+  networks:
+    osp_trunk: |
+      <network>
+        <name>osp_trunk</name>
+        <forward mode='nat'/>
+        <bridge name='osp_trunk' stp='on' delay='0'/>
+        <dns enable="no"/>
+        <ip family='ipv4'
+        address='{{ cifmw_networking_definition.networks.ctlplane.network |
+                    ansible.utils.nthhost(1) }}'
+        prefix='{{ cifmw_networking_definition.networks.ctlplane.network |
+                   ansible.utils.ipaddr('prefix') }}'>
+        </ip>
+      </network>
+    osptrunk2: |
+      <network>
+        <name>osptrunk2</name>
+        <forward mode='nat'/>
+        <bridge name='osptrunk2' stp='on' delay='0'/>
+        <dns enable="no"/>
+        <ip family='ipv4'
+        address='{{ cifmw_networking_definition.networks.ctlplane2.network |
+                    ansible.utils.nthhost(1) }}'
+        prefix='{{ cifmw_networking_definition.networks.ctlplane2.network |
+                   ansible.utils.ipaddr('prefix') }}'>
+        </ip>
+      </network>
+    ocpbm: |
+      <network>
+        <name>ocpbm</name>
+        <forward mode='nat'/>
+        <bridge name='ocpbm' stp='on' delay='0'/>
+        <dns enable="no"/>
+        <ip family='ipv4' address='192.168.111.1' prefix='24'>
+        </ip>
+      </network>
+    ocppr: |
+      <network>
+        <name>ocppr</name>
+        <forward mode='bridge'/>
+        <bridge name='ocppr'/>
+      </network>
+  vms:
+    ocp:
+      amount: 3
+      admin_user: core
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "ocp_master"
+      disksize: "100"
+      extra_disks_num: 3
+      extra_disks_size: "50G"
+      cpus: 16
+      memory: 32
+      root_part_id: 4
+      uefi: true
+      nets:
+        - ocppr
+        - ocpbm
+        - osp_trunk
+        - osptrunk2
+    compute:
+      uefi: "{{ cifmw_use_uefi }}"
+      root_part_id: "{{ cifmw_root_partition_id }}"
+      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 3] | max }}"
+      image_url: "{{ cifmw_discovered_image_url }}"
+      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "base-os.qcow2"
+      disksize: "{{ [cifmw_libvirt_manager_compute_disksize|int, 50] | max }}"
+      memory: "{{ [cifmw_libvirt_manager_compute_memory|int, 8] | max }}"
+      cpus: "{{ [cifmw_libvirt_manager_compute_cpus|int, 4] | max }}"
+      extra_disks_num: 3
+      extra_disks_size: 30G
+      nets:
+        - ocpbm
+        - osp_trunk
+    compute2:
+      uefi: "{{ cifmw_use_uefi }}"
+      root_part_id: "{{ cifmw_root_partition_id }}"
+      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 3] | max }}"
+      image_url: "{{ cifmw_discovered_image_url }}"
+      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "base-os.qcow2"
+      disksize: "{{ [cifmw_libvirt_manager_compute_disksize|int, 50] | max }}"
+      memory: "{{ [cifmw_libvirt_manager_compute_memory|int, 8] | max }}"
+      cpus: "{{ [cifmw_libvirt_manager_compute_cpus|int, 4] | max }}"
+      extra_disks_num: 3
+      extra_disks_size: 30G
+      nets:
+        - ocpbm
+        - osptrunk2
+    controller:
+      uefi: "{{ cifmw_use_uefi }}"
+      root_part_id: "{{ cifmw_root_partition_id }}"
+      image_url: "{{ cifmw_discovered_image_url }}"
+      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_local_dir: "{{ cifmw_basedir }}/images/"
+      disk_file_name: "base-os.qcow2"
+      disksize: 50
+      memory: 8
+      cpus: 4
+      nets:
+        - ocpbm
+        - osp_trunk
+        - osptrunk2
+
+## devscript support for OCP deploy
+cifmw_devscripts_config_overrides:
+  fips_mode: "{{ cifmw_fips_enabled | default(false) | bool }}"
+
+# Set Logical Volume Manager Storage by default for local storage
+cifmw_use_lvms: true
+cifmw_lvms_disk_list:
+  - /dev/vda
+  - /dev/vdb
+  - /dev/vdc
+
+cifmw_networking_definition:
+  networks:
+    ctlplane:
+      network: "192.168.122.0/24"
+      gateway: "192.168.122.1"
+      dns:
+        - "192.168.122.1"
+      mtu: 1500
+      tools:
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+        netconfig:
+          ranges:
+            - start: 100
+              end: 120
+            - start: 150
+              end: 170
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+    ctlplane2:
+      network: "192.168.133.0/24"
+      gateway: "192.168.133.1"
+      dns:
+        - "192.168.133.1"
+      mtu: 1500
+      tools:
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+        netconfig:
+          ranges:
+            - start: 100
+              end: 120
+            - start: 150
+              end: 170
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+    internalapi:
+      network: "172.17.0.0/24"
+      vlan: 20
+      mtu: 1496
+      tools:
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+    internalapi2:
+      network: "172.17.10.0/24"
+      vlan: 30
+      mtu: 1496
+      tools:
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+    storage:
+      network: "172.18.0.0/24"
+      vlan: 21
+      mtu: 1496
+      tools:
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+    storage2:
+      network: "172.18.10.0/24"
+      vlan: 31
+      mtu: 1496
+      tools:
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+    tenant:
+      network: "172.19.0.0/24"
+      tools:
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+      vlan: 22
+      mtu: 1496
+    tenant2:
+      network: "172.19.10.0/24"
+      tools:
+        metallb:
+          ranges:
+            - start: 80
+              end: 90
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+        multus:
+          ranges:
+            - start: 30
+              end: 70
+      vlan: 32
+      mtu: 1496
+    external:
+      network: "10.0.0.0/24"
+      tools:
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+      vlan: 22
+      mtu: 1500
+    external2:
+      network: "10.10.0.0/24"
+      tools:
+        netconfig:
+          ranges:
+            - start: 100
+              end: 250
+      vlan: 32
+      mtu: 1500
+
+  group-templates:
+    ocps:
+      network-template:
+        range:
+          start: 10
+          length: 10
+      networks: &ocps_nets
+        ctlplane: {}
+        internalapi:
+          trunk-parent: ctlplane
+        tenant:
+          trunk-parent: ctlplane
+        storage:
+          trunk-parent: ctlplane
+        ctlplane2: {}
+        internalapi2:
+          trunk-parent: ctlplane2
+        tenant2:
+          trunk-parent: ctlplane2
+        storage2:
+          trunk-parent: ctlplane2
+    ocp_workers:
+      network-template:
+        range:
+          start: 20
+          length: 10
+      networks: *ocps_nets
+    computes:
+      network-template:
+        range:
+          start: 100
+          length: 21
+      networks:
+        ctlplane: {}
+        internalapi:
+          trunk-parent: ctlplane
+        tenant:
+          trunk-parent: ctlplane
+        storage:
+          trunk-parent: ctlplane
+    compute2s:
+      network-template:
+        range:
+          start: 200
+          length: 21
+      networks:
+        ctlplane2: {}
+        internalapi2:
+          trunk-parent: ctlplane2
+        tenant2:
+          trunk-parent: ctlplane2
+        storage2:
+          trunk-parent: ctlplane2
+  instances:
+    controller-0:
+      networks:
+        ctlplane:
+          ip: "192.168.122.9"
+        ctlplane2:
+          ip: "192.168.133.9"
+
+# Hooks
+post_deploy:
+  - name: Discover hypervisors for openstack2 namespace
+    type: playbook
+    source: "/home/zuul/src/github.com/openstack-k8s-operators/ci-framework/hooks/playbooks/nova_manage_discover_hosts.yml"
+    extra_vars:
+      namespace: openstack2
+      _cell_conductors: nova-cell0-conductor-0
+
+pre_admin_setup:
+  - name: Prepare OSP networks in openstack2 namespace
+    type: playbook
+    source: "/home/zuul/src/github.com/openstack-k8s-operators/ci-framework/playbooks/multi-namespace/ns2_osp_networks.yaml"
+    extra_vars:
+      cifmw_os_net_setup_namespace: openstack2
+      cifmw_os_net_setup_public_cidr: "192.168.133.0/24"
+      cifmw_os_net_setup_public_start: "192.168.133.230"
+      cifmw_os_net_setup_public_end: "192.168.133.250"
+      cifmw_os_net_setup_public_gateway: "192.168.133.1"
+
+post_tests:
+  - name: Run tempest against openstack2 namespace
+    type: playbook
+    source: "/home/zuul/src/github.com/openstack-k8s-operators/ci-framework/playbooks/multi-namespace/ns2_validation.yaml"
+    extra_vars:
+      cifmw_test_operator_tempest_name: tempest-tests2
+      cifmw_test_operator_namespace: openstack2


### PR DESCRIPTION
CIFMW support for a new dual-namespace VA that deploys two basic OSP clouds in different namespaces (`openstack`, `openstack2`) in a single OCP cluster.

Jira: https://issues.redhat.com/browse/OSPRH-15434