### PR TITLE
fix upstream gate

### DIFF
--- a/ci/playbooks/edpm/run.yml
+++ b/ci/playbooks/edpm/run.yml
@@ -32,3 +32,21 @@
           {%-   endfor %}
           {%- endif %}
           -e "@{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml"
+
+    - name: Run Podified EDPM post deployment
+      ansible.builtin.command:
+        chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
+        cmd: >-
+          ansible-playbook post-deployment.yml
+          -i "{{ ansible_user_dir }}/ci-framework-data/artifacts/zuul_inventory.yml"
+          -e @scenarios/centos-9/base.yml
+          -e @scenarios/centos-9/edpm_ci.yml
+          {%- if edpm_file.stat.exists %}
+          -e @{{ ansible_user_dir }}/ci-framework-data/artifacts/edpm-ansible.yml
+          {%- endif %}
+          {%- if cifmw_extras is defined %}
+          {%-   for extra_var in cifmw_extras %}
+          -e "{{   extra_var }}"
+          {%-   endfor %}
+          {%- endif %}
+          -e "@{{ ansible_user_dir }}/ci-framework-data/artifacts/parameters/zuul-params.yml"


### PR DESCRIPTION
patch 3036 seperated testing from deployment but did not updated upstream job this patch should fix upstream gating and run post deployment as well as deployment playbook