### PR TITLE
Swap wait order for pod and deployment at openshift_obs role

### DIFF
--- a/roles/openshift_obs/tasks/main.yml
+++ b/roles/openshift_obs/tasks/main.yml
@@ -20,6 +20,18 @@
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
     state: present
 
+- name: Wait for observability operator deployment
+  kubernetes.core.k8s_info:
+    kind: Deployment
+    namespace: openshift-operators
+    name: observability-operator
+    wait: true
+    wait_timeout: 300
+    wait_condition:
+      type: Available
+      status: "True"
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+
 - name: Wait for observability-operator pod
   kubernetes.core.k8s_info:
     kind: Pod
@@ -30,17 +42,5 @@
     wait_timeout: 300
     wait_condition:
       type: Ready
-      status: "True"
-    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
-
-- name: Wait for observability operator deployment
-  kubernetes.core.k8s_info:
-    kind: Deployment
-    namespace: openshift-operators
-    name: observability-operator
-    wait: true
-    wait_timeout: 300
-    wait_condition:
-      type: Available
       status: "True"
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"


### PR DESCRIPTION
This patch is oriented to fix a race condition where sometimes
observability-operator-pod raise:
"AttributeError: ''NoneType'' object has no attribute ''status'''"

Definetely waiting first for the deployment and then for the pod
is more correct and might help in this situation, despite the fact
that this is a rare race condition.