### PR TITLE
Revert "Add reporting for playbook testing"

### DIFF
--- a/roles/validations/tasks/security/invoke_tlse_playbooks.yml
+++ b/roles/validations/tasks/security/invoke_tlse_playbooks.yml
@@ -9,4 +9,3 @@
       cd "{{ ansible_user_dir }}/src/gitlab.cee.redhat.com/OSP-DFG-security/automation"
       ansible-playbook -vv playbooks/renew_internal_cert_outer.yml || echo "renew_internal_cert_outer failed, continuing..."
       ansible-playbook -vv playbooks/data_plane_cert_testing_with_delete.yml
-      ansible-playbook -vv playbooks/get_test_results_of_playbook_tests.yml


### PR DESCRIPTION
This reverts commit 38e58336d35e3aba7cd577ea05127a87d15ec2ca. which is causing a CIX failure.

Jira: [OSPCIX-861](https://issues.redhat.com//browse/OSPCIX-861)