### PR TITLE
Fix cifmw-pod-zuul-files after adding fix_python_encodings role

### DIFF
--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -926,6 +926,15 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/fix_python_encodings/.*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-fix_python_encodings
+    parent: cifmw-molecule-noop
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/ipa/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -55,6 +55,7 @@
       - cifmw-molecule-edpm_prepare
       - cifmw-molecule-env_op_images
       - cifmw-molecule-federation
+      - cifmw-molecule-fix_python_encodings
       - cifmw-molecule-hci_prepare
       - cifmw-molecule-hive
       - cifmw-molecule-idrac_configuration


### PR DESCRIPTION
The role was added [1], but the command:

    make role_molecule

was not executed, so the cifmw-pod-zuul-files CI job is failing.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/3218