### PR TITLE
adoption_osp_deploy: allow to pass private overcloud args

### DIFF
--- a/roles/adoption_osp_deploy/README.md
+++ b/roles/adoption_osp_deploy/README.md
@@ -25,6 +25,9 @@ configure the OSP17.1 deployment.
   networks in the ci-framework Network Mapper data to exclude when generating
   the adoption variables. By default it excludes the ci-framework "public"
   network (`ocpbm`).
+* `cifmw_adoption_osp_deploy_overcloud_extra_args`: (String) The content of a
+  file which will be used with the -e option in the overcloud deploy command.
+  This is useful to specify private/restricted parameters.
 
 ### Break point
 

--- a/roles/adoption_osp_deploy/defaults/main.yml
+++ b/roles/adoption_osp_deploy/defaults/main.yml
@@ -28,3 +28,5 @@ cifmw_adoption_osp_deploy_repos:
 
 cifmw_adoption_osp_deploy_adoption_vars_exclude_nets:
   - "{{ cifmw_libvirt_manager_pub_net | default('ocpbm') }}"
+
+cifmw_adoption_osp_deploy_overcloud_extra_args: ''

--- a/roles/adoption_osp_deploy/tasks/deploy_overcloud.yml
+++ b/roles/adoption_osp_deploy/tasks/deploy_overcloud.yml
@@ -46,12 +46,20 @@
       }}
     _network_provision_output: "network_provision_{{ _overcloud_name }}_out.yaml"
     _vips_provision_output: "vips_provision_{{ _overcloud_name }}_out.yaml"
+    _private_overcloud_conf_file: "{{ ansible_user_dir }}/internal-configuration.yaml"
   block:
     - name: Copy roles file
       delegate_to: "osp-undercloud-0"
       ansible.builtin.copy:
         src: "{{ _roles_file }}"
         dest: "{{ _roles_file_dest }}"
+        mode: "0644"
+
+    - name: Create the private configuration file with the specified configuration or empty
+      delegate_to: "osp-undercloud-0"
+      ansible.builtin.copy:
+        content: "{{ cifmw_adoption_osp_deploy_overcloud_extra_args }}"
+        dest: "{{ _private_overcloud_conf_file }}"
         mode: "0644"
 
     - name: Run overcloud deploy
@@ -69,6 +77,7 @@
           -e {{ ansible_user_dir }}/config_download_{{ _overcloud_name }}.yaml
           -e {{ ansible_user_dir }}/{{ _vips_provision_output }}
           -e {{ ansible_user_dir }}/{{ _network_provision_output }}
+          -e {{ _private_overcloud_conf_file }}
         _source_cmd: "source {{ ansible_user_dir }}/stackrc"
         _default_overcloud_deploy_cmd: "{{ _source_cmd }}; {{ _overcloud_deploy_cmd }}"
       cifmw.general.ci_script:


### PR DESCRIPTION
A new parameter allow users to specify an additional
overcloud deploy environment file (-e), which can be used
to pass private/restricted parameters.

cifmw_adoption_osp_deploy_overcloud_extra_args: points to a string
which contains an environment file.
