### PR TITLE
Add test-operator into content-provider job

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -100,6 +100,7 @@
       - openstack-k8s-operators/swift-operator
       - openstack-k8s-operators/tcib
       - openstack-k8s-operators/telemetry-operator
+      - openstack-k8s-operators/test-operator
       - openstack-k8s-operators/watcher-operator
     pre-run:
       - ci/playbooks/content_provider/pre.yml


### PR DESCRIPTION
Test-operator was not part of the
openstack-k8s-operators-content-provider job and it wouldn't trigger PR rdo-check from other branches than main.