### PR TITLE
Set ovn-egress-iface=true for br-ex physical NIC

### DIFF
--- a/hooks/playbooks/fetch_compute_facts.yml
+++ b/hooks/playbooks/fetch_compute_facts.yml
@@ -234,6 +234,11 @@
                             mtu: {{ min_viable_mtu }}
                             # force the MAC address of the bridge to this interface
                             primary: true
+                        {% if edpm_network_config_nmstate | bool %}
+                            # this ovs_extra configuration fixes OSPRH-17551, but it will be not needed when FDP-1472 is resolved
+                            ovs_extra:
+                              - "set interface eth1 external-ids:ovn-egress-iface=true"
+                        {% endif %}
                         {% for network in nodeset_networks %}
                           - type: vlan
                             mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}


### PR DESCRIPTION
In order to fix [OSPRH-17551](https://issues.redhat.com//browse/OSPRH-17551) and make BW limits properly applied to physical ports (ports from neutron VLAN and flat networks), the br-ex member interfaces need to be configured with ovn-egress-iface=true.

This is applies when os-net-config is used with the nmstate driver.