### PR TITLE
Add retries to openshift_obs deployment and pod

### DIFF
--- a/roles/openshift_obs/tasks/main.yml
+++ b/roles/openshift_obs/tasks/main.yml
@@ -31,6 +31,10 @@
       type: Available
       status: "True"
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+  retries: 3
+  delay: 60
+  register: _openshift_obs_deployment
+  until: _openshift_obs_deployment is success
 
 - name: Wait for observability-operator pod
   kubernetes.core.k8s_info:
@@ -44,3 +48,7 @@
       type: Ready
       status: "True"
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+  retries: 3
+  delay: 60
+  register: _openshift_obs_pods
+  until: _openshift_obs_pods is success


### PR DESCRIPTION
We observe the following errors randomly occurring from `kubernetes.core.k8s_info` module:
`AttributeError: ''NoneType'' object has no attribute ''status''`.

This may be because the OpenShift cluster gets overwhelmed and sometimes the module receives the unexpected response, so in `custom_condition()` in `plugins/module_utils/k8s/waiter.py` there is no `status` field in `resource` [1].

As a mitigation, let's try retrying the task after some delay.

[1] https://github.com/ansible-collections/kubernetes.core/blob/main/plugins/module_utils/k8s/waiter.py#L86