### PR TITLE
Update cifmw_job_uri regex pattern

### DIFF
--- a/roles/reproducer/tasks/parse_cifmw_job_uri.yml
+++ b/roles/reproducer/tasks/parse_cifmw_job_uri.yml
@@ -1,7 +1,7 @@
 ---
 - name: Parse cifmw_job_uri
   vars:
-    regex_pattern: "^https://[a-zA-Z0-9\\.]+(?=\\w{3}(?:/|$))\\w{3}/.*/.*/.*/.*[a-f0-9]{7}"
+    regex_pattern: "^https://[a-zA-Z0-9-\\.]+/.*/.*/.*/.*[a-f0-9]{32}"
   block:
     - name: Apply regex match filter
       ansible.builtin.set_fact:


### PR DESCRIPTION
Downstream job uri's no longer match pattern, updating regex pattern to handle downstream format.