### PR TITLE
update ceph ipv6 when conditions

### DIFF
--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -161,7 +161,9 @@
       ansible.builtin.meta: end_play
 
     - name: Set IPv4 facts
-      when: ansible_all_ipv4_addresses | length > 0
+      when:
+        - ansible_all_ipv4_addresses | length > 0
+        - not ceph_ipv6 | default(false)
       ansible.builtin.set_fact:
         ssh_network_range: 192.168.122.0/24
         # storage_network_range: 172.18.0.0/24
@@ -171,7 +173,9 @@
         ms_bind_ipv6: false
 
     - name: Set IPv6 facts
-      when: ansible_all_ipv4_addresses | length == 0
+      when:
+        - ansible_all_ipv6_addresses | length > 0
+        - ceph_ipv6 | default(false)
       ansible.builtin.set_fact:
         ssh_network_range: "2620:cf:cf:aaaa::/64"
         # storage_network_range: "2620:cf:cf:cccc::/64"
@@ -210,6 +214,7 @@
           when:
             - cifmw_networking_env_definition is defined
             - ansible_all_ipv4_addresses | length > 0
+            - not ceph_ipv6 | default(false)
           ansible.builtin.set_fact:
             storage_network_range: >-
               {{
@@ -223,7 +228,8 @@
         - name: Set IPv6 network ranges vars
           when:
             - cifmw_networking_env_definition is defined
-            - ansible_all_ipv4_addresses | length == 0
+            - ansible_all_ipv6_addresses | length > 0
+            - ceph_ipv6 | default(false)
           ansible.builtin.set_fact:
             storage_network_range: >-
               {{
@@ -310,13 +316,17 @@
       ansible.builtin.meta: end_play
 
     - name: Set IPv4 facts
-      when: ansible_all_ipv4_addresses | length > 0
+      when:
+        - ansible_all_ipv4_addresses | length > 0
+        - not ceph_ipv6 | default(false)
       ansible.builtin.set_fact:
         all_addresses: ansible_all_ipv4_addresses
         cidr: 24
 
     - name: Set IPv6 facts
-      when: ansible_all_ipv4_addresses | length == 0
+      when:
+        - ansible_all_ipv6_addresses | length > 0
+        - ceph_ipv6 | default(false)
       ansible.builtin.set_fact:
         all_addresses: ansible_all_ipv6_addresses
         cidr: 64


### PR DESCRIPTION
ipv6 task when conditions should rely on ansible_all_ipv6_addresses but not ansible_all_ipv4_addresses parameter.