### PR TITLE
Make worker-Nodes take preference in nncp ci_kustomize

### DIFF
--- a/roles/ci_dcn_site/templates/network-values/values.yaml.j2
+++ b/roles/ci_dcn_site/templates/network-values/values.yaml.j2
@@ -3,6 +3,13 @@
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
                       lb_tools={}) %}
+{% if cifmw_networking_env_definition.instances.keys() | select('match', '^ocp-worker') | list | length > 0 %}
+{% set filter="^ocp-worker" %}
+{% elif cifmw_networking_env_definition.instances.keys() | select('match', 'crc') | list | length > 0 %}
+{% set filter="^crc" %}
+{% else %}
+{% set filter="^ocp" %}
+{% endif %}
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
 {%   for network in cifmw_networking_env_definition.instances[host]['networks'].values() -%}
@@ -13,7 +20,7 @@ data:
                                    },
                                    recursive=true) -%}
 {%   endfor -%}
-{%   if host is match('^(ocp|crc).*') %}
+{%   if host is match(filter) %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}

--- a/roles/ci_gen_kustomize_values/templates/bgp-l3-xl/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp-l3-xl/network-values/values.yaml.j2
@@ -3,6 +3,7 @@
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
                       lb_tools={}) %}
+
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
 {%   set hostname = cifmw_networking_env_definition.instances[host]['hostname'] %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/network-values/values.yaml.j2
@@ -3,6 +3,7 @@
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
                       lb_tools={}) %}
+
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
 {%   set hostname = cifmw_networking_env_definition.instances[host]['hostname'] %}

--- a/roles/ci_gen_kustomize_values/templates/bmo01/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bmo01/network-values/values.yaml.j2
@@ -2,9 +2,17 @@
 # source: bmo01/network-values/values.yaml.j2
 {% set _ipv = cifmw_ci_gen_kustomize_values_ip_version_var_mapping %}
 {% set ns = namespace(ocp_index=0) %}
+
+{% if cifmw_networking_env_definition.instances.keys() | select('match', '^ocp-worker') | list | length > 0 %}
+{% set filter="^ocp-worker" %}
+{% elif cifmw_networking_env_definition.instances.keys() | select('match', 'crc') | list | length > 0 %}
+{% set filter="^crc" %}
+{% else %}
+{% set filter="^ocp" %}
+{% endif %}
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
-{%   if host is match('^(ocp|crc).*') %}
+{%   if host is match(filter) %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}

--- a/roles/ci_gen_kustomize_values/templates/common/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/common/network-values/values.yaml.j2
@@ -4,9 +4,18 @@
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
                       lb_tools={}) %}
+
+{% if cifmw_networking_env_definition.instances.keys() | select('match', '^ocp-worker') | list | length > 0 %}
+{% set filter="^ocp-worker" %}
+{% elif cifmw_networking_env_definition.instances.keys() | select('match', 'crc') | list | length > 0 %}
+{% set filter="^crc" %}
+{% else %}
+{% set filter="^ocp" %}
+{% endif %}
+
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
-{%   if host is match('^(ocp|crc).*') %}
+{% if host is match(filter) %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}

--- a/roles/ci_gen_kustomize_values/templates/dcn/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/dcn/network-values/values.yaml.j2
@@ -3,6 +3,14 @@
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
                       lb_tools={}) %}
+
+{% if cifmw_networking_env_definition.instances.keys() | select('match', '^ocp-worker') | list | length > 0 %}
+{% set filter="^ocp-worker" %}
+{% elif cifmw_networking_env_definition.instances.keys() | select('match', 'crc') | list | length > 0 %}
+{% set filter="^crc" %}
+{% else %}
+{% set filter="^ocp" %}
+{% endif %}
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
 {%   for network in cifmw_networking_env_definition.instances[host]['networks'].values() -%}
@@ -13,7 +21,7 @@ data:
                                    },
                                    recursive=true) -%}
 {%   endfor -%}
-{%   if host is match('^(ocp|crc).*') %}
+{%   if host is match(filter) %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}

--- a/roles/ci_gen_kustomize_values/templates/multi-namespace/network-values2/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/multi-namespace/network-values2/values.yaml.j2
@@ -4,9 +4,17 @@
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
                       lb_tools={}) %}
+
+{% if cifmw_networking_env_definition.instances.keys() | select('match', '^ocp-worker') | list | length > 0 %}
+{% set filter="^ocp-worker" %}
+{% elif cifmw_networking_env_definition.instances.keys() | select('match', 'crc') | list | length > 0 %}
+{% set filter="^crc" %}
+{% else %}
+{% set filter="^ocp" %}
+{% endif %}
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
-{%   if host is match('^(ocp|crc).*') %}
+{%   if host is match(filter) %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}

--- a/roles/ci_gen_kustomize_values/templates/osasinfra-ipv6/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/osasinfra-ipv6/network-values/values.yaml.j2
@@ -4,9 +4,17 @@
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
                       lb_tools={}) %}
+
+{% if cifmw_networking_env_definition.instances.keys() | select('match', '^ocp-worker') | list | length > 0 %}
+{% set filter="^ocp-worker" %}
+{% elif cifmw_networking_env_definition.instances.keys() | select('match', 'crc') | list | length > 0 %}
+{% set filter="^crc" %}
+{% else %}
+{% set filter="^ocp" %}
+{% endif %}
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
-{%   if host is match('^(ocp|crc).*') %}
+{%   if host is match(filter) %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}

--- a/roles/ci_gen_kustomize_values/templates/shiftstack/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/shiftstack/network-values/values.yaml.j2
@@ -1,10 +1,16 @@
 ---
 # source: shiftstack/network-values/values.yaml.j2
 {% set ns = namespace(interfaces={}, ocp_index=0, lb_tools={}) %}
-
+{% if cifmw_networking_env_definition.instances.keys() | select('match', '^ocp-worker') | list | length > 0 %}
+{% set filter="^ocp-worker" %}
+{% elif cifmw_networking_env_definition.instances.keys() | select('match', 'crc') | list | length > 0 %}
+{% set filter="^crc" %}
+{% else %}
+{% set filter="^ocp" %}
+{% endif %}
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
-{%   if host is match('^(ocp|crc).*') %}
+{%   if host is match(filter) %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}

--- a/roles/ci_gen_kustomize_values/templates/uni01alpha-adoption/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni01alpha-adoption/network-values/values.yaml.j2
@@ -4,9 +4,16 @@
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
                       lb_tools={}) %}
+{% if cifmw_networking_env_definition.instances.keys() | select('match', '^ocp-worker') | list | length > 0 %}
+{% set filter="^ocp-worker" %}
+{% elif cifmw_networking_env_definition.instances.keys() | select('match', 'crc') | list | length > 0 %}
+{% set filter="^crc" %}
+{% else %}
+{% set filter="^ocp" %}
+{% endif %}
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
-{%   if host is match('^(ocp|crc).*') %}
+{%   if host is match(filter) %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}

--- a/roles/ci_gen_kustomize_values/templates/uni01alpha/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni01alpha/network-values/values.yaml.j2
@@ -4,9 +4,17 @@
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
                       lb_tools={}) %}
+
+{% if cifmw_networking_env_definition.instances.keys() | select('match', '^ocp-worker') | list | length > 0 %}
+{% set filter="^ocp-worker" %}
+{% elif cifmw_networking_env_definition.instances.keys() | select('match', 'crc') | list | length > 0 %}
+{% set filter="^crc" %}
+{% else %}
+{% set filter="^ocp" %}
+{% endif %}
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
-{%   if host is match('^(ocp|crc).*') %}
+{%   if host is match(filter) %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}

--- a/roles/ci_gen_kustomize_values/templates/uni04delta-ipv6-adoption/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni04delta-ipv6-adoption/network-values/values.yaml.j2
@@ -4,9 +4,17 @@
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
                       lb_tools={}) %}
+
+{% if cifmw_networking_env_definition.instances.keys() | select('match', '^ocp-worker') | list | length > 0 %}
+{% set filter="^ocp-worker" %}
+{% elif cifmw_networking_env_definition.instances.keys() | select('match', 'crc') | list | length > 0 %}
+{% set filter="^crc" %}
+{% else %}
+{% set filter="^ocp" %}
+{% endif %}
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
-{%   if host is match('^(ocp|crc).*') %}
+{%   if host is match(filter) %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}

--- a/roles/ci_gen_kustomize_values/templates/uni04delta-ipv6/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni04delta-ipv6/network-values/values.yaml.j2
@@ -4,9 +4,17 @@
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
                       lb_tools={}) %}
+
+{% if cifmw_networking_env_definition.instances.keys() | select('match', '^ocp-worker') | list | length > 0 %}
+{% set filter="^ocp-worker" %}
+{% elif cifmw_networking_env_definition.instances.keys() | select('match', 'crc') | list | length > 0 %}
+{% set filter="^crc" %}
+{% else %}
+{% set filter="^ocp" %}
+{% endif %}
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
-{%   if host is match('^(ocp|crc).*') %}
+{%   if host is match(filter) %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}

--- a/roles/ci_gen_kustomize_values/templates/uni05epsilon/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni05epsilon/network-values/values.yaml.j2
@@ -4,9 +4,16 @@
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
                       lb_tools={}) %}
+{% if cifmw_networking_env_definition.instances.keys() | select('match', '^ocp-worker') | list | length > 0 %}
+{% set filter="^ocp-worker" %}
+{% elif cifmw_networking_env_definition.instances.keys() | select('match', 'crc') | list | length > 0 %}
+{% set filter="^crc" %}
+{% else %}
+{% set filter="^ocp" %}
+{% endif %}
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
-{%   if host is match('^(ocp|crc).*') %}
+{%   if host is match(filter) %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}

--- a/roles/ci_gen_kustomize_values/templates/uni06zeta/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni06zeta/network-values/values.yaml.j2
@@ -4,9 +4,17 @@
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
                       lb_tools={}) %}
+
+{% if cifmw_networking_env_definition.instances.keys() | select('match', '^ocp-worker') | list | length > 0 %}
+{% set filter="^ocp-worker" %}
+{% elif cifmw_networking_env_definition.instances.keys() | select('match', 'crc') | list | length > 0 %}
+{% set filter="^crc" %}
+{% else %}
+{% set filter="^ocp" %}
+{% endif %}
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
-{%   if host is match('^(ocp|crc).*') %}
+{%   if host is match(filter) %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}

--- a/roles/ci_gen_kustomize_values/templates/uni07eta/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni07eta/network-values/values.yaml.j2
@@ -4,9 +4,17 @@
 {% set ns = namespace(interfaces={},
                       ocp_index=0,
                       lb_tools={}) %}
+
+{% if cifmw_networking_env_definition.instances.keys() | select('match', '^ocp-worker') | list | length > 0 %}
+{% set filter="^ocp-worker" %}
+{% elif cifmw_networking_env_definition.instances.keys() | select('match', 'crc') | list | length > 0 %}
+{% set filter="^crc" %}
+{% else %}
+{% set filter="^ocp" %}
+{% endif %}
 data:
 {% for host in cifmw_networking_env_definition.instances.keys() -%}
-{%   if host is match('^(ocp|crc).*') %}
+{%   if host is match(filter) %}
   node_{{ ns.ocp_index }}:
 {%     set ns.ocp_index = ns.ocp_index+1 %}
     name: {{ cifmw_networking_env_definition.instances[host]['hostname'] }}


### PR DESCRIPTION
As for example in 3+3 scenarios, we want to run all openstack namespaces pods
in the worker nodes.

As we have different type of nodes: ocp, crc and ocp-worker; we want to
select the nodes by taking precedende to worker nodes if defined.
If not, we want to check if it's a SNO crc deployment, and lastly, we'll
go by typical scenarios where the control-plane, master and workers in the same
nodes.