### PR TITLE
Patch samples registry

### DIFF
--- a/roles/openshift_setup/tasks/main.yml
+++ b/roles/openshift_setup/tasks/main.yml
@@ -218,5 +218,8 @@
 - name: Patch network operator when using OVNKubernetes backend
   ansible.builtin.import_tasks: patch_network_operator.yml
 
+- name: Patch samples registry
+  ansible.builtin.import_tasks: patch_samples_registry.yml
+
 - name: Fix openshift-marketplace pods
   ansible.builtin.import_tasks: fix_openshift_marketplace.yml

--- a/roles/openshift_setup/tasks/patch_samples_registry.yml
+++ b/roles/openshift_setup/tasks/patch_samples_registry.yml
@@ -1,0 +1,15 @@
+---
+- name: Patch samples registry configuration
+  when:
+    - not cifmw_openshift_setup_dry_run
+  kubernetes.core.k8s_json_patch:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    api_version: samples.operator.openshift.io/v1
+    kind: Config
+    name: cluster
+    patch:
+      - op: replace
+        path: /spec/samplesRegistry
+        value: registry.redhat.io


### PR DESCRIPTION
Due to https://issues.redhat.com/browse/OCPBUGS-30313 we observe the following message when checking the cluster health: `clusteroperators/openshift-samples is progressing and degraded`. This change simply patches the samples registry so the problem is not occurring anymore.