### PR TITLE
Create hook for adding custom CA certs

### DIFF
--- a/hooks/playbooks/install_custom_ca_certs.yaml
+++ b/hooks/playbooks/install_custom_ca_certs.yaml
@@ -1,0 +1,22 @@
+---
+- name: Set Up Custom CA Secret for OpenStack Control Plane
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Get custom CA cert
+      ansible.builtin.slurp:
+        src: "{{ custom_ca_cert_filepath }}"
+      register: custom_ca_certs
+
+    - name: Create Custom CA Secret
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          type: Opaque
+          metadata:
+            name: custom-ca-certs
+            namespace: openstack
+          data:
+            CustomCACerts: "{{ custom_ca_certs.content }}"


### PR DESCRIPTION
This patch enables adding custom CA certs using a hook. The intended usage is in downstream jobs that want to add certificates into the combined-ca-bundle, e.g. internal certificates.