### PR TITLE
[debug] Print the rhos-release URL

### DIFF
--- a/roles/repo_setup/tasks/rhos_release.yml
+++ b/roles/repo_setup/tasks/rhos_release.yml
@@ -8,6 +8,10 @@
         state: directory
         mode: "0755"
 
+    - name: Print the URL to request
+      ansible.builtin.debug:
+        msg: "{{ cifmw_repo_setup_rhos_release_rpm }}"
+
     - name: Download the RPM
       vars:
         cifmw_krb_request_url: "{{ cifmw_repo_setup_rhos_release_rpm }}"


### PR DESCRIPTION
We are investigating a case and it appeared that despite setting the variable to the desired value, in the end in the job it ends up requesting something else... This debug task would allow us inspecting what we really get.