### PR TITLE
Add pre playbook to copy tcib container config file

### DIFF
--- a/ci/playbooks/meta_content_provider/copy_container_files.yaml
+++ b/ci/playbooks/meta_content_provider/copy_container_files.yaml
@@ -1,0 +1,10 @@
+---
+- name: Copy watcher containers.yaml file
+  hosts: all
+  tasks:
+    - name: Copy containers.yaml file
+      when: cifmw_build_containers_config_file is defined
+      ansible.builtin.copy:
+        src: "{{ zuul_project_container_path }}"
+        dest: "{{ cifmw_build_containers_config_file }}"
+        remote_src: true

--- a/zuul.d/content_provider.yaml
+++ b/zuul.d/content_provider.yaml
@@ -10,6 +10,8 @@
       A zuul job to build content (rpms, openstack services containers,
       operators) from opendev and github changes.
     timeout: 5000
+    pre-run:
+      - ci/playbooks/meta_content_provider/copy_container_files.yaml
     run:
       - ci/playbooks/meta_content_provider/run.yml
 


### PR DESCRIPTION
In watcher-operator, we use custom containers.yamli[1] file to build containers in meta content provider. This pr moves the bits from watcher-operator to ci-framework so that other projects can reuse it.

Links:
[1]. https://github.com/openstack-k8s-operators/watcher-operator/commit/9e4c3951f7b28c4c175149d675351e0dc3fd882e#diff-57c6783bf06af1bbc1106fee66b30f0808322d79a77006567860245ddcd98d1b