### PR TITLE
Use role instead of playbooks - 04-build-containers.yml

### DIFF
--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -60,10 +60,16 @@
   tags:
     - build-packages
 
-- name: Import containers build playbook
-  ansible.builtin.import_playbook: playbooks/04-build-containers.yml
-  tags:
-    - build-containers
+- name: Build container playbook
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Build container playbook
+      ansible.builtin.import_role:
+        name: cifmw_setup
+        tasks_from: build_containers.yml
+      tags:
+        - build-containers
 
 - name: Import operators build playbook
   ansible.builtin.import_playbook: playbooks/05-build-operators.yml

--- a/playbooks/04-build-containers.yml
+++ b/playbooks/04-build-containers.yml
@@ -1,4 +1,8 @@
 ---
+#
+# NOTE: Playbook migrated to: cifmw_setup/build_containers.yml.
+# DO NOT EDIT THAT PLAYBOOK. IT WOULD BE REMOVED IN NEAR FUTURE.
+#
 - name: Build container playbook
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false

--- a/roles/cifmw_setup/tasks/build_containers.yml
+++ b/roles/cifmw_setup/tasks/build_containers.yml
@@ -1,0 +1,20 @@
+---
+- name: Run pre_container_build hooks
+  vars:
+    step: pre_container_build
+  ansible.builtin.import_role:
+    name: run_hook
+
+- name: Load parameters files
+  ansible.builtin.include_vars:
+    dir: "{{ cifmw_basedir }}/artifacts/parameters"
+
+- name: Nothing to do yet
+  ansible.builtin.debug:
+    msg: "No support for that step yet"
+
+- name: Run post_container_build hooks
+  vars:
+    step: post_container_build
+  ansible.builtin.import_role:
+    name: run_hook


### PR DESCRIPTION
It is continuation of simplification job execution [1].

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/2929