### PR TITLE
Remove non-ascii characters

### DIFF
--- a/ci/playbooks/architecture/run.yml
+++ b/ci/playbooks/architecture/run.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Run ci/playbooks/architecture/validate-architecture.yml"
-  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Filter out host if needed

--- a/ci/playbooks/architecture/validate-architecture.yml
+++ b/ci/playbooks/architecture/validate-architecture.yml
@@ -33,7 +33,7 @@
     cifmw_path: >-
       {{
         ['~/bin',
-         ansible_env.PATH] | join(':')
+         ansible_env.PATH] | join(':')
       }}
     _mock_file: >-
       {{
@@ -120,8 +120,8 @@
       ansible.builtin.set_fact:
         vas: >-
           {{
-            vas | default({}) |
-            combine(item.content | b64decode | from_yaml, recursive=true)
+            vas | default({}) |
+            combine(item.content | b64decode | from_yaml, recursive=true)
           }}
       loop: "{{ _automation_contents.results }}"
       loop_control:
@@ -165,23 +165,23 @@
       ansible.builtin.set_fact:
         cifmw_ci_gen_kustomize_values_ssh_authorizedkeys: >-
           {{
-            _pub_keys.results[1].content | b64decode
+            _pub_keys.results[1].content | b64decode
           }}
         cifmw_ci_gen_kustomize_values_ssh_private_key: >-
           {{
-            _priv_keys.results[1].content | b64decode
+            _priv_keys.results[1].content | b64decode
           }}
         cifmw_ci_gen_kustomize_values_ssh_public_key: >-
           {{
-            _pub_keys.results[1].content | b64decode
+            _pub_keys.results[1].content | b64decode
           }}
         cifmw_ci_gen_kustomize_values_migration_pub_key: >-
           {{
-            _pub_keys.results[0].content | b64decode
+            _pub_keys.results[0].content | b64decode
           }}
         cifmw_ci_gen_kustomize_values_migration_priv_key: >-
           {{
-            _priv_keys.results[0].content | b64decode
+            _priv_keys.results[0].content | b64decode
           }}
         cifmw_ci_gen_kustomize_values_sshd_ranges: >-
           {{

--- a/ci/playbooks/build_runner_image.yml
+++ b/ci/playbooks/build_runner_image.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Run ci/playbooks/build_runner_image.yml"
-  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   tasks:
     - name: Filter out host if needed
       when:

--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Run ci/playbooks/collect-logs.yml"
-  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Filter out host if needed

--- a/ci/playbooks/content_provider/pre.yml
+++ b/ci/playbooks/content_provider/pre.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Run ci/playbooks/content_provider/pre.yml"
-  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   tasks:
     - name: Filter out host if needed
       when:

--- a/ci/playbooks/content_provider/run.yml
+++ b/ci/playbooks/content_provider/run.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Run ci/playbooks/content_provider/run.yml"
-  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Filter out host if needed

--- a/ci/playbooks/e2e-collect-logs.yml
+++ b/ci/playbooks/e2e-collect-logs.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Run ci/playbooks/e2e-collect-logs.yml"
-  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Filter out host if needed

--- a/ci/playbooks/edpm/run.yml
+++ b/ci/playbooks/edpm/run.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Run ci/playbooks/edpm/run.yml"
-  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Filter out host if needed

--- a/ci/playbooks/edpm/update.yml
+++ b/ci/playbooks/edpm/update.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Run ci/playbooks/edpm/update.yml"
-  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Filter out host if needed

--- a/ci/playbooks/edpm_baremetal_deployment/run.yml
+++ b/ci/playbooks/edpm_baremetal_deployment/run.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Run ci/playbooks/edpm_baremetal_deployment/run.yml"
-  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Filter out host if needed

--- a/ci/playbooks/edpm_build_images/run.yml
+++ b/ci/playbooks/edpm_build_images/run.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Run ci/playbooks/edpm_build_images/run.yml"
-  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Filter out host if needed

--- a/ci/playbooks/meta_content_provider/run.yml
+++ b/ci/playbooks/meta_content_provider/run.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Run ci/playbooks/meta_content_provider/run.yml"
-  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Filter out host if needed

--- a/ci/playbooks/tcib/run.yml
+++ b/ci/playbooks/tcib/run.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Run ci/playbooks/tcib/run.yml"
-  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Filter out host if needed

--- a/ci/playbooks/test-base-job/test-run.yml
+++ b/ci/playbooks/test-base-job/test-run.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Run ci/playbooks/test-base-job/run.yml"
-  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   tasks:
     - name: Filter out host if needed

--- a/playbooks/99-logs.yml
+++ b/playbooks/99-logs.yml
@@ -23,7 +23,7 @@
 
         - name: Load parameters files
           when:
-            - param_dir.stat.exists | bool
+            - param_dir.stat.exists | bool
           ansible.builtin.include_vars:
             dir: "{{ cifmw_basedir }}/artifacts/parameters"
       always:

--- a/roles/libvirt_manager/defaults/main.yml
+++ b/roles/libvirt_manager/defaults/main.yml
@@ -62,7 +62,7 @@ cifmw_libvirt_manager_pub_net: public
 # Those parameters are usually set via the reproducer role.
 # We will therefore use them, and default to the same value set in the role.
 cifmw_libvirt_manager_dns_servers: "{{ cifmw_reproducer_dns_servers | default(['1.1.1.1', '8.8.8.8']) }}"
-cifmw_libvirt_manager_crc_private_nic: "{{ cifmw_reproducer_crc_private_nic | default('enp2s0') }}"
+cifmw_libvirt_manager_crc_private_nic: "{{ cifmw_reproducer_crc_private_nic | default('enp2s0') }}"
 
 # Allow to inject custom node family
 cifmw_libvirt_manager_vm_net_ip_set: {}

--- a/roles/openshift_login/molecule/login_token_based/prepare.yml
+++ b/roles/openshift_login/molecule/login_token_based/prepare.yml
@@ -26,15 +26,15 @@
 
     - name: Login as kubeadmin
       environment:
-        PATH: "{{ ansible_user_dir  }}/.crc/bin/oc/:{{ ansible_env.PATH }}"
-        KUBECONFIG: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+        PATH: "{{ ansible_user_dir }}/.crc/bin/oc/:{{ ansible_env.PATH }}"
+        KUBECONFIG: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
       ansible.builtin.command:
         cmd: oc login -u kubeadmin -p 123456789
 
     - name: Get initial token
       environment:
-        PATH: "{{ ansible_user_dir  }}/.crc/bin/oc/:{{ ansible_env.PATH }}"
-        KUBECONFIG: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+        PATH: "{{ ansible_user_dir }}/.crc/bin/oc/:{{ ansible_env.PATH }}"
+        KUBECONFIG: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
       register: whoami_out
       ansible.builtin.command:
         cmd: oc whoami -t

--- a/roles/operator_deploy/defaults/main.yml
+++ b/roles/operator_deploy/defaults/main.yml
@@ -19,7 +19,7 @@
 # All variables within this role should have a prefix of "cifmw_operator_deploy"
 
 # output base directory
-cifmw_operator_deploy_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+cifmw_operator_deploy_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
 # List of operators you want to deploy
 cifmw_operator_deploy_list: []
 # install_yamls repository location

--- a/roles/operator_deploy/molecule/default/converge.yml
+++ b/roles/operator_deploy/molecule/default/converge.yml
@@ -18,7 +18,7 @@
 - name: Converge
   hosts: all
   environment:
-    KUBECONFIG: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
+    KUBECONFIG: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
   vars:
     cifmw_installyamls_repos: "/tmp/install_yamls"
     cifmw_operator_deploy_list:

--- a/roles/operator_deploy/tasks/main.yml
+++ b/roles/operator_deploy/tasks/main.yml
@@ -16,8 +16,8 @@
 
 - name: Deploy selected operators
   ci_script:
-    output_dir: "{{ cifmw_operator_deploy_basedir }}/artifacts"
+    output_dir: "{{ cifmw_operator_deploy_basedir }}/artifacts"
     chdir: "{{ cifmw_operator_deploy_installyamls }}"
     script: "make {{ item.name }}"
-    extra_args: "{{ item.params | default({}) }}"
+    extra_args: "{{ item.params | default({}) }}"
   loop: "{{ cifmw_operator_deploy_list }}"

--- a/roles/pkg_build/tasks/build.yml
+++ b/roles/pkg_build/tasks/build.yml
@@ -5,7 +5,7 @@
       {% for pkg in cifmw_pkg_build_list -%}
       - "{{ pkg.src|default(cifmw_pkg_build_pkg_basedir ~ '/' ~ pkg.name) }}:/root/src/{{ pkg.name }}:z"
       - "{{ cifmw_pkg_build_basedir }}/volumes/packages/{{ pkg.name }}:/root/{{ pkg.name }}:z"
-      - "{{ cifmw_pkg_build_basedir }}/logs/build_{{ pkg.name }}:/root/logs:z"
+      - "{{ cifmw_pkg_build_basedir }}/logs/build_{{ pkg.name }}:/root/logs:z"
       {% endfor -%}
       - "{{ cifmw_pkg_build_basedir }}/volumes/packages/gating_repo:/root/gating_repo:z"
       - "{{ cifmw_pkg_build_basedir }}/artifacts/repositories:/root/yum.repos.d:z,ro"

--- a/roles/repo_setup/tasks/ci_mirror.yml
+++ b/roles/repo_setup/tasks/ci_mirror.yml
@@ -5,7 +5,7 @@
   register: mirror_path
 
 - name: Use proxy mirrors
-  become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"
+  become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"
   when:
     - mirror_path.stat.exists
   block:

--- a/roles/repo_setup/tasks/component_repo.yml
+++ b/roles/repo_setup/tasks/component_repo.yml
@@ -1,20 +1,20 @@
 ---
 - name: Get component repo
-  become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"
+  become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"
   ansible.builtin.get_url:
     url: "{{ cifmw_repo_setup_dlrn_uri }}/{{ cifmw_repo_setup_os_release }}{{ cifmw_repo_setup_dist_major_version }}-{{ cifmw_repo_setup_branch }}/component/{{ cifmw_repo_setup_component_name }}/{{ cifmw_repo_setup_component_promotion_tag }}/delorean.repo"
     dest: "{{ cifmw_repo_setup_output }}/{{ cifmw_repo_setup_component_name }}_{{ cifmw_repo_setup_component_promotion_tag }}_delorean.repo"
     mode: "0644"
 
 - name: Rename component repo
-  become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"
+  become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"
   ansible.builtin.replace:
     path: "{{ cifmw_repo_setup_output }}/{{ cifmw_repo_setup_component_name }}_{{ cifmw_repo_setup_component_promotion_tag }}_delorean.repo"
     regexp: 'delorean-component-{{ cifmw_repo_setup_component_name }}'
     replace: '{{ cifmw_repo_setup_component_name }}-{{ cifmw_repo_setup_component_promotion_tag }}'
 
 - name: Disable component repo in current-podified dlrn repo
-  become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"
+  become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"
   community.general.ini_file:
     path: "{{ cifmw_repo_setup_output }}/delorean.repo"
     section: 'delorean-component-{{ cifmw_repo_setup_component_name }}'

--- a/roles/repo_setup/tasks/configure.yml
+++ b/roles/repo_setup/tasks/configure.yml
@@ -8,7 +8,7 @@
     - (not cifmw_run_update|default(false)) or (update_playbook_run is defined and cifmw_run_update|default(false))
 
 - name: Run repo-setup
-  become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"
+  become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"
   ansible.builtin.command:
     cmd: >-
       {{ cifmw_repo_setup_venv }}/bin/repo-setup

--- a/roles/repo_setup/tasks/populate_gating_repo.yml
+++ b/roles/repo_setup/tasks/populate_gating_repo.yml
@@ -7,7 +7,7 @@
 
 - name: Construct gating repo
   when: _url_status.status == 200
-  become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"
+  become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"
   block:
     - name: Populate gating repo from content provider ip
       ansible.builtin.copy:

--- a/roles/reproducer/tasks/push_code.yml
+++ b/roles/reproducer/tasks/push_code.yml
@@ -161,5 +161,5 @@
 - name: Install collections on controller-0
   delegate_to: controller-0
   ansible.builtin.command:
-    chdir: "{{ _cifmw_reproducer_framework_location }}"
+    chdir: "{{ _cifmw_reproducer_framework_location }}"
     cmd: ansible-galaxy collection install --upgrade --force .

--- a/roles/run_hook/tasks/playbook.yml
+++ b/roles/run_hook/tasks/playbook.yml
@@ -25,7 +25,7 @@
         default('openstack')
       }}
   ansible.builtin.set_fact:
-    cifmw_basedir: "{{ _bdir }}"
+    cifmw_basedir: "{{ _bdir }}"
     hook_name: "{{ _hook_name }}"
     playbook_path: "{{ _play | realpath }}"
     log_path: >-

--- a/scenarios/reproducers/3-nodes.yml
+++ b/scenarios/reproducers/3-nodes.yml
@@ -30,7 +30,7 @@ cifmw_libvirt_manager_configuration:
         - osp_trunk
     compute:
       uefi: "{{ cifmw_use_uefi }}"
-      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 1] | max }}"
+      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 1] | max }}"
       root_part_id: "{{ cifmw_root_partition_id }}"
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"

--- a/scenarios/reproducers/bgp-4-racks-3-ocps.yml
+++ b/scenarios/reproducers/bgp-4-racks-3-ocps.yml
@@ -236,7 +236,7 @@ cifmw_libvirt_manager_configuration:
         - ocpbm
         - osp_trunk
     compute:
-      amount: "{{ cifmw_libvirt_manager_compute_amount }}"
+      amount: "{{ cifmw_libvirt_manager_compute_amount }}"
       root_part_id: "{{ cifmw_root_partition_id }}"
       uefi: "{{ cifmw_use_uefi }}"
       image_url: "{{ cifmw_discovered_image_url }}"

--- a/scenarios/reproducers/dt-dcn.yml
+++ b/scenarios/reproducers/dt-dcn.yml
@@ -116,7 +116,7 @@ cifmw_libvirt_manager_configuration:
     compute:
       uefi: "{{ cifmw_use_uefi }}"
       root_part_id: "{{ cifmw_root_partition_id }}"
-      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 3] | max }}"
+      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 3] | max }}"
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"

--- a/scenarios/reproducers/dt-osasinfra.yml
+++ b/scenarios/reproducers/dt-osasinfra.yml
@@ -97,7 +97,7 @@ cifmw_libvirt_manager_configuration:
     compute:
       uefi: "{{ cifmw_use_uefi }}"
       root_part_id: "{{ cifmw_root_partition_id }}"
-      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 3] | max }}"
+      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 3] | max }}"
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"

--- a/scenarios/reproducers/external-ceph.yml
+++ b/scenarios/reproducers/external-ceph.yml
@@ -46,7 +46,7 @@ cifmw_libvirt_manager_configuration:
     compute:
       uefi: "{{ cifmw_use_uefi | default(false) }}"
       root_part_id: 4
-      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 3] | max }}"
+      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 3] | max }}"
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"

--- a/scenarios/reproducers/va-hci.yml
+++ b/scenarios/reproducers/va-hci.yml
@@ -68,7 +68,7 @@ cifmw_libvirt_manager_configuration:
     compute:
       uefi: "{{ cifmw_use_uefi }}"
       root_part_id: "{{ cifmw_root_partition_id }}"
-      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 3] | max }}"
+      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 3] | max }}"
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"

--- a/scenarios/reproducers/va-multi.yml
+++ b/scenarios/reproducers/va-multi.yml
@@ -98,7 +98,7 @@ cifmw_libvirt_manager_configuration:
     compute:
       uefi: "{{ cifmw_use_uefi }}"
       root_part_id: "{{ cifmw_root_partition_id }}"
-      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 2] | max }}"
+      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 2] | max }}"
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"
@@ -112,7 +112,7 @@ cifmw_libvirt_manager_configuration:
     compute2:
       uefi: "{{ cifmw_use_uefi }}"
       root_part_id: "{{ cifmw_root_partition_id }}"
-      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 2] | max }}"
+      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 2] | max }}"
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"

--- a/scenarios/reproducers/va-pidone.yml
+++ b/scenarios/reproducers/va-pidone.yml
@@ -87,7 +87,7 @@ cifmw_libvirt_manager_configuration:
     compute:
       uefi: "{{ cifmw_use_uefi }}"
       root_part_id: "{{ cifmw_root_partition_id }}"
-      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 3] | max }}"
+      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 3] | max }}"
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"


### PR DESCRIPTION
Harmonization to ASCII can prevent errors due to encoding inconsistencies.

Executed command:

    LC_ALL=C find . -type f -name '*.yml' -exec  grep -l '[^[:print:]]' {} \;| grep -vE '\.git|_build|\.tox'