### PR TITLE
Fix setting fact for cifmw_test_operator_concurrency

### DIFF
--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -29,6 +29,7 @@ cifmw_test_operator_controller_namespace: openstack-operators
 cifmw_test_operator_bundle: ""
 cifmw_test_operator_timeout: 3600
 cifmw_test_operator_logs_image: quay.io/quay/busybox
+cifmw_test_operator_concurrency: 8
 cifmw_test_operator_cleanup: false
 cifmw_test_operator_dry_run: false
 cifmw_test_operator_default_groups:
@@ -139,7 +140,7 @@ cifmw_test_operator_tempest_config:
         {{ stage_vars_dict.cifmw_test_operator_tempest_exclude_list | default('') }}
       expectedFailuresList: |
         {{ stage_vars_dict.cifmw_test_operator_tempest_expected_failures_list | default('') }}
-      concurrency: "{{ stage_vars_dict.cifmw_test_operator_concurrency | default(8) }}"
+      concurrency: "{{ cifmw_test_operator_concurrency }}"
       externalPlugin: "{{ stage_vars_dict.cifmw_test_operator_tempest_external_plugin | default([]) }}"
       extraRPMs: "{{ stage_vars_dict.cifmw_test_operator_tempest_extra_rpms | default([]) }}"
       extraImages: "{{ stage_vars_dict.cifmw_test_operator_tempest_extra_images | default([]) }}"

--- a/roles/test_operator/tasks/stages.yml
+++ b/roles/test_operator/tasks/stages.yml
@@ -35,11 +35,7 @@
     start_with: cifmw_test_operator_{{ _stage_vars.type }}
   when: item.key.startswith(start_with)
   ansible.builtin.set_fact:
-    stage_vars_dict: "{{ stage_vars_dict | combine({item.key: _stage_test_vars[item.key] | default(lookup('vars', item.key, default=omit)) }) }}"
-
-- name: Overwrite concurrency in global_vars
-  ansible.builtin.set_fact:
-    stage_vars_dict: "{{ stage_vars_dict | combine({'cifmw_test_operator_concurrency': _stage_test_vars.cifmw_test_operator_concurrency | default(lookup('vars', 'concurrency', default=omit)) }) }}"
+    stage_vars_dict: "{{ stage_vars_dict | combine({item.key: _stage_test_vars[item.key] | default(lookup('vars', item.key, default=omit))} ) }}"
 
 - name: Override specific type config
   vars:


### PR DESCRIPTION
Fix setting fact for cifmw_test_operator_concurrency

Some part of previous commit [1] was not needed and it breaks
overwriting the values (it always was uing 8 value for concurrency).

This commit partially reverts commit proposed in PR [1].

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/2938

   