### PR TITLE
Update custom cert installation hook

### DIFF
--- a/hooks/playbooks/install_custom_ca_certs.yaml
+++ b/hooks/playbooks/install_custom_ca_certs.yaml
@@ -27,7 +27,7 @@
 
     - name: Patch OpenStack control plane to use custom CA secret
       kubernetes.core.k8s:
-        state: patched
+        state: present
         kind: OpenStackControlPlane
         api_version: core.openstack.org/v1beta1
         name: "{{ _controlplane_name }}"


### PR DESCRIPTION
According to Ansible module documentation [1] we should be fine to use `state=present` setting, as it will create resource if it does not exist and patch the existing one. After this change we should be able to effectively use this hook in early deployment stages and avoid having whole control plane being restarted when the patching occured for already deployed OpenStack cluster.

[1] https://docs.ansible.com/ansible/latest/collections/kubernetes/core/k8s_module.html#parameter-state