### PR TITLE
Allow setting up 8 OCP nodes

### DIFF
--- a/roles/devscripts/vars/main.yml
+++ b/roles/devscripts/vars/main.yml
@@ -41,7 +41,7 @@ cifmw_devscripts_config_defaults:
   provisioning_network_profile: "Managed"
   provisioning_network: "172.22.0.0/24"
   cluster_subnet_v4: "192.168.16.0/20"
-  cluster_host_prefix_v4: "22"
+  cluster_host_prefix_v4: "23"
   service_subnet_v4: "172.30.0.0/16"
   external_subnet_v4: "192.168.111.0/24"
   num_masters: 3


### PR DESCRIPTION
So with this change by default it will allow setting up 8 OCP nodes and 512 pods per node(previously it was 1024), previously was limited to 4 nodes.

Basically below two parameters responsible here https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/networking/cidr-range-definitions
cluster_subnet_v4: "192.168.16.0/20"
cluster_host_prefix_v4: "23"

2^(32 - 23) = 512
2^(23-20) = 8

Also it will not increase OCP nodes in a cluster just allow setting up 8 nodes by default and that should cover most of the dev cases by default. If more nodes are needed user can override these vars as per need.

Fix: #[OSPRH-15223](https://issues.redhat.com/browse/OSPRH-15223)