### PR TITLE
Set optimize.proxy_host_address value in tempest workflow

### DIFF
--- a/roles/test_operator/tasks/tempest-tests.yml
+++ b/roles/test_operator/tasks/tempest-tests.yml
@@ -159,7 +159,8 @@
               item |
               combine({'tempestconfRun': {'overrides':
                 item.tempestconfRun.overrides + ' ' +
-                'whitebox_neutron_plugin_options.proxy_host_address ' + controller_ip
+                'whitebox_neutron_plugin_options.proxy_host_address ' + controller_ip + ' ' +
+                'optimize.proxy_host_address ' + controller_ip
               }}, recursive=true)
           }}
       ansible.builtin.set_fact:


### PR DESCRIPTION
optimize.proxy_host_address needs controller_ip while running tempest in uni03gamma job. In order to achieve that, we need to set the value via ansible tasks.

This pr sets the same.