### PR TITLE
Use transparent vlan in ci bootstrap

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -48,6 +48,7 @@
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: ""
+            transparent: true
             range: 192.168.122.0/24
           internal-api:
             vlan: 20
@@ -222,6 +223,7 @@
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: ""
+            transparent: true
             range: 192.168.122.0/24
           internal-api:
             vlan: 20

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -166,6 +166,7 @@
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: ""
+            transparent: true
             range: 192.168.122.0/24
           internal-api:
             vlan: 20

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -13,6 +13,7 @@
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: ""
+            transparent: true
             range: 192.168.122.0/24
           internal-api:
             vlan: 20
@@ -76,6 +77,7 @@
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: ""
+            transparent: true
             range: 192.168.122.0/24
           internal-api:
             vlan: 20
@@ -153,6 +155,7 @@
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: ""
+            transparent: true
             range: 192.168.122.0/24
           internal-api:
             vlan: 20
@@ -245,6 +248,7 @@
           default:
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: ""
+            transparent: true
             range: 192.168.122.0/24
           internal-api:
             vlan: 20

--- a/zuul.d/kuttl_multinode.yaml
+++ b/zuul.d/kuttl_multinode.yaml
@@ -15,6 +15,7 @@
             range: 192.168.122.0/24
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: ""
+            transparent: true
             router: false
           internal-api:
             vlan: 20

--- a/zuul.d/podified_multinode.yaml
+++ b/zuul.d/podified_multinode.yaml
@@ -23,6 +23,7 @@
             range: 192.168.122.0/24
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: ""
+            transparent: true
           internal-api:
             vlan: 20
             range: 172.17.0.0/24

--- a/zuul.d/tempest_multinode.yaml
+++ b/zuul.d/tempest_multinode.yaml
@@ -23,6 +23,7 @@
             range: 192.168.122.0/24
             mtu: "{{ ('ibm' in nodepool.cloud) | ternary('1440', '1500') }}"
             router_net: ""
+            transparent: true
           internal-api:
             vlan: 20
             range: 172.17.0.0/24


### PR DESCRIPTION
Use transparent vlan in ci bootstrap

vexxhost and IBM cloud both have transparent vlan enabled now,
so let's use it. This will avoid creation and deletion of all vlan
and trunk ports.
Also will avoid env breakage due to cleanup of ports for autohold nodes.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3065
Depends-On: https://review.rdoproject.org/r/c/config/+/57549
Depends-On: https://review.rdoproject.org/r/c/config/+/57614

_This move crc_ci_bootstrap_instance_default_net_config.transparent to avoid creating VLANs ports and attach to trunk, update interface data to be used configuring back_
Depends-On: https://review.rdoproject.org/r/c/config/+/57840

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1499
Related-Issue: [OSPCIX-771](https://issues.redhat.com//browse/OSPCIX-771)