### PR TITLE
Add tempest test run in between services and system update to update role

### DIFF
--- a/roles/update/tasks/update_variant_split.yml
+++ b/roles/update/tasks/update_variant_split.yml
@@ -20,6 +20,15 @@
       {{ cifmw_update_artifacts_basedir }}/update_event.sh
       Services update sequence complete
 
+- name: Run tests after Services update
+  vars:
+    cifmw_test_operator_artifacts_basedir: "{{ cifmw_basedir|default(ansible_user_dir ~ '/ci-framework-data') }}/tests/test_operator_update"
+    cifmw_test_operator_tempest_name: "post-services-update-tempest-tests"
+  ansible.builtin.include_role:
+    name: cifmw_setup
+    tasks_from: run_tests.yml
+  when: cifmw_run_tests | default(false) | bool
+
 - name: Set update step to Starting the system update sequence
   ansible.builtin.command:
     cmd: >


### PR DESCRIPTION
Added new tempest test execution in between services and system update to update role for update_variant_split.

Resolves: [OSPRH-19220](https://issues.redhat.com//browse/OSPRH-19220)