### PR TITLE
ci_dcn_site: Set cross_az_attach at nova-api

### DIFF
--- a/roles/ci_dcn_site/templates/service-values.yaml.j2
+++ b/roles/ci_dcn_site/templates/service-values.yaml.j2
@@ -163,6 +163,8 @@ data:
       customServiceConfig: |
         [DEFAULT]
         default_schedule_zone=az0
+        [cinder]
+        cross_az_attach=False
       metadataServiceTemplate:
         enabled: false
       cellTemplates:


### PR DESCRIPTION
We set the cross_az_attach to False at the
nova compute level and we should set it at
the nova api level too.