### PR TITLE
Force dump admin password as a string

### DIFF
--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -284,7 +284,7 @@ cifmw_test_operator_horizontest_config:
     privileged: "{{ cifmw_test_operator_privileged }}"
     containerImage: "{{ stage_vars_dict.cifmw_test_operator_horizontest_image }}:{{ stage_vars_dict.cifmw_test_operator_horizontest_image_tag }}"
     adminUsername: "{{ stage_vars_dict.cifmw_test_operator_horizontest_admin_username }}"
-    adminPassword: "{{ stage_vars_dict.cifmw_test_operator_horizontest_admin_password }}"
+    adminPassword: "{{ stage_vars_dict.cifmw_test_operator_horizontest_admin_password | string }}"
     dashboardUrl: "{{ stage_vars_dict.cifmw_test_operator_horizontest_dashboard_url }}"
     authUrl: "{{ stage_vars_dict.cifmw_test_operator_horizontest_auth_url }}"
     repoUrl: "{{ stage_vars_dict.cifmw_test_operator_horizontest_repo_url }}"


### PR DESCRIPTION
If the password is just based on numbers, after we enabled jinja2_native [1], it is parsed to a integer not a string.

[1] https://github.com/openstack-k8s-operators/ci-framework/commit/d8f86c86284c1447f66ae3a0d8354d9bfea03ca3