### PR TITLE
Allow Ceph to deploy rbd-mirror daemon

### DIFF
--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -436,6 +436,12 @@
         # we reuse the same VIP reserved for rgw
         cifmw_cephadm_nfs_vip: "{{ cifmw_cephadm_vip }}/{{ cidr }}"
 
+    - name: Deploy rbd-mirror
+      when: cifmw_ceph_daemons_layout.ceph_rbd_mirror_enabled | default(false) | bool
+      ansible.builtin.import_role:
+        name: cifmw_cephadm
+        tasks_from: rbd_mirror
+
     - name: Create Cephx Keys for OpenStack
       ansible.builtin.import_role:
         name: cifmw_cephadm

--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -66,6 +66,7 @@ cifmw_cephadm_pacific_filter: "16.*"
 # The path of the rendered rgw spec file
 cifmw_ceph_rgw_spec_path: /tmp/ceph_rgw.yml
 cifmw_ceph_mds_spec_path: /tmp/ceph_mds.yml
+cifmw_ceph_rbd_mirror_spec_path: /tmp/ceph_rbd_mirror.yml
 cifmw_ceph_rgw_keystone_ep: "https://keystone-internal.openstack.svc:5000"
 cifmw_ceph_rgw_keystone_psw: 12345678
 cifmw_ceph_rgw_keystone_user: "swift"

--- a/roles/cifmw_cephadm/tasks/rbd_mirror.yml
+++ b/roles/cifmw_cephadm/tasks/rbd_mirror.yml
@@ -1,0 +1,37 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Collect the host and build the resulting host list
+  ansible.builtin.set_fact:
+    _hosts: "{{ _hosts|default([]) + [ item ] }}"
+  loop: "{{ groups[cifmw_ceph_target | default('computes')] | default([]) }}"
+
+- name: Create RBD Mirror spec
+  ansible.builtin.template:
+    src: templates/ceph_rbd_mirror.yml.j2
+    dest: "{{ cifmw_ceph_rbd_mirror_spec_path }}"
+    mode: '0644'
+    force: true
+
+- name: Get ceph_cli
+  ansible.builtin.include_tasks: ceph_cli.yml
+  vars:
+    mount_spec: true
+    cifmw_cephadm_spec: "{{ cifmw_ceph_rbd_mirror_spec_path }}"
+
+- name: Apply spec
+  ansible.builtin.command: "{{ cifmw_cephadm_ceph_cli }} orch apply --in-file {{ cifmw_cephadm_container_spec }}"
+  become: true

--- a/roles/cifmw_cephadm/templates/ceph_rbd_mirror.yml.j2
+++ b/roles/cifmw_cephadm/templates/ceph_rbd_mirror.yml.j2
@@ -1,0 +1,8 @@
+---
+service_type: rbd-mirror
+service_name: rbd-mirror
+placement:
+  hosts:
+{% for host in _hosts | unique %}
+  - {{ host }}
+{% endfor %}


### PR DESCRIPTION
This patch introduces the variables and the tasks required to deploy `rbd-mirror`, useful to test `cinder` replication.