### PR TITLE
Run postdeploy tasks one when deploy is enabled

### DIFF
--- a/reproducer.yml
+++ b/reproducer.yml
@@ -106,6 +106,7 @@
 
     - name: Run post deployment if instructed to
       when:
+        - cifmw_deploy_architecture | default(false) | bool
         - cifmw_post_deployment | default(true) | bool
       no_log: "{{ cifmw_nolog | default(true) | bool }}"
       async: "{{ 7200 + cifmw_test_operator_timeout | default(3600) }}"  # 2h should be enough to deploy EDPM and rest for tests.


### PR DESCRIPTION
When cifmw_deploy_architecture is false, the job fails as postdeploy tasks are very dependant on deployment. This patch adds and condition to run postdeployment tasks only when deployment is specified as well