### PR TITLE
Drop tracking requiements.yml file from Zuul CI base jobs

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -73,8 +73,6 @@
       # openstack-ansibleee-operator
       - examples
       - mkdocs.yml
-    files: &files
-      - ^requirements.yml
     required-projects:
       - opendev.org/zuul/zuul-jobs
       - openstack-k8s-operators/barbican-operator
@@ -129,7 +127,6 @@
     attempts: 1
     nodeset: centos-9-medium-centos-9-crc-cloud-ocp-4-18-1-3xl
     irrelevant-files: *ir_files
-    files: *files
     required-projects: &multinode_edpm_rp
       - openstack-k8s-operators/ci-framework
       - openstack-k8s-operators/install_yamls
@@ -217,7 +214,6 @@
     attempts: 1
     nodeset: centos-9-medium-centos-9-crc-cloud-ocp-4-18-1-3xl
     irrelevant-files: *ir_files
-    files: *files
     required-projects: *multinode_edpm_rp
     roles: *multinode_edpm_roles
     pre-run:
@@ -272,7 +268,6 @@
     timeout: 10800
     abstract: true
     irrelevant-files: *ir_files
-    files: *files
     required-projects:
       - openstack-k8s-operators/ci-framework
       - openstack-k8s-operators/install_yamls


### PR DESCRIPTION
We should track the files not in base job, but in "child" jobs.