### PR TITLE
Add retries to more kustomize_deploy tasks

### DIFF
--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -285,6 +285,9 @@
         PATH: "{{ cifmw_path }}"
       ansible.builtin.command:
         cmd: "oc apply -f {{ _cr }}"
+      retries: 3
+      delay: 60
+      until: oc_apply is success
 
     - name: "Build Wait Conditions for {{ stage.path }}"
       when:

--- a/roles/kustomize_deploy/tasks/install_operators.yml
+++ b/roles/kustomize_deploy/tasks/install_operators.yml
@@ -242,6 +242,10 @@
           type: Ready
           status: "True"
         wait_timeout: 300
+      retries: 3
+      delay: 60
+      register: _controller_manager_pods
+      until: _controller_manager_pods is success
 
     - name: Wait for webhook-server pods
       kubernetes.core.k8s_info:
@@ -255,6 +259,10 @@
           type: Ready
           status: "True"
         wait_timeout: 300
+      retries: 3
+      delay: 60
+      register: _webhook_server_pods
+      until: _webhook_server_pods is success
 
     - name: Wait until NMstate operator resources are deployed
       kubernetes.core.k8s_info:
@@ -272,6 +280,10 @@
           cifmw_kustomize_deploy_check_mode |
           default(false, true)
         }}
+      retries: 3
+      delay: 60
+      register: _nmstate_operator_pods
+      until: _nmstate_operator_pods is success
 
 - name: Generate MetalLB kustomization file
   ansible.builtin.copy:
@@ -314,6 +326,10 @@
           type: Ready
           status: "True"
         wait_timeout: 300
+      retries: 3
+      delay: 60
+      register: _metallb_speaker_pods
+      until: _metallb_speaker_pods is success
 
 - name: Generate NMstate kustomization file
   ansible.builtin.copy:
@@ -351,6 +367,10 @@
           type: Ready
           status: "True"
         wait_timeout: 300
+      retries: 3
+      delay: 60
+      register: _nmstate_handler_pods
+      until: _nmstate_handler_pods is success
 
     - name: Wait for NMstate webhook deployment
       kubernetes.core.k8s_info:
@@ -363,6 +383,10 @@
           type: Available
           status: "True"
         wait_timeout: 300
+      retries: 3
+      delay: 60
+      register: _nmstate_webhook_pods
+      until: _nmstate_webhook_pods is success
 
 - name: Check if the OpenStack initialization CRD exists
   kubernetes.core.k8s_info:


### PR DESCRIPTION
We still observe the Internal Server Errors randomly occurring from the underlying OpenShift cluster.
This commit extends the original attempt [1] that made the situation a little bit better in some places,
such as when there is attempt to call webhook
"nodenetworkconfigurationpolicies-mutate.nmstate.io".

So, TL;DR we want to guard few more sections with retries, to give the cluster some more time to stabilize and reply with expected value.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/3068