### PR TITLE
DNM: Decrease tempest concurrency

### DIFF
--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -29,7 +29,7 @@ cifmw_test_operator_controller_namespace: openstack-operators
 cifmw_test_operator_bundle: ""
 cifmw_test_operator_timeout: 3600
 cifmw_test_operator_logs_image: quay.io/quay/busybox
-cifmw_test_operator_concurrency: 8
+cifmw_test_operator_concurrency: 4
 cifmw_test_operator_cleanup: false
 cifmw_test_operator_dry_run: false
 cifmw_test_operator_default_groups:

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -604,6 +604,22 @@
       - name: ocps
         nodes:
           - crc
+- nodeset:
+    name: centos-9-medium-centos-9-xxl-crc-cloud-ocp-4-18-1-4xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo-xxl
+      - name: crc
+        label: crc-cloud-ocp-4-18-1-4xl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+      - name: ocps
+        nodes:
+          - crc
 
 - nodeset:
     name: centos-9-crc-2-48-0-3xl

--- a/zuul.d/tempest_multinode.yaml
+++ b/zuul.d/tempest_multinode.yaml
@@ -15,7 +15,6 @@
       cifmw_operator_build_operators: []
       cifmw_run_test_role: test_operator
       cifmw_test_operator_tempest_tests_include_override_scenario: true
-    extra-vars:
       crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"
       crc_ci_bootstrap_networking:
         networks:
@@ -117,6 +116,10 @@
 - job:
     name: cifmw-multinode-tempest
     parent: podified-multinode-edpm-deployment-crc-tempest
+    vars:
+      crc_disk_limitation: false
+      tune_kubelet_conf: true
+    nodeset: centos-9-medium-centos-9-xxl-crc-cloud-ocp-4-18-1-4xl
     files:
       - ^roles/test_operator
       - ^scenarios/centos-9/multinode-ci.yml


### PR DESCRIPTION
Once the tempest pod failed it gets the status OOMKilled, which means that it tried to get more memoery than the maximum.
Also those tempest execution has not the summary at the end of passing and failling tests.
We would need to increase the memory, but for testing purpose we went the way of reducing concurrency.

DNM