### PR TITLE
[bop] Donot parse changes for cifmw_bop_skipped_projects

### DIFF
--- a/roles/build_openstack_packages/defaults/main.yml
+++ b/roles/build_openstack_packages/defaults/main.yml
@@ -103,6 +103,7 @@ cifmw_bop_skipped_projects:
   - openstack-k8s-operators/repo-setup
   - openstack-k8s-operators/swift-operator
   - openstack-k8s-operators/telemetry-operator
+  - infrawatch/feature-verification-tests
 
 cifmw_bop_gating_port: 8766
 

--- a/roles/build_openstack_packages/tasks/parse_and_build_pkgs.yml
+++ b/roles/build_openstack_packages/tasks/parse_and_build_pkgs.yml
@@ -5,6 +5,7 @@
     - zuul is defined
     - "'change_url' in item"
     - '"-distgit" not in item.project'
+    - item.project.name not in cifmw_bop_skipped_projects
     - item.project.name not in cifmw_bop_change_list|default([]) | map(attribute='project') |list
     - >-
         cifmw_bop_release_mapping[cifmw_bop_openstack_release] in item.branch or
@@ -32,6 +33,7 @@
 
 - name: Build DLRN packages from zuul changes
   when:
+    - cifmw_bop_change_list | length > 0
     - '"-distgit" not in _change.project'
     - _change.project not in cifmw_bop_skipped_projects
     - >-


### PR DESCRIPTION
cifmw_bop_skipped_projects contains lists of projects on which build_openstack_package should not run.

We should not parse zuul change url on cifmw_bop_skipped_projects to avoid unwanted error. This pr adds the conditional for the same to avoid parsing.

Note: This pr also adds infrawatch/feature-verification-tests to cifmw_bop_skipped_projects list also. As there is no packaging support for this project.

Testresults: https://github.com/openstack-k8s-operators/ci-framework/pull/3144#issuecomment-3101718805

Signed-off-by: Chandan Kumar (raukadah) <raukadah@gmail.com>

Resolves: [OSPCIX-983](https://issues.redhat.com//browse/OSPCIX-983)