### PR TITLE
Use modules for enabling rhel subscription

### DIFF
--- a/roles/adoption_osp_deploy/tasks/login_registries.yml
+++ b/roles/adoption_osp_deploy/tasks/login_registries.yml
@@ -20,10 +20,12 @@
     - cifmw_adoption_osp_deploy_rhsm_key is defined
   become: true
   no_log: true
-  ansible.builtin.command: >-
-    subscription-manager register --force
-    --org "{{ cifmw_adoption_osp_deploy_rhsm_org }}"
-    --activationkey "{{ cifmw_adoption_osp_deploy_rhsm_key }}"
+  community.general.redhat_subscription:
+    activationkey: "{{ cifmw_adoption_osp_deploy_rhsm_key }}"
+    org_id: "{{ cifmw_adoption_osp_deploy_rhsm_org }}"
+    release: "{{ ansible_distribution_version }}"
+    force_register: true
+    state: present
 
 - name: Login in container registry
   when:

--- a/roles/adoption_osp_deploy/tasks/prepare_overcloud.yml
+++ b/roles/adoption_osp_deploy/tasks/prepare_overcloud.yml
@@ -113,8 +113,9 @@
     - name: Ensure repos are setup in overcloud nodes
       delegate_to: "{{ _vm }}"
       become: true
-      ansible.builtin.command:
-        cmd: "subscription-manager repos --enable {{ cifmw_adoption_osp_deploy_repos | join(' --enable ') }}"
+      community.general.rhsm_repository:
+        name: "{{ cifmw_adoption_osp_deploy_repos }}"
+        state: enabled
       loop: "{{ _tripleo_nodes_stack }}"
       loop_control:
         loop_var: _vm

--- a/roles/adoption_osp_deploy/tasks/prepare_undercloud.yml
+++ b/roles/adoption_osp_deploy/tasks/prepare_undercloud.yml
@@ -25,8 +25,9 @@
 
     - name: Ensure repos are setup
       become: true
-      ansible.builtin.command:
-        cmd: "subscription-manager repos --enable {{ cifmw_adoption_osp_deploy_repos | join(' --enable ') }}"
+      community.general.rhsm_repository:
+        name: "{{ cifmw_adoption_osp_deploy_repos }}"
+        state: enabled
 
     - name: Install director packages
       become: true


### PR DESCRIPTION
We should start using Ansible modules instead of executing commands via command/shell module. Dedicated modules might handle in better way that operation.