### PR TITLE
Improve generated JUnit XML from validations framework

### DIFF
--- a/roles/validations/filter_plugins/cifmw_validations_xml_filter.py
+++ b/roles/validations/filter_plugins/cifmw_validations_xml_filter.py
@@ -21,7 +21,7 @@ EXAMPLES = """
     _internal_results:
       test-1:
         time: 2.54512
-      test-case-2:
+      test-2.yml:
         time: 4.5450345
         error: "error message"
   ansible.builtin.set_fact:
@@ -80,6 +80,7 @@ class FilterModule:
             },
         )
         for name, data in test_results.items():
+            name = name.replace(".yml", "").replace(".yaml", "")
             attributes = {"name": name, "classname": "validations"}
             if "time" in data:
                 attributes["time"] = cls.__float_conversion(data["time"])

--- a/roles/validations/filter_plugins/cifmw_validations_xml_filter.py
+++ b/roles/validations/filter_plugins/cifmw_validations_xml_filter.py
@@ -39,8 +39,8 @@ RETURN = """
       <?xml version='1.0' encoding='utf-8'?>
       <testsuites>
         <testsuite name="validations" failures="0" skipped="0" tests="2" errors="1" time="7.090">
-          <testcase name="test-1" classname="validations.test-1" time="2.545" />
-          <testcase name="test-2" classname="validations.test-2" time="4.545">
+          <testcase name="test-1" classname="validations" time="2.545" />
+          <testcase name="test-2" classname="validations" time="4.545">
             <error message="error message" />
           </testcase>
         </testsuite>
@@ -80,7 +80,7 @@ class FilterModule:
             },
         )
         for name, data in test_results.items():
-            attributes = {"name": name, "classname": f"validations.{name}"}
+            attributes = {"name": name, "classname": "validations"}
             if "time" in data:
                 attributes["time"] = cls.__float_conversion(data["time"])
             tc_elm = ET.SubElement(ts_elm, "testcase", attrib=attributes)


### PR DESCRIPTION
**Remove test case name from class name**

The validations framework currently puts test case name
as part of the class name field, which in the end means
that the test case name is duplicated,
e.g. as it is processed by Polarion or other JUnit parser.

This change alters the class name field to be just `validations`.

**Remove YAML extension from test case name**

The validations are specified as Ansible playbooks
to be executed. Hence, in output, we see things like
`invoke_tlse_playbooks.yml` as case name in generated XML.
This change alters it to be presented as `invoke_tlse_playbooks`.