### PR TITLE
Fix network config in create_cloud_init_iso.yml

### DIFF
--- a/roles/libvirt_manager/tasks/create_cloud_init_iso.yml
+++ b/roles/libvirt_manager/tasks/create_cloud_init_iso.yml
@@ -63,7 +63,7 @@
     _default_uuid: "{{ 99999999 | random(seed=vm) | to_uuid | lower }}"
     cifmw_config_drive_uuid: "{{ _uuid.stdout | default(_default_uuid) | trim}}"
     cifmw_config_drive_hostname: "{{ vm }}"
-    cifmw_config_drive_networkconfig: "{{ _network_config | default(None) }}"
+    cifmw_config_drive_networkconfig: "{{ _network_data | default(None) }}"
     cifmw_config_drive_userdata: "{{ _user_data }}"
   ansible.builtin.include_role:
     name: config_drive

--- a/roles/libvirt_manager/tasks/create_cloud_init_iso.yml
+++ b/roles/libvirt_manager/tasks/create_cloud_init_iso.yml
@@ -50,12 +50,12 @@
       when:
         - vm_data.networkconfig | type_debug == "dict"
       ansible.builtin.set_fact:
-        _network_data: vm_data.networkconfig
+        _network_data: "{{ vm_data.networkconfig }}"
     - name: "Define the network config for each vm"
       when:
         - vm_data.networkconfig | type_debug == "list"
       ansible.builtin.set_fact:
-        _network_data: vm_data.networkconfig[vm_idx]
+        _network_data: "{{ vm_data.networkconfig[vm_idx] }}"
 
 - name: "Call the config_drive role"
   vars:


### PR DESCRIPTION
The tasks before this one set a fact `_network_data`, it was looking for a defined `_network_config` in this task which is never set so `cifmw_config_drive_networkconfig` end up being `None` even if we defined network config in `cifmw_libvirt_manager_configuration`.

Added a second commit, we need curly brackets to resolve the value, instead of setting
the fact to string `vm_data.networkconfig` ...


Jira: [OSPRH-17107](https://issues.redhat.com//browse/OSPRH-17107)