### PR TITLE
Fix undefined ansible_user_dir var in inject success flag task

### DIFF
--- a/post-deployment.yml
+++ b/post-deployment.yml
@@ -54,6 +54,14 @@
       ansible.builtin.import_role:
         name: run_hook
 
+      # Gemini 2.5 Flash Prompt: what gather_facts I can run to collect
+      # ansible_user_dir
+    - name: Gather minimal facts for ansible_user_dir
+      ansible.builtin.setup:
+        gather_subset:
+          - min
+        filter: "ansible_user_dir"
+
     - name: Inject success flag
       ansible.builtin.file:
         path: "{{ ansible_user_dir }}/cifmw-success"


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/ci-framework/pull/3036 Separate deployment from testing. As it also moves `inject success flag` task to post-deployment playbook.

The play where `inject success flag` task runs, gather_facts is set to false. ansible_user_dir is coming undefined.

In order to fix that, we are adding a task to collect ansible_user_dir fact. This will make sure ansible_user_dir exists.

Assisted-By: Gemini 2.5 Flash