### PR TITLE
Add cifmw_cleanup_architecture var to enable/disable cleanup

### DIFF
--- a/deploy-edpm-reuse.yaml
+++ b/deploy-edpm-reuse.yaml
@@ -29,6 +29,7 @@
       no_log: "{{ cifmw_nolog | default(true) | bool }}"
       async: "{{ 7200 + cifmw_test_operator_timeout | default(3600) }}"  # 2h should be enough to deploy EDPM and rest for tests.
       poll: 20
+      when: cifmw_cleanup_architecture | default(true) | bool
       delegate_to: controller-0
       ansible.builtin.command:
         cmd: "/home/zuul/cleanup-architecture.sh"


### PR DESCRIPTION
It will help to reuse the ocp environment when architecture deployment failed in pre step.