### PR TITLE
Use repo-setup provided repos instead of centos one

### DIFF
--- a/roles/build_openstack_packages/tasks/install_dlrn.yml
+++ b/roles/build_openstack_packages/tasks/install_dlrn.yml
@@ -102,6 +102,16 @@
       retries: 3
       delay: 5
 
+    - name: Use CentoS Mirror stream in DLRN CFG
+      when:
+        - ansible_distribution | lower == "centos"
+        - ansible_distribution_major_version is version('10', '==')
+      ansible.builtin.shell:
+        set -o pipefail
+        sed -i -e "s|https://mirrors.centos.org|http://mirror.stream.centos.org|g" centos-stream-10.cfg
+      args:
+        chdir: "{{ cifmw_bop_build_repo_dir }}/DLRN/scripts"
+
     - name: Install DLRN requirements
       ansible.builtin.pip:
         virtualenv: "{{ cifmw_bop_dlrn_venv }}"


### PR DESCRIPTION
Since we use repo-setup generated repos everywhere let's use the same everywhere instead of mixing with centos repos coming from base image.

It will try to avoid mirror issues.