### PR TITLE
Drop ceph playbook symlink

### DIFF
--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -1,1 +1,0 @@
-../hooks/playbooks/ceph.yml


### PR DESCRIPTION
After merging change [1], the places where Ceph playbook was used, have been moved to use hooks.
Let's drop the symlink and verify in all used job, that the playbook path has been updated correctly.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/3154