### PR TITLE
Fix LVMCluster until clause

### DIFF
--- a/roles/ci_lvms_storage/tasks/main.yml
+++ b/roles/ci_lvms_storage/tasks/main.yml
@@ -150,7 +150,7 @@
   retries: "{{ cifmw_lvms_retries }}"
   delay: "{{ cifmw_lvms_delay }}"
   until:
-    - _cifmw_lvms_storage_cluster_lvmscluster_out.resources | length == 1
+    - _cifmw_lvms_storage_cluster_lvmscluster_out.resources | default([]) | length == 1
     - _cifmw_lvms_storage_cluster_lvmscluster_out.failed is false
     - _cifmw_lvms_storage_cluster_lvmscluster_out.resources[0].status is defined
     - _cifmw_lvms_storage_cluster_lvmscluster_out.resources[0].status.ready is defined


### PR DESCRIPTION
We have faced some times a race error because of:
The error was: error while evaluating conditional (_cifmw_lvms_storage_cluster_lvmscluster_out.resources

| length == 1): ''dict object'' has no attribute ''resources''. ''dict object''

With this we should fix this and make the task more robust