### PR TITLE
Set concurrency for tempest config without reference

### DIFF
--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -29,7 +29,6 @@ cifmw_test_operator_controller_namespace: openstack-operators
 cifmw_test_operator_bundle: ""
 cifmw_test_operator_timeout: 3600
 cifmw_test_operator_logs_image: quay.io/quay/busybox
-cifmw_test_operator_concurrency: 8
 cifmw_test_operator_cleanup: false
 cifmw_test_operator_dry_run: false
 cifmw_test_operator_default_groups:
@@ -112,6 +111,10 @@ cifmw_tempest_tempestconf_config_defaults:
     catalog_type = volumev3
 
 # Please refer to https://openstack-k8s-operators.github.io/test-operator/guide.html#executing-tempest-tests
+# WARNING: Some variables that are type: int can be converted to string even
+# when force type is set: https://github.com/ansible/ansible/issues/18095.
+# In that case, some variables might be difficult to replace.
+# For example, check spec.tempestRun.concurrency.
 cifmw_test_operator_tempest_debug: false
 cifmw_test_operator_tempest_config:
   apiVersion: test.openstack.org/v1beta1
@@ -140,7 +143,8 @@ cifmw_test_operator_tempest_config:
         {{ stage_vars_dict.cifmw_test_operator_tempest_exclude_list | default('') }}
       expectedFailuresList: |
         {{ stage_vars_dict.cifmw_test_operator_tempest_expected_failures_list | default('') }}
-      concurrency: "{{ cifmw_test_operator_concurrency }}"
+      concurrency: |
+        {{ cifmw_test_operator_concurrency | default(8) | int }}
       externalPlugin: "{{ stage_vars_dict.cifmw_test_operator_tempest_external_plugin | default([]) }}"
       extraRPMs: "{{ stage_vars_dict.cifmw_test_operator_tempest_extra_rpms | default([]) }}"
       extraImages: "{{ stage_vars_dict.cifmw_test_operator_tempest_extra_images | default([]) }}"


### PR DESCRIPTION
There was many tests done to set the integer value for concurrency
parameter in tempest config. Even forcing the value to integer
does not meet with conversion in the end.
We thought that it is k8s module issue, but it seems not. It migth be
related to jinja2 according to issue [1].
Until the value is not parsed properly, we need to set it without
reference.

[1] https://github.com/ansible/ansible/issues/18095