### PR TITLE
Allow bmh cleanup and move cleanup to role

### DIFF
--- a/clean_openstack_deployment.yaml
+++ b/clean_openstack_deployment.yaml
@@ -1,23 +1,6 @@
 - name: Clean OpenStack deployment
   hosts: "{{ target_host | default('localhost') }}"
   tasks:
-    - name: Clean up testing resources
+    - name: Cleanup openstack deployment
       ansible.builtin.include_role:
-        name: test_operator
-        tasks_from: cleanup
-
-    - name: Clean up OpenStack operators
-      vars:
-        cifmw_kustomize_deploy_keep_generated_crs: false
-      ansible.builtin.include_role:
-        name: kustomize_deploy
-        tasks_from: cleanup
-
-    - name: Remove logs and tests directories
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: absent
-      loop:
-        - "/home/zuul/ci-framework-data/logs"
-        - "/home/zuul/ci-framework-data/tests"
-      become: true
+        name: cleanup_openstack

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -131,6 +131,7 @@ ddthh
 deepscrub
 delorean
 deployer
+deprovision
 deps
 dest
 dev

--- a/roles/cleanup_openstack/README.md
+++ b/roles/cleanup_openstack/README.md
@@ -1,0 +1,11 @@
+# cleanup_openstack
+
+Cleans up openstack resources created by CIFMW by deleting CRs
+
+## Privilege escalation
+None
+
+## Parameters
+As this role is for cleanup it utilizes default vars from other roles which can be referenced at their role readme page: kustomize_deploy, deploy_bmh
+
+* `cifmw_cleanup_openstack_detach_bmh`: (Boolean) Detach BMH when cleaning flag, this is used to avoid deprovision when is not required. Default: `true`

--- a/roles/cleanup_openstack/defaults/main.yaml
+++ b/roles/cleanup_openstack/defaults/main.yaml
@@ -1,0 +1,1 @@
+cifmw_cleanup_openstack_detach_bmh: true

--- a/roles/cleanup_openstack/tasks/cleanup_crs.yaml
+++ b/roles/cleanup_openstack/tasks/cleanup_crs.yaml
@@ -1,0 +1,31 @@
+---
+- name: Ensure that kustomization files are present
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  loop: "{{ _crs_to_delete }}"
+  register: _crs_to_delete_files
+
+- name: Cleaning operators resources
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit) }}"
+    context: "{{ cifmw_openshift_context | default(omit) }}"
+    state: absent
+    src: "{{ item.stat.path }}"
+    wait: true
+    wait_timeout: 600
+  loop: "{{ _crs_to_delete_files.results }}"
+  register: _cleanup_results
+  until: "_cleanup_results is success"
+  retries: 3
+  delay: 120
+  when:
+    - item.stat.exists
+
+- name: Cleanup generated CRs if requested
+  ansible.builtin.file:
+    path: "{{ item.stat.path }}"
+    state: absent
+  loop: "{{ _crs_to_delete_files.results }}"
+  when:
+    - item.stat.exists

--- a/roles/cleanup_openstack/tasks/detach_bmh.yaml
+++ b/roles/cleanup_openstack/tasks/detach_bmh.yaml
@@ -1,0 +1,42 @@
+# This task file detaches the BMH (Bare Metal Host) resources to prevent deprovisioning them
+---
+- name: Skip deprovision for BMH
+  when: cifmw_deploy_bmh_bm_hosts_list | length > 0
+  block:
+    - name: Patch bmh with detached
+      kubernetes.core.k8s:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit)}}"
+        context: "{{ cifmw_openshift_context | default(omit)}}"
+        state: patched
+        wait: true
+        wait_timeout: 600
+        api_version: metal3.io/v1alpha1
+        kind: BareMetalHost
+        namespace: "{{ cifmw_deploy_bmh_namespace }}"
+        name: "{{ item }}"
+        definition:
+          metadata:
+            annotations:
+              baremetalhost.metal3.io/detached: ""
+      loop: "{{ cifmw_deploy_bmh_bm_hosts_list }}"
+      loop_control:
+        label: "{{ item }}"
+
+    - name: Wait for operationalStatus to become detached
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit)}}"
+        context: "{{ cifmw_openshift_context | default(omit)}}"
+        namespace: "{{ cifmw_deploy_bmh_namespace }}"
+        kind: BareMetalHost
+        api_version: metal3.io/v1alpha1
+        name: "{{ item }}"
+      retries: 60
+      delay: 10
+      until:
+        - bmh_status.resources | length == 0 or bmh_status.resources[0].status.operationalStatus == 'detached'
+      register: bmh_status
+      loop: "{{ cifmw_deploy_bmh_bm_hosts_list }}"
+      loop_control:
+        label: "{{ item }}"

--- a/roles/cleanup_openstack/tasks/main.yaml
+++ b/roles/cleanup_openstack/tasks/main.yaml
@@ -1,0 +1,109 @@
+---
+- name: Include required vars
+  ansible.builtin.include_vars:
+    file: "{{ item }}"
+  loop:
+    - roles/kustomize_deploy/defaults/main.yml
+    - roles/deploy_bmh/defaults/main.yml
+
+- name: Load architecture automation file
+  register: _automation
+  ansible.builtin.slurp:
+    path: "{{ cifmw_architecture_automation_file }}"
+
+- name: Prepare automation data
+  vars:
+    _parsed: "{{ _automation.content | b64decode | from_yaml }}"
+  ansible.builtin.set_fact:
+    cifmw_deploy_architecture_steps: >-
+      {{ _parsed['vas'][cifmw_architecture_scenario] }}
+
+- name: Clean up testing resources
+  ansible.builtin.include_role:
+    name: test_operator
+    tasks_from: cleanup
+
+- name: Set baremetal hosts facts
+  vars:
+    _cifmw_deploy_bmh_bm_hosts: >-
+      {{
+        cifmw_baremetal_hosts | default({}) | dict2items |
+        rejectattr('key', 'in', ['crc', 'controller', 'ocp']) |
+        items2dict
+      }}
+  ansible.builtin.set_fact:
+    cifmw_deploy_bmh_bm_hosts_list: "{{ _cifmw_deploy_bmh_bm_hosts.keys() | list | default([]) }}"
+
+- name: Get bmh crs
+  ansible.builtin.find:
+    path: "{{ cifmw_deploy_bmh_dest_dir }}"
+    patterns: "*.yml"
+    excludes: "bmh-secret*"
+  register: bmh_crs
+
+- name: Get bmh secrets crs
+  ansible.builtin.find:
+    path: "{{ cifmw_deploy_bmh_dest_dir }}"
+    patterns: "bmh-secret*"
+  register: bmh_secrets_crs
+
+- name: Detach bmh to skip deprovisioning
+  ansible.builtin.import_tasks: detach_bmh.yaml
+  when: cifmw_cleanup_openstack_detach_bmh
+
+- name: Delete deployment CRs
+  vars:
+    _stages_crs: >-
+      {{
+        cifmw_deploy_architecture_steps['stages'] |
+        reverse |
+        selectattr('build_output', 'defined') |
+        map(attribute='build_output') |
+        map('basename') |
+        list
+      }}
+    _stages_crs_path: >-
+      {{
+        [cifmw_kustomize_deploy_kustomizations_dest_dir]
+        | product(_stages_crs)
+        | map('join', '/')
+        | unique
+      }}
+    _external_dns_crs:
+      - /home/zuul/ci-framework-data/artifacts/manifests/cifmw_external_dns/ceph-local-dns.yml
+      - /home/zuul/ci-framework-data/artifacts/manifests/cifmw_external_dns/ceph-local-cert.yml
+    _operators_crs:
+      - "{{ cifmw_kustomize_deploy_nmstate_dest_file }}"
+      - "{{ cifmw_kustomize_deploy_metallb_dest_file }}"
+      - "{{ cifmw_kustomize_deploy_kustomizations_dest_dir }}/openstack.yaml"
+      - "{{ cifmw_kustomize_deploy_olm_dest_file }}"
+    _bmh_crs: >-
+      {{
+        bmh_crs.files |
+        map(attribute='path') |
+        list
+      }}
+    _bmh_secrets_crs: >-
+      {{
+        bmh_secrets_crs.files |
+        map(attribute='path') |
+        list
+      }}
+    _crs_to_delete: >-
+      {{
+        _external_dns_crs +
+        _stages_crs_path +
+        _bmh_crs +
+        _bmh_secrets_crs +
+        _operators_crs
+      }}
+  ansible.builtin.import_tasks: cleanup_crs.yaml
+
+- name: Remove logs and tests directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "/home/zuul/ci-framework-data/logs"
+    - "/home/zuul/ci-framework-data/tests"
+  become: true


### PR DESCRIPTION
- Allow cleanup of baremetal hosts (BMH) in OpenStack deployments. (required due to bug/change in OCP 4.18)
- Move cleanup tasks to a dedicated Ansible role for better organization and reusability.
- reduce cleanup time by deataching BMHs from the cluster before removing them.