### PR TITLE
Add IPA role to ci-framework

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,9 +11,6 @@ playbooks/bgp-l3-computes-ready.yml @openstack-k8s-operators/bgp
 playbooks/bgp @openstack-k8s-operators/bgp
 scenarios/reproducers/bgp-l3-xl.yml @openstack-k8s-operators/bgp
 
-# Compliance
-roles/compliance @openstack-k8s-operators/security
-
 # DCN
 roles/ci_dcn_site @openstack-k8s-operators/dcn
 playbooks/dcn.yml @openstack-k8s-operators/dcn
@@ -37,6 +34,11 @@ roles/polarion @tosky @jparoly @jirimacku
 
 # Report portal
 roles/reportportal @jirimacku @dsariel @sdatko
+
+# Security
+roles/compliance @openstack-k8s-operators/security
+roles/federation @openstack-k8s-operators/security
+roles/ipa @openstack-k8s-operators/security
 
 # Shiftstack
 roles/shiftstack @rlobillo @eurijon

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -226,6 +226,7 @@ https
 ic
 icjbuue
 icokicagy
+IDM
 IdP
 idrac
 iface
@@ -285,6 +286,7 @@ kuttl
 kvm
 lacp
 lajly
+LDAP
 ldp
 libguestfs
 libvirt

--- a/hooks/playbooks/ipa-controlplane-config.yml
+++ b/hooks/playbooks/ipa-controlplane-config.yml
@@ -1,0 +1,91 @@
+---
+- name: Create kustomization to update Keystone to use LDAP
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  tasks:
+    - name: Create file to customize keystone for IPA deployed in the control plane
+      ansible.builtin.copy:
+        dest: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/controlplane/keystone_ldap.yaml"
+        content: |-
+          apiVersion: kustomize.config.k8s.io/v1beta1
+          kind: Kustomization
+          resources:
+          - namespace: {{ namespace }}
+          patches:
+          - target:
+              kind: OpenStackControlPlane
+              name: .*
+            patch: |-
+              - op: add
+                path: /spec/keystone/template/extraMounts
+                value:
+                  - name: v1
+                    region: r1
+                    extraVol:
+                      - propagation:
+                        - Keystone
+                        extraVolType: Conf
+                        volumes:
+                        - name: keystone-domains
+                          secret:
+                            secretName: keystone-domains
+                        mounts:
+                        - name: keystone-domains
+                          mountPath: "/etc/keystone/domains"
+                          readOnly: true
+              - op: add
+                path: /spec/keystone/template/customServiceConfig
+                value: |
+                  [DEFAULT]
+                  insecure_debug = true
+                  debug = true
+                  [identity]
+                  domain_specific_drivers_enabled = true
+        mode: "0644"
+
+    - name: Get ipa route
+      kubernetes.core.k8s_info:
+        api_version: route.openshift.io/v1
+        kind: Route
+        name: idm
+        namespace: "{{ cifmw_ipa_namespace | default('cert-manager') }}"
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+      register: idm_route
+
+    - name: Set IPA BaseDN, hostname and secret config key vars
+      ansible.builtin.set_fact:
+        cifmw_ipa_hostname: "{{ idm_route.resources.0.spec.host }}"
+        cifmw_ipa_basedn: "dc={{ idm_route.resources.0.spec.host.split('.')[1:] | join(',dc=') }}"
+        keystone_conf_key: "keystone.{{ cifmw_ipa_domain | default('REDHAT') }}.conf"
+
+    - name: Create Keystone domain config secret for LDAP
+      kubernetes.core.k8s:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: keystone-domains
+            namespace: openstack
+          type: Opaque
+          stringData: "{{ {keystone_conf_key: keystone_ldap_config_content} }}"
+      vars:
+        keystone_ldap_config_content: |
+          [identity]
+          driver = ldap
+          [ldap]
+          url = ldap://ipa-directory-service.{{ cifmw_ipa_namespace | default('cert-manager') }}.svc.cluster.local
+          user = uid=admin,cn=users,cn=accounts,{{ cifmw_ipa_basedn }}
+          password = {{ cifmw_ipa_admin_password | default('nomoresecrets') }}
+          suffix = {{ cifmw_ipa_basedn }}
+          user_tree_dn = cn=users,cn=accounts,{{ cifmw_ipa_basedn }}
+          user_objectclass = person
+          user_id_attribute = uid
+          user_name_attribute = uid
+          user_mail_attribute = mail
+          group_tree_dn = cn=groups,cn=accounts,{{ cifmw_ipa_basedn }}
+          group_objectclass = groupOfNames
+          group_id_attribute = cn
+          group_name_attribute = cn
+          group_member_attribute = member
+          group_desc_attribute = description

--- a/hooks/playbooks/ipa-post-deploy.yml
+++ b/hooks/playbooks/ipa-post-deploy.yml
@@ -1,0 +1,28 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Run federation setup on openstack post reproducer deploy
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  tasks:
+    - name: Run LDAP setup on OSP
+      ansible.builtin.import_role:
+        name: ipa
+        tasks_from: run_openstack_setup.yml
+
+    - name: Run LDAP OSP User Auth test
+      ansible.builtin.import_role:
+        name: ipa
+        tasks_from: run_openstack_ldap_test.yml

--- a/hooks/playbooks/ipa-pre-deploy.yml
+++ b/hooks/playbooks/ipa-pre-deploy.yml
@@ -1,0 +1,28 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Run IPA setup on reproducer
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  tasks:
+    - name: Run IPA pod setup on Openshift
+      ansible.builtin.import_role:
+        name: ipa
+        tasks_from: run_ipa_setup.yml
+
+    - name: Run IPA realm setup for OSP
+      ansible.builtin.import_role:
+        name: ipa
+        tasks_from: run_ipa_user_setup.yml

--- a/roles/ipa/README.md
+++ b/roles/ipa/README.md
@@ -1,0 +1,4 @@
+IPA
+=========
+
+This role will setup IPA with LDAP. The IDM system will be used for the LDAP domain-specific backend.

--- a/roles/ipa/defaults/main.yml
+++ b/roles/ipa/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+cifmw_ipa_deploy_type: crc
+cifmw_ipa_namespace: cert-manager
+cifmw_ipa_realm: openstack
+cifmw_ipa_admin_username: admin
+cifmw_ipa_admin_password: nomoresecrets
+cifmw_ipa_user_password: nomoresecrets
+cifmw_ipa_url_validate_certs: false
+cifmw_ipa_run_osp_cmd_namespace: openstack
+cifmw_ipa_domain: REDHAT
+cifmw_ipa_operator_version: "d5951bd27be04e06952c1510bfd6f96c2b12a052"

--- a/roles/ipa/tasks/run_ipa_setup.yml
+++ b/roles/ipa/tasks/run_ipa_setup.yml
@@ -1,0 +1,208 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Create namespace
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    name: "{{ cifmw_ipa_namespace }}"
+    api_version: v1
+    kind: Namespace
+    state: present
+
+- name: Get IPA operator deployment config from repository
+  ansible.builtin.git:
+    dest: "{{ ansible_user_dir }}/ci-framework-data/tmp/freeipa-operator"
+    repo: "https://github.com/freeipa/freeipa-operator"
+    version: "{{ cifmw_ipa_operator_version }}"
+    force: true
+
+- name: Wait for SecurityContextConstraints API to be available
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command: oc api-resources
+  register: api_resources_check
+  until: >
+    api_resources_check.rc == 0 and
+    'securitycontextconstraints' in api_resources_check.stdout
+  retries: 60
+  delay: 10
+  changed_when: false
+  check_mode: false
+  ignore_errors: true
+
+- name: Fail if SCCs did not become available
+  ansible.builtin.fail:
+    msg: "Timeout: SecurityContextConstraints API (securitycontextconstraints) did not become available after waiting."
+  when: "'securitycontextconstraints' not in api_resources_check.stdout"
+
+- name: Report success
+  ansible.builtin.debug:
+    msg: "SecurityContextConstraints API is available."
+  when: "'securitycontextconstraints' in api_resources_check.stdout"
+
+- name: Install IPA operator
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.shell:
+    cmd: |-
+      set -eo pipefail
+      cd "{{ ansible_user_dir }}/ci-framework-data/tmp/freeipa-operator"
+      oc create -f config/rbac/scc.yaml
+      (cd config/default && kustomize edit set namespace "{{ cifmw_ipa_namespace }}")
+      (cd config/manager && kustomize edit set image controller=quay.io/freeipa/freeipa-operator:nightly)
+      kustomize build config/default | kubectl apply -f -
+
+- name: Wait for it to be deployed
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_version: apps/v1
+    kind: Deployment
+    name: idm-operator-controller-manager
+    namespace: "{{ cifmw_ipa_namespace }}"
+    wait: true
+    wait_condition:
+      type: "Available"
+      reason: "MinimumReplicasAvailable"
+    wait_timeout: 60
+
+- name: Add IDM admin password secret
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      type: Opaque
+      metadata:
+        name: idm-secret
+        namespace: "{{ cifmw_ipa_namespace }}"
+      data:
+        IPA_DM_PASSWORD: "{{ cifmw_ipa_admin_password | b64encode }}"
+        IPA_ADMIN_PASSWORD: "{{ cifmw_ipa_admin_password | b64encode }}"
+
+- name: Read IPA instance template
+  ansible.builtin.template:
+    src: ipa.yaml.j2
+    dest: "{{ ansible_user_dir }}/ci-framework-data/tmp/ipa.yaml"
+    mode: "0644"
+
+- name: Install IPA pod
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: |-
+      oc apply -n {{ cifmw_ipa_namespace }} -f {{ ansible_user_dir }}/ci-framework-data/tmp/ipa.yaml
+
+- name: Wait on pod to be ready
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    kind: Pod
+    name: idm-main-0
+    namespace: "{{ cifmw_ipa_namespace }}"
+    wait: true
+    wait_timeout: 300
+
+- name: Get ipa route
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: idm
+    namespace: "{{ cifmw_ipa_namespace }}"
+  register: idm_route
+
+- name: Wait for IPA pod to be avalable
+  ansible.builtin.uri:
+    url: "https://{{ idm_route.resources.0.spec.host }}"
+    follow_redirects: true
+    method: GET
+    validate_certs: "{{ cifmw_ipa_url_validate_certs }}"
+  register: _result
+  until: _result.status == 200
+  retries: 100
+  delay: 10
+
+- name: Ensure IPA LDAP/LDAPS service is exposed
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: ipa-directory-service
+        namespace: "{{ cifmw_ipa_namespace | default('ipa') }}"
+      spec:
+        selector:
+          app: idm
+        ports:
+          - name: ldap
+            protocol: TCP
+            port: 389
+            targetPort: 389
+          - name: ldaps
+            protocol: TCP
+            port: 636
+            targetPort: 636
+
+- name: Wait or fail
+  block:
+    - name: Wait for FreeIPA server install completion in pod logs
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.command: "oc logs idm-main-0 -n cert-manager --tail=-1"
+      register: ipa_pod_logs
+      until: >
+        ipa_pod_logs.rc == 0 and
+        ("The ipa-server-install command was successful" in ipa_pod_logs.stdout or
+         "The ipa-server-install command failed" in ipa_pod_logs.stdout)
+      retries: 60
+      delay: 10
+      changed_when: false
+      check_mode: false
+
+    - name: Fail if IPA install reported an error in logs
+      ansible.builtin.fail:
+        msg: |
+          FreeIPA installation failed according to pod logs. Last 50 lines:
+          {{ (ipa_pod_logs.stdout_lines | default([]))[-50:] | join('\n') }}
+      when: "'The ipa-server-install command failed' in ipa_pod_logs.stdout"
+
+    - name: Report success if IPA install completed
+      ansible.builtin.debug:
+        msg: "FreeIPA installation appears successful in pod logs."
+      when: "'The ipa-server-install command was successful' in ipa_pod_logs.stdout"
+
+  rescue:
+    - name: Get the last 100 lines from IPA pod logs on failure/timeout
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.command: "oc logs idm-main-0 -n cert-manager --tail=100"
+      register: pod_log_tail_on_failure
+      changed_when: false
+      ignore_errors: true
+
+    - name: Print logs and fail task due to timeout or error
+      ansible.builtin.fail:
+        msg: |
+          Timeout or unexpected error waiting for FreeIPA server installation.
+          Last 100 log lines from 'idm-main-0':
+          {{ pod_log_tail_on_failure.stdout | default("Could not retrieve pod logs.") }}

--- a/roles/ipa/tasks/run_ipa_user_setup.yml
+++ b/roles/ipa/tasks/run_ipa_user_setup.yml
@@ -1,0 +1,55 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Copy user setup script into idm pod
+  kubernetes.core.k8s_cp:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    state: to_pod
+    pod: idm-main-0
+    namespace: "{{ cifmw_ipa_namespace }}"
+    remote_path: /tmp/user_setup.sh
+    content: |
+      export IPAADMINPW="{{ cifmw_ipa_admin_password }}"
+      export USERPW="{{ cifmw_ipa_user_password }}"
+      echo $IPAADMINPW|kinit admin
+      ipa user-add svc-ldap --first=Openstack --last=LDAP
+      echo $IPAADMINPW | ipa passwd svc-ldap
+      ipa user-add ipauser1 --first=ipa1 --last=user1
+      echo $IPAADMINPW | ipa passwd ipauser1
+      ipa user-add ipauser2 --first=ipa2 --last=user2
+      echo $IPAADMINPW | ipa passwd ipauser2
+      ipa user-add ipauser3 --first=ipa3 --last=user3
+      echo $IPAADMINPW | ipa passwd ipauser3
+      ipa group-add --desc="OpenStack Users" grp-openstack
+      ipa group-add --desc="OpenStack Admin Users" grp-openstack-admin
+      ipa group-add --desc="OpenStack Demo Users" grp-openstack-demo
+      ipa group-add-member --users=svc-ldap grp-openstack
+      ipa group-add-member --users=ipauser1 grp-openstack
+      ipa group-add-member --users=ipauser1 grp-openstack-admin
+      ipa group-add-member --users=ipauser2 grp-openstack
+      ipa group-add-member --users=ipauser2 grp-openstack-demo
+      ipa group-add-member --users=ipauser3 grp-openstack
+      echo -e "$IPAADMINPW\n$USERPW\n$USERPW"|/usr/bin/kinit svc-ldap
+      echo -e "$IPAADMINPW\n$USERPW\n$USERPW"|/usr/bin/kinit ipauser1
+      echo -e "$IPAADMINPW\n$USERPW\n$USERPW"|/usr/bin/kinit ipauser2
+      echo -e "$IPAADMINPW\n$USERPW\n$USERPW"|/usr/bin/kinit ipauser3
+
+- name: Setup openstack test users and groups in IPA
+  kubernetes.core.k8s_exec:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    pod: idm-main-0
+    namespace: "{{ cifmw_ipa_namespace }}"
+    command: bash /tmp/user_setup.sh

--- a/roles/ipa/tasks/run_openstack_ldap_test.yml
+++ b/roles/ipa/tasks/run_openstack_ldap_test.yml
@@ -1,0 +1,187 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Set test output filename
+  ansible.builtin.set_fact:
+    output_file: "{{ cifmw_basedir }}/artifacts/run_openstack_ldap_test_result.out"
+
+- name: Delete old file if existing
+  ansible.builtin.file:
+    path: "{{ output_file }}"
+    state: absent
+  ignore_errors: true  # noqa: ignore-errors
+
+- name: Create output file
+  ansible.builtin.file:
+    path: "{{ output_file }}"
+    mode: "u=rw,g=r,o=r"
+    state: touch
+
+- name: Get keystone route
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: keystone-public
+    namespace: "{{ cifmw_ipa_run_osp_cmd_namespace }}"
+  register: keystone_route
+
+- name: Wait for Keystone API to be avalable
+  ansible.builtin.uri:
+    url: "https://{{ keystone_route.resources.0.spec.host }}/v3"
+    follow_redirects: true
+    method: GET
+  register: _result
+  until: _result.status == 200
+  retries: 100
+  delay: 10
+
+- name: Read ipa test user1 cloudrc template
+  ansible.builtin.template:
+    src: ipauser1.j2
+    dest: "{{ ansible_user_dir }}/ci-framework-data/tmp/ipauser1"
+    mode: "0644"
+
+- name: Copy ipa test user1 cloudrc file into pod
+  kubernetes.core.k8s_cp:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    namespace: "{{ cifmw_ipa_run_osp_cmd_namespace }}"
+    pod: openstackclient
+    remote_path: "/home/cloud-admin/ipauser1"
+    local_path: "{{ ansible_user_dir }}/ci-framework-data/tmp/ipauser1"
+
+
+- name: RHELOSP-53684 - Security - List IPA ldap users
+  vars:
+    _osp_cmd: "openstack user list --domain REDHAT"
+  ansible.builtin.include_tasks: run_osp_cmd.yml
+
+- name: RHELOSP-53684 - Security - List IPA ldap users - success
+  ansible.builtin.lineinfile:
+    path: "{{ output_file }}"
+    line: "RHELOSP-53684=passed"
+  when: "'ipauser1' in ipa_run_osc_cmd.stdout and 'ipauser2' in ipa_run_osc_cmd.stdout and 'ipauser3' in ipa_run_osc_cmd.stdout"
+
+- name: RHELOSP-53684 - Security - List IPA ldap users - failed
+  ansible.builtin.lineinfile:
+    path: "{{ output_file }}"
+    line: "RHELOSP-53684=failed"
+  when: "'ipauser1' not in ipa_run_osc_cmd.stdout and 'ipauser2' not in ipa_run_osc_cmd.stdout and 'ipauser3' not in ipa_run_osc_cmd.stdout"
+
+- name: RHELOSP-53685 - Security - List IPA ldap groups
+  vars:
+    _osp_cmd: "openstack group list --domain REDHAT"
+  ansible.builtin.include_tasks: run_osp_cmd.yml
+
+- name: RHELOSP-53685 - Security - List IPA ldap groups - success
+  ansible.builtin.lineinfile:
+    path: "{{ output_file }}"
+    line: "RHELOSP-53685=passed"
+  when: "'grp-openstack' in ipa_run_osc_cmd.stdout and 'grp-openstack-admin' in ipa_run_osc_cmd.stdout and 'grp-openstack-demo' in ipa_run_osc_cmd.stdout"
+
+- name: RHELOSP-53685 - Security - List IPA ldap groups - failed
+  ansible.builtin.lineinfile:
+    path: "{{ output_file }}"
+    line: "RHELOSP-53685=failed"
+  when: "'grp-openstack' not in ipa_run_osc_cmd.stdout and 'grp-openstack-admin' not in ipa_run_osc_cmd.stdout and 'grp-openstack-demo' not in ipa_run_osc_cmd.stdout"
+
+- name: RHELOSP-53932 - Security - Check ipauser1 in ldap group grp-openstack-admin
+  vars:
+    _osp_cmd: "openstack group contains user --group-domain REDHAT --user-domain REDHAT grp-openstack-admin ipauser1"
+  ansible.builtin.include_tasks: run_osp_cmd.yml
+
+- name: RHELOSP-53932 - Security - Check ipauser1 in ldap group grp-openstack-admin - success
+  ansible.builtin.lineinfile:
+    path: "{{ output_file }}"
+    line: "RHELOSP-53932=passed"
+  when: "'ipauser1 in group grp-openstack-admin' in ipa_run_osc_cmd.stdout"
+
+- name: RHELOSP-53932 - Security - Check ipauser1 in ldap group grp-openstack-admin - failed
+  ansible.builtin.lineinfile:
+    path: "{{ output_file }}"
+    line: "RHELOSP-53932=failed"
+  when: "'ipauser1 in group grp-openstack-admin' not in ipa_run_osc_cmd.stdout"
+
+- name: RHELOSP-53933 - Security - Check ipauser2 in ldap group grp-openstack-demo
+  vars:
+    _osp_cmd: "openstack group contains user --group-domain REDHAT --user-domain REDHAT grp-openstack-demo ipauser2"
+  ansible.builtin.include_tasks: run_osp_cmd.yml
+
+- name: RHELOSP-53933 - Security - Check ipauser2 in ldap group grp-openstack-demo - success
+  ansible.builtin.lineinfile:
+    path: "{{ output_file }}"
+    line: "RHELOSP-53933=passed"
+  when: "'ipauser2 in group grp-openstack-demo' in ipa_run_osc_cmd.stdout"
+
+- name: RHELOSP-53933 - Security - Check ipauser2 in ldap group grp-openstack-demo - failed
+  ansible.builtin.lineinfile:
+    path: "{{ output_file }}"
+    line: "RHELOSP-53933=failed"
+  when: "'ipauser2 in group grp-openstack-demo' not in ipa_run_osc_cmd.stdout"
+
+- name: RHELOSP-53934 - Security - Check ipauser3 ldap in group grp-openstack
+  vars:
+    _osp_cmd: "openstack group contains user --group-domain REDHAT --user-domain REDHAT grp-openstack ipauser3"
+  ansible.builtin.include_tasks: run_osp_cmd.yml
+
+- name: RHELOSP-53934 - Security - Check ipauser3 in ldap group grp-openstack - success
+  ansible.builtin.lineinfile:
+    path: "{{ output_file }}"
+    line: "RHELOSP-53934=passed"
+  when: "'ipauser3 in group grp-openstack' in ipa_run_osc_cmd.stdout"
+
+- name: RHELOSP-53934 - Security - Check ipauser3 in ldap group grp-openstack - failed
+  ansible.builtin.lineinfile:
+    path: "{{ output_file }}"
+    line: "RHELOSP-53934=failed"
+  when: "'ipauser3 in group grp-openstack' not in ipa_run_osc_cmd.stdout"
+
+- name: Template get-token.sh script
+  ansible.builtin.template:
+    src: get-token.sh.j2
+    dest: "{{ ansible_user_dir }}/ci-framework-data/tmp/get-token.sh"
+    mode: "0755"
+
+- name: Copy get-token.sh script into openstackclient pod
+  kubernetes.core.k8s_cp:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    namespace: "{{ cifmw_ipa_run_osp_cmd_namespace }}"
+    pod: openstackclient
+    remote_path: "/home/cloud-admin/get-token.sh"
+    local_path: "{{ ansible_user_dir }}/ci-framework-data/tmp/get-token.sh"
+
+- name: RHELOSP-53935 - Security - Get token with ipauser1 user
+  vars:
+    _osp_cmd: "/home/cloud-admin/get-token.sh ipauser1"
+  ansible.builtin.include_tasks: run_osp_cmd.yml
+
+- name: RHELOSP-53935 - Security - Get token with ipauser1 user - success
+  ansible.builtin.lineinfile:
+    path: "{{ output_file }}"
+    line: "RHELOSP-53935=passed"
+  when: ipa_run_osc_cmd.stdout|length >= 180
+
+- name: RHELOSP-53935 - Security - Get token with ipauser1 user - failed
+  ansible.builtin.lineinfile:
+    path: "{{ output_file }}"
+    line: "RHELOSP-53935=failed"
+  when: ipa_run_osc_cmd.stdout|length < 180
+
+- name: Fail in case one of the above tests failed
+  ansible.builtin.command: "grep failed {{ output_file }}"
+  changed_when: false
+  register: grep_cmd
+  failed_when: grep_cmd.rc != 1

--- a/roles/ipa/tasks/run_openstack_setup.yml
+++ b/roles/ipa/tasks/run_openstack_setup.yml
@@ -1,0 +1,36 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Run create domain
+  vars:
+    _osp_cmd: "openstack domain create {{ cifmw_ipa_domain }}"
+  ansible.builtin.include_tasks: run_osp_cmd.yml
+
+- name: Restart keystone
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: >-
+      oc exec
+      -n {{ cifmw_ipa_run_osp_cmd_namespace }}
+      deploy/keystone
+      --
+      kill 1
+
+- name: Wait for a couple of seconds for keystone to start restarting
+  ansible.builtin.pause:
+    seconds: 10

--- a/roles/ipa/tasks/run_osp_cmd.yml
+++ b/roles/ipa/tasks/run_osp_cmd.yml
@@ -1,0 +1,30 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Run OpenStack Command
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: >-
+      oc exec
+      -n {{ cifmw_ipa_run_osp_cmd_namespace }}
+      -t openstackclient
+      --
+      {{ _osp_cmd }}
+  register: ipa_run_osc_cmd
+  retries: 10
+  delay: 10

--- a/roles/ipa/templates/get-token.sh.j2
+++ b/roles/ipa/templates/get-token.sh.j2
@@ -1,0 +1,3 @@
+#!/bin/bash
+source /home/cloud-admin/$1
+openstack token issue -c id -f value

--- a/roles/ipa/templates/ipa.yaml.j2
+++ b/roles/ipa/templates/ipa.yaml.j2
@@ -1,0 +1,20 @@
+---
+apiVersion: idmocp.redhat.com/v1alpha1
+kind: IDM
+metadata:
+  name: idm
+spec:
+  # Add fields here
+  # Update this value for your cluster ingress
+  # host: this-is.64-char-length-12345678-freeipa-invalid.apps-crc.testing
+  # host: this-is.65-char-length-123456789-freeipa-invalid.apps-crc.testing
+  # host: ipa.apps-crc.testing
+  realm: EXAMPLE.TESTING
+  passwordSecret: idm-secret
+  resources:
+    requests:
+      cpu: "2000m"
+      memory: "3Gi"
+    limits:
+      cpu: "3000m"
+      memory: "4Gi"

--- a/roles/ipa/templates/ipauser1.j2
+++ b/roles/ipa/templates/ipauser1.j2
@@ -1,0 +1,6 @@
+unset OS_CLOUD
+export OS_IDENTITY_API_VERSION=3
+export OS_AUTH_URL="https://{{ keystone_route.resources.0.spec.host }}/v3"
+export OS_USER_DOMAIN_NAME="{{ cifmw_ipa_domain }}"
+export OS_USERNAME=ipauser1
+export OS_PASSWORD="{{ cifmw_ipa_user_password }}"


### PR DESCRIPTION
Add IPA role to ci-framework. The role is used to set up IPA using the FreeIPA opeator and then test configuring LDAP with domain-specific drivers.