### PR TITLE
Ignore ansible lint in few tasks

### DIFF
--- a/roles/ci_dcn_site/tasks/ceph.yml
+++ b/roles/ci_dcn_site/tasks/ceph.yml
@@ -26,7 +26,7 @@
 - name: Update the hosts file on the Ceph bootstrap host
   become: true
   vars:
-    ceph_boot_ssh_ip: "{{ ansible_all_ipv4_addresses | ansible.utils.ipaddr(_subnet_network_range) | first }}"
+    ceph_boot_ssh_ip: "{{ ansible_all_ipv4_addresses | ansible.utils.ipaddr(_subnet_network_range) | first }}" # noqa: jinja[invalid]
   delegate_to: "{{ _ceph_bootstrap_node }}"
   run_once: true
   ansible.builtin.lineinfile:

--- a/roles/libvirt_manager/tasks/create_cloud_init_iso.yml
+++ b/roles/libvirt_manager/tasks/create_cloud_init_iso.yml
@@ -60,7 +60,7 @@
 - name: "Call the config_drive role"
   vars:
     cifmw_config_drive_iso_image: "{{ _iso_path }}"
-    _default_uuid: "{{ 99999999 | random(seed=vm) | to_uuid | lower }}"
+    _default_uuid: "{{ 99999999 | random(seed=vm) | to_uuid | lower }}" # noqa: jinja[invalid]
     cifmw_config_drive_uuid: "{{ _uuid.stdout | default(_default_uuid) | trim}}"
     cifmw_config_drive_hostname: "{{ vm }}"
     cifmw_config_drive_networkconfig: "{{ _libvirt_manager_network_data | default(None) }}"


### PR DESCRIPTION
The ansible-lint tool raises a warning message:

    roles/ci_dcn_site/tasks/ceph.yml:33:
    jinja[invalid]: An unhandled exception occurred while templating
    '{{ ansible_all_ipv4_addresses | ansible.utils.ipaddr(_subnet_network_range) | first }}'.
    Error was a <class 'ansible.errors.AnsibleFilterError'>, original message: Unrecognized
    type <<class 'ansible.template.native_helpers.AnsibleUndefined'>>
    for ipaddr filter <value>

    roles/libvirt_manager/tasks/create_cloud_init_iso.yml:62:
    jinja[invalid]: An unhandled exception occurred while templating
    '{{ 99999999 | random(seed=vm) | to_uuid | lower }}'.
    Error was a <class 'ansible.errors.AnsibleError'>, original message:
    Unexpected templating type error occurred on
    ({{ 99999999 | random(seed=vm) | to_uuid | lower }}):
    The only supported seed types are:
      None, int, float, str, bytes, and bytearray.

which might be confusing for community members.