### PR TITLE
Revert "Trigger cifmw-pod-zuul-files on each change"

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -12,7 +12,6 @@
             dependencies:
               - openstack-k8s-operators-content-provider
         - cifmw-crc-podified-edpm-baremetal: *content_provider
-        - cifmw-pod-zuul-files
 
 - project-template:
     name: podified-multinode-edpm-pipeline
@@ -23,7 +22,6 @@
         - openstack-k8s-operators-content-provider
         - podified-multinode-edpm-deployment-crc: *content_provider
         - podified-multinode-hci-deployment-crc: *content_provider
-        - cifmw-pod-zuul-files
 
 - project-template:
     name: podified-ironic-operator-pipeline
@@ -31,11 +29,11 @@
       Project template to run content provider with ironic podified job.
     github-check:
       jobs:
+        - noop
         - openstack-k8s-operators-content-provider
         - podified-multinode-ironic-deployment:
             dependencies:
               - openstack-k8s-operators-content-provider
-        - cifmw-pod-zuul-files
 
 - project-template:
     name: podified-multinode-edpm-ci-framework-pipeline
@@ -52,7 +50,6 @@
         - cifmw-crc-podified-edpm-baremetal: *content_provider
         - podified-multinode-hci-deployment-crc: *content_provider
         - cifmw-multinode-tempest: *content_provider
-        - cifmw-pod-zuul-files
 
 - project-template:
     name: data-plane-adoption-ci-framework-pipeline
@@ -68,7 +65,6 @@
         - adoption-standalone-to-crc-ceph-provider:
             dependencies:
               - openstack-k8s-operators-content-provider
-        - cifmw-pod-zuul-files
 
 - project-template:
     name: data-plane-adoption-pipeline
@@ -80,4 +76,3 @@
         - adoption-standalone-to-crc-ceph-provider:
             dependencies:
               - openstack-k8s-operators-content-provider
-        - cifmw-pod-zuul-files


### PR DESCRIPTION
Reverts openstack-k8s-operators/ci-framework#3152

This patch is breaking other buildsets. Reverting it to unblock other buildsets.
Ref: https://softwarefactory-project.io/zuul/t/rdoproject.org/buildset/36068ef9763d4be0830a7348feaad7c7