### PR TITLE
[DNM] Check zuul jobs without router gateway

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -47,7 +47,7 @@
         networks:
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
-            router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            router_net: ""
             range: 192.168.122.0/24
           internal-api:
             vlan: 20
@@ -221,7 +221,7 @@
         networks: &multinode_networks
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
-            router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            router_net: ""
             range: 192.168.122.0/24
           internal-api:
             vlan: 20

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -165,7 +165,7 @@
         networks:
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
-            router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            router_net: ""
             range: 192.168.122.0/24
           internal-api:
             vlan: 20

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -12,7 +12,7 @@
         networks:
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
-            router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            router_net: ""
             range: 192.168.122.0/24
           internal-api:
             vlan: 20
@@ -75,7 +75,7 @@
         networks:
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
-            router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            router_net: ""
             range: 192.168.122.0/24
           internal-api:
             vlan: 20
@@ -152,7 +152,7 @@
         networks:
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
-            router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            router_net: ""
             range: 192.168.122.0/24
           internal-api:
             vlan: 20
@@ -244,7 +244,7 @@
         networks:
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
-            router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            router_net: ""
             range: 192.168.122.0/24
           internal-api:
             vlan: 20

--- a/zuul.d/kuttl_multinode.yaml
+++ b/zuul.d/kuttl_multinode.yaml
@@ -14,7 +14,7 @@
           default:
             range: 192.168.122.0/24
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
-            router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            router_net: ""
             router: false
           internal-api:
             vlan: 20

--- a/zuul.d/podified_multinode.yaml
+++ b/zuul.d/podified_multinode.yaml
@@ -22,7 +22,7 @@
           default:
             range: 192.168.122.0/24
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
-            router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            router_net: ""
           internal-api:
             vlan: 20
             range: 172.17.0.0/24

--- a/zuul.d/tempest_multinode.yaml
+++ b/zuul.d/tempest_multinode.yaml
@@ -22,7 +22,7 @@
           default:
             range: 192.168.122.0/24
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
-            router_net: "{{ ('ibm' in nodepool.cloud) | ternary('hostonly', 'public') }}"
+            router_net: ""
           internal-api:
             vlan: 20
             range: 172.17.0.0/24


### PR DESCRIPTION
For clouds where instances directly attached to public network, having a router with default gateway is unnecessary. This to test if we can avoid this and save some public IPs.

Depends-On: https://review.rdoproject.org/r/c/config/+/57579
Related-Issue: OSPCIX-771