### PR TITLE
Add ocp_agent_installer role

### DIFF
--- a/roles/ocp_agent_installer/README.md
+++ b/roles/ocp_agent_installer/README.md
@@ -1,0 +1,12 @@
+# ocp_agent_installer
+
+> **NOTE**: This Work-in-Progress ...
+
+
+* Create PXE bootstrap-artifects using the OCP Agent Installer
+* Customizations:
+  * Cnable iscsi
+  * Enable multipath
+  * Stand up cinder-volumes LVM
+  * Extra config for OVN-Kubernetes
+  * Etcd hardware speed (Slower)

--- a/roles/ocp_agent_installer/defaults/main.yml
+++ b/roles/ocp_agent_installer/defaults/main.yml
@@ -1,0 +1,74 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# Can be one of ['pxe', 'iso']
+ocp_agent_installer_bootstrap_assets: pxe
+ocp_agent_installer_add_ingress_cert_to_ca_trust: true
+
+ocp_agent_installer_openshift_version: stable-4.18
+ocp_agent_installer_mirror_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp
+ocp_agent_installer_client_url: "{{ ocp_agent_installer_mirror_url }}/{{ ocp_agent_installer_openshift_version }}/openshift-client-linux.tar.gz"
+ocp_agent_installer_installer_url: "{{ ocp_agent_installer_mirror_url }}/{{ ocp_agent_installer_openshift_version }}/openshift-install-linux.tar.gz"
+
+ocp_agent_installer_base_dir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}/ocp-agent-installer"
+ocp_agent_installer_bin_dir: "{{ ansible_user_dir }}/bin"
+ocp_agent_installer_kube_config_dir: "{{ ansible_user_dir }}/.kube"
+ocp_agent_installer_cluster_dir: "{{ ocp_agent_installer_base_dir }}/ocp-cluster"
+ocp_agent_installer_manifests_dir: "{{ ocp_agent_installer_cluster_dir }}/openshift"
+ocp_agent_installer_agent_installer_dir: "{{ ocp_agent_installer_base_dir }}/agent-installer"
+ocp_agent_installer_cluster_custom_config_dir: "{{ ocp_agent_installer_base_dir }}/cluster-custom-config/"
+ocp_agent_installer_butane_dir: "{{ ocp_agent_installer_cluster_custom_config_dir }}/butane"
+ocp_agent_installer_machine_configs_dir: "{{ ocp_agent_installer_cluster_custom_config_dir }}/machine-configs"
+ocp_agent_installer_config_assets_dir: "{{ ocp_agent_installer_cluster_custom_config_dir }}/config-assets"
+
+ocp_agent_installer_boot_artifacts_dir: /var/www/html/boot-artifacts
+
+ocp_agent_installer_install_config:
+ocp_agent_installer_agent_config:
+ocp_agent_installer_pull_secret:
+
+ocp_agent_installer_cinder_volume_pvs: []
+ocp_agent_installer_cinder_volume_roles:
+  - master
+ocp_agent_installer_enable_multipath: false
+ocp_agent_installer_multipath_roles:
+  - master
+ocp_agent_installer_enable_iscsi: false
+ocp_agent_installer_iscsi_roles:
+  - master
+ocp_agent_installer_disable_net_ifnames: true
+ocp_agent_installer_net_ifnames_roles:
+  - master
+
+# OVN Configuration
+ocp_agent_installer_enable_ovn_k8s_overrides: true
+ocp_agent_installer_ovn_k8s_gateway_config_ip_forwarding: true
+ocp_agent_installer_ovn_k8s_gateway_config_host_routing: false
+
+# Etcd - set to true for controlPlaneHardwareSpeed = Slower
+# https://www.redhat.com/en/blog/introducing-selectable-profiles-for-etcd
+ocp_agent_installer_enable_etcd_hardware_speed_slow: true
+
+ocp_agent_installer_enable_image_content_source_policy: false
+# To enable ImageContentSourcePolicy (ICSP), set this variable to contain the value
+# for the ICSP spec's repositoryDigestMirrors field.
+ocp_agent_installer_image_content_source_policy_mirrors: []
+
+ocp_agent_installer_enable_additional_trusted_ca: false
+ocp_agent_installer_ocp_additional_trusted_ca:
+  - name: registry-proxy.engineering.redhat.com
+    url: https://url.corp.redhat.com/hotstack-ca

--- a/roles/ocp_agent_installer/files/additional-trusted-ca-config-image.yaml
+++ b/roles/ocp_agent_installer/files/additional-trusted-ca-config-image.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: config.openshift.io/v1
+kind: Image
+metadata:
+  name: cluster
+spec:
+  additionalTrustedCA:
+    name: hotstack-additional-trusted-ca

--- a/roles/ocp_agent_installer/files/etcd-config.yaml
+++ b/roles/ocp_agent_installer/files/etcd-config.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: operator.openshift.io/v1
+kind: Etcd
+metadata:
+  name: cluster
+spec:
+  controlPlaneHardwareSpeed: Slower
+  managementState: Managed

--- a/roles/ocp_agent_installer/meta/main.yml
+++ b/roles/ocp_agent_installer/meta/main.yml
@@ -1,0 +1,15 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.

--- a/roles/ocp_agent_installer/tasks/additional_ca.yml
+++ b/roles/ocp_agent_installer/tasks/additional_ca.yml
@@ -1,0 +1,53 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Assert
+  ansible.builtin.assert:
+    that:
+      - ca.name is defined
+      - ca.name | length > 0
+      - ca.url is defined or ca.data is defined
+      - (
+          ca.url | length > 0 or
+          ca.data | length > 0
+        )
+
+- name: Download the CA bundle if url
+  when: ca.url is defined
+  ansible.builtin.uri:
+    url: "{{ ca.url }}"
+    method: get
+    return_content: true
+    validate_certs: false
+  register: __get_ca_from_url_result
+  ignore_errors: true
+
+- name: Append to _ocp_additional_trusted_ca_map
+  when: (
+          ca.data is defined or
+          (
+            ca.url is defined and
+            not __get_ca_from_url_result.failed
+          )
+        )
+  ansible.builtin.set_fact:
+    _ocp_additional_trusted_ca_map: >-
+      {{
+        _ocp_additional_trusted_ca_map |
+        combine(
+          {ca.name: ca.data | default(__get_ca_from_url_result.content)}
+        )
+      }}

--- a/roles/ocp_agent_installer/tasks/config_assets.yml
+++ b/roles/ocp_agent_installer/tasks/config_assets.yml
@@ -1,0 +1,94 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Template ovn-k8s customization
+  when: ocp_agent_installer_enable_ovn_k8s_overrides | bool
+  ansible.builtin.template:
+    src: ovn-k8s-config.j2
+    dest: >-
+      {{
+        [
+          ocp_agent_installer_config_assets_dir,
+          'ovn_k8s_config.yaml'
+        ] | ansible.builtin.path_join
+      }}
+    mode: '0644'
+
+- name: Copy Etcd customization
+  when: ocp_agent_installer_enable_etcd_hardware_speed_slow | bool
+  ansible.builtin.copy:
+    src: etcd-config.yaml
+    dest: >-
+      {{
+        [
+          ocp_agent_installer_config_assets_dir,
+          '95-etcd_config.yaml'
+        ] | ansible.builtin.path_join
+      }}
+    mode: '0644'
+
+- name: Template ImageContentSourcePolicy customization
+  when: ocp_agent_installer_enable_image_content_source_policy | bool
+  ansible.builtin.template:
+    src: image-content-source-policy.yaml.j2
+    dest: >-
+      {{
+        [
+          ocp_agent_installer_config_assets_dir,
+          '95-image-content-source-policy.yaml'
+        ] | ansible.builtin.path_join
+      }}
+    mode: '0644'
+
+- name: Additional trusted CA
+  when:
+    - ocp_agent_installer_enable_additional_trusted_ca | bool
+    - ocp_agent_installer_ocp_additional_trusted_ca is defined
+    - ocp_agent_installer_ocp_additional_trusted_ca | length > 0
+  block:
+    - name: Initialize _ocp_additional_trusted_ca_map fact
+      ansible.builtin.set_fact:
+        _ocp_additional_trusted_ca_map: {}
+
+    - name: Append to _ocp_additional_trusted_ca_map fact
+      ansible.builtin.include_tasks: additional_ca.yml
+      loop: "{{ ocp_agent_installer_ocp_additional_trusted_ca }}"
+      loop_control:
+        loop_var: ca
+
+    - name: Template additional CA config map
+      ansible.builtin.template:
+        src: additional-trusted-ca-config-map.yaml.j2
+        dest: >-
+          {{
+            [
+              ocp_agent_installer_config_assets_dir,
+              '93-additional-ca-config-map.yaml'
+            ] | ansible.builtin.path_join
+          }}
+        mode: '0644'
+
+    - name: Copy additional CA config image
+      ansible.builtin.copy:
+        src: additional-trusted-ca-config-image.yaml
+        dest: >-
+          {{
+            [
+              ocp_agent_installer_config_assets_dir,
+              '94-additional-ca-config-image.yaml'
+            ] | ansible.builtin.path_join
+          }}
+        mode: '0644'

--- a/roles/ocp_agent_installer/tasks/ingress_cert.yml
+++ b/roles/ocp_agent_installer/tasks/ingress_cert.yml
@@ -1,0 +1,39 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Extract ingress CA cert
+  register: _ingress_cert
+  ansible.builtin.shell: |
+    POD_NAME=$({{ ocp_agent_installer_bin_dir }}/oc get pods -n openshift-authentication -o jsonpath='{.items[0].metadata.name}')
+    {{ ocp_agent_installer_bin_dir }}/oc rsh -n openshift-authentication $POD_NAME \
+      cat /run/secrets/kubernetes.io/serviceaccount/ca.crt
+  retries: 10
+  delay: 10
+  until: _ingress_cert.rc == 0
+
+- name: Write ingress cert to ca-trust
+  become: true
+  ansible.builtin.copy:
+    content: "{{ _ingress_cert.stdout }}"
+    dest: /etc/pki/ca-trust/source/anchors/ingress-ca.crt
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Update CA trust
+  become: true
+  ansible.builtin.command:
+    cmd: update-ca-trust

--- a/roles/ocp_agent_installer/tasks/install_client.yml
+++ b/roles/ocp_agent_installer/tasks/install_client.yml
@@ -1,0 +1,47 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Download the client
+  ansible.builtin.get_url:
+    url: "{{ ocp_agent_installer_client_url }}"
+    dest: >-
+      {{
+        [
+          ocp_agent_installer_agent_installer_dir,
+          'openshift-client-linux.tar.gz'
+        ] | ansible.builtin.path_join
+      }}
+    mode: '0644'
+
+- name: Extract client to /home/zuul/bin
+  ansible.builtin.unarchive:
+    src: >-
+      {{
+        [
+          ocp_agent_installer_agent_installer_dir,
+          'openshift-client-linux.tar.gz'
+        ] | ansible.builtin.path_join
+      }}
+    dest: "{{ ocp_agent_installer_bin_dir }}"
+    remote_src: true
+    creates: "{{ ocp_agent_installer_bin_dir }}/oc"
+
+- name: Configure bash completion
+  become: true
+  ansible.builtin.shell: |
+    {{ ocp_agent_installer_bin_dir }}/oc completion bash > /etc/bash_completion.d/oc_bash_completion
+  args:
+    creates: /etc/bash_completion.d/oc_bash_completion

--- a/roles/ocp_agent_installer/tasks/install_installer.yml
+++ b/roles/ocp_agent_installer/tasks/install_installer.yml
@@ -1,0 +1,40 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Download the installer
+  ansible.builtin.get_url:
+    url: "{{ ocp_agent_installer_installer_url }}"
+    dest: >-
+      {{
+        [
+          ocp_agent_installer_agent_installer_dir,
+          'openshift-install-linux.tar.gz'
+        ] | ansible.builtin.path_join
+      }}
+    mode: '0644'
+
+- name: Extract installer to /home/zuul/bin
+  ansible.builtin.unarchive:
+    src: >-
+      {{
+        [
+          ocp_agent_installer_agent_installer_dir,
+          'openshift-install-linux.tar.gz'
+        ] | ansible.builtin.path_join
+      }}
+    dest: "{{ ocp_agent_installer_bin_dir }}"
+    remote_src: true
+    creates: "{{ ocp_agent_installer_bin_dir }}/openshift-install"

--- a/roles/ocp_agent_installer/tasks/iso_assets.yml
+++ b/roles/ocp_agent_installer/tasks/iso_assets.yml
@@ -1,0 +1,19 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Fail - not implemented
+  ansible.builtin.fail:
+    msg: "Assisted Installer with ISO assets has not been implemented in ocp_agent_installer"

--- a/roles/ocp_agent_installer/tasks/machine_configs.yml
+++ b/roles/ocp_agent_installer/tasks/machine_configs.yml
@@ -1,0 +1,90 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Disable net.ifnames
+  when: ocp_agent_installer_disable_net_ifnames | bool
+  block:
+    - name: Template butane config for net.ifnames
+      vars:
+        role: "{{ item }}"
+      ansible.builtin.template:
+        src: disable-netifnames.bu.j2
+        dest: "{{ ocp_agent_installer_butane_dir }}/90-{{ item }}-disable-netifnames.bu"
+        mode: '0644'
+      loop: "{{ ocp_agent_installer_net_ifnames_roles }}"
+    - name: Generate MachineConfig for iscsi
+      ansible.builtin.command:
+        cmd: >-
+          butane {{ ocp_agent_installer_butane_dir }}/90-{{ item }}-disable-netifnames.bu
+          -o {{ ocp_agent_installer_machine_configs_dir }}/90-{{ item }}-disable-netifnames.yaml
+      loop: "{{ ocp_agent_installer_net_ifnames_roles }}"
+
+- name: Enable iscsi
+  when: ocp_agent_installer_enable_iscsi | bool
+  block:
+    - name: Template butane config for iscsi
+      vars:
+        role: "{{ item }}"
+      ansible.builtin.template:
+        src: enable-iscsi.bu.j2
+        dest: "{{ ocp_agent_installer_butane_dir }}/90-{{ item }}-enable-iscsi.bu"
+        mode: '0644'
+      loop: "{{ ocp_agent_installer_iscsi_roles }}"
+
+    - name: Generate MachineConfig for iscsi
+      ansible.builtin.command:
+        cmd: >-
+          butane {{ ocp_agent_installer_butane_dir }}/90-{{ item }}-enable-iscsi.bu
+          -o {{ ocp_agent_installer_machine_configs_dir }}/90-{{ item }}-enable-iscsi.yaml
+      loop: "{{ ocp_agent_installer_iscsi_roles }}"
+
+- name: Enable Multipath
+  when: ocp_agent_installer_enable_multipath | bool
+  block:
+    - name: Template butane config for multipath
+      vars:
+        role: "{{ item }}"
+      ansible.builtin.template:
+        src: enable-multipath.bu.j2
+        dest: "{{ ocp_agent_installer_butane_dir }}/91-{{ item }}-enable-multipath.bu"
+        mode: '0644'
+      loop: "{{ ocp_agent_installer_multipath_roles }}"
+
+    - name: Generate MachineConfig for multipath
+      ansible.builtin.command:
+        cmd: >-
+          butane {{ ocp_agent_installer_butane_dir }}/91-{{ item }}-enable-multipath.bu
+          -o {{ ocp_agent_installer_machine_configs_dir }}/91-{{ item }}-enable-multipath.yaml
+      loop: "{{ ocp_agent_installer_multipath_roles }}"
+
+- name: LVM cinder-volumes
+  when: ocp_agent_installer_cinder_volume_pvs | length > 0
+  block:
+    - name: Template butane config for LVM cinder-volumes
+      vars:
+        role: "{{ item }}"
+      ansible.builtin.template:
+        src: lv-cinder-volumes.bu.j2
+        dest: "{{ ocp_agent_installer_butane_dir }}/92-{{ item }}-lv-cinder-volumes.bu"
+        mode: '0644'
+      loop: "{{ ocp_agent_installer_cinder_volume_roles }}"
+
+    - name: Generate MachineConfig for multipath
+      ansible.builtin.command:
+        cmd: >-
+          butane {{ ocp_agent_installer_butane_dir }}/92-{{ item }}-lv-cinder-volumes.bu
+          -o {{ ocp_agent_installer_machine_configs_dir }}/92-{{ item }}-lv-cinder-volumes.yaml
+      loop: "{{ ocp_agent_installer_cinder_volume_roles }}"

--- a/roles/ocp_agent_installer/tasks/main.yml
+++ b/roles/ocp_agent_installer/tasks/main.yml
@@ -1,0 +1,162 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Assert config is defined
+  ansible.builtin.assert:
+    that:
+      - ocp_agent_installer_pull_secret is defined
+      - ocp_agent_installer_pull_secret | length > 0
+      - ocp_agent_installer_install_config is defined
+      - ocp_agent_installer_install_config | length > 0
+      - ocp_agent_installer_agent_config is defined
+      - ocp_agent_installer_agent_config | length > 0
+
+- name: Include client install tasks
+  ansible.builtin.include_tasks: install_client.yml
+
+- name: Include installer install tasks
+  ansible.builtin.include_tasks: install_installer.yml
+
+- name: Include config asset tasks
+  ansible.builtin.include_tasks: config_assets.yml
+
+- name: Include machine config tasks
+  ansible.builtin.include_tasks: machine_configs.yml
+
+- name: Include additional ca tasks
+  ansible.builtin.include_tasks: additional_ca.yml
+
+- name: Install package requirements for agent installer
+  become: true
+  ansible.builtin.dnf:
+    name:
+      - nmstate
+      - butane
+    state: present
+
+- name: Create the cluster directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ ansible_user | default(ansible_user_id) }}"
+    group: "{{ ansible_user | default(ansible_user_id) }}"
+    mode: '0755'
+  loop:
+    - "{{ ocp_agent_installer_bin_dir }}"
+    - "{{ ocp_agent_installer_kube_config_dir }}"
+    - "{{ ocp_agent_installer_cluster_dir }}"
+    - "{{ ocp_agent_installer_manifests_dir }}"
+    - "{{ ocp_agent_installer_agent_installer_dir }}"
+    - "{{ ocp_agent_installer_cluster_custom_config_dir }}"
+    - "{{ ocp_agent_installer_butane_dir }}"
+    - "{{ ocp_agent_installer_machine_configs_dir }}"
+    - "{{ ocp_agent_installer_config_assets_dir }}"
+
+- name: Generate install-config.yaml file
+  ansible.builtin.copy:
+    content: |
+      apiVersion: v1
+      baseDomain: {{ ocp_agent_installer_install_config.baseDomain }}
+      compute:
+      {{ ocp_agent_installer_install_config.compute | to_nice_yaml(indent=2) | indent(width=2) }}
+      controlPlane:
+      {{ ocp_agent_installer_install_config.controlPlane | to_nice_yaml(indent=2) | indent(width=2) }}
+      metadata:
+        name: {{ ocp_agent_installer_install_config.metadata.name }}
+      networking:
+      {{ ocp_agent_installer_install_config.networking | to_nice_yaml(indent=2) | indent(width=2) }}
+      platform:
+      {{ ocp_agent_installer_install_config.platform | to_nice_yaml(indent=2) | indent(width=2) }}
+      pullSecret: '{{ ocp_agent_installer_pull_secret | b64decode }}'
+      sshKey: '{{ ocp_agent_installer_install_config.sshKey }}'
+    dest: "{{ ocp_agent_installer_cluster_dir }}/install-config.yaml"
+    owner: "{{ ansible_user | default(ansible_user_id) }}"
+    group: "{{ ansible_user | default(ansible_user_id) }}"
+    mode: '0600'
+
+- name: Generate agent-config.yaml file
+  ansible.builtin.copy:
+    content: |
+      apiVersion: v1alpha1
+      kind: AgentConfig
+      metadata:
+        name: {{ ocp_agent_installer_agent_config.metadata.name }}
+      {{ ocp_agent_installer_agent_config | to_nice_yaml(indent=2) | indent(width=2) }}
+    dest: "{{ ocp_agent_installer_cluster_dir }}/agent-config.yaml"
+    owner: "{{ ansible_user | default(ansible_user_id) }}"
+    group: "{{ ansible_user | default(ansible_user_id) }}"
+    mode: '0600'
+
+- name: Generate custom manifests
+  ansible.builtin.shell: |
+    cd {{ ocp_agent_installer_cluster_dir }}
+    {{ ocp_agent_installer_bin_dir }}/openshift-install create manifests
+
+- name: Copy machine_configs to manifests dir
+  ansible.builtin.copy:
+    remote_src: true
+    src: "{{ ocp_agent_installer_machine_configs_dir }}/"
+    dest: "{{ ocp_agent_installer_manifests_dir }}/"
+    mode: '0644'
+
+- name: Copy config assets to manifests dir
+  ansible.builtin.copy:
+    remote_src: true
+    src: "{{ ocp_agent_installer_config_assets_dir }}/"
+    dest: "{{ ocp_agent_installer_manifests_dir }}/"
+    mode: '0644'
+
+- name: Include pxe assets tasks
+  ansible.builtin.include_tasks: pxe_assets.yml
+  when: ocp_agent_installer_bootstrap_assets == 'pxe'
+
+- name: Include iso assets tasks
+  ansible.builtin.include_tasks: iso_assets.yml
+  when: ocp_agent_installer_bootstrap_assets == 'iso'
+
+- name: Copy auth/kubeconfig to ~/.kube/config
+  ansible.builtin.copy:
+    remote_src: true
+    src: >-
+      {{
+        [
+          ocp_agent_installer_cluster_dir,
+          'auth',
+          'kubeconfig'
+        ] | ansible.builtin.path_join
+      }}
+    dest: >-
+      {{
+        [
+          ocp_agent_installer_kube_config_dir,
+          'config'
+        ] | ansible.builtin.path_join
+      }}
+    mode: '0600'
+
+- name: Wait for bootstrap-complete
+  ansible.builtin.command:
+    cmd: >
+      {{ ocp_agent_installer_bin_dir }}/openshift-install --dir {{ ocp_agent_installer_cluster_dir }} agent wait-for bootstrap-complete --log-level=info
+
+- name: Wait for install-complete
+  ansible.builtin.command:
+    cmd: >
+      {{ ocp_agent_installer_bin_dir }}/openshift-install --dir {{ ocp_agent_installer_cluster_dir }} agent wait-for install-complete
+
+- name: Add ingress certificate to CA trust
+  when: ocp_agent_installer_add_ingress_cert_to_ca_trust | bool
+  ansible.builtin.include_tasks: ingress_cert.yml

--- a/roles/ocp_agent_installer/tasks/pxe_assets.yml
+++ b/roles/ocp_agent_installer/tasks/pxe_assets.yml
@@ -1,0 +1,66 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Create the boot-artifacts directory
+  become: true
+  ansible.builtin.file:
+    path: "{{ ocp_agent_installer_boot_artifacts_dir }}"
+    state: directory
+    mode: '0755'
+
+- name: Create PXE assets
+  ansible.builtin.command:
+    chdir: "{{ ocp_agent_installer_cluster_dir }}"
+    cmd: >
+      {{ ocp_agent_installer_bin_dir }}/openshift-install agent create pxe-files
+
+- name: Set serial console in ipxe
+  ansible.builtin.lineinfile:
+    path: "{{ ocp_agent_installer_cluster_dir }}/boot-artifacts/agent.x86_64.ipxe"
+    backrefs: true
+    regexp: "^(kernel.*)$"
+    line: '\1 console=ttyS0'
+
+- name: Disable net.ifnames
+  when: ocp_agent_installer_disable_net_ifnames | bool
+  ansible.builtin.lineinfile:
+    path: "{{ ocp_agent_installer_cluster_dir }}/boot-artifacts/agent.x86_64.ipxe"
+    backrefs: true
+    regexp: "^(kernel.*)$"
+    line: '\1 net.ifnames=0'
+
+- name: Copy boot-artifacts to the web server - (ocp_agent_installer_boot_artifacts_dir)
+  become: true
+  ansible.builtin.copy:
+    remote_src: true
+    src: >-
+      {{
+        [
+          ocp_agent_installer_cluster_dir,
+          'boot-artifacts',
+          item
+        ] | ansible.builtin.path_join
+      }}
+    dest: "{{ ocp_agent_installer_boot_artifacts_dir }}"
+    owner: root
+    group: root
+    mode: '0644'
+  loop:
+    - agent.x86_64-vmlinuz
+    - agent.x86_64-initrd.img
+    - agent.x86_64-rootfs.img
+    # Copy the iPXE last, the other files should be ready before iPXE try to load them.
+    - agent.x86_64.ipxe

--- a/roles/ocp_agent_installer/templates/additional-trusted-ca-config-map.yaml.j2
+++ b/roles/ocp_agent_installer/templates/additional-trusted-ca-config-map.yaml.j2
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-config
+  name: hotstack-additional-trusted-ca
+data:
+{% for ca in ocp_agent_installer_ocp_additional_trusted_ca %}
+  {{ ca.name }}: |
+    {{ _ocp_additional_trusted_ca_map[ca.name] | indent(width=4) }}
+{% endfor %}

--- a/roles/ocp_agent_installer/templates/disable-netifnames.bu.j2
+++ b/roles/ocp_agent_installer/templates/disable-netifnames.bu.j2
@@ -1,0 +1,10 @@
+---
+variant: openshift
+version: 4.17.0
+metadata:
+  name: 90-{{ role | default('master') }}-netifnames-conf
+  labels:
+    machineconfiguration.openshift.io/role: {{ role | default('master') }}
+openshift:
+  kernel_arguments:
+    - net.ifnames=0

--- a/roles/ocp_agent_installer/templates/enable-iscsi.bu.j2
+++ b/roles/ocp_agent_installer/templates/enable-iscsi.bu.j2
@@ -1,0 +1,32 @@
+---
+variant: openshift
+version: 4.17.0
+metadata:
+  name: 90-{{ role | default('master') }}-nable-iscsi
+  labels:
+    machineconfiguration.openshift.io/role: {{ role | default('master') }}
+storage:
+  files:
+    - path: /etc/iscsi/iscsid.conf
+      overwrite: true
+      mode: 384
+      user:
+        name: root
+      group:
+        name: root
+      contents:
+        inline: |
+          # Default to 3 retries and 5 seconds each (15 seconds in total),
+          # which is convenient for testing, as any healthy deployment and
+          # backend should be able to login to the backend in that amount of
+          # time, and if there is a broken path it will not take 2 minutes to
+          # give up, just around 15 seconds.
+          node.session.initial_login_retry_max = 3
+          node.conn[0].timeo.login_timeout = 5
+          # The default CHAP algorithms include MD5 will does not work under
+          # FIPS. Set this parameter to exclude MD5 and SHA-1.
+          node.session.auth.chap_algs = SHA3-256,SHA256
+systemd:
+  units:
+    - enabled: true
+      name: iscsid.service

--- a/roles/ocp_agent_installer/templates/enable-multipath.bu.j2
+++ b/roles/ocp_agent_installer/templates/enable-multipath.bu.j2
@@ -1,0 +1,30 @@
+---
+variant: openshift
+version: 4.17.0
+metadata:
+  name: 91-{{ role | default('master') }}-multipath-conf
+  labels:
+    machineconfiguration.openshift.io/role: {{ role | default('master') }}
+storage:
+  files:
+    - path: /etc/multipath.conf
+      overwrite: false
+      mode: 344
+      user:
+        name: root
+      group:
+        name: root
+      contents:
+        inline: |
+          defaults {
+            user_friendly_names    no
+            recheck_wwid    yes
+            skip_kpartx    yes
+            find_multipaths  yes
+          }
+          blacklist {
+          }
+systemd:
+  units:
+    - enabled: true
+      name: multipathd.service

--- a/roles/ocp_agent_installer/templates/image-content-source-policy.yaml.j2
+++ b/roles/ocp_agent_installer/templates/image-content-source-policy.yaml.j2
@@ -1,0 +1,8 @@
+---
+apiVersion: operator.openshift.io/v1alpha1
+kind: ImageContentSourcePolicy
+metadata:
+  name: brew-registry
+spec:
+  repositoryDigestMirrors:
+    {{ ocp_agent_installer_image_content_source_policy_mirrors | to_nice_yaml(indent=2) | indent(width=4) }}

--- a/roles/ocp_agent_installer/templates/lv-cinder-volumes.bu.j2
+++ b/roles/ocp_agent_installer/templates/lv-cinder-volumes.bu.j2
@@ -1,0 +1,31 @@
+---
+variant: openshift
+version: 4.17.0
+metadata:
+  name: 91-{{ role | default('master') }}-lv-cinder-volumes
+  labels:
+    machineconfiguration.openshift.io/role: {{ role | default('master') }}
+storage:
+  disks:
+{% for _disk in ocp_agent_installer_cinder_volume_pvs %}
+    - device: {{ _disk }}
+      wipe_table: true
+{% endfor %}
+systemd:
+  units:
+    - name: lv-cinder-volumes.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Create logical volume with name cinder-volumes.
+        After=var.mount systemd-udev-settle.service
+
+        [Service]
+        Type=oneshot
+        ExecCondition=/bin/bash -c '! /usr/sbin/vgdisplay cinder-volumes'
+        ExecStartPre=/usr/sbin/pvcreate {{ ocp_agent_installer_cinder_volume_pvs | join(' ') }}
+ExecStart=/usr/sbin/vgcreate cinder-volumes {{ ocp_agent_installer_cinder_volume_pvs | join(' ') }}
+        RemainAfterExit=yes
+
+        [Install]
+        WantedBy=multi-user.target

--- a/roles/ocp_agent_installer/templates/ovn-k8s-config.j2
+++ b/roles/ocp_agent_installer/templates/ovn-k8s-config.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  defaultNetwork:
+    ovnKubernetesConfig:
+      gatewayConfig:
+{% if ocp_agent_installer_ovn_k8s_gateway_config_ip_forwarding %}
+        ipForwarding: Global
+{% endif %}
+        routingViaHost: {{ ocp_agent_installer_ovn_k8s_gateway_config_host_routing }}


### PR DESCRIPTION
This is a port of the OCP Agent Installer role used in hotstack.

I used Claude 4 Sonnet to rename all the variables, and removed some hotstack specific snapshot features.

Follow up changes to integrate this with other ci-framework would follow, and that will most likely also mean edits to this role.

Assisted-By: claude-4-sonnet