### PR TITLE
Drop PyYAML package for bindep 

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -22,7 +22,6 @@ podman            [platform:rpm]
 python3-devel     [platform:rpm !platform:rhel-7 !platform:centos-7]
 python3-libvirt   [platform:rpm]
 python3-lxml      [platform:rpm]
-PyYAML            [platform:rpm !platform:rhel-8 !platform:centos-8 !platform:rhel-9 !platform:centos-9 !platform:fedora]
 python3-pyyaml    [platform:rpm !platform:rhel-7 !platform:centos-7]
 python3-dnf       [platform:rpm !platform:rhel-7 !platform:centos-7]
 


### PR DESCRIPTION
PyYAML package is not available on RHEL distro and is replaced with
python-pyyaml, which is already there.

This pr will drops PyYAML from bindep.

Resolves: [OSPRH-16716](https://issues.redhat.com//browse/OSPRH-16716)