### PR TITLE
Use role instead of playbooks - 08-run-tests.yml

### DIFF
--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -85,13 +85,21 @@
   tags:
     - admin-setup
 
-- name: Import run test playbook
-  ansible.builtin.import_playbook: playbooks/08-run-tests.yml
-  vars:
-    pre_tests: "{{ (lookup('vars', 'pre_tempest', default=[])) }}"
-    post_tests: "{{ (lookup('vars', 'post_tempest', default=[])) }}"
-  tags:
-    - run-tests
+- name: Run cifmw_setup run_tests.yml
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Run Test
+      vars:
+        pre_tests: "{{ (lookup('vars', 'pre_tempest', default=[])) }}"
+        post_tests: "{{ (lookup('vars', 'post_tempest', default=[])) }}"
+      ansible.builtin.import_role:
+        name: cifmw_setup
+        tasks_from: run_tests.yml
+      when:
+        - cifmw_run_tests | default('false') | bool
+      tags:
+        - run-tests
 
 - name: Run compliance tests
   ansible.builtin.import_playbook: playbooks/09-compliance.yml

--- a/playbooks/08-run-tests.yml
+++ b/playbooks/08-run-tests.yml
@@ -1,4 +1,8 @@
 ---
+#
+# NOTE: Playbook migrated to: cifmw_setup/tasks/run_tests.yml.
+# DO NOT EDIT THAT PLAYBOOK. IT WOULD BE REMOVED IN NEAR FUTURE.
+#
 - name: "Test playbook"
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false

--- a/roles/cifmw_setup/tasks/run_tests.yml
+++ b/roles/cifmw_setup/tasks/run_tests.yml
@@ -1,0 +1,18 @@
+---
+- name: Run pre_tests hooks
+  vars:
+    step: pre_tests
+  ansible.builtin.import_role:
+    name: run_hook
+
+- name: Run tests
+  tags:
+    - tests
+  ansible.builtin.import_role:
+    name: "{{ cifmw_run_test_role | default('tempest') }}"
+
+- name: Run post_tests hooks
+  vars:
+    step: post_tests
+  ansible.builtin.import_role:
+    name: run_hook

--- a/update-edpm.yml
+++ b/update-edpm.yml
@@ -20,17 +20,23 @@
   tags:
     - update
 
-- name: Import run test playbook
-  ansible.builtin.import_playbook: playbooks/08-run-tests.yml
-  vars:
-    pre_tests: "{{ (lookup('vars', 'pre_tempest', default=[])) }}"
-    post_tests: "{{ (lookup('vars', 'post_tempest', default=[])) }}"
-    cifmw_test_operator_artifacts_basedir: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/tests/test_operator_update"
-    cifmw_test_operator_tempest_name: "post-update-tempest-tests"
-  when:
-    - cifmw_run_tests | default('false') | bool
-  tags:
-    - run-tests
+- name: Run cifmw_setup run_tests.yml
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Run Test
+      vars:
+        pre_tests: "{{ (lookup('vars', 'pre_tempest', default=[])) }}"
+        post_tests: "{{ (lookup('vars', 'post_tempest', default=[])) }}"
+        cifmw_test_operator_artifacts_basedir: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/tests/test_operator_update"
+        cifmw_test_operator_tempest_name: "post-update-tempest-tests"
+      ansible.builtin.import_role:
+        name: cifmw_setup
+        tasks_from: run_tests.yml
+      when:
+        - cifmw_run_tests | default('false') | bool
+      tags:
+        - run-tests
 
 - name: Inject status flag
   hosts: "{{ cifmw_target_host | default('localhost') }}"


### PR DESCRIPTION
It is continuation of simplification job execution [1].

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/2929