### PR TITLE
Add registry.k8s.io to allowed registries

### DIFF
--- a/roles/openshift_setup/tasks/main.yml
+++ b/roles/openshift_setup/tasks/main.yml
@@ -174,6 +174,7 @@
     default_allowed_registries:
       - "quay.io"
       - "gcr.io"
+      - "registry.k8s.io"
       - "registry.redhat.io"
       - "registry-proxy.engineering.redhat.com"
       - "images.paas.redhat.com"


### PR DESCRIPTION
Openstack operator needs access to registry.k8s.io for downloading kube-state-metrics image [1].

[1] https://github.com/openstack-k8s-operators/openstack-operator/blob/main/config/operator/default_images.yaml#L47