### PR TITLE
Add epoxy release mapping in build_openstack_packages role

### DIFF
--- a/roles/build_openstack_packages/defaults/main.yml
+++ b/roles/build_openstack_packages/defaults/main.yml
@@ -70,6 +70,7 @@ cifmw_bop_change_list: []
 cifmw_bop_release_mapping:
   master: master
   antelope: unmaintained/2023.1
+  epoxy: stable/2025.1
 
 cifmw_bop_versions_url:
   rhos-18.0: "https://trunk.rdoproject.org/centos9-antelope/current-podified/versions.csv"


### PR DESCRIPTION
It will allow us to build rpms from opendev epoxy depends-on in the content provider jobs.