### PR TITLE
Add required-projects to cifmw-pod-base job

### DIFF
--- a/zuul.d/pods.yaml
+++ b/zuul.d/pods.yaml
@@ -7,6 +7,8 @@
           label: pod-centos-9-stream
     description: |
       Run lightweight jobs in pods
+    required-projects:
+      - openstack-k8s-operators/ci-framework
     run: ci/playbooks/pod-jobs.yml
 
 - job:


### PR DESCRIPTION
In the run playbook `ci/playbooks/pod-jobs.yml` there is a hard-coded dependency on CI-Framework in Zuul projects. However, if that job is called in other repositories, such as `edpm-ansible`, the ci-framework will not exist in the Zuul environment. This change ensures the `ci-framework` repository to be always present in job environment.