### PR TITLE
Fix replacing osp network names

### DIFF
--- a/roles/adoption_osp_deploy/tasks/config_files.yml
+++ b/roles/adoption_osp_deploy/tasks/config_files.yml
@@ -115,11 +115,11 @@
           {%- set nodeport = {node: {}} -%}
           {% for network, net_info in _node_instance_net.networks.items() if network != 'ocpbm' %}
             {%- set subnet = cifmw_networking_env_definition.networks[network][network_version|default("network_v4")] -%}
-            {%- set network_name = ['storage_mgmt'] if network == 'storagemgmt' else [network] -%}
-            {%- set network_name = ['internal_api'] if network == 'internalapi' else [network] -%}
+            {%- set network_name = network.replace('storagemgmt', 'storage_mgmt') -%}
+            {%- set network_name = network_name.replace('internalapi', 'internal_api') -%}
             {%- set _ = nodeport[node].update(
               {
-                network_name[0]: {
+                network_name: {
                 'ip_address': net_info[ip_version|default("ip_v4")],
                 'ip_address_uri': net_info[ip_version|default("ip_v4")],
                 'ip_subnet': subnet


### PR DESCRIPTION
Do not overwrite the replaced 'storage_mgmt' back to 'storagemgmt'. That happens, when the network_name is compared to 'internalapi' after its 'storagemgmt' was fixed. As this name is not 'internalapi', it gets rewritten back to the original network name.

Jira: [OSPRH-15520](https://issues.redhat.com//browse/OSPRH-15520)