### PR TITLE
Testing Nonetype with cifmw_dnsmasq_network_state data

### DIFF
--- a/roles/dnsmasq/templates/network.conf.j2
+++ b/roles/dnsmasq/templates/network.conf.j2
@@ -5,18 +5,18 @@ enable-ra
 {% endif                                                                                           -%}
 
 {% for range in cifmw_dnsmasq_network_definition['ranges']                                         -%}
-{%   if range.start_v4 is defined and range.start_v4 | length > 0                                  -%}
+{%   if range.start_v4 is defined and range.start_v4 | default('', true) | length > 0              -%}
 dhcp-range=set:{{ range.label }},{{ range.start_v4 }},static,{{ (range.start_v4 + "/" + range.prefix_length_v4 | default(24) | string) | ansible.utils.ipaddr('netmask') }},{{ range.ttl | default('1h') }}
 {%      if range.domain is defined and range.domain | length > 0                                   -%}
-{%          set range_v4_allowed = (range.start_v4 ~ "/" ~ range.prefix_length_v4 | default('24')) |
+{%          set range_v4_allowed = (range.start_v4 ~ "/" ~ (range.prefix_length_v4 | default('24'))) |
                                     ansible.utils.ipaddr('range_usable') | replace("-",",")         %}
 domain={{ range.domain }},{{ range_v4_allowed }},local
 {%      endif                                                                                       %}
 {%   endif                                                                                          %}
-{%   if range.start_v6 is defined and range.start_v6 | length > 0                                  -%}
+{%   if range.start_v6 is defined and range.start_v6 | default('', true)  | length > 0             -%}
 dhcp-range=set:{{ range.label }},{{ range.start_v6 }},static,{{ range.prefix_length_v6 | default('64') }},{{ range.ttl | default('1h') }}
 {%      if range.domain is defined and range.domain | length > 0                                   -%}
-{%          set range_v6_allowed = (range.start_v6 ~ "/" ~ range.prefix_length_v6 | default('64')) |
+{%          set range_v6_allowed = (range.start_v6 ~ "/" ~ (range.prefix_length_v6 | default('64'))) |
                                     ansible.utils.ipaddr('range_usable') | replace("-",",")         %}
 domain={{ range.domain }},{{ range_v6_allowed }},local
 {%      endif                                                                                       %}


### PR DESCRIPTION
Testing why `object of type 'NoneType' has no len(). object of type 'NoneType' has no len()` is happening when rendering network.conf.j2.