### PR TITLE
Add multus bridge attach to

### DIFF
--- a/plugins/module_utils/net_map/networking_definition.py
+++ b/plugins/module_utils/net_map/networking_definition.py
@@ -1045,6 +1045,7 @@ class SubnetBasedNetworkToolDefinition:
     __FIELD_ROUTES_IPV4 = "routes-v4"
     __FIELD_ROUTES_IPV6 = "routes-v6"
     __FIELD_TYPE = "type"
+    __FIELD_ATTACH = "attach"
 
     def __init__(
         self,
@@ -1069,6 +1070,7 @@ class SubnetBasedNetworkToolDefinition:
         self.__ipv4_routes: typing.List[HostNetworkRoute] = []
         self.__ipv6_routes: typing.List[HostNetworkRoute] = []
         self.__type: typing.Optional[str] = None
+        self.__attach: typing.Optional[str] = None
 
         self.__parse_raw(raw_config)
 
@@ -1093,10 +1095,16 @@ class SubnetBasedNetworkToolDefinition:
             parent_name=self.__object_name,
             alone_field=self.__FIELD_ROUTES,
         )
-
         _validate_fields_one_of(
             [
                 self.__FIELD_TYPE,
+            ],
+            raw_definition,
+            parent_name=self.__object_name,
+        )
+        _validate_fields_one_of(
+            [
+                self.__FIELD_ATTACH,
             ],
             raw_definition,
             parent_name=self.__object_name,
@@ -1117,6 +1125,7 @@ class SubnetBasedNetworkToolDefinition:
             raw_definition, self.__FIELD_ROUTES_IPV6, ip_version=6
         )
         self.__parse_raw_type_field(raw_definition, self.__FIELD_TYPE)
+        self.__parse_raw_type_attach(raw_definition, self.__FIELD_ATTACH)
 
     def __parse_raw_range_field(
         self,
@@ -1214,6 +1223,21 @@ class SubnetBasedNetworkToolDefinition:
                 parent_name=self.__object_name,
             )
             self.__type = type
+
+    @property
+    def attach(self) -> str:
+        """Where to attach the multus bridge"""
+        return self.__attach
+
+    def __parse_raw_type_attach(self, raw_definition, field_name: str):
+        if field_name in raw_definition:
+            attach = _validate_parse_field_type(
+                field_name,
+                raw_definition,
+                str,
+                parent_name=self.__object_name,
+            )
+            self.__attach = attach
 
 
 class MultusNetworkDefinition(SubnetBasedNetworkToolDefinition):

--- a/plugins/module_utils/net_map/networking_env_definitions.py
+++ b/plugins/module_utils/net_map/networking_env_definitions.py
@@ -137,6 +137,7 @@ class MappedMultusNetworkConfig:
         ipv4_routes: IPv4 routes assigned to Multus.
         ipv6_routes: IPv6 routes assigned to Multus.
         multus_type: The type of the multus network.
+        multus_attach: The type of the multus network.
 
     """
 
@@ -145,6 +146,7 @@ class MappedMultusNetworkConfig:
     ipv4_routes: typing.List[MappedIpv4NetworkRoute]
     ipv6_routes: typing.List[MappedIpv6NetworkRoute]
     multus_type: typing.Optional[str] = None
+    multus_attach: typing.Optional[str] = None
 
 
 @dataclasses.dataclass(frozen=True)

--- a/plugins/module_utils/net_map/networking_mapper.py
+++ b/plugins/module_utils/net_map/networking_mapper.py
@@ -679,14 +679,16 @@ class NetworkingNetworksMapper:
             ],
         ]
         multus_type = []
+        multus_attach = []
         if tool_type.__name__ == "MappedMultusNetworkConfig":
             multus_type.append(tool_net_def.type)
+            multus_attach.append(tool_net_def.attach)
 
         if any(
             route_field in tool_type.__dataclass_fields__
             for route_field in ["ipv4_routes", "ipv6_routes"]
         ):
-            args_list = args_list + route_args_list + multus_type
+            args_list = args_list + route_args_list + multus_type + multus_attach
         return tool_type(*args_list)
 
 

--- a/roles/ci_multus/README.md
+++ b/roles/ci_multus/README.md
@@ -11,6 +11,7 @@ Creates additional networks in a OCP cluster using NetworkAttachmentDefinition
 * `cifmw_ci_multus_ocp_hostname`: (String) The OCP inventory hostname. Used to gather network information specific to those nodes, mostly the interfaces. Defaults to `crc`.
 * `cifmw_ci_multus_cniversion`: (String) The CNI specification version used when creating the resource. Defaults to `0.3.1`.
 * `cifmw_ci_multus_default_nad_type`: (String) Default NAD type used when not specified by the network configuration. Defaults to `macvlan`. You can select the type of each NAD by "multus_type"
+* `cifmw_ci_multus_default_bridge_attach`: (String) Set place to attach the bridge when NAD type is bridge. Defaults to `interface`. You can select the place to attach it by "multus_attach".
 * `cifmw_ci_multus_default_nad_ipam_type`: (String) Default NAD IPAM type to be used when not specified by the network configuration. Defaults to `whereabouts`.
 * `cifmw_ci_multus_default_nad_ipam_type_ip_version``: (String) Default IP version to use in IPAM config. Defaults to `v4`.
 * `cifmw_ci_multus_dryrun`: (Bool) When enabled, tasks that require an OCP environment are skipped. Defaults to `false`.
@@ -37,6 +38,7 @@ cifmw_ci_multus_net_info_patch_1:
           - start: 192.168.122.30
             end: 192.168.122.70
         type: bridge
+        attach: linux-bridge
 ```
 
 ## Limitations

--- a/roles/ci_multus/defaults/main.yml
+++ b/roles/ci_multus/defaults/main.yml
@@ -24,6 +24,7 @@ cifmw_ci_multus_namespace: "openstack"
 cifmw_ci_multus_ocp_hostname: "crc"
 cifmw_ci_multus_cniversion: "0.3.1"
 cifmw_ci_multus_default_nad_type: "macvlan"
+cifmw_ci_multus_default_bridge_attach: "interface"
 cifmw_ci_multus_default_nad_ipam_type: "whereabouts"
 cifmw_ci_multus_default_nad_ipam_type_ip_version: "v4"
 # Input configuration for ci_multus role

--- a/roles/ci_multus/molecule/default/molecule.yml
+++ b/roles/ci_multus/molecule/default/molecule.yml
@@ -15,6 +15,7 @@ provisioner:
         _expected_multus_networks:
           - default
           - patchnetwork
+          - bridge-to-linux-bridge
         cifmw_ci_multus_net_info_patch_1:
           patchnetwork:
             gw_v4: 192.168.122.1
@@ -27,6 +28,19 @@ provisioner:
                   - start: 192.168.122.30
                     end: 192.168.122.70
                 multus_type: macvlan
+        cifmw_ci_multus_net_info_patch_2:
+          bridge-to-linux-bridge:
+            gw_v4: 192.168.122.1
+            network_name: bridge-to-linux-bridge
+            network_v4: 192.168.122.0/24
+            interface_name: eth1
+            tools:
+              multus:
+                ipv4_ranges:
+                  - start: 192.168.122.30
+                    end: 192.168.122.70
+                multus_type: bridge
+                multus_attach: linux-bridge
 
         cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
         cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"

--- a/roles/ci_multus/molecule/default/nads_output.yml
+++ b/roles/ci_multus/molecule/default/nads_output.yml
@@ -3,6 +3,28 @@ apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
 metadata:
   labels:
+    osp/net: bridge-to-linux-bridge
+  name: bridge-to-linux-bridge
+  namespace: openstack
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "bridge-to-linux-bridge",
+      "type": "bridge",
+      "bridge": "bridge-to-linux-bridge",
+      "ipam": {
+        "type": "whereabouts",
+        "range": "192.168.122.0/24",
+        "range_start": "192.168.122.30",
+        "range_end": "192.168.122.70"
+      }
+    }
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  labels:
     osp/net: default
   name: default
   namespace: openstack

--- a/roles/ci_multus/molecule/default/verify_crc.yml
+++ b/roles/ci_multus/molecule/default/verify_crc.yml
@@ -17,6 +17,8 @@
 - name: Verify CRC
   hosts: all
   gather_facts: true
+  vars:
+    _ci_multus_expected_spec: "{{ lookup('file', 'nads_output.yml', rstrip=True) | from_yaml_all | map(attribute='spec.config') }}"
   tasks:
     - name: Include default vars
       ansible.builtin.include_vars:
@@ -43,11 +45,16 @@
             map(attribute='spec.config')
           }}
 
-    - name: Assert expected Network Attachment Definitions content spec with the expected
-      vars:
-        _ci_multus_expected_spec: "{{ lookup('file', 'nads_output.yml', rstrip=True) | from_yaml_all | map(attribute='spec.config') }}"
+    - name: Ensure both lists have the same length
       ansible.builtin.assert:
-        that: _ci_multus_out_spec  == _ci_multus_expected_spec
+        that:
+          - _ci_multus_out_spec | length == _ci_multus_expected_spec | length
+
+    - name: Compare each corresponding element in the lists
+      ansible.builtin.assert:
+        that:
+          - (item.0 | replace('\n', '')) == (item.1 | replace('\n', ''))
+      loop: "{{ _ci_multus_out_spec | zip(_ci_multus_expected_spec) | list }}"
 
     - name: Create a test pod to attach a network
       kubernetes.core.k8s:

--- a/roles/ci_multus/molecule/resources/vars/shared_vars.yml
+++ b/roles/ci_multus/molecule/resources/vars/shared_vars.yml
@@ -63,3 +63,4 @@ cifmw_ci_multus_deny_list:
 cifmw_ci_multus_allow_list:
   - default
   - patchnetwork
+  - bridge-to-linux-bridge

--- a/roles/ci_multus/templates/nad.yml.j2
+++ b/roles/ci_multus/templates/nad.yml.j2
@@ -4,6 +4,11 @@
 {% else %}
 {% set multus_type = cifmw_ci_multus_default_nad_type %}
 {% endif %}
+{% if network_details.tools.get('multus', {}).get('multus_attach', None) %}
+{% set multus_attach = network_details.tools.multus.multus_attach %}
+{% else %}
+{% set multus_attach = cifmw_ci_multus_default_bridge_attach %}
+{% endif %}
 ---
 apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
@@ -22,7 +27,11 @@ spec:
       "master": "{{ network_details.interface_name }}",
 {% endif %}
 {% if multus_type == "bridge" %}
+{% if multus_attach == "interface" %}
       "bridge": "{{ network_details.interface_name }}",
+{% elif multus_attach == "linux-bridge" %}
+      "bridge": "{{ network_name }}",
+{% endif %}
 {% endif %}
       "ipam": {
         "type": "{{ cifmw_ci_multus_default_nad_ipam_type }}",

--- a/roles/networking_mapper/molecule/default/converge.yml
+++ b/roles/networking_mapper/molecule/default/converge.yml
@@ -192,3 +192,4 @@
         that:
           - "_content.networks['internalapi'].vlan_id == 100"
           - "_content.networks['internalapi'].tools.multus.multus_type == 'bridge'"
+          - "_content.networks['internalapi'].tools.multus.multus_attach == 'linux-bridge'"

--- a/roles/networking_mapper/molecule/default/vars/input.yml
+++ b/roles/networking_mapper/molecule/default/vars/input.yml
@@ -40,6 +40,7 @@ networks:
           - start: 50
             end: 59
         type: "bridge"
+        attach: "linux-bridge"
   storage:
     network: "172.18.0.0/24"
     vlan: 21

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-full-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-full-map-out.json
@@ -90,7 +90,8 @@
             }
           ],
           "ipv6_routes": [],
-          "multus_type": "bridge"
+          "multus_type": "bridge",
+          "multus_attach": "linux-bridge"
         },
         "netconfig": {
           "ipv4_ranges": [

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-networks-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-networks-out.json
@@ -89,7 +89,8 @@
           }
         ],
         "ipv6_routes": [],
-        "multus_type": "bridge"
+        "multus_type": "bridge",
+        "multus_attach": "linux-bridge"
       },
       "netconfig": {
         "ipv4_ranges": [

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-partial-map-out.json
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools-partial-map-out.json
@@ -90,7 +90,8 @@
             }
           ],
           "ipv6_routes": [],
-          "multus_type": "bridge"
+          "multus_type": "bridge",
+          "multus_attach": "linux-bridge"
         },
         "netconfig": {
           "ipv4_ranges": [

--- a/tests/unit/module_utils/test_files/networking-definition-valid-all-tools.yml
+++ b/tests/unit/module_utils/test_files/networking-definition-valid-all-tools.yml
@@ -28,6 +28,7 @@ networks:
           - start: 30
             end: 39
         type: bridge
+        attach: linux-bridge
         routes:
           - destination: "192.168.121.0/24"
             gateway: "192.168.122.1"


### PR DESCRIPTION
We're adding a new variable attach at the networking_mapper to map its value
to the output variable multus_attach.
This is used then to generate NAD with information about where to attach
the multus type bridge, if in a interface or a linux-bridge.