### PR TITLE
Adjust the MTU for tcib job

### DIFF
--- a/ci/playbooks/tcib/run.yml
+++ b/ci/playbooks/tcib/run.yml
@@ -17,6 +17,11 @@
           is match("[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+")
           else hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}
 
+    - name: Set lower MTU for container network
+      ansible.builtin.command: ip link set dev eth0 mtu 1490
+      become: true
+      failed_when: false
+
     - name: Run tcib playbook
       ansible.builtin.command:
         chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"


### PR DESCRIPTION
This change tries to fix an issue with container build timing out when the host has a large MTU.