### PR TITLE
Increase timeout for integration tests

### DIFF
--- a/tests/integration/targets/make/files/get_makefiles_env/expected_variables_values.yml
+++ b/tests/integration/targets/make/files/get_makefiles_env/expected_variables_values.yml
@@ -259,4 +259,4 @@ variables:
   TELEMETRY_CR: "/home/test-user/out/operator/telemetry-operator/config/samples/telemetry_v1beta1_telemetry.yaml"
   TELEMETRY_IMG: "quay.io/openstack-k8s-operators/telemetry-operator-index:latest"
   TELEMETRY_REPO: "https://github.com/openstack-k8s-operators/telemetry-operator.git"
-  TIMEOUT: "300s"
+  TIMEOUT: "600s"

--- a/tests/integration/targets/make/files/get_makefiles_env/makefiles/Makefile
+++ b/tests/integration/targets/make/files/get_makefiles_env/makefiles/Makefile
@@ -6,7 +6,7 @@ NAMESPACE                ?= openstack
 PASSWORD                 ?= 12345678
 SECRET                   ?= osp-secret
 OUT                      ?= ${PWD}/out
-TIMEOUT                  ?= 300s
+TIMEOUT                  ?= 600s
 DBSERVICE           ?= galera
 ifeq ($(DBSERVICE), galera)
 DBSERVICE_CONTAINER = openstack-galera-0


### PR DESCRIPTION
On some infras, sometimes there is a proxy error and the pods can not start properly because it can not pull images, so the CI job fails and in the log file, there is information:

    oc wait openstack/openstack -n openstack-operators --for condition=Ready --timeout=300s
    error: timed out waiting for the condition on openstacks/openstack
    make[1]: *** [Makefile:760: openstack_init] Error 1

Increase timeout twice to avoid potential errors and give some time for proxy and kubernetes to recover and retry pull image.