### PR TITLE
Trigger cifmw-pod-zuul-files on each change

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -12,6 +12,7 @@
             dependencies:
               - openstack-k8s-operators-content-provider
         - cifmw-crc-podified-edpm-baremetal: *content_provider
+        - cifmw-pod-zuul-files
 
 - project-template:
     name: podified-multinode-edpm-pipeline
@@ -22,6 +23,7 @@
         - openstack-k8s-operators-content-provider
         - podified-multinode-edpm-deployment-crc: *content_provider
         - podified-multinode-hci-deployment-crc: *content_provider
+        - cifmw-pod-zuul-files
 
 - project-template:
     name: podified-ironic-operator-pipeline
@@ -29,11 +31,11 @@
       Project template to run content provider with ironic podified job.
     github-check:
       jobs:
-        - noop
         - openstack-k8s-operators-content-provider
         - podified-multinode-ironic-deployment:
             dependencies:
               - openstack-k8s-operators-content-provider
+        - cifmw-pod-zuul-files
 
 - project-template:
     name: podified-multinode-edpm-ci-framework-pipeline
@@ -50,6 +52,7 @@
         - cifmw-crc-podified-edpm-baremetal: *content_provider
         - podified-multinode-hci-deployment-crc: *content_provider
         - cifmw-multinode-tempest: *content_provider
+        - cifmw-pod-zuul-files
 
 - project-template:
     name: data-plane-adoption-ci-framework-pipeline
@@ -65,6 +68,7 @@
         - adoption-standalone-to-crc-ceph-provider:
             dependencies:
               - openstack-k8s-operators-content-provider
+        - cifmw-pod-zuul-files
 
 - project-template:
     name: data-plane-adoption-pipeline
@@ -76,3 +80,4 @@
         - adoption-standalone-to-crc-ceph-provider:
             dependencies:
               - openstack-k8s-operators-content-provider
+        - cifmw-pod-zuul-files


### PR DESCRIPTION
It is not a first time, that some molecule job is missing, because some role was added and cifmw-pod-zuul-files job was not triggered.

Add the CI job and run it for each change that was done.