### PR TITLE
Add missing molecule jobs

### DIFF
--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -879,10 +879,28 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/cifmw_nfs/.*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-cifmw_nfs
+    parent: cifmw-molecule-noop
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/cifmw_setup/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cifmw_setup
+    parent: cifmw-molecule-noop
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
+    - ^roles/cleanup_openstack/.*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-cleanup_openstack
     parent: cifmw-molecule-noop
 - job:
     files:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -33,9 +33,11 @@
       - cifmw-molecule-cifmw_cephadm
       - cifmw-molecule-cifmw_create_admin
       - cifmw-molecule-cifmw_external_dns
+      - cifmw-molecule-cifmw_nfs
       - cifmw-molecule-cifmw_ntp
       - cifmw-molecule-cifmw_setup
       - cifmw-molecule-cifmw_test_role
+      - cifmw-molecule-cleanup_openstack
       - cifmw-molecule-compliance
       - cifmw-molecule-config_drive
       - cifmw-molecule-copy_container


### PR DESCRIPTION
After merging [1] [2] it seems the CI job did not trigger tests for verifying molecule roles.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/3038/
[2] https://github.com/openstack-k8s-operators/ci-framework/pull/3020/