### PR TITLE
Trigger subscription-manager refresh command after registration

### DIFF
--- a/roles/adoption_osp_deploy/tasks/login_registries.yml
+++ b/roles/adoption_osp_deploy/tasks/login_registries.yml
@@ -32,13 +32,18 @@
       register: _rh_result
       until: not _rh_result.failed
 
+    - name: Pull latest subscription data
+      become: true
+      no_log: true
+      ansible.builtin.command: subscription-manager refresh
+      retries: 5
+      delay: 30
+      register: _rh_refresh
+      until: _rh_refresh is success
+
     - name: Get current /etc/redhat-release
       ansible.builtin.command: cat /etc/redhat-release
       register: _current_rh_release
-
-    - name: Print current /etc/redhat-release
-      ansible.builtin.debug:
-        msg: "{{ _current_rh_release.stdout }}"
 
 - name: Login in container registry
   when:


### PR DESCRIPTION
From time to time we have an issue that it is raising an error:

    System certificates corrupted. Please reregister

Normally, the procedure described in article [1] is different, but after checking all should be fine.
Let's execute "post" actions that have been done after registration that was described in the Red_Hat_Product_Certificates.sh script [2].

[1] https://access.redhat.com/solutions/4378801
[2] https://access.redhat.com/labs/rhpc/