### PR TITLE
feat: enhance check if local common-requirements.txt exists

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -369,6 +369,13 @@
         - cifmw_reproducer_src_dir_stat.stat.exists
         - cifmw_reproducer_src_dir_stat.stat.isdir
 
+    - name: Check if local common-requirements.txt exists
+      delegate_to: localhost
+      ansible.builtin.stat:
+        path: "{{ cifmw_reproducer_src_dir }}/github.com/openstack-k8s-operators/ci-framework/common-requirements.txt"
+      register: _local_common_requirements_check
+      run_once: true
+
     - name: Install ansible dependencies
       register: _async_dep_install
       async: 600  # 10 minutes should be more than enough
@@ -376,8 +383,8 @@
       ansible.builtin.pip:
         requirements: "{{ have_local | ternary(local, remote) }}"
       vars:
-        have_local: "{{ cifmw_reproducer_src_dir_stat.stat.exists and cifmw_reproducer_src_dir_stat.stat.isdir }}"
-        local: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/common-requirements.txt"
+        have_local: "{{ _local_common_requirements_check.stat.exists }}"
+        local: "{{ cifmw_reproducer_src_dir }}/github.com/openstack-k8s-operators/ci-framework/common-requirements.txt"
         remote: https://raw.githubusercontent.com/openstack-k8s-operators/ci-framework/main/common-requirements.txt
 
     - name: Inject most of the cifmw_ parameters passed to the reproducer run


### PR DESCRIPTION
  Enhanced the check for local common-requirements.txt file to improve reliability and accuracy:

  - Added explicit check for local common-requirements.txt existence using ansible.builtin.stat
  - Updated pip requirements installation logic to use dedicated check result instead of generic directory validation
  - Fixed path reference to use cifmw_reproducer_src_dir instead of ansible_user_dir for consistency
  - Added run_once: true and delegate_to: localhost for optimal performance

  This change ensures the framework correctly detects and uses local common-requirements.txt when available, falling back
   to the remote version when needed.