### PR TITLE
Fix docs ci job because of snowballstemmer

### DIFF
--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -7,3 +7,4 @@ sphinxemoji
 myst-parser[linkify]
 ansible-core
 ansible-doc-extractor
+snowballstemmer<3


### PR DESCRIPTION
We need to pin snowballstemmer < 3 due to
https://github.com/sphinx-doc/sphinx/issues/13533