### PR TITLE
Add become for log delete

### DIFF
--- a/clean_openstack_deployment.yaml
+++ b/clean_openstack_deployment.yaml
@@ -15,3 +15,4 @@
       loop:
         - "/home/zuul/ci-framework-data/logs"
         - "/home/zuul/ci-framework-data/tests"
+      become: true


### PR DESCRIPTION
In certain usecases some log files are generated by other tools and might have unexpected permissions set to them added become to avoid issues related in permissions