### PR TITLE
Add retries to kinit call

### DIFF
--- a/roles/dlrn_report/tasks/dlrn_report_results.yml
+++ b/roles/dlrn_report/tasks/dlrn_report_results.yml
@@ -20,6 +20,10 @@
       kinit
       {{ cifmw_dlrn_report_krb_user_realm }}
       -k -t {{ cifmw_dlrn_report_keytab }}
+  retries: 5
+  delay: 60
+  register: _kinit_status
+  until: _kinit_status.rc == 0
   when: cifmw_dlrn_report_kerberos_auth|bool
 
 - name: Set empty value for dlrnapi password


### PR DESCRIPTION
We observe at times there are failures that seem related to the temporary unavailability of the authentication service when a lot of jobs attempt to get token. Hence, we add retry.

Jira: [OSPCIX-797](https://issues.redhat.com//browse/OSPCIX-797)