### PR TITLE
[os_must_gather] collect logs from openshift-operators namespace

### DIFF
--- a/roles/os_must_gather/defaults/main.yml
+++ b/roles/os_must_gather/defaults/main.yml
@@ -23,7 +23,7 @@ cifmw_os_must_gather_image_registry: "quay.rdoproject.org/openstack-k8s-operator
 cifmw_os_must_gather_output_dir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_os_must_gather_repo_path: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/openstack-must-gather"
 cifmw_os_must_gather_timeout: "10m"
-cifmw_os_must_gather_additional_namespaces: "kuttl,openshift-storage,openshift-marketplace,sushy-emulator,tobiko"
+cifmw_os_must_gather_additional_namespaces: "kuttl,openshift-storage,openshift-marketplace,openshift-operators,sushy-emulator,tobiko"
 cifmw_os_must_gather_namespaces:
   - openstack-operators
   - openstack


### PR DESCRIPTION
cluster-observability-operator(coo) is deployed in openshift-operators namespace in watcher-operator related jobs.

Currently coo deployment is failing and we are not logs collecting logs from this namespace. It is hard to debug.

Jira: [OSPCIX-884](https://issues.redhat.com//browse/OSPCIX-884)