### PR TITLE
Fix lvms csv deploy

### DIFF
--- a/roles/ci_lvms_storage/tasks/main.yml
+++ b/roles/ci_lvms_storage/tasks/main.yml
@@ -113,7 +113,7 @@
     cmd: >-
       oc get ClusterServiceVersion
       -n "{{ cifmw_lvms_namespace }}"
-      -l operators.coreos.com/lvms-operator.openshift-storage
+      -l operators.coreos.com/lvms-operator."{{ cifmw_lvms_namespace}}"
       -o jsonpath='{.items[*].status.phase}'
   changed_when: false
   register: _cifmw_lvms_storage_cluster_csv_phase_out


### PR DESCRIPTION
We should be consistent and pass the namespace to the csv deployment command.