### PR TITLE
Added cs10 nodeset needed for meta content provider 

### DIFF
--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -60,6 +60,21 @@
           - crc
 
 #
+#  CentOS Stream 10 nodeset
+#
+- nodeset:
+    name: centos-stream-10-vexxhost
+    nodes:
+      - name: controller
+        label: cloud-centos-10-stream-tripleo-vexxhost
+    groups:
+      - name: switch
+        nodes:
+          - controller
+      - name: peers
+        nodes: []
+
+#
 # CRC-2.30 (OCP4.14) nodesets
 #
 
@@ -578,7 +593,6 @@
       - name: ocps
         nodes:
           - crc
-
 
 # todo: Remove. Temporal. Needed as the credentials used in ci-bootstrap jobs for IBM don't work
 - nodeset:


### PR DESCRIPTION
For meta content provider, centos-stream-10-vexxhost is needed.

This pr adds the required nodeset in order to consume it with
cs10 jobs.

Resolves: [OSPRH-16773](https://issues.redhat.com//browse/OSPRH-16773)