### PR TITLE
Replace deprecated 'cifmw_test_operator_concurrency'

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -10,7 +10,6 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_version`: (String) The commit hash corresponding to the version of test-operator the user wants to use. This parameter is only used when `cifmw_test_operator_bundle` is also set.
 * `cifmw_test_operator_timeout`: (Integer) Timeout in seconds for the execution of the tests. Default value: `3600`
 * `cifmw_test_operator_logs_image`: (String) Image that should be used to collect logs from the pods spawned by the test-operator. Default value: `quay.io/quay/busybox`
-* `cifmw_test_operator_concurrency`: (Integer) Tempest concurrency value. NOTE: This parameter is deprecated, please use `cifmw_test_operator_tempest_concurrency` instead. Default value: `8`
 * `cifmw_test_operator_clean_last_run`: (Bool) Delete all resources created by the previous run at the beginning of the role. Default value: `false`
 * `cifmw_test_operator_cleanup`: (Bool) Delete all resources created by the role at the end of the testing. Default value: `false`
 * `cifmw_test_operator_tempest_cleanup`: (Bool) Run tempest cleanup after test execution (tempest run) to delete any resources created by tempest that may have been left out.

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -29,7 +29,6 @@ cifmw_test_operator_controller_namespace: openstack-operators
 cifmw_test_operator_bundle: ""
 cifmw_test_operator_timeout: 3600
 cifmw_test_operator_logs_image: quay.io/quay/busybox
-cifmw_test_operator_concurrency: 8
 cifmw_test_operator_cleanup: false
 cifmw_test_operator_clean_last_run: false
 cifmw_test_operator_dry_run: false
@@ -66,6 +65,7 @@ cifmw_test_operator_default_image_tag: current-podified
 
 # Section 2: tempest parameters - used when run_test_fw is 'tempest'
 cifmw_test_operator_tempest_name: "tempest-tests"
+cifmw_test_operator_tempest_concurrency: 8
 cifmw_test_operator_tempest_registry: "{{ cifmw_test_operator_default_registry }}"
 cifmw_test_operator_tempest_namespace: "{{ cifmw_test_operator_default_namespace }}"
 cifmw_test_operator_tempest_container: openstack-tempest-all
@@ -157,8 +157,7 @@ cifmw_test_operator_tempest_config:
         {{ stage_vars_dict.cifmw_test_operator_tempest_exclude_list | default('') }}
       expectedFailuresList: |
         {{ stage_vars_dict.cifmw_test_operator_tempest_expected_failures_list | default('') }}
-      # NOTE: cifmw_test_operator_concurrency is deprecated, use cifmw_test_operator_tempest_concurrency instead
-      concurrency: "{{ stage_vars_dict.cifmw_test_operator_tempest_concurrency | default(cifmw_test_operator_concurrency) }}"
+      concurrency: "{{ stage_vars_dict.cifmw_test_operator_tempest_concurrency }}"
       externalPlugin: "{{ stage_vars_dict.cifmw_test_operator_tempest_external_plugin | default([]) }}"
       extraRPMs: "{{ stage_vars_dict.cifmw_test_operator_tempest_extra_rpms | default([]) }}"
       extraImages: "{{ stage_vars_dict.cifmw_test_operator_tempest_extra_images | default([]) }}"

--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -18,7 +18,7 @@
       cifmw_os_must_gather_timeout: 28800
       cifmw_test_operator_timeout: 14400
       cifmw_block_device_size: 40G
-      cifmw_test_operator_concurrency: 6
+      cifmw_test_operator_tempest_concurrency: 6
       cifmw_test_operator_tempest_network_attachments:
         - ctlplane
       cifmw_test_operator_tempest_container: openstack-tempest-all


### PR DESCRIPTION
Replace deprecated 'cifmw_test_operator_concurrency' with 'cifmw_test_operator_tempest_concurrency'
This aligns with the DoD described in https://issues.redhat.com/browse/OSPRH-16755