### PR TITLE
Temporary override keystone config in job v2

### DIFF
--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -317,6 +317,26 @@
       cifmw_extras:
         - '@scenarios/centos-9/multinode-ci.yml'
         - '@scenarios/centos-9/horizon.yml'
+      # Temporary until https://review.opendev.org/c/openstack/oslo.cache/+/952014
+      # is included in rdo and promoted
+      cifmw_edpm_prepare_kustomizations:
+        - apiVersion: kustomize.config.k8s.io/v1beta1
+          kind: Kustomization
+          namespace: openstack
+          patches:
+            - patch: |-
+                apiVersion: core.openstack.org/v1beta1
+                kind: OpenStackControlPlane
+                metadata:
+                  name: unused
+                spec:
+                  keystone:
+                    template:
+                      customServiceConfig: |
+                        [cache]
+                        memcache_sasl_enabled = true
+              target:
+                kind: OpenStackControlPlane
     run:
       - ci/playbooks/edpm/run.yml
 

--- a/zuul.d/tempest_multinode.yaml
+++ b/zuul.d/tempest_multinode.yaml
@@ -72,26 +72,6 @@
         - '@scenarios/centos-9/ci.yml'
         - '@scenarios/centos-9/multinode-ci.yml'
         - '@scenarios/centos-9/ceph_backends.yml'
-      # Temporary until https://review.opendev.org/c/openstack/oslo.cache/+/952014
-      # is included in rdo and promoted
-      cifmw_edpm_prepare_kustomizations:
-        - apiVersion: kustomize.config.k8s.io/v1beta1
-          kind: Kustomization
-          namespace: openstack
-          patches:
-            - patch: |-
-                apiVersion: core.openstack.org/v1beta1
-                kind: OpenStackControlPlane
-                metadata:
-                  name: unused
-                spec:
-                  keystone:
-                    template:
-                      customServiceConfig: |
-                        [cache]
-                        memcache_sasl_enabled = true
-              target:
-                kind: OpenStackControlPlane
       cifmw_test_operator_tempest_include_list: |
         ^tempest.api.identity.*.v3
         ^tempest.api.volume


### PR DESCRIPTION
Until [1] get's included in RDO antelope and promoted temporary patch to workaround the issue.

Previous PR[2] applied it on one job, moving it to parent job to cover other impacted jobs.

[1] https://review.opendev.org/c/openstack/oslo.cache/+/952014
[2] https://github.com/openstack-k8s-operators/ci-framework/pull/3049

Related-Issue: #OSPCIX-901