### PR TITLE
Use local copy of common-requirements.txt instead of reaching out to github

### DIFF
--- a/roles/reproducer/defaults/main.yml
+++ b/roles/reproducer/defaults/main.yml
@@ -18,6 +18,7 @@
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_reproducer"
 cifmw_reproducer_basedir: "{{ cifmw_basedir | default( ansible_user_dir ~ '/ci-framework-data') }}"
+cifmw_reproducer_src_dir: "{{ cifmw_ci_src_dir | default( ansible_user_dir ~ '/src') }}"
 cifmw_reproducer_kubecfg: "{{ cifmw_libvirt_manager_configuration.vms.crc.image_local_dir }}/kubeconfig"
 cifmw_reproducer_params: {}
 cifmw_reproducer_run_job: true

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -350,12 +350,13 @@
             name: sushy_emulator
             tasks_from: verify.yml
 
+    # NOTE: src dir is synchronized in libvirt_layout.yml
     - name: Install ansible dependencies
       register: _async_dep_install
       async: 600  # 10 minutes should be more than enough
       poll: 0
       ansible.builtin.pip:
-        requirements: https://raw.githubusercontent.com/openstack-k8s-operators/ci-framework/main/common-requirements.txt
+        requirements: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/common-requirements.txt"
 
     - name: Inject most of the cifmw_ parameters passed to the reproducer run
       tags:

--- a/roles/reproducer/tasks/libvirt_layout.yml
+++ b/roles/reproducer/tasks/libvirt_layout.yml
@@ -48,6 +48,12 @@
           rsync -r {{ cifmw_reproducer_basedir }}/reproducer-inventory/
           zuul@controller-0:reproducer-inventory
 
+    - name: Push src dir to controller-0
+      ansible.builtin.command:  # noqa: command-instead-of-module
+        cmd: >-
+          rsync -r {{ cifmw_reproducer_src_dir }}/
+          zuul@controller-0:src
+
 - name: Run post tasks in OCP cluster case
   when:
     - _use_ocp | bool


### PR DESCRIPTION
This looks like something that can be avoided by using the local copy of that file instead of reaching out to github. It also seems like it will improve testing if the requirements file used is in-tree.

Error: ERROR: 429 Client Error: Too Many Requests for url: https://raw.githubusercontent.com/openstack-k8s-operators/ci-framework/main/common-requirements.txt