### PR TITLE
Allow skiping edpm log gathering

### DIFF
--- a/roles/artifacts/README.md
+++ b/roles/artifacts/README.md
@@ -12,6 +12,7 @@ None - writes happen only in the user home.
 * `cifmw_artifacts_crc_sshkey`: (String) Path to the private SSH key to connect to CRC. Defaults to `~/.crc/machines/crc/id_ecdsa`.
 * `cifmw_artifacts_crc_sshkey_ed25519`: (String) Path to the private SSH key to connect to CRC (newer CRC images). Defaults to `~/.crc/machines/crc/id_ed25519`.
 * `cifmw_artifacts_gather_logs`: (Boolean) Enables must-gather logs fetching. Defaults to `true`
+* `cifmw_artifacts_gather_edpm_logs`: (Boolean) Enables edpm logs fetching. Defaults to `true`
 
 ## Examples
 Usually we'll import the role as-is at the very start of the playbook, and

--- a/roles/artifacts/tasks/main.yml
+++ b/roles/artifacts/tasks/main.yml
@@ -72,6 +72,8 @@
   ansible.builtin.import_tasks: crc.yml
 
 - name: Get EDPM logs
+  when:
+    - cifmw_artifacts_gather_edpm_logs | default(true) | bool
   ignore_errors: true  # noqa: ignore-errors
   ansible.builtin.import_tasks: edpm.yml
 


### PR DESCRIPTION
Add a var to allow skipping compute/edpm logs which might be too big in certain cases and cause failures with zuul