### PR TITLE
Allow setting container name prefix

### DIFF
--- a/roles/update_containers/README.md
+++ b/roles/update_containers/README.md
@@ -13,6 +13,7 @@ If apply, please explain the privilege escalation done in this role.
 * `cifmw_update_containers_base_dir`: The base directory of update_containers role. Default is "ansible_user_dir ~ '/ci-framework-data')".
 * `cifmw_update_containers_dest_path`: The destination file path to create update containers CR file.
 * `cifmw_update_containers_registry`: The container registry to pull containers from. Default to "quay.io".
+* `cifmw_update_containers_name_prefix`: The container name prefix. Default to "openstack".
 * `cifmw_update_containers_org`: The container registry namespace to pull container from. Default to `podified-antelope-centos9`
 * `cifmw_update_containers_tag`: The container tag. Default to "current-podified".
 * `cifmw_update_containers_cindervolumes`: The names of the cinder volumes prefix. Default to `[]`.

--- a/roles/update_containers/defaults/main.yml
+++ b/roles/update_containers/defaults/main.yml
@@ -37,6 +37,7 @@ cifmw_update_containers_dest_path: >-
 cifmw_update_containers_registry: "quay.io"
 cifmw_update_containers_org: "podified-antelope-centos9"
 cifmw_update_containers_tag: "current-podified"
+cifmw_update_containers_name_prefix: "openstack"
 cifmw_update_containers_openstack: false
 cifmw_update_containers_rollback: false
 cifmw_update_containers_cindervolumes:

--- a/roles/update_containers/templates/update_containers.j2
+++ b/roles/update_containers/templates/update_containers.j2
@@ -6,87 +6,87 @@ metadata:
 spec:
   customContainerImages:
 {% if cifmw_update_containers_openstack | bool %}
-    aodhAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-aodh-api:{{ cifmw_update_containers_tag }}
-    aodhEvaluatorImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-aodh-evaluator:{{ cifmw_update_containers_tag }}
-    aodhListenerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-aodh-listener:{{ cifmw_update_containers_tag }}
-    aodhNotifierImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-aodh-notifier:{{ cifmw_update_containers_tag }}
-    barbicanAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-barbican-api:{{ cifmw_update_containers_barbican_custom_tag | default(cifmw_update_containers_tag) }}
-    barbicanKeystoneListenerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-barbican-keystone-listener:{{ cifmw_update_containers_tag }}
-    barbicanWorkerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-barbican-worker:{{ cifmw_update_containers_barbican_custom_tag | default(cifmw_update_containers_tag) }}
-    ceilometerCentralImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ceilometer-central:{{ cifmw_update_containers_tag }}
-    ceilometerComputeImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ceilometer-compute:{{ cifmw_update_containers_tag }}
-    ceilometerIpmiImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ceilometer-ipmi:{{ cifmw_update_containers_tag }}
-    ceilometerNotificationImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ceilometer-notification:{{ cifmw_update_containers_tag }}
-    cinderAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-cinder-api:{{ cifmw_update_containers_tag }}
-    cinderBackupImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-cinder-backup:{{ cifmw_update_containers_tag }}
-    cinderSchedulerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-cinder-scheduler:{{ cifmw_update_containers_tag }}
-    cinderVolumeImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-cinder-volume:{{ cifmw_update_containers_tag }}
-    designateAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-designate-api:{{ cifmw_update_containers_tag }}
-    designateBackendbind9Image: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-designate-backend-bind9:{{ cifmw_update_containers_tag }}
-    designateCentralImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-designate-central:{{ cifmw_update_containers_tag }}
-    designateMdnsImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-designate-mdns:{{ cifmw_update_containers_tag }}
-    designateProducerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-designate-producer:{{ cifmw_update_containers_tag }}
-    designateUnboundImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-unbound:{{ cifmw_update_containers_tag }}
-    designateWorkerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-designate-worker:{{ cifmw_update_containers_tag }}
-    edpmFrrImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-frr:{{ cifmw_update_containers_tag }}
-    edpmIscsidImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-iscsid:{{ cifmw_update_containers_tag }}
-    edpmLogrotateCrondImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-cron:{{ cifmw_update_containers_tag }}
-    edpmMultipathdImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-multipathd:{{ cifmw_update_containers_tag }}
-    edpmNeutronDhcpAgentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-neutron-dhcp-agent:{{ cifmw_update_containers_tag }}
-    edpmNeutronMetadataAgentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-neutron-metadata-agent-ovn:{{ cifmw_update_containers_tag }}
-    edpmNeutronOvnAgentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-neutron-ovn-agent:{{ cifmw_update_containers_tag }}
-    edpmNeutronSriovAgentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-neutron-sriov-agent:{{ cifmw_update_containers_tag }}
-    edpmOvnBgpAgentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ovn-bgp-agent:{{ cifmw_update_containers_tag }}
-    glanceAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-glance-api:{{ cifmw_update_containers_tag }}
-    heatAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-heat-api:{{ cifmw_update_containers_tag }}
-    heatCfnapiImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-heat-api-cfn:{{ cifmw_update_containers_tag }}
-    heatEngineImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-heat-engine:{{ cifmw_update_containers_tag }}
-    horizonImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-horizon:{{ cifmw_update_containers_tag }}
-    infraDnsmasqImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-neutron-server:{{ cifmw_update_containers_tag }}
-    infraMemcachedImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-memcached:{{ cifmw_update_containers_tag }}
-    ironicAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ironic-api:{{ cifmw_update_containers_tag }}
-    ironicConductorImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ironic-conductor:{{ cifmw_update_containers_tag }}
-    ironicInspectorImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ironic-inspector:{{ cifmw_update_containers_tag }}
-    ironicNeutronAgentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ironic-neutron-agent:{{ cifmw_update_containers_tag }}
-    ironicPxeImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ironic-pxe:{{ cifmw_update_containers_tag }}
-    keystoneAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-keystone:{{ cifmw_update_containers_tag }}
-    manilaAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-manila-api:{{ cifmw_update_containers_tag }}
-    manilaSchedulerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-manila-scheduler:{{ cifmw_update_containers_tag }}
-    manilaShareImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-manila-share:{{ cifmw_update_containers_tag }}
-    mariadbImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-mariadb:{{ cifmw_update_containers_tag }}
-    neutronAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-neutron-server:{{ cifmw_update_containers_tag }}
-    novaAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-nova-api:{{ cifmw_update_containers_tag }}
-    novaComputeImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-nova-compute:{{ cifmw_update_containers_tag }}
-    novaConductorImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-nova-conductor:{{ cifmw_update_containers_tag }}
-    novaNovncImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-nova-novncproxy:{{ cifmw_update_containers_tag }}
-    novaSchedulerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-nova-scheduler:{{ cifmw_update_containers_tag }}
-    octaviaAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-octavia-api:{{ cifmw_update_containers_tag }}
-    octaviaHealthmanagerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-octavia-health-manager:{{ cifmw_update_containers_tag }}
-    octaviaHousekeepingImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-octavia-housekeeping:{{ cifmw_update_containers_tag }}
-    octaviaWorkerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-octavia-worker:{{ cifmw_update_containers_tag }}
-    openstackClientImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-openstackclient:{{ cifmw_update_containers_tag }}
-    ovnControllerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ovn-controller:{{ cifmw_update_containers_tag }}
-    ovnControllerOvsImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ovn-base:{{ cifmw_update_containers_tag }}
-    ovnNbDbclusterImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ovn-nb-db-server:{{ cifmw_update_containers_tag }}
-    ovnNorthdImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ovn-northd:{{ cifmw_update_containers_tag }}
-    ovnSbDbclusterImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-ovn-sb-db-server:{{ cifmw_update_containers_tag }}
-    placementAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-placement-api:{{ cifmw_update_containers_tag }}
-    rabbitmqImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-rabbitmq:{{ cifmw_update_containers_tag }}
-    swiftAccountImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-swift-account:{{ cifmw_update_containers_tag }}
-    swiftContainerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-swift-container:{{ cifmw_update_containers_tag }}
-    swiftObjectImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-swift-object:{{ cifmw_update_containers_tag }}
-    swiftProxyImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-swift-proxy-server:{{ cifmw_update_containers_tag }}
-    testTempestImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-tempest-all:{{ cifmw_update_containers_tag }}
+    aodhAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-aodh-api:{{ cifmw_update_containers_tag }}
+    aodhEvaluatorImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-aodh-evaluator:{{ cifmw_update_containers_tag }}
+    aodhListenerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-aodh-listener:{{ cifmw_update_containers_tag }}
+    aodhNotifierImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-aodh-notifier:{{ cifmw_update_containers_tag }}
+    barbicanAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-barbican-api:{{ cifmw_update_containers_barbican_custom_tag | default(cifmw_update_containers_tag) }}
+    barbicanKeystoneListenerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-barbican-keystone-listener:{{ cifmw_update_containers_tag }}
+    barbicanWorkerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-barbican-worker:{{ cifmw_update_containers_barbican_custom_tag | default(cifmw_update_containers_tag) }}
+    ceilometerCentralImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-ceilometer-central:{{ cifmw_update_containers_tag }}
+    ceilometerComputeImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-ceilometer-compute:{{ cifmw_update_containers_tag }}
+    ceilometerIpmiImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-ceilometer-ipmi:{{ cifmw_update_containers_tag }}
+    ceilometerNotificationImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-ceilometer-notification:{{ cifmw_update_containers_tag }}
+    cinderAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-cinder-api:{{ cifmw_update_containers_tag }}
+    cinderBackupImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-cinder-backup:{{ cifmw_update_containers_tag }}
+    cinderSchedulerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-cinder-scheduler:{{ cifmw_update_containers_tag }}
+    cinderVolumeImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-cinder-volume:{{ cifmw_update_containers_tag }}
+    designateAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-designate-api:{{ cifmw_update_containers_tag }}
+    designateBackendbind9Image: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-designate-backend-bind9:{{ cifmw_update_containers_tag }}
+    designateCentralImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-designate-central:{{ cifmw_update_containers_tag }}
+    designateMdnsImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-designate-mdns:{{ cifmw_update_containers_tag }}
+    designateProducerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-designate-producer:{{ cifmw_update_containers_tag }}
+    designateUnboundImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-unbound:{{ cifmw_update_containers_tag }}
+    designateWorkerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-designate-worker:{{ cifmw_update_containers_tag }}
+    edpmFrrImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-frr:{{ cifmw_update_containers_tag }}
+    edpmIscsidImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-iscsid:{{ cifmw_update_containers_tag }}
+    edpmLogrotateCrondImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-cron:{{ cifmw_update_containers_tag }}
+    edpmMultipathdImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-multipathd:{{ cifmw_update_containers_tag }}
+    edpmNeutronDhcpAgentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-neutron-dhcp-agent:{{ cifmw_update_containers_tag }}
+    edpmNeutronMetadataAgentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-neutron-metadata-agent-ovn:{{ cifmw_update_containers_tag }}
+    edpmNeutronOvnAgentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-neutron-ovn-agent:{{ cifmw_update_containers_tag }}
+    edpmNeutronSriovAgentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-neutron-sriov-agent:{{ cifmw_update_containers_tag }}
+    edpmOvnBgpAgentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-ovn-bgp-agent:{{ cifmw_update_containers_tag }}
+    glanceAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-glance-api:{{ cifmw_update_containers_tag }}
+    heatAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-heat-api:{{ cifmw_update_containers_tag }}
+    heatCfnapiImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-heat-api-cfn:{{ cifmw_update_containers_tag }}
+    heatEngineImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-heat-engine:{{ cifmw_update_containers_tag }}
+    horizonImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-horizon:{{ cifmw_update_containers_tag }}
+    infraDnsmasqImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-neutron-server:{{ cifmw_update_containers_tag }}
+    infraMemcachedImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-memcached:{{ cifmw_update_containers_tag }}
+    ironicAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-ironic-api:{{ cifmw_update_containers_tag }}
+    ironicConductorImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-ironic-conductor:{{ cifmw_update_containers_tag }}
+    ironicInspectorImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-ironic-inspector:{{ cifmw_update_containers_tag }}
+    ironicNeutronAgentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-ironic-neutron-agent:{{ cifmw_update_containers_tag }}
+    ironicPxeImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-ironic-pxe:{{ cifmw_update_containers_tag }}
+    keystoneAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-keystone:{{ cifmw_update_containers_tag }}
+    manilaAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-manila-api:{{ cifmw_update_containers_tag }}
+    manilaSchedulerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-manila-scheduler:{{ cifmw_update_containers_tag }}
+    manilaShareImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-manila-share:{{ cifmw_update_containers_tag }}
+    mariadbImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-mariadb:{{ cifmw_update_containers_tag }}
+    neutronAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-neutron-server:{{ cifmw_update_containers_tag }}
+    novaAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-nova-api:{{ cifmw_update_containers_tag }}
+    novaComputeImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-nova-compute:{{ cifmw_update_containers_tag }}
+    novaConductorImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-nova-conductor:{{ cifmw_update_containers_tag }}
+    novaNovncImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-nova-novncproxy:{{ cifmw_update_containers_tag }}
+    novaSchedulerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-nova-scheduler:{{ cifmw_update_containers_tag }}
+    octaviaAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-octavia-api:{{ cifmw_update_containers_tag }}
+    octaviaHealthmanagerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-octavia-health-manager:{{ cifmw_update_containers_tag }}
+    octaviaHousekeepingImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-octavia-housekeeping:{{ cifmw_update_containers_tag }}
+    octaviaWorkerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-octavia-worker:{{ cifmw_update_containers_tag }}
+    openstackClientImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-openstackclient:{{ cifmw_update_containers_tag }}
+    ovnControllerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-ovn-controller:{{ cifmw_update_containers_tag }}
+    ovnControllerOvsImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-ovn-base:{{ cifmw_update_containers_tag }}
+    ovnNbDbclusterImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-ovn-nb-db-server:{{ cifmw_update_containers_tag }}
+    ovnNorthdImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-ovn-northd:{{ cifmw_update_containers_tag }}
+    ovnSbDbclusterImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-ovn-sb-db-server:{{ cifmw_update_containers_tag }}
+    placementAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-placement-api:{{ cifmw_update_containers_tag }}
+    rabbitmqImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-rabbitmq:{{ cifmw_update_containers_tag }}
+    swiftAccountImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-swift-account:{{ cifmw_update_containers_tag }}
+    swiftContainerImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-swift-container:{{ cifmw_update_containers_tag }}
+    swiftObjectImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-swift-object:{{ cifmw_update_containers_tag }}
+    swiftProxyImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-swift-proxy-server:{{ cifmw_update_containers_tag }}
+    testTempestImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-tempest-all:{{ cifmw_update_containers_tag }}
 {% if cifmw_update_containers_cindervolumes | length > 0     %}
     cinderVolumeImages:
 {% for vol in cifmw_update_containers_cindervolumes          %}
-      {{ vol }}: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-cinder-volume:{{ cifmw_update_containers_tag }}
+      {{ vol }}: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-cinder-volume:{{ cifmw_update_containers_tag }}
 {% endfor                                                    %}
 {% endif                                                     %}
 {% if cifmw_update_containers_manilashares | length > 0      %}
     manilaShareImages:
 {% for shares in cifmw_update_containers_manilashares        %}
-      {{ shares }}: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-manila-share:{{ cifmw_update_containers_tag }}
+      {{ shares }}: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-manila-share:{{ cifmw_update_containers_tag }}
 {% endfor                                                    %}
 {% endif                                                     %}
 {% endif                                                     %}
@@ -106,5 +106,5 @@ spec:
     edpmNodeExporterImage: {{ cifmw_update_containers_edpmnodeexporterimage }}
 {% endif %}
 {% if cifmw_update_containers_agentimage is defined %}
-	    agentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/openstack-baremetal-operator-agent:{{ cifmw_update_containers_tag }}
+	    agentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-baremetal-operator-agent:{{ cifmw_update_containers_tag }}
 {% endif %}


### PR DESCRIPTION
Allows setting a prefix for container names in the update_containers role.
This is useful for deploying older versions of containers that may have
different naming conventions.