### PR TITLE
Fix ansible.posix requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -17,7 +17,7 @@
 collections:
   - name: https://github.com/ansible-collections/ansible.posix
     type: git
-    version: "v2.0.0"
+    version: "2.0.0"
   - name: https://github.com/ansible-collections/ansible.utils
     type: git
     version: "v6.0.0"


### PR DESCRIPTION
There is no branch v2.0.0. This patch changes to actual branch which is 2.0.0