### PR TITLE
fix sushy_emulator: move register out of slurp module block

### DIFF
--- a/roles/sushy_emulator/tasks/collect_details.yml
+++ b/roles/sushy_emulator/tasks/collect_details.yml
@@ -80,7 +80,7 @@
         - name: "Slurp content of: {{ _uuid_file }}"
           ansible.builtin.slurp:
             src: "{{ _uuid_file }}"
-            register: _libvirt_uuids_file
+          register: _libvirt_uuids_file
 
         - name: "Set cifmw_libvirt_manager_uuids fact from {{ _uuid_file }}"
           vars:


### PR DESCRIPTION
This patch fixes a syntax error in the sushy_emulator role where the `register` keyword
was incorrectly placed inside the `slurp` module block. Ansible does not support that usage
and fails with:

  "Unsupported parameters for (ansible.builtin.slurp) module: register"

The fix moves `register` outside of the module block, restoring correct behavior.

Affected file:
- roles/sushy_emulator/tasks/collect_details.yml

Tested on a local deployment using ci-framework with an RHOSP17 undercloud.