### PR TITLE
Use FQCN during the use of a module

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -57,7 +57,7 @@ Any of the `ansible.builtin.uri` module is supported.
 ```YAML
 - name: Get latest CentOS 9 Stream image
   register: discovered_image
-  discover_latest_image:
+  cifmw.general.discover_latest_image:
     url: "https://cloud.centos.org/centos/9-stream/x86_64/images/"
     image_prefix: "CentOS-Stream-GenericCloud"
 

--- a/plugins/action/ci_kustomize.py
+++ b/plugins/action/ci_kustomize.py
@@ -105,7 +105,7 @@ EXAMPLES = r"""
 # Apply the kustomizations in `/home/user/source/k8s-manifets-dir` to the
 # `target_path` manifest and output the result in `output_pat`
 - name: Apply the file and variables kustomizations to multiple CRs
-  ci_kustomize:
+  cifmw.general.ci_kustomize:
     target_path: /home/user/source/k8s-manifets-dir/manifest.yaml
     output_path: /home/user/source/k8s-manifets-dir/out.yaml
 
@@ -113,7 +113,7 @@ EXAMPLES = r"""
 # `/home/user/source/k8s-manifets-dir` and `extra_dir` dirs to the
 # manifests available in the `target_path` dir
 - name: Apply the file and variables kustomizations to multiple CRs
-  ci_kustomize:
+  cifmw.general.ci_kustomize:
     target_path: /home/user/source/k8s-manifets-dir
     kustomizations:
       - apiVersion: kustomize.config.k8s.io/v1beta1

--- a/plugins/action/ci_script.py
+++ b/plugins/action/ci_script.py
@@ -56,7 +56,7 @@ options:
 EXAMPLES = r"""
 - name: Run custom script
   register: script_output
-  ci_script:
+  cifmw.general.ci_script:
     output_dir: "/home/zuul/ci-framework-data/artifacts"
     script: |
       mkdir /home/zuul/test-dir

--- a/plugins/action/discover_latest_image.py
+++ b/plugins/action/discover_latest_image.py
@@ -31,7 +31,7 @@ options: Please refer to ansible.builtin.uri options
 EXAMPLES = r"""
 - name: Get latest CentOS 9 Stream image
   register: discovered_images
-  discover_latest_image:
+  cifmw.general.discover_latest_image:
     base_url: "https://cloud.centos.org/centos/{{ ansible_distribution_major_version }}-stream/x86_64/images"
     image_prefix: "CentOS-Stream-GenericCloud-"
     images_file: "CHECKSUM"

--- a/plugins/modules/generate_make_tasks.py
+++ b/plugins/modules/generate_make_tasks.py
@@ -73,7 +73,7 @@ MAKE_TMPL = """---
   delay: "{{ make_%(target)s_delay | default(omit) }}"
   until: "{{ make_%(target)s_until | default(true) }}"
   register: "make_%(target)s_status"
-  ci_script:
+  cifmw.general.ci_script:
     output_dir: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts"
     chdir: "%(chdir)s"
     script: "make %(target)s"

--- a/roles/artifacts/tasks/crc.yml
+++ b/roles/artifacts/tasks/crc.yml
@@ -30,7 +30,7 @@
 
     - name: Prepare root ssh accesses
       ignore_errors: true  # noqa: ignore-errors
-      ci_script:
+      cifmw.general.ci_script:
         output_dir: "{{ cifmw_artifacts_basedir }}/artifacts"
         script: |-
           ssh -i {{ new_keypair_path | default(cifmw_artifacts_crc_sshkey) }} {{ cifmw_artifacts_crc_user }}@{{ cifmw_artifacts_crc_host }} <<EOF
@@ -43,7 +43,7 @@
           EOF
     - name: Copy logs from CRC VM
       ignore_errors: true  # noqa: ignore-errors
-      ci_script:
+      cifmw.general.ci_script:
         output_dir: "{{ cifmw_artifacts_basedir }}/artifacts"
         script: >-
           scp -v -r -i {{ new_keypair_path | default(cifmw_artifacts_crc_sshkey) }}

--- a/roles/artifacts/tasks/main.yml
+++ b/roles/artifacts/tasks/main.yml
@@ -94,7 +94,7 @@
   when: cifmw_artifacts_mask_logs |bool
   ignore_errors: true  # noqa: ignore-errors
   timeout: 3600
-  crawl_n_mask:
+  cifmw.general.crawl_n_mask:
     path: "{{ item }}"
     isdir: true
   loop:

--- a/roles/discover_latest_image/tasks/main.yml
+++ b/roles/discover_latest_image/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: Get latest image
   register: discovered_image
-  discover_latest_image:
+  cifmw.general.discover_latest_image:
     url: "{{ cifmw_discover_latest_image_base_url }}"
     image_prefix: "{{ cifmw_discover_latest_image_qcow_prefix }}"
     images_file: "{{ cifmw_discover_latest_image_images_file }}"

--- a/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
+++ b/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
@@ -63,7 +63,7 @@
           'cr'
         ] | ansible.builtin.path_join
       }}
-  ci_kustomize:
+  cifmw.general.ci_kustomize:
     target_path: "{{ cifmw_edpm_prepare_openstack_crs_path }}"
     sort_ascending: false
     kustomizations: "{{ cifmw_edpm_prepare_kustomizations + _ctlplane_name_kustomizations }}"

--- a/roles/install_yamls/README.md
+++ b/roles/install_yamls/README.md
@@ -41,7 +41,7 @@ The created role directory contains multiple task files, similar to
   delay: "{{ make_crc_storage_delay | default(omit) }}"
   until: "{{ make_crc_storage_until | default(true) }}"
   register: "make_crc_storage_status"
-  ci_script:
+  cifmw.general.ci_script:
     output_dir: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts"
     chdir: "/home/zuul/src/github.com/openstack-k8s-operators/install_yamls"
     script: make crc_storage
@@ -119,7 +119,7 @@ Let's look at below example:-
       delay: "{{ make_ansibleee_cleanup_delay | default(omit) }}"
       until: "{{ make_ansibleee_cleanup_until | default(true) }}"
       register: "make_ansibleee_cleanup_status"
-      ci_script:
+      cifmw.general.ci_script:
         output_dir: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/artifacts"
         chdir: "/home/zuul/src/github.com/openstack-k8s-operators/install_yamls"
         script: "make ansibleee_cleanup"

--- a/roles/operator_build/tasks/build.yml
+++ b/roles/operator_build/tasks/build.yml
@@ -128,7 +128,7 @@
 - name: "{{ operator.name }} - Call manifests"  # noqa: name[template]
   when:
     - operator.name != "rabbitmq-cluster-operator"
-  ci_script:
+  cifmw.general.ci_script:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
     chdir: "{{ operator.src }}"
     output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
@@ -153,7 +153,7 @@
           } if 'image_base' in operator else {}
         )
       }}
-  ci_script:
+  cifmw.general.ci_script:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
     chdir: "{{ operator.src }}"
     output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
@@ -163,7 +163,7 @@
 - name: "{{ operator.name }} - Call docker-build"  # noqa: name[template]
   when:
     - operator.name != "rabbitmq-cluster-operator"
-  ci_script:
+  cifmw.general.ci_script:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
     chdir: "{{ operator.src }}"
     output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
@@ -175,7 +175,7 @@
   when:
     - cifmw_operator_build_push_ct|bool
     - operator.name != "rabbitmq-cluster-operator"
-  ci_script:
+  cifmw.general.ci_script:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
     chdir: "{{ operator.src }}"
     output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
@@ -191,7 +191,7 @@
 - name: "{{ operator.name }} - Call bundle"  # noqa: name[template]
   when:
     - operator.name != "rabbitmq-cluster-operator"
-  ci_script:
+  cifmw.general.ci_script:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
     chdir: "{{ operator.src }}"
     output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
@@ -206,7 +206,7 @@
 - name: "{{ operator.name }} - Call bundle-build"  # noqa: name[template]
   when:
     - operator.name != "rabbitmq-cluster-operator"
-  ci_script:
+  cifmw.general.ci_script:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
     chdir: "{{ operator.src }}"
     output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
@@ -235,7 +235,7 @@
 - name: "{{ operator.name }} - Call catalog-build"  # noqa: name[template]
   when:
     - operator.name != "rabbitmq-cluster-operator"
-  ci_script:
+  cifmw.general.ci_script:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
     chdir: "{{ operator.src }}"
     output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"
@@ -253,7 +253,7 @@
   when:
     - cifmw_operator_build_push_ct|bool
     - operator.name != "rabbitmq-cluster-operator"
-  ci_script:
+  cifmw.general.ci_script:
     dry_run: "{{ cifmw_operator_build_dryrun|bool }}"
     chdir: "{{ operator.src }}"
     output_dir: "{{ cifmw_operator_build_basedir }}/artifacts"

--- a/roles/operator_deploy/tasks/main.yml
+++ b/roles/operator_deploy/tasks/main.yml
@@ -15,7 +15,7 @@
 # under the License.
 
 - name: Deploy selected operators
-  ci_script:
+  cifmw.general.ci_script:
     output_dir: "{{ cifmw_operator_deploy_basedir }}/artifacts"
     chdir: "{{ cifmw_operator_deploy_installyamls }}"
     script: "make {{ item.name }}"

--- a/roles/os_must_gather/tasks/build_openstack-must-gather_image.yml
+++ b/roles/os_must_gather/tasks/build_openstack-must-gather_image.yml
@@ -25,7 +25,7 @@
     msg: "{{ openstack_must_gather_tag }}"
 
 - name: Build openstack-must-gather container
-  ci_script:
+  cifmw.general.ci_script:
     chdir: "{{ cifmw_os_must_gather_repo_path }}"
     output_dir: "{{ cifmw_os_must_gather_output_dir }}/artifacts"
     script: make podman-build
@@ -35,7 +35,7 @@
       MUST_GATHER_IMAGE: "openstack-must-gather"
 
 - name: Push openstack-must-gather container
-  ci_script:
+  cifmw.general.ci_script:
     chdir: "{{ cifmw_os_must_gather_repo_path }}"
     output_dir: "{{ cifmw_os_must_gather_output_dir }}/artifacts"
     script: make podman-push

--- a/tests/integration/targets/kustomize/tasks/run_test_case.yml
+++ b/tests/integration/targets/kustomize/tasks/run_test_case.yml
@@ -127,7 +127,7 @@
       {%   endif -%}
       {% endfor -%}
       {{ paths }}
-  ci_kustomize:
+  cifmw.general.ci_kustomize:
     target_path: >-
       {{
         (

--- a/tests/integration/targets/make/tasks/ci_make.yml
+++ b/tests/integration/targets/make/tasks/ci_make.yml
@@ -24,7 +24,7 @@
 
 - name: Run ci_script make without any extra_args
   register: no_extra_args
-  ci_script:
+  cifmw.general.ci_script:
     script: make help
     chdir: /tmp/project_makefile
     output_dir: /tmp/artifacts
@@ -38,7 +38,7 @@
 
 - name: Run ci_script make with extra_args
   register: with_extra_args
-  ci_script:
+  cifmw.general.ci_script:
     script: make help
     chdir: /tmp/project_makefile
     output_dir: /tmp/artifacts
@@ -52,7 +52,7 @@
       - "'This is the help thing showing starwars' in with_extra_args.stdout"
 
 - name: Try dry_run parameter
-  ci_script:
+  cifmw.general.ci_script:
     chdir: /tmp/project_makefile
     output_dir: /tmp/artifacts
     dry_run: true
@@ -62,7 +62,7 @@
 
 
 - name: Test with extra_args
-  ci_script:
+  cifmw.general.ci_script:
     chdir: /tmp/project_makefile
     output_dir: /tmp/artifacts
     script: make help
@@ -82,20 +82,20 @@
           ONE: 1
           FOO_BAR: Baz
     - name: Run ci_script make with custom env variable
-      ci_script:
+      cifmw.general.ci_script:
         chdir: /tmp/project_makefile
         output_dir: /tmp/artifacts
         script: make help
         extra_args: "{{ dict((my_env_vars|default({})), **(other_env_vars|default({}))) }}"
     - name: Run ci_script make custom env var and default
-      ci_script:
+      cifmw.general.ci_script:
         chdir: /tmp/project_makefile
         output_dir: /tmp/artifacts
         script: make help
         extra_args: "{{ my_env_vars | default({}) }}"
 
 - name: Run ci_script make with extra_args and default
-  ci_script:
+  cifmw.general.ci_script:
     chdir: /tmp/project_makefile
     output_dir: /tmp/artifacts
     script: make help
@@ -107,7 +107,7 @@
       register: failing_make
       failed_when:
         - "'Error 255' not in failing_make.stdout"
-      ci_script:
+      cifmw.general.ci_script:
         chdir: /tmp/project_makefile
         output_dir: /tmp/artifacts
         script: make failing

--- a/tests/integration/targets/script/tasks/main.yml
+++ b/tests/integration/targets/script/tasks/main.yml
@@ -12,7 +12,7 @@
   register: out_ok
   environment:
     TEST_VAR: "test-value"
-  ci_script:
+  cifmw.general.ci_script:
     output_dir: /tmp/artifacts
     script: |
       mkdir -p /tmp/test/target
@@ -23,7 +23,7 @@
   register: out_fail
   environment:
     TEST_VAR: "test-value"
-  ci_script:
+  cifmw.general.ci_script:
     output_dir: /tmp/artifacts
     script: |
       printf "I am about to fail" >&2
@@ -43,7 +43,7 @@
 - name: Run with global debug enabled
   vars:
     cifmw_debug: true
-  ci_script:
+  cifmw.general.ci_script:
     output_dir: /tmp/artifacts
     script: |
       printf "Debug 1"
@@ -51,7 +51,7 @@
 - name: Run with action debug enabled
   vars:
     cifmw_ci_script_debug: true
-  ci_script:
+  cifmw.general.ci_script:
     output_dir: /tmp/artifacts
     script: |
       printf "Debug 2"
@@ -66,7 +66,7 @@
 - name: Run using chdir option
   vars:
     cifmw_ci_script_debug: true
-  ci_script:
+  cifmw.general.ci_script:
     output_dir: /tmp/artifacts
     chdir: /tmp/dummy/test
     script: |


### PR DESCRIPTION
    Use FQCN during the use of a module

    Usage of FQCN while calling a module avoids ambiguity [1]
    [1] https://ansible.readthedocs.io/projects/lint/rules/fqcn/\#problematic-code

https://issues.redhat.com/browse/OSPRH-18427