### PR TITLE
Add option to update Watcher containers in OpenStackVersion

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -409,6 +409,7 @@ openstackdataplanenodeset
 openstackdataplanenodesets
 openstackprovisioner
 openstacksdk
+openstackversion
 operatorgroup
 opn
 orchestrator

--- a/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
+++ b/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
@@ -33,7 +33,9 @@
       (cifmw_update_containers_edpm_image_url is defined) or
       (cifmw_update_containers_ansibleee_image_url is defined) or
       ((cifmw_update_containers_openstack is defined and
-      cifmw_update_containers_openstack | bool))
+      cifmw_update_containers_openstack | bool)) or
+      ((cifmw_update_containers_watcher is defined and
+      cifmw_update_containers_watcher | bool))
   vars:
     cifmw_update_containers_metadata: "{{ _ctlplane_name }}"
   ansible.builtin.include_role:

--- a/roles/update_containers/README.md
+++ b/roles/update_containers/README.md
@@ -26,7 +26,8 @@ If apply, please explain the privilege escalation done in this role.
 * `cifmw_update_containers_edpm_image_url`: Full EDPM Image url for updating EDPM OS image.
 * `cifmw_update_containers_ipa_image_url`: Full Ironic Python Agent url needed in Ironic specific podified deployment
 * `cifmw_update_containers_rollback`: Rollback the container update changes. Default to `false`. It will be used with cleanup.
-* `cifmw_update_containers_barbican_custom_tag: Custom tag for barbican API and worker images.  Used for HSM deployments.
+* `cifmw_update_containers_barbican_custom_tag`: Custom tag for barbican API and worker images.  Used for HSM deployments.
+* `cifmw_update_containers_watcher`: Whether to update the Watcher service containers in the openstackversion. Default to `false`.
 
 ## Examples
 ### 1 - Update OpenStack container

--- a/roles/update_containers/defaults/main.yml
+++ b/roles/update_containers/defaults/main.yml
@@ -44,6 +44,7 @@ cifmw_update_containers_cindervolumes:
   - default
 cifmw_update_containers_manilashares:
   - default
+cifmw_update_containers_watcher: false
 # cifmw_update_containers_ansibleee_image_url:
 # cifmw_update_containers_edpm_image_url:
 # cifmw_update_containers_ipa_image_url:

--- a/roles/update_containers/templates/update_containers.j2
+++ b/roles/update_containers/templates/update_containers.j2
@@ -108,3 +108,8 @@ spec:
 {% if cifmw_update_containers_agentimage is defined %}
 	    agentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-baremetal-operator-agent:{{ cifmw_update_containers_tag }}
 {% endif %}
+{% if cifmw_update_containers_watcher | bool  %}
+    watcherAPIImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-watcher-api:{{ cifmw_update_containers_tag }}
+    watcherApplierImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-watcher-applier:{{ cifmw_update_containers_tag }}
+    watcherDecisionEngineImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-watcher-decision-engine:{{ cifmw_update_containers_tag }}
+{% endif %}


### PR DESCRIPTION
Watcher is now integrated into the openstack-controlplane [1].

This patch is adding a new option to the update_containers role to enable updating the watcher containers in the OpenStackVersion based on the same parameters as the rest of OpenStack operators.

I am adding them with a different parameter
cifmw_update_containers_watcher for two reason:

- In case ci-framework is also used in environments where watcher is still not integrated.
- In watcher-operator pipelines there are some jobs where it is desired to update only the watcher containers while keeping the rest by default