### PR TITLE
[BGP] ipv4routes can be defined for netconfig

### DIFF
--- a/plugins/module_utils/net_map/networking_env_definitions.py
+++ b/plugins/module_utils/net_map/networking_env_definitions.py
@@ -171,6 +171,8 @@ class MappedNetconfigNetworkConfig:
 
     ipv4_ranges: typing.List[MappedIpv4NetworkRange]
     ipv6_ranges: typing.List[MappedIpv6NetworkRange]
+    ipv4_routes: typing.List[MappedIpv4NetworkRoute]
+    ipv6_routes: typing.List[MappedIpv6NetworkRoute]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/network-values/values.yaml.j2
@@ -94,6 +94,13 @@ data:
 {%        endif %}
 {%      endfor %}
 {%    endif %}
+{%    if network.tools.netconfig.ipv4_routes | default([]) | length > 0 %}
+        routes:
+{%      for route in network.tools.netconfig.ipv4_routes %}
+        - destination: {{ route.destination }}
+          nexthop: {{ route.gateway }}
+{%      endfor %}
+{%    endif %}
 {%    if ns.lb_tools | length > 0 %}
     lb_addresses:
 {%      for tool in ns.lb_tools.keys() %}


### PR DESCRIPTION
In case of octavia, ipv4routes will be needed to connect to the management network.