### PR TITLE
Call tasks from roles if play host is same

### DIFF
--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -43,7 +43,7 @@
       tags:
         - infra
 
-- name: Run cifmw_setup infra.yml
+- name: Run cifmw_setup infra, build package, container and operators, deploy EDPM
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   tasks:
     - name: Prepare the platform
@@ -55,10 +55,6 @@
       tags:
         - infra
 
-- name: Build package playbook
-  hosts: "{{ cifmw_target_host | default('localhost') }}"
-  gather_facts: false
-  tasks:
     - name: Build package playbook
       ansible.builtin.import_role:
         name: cifmw_setup
@@ -66,10 +62,6 @@
       tags:
         - build-packages
 
-- name: Build container playbook
-  hosts: "{{ cifmw_target_host | default('localhost') }}"
-  gather_facts: false
-  tasks:
     - name: Build container playbook
       ansible.builtin.import_role:
         name: cifmw_setup
@@ -77,23 +69,15 @@
       tags:
         - build-containers
 
-- name: Build operators playbook
-  hosts: "{{ cifmw_target_host | default('localhost') }}"
-  gather_facts: false
-  environment:
-    PATH: "{{ cifmw_path }}"
-  tasks:
     - name: Build operators playbook
       ansible.builtin.import_role:
         name: cifmw_setup
         tasks_from: build_operators.yml
       tags:
         - build-operators
+      environment:
+        PATH: "{{ cifmw_path }}"
 
-- name: Deploy EDPM
-  hosts: "{{ cifmw_target_host | default('localhost') }}"
-  gather_facts: false
-  tasks:
     - name: Deploy EDPM
       ansible.builtin.import_role:
         name: cifmw_setup
@@ -139,7 +123,7 @@
     storage_mgmt_network_range: 172.20.0.0/24
   ansible.builtin.import_playbook: playbooks/ceph.yml
 
-- name: Continue HCI deploy
+- name: Continue HCI deploy, deploy architecture and validate workflow
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
@@ -150,10 +134,6 @@
       tags:
         - edpm
 
-- name: Deploy architecture and validate workflow
-  hosts: "{{ cifmw_target_host | default('localhost') }}"
-  gather_facts: false
-  tasks:
     - name: Run pre_deploy hooks
       when: cifmw_architecture_scenario is defined
       vars:


### PR DESCRIPTION
After we migrate some playbooks into roles, we can drop the convention how it was done earlier - few plays where each was done on same host and each was calling one (or few) task in role. It is not needed, we can call other tasks in role in one play, because all is done on same host.