### PR TITLE
Use role instead of playbooks - 03-build-packages.yml

### DIFF
--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -55,10 +55,16 @@
       tags:
         - infra
 
-- name: Import package build playbook
-  ansible.builtin.import_playbook: playbooks/03-build-packages.yml
-  tags:
-    - build-packages
+- name: Build package playbook
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Build package playbook
+      ansible.builtin.import_role:
+        name: cifmw_setup
+        tasks_from: build_packages.yml
+      tags:
+        - build-packages
 
 - name: Import containers build playbook
   ansible.builtin.import_playbook: playbooks/04-build-containers.yml

--- a/playbooks/03-build-packages.yml
+++ b/playbooks/03-build-packages.yml
@@ -1,4 +1,8 @@
 ---
+#
+# NOTE: Playbook migrated to: cifmw_setup/build_packages.yml.
+# DO NOT EDIT THAT PLAYBOOK. IT WOULD BE REMOVED IN NEAR FUTURE.
+#
 - name: Build package playbook
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false

--- a/roles/cifmw_setup/tasks/build_packages.yml
+++ b/roles/cifmw_setup/tasks/build_packages.yml
@@ -1,0 +1,24 @@
+---
+- name: Run pre_package_build hooks
+  vars:
+    step: pre_package_build
+  ansible.builtin.import_role:
+    name: run_hook
+
+- name: Load parameters files
+  ansible.builtin.include_vars:
+    dir: "{{ cifmw_basedir }}/artifacts/parameters"
+
+- name: Build packages
+  when:
+    - cifmw_pkg_build_list is defined
+    - cifmw_pkg_build_list | length > 0
+  ansible.builtin.import_role:
+    name: pkg_build
+    tasks_from: build.yml
+
+- name: Run post_package_build hooks
+  vars:
+    step: post_package_build
+  ansible.builtin.import_role:
+    name: run_hook


### PR DESCRIPTION
It is continuation of simplification job execution [1].

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/2929