### PR TITLE
Support podified-ci-testing-tcib repo in ebi role

### DIFF
--- a/roles/edpm_build_images/tasks/post.yaml
+++ b/roles/edpm_build_images/tasks/post.yaml
@@ -12,7 +12,8 @@
     - ironic-python-agent
 
 - name: Retag and push the images with podified-ci-testing tag
-  when: cifmw_repo_setup_promotion == "podified-ci-testing"
+  when: cifmw_repo_setup_promotion
+        in ("podified-ci-testing", "podified-ci-testing-tcib")
   block:
     - name: Retag the images with podified-ci-testing tag
       containers.podman.podman_tag:


### PR DESCRIPTION
This DRLN tag would be used just for building the containers, so the `podified-ci-testing` then will be only updated after we ensure we can properly build the containers. The reason for this is that we have a lot of jobs that expect to find container tag for `podified-ci-testing` already in repository, while the containers may never be pushed due to tcib issues. The intermediate tag would allow us to bypass this without redesigning all existing jobs.