### PR TITLE
Reduce comps and disks count for multi-ns VA

### DIFF
--- a/scenarios/reproducers/va-multi.yml
+++ b/scenarios/reproducers/va-multi.yml
@@ -95,7 +95,7 @@ cifmw_libvirt_manager_configuration:
     compute:
       uefi: "{{ cifmw_use_uefi }}"
       root_part_id: "{{ cifmw_root_partition_id }}"
-      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 3] | max }}"
+      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 2] | max }}"
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"
@@ -103,15 +103,13 @@ cifmw_libvirt_manager_configuration:
       disksize: "{{ [cifmw_libvirt_manager_compute_disksize|int, 50] | max }}"
       memory: "{{ [cifmw_libvirt_manager_compute_memory|int, 8] | max }}"
       cpus: "{{ [cifmw_libvirt_manager_compute_cpus|int, 4] | max }}"
-      extra_disks_num: 3
-      extra_disks_size: 30G
       nets:
         - ocpbm
         - osp_trunk
     compute2:
       uefi: "{{ cifmw_use_uefi }}"
       root_part_id: "{{ cifmw_root_partition_id }}"
-      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 3] | max }}"
+      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 2] | max }}"
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"
@@ -119,8 +117,6 @@ cifmw_libvirt_manager_configuration:
       disksize: "{{ [cifmw_libvirt_manager_compute_disksize|int, 50] | max }}"
       memory: "{{ [cifmw_libvirt_manager_compute_memory|int, 8] | max }}"
       cpus: "{{ [cifmw_libvirt_manager_compute_cpus|int, 4] | max }}"
-      extra_disks_num: 3
-      extra_disks_size: 30G
       nets:
         - ocpbm
         - osptrunk2


### PR DESCRIPTION
We were using extra computes and disks on those computes that are unnecessary for the VA in question, which is leading to resource constraint problems in CI