### PR TITLE
Introduce the split update (alternative to monolithic)

### DIFF
--- a/roles/update/README.md
+++ b/roles/update/README.md
@@ -6,6 +6,7 @@ Role to run update
 * `cifmw_update_openstack_update_run_operators_updated`: (Boolean) Set if openstack_update_run make target should not modify openstack-operator csv to fake openstack services container change. Default to `True`.
 * `cifmw_update_openstack_update_run_target_version`: (String) Define openstack target version to run update to.
 * `cifmw_update_openstack_update_run_timeout`: (String) Define `oc wait` global timeout passed to each step of update procedure. It should be a value of a longest step of the procedure. Defaults to `600s`.
+* `cifmw_update_variant`: (String) Defines the update procedure. Can be `'monolithic'` for a single update step, or `'split'` for a two-step (services, system) update. Defaults to `'monolithic'`.
 * `cifmw_update_run_dryrun`: (Boolean) Do a dry run on make openstack_update_run command. Defaults to `False`.
 * `cifmw_update_ping_test`: (Boolean) Activate the ping test during update. Default to `False`.
 * `cifmw_update_create_volume`: (Boolean) Attach a volume to the test OS instance when set to true.  Default to `False`

--- a/roles/update/defaults/main.yml
+++ b/roles/update/defaults/main.yml
@@ -24,6 +24,11 @@ cifmw_update_openstack_update_run_containers_namespace: "podified-antelope-cento
 cifmw_update_openstack_update_run_containers_target_tag: "current-podified"
 cifmw_update_openstack_update_run_timeout: "600s"
 
+# Update variant. Can be 'monolithic' or 'split'.
+# 'monolithic' uses the single openstack_update_run make target.
+# 'split' uses the update_services and update_system make targets.
+cifmw_update_variant: "monolithic"
+
 # Avoid certain tasks during molecule run
 cifmw_update_run_dryrun: false
 

--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -149,7 +149,7 @@
   tags:
     - always
   ansible.builtin.set_fact:
-    _make_openstack_update_run_params: |
+    _make_update_params: |
       TIMEOUT: {{ cifmw_update_openstack_update_run_timeout }}
       {% if _cifmw_update_use_fake_update | bool -%}
       FAKE_UPDATE: true
@@ -180,14 +180,8 @@
       {{ cifmw_update_artifacts_basedir }}/update_event.sh
       Update to start the Update sequence
 
-- name: Run make openstack_update_run
-  vars:
-    make_openstack_update_run_env: "{{ cifmw_install_yamls_environment | combine({'PATH': cifmw_path }) }}"
-    make_openstack_update_run_params: "{{ _make_openstack_update_run_params | from_yaml }}"
-    make_openstack_update_run_dryrun: "{{ cifmw_update_run_dryrun | bool }}"
-  ansible.builtin.include_role:
-    name: 'install_yamls_makes'
-    tasks_from: 'make_openstack_update_run'
+- name: Run the selected update variant
+  ansible.builtin.include_tasks: "update_variant_{{ cifmw_update_variant }}.yml"
 
 - name: Set update step to Update Sequence complete
   ansible.builtin.command:

--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -174,20 +174,8 @@
       default(cifmw_update_openstack_update_run_target_version)
       }}
 
-- name: Set update step to About to start the Update sequence
-  ansible.builtin.command:
-    cmd: >
-      {{ cifmw_update_artifacts_basedir }}/update_event.sh
-      Update to start the Update sequence
-
 - name: Run the selected update variant
   ansible.builtin.include_tasks: "update_variant_{{ cifmw_update_variant }}.yml"
-
-- name: Set update step to Update Sequence complete
-  ansible.builtin.command:
-    cmd: >
-      {{ cifmw_update_artifacts_basedir }}/update_event.sh
-      Update Sequence complete
 
 - name: Stop the ping test
   ansible.builtin.include_tasks: l3_agent_connectivity_check_stop.yml

--- a/roles/update/tasks/update_variant_monolithic.yml
+++ b/roles/update/tasks/update_variant_monolithic.yml
@@ -1,0 +1,9 @@
+---
+- name: Run make openstack_update_run
+  vars:
+    make_openstack_update_run_env: "{{ cifmw_install_yamls_environment | combine({'PATH': cifmw_path }) }}"
+    make_openstack_update_run_params: "{{ _make_update_params | from_yaml }}"
+    make_openstack_update_run_dryrun: "{{ cifmw_update_run_dryrun | bool }}"
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_openstack_update_run'

--- a/roles/update/tasks/update_variant_monolithic.yml
+++ b/roles/update/tasks/update_variant_monolithic.yml
@@ -1,4 +1,10 @@
 ---
+- name: Set update step to Starting the update sequence
+  ansible.builtin.command:
+    cmd: >
+      {{ cifmw_update_artifacts_basedir }}/update_event.sh
+      Starting the update sequence
+
 - name: Run make openstack_update_run
   vars:
     make_openstack_update_run_env: "{{ cifmw_install_yamls_environment | combine({'PATH': cifmw_path }) }}"
@@ -7,3 +13,9 @@
   ansible.builtin.include_role:
     name: 'install_yamls_makes'
     tasks_from: 'make_openstack_update_run'
+
+- name: Set update step to Update sequence complete
+  ansible.builtin.command:
+    cmd: >
+      {{ cifmw_update_artifacts_basedir }}/update_event.sh
+      Update sequence complete

--- a/roles/update/tasks/update_variant_split.yml
+++ b/roles/update/tasks/update_variant_split.yml
@@ -1,0 +1,18 @@
+---
+- name: Run make update_services
+  vars:
+    make_update_services_env: "{{ cifmw_install_yamls_environment | combine({'PATH': cifmw_path }) }}"
+    make_update_services_params: "{{ _make_update_params | from_yaml }}"
+    make_update_services_dryrun: "{{ cifmw_update_run_dryrun | bool }}"
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_update_services'
+
+- name: Run make update_system
+  vars:
+    make_update_system_env: "{{ cifmw_install_yamls_environment | combine({'PATH': cifmw_path }) }}"
+    make_update_system_params: "{{ _make_update_params | from_yaml }}"
+    make_update_system_dryrun: "{{ cifmw_update_run_dryrun | bool }}"
+  ansible.builtin.include_role:
+    name: 'install_yamls_makes'
+    tasks_from: 'make_update_system'

--- a/roles/update/tasks/update_variant_split.yml
+++ b/roles/update/tasks/update_variant_split.yml
@@ -1,4 +1,10 @@
 ---
+- name: Set update step to Starting the services update sequence
+  ansible.builtin.command:
+    cmd: >
+      {{ cifmw_update_artifacts_basedir }}/update_event.sh
+      Starting the services update sequence
+
 - name: Run make update_services
   vars:
     make_update_services_env: "{{ cifmw_install_yamls_environment | combine({'PATH': cifmw_path }) }}"
@@ -8,6 +14,18 @@
     name: 'install_yamls_makes'
     tasks_from: 'make_update_services'
 
+- name: Set update step to Services update sequence complete
+  ansible.builtin.command:
+    cmd: >
+      {{ cifmw_update_artifacts_basedir }}/update_event.sh
+      Services update sequence complete
+
+- name: Set update step to Starting the system update sequence
+  ansible.builtin.command:
+    cmd: >
+      {{ cifmw_update_artifacts_basedir }}/update_event.sh
+      Starting the system update sequence
+
 - name: Run make update_system
   vars:
     make_update_system_env: "{{ cifmw_install_yamls_environment | combine({'PATH': cifmw_path }) }}"
@@ -16,3 +34,9 @@
   ansible.builtin.include_role:
     name: 'install_yamls_makes'
     tasks_from: 'make_update_system'
+
+- name: Set update step to System update sequence complete
+  ansible.builtin.command:
+    cmd: >
+      {{ cifmw_update_artifacts_basedir }}/update_event.sh
+      System update sequence complete


### PR DESCRIPTION
This commit refactors the update role to support two distinct update variants, controlled by the new `cifmw_update_variant` variable. The variants are:

- `monolithic`: (Default) Preserves the existing behavior by running the single `make openstack_update_run` target.

- `split`: Implements a new two-phase update by running the `make update_services` and `make update_system` targets.

To achieve this, the main task has been modified to dynamically include either `update_variant_monolithic.yml` or
`update_variant_split.yml` based on the selected variant.