### PR TITLE
Pin ansible-core version for doc-requirements

### DIFF
--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -5,5 +5,5 @@ Pygments>=2.2.0
 reno>=2.5.0
 sphinxemoji
 myst-parser[linkify]
-ansible-core
+ansible-core==2.15.13
 ansible-doc-extractor


### PR DESCRIPTION
The new release of Ansible Core 2.19 is breaking our doc jobs. Until the reason is investigated, doc jobs should use older Ansible version.