### PR TITLE
Remove public DNS nameservers on other hosts

### DIFF
--- a/roles/reproducer/files/pre-ci-play.yml
+++ b/roles/reproducer/files/pre-ci-play.yml
@@ -52,8 +52,6 @@
     - name: Inject custom nameservers in /etc/resolv.conf
       become: true
       vars:
-        _pub_resolver: >-
-          {{ _net_env.networks.ctlplane.dns_v4.0 }}
         _crc_resolver: >-
           {{ _net_env.networks.ctlplane.tools.metallb.ipv4_ranges.0.start }}
       ansible.builtin.copy:
@@ -61,7 +59,6 @@
         dest: "/etc/resolv.conf"
         content: |
           nameserver {{ _crc_resolver }}
-          nameserver {{ _pub_resolver }}
 
 - name: Prepare computes for next steps
   hosts: computes


### PR DESCRIPTION
All hosts should pick CRC vlan ip address as default or its public ip address, but it should not make queries to DNS servers from cloud providers, to avoid request flood.