### PR TITLE
dnsmasq: Fix start_v[4|6] is None

### DIFF
--- a/roles/config_drive/tasks/main.yml
+++ b/roles/config_drive/tasks/main.yml
@@ -63,7 +63,7 @@
   register: _net_data_change
   when:
     - cifmw_config_drive_networkconfig is defined
-    - cifmw_config_drive_networkconfig | length > 0
+    - cifmw_config_drive_networkconfig
   ansible.builtin.template:
     backup: true
     src: "network-config.j2"
@@ -101,6 +101,6 @@
       -joliet
       -rock user-data meta-data
       {% if cifmw_config_drive_networkconfig is defined and
-            cifmw_config_drive_networkconfig | length > 0 -%}
+            cifmw_config_drive_networkconfig -%}
        network-config
       {%- endif -%}

--- a/roles/dnsmasq/templates/network.conf.j2
+++ b/roles/dnsmasq/templates/network.conf.j2
@@ -1,21 +1,21 @@
 # Managed by ci-framework/dnsmasq
 {% if cifmw_dnsmasq_network_definition.ranges | selectattr('start_v6', 'defined') |
-    rejectattr('start_v6', 'match', '^$')                                                          -%}
+    rejectattr('start_v6', 'none') | rejectattr('start_v6', 'match', '^$')                         -%}
 enable-ra
 {% endif                                                                                           -%}
 
 {% for range in cifmw_dnsmasq_network_definition['ranges']                                         -%}
-{%   if range.start_v4 is defined and range.start_v4 | length > 0                                  -%}
+{%   if range.start_v4 is defined and range.start_v4                                               -%}
 dhcp-range=set:{{ range.label }},{{ range.start_v4 }},static,{{ (range.start_v4 + "/" + range.prefix_length_v4 | default(24) | string) | ansible.utils.ipaddr('netmask') }},{{ range.ttl | default('1h') }}
-{%      if range.domain is defined and range.domain | length > 0                                   -%}
+{%      if range.domain is defined and range.domain                                                -%}
 {%          set range_v4_allowed = (range.start_v4 ~ "/" ~ range.prefix_length_v4 | default('24')) |
                                     ansible.utils.ipaddr('range_usable') | replace("-",",")         %}
 domain={{ range.domain }},{{ range_v4_allowed }},local
 {%      endif                                                                                       %}
 {%   endif                                                                                          %}
-{%   if range.start_v6 is defined and range.start_v6 | length > 0                                  -%}
+{%   if range.start_v6 is defined and range.start_v6                                               -%}
 dhcp-range=set:{{ range.label }},{{ range.start_v6 }},static,{{ range.prefix_length_v6 | default('64') }},{{ range.ttl | default('1h') }}
-{%      if range.domain is defined and range.domain | length > 0                                   -%}
+{%      if range.domain is defined and range.domain                                                -%}
 {%          set range_v6_allowed = (range.start_v6 ~ "/" ~ range.prefix_length_v6 | default('64')) |
                                     ansible.utils.ipaddr('range_usable') | replace("-",",")         %}
 domain={{ range.domain }},{{ range_v6_allowed }},local

--- a/roles/libvirt_manager/tasks/generate_networking_data.yml
+++ b/roles/libvirt_manager/tasks/generate_networking_data.yml
@@ -180,11 +180,11 @@
       {% set ns = namespace(ip_start=30) %}
       networks:
         {{ _lnet_data.name | replace('cifmw_', '') }}:
-      {% if _lnet_data.ranges[0].start_v4 is defined and _lnet_data.ranges[0].start_v4 | length > 0                     %}
+      {% if _lnet_data.ranges[0].start_v4 is defined and _lnet_data.ranges[0].start_v4                                  %}
         {% set net_4 = _lnet_data.ranges[0].start_v4 | ansible.utils.ipsubnet(_lnet_data.ranges[0].prefix_length_v4)    %}
           network-v4: {{ net_4}}
       {% endif                                                                                                          %}
-      {% if _lnet_data.ranges[0].start_v6 is defined and _lnet_data.ranges[0].start_v6 | length > 0                     %}
+      {% if _lnet_data.ranges[0].start_v6 is defined and _lnet_data.ranges[0].start_v6                                  %}
           {% set net_6 = _lnet_data.ranges[0].start_v6 | ansible.utils.ipsubnet(_lnet_data.ranges[0].prefix_length_v6)  %}
           network-v6: {{ net_6 }}
       {% endif %}


### PR DESCRIPTION
The task[1] has started to fail recently on following error:

_"object of type 'NoneType' has no len(). object of type 'NoneType' has no len()"_


I can see that **cifmw_dnsmasq_network_definition** variable in my case has this content:
```
    name: osp_trunk
    original_name: cifmw-osp_trunk
    ranges:
    - label: osp_trunk options:
      - option:dns-server,192.168.122.1
      - option:router
    prefix_length_v4: 24
    prefix_length_v6: null
    start_v4: 192.168.122.2
    start_v6: null
```
Which means that start_v6 is None and
that's defined but of NoneType so length
filter can't be used on it. The filter
does not need to be used tho It's enough
to condition, i.e. "if variable" (instead of
"If variable | length > 0") which
would be false if values is None, false,
0, empty string, dictionary or list.

The same happens with cifmw_config_drive_networkconfig which happens to be initialized as None and
is used as that.

[1] https://github.com/openstack-k8s-operators/ci-framework/blob/main/roles/dnsmasq/tasks/manage_network.yml#L35