### PR TITLE
Let sync workflow work with non-default branches

### DIFF
--- a/.github/workflows/sync_branches_reusable_workflow.yml
+++ b/.github/workflows/sync_branches_reusable_workflow.yml
@@ -36,5 +36,5 @@ jobs:
         run: |
           git fetch origin ${{ inputs.source-branch }}
           git checkout ${{ inputs.target-branch }}
-          git rebase ${{ inputs.source-branch }}
+          git rebase FETCH_HEAD
           git push --force origin ${{ inputs.target-branch }}


### PR DESCRIPTION
Currently the sync workflow checkouts always the default branch in repository, so in case where we want to sync other branch, such as `18.0-fr2`, the attempt of rebase will result in unknown branch (as it was not pulled by default to the locally cloned repository).

Hence, after this commit is applied, we will perform rebase to what was explicitly fetched.