### PR TITLE
Fix pre_tests not running

### DIFF
--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -80,7 +80,7 @@
   tags:
     - edpm
 
-- name: Post-deployment admin setup steps
+- name: Run Post-deployment admin setup steps, test, and compliance scan
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
@@ -91,10 +91,6 @@
       tags:
         - admin-setup
 
-- name: Run cifmw_setup run_tests.yml
-  hosts: "{{ cifmw_target_host | default('localhost') }}"
-  gather_facts: false
-  tasks:
     - name: Run Test
       vars:
         pre_tests: "{{ (lookup('vars', 'pre_tempest', default=[])) }}"
@@ -102,15 +98,9 @@
       ansible.builtin.import_role:
         name: cifmw_setup
         tasks_from: run_tests.yml
-      when:
-        - cifmw_run_tests | default('false') | bool
       tags:
         - run-tests
 
-- name: Run operators compliance scans
-  hosts: "{{ cifmw_target_host | default('localhost') }}"
-  gather_facts: false
-  tasks:
     - name: Run compliance scan for controllers
       ansible.builtin.import_role:
         name: compliance
@@ -118,8 +108,8 @@
         cifmw_compliance_podman_username: "{{ cifmw_registry_token.credentials.username }}"
         cifmw_compliance_podman_password: "{{ cifmw_registry_token.credentials.password }}"
       when: cifmw_run_operators_compliance_scans | default('false') | bool
-  tags:
-    - compliance
+      tags:
+        - compliance
 
 - name: Run compliance scan for computes
   hosts: "{{ groups['computes'] | default ([]) }}"

--- a/roles/cifmw_setup/tasks/run_tests.yml
+++ b/roles/cifmw_setup/tasks/run_tests.yml
@@ -10,9 +10,11 @@
     - tests
   ansible.builtin.import_role:
     name: "{{ cifmw_run_test_role | default('tempest') }}"
+  when: cifmw_run_tests | default('false') | bool
 
 - name: Run post_tests hooks
   vars:
     step: post_tests
   ansible.builtin.import_role:
     name: run_hook
+  when: cifmw_run_tests | default('false') | bool

--- a/update-edpm.yml
+++ b/update-edpm.yml
@@ -33,14 +33,9 @@
       ansible.builtin.import_role:
         name: cifmw_setup
         tasks_from: run_tests.yml
-      when:
-        - cifmw_run_tests | default('false') | bool
       tags:
         - run-tests
 
-- name: Inject status flag
-  hosts: "{{ cifmw_target_host | default('localhost') }}"
-  tasks:
     - name: Inject success flag
       ansible.builtin.file:
         path: "{{ ansible_user_dir }}/cifmw-success"


### PR DESCRIPTION
This patch fix the issue created by the recent patch https://github.com/openstack-k8s-operators/ci-framework/pull/3027

Now, it will run pre_tests without checking cifmw_run_tests var, just like the older playbook way.