### PR TITLE
[podman] Set the default value for ansible_user

### DIFF
--- a/roles/podman/tasks/main.yml
+++ b/roles/podman/tasks/main.yml
@@ -29,7 +29,7 @@
 - name: Configure User Namespace for EL 10
   when: ansible_distribution_major_version is version('10', '==')
   vars:
-    target_user: "{{ ansible_user }}"
+    target_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
     sub_id_start: 100000
     sub_id_count: 65536
   block:


### PR DESCRIPTION
Sometime meta content provider is failing with ansible_user udefined. Let's set the default value to avoid issue.