### PR TITLE
Increase wait_timeout for removing storage

### DIFF
--- a/roles/ci_local_storage/tasks/cleanup.yml
+++ b/roles/ci_local_storage/tasks/cleanup.yml
@@ -64,3 +64,4 @@
     kind: Namespace
     name: "{{ cifmw_cls_namespace }}"
     wait: true
+    wait_timeout: 300


### PR DESCRIPTION
On some infras, the CI job is failing because it gets timeout, where it is removed 30 seconds later. The error looks like:

     TASK [ci_local_storage : Remove the cifmw_cls_namespace namespace
     task path: /home/zuul/src/github.com/openstack-k8s-operators/ci-framework/roles/ci_local_storage/tasks/cleanup.yml:58
     fatal: [localhost]: FAILED! =>
         changed: true
         duration: 120
         method: delete
         msg: '"Namespace" "openstack": Timed out waiting on resource'
         result:
           apiVersion: v1
           kind: Namespace

Increase timeout from 120 to 300.