### PR TITLE
Fix ansible 2.19 jinja incompatibility

### DIFF
--- a/hooks/playbooks/fetch_compute_facts.yml
+++ b/hooks/playbooks/fetch_compute_facts.yml
@@ -211,7 +211,7 @@
                         ---
                         {% set mtu_list = [ctlplane_mtu] %}
                         {% for network in nodeset_networks %}
-                        {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+                        {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
                         {%- endfor %}
                         {% set min_viable_mtu = mtu_list | max %}
                         network_config:

--- a/roles/ci_dcn_site/templates/edpm-pre-ceph/nodeset/values.yaml.j2
+++ b/roles/ci_dcn_site/templates/edpm-pre-ceph/nodeset/values.yaml.j2
@@ -40,7 +40,7 @@ data:
           ---
           {% set mtu_list = [ctlplane_mtu] %}
           {% for network in nodeset_networks %}
-          {{ mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) }}
+          {% set _ = mtu_list.append(lookup('vars', networks_lower[network] ~ '_mtu')) %}
           {%- endfor %}
           {% set min_viable_mtu = mtu_list | max %}
           network_config:


### PR DESCRIPTION
With ansible 2.19 it prints the return value of the mtu_list.append() as None and the network config is not parseable with os-net-config and it fails with,

os_net_config.main No interfaces defined in config: /etc/os-net-config/config.yaml"]}

jira: [OSPRH-18609](https://issues.redhat.com//browse/OSPRH-18609)