### PR TITLE
[nat64_appliance] Allow to specify a base image URL

### DIFF
--- a/roles/nat64_appliance/README.md
+++ b/roles/nat64_appliance/README.md
@@ -27,6 +27,7 @@
 * `cifmw_nat64_appliance_ssh_pub_keys`: (List) List of SSH public key for the nat64 appliance VM. Defaults to: `[]`.
 * `cifmw_nat64_ipv6_prefix`: (String) IPv6 prefix for nat64. Defaults to: `fc00:abcd:abcd:fc00::/64`.
 * `cifmw_nat64_ipv6_tayga_address`: (String) Tayga IPv6 address. Defaults to: `fc00:abcd:abcd:fc00::3`.
+* `cifmw_nat64_appliance_image_url`: (String) When defined, a specific image is downloaded from that URL and used as the nat64 appliance base image. Defaults to `""`.
 
 ## Building the image
 

--- a/roles/nat64_appliance/defaults/main.yml
+++ b/roles/nat64_appliance/defaults/main.yml
@@ -43,3 +43,5 @@ cifmw_nat64_appliance_ssh_pub_keys: []
 
 cifmw_nat64_ipv6_prefix: "2620:cf:cf:fc00::/64"
 cifmw_nat64_ipv6_tayga_address: "2620:cf:cf:fc00::3"
+
+cifmw_nat64_appliance_image_url: ""

--- a/roles/nat64_appliance/files/nat64-appliance.yaml
+++ b/roles/nat64_appliance/files/nat64-appliance.yaml
@@ -12,7 +12,7 @@
   environment:
     DIB_RELEASE: '9-stream'
     DIB_PYTHON_VERSION: '3'
-    DIB_IMAGE_SIZE: '2'
+    DIB_IMAGE_SIZE: '3'
     COMPRESS_IMAGE: '1'
     DIB_BLOCK_DEVICE_CONFIG: |
       - local_loop:

--- a/roles/nat64_appliance/molecule/default/converge.yml
+++ b/roles/nat64_appliance/molecule/default/converge.yml
@@ -63,6 +63,8 @@
         #  This permission error is only seen in CI and when using the
         #  ci-framework reproducer.
         cifmw_nat64_appliance_run_dib_as_root: true
+        # TODO(eolivare): remove cifmw_nat64_appliance_image_url when CS-2983 is fixed
+        cifmw_nat64_appliance_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-x86_64-9-20250812.1.x86_64.qcow2
       ansible.builtin.include_role:
         name: nat64_appliance
 

--- a/roles/nat64_appliance/tasks/main.yml
+++ b/roles/nat64_appliance/tasks/main.yml
@@ -66,12 +66,33 @@
     dest: "{{ cifmw_nat64_appliance_workdir }}/edpm-image-builder"
     version: main
 
+- name: Download nat64 source image
+  when: cifmw_nat64_appliance_image_url | length > 0
+  block:
+    - name: Create nat64 appliance cache directory
+      ansible.builtin.file:
+        path: "{{ cifmw_nat64_appliance_workdir }}/cache"
+        state: directory
+        mode: "0755"
+
+    - name: Download the nat64 source image
+      ansible.builtin.get_url:
+        url: "{{ cifmw_nat64_appliance_image_url }}"
+        dest: "{{ cifmw_nat64_appliance_workdir }}/cache"
+        timeout: 20
+        mode: "0644"
+      register: download_result
+      until: download_result is success
+      retries: 60
+      delay: 10
+
 - name: Build the nat64-appliance image using DIB
   become: "{{ cifmw_nat64_appliance_run_dib_as_root | default(false) | bool }}"
   environment:
     ELEMENTS_PATH: "{{ cifmw_nat64_appliance_workdir }}/elements:{{ cifmw_nat64_appliance_workdir }}/edpm-image-builder/dib/"
-    DIB_IMAGE_CACHE: "{{ cifmw_nat64_appliance_workdir }}/cache"
+    DIB_IMAGE_CACHE: "{{ cifmw_nat64_appliance_workdir ~ '/cache' if cifmw_nat64_appliance_image_url | length == 0 else '' }}"
     DIB_DEBUG_TRACE: '1'
+    DIB_LOCAL_IMAGE: "{{ '' if cifmw_nat64_appliance_image_url | length == 0 else download_result.dest }}"
   cifmw.general.ci_script:
     chdir: "{{ cifmw_nat64_appliance_workdir }}"
     output_dir: "{{ cifmw_nat64_appliance_basedir }}/artifacts"


### PR DESCRIPTION
The nat64_appliance runs diskimage-builder to build the qcow image that
is used for the nat64 VM. The diskimage-builder by default downloads the
latest CentOS image from the provided CentOS version:
https://github.com/openstack/diskimage-builder/blob/75b99e1990a45d33b694740f6fa20bc691de9ef9/diskimage_builder/elements/centos/root.d/10-centos-cloud-image#L45

With this patch, instead of delegating the download of the CentOS image
to diskimage-builder, an image URL can be provided.
For example:
```
cifmw_nat64_appliance_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20250818.1.x86_64.qcow2
```