### PR TITLE
Copy on remote host when pull secret is available there

### DIFF
--- a/roles/manage_secrets/tasks/_push_secret.yml
+++ b/roles/manage_secrets/tasks/_push_secret.yml
@@ -38,8 +38,14 @@
         msg: |
           {{ _secret_file }} must be an absolute path
 
+    - name: Check if pull secret src file exists
+      ansible.builtin.stat:
+        path: "{{ _secret_file }}"
+      register: _ps_exists
+
     - name: Copy file to location
       ansible.builtin.copy:
+        remote_src: "{{ _ps_exists.stat.exists }}"
         dest: "{{ _secret_dest }}"
         src: "{{ _secret_file }}"
         mode: "0600"


### PR DESCRIPTION
The commit helps to run reproducer playbook locally and not on remote host directly.