### PR TITLE
Move ping test execution from openshift pod to local openstackclient

### DIFF
--- a/roles/update/tasks/create_instance.yml
+++ b/roles/update/tasks/create_instance.yml
@@ -15,20 +15,13 @@
 # under the License.
 
 - name: Create an instance on the overcloud
-  environment:
-    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-    PATH: "{{ cifmw_path }}"
   ansible.builtin.shell: |
     set -o pipefail
     cat {{ cifmw_update_workload_launch_script }} | \
-       oc rsh -n {{ cifmw_update_namespace }} openstackclient bash 2>&1 \
-       {{ cifmw_update_timestamper_cmd }} | tee {{ cifmw_update_artifacts_basedir }}/workload_launch.log
+    podman exec -i lopenstackclient bash -i 2>&1 \
+    {{ cifmw_update_timestamper_cmd }} | tee {{ cifmw_update_artifacts_basedir }}/workload_launch.log
 
 - name: Get logs from update instance creation
-  environment:
-    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-    PATH: "{{ cifmw_path }}"
   ansible.builtin.shell: >
-    oc cp -n {{ cifmw_update_namespace }}
-    openstack/openstackclient:{{ cifmw_update_artifacts_basedir_suffix }}
+    podman cp lopenstackclient:{{ cifmw_update_artifacts_basedir_suffix }}/.
     {{ cifmw_update_artifacts_basedir }}

--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -17,6 +17,12 @@
 - name: Create the support files for test
   ansible.builtin.include_tasks: create_test_files.yml
 
+- name: Create local openstackclient
+  when:
+    - (cifmw_update_control_plane_check | bool) or (cifmw_update_ping_test | bool)
+    - not cifmw_update_run_dryrun | bool
+  ansible.builtin.include_tasks: create_local_openstackclient.yml
+
 - name: Trigger the ping test
   when:
     - cifmw_update_ping_test | bool
@@ -28,12 +34,6 @@
 
     - name: Start ping test
       ansible.builtin.include_tasks: l3_agent_connectivity_check_start.yml
-
-- name: Create local openstackclient
-  when:
-    - cifmw_update_control_plane_check | bool
-    - not cifmw_update_run_dryrun | bool
-  ansible.builtin.include_tasks: create_local_openstackclient.yml
 
 - name: Trigger the continuous control plane test
   when:


### PR DESCRIPTION
Move ping test execution from openshift pod to local openstackclient running on controller-0. This alligns execution method with continuous control plane test. It also solves problem with incompatibility of workload script with ipv6 enviroments.

Closes: [OSPRH-17249](https://issues.redhat.com//browse/OSPRH-17249)