### PR TITLE
Use role instead of playbooks - nfs.yml

### DIFF
--- a/playbooks/06-deploy-edpm.yml
+++ b/playbooks/06-deploy-edpm.yml
@@ -102,7 +102,17 @@
             name: edpm_deploy
 
 - name: Deploy NFS server on target nodes
-  ansible.builtin.import_playbook: "nfs.yml"
+  become: true
+  hosts: "{{ groups[cifmw_nfs_target | default('computes')][0] | default([]) }}"
+  tasks:
+    - name: Run cifmw_nfs role
+      vars:
+        nftables_path: /etc/nftables
+        nftables_conf: /etc/sysconfig/nftables.conf
+      when:
+        - cifmw_edpm_deploy_nfs | default('false') | bool
+      ansible.builtin.import_role:
+        name: cifmw_nfs
 
 - name: Clear ceph target hosts facts to force refreshing in HCI deployments
   hosts: "{{ cifmw_ceph_target | default('computes')  }}"

--- a/playbooks/nfs.yml
+++ b/playbooks/nfs.yml
@@ -14,6 +14,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+#
+# NOTE: Playbook migrated to: roles/cifmw_nfs/tasks/main.yml.
+# DO NOT EDIT THAT PLAYBOOK. IT WOULD BE REMOVED IN NEAR FUTURE.
+#
+
 - name: Deploy an NFS server
   become: true
   hosts: "{{ groups[cifmw_nfs_target | default('computes')][0] | default([]) }}"

--- a/roles/cifmw_nfs/README.md
+++ b/roles/cifmw_nfs/README.md
@@ -1,0 +1,23 @@
+# cifmw_nfs
+This role deploys an NFS Server.
+
+## Privilege escalation
+sudo privilege is required for this role.
+
+## Parameters
+* `nftables_path`: path to nftables files
+* `nftables_conf`: path to nftables config file
+
+## Examples
+```
+- name: Deploy NFS server on target nodes
+  become: true
+  hosts: "{{ groups[cifmw_nfs_target | default('computes')][0] | default([]) }}"
+  vars:
+    nftables_path: /etc/nftables
+    nftables_conf: /etc/sysconfig/nftables.conf
+  when:
+    - cifmw_edpm_deploy_nfs | default('false') | bool
+  ansible.builtin.import_role:
+    name: cifmw_nfs
+```

--- a/roles/cifmw_nfs/defaults/main.yml
+++ b/roles/cifmw_nfs/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_nfs"
+
+cifmw_nfs_network: "storage"
+cifmw_nfs_target: "compute"

--- a/roles/cifmw_nfs/meta/main.yml
+++ b/roles/cifmw_nfs/meta/main.yml
@@ -1,0 +1,30 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- cifmw_nfs
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: "2.14"
+  namespace: cifmw
+  galaxy_tags:
+    - cifmw
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/roles/cifmw_nfs/tasks/main.yml
+++ b/roles/cifmw_nfs/tasks/main.yml
@@ -1,0 +1,136 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Set custom cifmw PATH reusable fact
+  tags:
+    - always
+  when:
+    - cifmw_path is not defined
+  ansible.builtin.set_fact:
+    cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+    cacheable: true
+
+- name: Install required packages
+  ansible.builtin.package:
+    name:
+      - nfs-utils
+      - iptables
+
+- name: Configure nfs to use v4 only
+  community.general.ini_file:
+    path: /etc/nfs.conf
+    section: nfsd
+    option: vers3
+    value: n
+    backup: true
+    mode: "0644"
+
+- name: Disable NFSv3-related services
+  ansible.builtin.systemd_service:
+    name: "{{ item }}"
+    masked: true
+  loop:
+    - rpc-statd.service
+    - rpcbind.service
+    - rpcbind.socket
+
+- name: Ensure shared folder exist
+  ansible.builtin.file:
+    path: "/data/{{ item }}"
+    state: directory
+    mode: '755'
+  loop: "{{ cifmw_nfs_shares }}"
+
+- name: Set nfs network vars
+  delegate_to: controller
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  vars:
+    _nfs_network_name: "{{ cifmw_nfs_network }}"
+    _nfs_host: "{{ [groups[cifmw_nfs_target][0], ansible_domain] | select() | join('.') | default('') }}"
+    _ipset_namespace: "{{ cifmw_install_yamls_defaults['NAMESPACE'] | default('openstack') }}"
+  ansible.builtin.command:
+    cmd: oc get ipset {{ _nfs_host }} -n {{ _ipset_namespace }} -o jsonpath='{.status.reservations[?(@.network=="{{ _nfs_network_name }}")]}'
+  register: cifmw_nfs_network_out
+
+- name: Store nfs network vars
+  delegate_to: controller
+  ansible.builtin.copy:
+    dest: "{{ cifmw_basedir }}/artifacts/parameters/nfs-params.yml"
+    content: >-
+      {{
+        {
+        'cifmw_nfs_ip': cifmw_nfs_network_out.stdout | from_json | json_query('address'),
+        'cifmw_nfs_network_range': cifmw_nfs_network_out.stdout | from_json | json_query('cidr')
+        } | to_nice_yaml
+      }}
+    mode: "0644"
+
+# NOTE: This represents a workaround because there's an edpm-nftables role
+#       in edpm-ansible already. That role should contain the implementation
+#       of the firewall rules for NFS, and they should be included in the
+#       main edpm-rules.nft file. The following firewall config assumes that
+#       the EDPM node has been configured in terms of networks and firewall.
+- name: Configure firewall
+  become: true
+  tags:
+    - nft
+  block:
+    - name: Generate nftables rules file
+      ansible.builtin.copy:
+        content: |
+          add rule inet filter EDPM_INPUT tcp dport 2049 accept
+        dest: "{{ nftables_path }}/nfs-server.nft"
+        mode: '0666'
+
+    - name: Update nftables.conf and include nfs rules at the bottom
+      ansible.builtin.lineinfile:
+        path: "{{ nftables_conf }}"
+        line: include "{{ nftables_path }}/nfs-server.nft"
+        insertafter: EOF
+
+    - name: Restart nftables service
+      ansible.builtin.systemd:
+        name: nftables
+        state: restarted
+
+- name: Configure the ip the nfs server should listen on
+  community.general.ini_file:
+    path: /etc/nfs.conf
+    section: nfsd
+    option: host
+    value: "{{ cifmw_nfs_network_out.stdout | from_json | json_query('address') }}"
+    backup: true
+    mode: "0644"
+
+- name: Enable and restart nfs-server service
+  ansible.builtin.systemd:
+    name: nfs-server
+    state: restarted
+    enabled: true
+
+- name: Add shares to /etc/exports
+  ansible.builtin.lineinfile:
+    path: /etc/exports
+    line: "/data/{{ item }} {{ cifmw_nfs_network_out.stdout | from_json | json_query('cidr') }}(rw,sync,no_root_squash)"
+  loop: "{{ cifmw_nfs_shares }}"
+  register: _export_shares
+
+- name: Export the shares # noqa: no-handler
+  when:
+    - _export_shares.changed
+  ansible.builtin.command: exportfs -a


### PR DESCRIPTION
Before simplifying 06-deploy-edpm.yml, it is necessary to take care of import_playbook calls within that play

There are three import_playbook calls within 06-deploy-edpm.yml
- validations.yml
- nfs.yml
- ceph.yml

This PR takes care of nfs.yml

It is continuation of simplification job execution [1].

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/2929