### PR TITLE
Update: Don't fail if the monitoring process is not up anymore.

### DIFF
--- a/playbooks/update.yml
+++ b/playbooks/update.yml
@@ -141,6 +141,8 @@
             cmd: >-
               kill
               $(cat {{ cifmw_basedir }}/tests/update/monitor_resources_changes.pid)
+          register: _kill_result
+          failed_when: _kill_result.rc not in [0, 1]
           when: cifmw_update_monitoring_pid.stat.exists | bool
 
     - name: Run post_update hooks


### PR DESCRIPTION
We don't want the job to fail because monitoring had some issue.