### PR TITLE
Avoid switching OpenShift project in hook

### DIFF
--- a/hooks/playbooks/cinder_multiattach_volume_type.yml
+++ b/hooks/playbooks/cinder_multiattach_volume_type.yml
@@ -16,12 +16,11 @@
         PATH: "{{ cifmw_path }}"
       ansible.builtin.shell: |
         set -xe -o pipefail
-        oc project {{ namespace }}
-        oc rsh openstackclient \
+        oc -n {{ namespace }} rsh openstackclient \
             openstack volume type show {{ cifmw_volume_multiattach_type }} &>/dev/null || \
             oc rsh openstackclient \
             openstack volume type create {{ cifmw_volume_multiattach_type }}
-        oc rsh openstackclient \
+        oc -n {{ namespace }} rsh openstackclient \
             openstack volume type set --property multiattach="<is> True" \
             {{ cifmw_volume_multiattach_type }}
 


### PR DESCRIPTION
I encountered a case where the hook related to cinder multi-attach volume type fails, as on some race condition between commands execution the default OpenShift project was changed and the assumed pod was not found.

To make the shell call more predictable, it is better to run `oc` command with `-n` parameter, rather than relying on switching the default project in earlier command.