### PR TITLE
Add variable to overwrite NNCP_DNS_SERVER

### DIFF
--- a/ci/playbooks/kuttl/deploy-deps.yaml
+++ b/ci/playbooks/kuttl/deploy-deps.yaml
@@ -80,7 +80,7 @@
               NETWORK_MTU: "{{ crc_ci_bootstrap_networks_out.crc.default.mtu }}"
               NNCP_DNS_SERVER: >-
                 {{
-                  crc_ci_bootstrap_networks_out[_crc_hostname].default.ip4 |
+                  cifmw_nncp_dns_server |
                   default(crc_ci_bootstrap_networks_out[_crc_hostname].default.ip) |
                   split('/') | first
                 }}

--- a/hooks/playbooks/fetch_compute_facts.yml
+++ b/hooks/playbooks/fetch_compute_facts.yml
@@ -68,7 +68,7 @@
           NNCP_INTERFACE: "{{ crc_ci_bootstrap_networks_out[_crc_hostname].default.iface }}"
           NNCP_DNS_SERVER: >-
             {{
-              crc_ci_bootstrap_networks_out[_crc_hostname].default.ip4 |
+              cifmw_nncp_dns_server |
               default(crc_ci_bootstrap_networks_out[_crc_hostname].default.ip) |
               split('/') | first
             }}

--- a/hooks/playbooks/kuttl_openstack_prep.yml
+++ b/hooks/playbooks/kuttl_openstack_prep.yml
@@ -29,7 +29,7 @@
           NNCP_INTERFACE: "{{ crc_ci_bootstrap_networks_out[_crc_hostname].default.iface }}"
           NNCP_DNS_SERVER: >-
             {{
-              crc_ci_bootstrap_networks_out[_crc_hostname].default.ip4 |
+              cifmw_nncp_dns_server |
               default(crc_ci_bootstrap_networks_out[_crc_hostname].default.ip) |
               split('/') | first
             }}


### PR DESCRIPTION
Earlier Ansible was relay on variable that was taken from /etc/ci/env/networking-info.yml which was generated during base job, but it does not include value with "ip4". This commit gives possibility to set custom NNCP_DNS_SERVER value.