### PR TITLE
Revert "dt-dcn: Make VM's names of DCN compute grouos not to be subst…

### DIFF
--- a/playbooks/dcn.yml
+++ b/playbooks/dcn.yml
@@ -68,8 +68,8 @@
       ansible.builtin.set_fact:
         az_to_group_map:
           az0: computes
-          az1: dcn1-compute-az1s
-          az2: dcn2-compute-az2s
+          az1: dcn1-computes
+          az2: dcn2-computes
 
     - name: Scaledown the DCN site
       vars:

--- a/roles/reproducer/tasks/libvirt_layout.yml
+++ b/roles/reproducer/tasks/libvirt_layout.yml
@@ -99,8 +99,8 @@
       (compute.key in (groups['computes'] | default([]))) or
       (compute.key in (groups['cephs'] | default([]))) or
       (compute.key in (groups['networkers'] | default([]))) or
-      (compute.key in (groups['dcn1-compute-az1s'] | default([]))) or
-      (compute.key in (groups['dcn2-compute-az2s'] | default([]))) or
+      (compute.key in (groups['dcn1-computes'] | default([]))) or
+      (compute.key in (groups['dcn2-computes'] | default([]))) or
       (compute.key is match('^r[0-9]-compute-.*')) or
       (compute.key is match('^r[0-9]-networker-.*')) or
       (compute.key is match('^compute2-.*'))

--- a/scenarios/reproducers/dt-dcn.yml
+++ b/scenarios/reproducers/dt-dcn.yml
@@ -142,7 +142,7 @@ cifmw_libvirt_manager_configuration:
       nets:
         - ocpbm
         - osp_trunk
-    dcn1-compute-az1:
+    dcn1-compute:
       uefi: "{{ cifmw_use_uefi }}"
       root_part_id: "{{ cifmw_root_partition_id }}"
       amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 3] | max }}"
@@ -158,7 +158,7 @@ cifmw_libvirt_manager_configuration:
       nets:
         - dcn1_pb
         - dcn1_tr
-    dcn2-compute-az2:
+    dcn2-compute:
       uefi: "{{ cifmw_use_uefi }}"
       root_part_id: "{{ cifmw_root_partition_id }}"
       amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 3] | max }}"
@@ -470,7 +470,7 @@ cifmw_networking_definition:
           trunk-parent: ctlplane
         storagemgmt:
           trunk-parent: ctlplane
-    dcn1-compute-az1s:
+    dcn1-computes:
       network-template:
         range:
           start: 111
@@ -485,7 +485,7 @@ cifmw_networking_definition:
           trunk-parent: ctlplanedcn1
         storagemgmtdcn1:
           trunk-parent: ctlplanedcn1
-    dcn2-compute-az2s:
+    dcn2-computes:
       network-template:
         range:
           start: 121


### PR DESCRIPTION
This is to reproduce a bug in neutron https://bugs.launchpad.net/neutron/+bug/2110094
(It was observed in a dcn environment where compute hostnames overlapped, like compute-0 and dcn1-compute-0, and the current code filters both of these host when any of these as passed as filter i.e host=dcn1-compute-0.)

This reverts commit 181771e072952402a24f30797e8e4006d52e549d.