### PR TITLE
Set namespace for oc calls in cephadm role

### DIFF
--- a/roles/cifmw_cephadm/tasks/configure_object.yml
+++ b/roles/cifmw_cephadm/tasks/configure_object.yml
@@ -98,7 +98,7 @@
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
       ansible.builtin.shell: |
         set -euo pipefail
-        oc exec -t openstackclient -- \
+        oc -n {{ cifmw_cephadm_ns }} exec -t openstackclient -- \
         openstack endpoint list -f json | \
         jq -r '.[] | select(.["Service Name"] == "swift" and .Interface == "public") | .ID'
       register: uuid_swift_public_ep
@@ -109,7 +109,7 @@
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
       ansible.builtin.shell: |
         set -euo pipefail
-        oc exec -t openstackclient -- \
+        oc -n {{ cifmw_cephadm_ns }} exec -t openstackclient -- \
         openstack endpoint list -f json | \
         jq -r '.[] | select(.["Service Name"] == "swift" and .Interface == "internal") | .ID'
       register: uuid_swift_internal_ep


### PR DESCRIPTION
Some calls in `roles/cifmw_cephadm/tasks/configure_object.yml` assume that oc commands will be running in the `openstack` namespace, but it is not true in day2 job, during the 2nd reproducer run. Looking at other tasks in this file, it should be executed explicitly in namespace defined via `cifmw_cephadm_ns` variable.