### PR TITLE
Add missing conditional for Update the go.mod file for no pr case

### DIFF
--- a/roles/operator_build/tasks/build.yml
+++ b/roles/operator_build/tasks/build.yml
@@ -29,12 +29,12 @@
         operator_base_module: "{{ go_mod_out['content'] | b64decode | regex_search(cifmw_operator_build_org + '/' + operator.name + '/(\\w*)\\s', '\\1') }}"
 
     - name: Get the base module name not empty operator_base_module
-      when: operator_base_module is not none
+      when: operator_base_module
       ansible.builtin.set_fact:
         operator_base_module_name: "{{ operator_base_module | first }}"
 
     - name: "{{ operator.name }} - Set default api path"  # noqa: name[template]
-      when: operator_base_module is not none
+      when: operator_base_module
       ansible.builtin.set_fact:
         operator_api_path: "github.com/{{ cifmw_operator_build_org }}/{{ operator.name }}/{{ operator_base_module_name }}"
 
@@ -55,7 +55,7 @@
     - operator.name != cifmw_operator_build_meta_name
     - operator.pr_owner is defined
     - operator.pr_sha is defined
-    - operator_base_module is not none
+    - operator_base_module
 
 - name: "{{ operator.name }} - Get latest commit when no PR is provided"  # noqa: name[template] command-instead-of-module
   ansible.builtin.command:
@@ -83,6 +83,7 @@
     - cifmw_operator_build_meta_build
     - operator.name != cifmw_operator_build_meta_name
     - operator.pr_owner is not defined
+    - operator_base_module
 
 - name: Get container image
   block:


### PR DESCRIPTION
Without this conditional, the meta content provider is failing with following error:
```
  msg: |
2025-06-27 06:20:22.612671 | controller |       The task includes an option with an undefined variable. The error was: 'operator_api_path' is undefined. 'operator_api_path' is undefined
2025-06-27 06:20:22.612685 | controller |
2025-06-27 06:20:22.612699 | controller |       The error appears to be in '/home/zuul-worker/src/github.com/openstack-k8s-operators/ci-framework/roles/operator_build/tasks/build.yml': line 70, column 3, but may
2025-06-27 06:20:22.612713 | controller |       be elsewhere in the file depending on the exact syntax problem.
2025-06-27 06:20:22.612740 | controller |
2025-06-27 06:20:22.612753 | controller |       The offending line appears to be:
2025-06-27 06:20:22.612766 | controller |
2025-06-27 06:20:22.612779 | controller |
2025-06-27 06:20:22.612792 | controller |       - name: "{{ operator.name }} - Update the go.mod file using latest commit if no PR is provided"  # noqa: name[template]
2025-06-27 06:20:22.612805 | controller |         ^ here
2025-06-27 06:20:22.612818 | controller |       We could be wrong, but this one looks like it might be an issue with
2025-06-27 06:20:22.612830 | controller |       missing quotes. Always quote template expression brackets when they
2025-06-27 06:20:22.612843 | controller |       start a value. For instance:
2025-06-27 06:20:22.612856 | controller |
```

By adding the conditional fixes the issue.

Note: it also fixes the same conditional for other tasks.