### PR TITLE
Print /etc/redhat-release after setting subscription or enabling repos

### DIFF
--- a/roles/adoption_osp_deploy/tasks/login_registries.yml
+++ b/roles/adoption_osp_deploy/tasks/login_registries.yml
@@ -18,17 +18,27 @@
   when:
     - cifmw_adoption_osp_deploy_rhsm_org is defined
     - cifmw_adoption_osp_deploy_rhsm_key is defined
-  become: true
-  no_log: true
-  community.general.redhat_subscription:
-    activationkey: "{{ cifmw_adoption_osp_deploy_rhsm_key }}"
-    org_id: "{{ cifmw_adoption_osp_deploy_rhsm_org }}"
-    force_register: true
-    state: present
-  retries: 5
-  delay: 30
-  register: _rh_result
-  until: not _rh_result.failed
+  block:
+    - name: Make redhat subscription
+      become: true
+      no_log: true
+      community.general.redhat_subscription:
+        activationkey: "{{ cifmw_adoption_osp_deploy_rhsm_key }}"
+        org_id: "{{ cifmw_adoption_osp_deploy_rhsm_org }}"
+        force_register: true
+        state: present
+      retries: 5
+      delay: 30
+      register: _rh_result
+      until: not _rh_result.failed
+
+    - name: Get current /etc/redhat-release
+      ansible.builtin.command: cat /etc/redhat-release
+      register: _current_rh_release
+
+    - name: Print current /etc/redhat-release
+      ansible.builtin.debug:
+        msg: "{{ _current_rh_release.stdout }}"
 
 - name: Login in container registry
   when:

--- a/roles/adoption_osp_deploy/tasks/prepare_overcloud.yml
+++ b/roles/adoption_osp_deploy/tasks/prepare_overcloud.yml
@@ -121,6 +121,15 @@
         loop_var: _vm
         pause: 1
 
+    - name: Get current /etc/redhat-release
+      delegate_to: "{{ _vm }}"
+      ansible.builtin.command: cat /etc/redhat-release
+      register: _current_rh_release
+
+    - name: Print current /etc/redhat-release
+      ansible.builtin.debug:
+        msg: "{{ _current_rh_release.stdout }}"
+
     - name: Copy network data file if it's not a template
       when: _network_data_extension != '.j2'
       delegate_to: "osp-undercloud-0"

--- a/roles/adoption_osp_deploy/tasks/prepare_undercloud.yml
+++ b/roles/adoption_osp_deploy/tasks/prepare_undercloud.yml
@@ -29,6 +29,14 @@
         name: "{{ cifmw_adoption_osp_deploy_repos }}"
         state: enabled
 
+    - name: Get current /etc/redhat-release
+      ansible.builtin.command: cat /etc/redhat-release
+      register: _current_rh_release
+
+    - name: Print current /etc/redhat-release
+      ansible.builtin.debug:
+        msg: "{{ _current_rh_release.stdout }}"
+
     - name: Install director packages
       become: true
       ansible.builtin.dnf:

--- a/roles/ci_setup/tasks/repos.yml
+++ b/roles/ci_setup/tasks/repos.yml
@@ -39,6 +39,15 @@
         name: "{{ item }}"
         state: "{{ rhsm_repo_state | default('enabled') }}"
       loop: "{{ _repos }}"
+
+    - name: Get current /etc/redhat-release
+      ansible.builtin.command: cat /etc/redhat-release
+      register: _current_rh_release
+
+    - name: Print current /etc/redhat-release
+      ansible.builtin.debug:
+        msg: "{{ _current_rh_release.stdout }}"
+
   rescue:
     - name: RHSM unavailable
       ansible.builtin.debug:


### PR DESCRIPTION
Sometimes the CI jobs can not find packages that normally are available in the repository for the RHEL release that the image is started in the CI, but the packages are not available in newer version.

Print the version to make sure that we are using proper version.