### PR TITLE
Use role instead of playbooks - 06-deploy-architecture.yml

### DIFF
--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -150,7 +150,40 @@
       tags:
         - edpm
 
-- name: Import VA deployment playbook
-  ansible.builtin.import_playbook: playbooks/06-deploy-architecture.yml
-  tags:
-    - edpm
+- name: Deploy VA and validate workflow
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Run pre_deploy hooks
+      when: cifmw_architecture_scenario is defined
+      vars:
+        step: pre_deploy
+      ansible.builtin.import_role:
+        name: run_hook
+
+    # FIXME:Earlier, where we were using import_playbook, the cifmw_architecture_scenario
+    # variable was not available in playbooks/06-deploy-architecture.yml,
+    # but by using import_playbook, the variables are parsed in different way,
+    # so instead of cifmw_architecture_scenario not being defined, it is defined
+    # and it is executing additional tasks, which should not.
+    # Temporary move the end_play here and let's improve the tasks execution
+    # where tasks execution would be merged into one if the tasks should
+    # be done on same host.
+    - name: Early end if not architecture deploy
+      tags:
+        - always
+      when: cifmw_architecture_scenario is not defined
+      ansible.builtin.meta: end_play
+
+    - name: Run cifmw_setup deploy_architecture
+      when: cifmw_architecture_scenario is defined
+      ansible.builtin.import_role:
+        name: cifmw_setup
+        tasks_from: deploy_architecture.yml
+      tags:
+        - edpm
+
+    - name: Run validations
+      ansible.builtin.include_role:
+        name: validations
+      when: cifmw_execute_validations | default(false) | bool

--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -1,4 +1,8 @@
 ---
+#
+# NOTE: Playbook migrated to: roles/cifmw_setup/tasks/deploy_architecture.yml
+# DO NOT EDIT THIS PLAYBOOK. IT WILL BE REMOVED IN NEAR FUTURE..
+#
 - name: Deploy VA
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   tasks:

--- a/playbooks/validations.yml
+++ b/playbooks/validations.yml
@@ -1,5 +1,6 @@
 #
-# NOTE: Playbook migrated to: roles/cifmw_setup/tasks/hci_deploy.yml:L29-35 & 06-deploy-architecture.yml.
+# NOTE: Playbook migrated to: roles/cifmw_setup/tasks/hci_deploy.yml &
+# 06-deploy-architecture.yml.
 # This migration is temporary, and will be further migrated to role.
 # DO NOT EDIT THAT PLAYBOOK. IT WOULD BE REMOVED IN NEAR FUTURE.
 #
@@ -7,7 +8,6 @@
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
-
     - name: Run validations
       ansible.builtin.include_role:
         name: validations

--- a/roles/ci_lvms_storage/README.md
+++ b/roles/ci_lvms_storage/README.md
@@ -30,18 +30,18 @@ clean and adds to an LVMS cluster.
 * `cifmw_use_lvms`: (Boolean) Whether or not to use LVMS (default: `false`)
 
 If the ci-framework is called and `cifmw_use_lvms` is true, then
-the playbooks `06-deploy-architecture.yml` and `06-deploy-edpm.yml`
-call the `ci_lvms_storage` role to create a storage class called
-`lvms-local-storage` and the `ci_gen_kustomize_values` role will
-set the `storageClass` to `lvms-local-storage` in the generated
+the tasks in role `roles/cifmw_setup/tasks/deploy_architecture.yml`
+and playbook `06-deploy-edpm.yml` call the `ci_lvms_storage` role to create
+a storage class called `lvms-local-storage` and the `ci_gen_kustomize_values`
+role will set the `storageClass` to `lvms-local-storage` in the generated
 values.yaml files used to build architecture CRs. The Tempest
 CR file, created by the `test_operator` role, will also set its
 `storageClass` value to `lvms-local-storage`.
 
 If the ci-framework is called and `cifmw_use_lvms` is false, then the
-playbooks `06-deploy-architecture.yml` and `06-deploy-edpm.yml`
-call the `ci_local_storage` role to create a storage class called
-`local-storage` and the `ci_gen_kustomize_values` role will set
+tasks in role `roles/cifmw_setup/tasks/deploy_architecture.yml` and playbook
+`06-deploy-edpm.yml` call the `ci_local_storage` role to create a storage class
+called `local-storage` and the `ci_gen_kustomize_values` role will set
 the `storageClass` to `local-storage` in the generated values.yaml
 files used to build architecture CRs. The Tempest CR file, created by
 the `test_operator` role, will also set its `storageClass` value to

--- a/roles/cifmw_setup/defaults/main.yml
+++ b/roles/cifmw_setup/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 ansible_user_dir: "{{ lookup('env', 'HOME') }}"
+openstack_namespace: openstack

--- a/roles/cifmw_setup/tasks/deploy_architecture.yml
+++ b/roles/cifmw_setup/tasks/deploy_architecture.yml
@@ -1,0 +1,269 @@
+---
+- name: Load Networking Environment Definition
+  tags:
+    - always
+  ansible.builtin.import_role:
+    name: networking_mapper
+    tasks_from: load_env_definition.yml
+
+- name: Fetch network facts
+  tags:
+    - always
+  when:
+    - "not item.startswith('ocp-')"
+  ansible.builtin.setup:
+    gather_subset: network
+  delegate_facts: true
+  delegate_to: "{{ item }}"
+  loop: "{{ groups['all'] }}"
+  loop_control:
+    label: "{{ item }}"
+
+- name: Look for nova migration keypair file
+  tags:
+    - edpm_bootstrap
+  register: _nova_key_file
+  ansible.builtin.stat:
+    path: "{{ cifmw_basedir }}/artifacts/nova_migration_key"
+
+- name: Ensure nova migration keypair details are propagated
+  tags:
+    - always
+  vars:
+    _ssh_file: >-
+      {{
+        _nova_key_file.stat.path |
+        default(
+          (cifmw_basedir, 'artifacts', 'nova_migration_key') |
+          ansible.builtin.path_join
+        )
+      }}
+  block:
+    - name: Create nova migration keypair if does not exists
+      when:
+        - not _nova_key_file.stat.exists | default(false)
+      community.crypto.openssh_keypair:
+        comment: "nova migration"
+        path: "{{ _ssh_file }}"
+        type: "{{ cifmw_ssh_keytype | default('ecdsa') }}"
+        size: "{{ cifmw_ssh_keysize | default(521) }}"
+
+    - name: Try/catch block
+      vars:
+        # We want to match anything like:
+        # - controller (in Zuul)
+        # - controller-0.foo.com (FQDN)
+        # - controller-0 (no FQDN) - compatibility match
+        _ctl_data: >-
+          {{
+            hostvars | dict2items |
+            selectattr('key', 'match', '^(controller-0.*|controller)') |
+            map(attribute='value') | first
+          }}
+        _ifaces_vars: >-
+          {{
+            _ctl_data.ansible_interfaces |
+            map('regex_replace', '^(.*)$', 'ansible_\1')
+          }}
+        _controller_host: "{{ _ctl_data.ansible_host }}"
+      block:
+        - name: Generate needed facts out of local files
+          vars:
+            _ctl_ifaces_vars: >-
+              {{
+                _ctl_data | dict2items | selectattr('key', 'in', _ifaces_vars)
+              }}
+            _ipv4_network_data: >-
+              {{
+                _ctl_ifaces_vars |
+                selectattr('value.ipv4.address', 'defined') |
+                selectattr('value.ipv4.address', 'equalto', _controller_host) |
+                map(attribute='value.ipv4') | first | default({})
+              }}
+            _ipv6_network_data: >-
+              {{
+                _ctl_ifaces_vars |
+                selectattr('value.ipv6.address', 'defined') |
+                selectattr('value.ipv6.address', 'equalto', _controller_host) |
+                map(attribute='value.ipv6') | first | default({})
+              }}
+            _ipv4_sshd_ranges: >-
+              {{
+                (
+                  [cifmw_networking_env_definition.networks.ctlplane.network_v4]
+                  if cifmw_networking_env_definition.networks.ctlplane.network_v4 is defined else []
+                ) +
+                (
+                  [
+                    _ipv4_network_data.network + '/' + _ipv4_network_data.prefix
+                  ]
+                ) if (_ipv4_network_data | length > 0) else []
+              }}
+            _ipv6_sshd_ranges: >-
+              {{
+                (
+                  [cifmw_networking_env_definition.networks.ctlplane.network_v6]
+                  if cifmw_networking_env_definition.networks.ctlplane.network_v6 is defined else []
+                ) +
+                (
+                  [
+                    _ipv6_network_data.network + '/' + _ipv6_network_data.prefix
+                  ]
+                ) if (_ipv6_network_data | length > 0) else []
+              }}
+          ansible.builtin.set_fact:
+            cifmw_ci_gen_kustomize_values_ssh_authorizedkeys: >-
+              {{ lookup('file', '~/.ssh/id_cifw.pub', rstrip=False) }}
+            cifmw_ci_gen_kustomize_values_ssh_private_key: >-
+              {{ lookup('file', '~/.ssh/id_cifw', rstrip=False) }}
+            cifmw_ci_gen_kustomize_values_ssh_public_key: >-
+              {{ lookup('file', '~/.ssh/id_cifw.pub', rstrip=False) }}
+            cifmw_ci_gen_kustomize_values_migration_pub_key: >-
+              {{ lookup('file', _ssh_file ~ '.pub', rstrip=False)}}
+            cifmw_ci_gen_kustomize_values_migration_priv_key: >-
+              {{ lookup('file', _ssh_file, rstrip=False) }}
+            cifmw_ci_gen_kustomize_values_sshd_ranges: >-
+              {{
+                _ipv4_sshd_ranges + _ipv6_sshd_ranges
+              }}
+      rescue:
+        - name: Debug _ctl_data
+          ansible.builtin.debug:
+            var: _ctl_data
+
+        - name: Debug _ifaces_vars
+          ansible.builtin.debug:
+            var: _ifaces_vars
+
+        - name: Fail for good
+          ansible.builtin.fail:
+            msg: >-
+              Error detected. Check debugging output above.
+
+- name: Set cifmw_architecture_automation_file if not set before
+  when: cifmw_architecture_automation_file is not defined
+  ansible.builtin.set_fact:
+    cifmw_architecture_automation_file: >-
+      {{
+        (
+          cifmw_architecture_repo | default(ansible_user_dir+'/src/github.com/openstack-k8s-operators/architecture'),
+          'automation/vars',
+          cifmw_architecture_scenario~'.yaml'
+        ) | ansible.builtin.path_join
+      }}
+
+- name: Load architecture automation file
+  tags:
+    - edpm_deploy
+  register: _automation
+  ansible.builtin.slurp:
+    path: "{{ cifmw_architecture_automation_file }}"
+
+- name: Prepare automation data
+  tags:
+    - edpm_deploy
+  vars:
+    _parsed: "{{ _automation.content | b64decode | from_yaml }}"
+  ansible.builtin.set_fact:
+    cifmw_deploy_architecture_steps: >-
+      {{ _parsed['vas'][cifmw_architecture_scenario] }}
+
+- name: Check requirements
+  tags:
+    - edpm_bootstrap
+  ansible.builtin.import_role:
+    name: kustomize_deploy
+    tasks_from: check_requirements.yml
+
+- name: Reduce OCP cluster size in architecture
+  when:
+    - groups['ocps'] | length == 1
+  ansible.builtin.import_role:
+    name: kustomize_deploy
+    tasks_from: reduce_ocp_cluster.yml
+  tags:
+    - edpm_bootstrap
+
+- name: Configure Storage Class
+  ansible.builtin.import_role:
+    name: ci_local_storage
+  when: not cifmw_use_lvms | default(false)
+  tags:
+    - storage
+    - edpm_bootstrap
+
+- name: Deploy OSP operators
+  ansible.builtin.import_role:
+    name: kustomize_deploy
+    tasks_from: install_operators.yml
+  tags:
+    - operator
+    - edpm_bootstrap
+
+- name: Update containers in deployed OSP operators
+  vars:
+    cifmw_update_containers_metadata: controlplane
+  ansible.builtin.include_role:
+    name: update_containers
+  tags:
+    - update_containers
+    - edpm_bootstrap
+  when: cifmw_ci_gen_kustomize_values_deployment_version is not defined
+
+- name: Update containers in deployed OSP operators using set_openstack_containers role
+  when:
+    - cifmw_set_openstack_containers | default(false) | bool
+    - cifmw_ci_gen_kustomize_values_deployment_version is not defined
+  ansible.builtin.include_role:
+    name: set_openstack_containers
+  tags:
+    - set_openstack_containers
+    - edpm_bootstrap
+
+- name: Configure LVMS Storage Class
+  ansible.builtin.include_role:
+    name: ci_lvms_storage
+  when: cifmw_use_lvms | default(false)
+  tags:
+    - storage
+    - edpm_bootstrap
+
+- name: Execute deployment steps
+  tags:
+    - edpm_deploy
+  ansible.builtin.include_role:
+    name: kustomize_deploy
+    tasks_from: execute_step.yml
+    apply:
+      tags:
+        - edpm_deploy
+  loop: "{{ cifmw_deploy_architecture_steps.stages }}"
+  loop_control:
+    label: "{{ stage.path }}"
+    loop_var: stage
+    index_var: stage_id
+
+- name: Extract and install OpenStackControlplane CA
+  ansible.builtin.import_role:
+    role: install_openstack_ca
+  tags:
+    - openstack_ca
+    - edpm_post
+
+- name: Run nova host discover process
+  tags:
+    - edpm_post
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command: >-
+    oc rsh
+    -n {{ openstack_namespace }}
+    nova-cell0-conductor-0
+    nova-manage cell_v2 discover_hosts --verbose
+
+- name: Run post_deploy hooks
+  vars:
+    step: post_deploy
+  ansible.builtin.import_role:
+    name: run_hook


### PR DESCRIPTION
Reason why we move playbook execution to roles was described in pull request [1], but in few words: it would be easier for mainteners to understand playbook/role execution, it is just better to control variables, easier to debug, etc.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/2930