### PR TITLE
Fix the default value of cifmw_nfs_target

### DIFF
--- a/roles/cifmw_nfs/defaults/main.yml
+++ b/roles/cifmw_nfs/defaults/main.yml
@@ -19,4 +19,4 @@
 # All variables within this role should have a prefix of "cifmw_nfs"
 
 cifmw_nfs_network: "storage"
-cifmw_nfs_target: "compute"
+cifmw_nfs_target: "computes"


### PR DESCRIPTION
Change default variable value for cifmw_nfs role

The target var should be "computes", not "compute".
It raises an issue that later the host is skipped by the Ansible.

This commit fixes porting issue raised in Pull Request [1].

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/3038