### PR TITLE
Enable horizon in upstream CI jobs to test Glance CORS configuration

### DIFF
--- a/hooks/playbooks/templates/config_ceph_backends.yaml.j2
+++ b/hooks/playbooks/templates/config_ceph_backends.yaml.j2
@@ -30,6 +30,10 @@ patches:
                 readOnly: true
 
     - op: replace
+      path: /spec/horizon/enabled
+      value: true
+
+    - op: replace
       path: /spec/cinder/template/cinderBackup/replicas
       value: {{ cifmw_services_cinder_bkp_replicas | default(1) }}
 


### PR DESCRIPTION
This patch enables `horizon` as part of the control plane update where `glance` is deployed with `Ceph` to test that the `CORS` section is properly configured.

Jira: https://issues.redhat.com/browse/OSPRH-19261