### PR TITLE
Fix SNR/NHC role CRD availability timing issues

### DIFF
--- a/roles/cifmw_snr_nhc/defaults/main.yml
+++ b/roles/cifmw_snr_nhc/defaults/main.yml
@@ -4,3 +4,5 @@ cifmw_snr_nhc_kubeadmin_password_file: "/home/{{ ansible_user | default('zuul') 
 cifmw_snr_nhc_namespace: openshift-workload-availability
 cifmw_snr_nhc_cleanup_before_install: false
 cifmw_snr_nhc_cleanup_namespace: false
+cifmw_snr_nhc_retries: 10
+cifmw_snr_nhc_delay: 15

--- a/roles/cifmw_snr_nhc/tasks/main.yml
+++ b/roles/cifmw_snr_nhc/tasks/main.yml
@@ -509,10 +509,13 @@
     kind: NodeHealthCheck
     name: nodehealthcheck-sample
   register: existing_nhc_cr_check
+  until: existing_nhc_cr_check is succeeded
+  retries: "{{ cifmw_snr_nhc_retries }}"
+  delay: "{{ cifmw_snr_nhc_delay }}"
   ignore_errors: true
 
 - name: Create Node Health Check CR to use SNR
-  when: existing_nhc_cr_check.resources | length == 0
+  when: existing_nhc_cr_check is succeeded and (existing_nhc_cr_check.resources | length == 0)
   kubernetes.core.k8s:
     kubeconfig: "{{ cifmw_snr_nhc_kubeconfig }}"
     state: present
@@ -540,9 +543,12 @@
             status: Unknown
             duration: 30s
   register: nhc_cr_creation
+  until: nhc_cr_creation is succeeded
+  retries: "{{ cifmw_snr_nhc_retries }}"
+  delay: "{{ cifmw_snr_nhc_delay }}"
 
 - name: Display info if NodeHealthCheck CR already exists
-  when: existing_nhc_cr_check.resources | length > 0
+  when: existing_nhc_cr_check is succeeded and (existing_nhc_cr_check.resources | length > 0)
   ansible.builtin.debug:
     msg: |
       NodeHealthCheck CR 'nodehealthcheck-sample' already exists and will not be recreated.


### PR DESCRIPTION
Add retry logic and configurable timeouts to handle cases where NodeHealthCheck CRDs are not immediately available after operator installation.

Changes:
- Add cifmw_snr_nhc_retries (default: 10) and cifmw_snr_nhc_delay (default: 15) variables to defaults/main.yml
- Add retry logic to NodeHealthCheck CR existence check with configurable timeout
- Add retry logic to NodeHealthCheck CR creation task
- Fix task conditions to properly handle API call failures when CRDs are not yet available
- Improve robustness by waiting for CRDs to be ready before attempting CR operations

This addresses timing issues where the role would fail with "Failed to find exact match for remediation.medik8s.io/v1alpha1.NodeHealthCheck" when CRDs were not fully available immediately after operator installation.

Jira: https://issues.redhat.com/browse/OSPRH-19454