### PR TITLE
Simplify files to track by Zuul

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -2,9 +2,9 @@
 - job:
     name: cifmw-molecule-libvirt_manager
     files:
-      - ^roles/dnsmasq/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/networking_mapper/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/config_drive/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+      - ^roles/dnsmasq/.*
+      - ^roles/networking_mapper/.*
+      - ^roles/config_drive/.*
     timeout: 3600
 - job:
     name: cifmw-molecule-openshift_login
@@ -54,12 +54,12 @@
     nodeset: centos-9-crc-2-48-0-xxl-ibm
     timeout: 5400
     files:
-      - ^roles/dnsmasq/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/libvirt_manager/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/networking_mapper/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/podman/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/sushy_emulator/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/rhol_crc/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/dnsmasq/.*
+      - ^roles/libvirt_manager/.*
+      - ^roles/networking_mapper/.*
+      - ^roles/podman/.*
+      - ^roles/sushy_emulator/.*
+      - ^roles/rhol_crc/.*
 - job:
     name: cifmw-molecule-cert_manager
     nodeset: centos-9-crc-2-48-0-xxl-ibm
@@ -69,17 +69,17 @@
 - job:
     name: cifmw_molecule-pkg_build
     files:
-      - ^roles/build_openstack_packages/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/build_openstack_packages/.*
 - job:
     name: cifmw_molecule-build_containers
     files:
-      - ^roles/build_openstack_packages/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/repo_setup/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/build_openstack_packages/.*
+      - ^roles/repo_setup/.*
 - job:
     name: cifmw-molecule-build_openstack_packages
     files:
-      - ^roles/pkg_build/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/repo_setup/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/pkg_build/.*
+      - ^roles/repo_setup/.*
 - job:
     name: cifmw-molecule-manage_secrets
     nodeset: centos-9-crc-2-48-0-xl-ibm

--- a/ci/templates/molecule.yaml.j2
+++ b/ci/templates/molecule.yaml.j2
@@ -1,8 +1,5 @@
 # Don't modify this file.
 # If you need apply custom molecule changes, please edit ci/config/molecule.yaml
-{% set want_list = ['defaults', 'files', 'handlers', 'library',
-                    'lookup_plugins', 'module_utils', 'molecule',
-                    'tasks', 'templates', 'vars'] -%}
 {% for role_name in role_names | sort %}
 - job:
     name: cifmw-molecule-{{ role_name }}
@@ -12,7 +9,7 @@
     files:
       - ^common-requirements.txt
       - ^test-requirements.txt
-      - ^roles/{{ role_name }}/({{ want_list | sort | join('|') }}).*
+      - ^roles/{{ role_name }}/.*
       - ^ci/playbooks/molecule.*
       - ^.config/molecule/.*
 {% endfor %}

--- a/ci/templates/noop-molecule.yaml.j2
+++ b/ci/templates/noop-molecule.yaml.j2
@@ -1,6 +1,3 @@
-{% set want_list = ['defaults', 'files', 'handlers', 'library',
-                    'lookup_plugins', 'module_utils', 'molecule',
-                    'tasks', 'templates', 'vars'] -%}
 {% for role_name in role_names | sort %}
 - job:
     name: cifmw-molecule-{{ role_name }}
@@ -8,7 +5,7 @@
     files:
       - ^common-requirements.txt
       - ^test-requirements.txt
-      - ^roles/{{ role_name }}/{{ want_list | sort | join('|') }}.*
+      - ^roles/{{ role_name }}/.*
       - ^ci/playbooks/molecule.*
       - ^.config/molecule/.*
 {% endfor %}

--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -120,13 +120,13 @@
       - ^playbooks/01-bootstrap.yml
       - ^playbooks/02-infra.yml
       - ^playbooks/06-deploy-edpm.yml
-      - ^roles/discover_latest_image/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/edpm_prepare/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/install_ca/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/install_yamls/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/openshift_login/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/openshift_setup/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/repo_setup/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/discover_latest_image/.*
+      - ^roles/edpm_prepare/.*
+      - ^roles/install_ca/.*
+      - ^roles/install_yamls/.*
+      - ^roles/openshift_login/.*
+      - ^roles/openshift_setup/.*
+      - ^roles/repo_setup/.*
       - ^hooks/playbooks/fetch_compute_facts.yml
       - ^zuul.d/adoption.yaml
       # openstack-operator

--- a/zuul.d/architecture-jobs.yaml
+++ b/zuul.d/architecture-jobs.yaml
@@ -40,5 +40,5 @@
       cifmw_architecture_scenario: hci
     files:
       - zuul.d/architecture-jobs.yaml
-      - ^roles/ci_gen_kustomize_values/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/kustomize_deploy/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/ci_gen_kustomize_values/.*
+      - ^roles/kustomize_deploy/.*

--- a/zuul.d/content_provider.yaml
+++ b/zuul.d/content_provider.yaml
@@ -22,9 +22,9 @@
       against ci-framework repo to validate meta content provider
       changes.
     files:
-      - ^roles/build_containers/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/build_openstack_packages/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/registry_deploy/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/edpm_build_images/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/operator_build/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/build_containers/.*
+      - ^roles/build_openstack_packages/.*
+      - ^roles/registry_deploy/.*
+      - ^roles/edpm_build_images/.*
+      - ^roles/operator_build/.*
       - ^ci/playbooks/meta_content_provider/.*

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -35,8 +35,8 @@
     parent: cifmw-crc-podified-edpm-deployment
     files:
       - ^playbooks/*
-      - ^roles/edpm_prepare/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/edpm_deploy/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/edpm_prepare/.*
+      - ^roles/edpm_deploy/.*
       - ^roles/artifacts/tasks/edpm.yml
       - ^deploy-edpm.yml
       - ^scenarios/centos-9/edpm_ci.yml
@@ -46,7 +46,7 @@
     parent: cifmw-crc-podified-galera-deployment
     files:
       - ^playbooks/*
-      - ^roles/edpm_prepare/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/edpm_prepare/.*
       - ^deploy-edpm.yml
       - ^scenarios/centos-9/edpm_ci.yml
 
@@ -55,7 +55,7 @@
     parent: cifmw-crc-podified-edpm-baremetal
     files:
       - ^playbooks/*
-      - ^roles/edpm_deploy_baremetal/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/edpm_deploy_baremetal/.*
       - ^roles/artifacts/tasks/edpm.yml
       - ^ci/playbooks/edpm_baremetal_deployment/run.yml
       - ^deploy-edpm.yml

--- a/zuul.d/end-to-end.yaml
+++ b/zuul.d/end-to-end.yaml
@@ -23,9 +23,9 @@
     name: cifmw-end-to-end
     parent: cifmw-end-to-end-base
     files:
-      - ^roles/.*_build/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/build.*/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-      - ^roles/openshift_.*/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/.*_build/.*
+      - ^roles/build.*/.*
+      - ^roles/openshift_.*/.*
       - ^playbooks/.*build.*.yml
     irrelevant-files:
       - ^.*/*.md

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -2,7 +2,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/artifacts/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/artifacts/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-artifacts
@@ -13,7 +13,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/build_containers/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/build_containers/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-build_containers
@@ -24,11 +24,11 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/build_openstack_packages/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/build_openstack_packages/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
-    - ^roles/pkg_build/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-    - ^roles/repo_setup/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+    - ^roles/pkg_build/.*
+    - ^roles/repo_setup/.*
     name: cifmw-molecule-build_openstack_packages
     parent: cifmw-molecule-base
     vars:
@@ -37,7 +37,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/build_push_container/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/build_push_container/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-build_push_container
@@ -48,7 +48,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/cert_manager/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/cert_manager/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cert_manager
@@ -60,7 +60,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/ci_gen_kustomize_values/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/ci_gen_kustomize_values/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_gen_kustomize_values
@@ -73,7 +73,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/ci_local_storage/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/ci_local_storage/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_local_storage
@@ -85,7 +85,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/ci_multus/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/ci_multus/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_multus
@@ -96,7 +96,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/ci_network/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/ci_network/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_network
@@ -107,7 +107,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/ci_nmstate/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/ci_nmstate/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_nmstate
@@ -118,7 +118,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/ci_setup/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/ci_setup/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_setup
@@ -129,7 +129,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/cifmw_block_device/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/cifmw_block_device/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_block_device
@@ -140,7 +140,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/cifmw_ceph_client/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/cifmw_ceph_client/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_ceph_client
@@ -151,7 +151,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/cifmw_ceph_spec/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/cifmw_ceph_spec/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_ceph_spec
@@ -162,7 +162,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/cifmw_cephadm/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/cifmw_cephadm/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_cephadm
@@ -173,7 +173,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/cifmw_create_admin/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/cifmw_create_admin/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_create_admin
@@ -184,7 +184,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/cifmw_ntp/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/cifmw_ntp/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_ntp
@@ -195,7 +195,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/cifmw_test_role/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/cifmw_test_role/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_test_role
@@ -206,7 +206,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/compliance/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/compliance/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-compliance
@@ -217,7 +217,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/config_drive/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/config_drive/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-config_drive
@@ -228,7 +228,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/copy_container/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/copy_container/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-copy_container
@@ -239,7 +239,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/deploy_bmh/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/deploy_bmh/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-deploy_bmh
@@ -250,7 +250,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/devscripts/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/devscripts/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-devscripts
@@ -261,7 +261,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/discover_latest_image/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/discover_latest_image/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-discover_latest_image
@@ -272,7 +272,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/dlrn_promote/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/dlrn_promote/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-dlrn_promote
@@ -283,7 +283,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/dlrn_report/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/dlrn_report/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-dlrn_report
@@ -294,7 +294,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/dnsmasq/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/dnsmasq/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-dnsmasq
@@ -305,7 +305,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/edpm_build_images/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/edpm_build_images/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-edpm_build_images
@@ -316,7 +316,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/edpm_deploy/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/edpm_deploy/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-edpm_deploy
@@ -327,7 +327,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/edpm_deploy_baremetal/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/edpm_deploy_baremetal/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-edpm_deploy_baremetal
@@ -338,7 +338,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/edpm_kustomize/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/edpm_kustomize/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-edpm_kustomize
@@ -349,7 +349,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/edpm_prepare/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/edpm_prepare/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-edpm_prepare
@@ -360,7 +360,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/env_op_images/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/env_op_images/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-env_op_images
@@ -372,7 +372,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/hci_prepare/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/hci_prepare/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-hci_prepare
@@ -383,7 +383,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/hive/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/hive/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-hive
@@ -394,7 +394,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/idrac_configuration/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/idrac_configuration/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-idrac_configuration
@@ -405,7 +405,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/install_ca/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/install_ca/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-install_ca
@@ -418,7 +418,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/install_openstack_ca/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/install_openstack_ca/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-install_openstack_ca
@@ -431,7 +431,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/install_yamls/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/install_yamls/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-install_yamls
@@ -442,7 +442,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/kustomize_deploy/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/kustomize_deploy/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-kustomize_deploy
@@ -455,12 +455,12 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/libvirt_manager/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/libvirt_manager/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
-    - ^roles/dnsmasq/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-    - ^roles/networking_mapper/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-    - ^roles/config_drive/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/dnsmasq/.*
+    - ^roles/networking_mapper/.*
+    - ^roles/config_drive/.*
     name: cifmw-molecule-libvirt_manager
     parent: cifmw-molecule-base
     timeout: 3600
@@ -470,7 +470,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/manage_secrets/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/manage_secrets/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-manage_secrets
@@ -482,7 +482,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/mirror_registry/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/mirror_registry/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-mirror_registry
@@ -493,7 +493,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/nat64_appliance/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/nat64_appliance/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-nat64_appliance
@@ -504,7 +504,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/networking_mapper/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/networking_mapper/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-networking_mapper
@@ -516,7 +516,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/openshift_login/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/openshift_login/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_login
@@ -528,7 +528,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/openshift_obs/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/openshift_obs/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_obs
@@ -540,7 +540,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/openshift_provisioner_node/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/openshift_provisioner_node/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_provisioner_node
@@ -552,7 +552,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/openshift_setup/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/openshift_setup/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_setup
@@ -564,7 +564,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/operator_build/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/operator_build/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-operator_build
@@ -575,7 +575,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/operator_deploy/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/operator_deploy/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-operator_deploy
@@ -587,7 +587,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/os_must_gather/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/os_must_gather/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-os_must_gather
@@ -598,7 +598,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/os_net_setup/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/os_net_setup/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-os_net_setup
@@ -609,7 +609,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/pkg_build/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/pkg_build/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-pkg_build
@@ -620,7 +620,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/podman/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/podman/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-podman
@@ -631,7 +631,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/registry_deploy/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/registry_deploy/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-registry_deploy
@@ -642,7 +642,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/repo_setup/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/repo_setup/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-repo_setup
@@ -653,7 +653,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/reportportal/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/reportportal/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-reportportal
@@ -664,15 +664,15 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/reproducer/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/reproducer/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
-    - ^roles/dnsmasq/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-    - ^roles/libvirt_manager/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-    - ^roles/networking_mapper/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-    - ^roles/podman/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-    - ^roles/sushy_emulator/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
-    - ^roles/rhol_crc/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+    - ^roles/dnsmasq/.*
+    - ^roles/libvirt_manager/.*
+    - ^roles/networking_mapper/.*
+    - ^roles/podman/.*
+    - ^roles/sushy_emulator/.*
+    - ^roles/rhol_crc/.*
     name: cifmw-molecule-reproducer
     nodeset: centos-9-crc-2-48-0-xxl-ibm
     parent: cifmw-molecule-base
@@ -683,7 +683,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/rhol_crc/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/rhol_crc/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-rhol_crc
@@ -696,7 +696,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/run_hook/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/run_hook/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-run_hook
@@ -707,7 +707,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/set_openstack_containers/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/set_openstack_containers/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-set_openstack_containers
@@ -718,7 +718,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/shiftstack/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/shiftstack/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-shiftstack
@@ -730,7 +730,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/ssh_jumper/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/ssh_jumper/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ssh_jumper
@@ -741,7 +741,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/sushy_emulator/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/sushy_emulator/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-sushy_emulator
@@ -753,7 +753,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/tempest/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/tempest/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-tempest
@@ -764,7 +764,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/test_deps/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/test_deps/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-test_deps
@@ -775,7 +775,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/test_operator/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/test_operator/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-test_operator
@@ -786,7 +786,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/tofu/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/tofu/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     - ^ci_framework/playbooks/run_tofu.yml
@@ -799,7 +799,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/update/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/update/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-update
@@ -810,7 +810,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/update_containers/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/update_containers/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-update_containers
@@ -821,7 +821,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/validations/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/validations/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-validations
@@ -832,7 +832,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/virtualbmc/(defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars).*
+    - ^roles/virtualbmc/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-virtualbmc
@@ -843,7 +843,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/adoption_osp_deploy/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
+    - ^roles/adoption_osp_deploy/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-adoption_osp_deploy
@@ -852,7 +852,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/ci_dcn_site/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
+    - ^roles/ci_dcn_site/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_dcn_site
@@ -861,7 +861,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/ci_lvms_storage/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
+    - ^roles/ci_lvms_storage/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_lvms_storage
@@ -870,7 +870,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/cifmw_external_dns/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
+    - ^roles/cifmw_external_dns/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_external_dns
@@ -879,7 +879,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/federation/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
+    - ^roles/federation/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-federation
@@ -888,7 +888,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/krb_request/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
+    - ^roles/krb_request/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-krb_request
@@ -897,7 +897,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/openshift_adm/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
+    - ^roles/openshift_adm/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_adm
@@ -906,7 +906,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/ovirt/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
+    - ^roles/ovirt/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ovirt
@@ -915,7 +915,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/polarion/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
+    - ^roles/polarion/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-polarion
@@ -924,7 +924,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/recognize_ssh_keypair/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
+    - ^roles/recognize_ssh_keypair/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-recognize_ssh_keypair
@@ -933,7 +933,7 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
-    - ^roles/switch_config/defaults|files|handlers|library|lookup_plugins|module_utils|molecule|tasks|templates|vars.*
+    - ^roles/switch_config/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-switch_config

--- a/zuul.d/tcib.yaml
+++ b/zuul.d/tcib.yaml
@@ -25,6 +25,6 @@
     name: cifmw-tcib
     parent: cifmw-tcib-base
     files:
-      - ^roles/build_containers/(defaults|files|handlers|library|lookup_plugins|module_utils|tasks|templates|vars).*
+      - ^roles/build_containers/.*
       - ^scenarios/centos-9/tcib.yml
       - ^ci/playbooks/tcib


### PR DESCRIPTION
In many places it was not necessary to add a regex, due the whole role/playbook/module should be tracked.
In other words, we can live if README file would be changed and there would be a CI job running for veryfing that.