### PR TITLE
Drop -4 flag from curl command in download cirros-cloud image

### DIFF
--- a/roles/update/templates/workload_launch.sh.j2
+++ b/roles/update/templates/workload_launch.sh.j2
@@ -291,7 +291,7 @@ function workload_launch {
     openstack image list | grep ${IMAGE_NAME}
     if [ $? -ne 0 ]; then
         echo "Downloading image ${IMAGE_URL}"
-        curl -4fsSLk --retry 5 -o ${IMAGE_FILE} ${IMAGE_URL}
+        curl -fsSLk --retry 5 -o ${IMAGE_FILE} ${IMAGE_URL}
 
         if [ $? -ne 0 ]; then
             echo "Failed to download ${IMAGE_URL}"


### PR DESCRIPTION
Do not force ipv4 in curl command only when resolving hostnames. In environment with ipv6 only let curl use ipv6 addresses when resolving hostnames.