### PR TITLE
rsync only if source directory exists

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -350,7 +350,14 @@
             name: sushy_emulator
             tasks_from: verify.yml
 
-    - name: Sync local repositories to other hosts
+    - name: Check if cifmw_reproducer_src_dir is on localhost
+      delegate_to: localhost
+      ansible.builtin.stat:
+        path: "{{ cifmw_reproducer_src_dir }}"
+      register: cifmw_reproducer_src_dir_stat
+      run_once: true
+
+    - name: Sync local repositories to other hosts if present
       delegate_to: localhost
       ansible.posix.synchronize:
         src: "{{ cifmw_reproducer_src_dir }}/"
@@ -358,14 +365,20 @@
         archive: true
         recursive: true
       loop: "{{ groups['controllers'] }}"
+      when:
+        - cifmw_reproducer_src_dir_stat.stat.exists
+        - cifmw_reproducer_src_dir_stat.stat.isdir
 
-    # NOTE: src dir is synchronized in libvirt_layout.yml
     - name: Install ansible dependencies
       register: _async_dep_install
       async: 600  # 10 minutes should be more than enough
       poll: 0
       ansible.builtin.pip:
-        requirements: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/common-requirements.txt"
+        requirements: "{{ have_local | ternary(local, remote) }}"
+      vars:
+        have_local: "{{ cifmw_reproducer_src_dir_stat.stat.exists and cifmw_reproducer_src_dir_stat.stat.isdir }}"
+        local: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/common-requirements.txt"
+        remote: https://raw.githubusercontent.com/openstack-k8s-operators/ci-framework/main/common-requirements.txt
 
     - name: Inject most of the cifmw_ parameters passed to the reproducer run
       tags:


### PR DESCRIPTION
In reproducer role's configure_controller.yml tasks file, stat the cifmw_reproducer_src_dir before attempting to rsync it and then only rsync it if it exists. This is a reasonable thing to do before calling rsync.

If the cifmw_reproducer_src_dir does not exist, then fall back to github for the Ansible dependencies. This will not break the current behavior for which the rsync task was added.

Jira: [OSPRH-17434](https://issues.redhat.com//browse/OSPRH-17434)