### PR TITLE
Use role instead of playbooks - validations.yml

### DIFF
--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -290,5 +290,10 @@
         name: run_hook
 
 - name: Validations workflow
-  ansible.builtin.import_playbook: validations.yml
-  when: cifmw_execute_validations | default('false') | bool
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Run validations
+      ansible.builtin.include_role:
+        name: validations
+      when: cifmw_execute_validations | default('false') | bool

--- a/playbooks/06-deploy-edpm.yml
+++ b/playbooks/06-deploy-edpm.yml
@@ -163,7 +163,12 @@
 - name: Validations workflow
   # If we're doing an architecture deployment, we need to skip validations here.
   # Instead, they will be executed in the 06-deploy-architecture.yml playbook.
-  when:
-    - cifmw_architecture_scenario is not defined
-    - cifmw_execute_validations | default('false') | bool
-  ansible.builtin.import_playbook: validations.yml
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Run validations
+      ansible.builtin.include_role:
+        name: validations
+      when:
+        - cifmw_architecture_scenario is not defined
+        - cifmw_execute_validations | default('false') | bool

--- a/playbooks/validations.yml
+++ b/playbooks/validations.yml
@@ -1,3 +1,8 @@
+#
+# NOTE: Playbook migrated to: 06-deploy-edpm.yml & 06-deploy-architecture.yml.
+# This migration is temporary, and will be further migrated to role.
+# DO NOT EDIT THAT PLAYBOOK. IT WOULD BE REMOVED IN NEAR FUTURE.
+#
 - name: Execute the validations role
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false


### PR DESCRIPTION
Before simplifying 06-deploy-edpm.yml, it is necessary to take care of import_playbook calls within that play

There are three import_playbook calls within 06-deploy-edpm.yml
- validations.yml
- nfs.yml
- ceph.yml

This PR takes care of validations.yml

It is continuation of simplification job execution [1].

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/2929