### PR TITLE
Expose new parameter TimingData

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -87,6 +87,7 @@ cifmw_test_operator_stages:
 * `cifmw_test_operator_tempest_extra_configmaps_mounts`: (List) A list of configmaps that should be mounted into the tempest test pods. Default value: `[]`
 * `cifmw_test_operator_tempest_extra_mounts`: (List) A list of additional volume mounts for the tempest test pods. Each item specifies a volume name, mount path, and other mount properties. Default value: `[]`
 * `cifmw_test_operator_tempest_debug`: (Bool) Run Tempest in debug mode, it keeps the operator pod sleeping infinity (it must only set to `true`only for debugging purposes). Default value: `false`
+* `cifmw_test_operator_tempest_timing_data`: (Boolean) Enables saving stestr timing data to save time in subsequent Tempest test runs. Default value: `false`
 * `cifmw_test_operator_tempest_resources`: (Dict) A dictionary that specifies resources (cpu, memory) for the test pods. When untouched it clears the default values set on the test-operator side. This means that the tempest test pods run with unspecified resource limits. Default value: `{requests: {}, limits: {}}`
 * `cifmw_tempest_tempestconf_config`: Deprecated, please use `cifmw_test_operator_tempest_tempestconf_config` instead
 * `cifmw_test_operator_tempest_tempestconf_config`: (Dict) This parameter can be used to customize the execution of the `discover-tempest-config` run. Please consult the test-operator documentation. For example, to pass a custom configuration for `tempest.conf`, use the `overrides` section:

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -76,6 +76,7 @@ cifmw_test_operator_tempest_tests_include_override_scenario: false
 cifmw_test_operator_tempest_tests_exclude_override_scenario: false
 cifmw_test_operator_tempest_workflow: []
 cifmw_test_operator_tempest_cleanup: false
+cifmw_test_operator_tempest_timing_data: false
 cifmw_test_operator_tempest_tempestconf_config: "{{ cifmw_tempest_tempestconf_config }}"
 
 # TODO: The default value of this parameter should be changed to {} once this fix
@@ -163,6 +164,7 @@ cifmw_test_operator_tempest_config:
       extraImages: "{{ stage_vars_dict.cifmw_test_operator_tempest_extra_images | default([]) }}"
     tempestconfRun: "{{ cifmw_tempest_tempestconf_config_defaults | combine(stage_vars_dict.cifmw_test_operator_tempest_tempestconf_config | default({})) }}"
     cleanup: "{{ stage_vars_dict.cifmw_test_operator_tempest_cleanup | bool }}"
+    timingData: "{{ stage_vars_dict.cifmw_test_operator_tempest_timing_data | bool }}"
     workflow: "{{ stage_vars_dict.cifmw_test_operator_tempest_workflow }}"
     debug: "{{ stage_vars_dict.cifmw_test_operator_tempest_debug }}"
 


### PR DESCRIPTION
This change is needed for the introduction of a new parameter timingData to the test-operator. This parameter will enable saving stestr timing data, which will be used in subsequent Tempest test runs to save time.