### PR TITLE
Move BGP playbooks to ci-fmw

### DIFF
--- a/playbooks/bgp/discover-hosts-loop.yaml
+++ b/playbooks/bgp/discover-hosts-loop.yaml
@@ -1,0 +1,24 @@
+---
+- name: BGP discover hosts
+  hosts: controller-0
+  gather_facts: true
+  tasks:
+    - name: Wait for expected number of discovered hypervisor
+      vars:
+        num_computes: >-
+          {{
+            groups['r0-computes'] | length +
+            groups['r1-computes'] | length +
+            groups['r2-computes'] | length
+          }}
+      ansible.builtin.shell:
+        cmd: >
+          oc rsh -n openstack nova-cell0-conductor-0 nova-manage cell_v2 discover_hosts > /dev/null &&
+          oc -n openstack rsh openstackclient openstack hypervisor list -f value -c State
+      register: hv_result
+      changed_when: false
+      retries: 50
+      delay: 2
+      until:
+        - hv_result.rc == 0
+        - hv_result.stdout_lines == ["up"] * (num_computes | int)

--- a/playbooks/bgp/prepare-bgp-computes.yaml
+++ b/playbooks/bgp/prepare-bgp-computes.yaml
@@ -1,6 +1,8 @@
 ---
 - name: Configure computes
-  hosts: "computes{{ networkers_bool | default(false) | bool | ternary(',networkers', '') }}"
+  hosts: >-
+    r0-computes,r1-computes,r2-computes
+    {{ networkers_bool | default(false) | bool | ternary(',r0-networkers,r1-networkers,r2-networkers', '') }}"
   tasks:
     - name: Check default route corresponds with BGP
       ansible.builtin.command:

--- a/playbooks/bgp/prepare-bgp-spines-leaves.yaml
+++ b/playbooks/bgp/prepare-bgp-spines-leaves.yaml
@@ -39,11 +39,9 @@
         sysctl_file: /etc/sysctl.d/sysctl.conf
         state: present
         reload: true
-      loop: "{{ sysctls | dict2items }}"
-      vars:
-        sysctls:
-          net.ipv4.conf.all.rp_filter: '0'
-          net.ipv4.conf.default.rp_filter: '0'
+      with_dict:
+        net.ipv4.conf.all.rp_filter: '0'
+        net.ipv4.conf.default.rp_filter: '0'
       register: result
       retries: 3
       timeout: 60
@@ -94,6 +92,10 @@
           ansible.builtin.package:
             name: frr
             state: present
+          register: frr_present
+          retries: 10
+          delay: 2
+          until: frr_present is success
 
     - name: Enable FRR BGP daemon
       become: true
@@ -189,7 +191,8 @@
       community.general.nmcli:
         autoconnect: true
         conn_name: "{{ router_uplink_conn }}"
-        ip4: "{{ router_uplink_ip }}/30"
+        # mask changed to /24 due to https://github.com/openstack-k8s-operators/architecture/pull/466
+        ip4: "{{ router_uplink_ip }}/24"
         method4: manual
         method6: link-local
         state: present

--- a/playbooks/bgp/templates/leaf-frr.conf.j2
+++ b/playbooks/bgp/templates/leaf-frr.conf.j2
@@ -27,7 +27,10 @@ router bgp 64999
   neighbor downlink remote-as internal
   neighbor downlink bfd
   neighbor downlink bfd profile tripleo
+{# TODO: remove the next if when RHEL-63205 is fixed #}
+{% if not (fips_mode | bool) %}
   neighbor downlink password f00barZ
+{% endif %}
   ! neighbor downlink capability extended-nexthop
 {% for iface in downlink_interfaces %}
   neighbor {{iface}} interface peer-group downlink


### PR DESCRIPTION
These BGP playbooks were duplicated in both ci-fmw and ci-fmw-jobs (downstream project).
They had been recently updated in downstream only.

With this patch the playbooks are updated in upstream. They will be removed from the downstream repo too.

[OSPRH-19224](https://issues.redhat.com//browse/OSPRH-19224)