### PR TITLE
Temporary override keystone config in job

### DIFF
--- a/zuul.d/tempest_multinode.yaml
+++ b/zuul.d/tempest_multinode.yaml
@@ -72,6 +72,26 @@
         - '@scenarios/centos-9/ci.yml'
         - '@scenarios/centos-9/multinode-ci.yml'
         - '@scenarios/centos-9/ceph_backends.yml'
+      # Temporary until https://review.opendev.org/c/openstack/oslo.cache/+/952014
+      # is included in rdo and promoted
+      cifmw_edpm_prepare_kustomizations:
+        - apiVersion: kustomize.config.k8s.io/v1beta1
+          kind: Kustomization
+          namespace: openstack
+          patches:
+            - patch: |-
+                apiVersion: core.openstack.org/v1beta1
+                kind: OpenStackControlPlane
+                metadata:
+                  name: unused
+                spec:
+                  keystone:
+                    template:
+                      customServiceConfig: |
+                        [cache]
+                        memcache_sasl_enabled = true
+              target:
+                kind: OpenStackControlPlane
       cifmw_test_operator_tempest_include_list: |
         ^tempest.api.identity.*.v3
         ^tempest.api.volume


### PR DESCRIPTION
Until [1] get's included in RDO antelope and promoted temporary patch to workaround the issue.

[1] https://review.opendev.org/c/openstack/oslo.cache/+/952014

Related-Issue: #[OSPCIX-901](https://issues.redhat.com//browse/OSPCIX-901)