### PR TITLE
Sync the src dir with all hosts in inventory in reproducer

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -350,6 +350,15 @@
             name: sushy_emulator
             tasks_from: verify.yml
 
+    - name: Sync local repositories to other hosts
+      delegate_to: localhost
+      ansible.posix.synchronize:
+        src: "{{ cifmw_reproducer_src_dir }}/"
+        dest: "zuul@{{ item }}:{{ cifmw_reproducer_src_dir }}"
+        archive: true
+        recursive: true
+      loop: "{{ groups['computes'] + groups['controllers'] }}"
+
     # NOTE: src dir is synchronized in libvirt_layout.yml
     - name: Install ansible dependencies
       register: _async_dep_install

--- a/roles/reproducer/tasks/libvirt_layout.yml
+++ b/roles/reproducer/tasks/libvirt_layout.yml
@@ -48,12 +48,6 @@
           rsync -r {{ cifmw_reproducer_basedir }}/reproducer-inventory/
           zuul@controller-0:reproducer-inventory
 
-    - name: Push src dir to controller-0
-      ansible.builtin.command:  # noqa: command-instead-of-module
-        cmd: >-
-          rsync -r {{ cifmw_reproducer_src_dir }}/
-          zuul@controller-0:src
-
 - name: Run post tasks in OCP cluster case
   when:
     - _use_ocp | bool


### PR DESCRIPTION
Some files are required on the instance spawned by the reproducer.