### PR TITLE
Add nodesets for 3xl crc nodes with 2 compute nodes

### DIFF
--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -244,6 +244,26 @@
           - crc
 
 - nodeset:
+    name: centos-9-medium-2x-centos-9-crc-extracted-2-39-0-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: coreos-crc-extracted-2-39-0-3xl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
     name: centos-9-2x-centos-9-xxl-crc-extracted-2-39-0-xxl
     nodes:
       - name: controller
@@ -361,6 +381,26 @@
         label: cloud-centos-9-stream-tripleo
       - name: crc
         label: crc-cloud-ocp-4-18-1-xxl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-medium-2x-centos-9-crc-cloud-ocp-4-18-1-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: crc-cloud-ocp-4-18-1-3xl
     groups:
       - name: computes
         nodes:


### PR DESCRIPTION
Currently, for crc 2.39.0, there are nodesets only for 1 or three compute nodes. In watcher-operator, we use 2 compute nodes, so I am creating a new nodeset definition for it both with openshift 4.16 and 4.18.