### PR TITLE
Add support for tempest re-run feature

### DIFF
--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -76,6 +76,8 @@ cifmw_test_operator_tempest_tests_include_override_scenario: false
 cifmw_test_operator_tempest_tests_exclude_override_scenario: false
 cifmw_test_operator_tempest_workflow: []
 cifmw_test_operator_tempest_cleanup: false
+cifmw_test_operator_tempest_rerun_failed_tests: false
+cifmw_test_operator_tempest_rerun_override_status: false
 cifmw_test_operator_tempest_tempestconf_config: "{{ cifmw_tempest_tempestconf_config }}"
 
 # TODO: The default value of this parameter should be changed to {} once this fix
@@ -163,6 +165,8 @@ cifmw_test_operator_tempest_config:
       extraImages: "{{ stage_vars_dict.cifmw_test_operator_tempest_extra_images | default([]) }}"
     tempestconfRun: "{{ cifmw_tempest_tempestconf_config_defaults | combine(stage_vars_dict.cifmw_test_operator_tempest_tempestconf_config | default({})) }}"
     cleanup: "{{ stage_vars_dict.cifmw_test_operator_tempest_cleanup | bool }}"
+    rerunFailedTests: "{{ stage_vars_dict.cifmw_test_operator_tempest_rerun_failed_tests | bool }}"
+    rerunOverrideStatus: "{{ stage_vars_dict.cifmw_test_operator_tempest_rerun_override_status | bool }}"
     workflow: "{{ stage_vars_dict.cifmw_test_operator_tempest_workflow }}"
     debug: "{{ stage_vars_dict.cifmw_test_operator_tempest_debug }}"
 


### PR DESCRIPTION
The tempest runner script has recently got a feature that allows re-running the failed tests – for having additional insight on the issues repeatability. This commit adds the support of enabling that feature from the test-operator perspective.

Related: https://github.com/openstack-k8s-operators/tcib/pull/320
Related: https://github.com/openstack-k8s-operators/test-operator/pull/330