### PR TITLE
Add retries when creating OpenstackVersion

### DIFF
--- a/roles/update_containers/tasks/main.yml
+++ b/roles/update_containers/tasks/main.yml
@@ -33,3 +33,7 @@
     PATH: "{{ cifmw_path }}"
   ansible.builtin.command:
     cmd: "oc apply -f {{ cifmw_update_containers_dest_path }}"
+  register: apply_result
+  retries: 20
+  delay: 120
+  until: apply_result.rc == 0 


### PR DESCRIPTION
Still seeing this in very specific virtualized DT/VA jobs downstream.  Using this to unblock test environment for the interim.