### PR TITLE
Reduce retry count for iscsi login

### DIFF
--- a/hooks/playbooks/compute-iscsi-config.yml
+++ b/hooks/playbooks/compute-iscsi-config.yml
@@ -9,7 +9,7 @@
         path: /etc/iscsi/iscsid.conf
         line: "{{ item }}"
       loop:
-        - 'node.session.initial_login_retry_max = 3'
+        - 'node.session.initial_login_retry_max = 1'
         - 'node.conn[0].timeo.login_timeout = 5'
 
     - name: Restart iscsid container to refresh /etcd/iscsid.conf


### PR DESCRIPTION
In a previous PR, we added custom login timeout values in the iscsid.conf file[1].
However, even with reduced values (from 120 seconds to 15 seconds), we still see failures in CI jobs due to timeout.

To further improve the situation, we can set the retry count to 1 making the wait time 5 seconds which should be sufficient to pass the tempest wait threshold (and we shouldn't really need to retry in jobs anyway).

CIX: https://issues.redhat.com/browse/OSPCIX-805

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/2060