### PR TITLE
Use role instead of playbooks - 05-build-operators.yml

### DIFF
--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -65,10 +65,18 @@
   tags:
     - build-containers
 
-- name: Import operators build playbook
-  ansible.builtin.import_playbook: playbooks/05-build-operators.yml
-  tags:
-    - build-operators
+- name: Build operators playbook
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  environment:
+    PATH: "{{ cifmw_path }}"
+  tasks:
+    - name: Build operators playbook
+      ansible.builtin.import_role:
+        name: cifmw_setup
+        tasks_from: build_operators.yml
+      tags:
+        - build-operators
 
 - name: Import deploy edpm playbook
   ansible.builtin.import_playbook: playbooks/06-deploy-edpm.yml

--- a/playbooks/05-build-operators.yml
+++ b/playbooks/05-build-operators.yml
@@ -1,4 +1,8 @@
 ---
+#
+# NOTE: Playbook migrated to: cifmw_setup/tasks/build_operators.yml.
+# DO NOT EDIT THAT PLAYBOOK. IT WOULD BE REMOVED IN NEAR FUTURE.
+#
 - name: Build operators playbook
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false

--- a/roles/cifmw_setup/tasks/build_operators.yml
+++ b/roles/cifmw_setup/tasks/build_operators.yml
@@ -1,0 +1,23 @@
+---
+- name: Run pre_operator_build hooks
+  vars:
+    step: pre_operator_build
+  ansible.builtin.import_role:
+    name: run_hook
+
+- name: Load parameters files
+  ansible.builtin.include_vars:
+    dir: "{{ cifmw_basedir }}/artifacts/parameters"
+
+- name: Build operator and meta-operator
+  when:
+    - cifmw_operator_build_operators is defined
+    - cifmw_operator_build_operators | length > 0
+  ansible.builtin.import_role:
+    name: operator_build
+
+- name: Run post_operator_build hooks
+  vars:
+    step: post_operator_build
+  ansible.builtin.import_role:
+    name: run_hook


### PR DESCRIPTION
It is continuation of simplification job execution [1].

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/2929