### PR TITLE
Remove printing redhat-release in adoption_osp_deploy

### DIFF
--- a/roles/adoption_osp_deploy/tasks/prepare_overcloud.yml
+++ b/roles/adoption_osp_deploy/tasks/prepare_overcloud.yml
@@ -121,15 +121,6 @@
         loop_var: _vm
         pause: 1
 
-    - name: Get current /etc/redhat-release
-      delegate_to: "{{ _vm }}"
-      ansible.builtin.command: cat /etc/redhat-release
-      register: _current_rh_release
-
-    - name: Print current /etc/redhat-release
-      ansible.builtin.debug:
-        msg: "{{ _current_rh_release.stdout }}"
-
     - name: Copy network data file if it's not a template
       when: _network_data_extension != '.j2'
       delegate_to: "osp-undercloud-0"


### PR DESCRIPTION
The task should iterate on list of hosts, which should be provided
later as "_vm" variable. That was missing, so the Ansible was
failing because of undefined variable.
Printing the redhat-release should be added into pre-run config after
registration, but in this kind of CI jobs we did not spotted any issues
now.