### PR TITLE
Add retry when registering node in RH subscription or container registry

### DIFF
--- a/roles/adoption_osp_deploy/tasks/login_registries.yml
+++ b/roles/adoption_osp_deploy/tasks/login_registries.yml
@@ -26,6 +26,10 @@
     release: "{{ ansible_distribution_version }}"
     force_register: true
     state: present
+  retries: 5
+  delay: 30
+  register: _rh_result
+  until: not _rh_result.failed
 
 - name: Login in container registry
   when:
@@ -50,3 +54,7 @@
       loop:
         - zuul
         - root
+      retries: 5
+      delay: 30
+      register: _podman_login
+      until: _podman_login.rc == 0


### PR DESCRIPTION
Sometimes the CI jobs fails because there is too many request done for login to the container registry or to register system in Red Hat registration service.
Let's add delay and retry again to register the system or login to the container service.