### PR TITLE
Fix a few more oc rsh openstacklient calls (add namespace)

### DIFF
--- a/hooks/playbooks/cinder-default-volume-type-props.yml
+++ b/hooks/playbooks/cinder-default-volume-type-props.yml
@@ -10,7 +10,6 @@
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
       ansible.builtin.shell: |
-        oc project {{ namespace }}
-        oc rsh openstackclient \
+        oc rsh -n {{ namespace }} openstackclient \
            openstack volume type set --property {{ cifmw_cinder_default_type_properties|items|map('join', '=')|join(' --property') }} __DEFAULT__
       when: "cifmw_cinder_default_type_properties | default('') | length > 0"

--- a/hooks/playbooks/service-project-more-quota.yml
+++ b/hooks/playbooks/service-project-more-quota.yml
@@ -8,6 +8,5 @@
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
       ansible.builtin.shell: |
-        oc project {{ namespace }}
-        oc rsh openstackclient \
+        oc rsh -n {{ namespace }} openstackclient \
            openstack quota set --volumes 50 service

--- a/hooks/playbooks/service-project-more-quota.yml
+++ b/hooks/playbooks/service-project-more-quota.yml
@@ -8,5 +8,11 @@
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
       ansible.builtin.shell: |
+        oc get namespaces
+        sleep 1
+        oc get pods
+        sleep 1
+        oc get -n {{ namespace }} pods
+        sleep 1
         oc rsh -n {{ namespace }} openstackclient \
            openstack quota set --volumes 50 service


### PR DESCRIPTION
It seems that previous switch to the openstack project is not effective (maybe it takes more time than expected?) so let's specify the namespace explicitly in a few more places.