### PR TITLE
Update labels related to nodesets with rhel

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -7,7 +7,7 @@
     abstract: true
     timeout: 14400
     attempts: 1
-    nodeset: centos-9-rhel-9-2-crc-cloud-ocp-4-18-1-3xl
+    nodeset: centos-9-rhel-9-5-crc-cloud-ocp-4-18-1-3xl
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run:
@@ -203,7 +203,7 @@
     abstract: true
     timeout: 14400
     attempts: 1
-    nodeset: centos-9-multinode-rhel-9-2-crc-cloud-ocp-4-18-1-3xl
+    nodeset: centos-9-multinode-rhel-9-5-crc-cloud-ocp-4-18-1-3xl
     roles: &multinode-roles
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run: &multinode-prerun
@@ -413,7 +413,7 @@
     voting: false
     timeout: 14400
     attempts: 1
-    nodeset: centos-9-multinode-rhel-9-2-crc-cloud-ocp-4-18-1-3xl-novacells
+    nodeset: centos-9-multinode-rhel-9-5-crc-cloud-ocp-4-18-1-3xl-novacells
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run: *multinode-prerun

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -94,14 +94,14 @@
         label: centos-9-stream-crc-2-39-0-xxl
 
 - nodeset:
-    name: centos-9-rhel-9-2-crc-extracted-2-39-0-3xl
+    name: centos-9-rhel-9-5-crc-extracted-2-39-0-3xl
     nodes:
       - name: controller
         label: cloud-centos-9-stream-tripleo
       - name: crc
         label: coreos-crc-extracted-2-39-0-3xl
       - name: standalone
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
     groups:
       - name: computes
         nodes: []
@@ -113,26 +113,26 @@
           - standalone
 
 - nodeset:
-    name: centos-9-multinode-rhel-9-2-crc-extracted-2-39-0-3xl
+    name: centos-9-multinode-rhel-9-5-crc-extracted-2-39-0-3xl
     nodes:
       - name: controller
         label: cloud-centos-9-stream-tripleo
       - name: crc
         label: coreos-crc-extracted-2-39-0-3xl
       - name: undercloud
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
       - name: overcloud-controller-0
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
       - name: overcloud-controller-1
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
       - name: overcloud-controller-2
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
       - name: overcloud-novacompute-0
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
       - name: overcloud-novacompute-1
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
       - name: overcloud-novacompute-2
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
     groups:
       - name: computes
         nodes: []
@@ -160,22 +160,22 @@
           - overcloud-novacompute-2
 
 - nodeset:
-    name: centos-9-multinode-rhel-9-2-crc-extracted-2-39-0-3xl-novacells
+    name: centos-9-multinode-rhel-9-5-crc-extracted-2-39-0-3xl-novacells
     nodes:
       - name: controller
         label: cloud-centos-9-stream-tripleo
       - name: crc
         label: coreos-crc-extracted-2-39-0-3xl
       - name: undercloud
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
       - name: overcloud-controller-0
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
       - name: cell1-controller-0
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
       - name: cell1-compute-0
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
       - name: cell2-controller-compute-0
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
     groups:
       - name: computes
         nodes: []
@@ -428,14 +428,14 @@
           - crc
 
 - nodeset:
-    name: centos-9-rhel-9-2-crc-cloud-ocp-4-18-1-3xl
+    name: centos-9-rhel-9-5-crc-cloud-ocp-4-18-1-3xl
     nodes:
       - name: controller
         label: cloud-centos-9-stream-tripleo
       - name: crc
         label: crc-cloud-ocp-4-18-1-3xl
       - name: standalone
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
     groups:
       - name: computes
         nodes: []
@@ -447,26 +447,26 @@
           - standalone
 
 - nodeset:
-    name: centos-9-multinode-rhel-9-2-crc-cloud-ocp-4-18-1-3xl
+    name: centos-9-multinode-rhel-9-5-crc-cloud-ocp-4-18-1-3xl
     nodes:
       - name: controller
         label: cloud-centos-9-stream-tripleo
       - name: crc
         label: crc-cloud-ocp-4-18-1-3xl
       - name: undercloud
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
       - name: overcloud-controller-0
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
       - name: overcloud-controller-1
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
       - name: overcloud-controller-2
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
       - name: overcloud-novacompute-0
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
       - name: overcloud-novacompute-1
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
       - name: overcloud-novacompute-2
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
     groups:
       - name: computes
         nodes: []
@@ -494,22 +494,22 @@
           - overcloud-novacompute-2
 
 - nodeset:
-    name: centos-9-multinode-rhel-9-2-crc-cloud-ocp-4-18-1-3xl-novacells
+    name: centos-9-multinode-rhel-9-5-crc-cloud-ocp-4-18-1-3xl-novacells
     nodes:
       - name: controller
         label: cloud-centos-9-stream-tripleo
       - name: crc
         label: crc-cloud-ocp-4-18-1-3xl
       - name: undercloud
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
       - name: overcloud-controller-0
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
       - name: cell1-controller-0
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
       - name: cell1-compute-0
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
       - name: cell2-controller-compute-0
-        label: cloud-rhel-9-2-tripleo
+        label: cloud-rhel-9-5
     groups:
       - name: computes
         nodes: []


### PR DESCRIPTION
Some CI jobs when using multiple nodes, some VMs are running on RHEL 9.2, where it should been using newer version.