### PR TITLE
Trigger documentation Github action job when "recheck" provided

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,6 +14,7 @@ on:  # noqa: yaml[truthy]
 jobs:
   build-and-check:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request' || github.event.comment.body == 'recheck'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Currently, when the documentation job fails, it is not possible to re-trigger the GH action to verify again the commit. Let's add a condition, that would trigger the CI job when "recheck" comment is provided.