### PR TITLE
Pin nat64 CentOS image

### DIFF
--- a/roles/nat64_appliance/tasks/main.yml
+++ b/roles/nat64_appliance/tasks/main.yml
@@ -72,6 +72,7 @@
     ELEMENTS_PATH: "{{ cifmw_nat64_appliance_workdir }}/elements:{{ cifmw_nat64_appliance_workdir }}/edpm-image-builder/dib/"
     DIB_IMAGE_CACHE: "{{ cifmw_nat64_appliance_workdir }}/cache"
     DIB_DEBUG_TRACE: '1'
+    BASE_IMAGE_FILE: CentOS-Stream-GenericCloud-x86_64-9-20250812.1.x86_64.qcow2
   cifmw.general.ci_script:
     chdir: "{{ cifmw_nat64_appliance_workdir }}"
     output_dir: "{{ cifmw_nat64_appliance_basedir }}/artifacts"


### PR DESCRIPTION
The CentOS images are broken, let's pin image to an older CS9 image until the CentOS image issues[1] has been resolved.

[1] https://issues.redhat.com/browse/CS-2983

Jira: OSPCIX-1020