### PR TITLE
Stop test-operator pod when ImagePullError

### DIFF
--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -19,6 +19,7 @@
 # All variables within this role should have a prefix of "cifmw_test_operator"
 
 # Section 1: generic parameters (applied to all supported test frameworks)
+tune_kubelet_conf: true
 cifmw_test_operator_stages:
   - name: tempest
     type: tempest

--- a/roles/test_operator/tasks/run-test-operator-job.yml
+++ b/roles/test_operator/tasks/run-test-operator-job.yml
@@ -42,6 +42,10 @@
         dest: "{{ cifmw_test_operator_crs_path }}/{{ test_operator_instance_name }}.yaml"
         mode: '0644'
 
+    - name: Record start time of the pod
+      ansible.builtin.set_fact:
+        pod_start_time: "{{ lookup('pipe', 'date +%s') | int }}"
+
     - name: Start tests - {{ run_test_fw }}
       kubernetes.core.k8s:
         kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
@@ -65,9 +69,31 @@
       delay: 10
       until: >
         testpod.resources[0].status.phase | default(omit) == "Succeeded" or
-        testpod.resources[0].status.phase | default(omit) == "Failed"
+        testpod.resources[0].status.phase | default(omit) == "Failed" or
+        (
+          (lookup('pipe', 'date +%s') | int) > (pod_start_time + 600) and
+          (
+            testpod.resources[0].status.containerStatuses | default([]) |
+            selectattr('state.waiting.reason', 'defined') |
+            selectattr('state.waiting.reason', 'in', ['ImagePullBackOff', 'ErrImagePull']) |
+            list | length > 0
+          )
+        )
       ignore_errors: true
       register: testpod
+
+    - name: Check whether image pull error - {{ run_test_fw }}
+      ansible.builtin.set_fact:
+        testpod_image_error: >-
+          {{
+            (testpod.resources[0].status.phase not in ['Succeeded', 'Failed']) and
+            (
+              testpod.resources[0].status.containerStatuses | default([]) |
+              selectattr('state.waiting.reason', 'defined') |
+              selectattr('state.waiting.reason', 'in', ['ImagePullBackOff', 'ErrImagePull']) |
+              list | length > 0
+            )
+          }}
 
     - name: Check whether timed out - {{ run_test_fw }}
       ansible.builtin.set_fact:


### PR DESCRIPTION
When encountering ImagePullError in the test-operator role, the pod would be stuck in that state for a longer period of time. This patch aims to stop the pod, if the waiting reason is ImagePullError to report the issue faster.