### PR TITLE
[Not tested!] Adds option to sync branches with specific commit-id

### DIFF
--- a/.github/workflows/sync_branches_reusable_workflow.yml
+++ b/.github/workflows/sync_branches_reusable_workflow.yml
@@ -9,6 +9,9 @@ on:
       target-branch:
         required: true
         type: string
+      commit-id:
+        required: true
+        type: string
     secrets:
       ssh-key:
         description: 'Deploy token write access'
@@ -35,6 +38,7 @@ jobs:
       - name: Rebase and Push
         run: |
           git fetch origin ${{ inputs.source-branch }}
+          git reset --hard ${{ inputs.commit-id }}
           git checkout ${{ inputs.target-branch }}
           git rebase ${{ inputs.source-branch }}
           git push --force origin ${{ inputs.target-branch }}

--- a/.github/workflows/sync_branches_with_ext_trigger.yml
+++ b/.github/workflows/sync_branches_with_ext_trigger.yml
@@ -10,5 +10,6 @@ jobs:
     with:
       source-branch: ${{ github.event.client_payload.source-branch }}
       target-branch: ${{ github.event.client_payload.target-branch }}
+      commit-id: ${{ github.event.client_payload.commit-id || "HEAD"}}
     secrets:
       ssh-key: ${{ secrets.DEPLOY_KEY }}


### PR DESCRIPTION
This will allow the user to pass a commit-id, thus the stable branch can be synced to a specific commit on main and not always HEAD
This can be triggered by:
```
  curl -L \
  -X POST \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer <PAT>" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/openstack-k8s-operators/ci-framework/dispatches \
  -d '{"event_type":"trigger-sync","client_payload":{"source-branch":"main","target-branch":"stable","commit-id":"abcd123"}}'
```