### PR TITLE
Multinode EDPM CI job failing for nmstate provider

### DIFF
--- a/hooks/playbooks/fetch_compute_facts.yml
+++ b/hooks/playbooks/fetch_compute_facts.yml
@@ -157,6 +157,12 @@
                     path: /spec/nodeTemplate/ansible/ansibleVars/neutron_public_interface_name
                     value: "{{ crc_ci_bootstrap_networks_out[_first_compute].default.iface | default('') }}"
 
+              {% for compute_node in groups['computes'] %}
+                  - op: replace
+                    path: /spec/nodes/edpm-{{ compute_node }}/networks/0/defaultRoute
+                    value: false
+              {% endfor %}
+
               {% for compute_node in groups['computes'] if compute_node != _first_compute %}
                   - op: replace
                     path: /spec/nodes/edpm-{{ compute_node }}/ansible/ansibleHost


### PR DESCRIPTION
This change is to update the incorrect network config template where used nic1 for dhcp and also used
br-ex controlplane config with default route.
so two default routes creating for nmstate provider scenario and this is not happened for ifcfg
provider and only one default route created for nic1. Proposed this PR is to fix incorrect network config.