### PR TITLE
Run nested ansible command and call run_logs tasks to drop 99-logs play

### DIFF
--- a/ci/playbooks/e2e-collect-logs.yml
+++ b/ci/playbooks/e2e-collect-logs.yml
@@ -20,22 +20,28 @@
         - not cifmw_status.stat.exists
       ansible.builtin.meta: end_host
 
-    - name: Run log collection
-      ansible.builtin.command:
+- name: Run log collection when zuul_log_collection
+  hosts: "{{ cifmw_target_host | default(cifmw_zuul_target_host) | default('controller') }}"
+  gather_facts: true
+  tasks:
+    - name: Run run_logs tasks from cifmw_setup
+      ansible.builtin.command: >
+        ansible localhost
+        -m include_role
+        -a "name=cifmw_setup tasks_from=run_logs.yml"
+        -e "@scenarios/centos-9/base.yml"
+      args:
         chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
-        cmd: >-
-          ansible-playbook playbooks/99-logs.yml
-          -e @scenarios/centos-9/base.yml
 
 - name: "Run ci/playbooks/collect-logs.yml on CRC host"
   hosts: crc
   gather_facts: false
   tasks:
     - name: Get kubelet journalctl logs
-      ignore_errors: true  # noqa: ignore-errors
+      ignore_errors: true # noqa: ignore-errors
       become: true
       ansible.builtin.shell: |
-          journalctl -u kubelet > kubelet.log
+        journalctl -u kubelet > kubelet.log
       no_log: true
       args:
         chdir: "{{ ansible_user_dir }}/zuul-output/logs/"

--- a/roles/cifmw_setup/tasks/run_logs.yml
+++ b/roles/cifmw_setup/tasks/run_logs.yml
@@ -1,5 +1,6 @@
+---
 - name: Check if the logging requires
-  when: not zuul_log_collection | default('false') | bool
+  when: not (zuul_log_collection | default(false))
   block:
     - name: Ensure cifmw_basedir param is set
       when:
@@ -9,7 +10,7 @@
 
     - name: Try to load parameters files
       block:
-        - name: Check directory availabilty
+        - name: Check directory availability
           register: param_dir
           ansible.builtin.stat:
             path: "{{ cifmw_basedir }}/artifacts/parameters"
@@ -54,7 +55,7 @@
     - name: Return a list of log files in home directory
       ansible.builtin.find:
         paths: "{{ ansible_user_dir }}"
-        patterns: '*.log'
+        patterns: "*.log"
       register: _log_files
 
     - name: Ensure ansible facts cache exists

--- a/zuul.d/kuttl.yaml
+++ b/zuul.d/kuttl.yaml
@@ -23,6 +23,8 @@
     name: cifmw-kuttl
     parent: cifmw-base-kuttl
     files:
+      - ^ci/playbooks/e2e-collect-logs.yml
+      - ^ci/playbooks/collect-logs.yml
       - ^ci/playbooks/kuttl/.*
       - ^scenarios/centos-9/kuttl.yml
       - ^zuul.d/kuttl.yaml


### PR DESCRIPTION
Earlier the 99-logs.yml playbook was executed as nested Ansible.
After we migrate that playbook to role, it can not be called directly,
because it contains: cimfw collection to be installed on Zuul executor
and include_vars can not read files, that are located on the controller,
so they needs to be synchronized with Zuul executor job dir.