### PR TITLE
update: fix naming convention.

### DIFF
--- a/roles/update/tasks/create_local_openstackclient.yml
+++ b/roles/update/tasks/create_local_openstackclient.yml
@@ -28,7 +28,7 @@
 
 - name: Determine registry
   ansible.builtin.set_fact:
-    osc_podman_login_registry: >-
+    cifmw_update_login_registry: >-
       {{
       (cifmw_ci_gen_kustomize_values_ooi_image.split('/')[0])
       if cifmw_ci_gen_kustomize_values_ooi_image is defined
@@ -38,30 +38,30 @@
 
 - name: Check if credentials exist
   ansible.builtin.set_fact:
-    osc_podman_login_username: "{{ login_username }}"
-    osc_podman_login_password: "{{ login_dict[login_username] }}"
+    cifmw_update_login_username: "{{ login_username }}"
+    cifmw_update_login_password: "{{ login_dict[login_username] }}"
   vars:
     login_dict: >-
       {{
       _cifmw_update_osdpns_info.spec.nodeTemplate.ansible.ansibleVars.
-      edpm_container_registry_logins[osc_podman_login_registry]
+      edpm_container_registry_logins[cifmw_update_login_registry]
       }}
     login_username: "{{ login_dict.keys()|list|first }}"
   when:
     - _cifmw_update_osdpns_info.spec.nodeTemplate.ansible.ansibleVars.edpm_container_registry_logins is defined
     - login_dict is defined
     - login_dict|length > 0
-    - osc_podman_login_registry != 'quay.io'
+    - cifmw_update_login_registry != 'quay.io'
 
 - name: Log in to registry when needed
   containers.podman.podman_login:
-    registry: "{{ osc_podman_login_registry }}"
-    username: "{{ osc_podman_login_username }}"
-    password: "{{ osc_podman_login_password }}"
+    registry: "{{ cifmw_update_login_registry }}"
+    username: "{{ cifmw_update_login_username }}"
+    password: "{{ cifmw_update_login_password }}"
   when:
-    - osc_podman_login_username is defined
-    - osc_podman_login_password is defined
-    - osc_podman_login_registry != 'quay.io'
+    - cifmw_update_login_username is defined
+    - cifmw_update_login_password is defined
+    - cifmw_update_login_registry != 'quay.io'
 
 - name: Retrieve the openstackclient Pod
   kubernetes.core.k8s_info:


### PR DESCRIPTION
All variables in the update role should start with `cifmw_update`.