### PR TITLE
Remove release parameter in redhat_subscription

### DIFF
--- a/roles/adoption_osp_deploy/tasks/login_registries.yml
+++ b/roles/adoption_osp_deploy/tasks/login_registries.yml
@@ -23,7 +23,6 @@
   community.general.redhat_subscription:
     activationkey: "{{ cifmw_adoption_osp_deploy_rhsm_key }}"
     org_id: "{{ cifmw_adoption_osp_deploy_rhsm_org }}"
-    release: "{{ ansible_distribution_version }}"
     force_register: true
     state: present
   retries: 5


### PR DESCRIPTION
Earlier, before commit [1], the release was not set. It seems that by setting the release, some packages might not be available after.
Let's remove that parameter.

[1] https://github.com/openstack-k8s-operators/ci-framework/commit/2d3aed4e1ac225adddfc32415dd6a13535084195