### PR TITLE
Rename _network_data in create_cloud_init_iso to _network_data_config_drive

### DIFF
--- a/roles/libvirt_manager/tasks/create_cloud_init_iso.yml
+++ b/roles/libvirt_manager/tasks/create_cloud_init_iso.yml
@@ -50,12 +50,12 @@
       when:
         - vm_data.networkconfig | type_debug == "dict"
       ansible.builtin.set_fact:
-        _network_data: "{{ vm_data.networkconfig }}"
+        _libvirt_manager_network_data: "{{ vm_data.networkconfig }}"
     - name: "Define the network config for each vm"
       when:
         - vm_data.networkconfig | type_debug == "list"
       ansible.builtin.set_fact:
-        _network_data: "{{ vm_data.networkconfig[vm_idx] }}"
+        _libvirt_manager_network_data: "{{ vm_data.networkconfig[vm_idx] }}"
 
 - name: "Call the config_drive role"
   vars:
@@ -63,7 +63,7 @@
     _default_uuid: "{{ 99999999 | random(seed=vm) | to_uuid | lower }}"
     cifmw_config_drive_uuid: "{{ _uuid.stdout | default(_default_uuid) | trim}}"
     cifmw_config_drive_hostname: "{{ vm }}"
-    cifmw_config_drive_networkconfig: "{{ _network_data | default(None) }}"
+    cifmw_config_drive_networkconfig: "{{ _libvirt_manager_network_data | default(None) }}"
     cifmw_config_drive_userdata: "{{ _user_data }}"
   ansible.builtin.include_role:
     name: config_drive


### PR DESCRIPTION
There is conflict of variable names. _network_data is already defined and exposed using set_fact[1]. Variable for config_drive should be named diffrently to not generate wrong network-configs for vms.

[1] https://github.com/openstack-k8s-operators/ci-framework/blob/main/roles/libvirt_manager/tasks/create_networks.yml#L185