### PR TITLE
Set gather_facts to true for post deployment

### DIFF
--- a/post-deployment.yml
+++ b/post-deployment.yml
@@ -1,6 +1,6 @@
 - name: Run Post-deployment admin setup steps, test, and compliance scan
   hosts: "{{ cifmw_target_host | default('localhost') }}"
-  gather_facts: false
+  gather_facts: true
   tasks:
     - name: Run cifmw_setup admin_setup.yml
       ansible.builtin.import_role:
@@ -44,7 +44,7 @@
 
 - name: Run hooks and inject status flag
   hosts: "{{ cifmw_target_host | default('localhost') }}"
-  gather_facts: false
+  gather_facts: true
   tasks:
     - name: Run pre_end hooks
       tags:
@@ -53,12 +53,6 @@
         step: pre_end
       ansible.builtin.import_role:
         name: run_hook
-
-    - name: Gather minimal facts for ansible_user_dir
-      ansible.builtin.setup:
-        gather_subset:
-          - min
-        filter: "ansible_user_dir"
 
     - name: Inject success flag
       ansible.builtin.file:


### PR DESCRIPTION
some issues are caused by missing facts after new post deployment seperation was introduced, setting gather_facts to true for post deployment to avoid those issues