### PR TITLE
Use role instead of playbooks - 99-logs.yml

### DIFF
--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -117,6 +117,13 @@
         mode: "0644"
 
 - name: Run log related tasks
-  ansible.builtin.import_playbook: playbooks/99-logs.yml
-  tags:
-    - logs
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: true
+  tasks:
+    - name: Run 99-logs.yml 
+      ansible.builtin.import_role:
+        name: os_must_gather
+        tasks_from: 99-logs.yml
+      tags:
+        - logs
+

--- a/roles/os_must_gather/tasks/99-logs.yml
+++ b/roles/os_must_gather/tasks/99-logs.yml
@@ -1,0 +1,107 @@
+- name: Early exit if no tests
+  when:
+    - zuul_log_collection | default('false') | bool
+  ansible.builtin.meta: end_play
+
+- name: Ensure cifmw_basedir param is set
+  when:
+    - cifmw_basedir is not defined
+  ansible.builtin.set_fact:
+    cifmw_basedir: "{{ ansible_user_dir }}/ci-framework-data"
+
+- name: Try to load parameters files
+  block:
+    - name: Check directory availabilty
+      register: param_dir
+      ansible.builtin.stat:
+        path: "{{ cifmw_basedir }}/artifacts/parameters"
+
+    - name: Load parameters files
+      when:
+        - param_dir.stat.exists | bool
+      ansible.builtin.include_vars:
+        dir: "{{ cifmw_basedir }}/artifacts/parameters"
+  always:
+    - name: Set custom cifmw PATH reusable fact
+      when:
+        - cifmw_path is not defined
+      ansible.builtin.set_fact:
+        cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+        cacheable: true
+
+- name: Set destination folder for the logs
+  ansible.builtin.set_fact:
+    logfiles_dest_dir: >-
+      {{
+        (
+          cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data'),
+          'logs/',
+          now(fmt='%Y-%m-%d_%H-%M')
+        ) | path_join
+      }}
+
+- name: Generate artifacts
+  ansible.builtin.import_role:
+    name: artifacts
+
+- name: Collect container images used in the environment
+  ansible.builtin.import_role:
+    name: env_op_images
+
+- name: Create a versioned log folder
+  ansible.builtin.file:
+    path: "{{ logfiles_dest_dir }}"
+    state: directory
+    mode: "0775"
+
+- name: Return a list of log files in home directory
+  ansible.builtin.find:
+    paths: "{{ ansible_user_dir }}"
+    patterns: '*.log'
+  register: _log_files
+
+- name: Ensure ansible facts cache exists
+  register: ansible_facts_cache_state
+  ansible.builtin.stat:
+    path: "{{ ansible_user_dir }}/ansible_facts_cache"
+
+- name: Copy log files
+  when:
+    - _log_files.matched > 0
+  block:
+    - name: Copy logs to proper location
+      ansible.builtin.copy:
+        src: "{{ item.path }}"
+        dest: "{{ [ logfiles_dest_dir , item.path | basename ] | path_join }}"
+        remote_src: true
+        mode: "0666"
+      loop: "{{ _log_files.files }}"
+
+    - name: Remove original log from home directory
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: absent
+      loop: "{{ _log_files.files }}"
+
+- name: Copy Ansible facts if exists
+  when:
+    - ansible_facts_cache_state.stat.exists is defined
+    - ansible_facts_cache_state.stat.exists | bool
+  block:
+    - name: Copy facts to dated directory
+      ansible.builtin.copy:
+        src: "{{ ansible_user_dir }}/ansible_facts_cache"
+        dest: >-
+          {{
+            (
+              cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data'),
+              "artifacts/ansible_facts." + now(fmt='%Y-%m-%d_%H-%M')
+            ) | path_join
+          }}
+        mode: "0777"
+        remote_src: true
+
+    - name: Clean ansible fact cache
+      ansible.builtin.file:
+        path: "{{ ansible_user_dir }}/ansible_facts_cache"
+        state: absent

--- a/update-edpm.yml
+++ b/update-edpm.yml
@@ -42,7 +42,13 @@
         mode: "0644"
 
 - name: Run log related tasks
-  ansible.builtin.import_playbook: playbooks/99-logs.yml
-  when: not zuul_log_collection | default('false') | bool
-  tags:
-    - logs
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: true
+  tasks:
+    - name: Run 99-logs.yml
+      when: not zuul_log_collection | default('false') | bool
+      ansible.builtin.import_role:
+        name: os_must_gather
+        tasks_from: 99-logs.yml
+      tags:
+        - logs


### PR DESCRIPTION
It is continuation of simplification job execution [1].

[1]: https://github.com/openstack-k8s-operators/ci-framework/pull/2929