### PR TITLE
feat: Refactor HCI template node filtering from hardcoded regex to dynamic pattern matching for 3+3 scenarios

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/hci/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/hci/network-values/values.yaml.j2
@@ -6,6 +6,8 @@
                       lb_tools={}) %}
 {% if cifmw_networking_env_definition.instances.keys() | select('match', '^ocp-worker') | list | length > 0 %}
 {% set filter="^ocp-worker" %}
+{% elif cifmw_networking_env_definition.instances.keys() | select('match', '^worker') | list | length > 0 %}
+{% set filter="^worker" %}
 {% elif cifmw_networking_env_definition.instances.keys() | select('match', '^crc') | list | length > 0 %}
 {% set filter="^crc" %}
 {% else %}


### PR DESCRIPTION
Refactored the HCI template node filtering logic from a hardcoded regex approach to dynamic pattern matching, enabling proper master/worker node differentiation in 3+3 deployment scenarios. This implementation is related to this one:  #3056 
