### PR TITLE
Fix terminology: use "architecture-based" instead of "VA"

### DIFF
--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -150,7 +150,7 @@
       tags:
         - edpm
 
-- name: Deploy VA and validate workflow
+- name: Deploy architecture and validate workflow
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:

--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -46,7 +46,7 @@ are shared among multiple roles:
 - `cifmw_ssh_keysize`: (Integer) Size of ssh keys that will be injected into the controller in order to connect to the rest of the nodes. Defaults to 521.
 - `cifmw_architecture_repo`: (String) Path of the architecture repository on the controller node.
   Defaults to `~/src/github.com/openstack-k8s-operators/architecture`
-- `cifmw_architecture_scenario`: (String) The selected VA scenario to deploy.
+- `cifmw_architecture_scenario`: (String) The selected architecture-based scenario to deploy.
 - `cifmw_architecture_wait_condition`: (Dict) Structure defining custom wait_conditions for the automation.
 - `cifmw_architecture_user_kustomize.*`: (Dict) Structures defining user provided kustomization for automation. All these variables are combined together.
 - `cifmw_architecture_user_kustomize_base_dir`: (String) Path where to lock for kustomization patches.

--- a/playbooks/06-deploy-architecture.yml
+++ b/playbooks/06-deploy-architecture.yml
@@ -3,7 +3,7 @@
 # NOTE: Playbook migrated to: roles/cifmw_setup/tasks/deploy_architecture.yml
 # DO NOT EDIT THIS PLAYBOOK. IT WILL BE REMOVED IN NEAR FUTURE.
 #
-- name: Deploy VA
+- name: Deploy an architecture-based scenario
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   tasks:
     - name: Run pre_deploy hooks

--- a/roles/ci_gen_kustomize_values/README.md
+++ b/roles/ci_gen_kustomize_values/README.md
@@ -8,7 +8,7 @@ None
 
 ```{warning}
 The top level parameter `cifmw_architecture_scenario` is required in order
-to select the proper VA scenario to deploy. If not provided, the role will fail
+to select the proper architecture-based scenario to deploy. If not provided, the role will fail
 with a message.
 ```
 

--- a/roles/kustomize_deploy/README.md
+++ b/roles/kustomize_deploy/README.md
@@ -1,12 +1,12 @@
 # kustomize_deploy
 
-Ansible role designed to deploy VA scenarios using the kustomize tool.
+Ansible role designed to deploy architecture-based scenarios using the kustomize tool.
 
 ## Parameters
 
 ```{warning}
 The top level parameter `cifmw_architecture_scenario` is required in order
-to select the proper VA scenario to deploy. If not provided, the role will fail
+to select the proper architecture-based scenario to deploy. If not provided, the role will fail
 with a message.
 ```
 
@@ -15,7 +15,7 @@ with a message.
 - `cifmw_kustomize_deploy_basedir`: _(string)_ Base directory for the
   ci-framework artifacts. Defaults to `~/ci-framework-data/`
 - `cifmw_kustomize_deploy_architecture_repo_url`: _(string)_ URL of The
-  "architecture" repository, where the VA scenarios are defined.
+  "architecture" repository, where the architecture-based scenarios are defined.
   Defaults to `https://github.com/openstack-k8s-operators/architecture`
 - `cifmw_kustomize_deploy_architecture_repo_dest_dir`: _(string)_ Directory
   where the architecture repo is cloned on the controller node.
@@ -26,7 +26,7 @@ with a message.
   Relative path of the common CRs in the architecture repo. Defaults to
   `/examples/common`
 - `cifmw_kustomize_deploy_architecture_examples_path`: _(string)_ Relative
-  path of the VA scenario list in the operator repo. Defaults to `/examples/va`
+  path of the architecture-based scenario list in the operator repo. Defaults to `/examples/va`
 - `cifmw_kustomize_deploy_kustomizations_dest_dir`: _(string)_ Path for the
   generated CR files. Defaults to
   `cifmw_kustomize_deploy_destfiles_basedir + /artifacts/kustomize_deploy`

--- a/roles/kustomize_deploy/tasks/check_requirements.yml
+++ b/roles/kustomize_deploy/tasks/check_requirements.yml
@@ -41,7 +41,7 @@
       ansible.builtin.fail:
         msg: >
           You need to properly set the `cifmw_architecture_scenario` variable
-          in order to select the VA scenario to deploy. You can take a list of
+          in order to select the architecture-based scenario to deploy. You can take a list of
           scenario in the `examples/va` folder in the architecture repo.
       when:
         - cifmw_architecture_scenario is not defined

--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -360,7 +360,7 @@
         - cifmw_job_uri is defined
       ansible.builtin.include_tasks: ci_job.yml
 
-    - name: Prepare VA deployment
+    - name: Prepare architecture-based deployment
       when:
         - cifmw_architecture_scenario is defined
         - cifmw_job_uri is undefined
@@ -372,7 +372,7 @@
           tags:
             - deploy_architecture
 
-    - name: Prepare VA post deployment
+    - name: Prepare architecture-based post deployment
       when:
         - cifmw_architecture_scenario is defined
         - cifmw_job_uri is undefined

--- a/roles/reproducer/tasks/reuse_main.yaml
+++ b/roles/reproducer/tasks/reuse_main.yaml
@@ -180,7 +180,7 @@
         - cifmw_job_uri is defined
       ansible.builtin.include_tasks: ci_job.yml
 
-    - name: Prepare VA deployment
+    - name: Prepare architecture-based deployment
       when:
         - cifmw_architecture_scenario is defined
         - cifmw_job_uri is undefined
@@ -192,7 +192,7 @@
           tags:
             - deploy_architecture
 
-    - name: Prepare VA post deployment
+    - name: Prepare architecture-based post deployment
       when:
         - cifmw_architecture_scenario is defined
         - cifmw_job_uri is undefined


### PR DESCRIPTION
The architecture repository contains severals DTs, some of which are VAs. At the beginning the architecture-runner code was developed with VA1 (later HCI VA) in mind, but we are really talking about architecture-based deployments, not specifically to VAs.

This change only affects the ansible output and it has no functional impact.