### PR TITLE
Reboot controller-0 to avoid running deployments

### DIFF
--- a/deploy-edpm-reuse.yaml
+++ b/deploy-edpm-reuse.yaml
@@ -2,6 +2,20 @@
 - name: Manage unique ID
   ansible.builtin.import_playbook: playbooks/unique-id.yml
 
+- name: Reboot controller-0 to make sure there are no running deployments
+  hosts: controller-0
+  gather_facts: false
+  tasks:
+    - name: Reboot controller-0
+      ansible.builtin.reboot:
+        reboot_timeout: 600
+      become: true
+
+    - name: Wait for controller-0 to come back online
+      ansible.builtin.wait_for_connection:
+        timeout: 600
+        delay: 10
+
 - name: Reproducer prepare play
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: true


### PR DESCRIPTION
Because deploy architecture runs detached from the zuul job and might run other playbooks in a detached way we need to make sure there are no leftover running deployments that might break the cleanup (trying to create additional resources while the cleanup is running). Added a reboot for controller-0 before cleanup to avoid such cases.