### PR TITLE
Remove condition from run_logs tasks of cifmw_setup

### DIFF
--- a/ci/playbooks/e2e-collect-logs.yml
+++ b/ci/playbooks/e2e-collect-logs.yml
@@ -21,11 +21,18 @@
       ansible.builtin.meta: end_host
 
 - name: Run log related tasks
-  hosts: "{{ cifmw_target_host | default('all') }}"
+  hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true
   vars_files:
     - ../../scenarios/centos-9/base.yml
   tasks:
+    - name: Filter out host if needed
+      when:
+        - cifmw_zuul_target_host is defined
+        - cifmw_zuul_target_host != 'all'
+        - inventory_hostname != cifmw_zuul_target_host
+      ansible.builtin.meta: end_host
+
     - name: Run logging
       ansible.builtin.import_role:
         name: cifmw_setup

--- a/roles/cifmw_setup/tasks/run_logs.yml
+++ b/roles/cifmw_setup/tasks/run_logs.yml
@@ -1,5 +1,4 @@
 - name: Check if the logging requires
-  when: not zuul_log_collection | default('false') | bool
   block:
     - name: Ensure cifmw_basedir param is set
       when:


### PR DESCRIPTION
After merging[1], jobs have stopped running must-gather to collect
service logs, e.g [2,3]. This seems to be caused by the change in [4].
Where before the 99-logs.yml playbook was run from an 'ansible-playbook'
invocation, without any inventory and thus the check for
'zuul_log_collection' was never triggered because the variable was never
set. Now, when importing the cifmw_setup role, the cifmw variables are
loaded and that variable which is in most jobs set to True prevents the
log collection, and most critically, must-gather collection.
This change removes the condition to preserve the previous behaviour.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/3032
[2] https://softwarefactory-project.io/zuul/t/rdoproject.org/build/63673310b4f94883a9aff2db719a2095
[3] https://softwarefactory-project.io/zuul/t/rdoproject.org/build/03e87102fbf04dc7b482ecdba7128085
[4] https://github.com/openstack-k8s-operators/ci-framework/commit/cc87f54332d129fc6af4e048870bfd293c1b7318#diff-691dae244b4fb4bfc1270fb5d3b708c6be6073b0e33d997db15850edfa3fd976L23
