### PR TITLE
Add zuul jobs for ipa role which were missing

### DIFF
--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -915,6 +915,15 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/ipa/.*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-ipa
+    parent: cifmw-molecule-noop
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/krb_request/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -60,6 +60,7 @@
       - cifmw-molecule-install_ca
       - cifmw-molecule-install_openstack_ca
       - cifmw-molecule-install_yamls
+      - cifmw-molecule-ipa
       - cifmw-molecule-krb_request
       - cifmw-molecule-kustomize_deploy
       - cifmw-molecule-libvirt_manager


### PR DESCRIPTION
Zuul and molecule jobs for IPA roles were missing in https://github.com/openstack-k8s-operators/ci-framework/pull/2972.
This patch adds them.