### PR TITLE
Fix 2-compute setting for multi-namespace VA

### DIFF
--- a/scenarios/reproducers/va-multi.yml
+++ b/scenarios/reproducers/va-multi.yml
@@ -31,6 +31,9 @@ cifmw_networking_mapper_interfaces_info_translations:
   osptrunk2:
     - ctlplane2
 
+# Override the default 3-compute VA setting, since 3 computes in both namespaces is too expensive
+cifmw_libvirt_manager_compute_amount: 2
+
 cifmw_libvirt_manager_configuration:
   networks:
     osp_trunk: |


### PR DESCRIPTION
While https://github.com/openstack-k8s-operators/ci-framework/pull/3084 attempted to reduce the number of computes for the multi-namespace VA, it was still being thwarted by [1].  Let's explicitly set `cifmw_libvirt_manager_compute_amount: 2` to ensure a default of 2 computes per namespace.

[1] https://github.com/openstack-k8s-operators/ci-framework/blob/0652b7b9039589e38a80e0164a05b119f5b75795/scenarios/reproducers/va-common.yml#L40