### PR TITLE
Correct the default value to import cifmw_nfs role

### DIFF
--- a/playbooks/06-deploy-edpm.yml
+++ b/playbooks/06-deploy-edpm.yml
@@ -110,7 +110,7 @@
         nftables_path: /etc/nftables
         nftables_conf: /etc/sysconfig/nftables.conf
       when:
-        - cifmw_edpm_deploy_nfs | default('false') | bool
+        - cifmw_edpm_deploy_nfs | default('true') | bool
       ansible.builtin.import_role:
         name: cifmw_nfs
 


### PR DESCRIPTION
Due to wrong default value in when condition, cifmw_nfs role was getting skipped, thus other required tasks were also getting skipped (For example, `cifmw_nfs_ip` var is set to the file during cifmw_nfs role / or earlier through nfs.yml playbook)

This PR fixes the issue caused through https://github.com/openstack-k8s-operators/ci-framework/pull/3038