### PR TITLE
Removing pre_tempest and post_tempest is no longer in use

### DIFF
--- a/post-deployment.yml
+++ b/post-deployment.yml
@@ -10,9 +10,6 @@
         - admin-setup
 
     - name: Run Test
-      vars:
-        pre_tests: "{{ (lookup('vars', 'pre_tempest', default=[])) }}"
-        post_tests: "{{ (lookup('vars', 'post_tempest', default=[])) }}"
       ansible.builtin.import_role:
         name: cifmw_setup
         tasks_from: run_tests.yml

--- a/update-edpm.yml
+++ b/update-edpm.yml
@@ -26,8 +26,6 @@
   tasks:
     - name: Run Test
       vars:
-        pre_tests: "{{ (lookup('vars', 'pre_tempest', default=[])) }}"
-        post_tests: "{{ (lookup('vars', 'post_tempest', default=[])) }}"
         cifmw_test_operator_artifacts_basedir: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/tests/test_operator_update"
         cifmw_test_operator_tempest_name: "post-update-tempest-tests"
       ansible.builtin.import_role:


### PR DESCRIPTION
Ticket: https://issues.redhat.com/browse/OSPRH-6826