### PR TITLE
Create symlink to cifmw plugins dir in playbook directory

### DIFF
--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/action/ci_kustomize.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/action/ci_kustomize.py
@@ -1,0 +1,1 @@
+../../../../../../../plugins/action/ci_kustomize.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/action/ci_make.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/action/ci_make.py
@@ -1,0 +1,1 @@
+../../../../../../../plugins/action/ci_make.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/action/ci_net_map.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/action/ci_net_map.py
@@ -1,0 +1,1 @@
+../../../../../../../plugins/action/ci_net_map.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/action/ci_script.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/action/ci_script.py
@@ -1,0 +1,1 @@
+../../../../../../../plugins/action/ci_script.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/action/discover_latest_image.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/action/discover_latest_image.py
@@ -1,0 +1,1 @@
+../../../../../../../plugins/action/discover_latest_image.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/filter/reproducer_gerrit_infix.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/filter/reproducer_gerrit_infix.py
@@ -1,0 +1,1 @@
+../../../../../../../plugins/filter/reproducer_gerrit_infix.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/filter/reproducer_refspec.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/filter/reproducer_refspec.py
@@ -1,0 +1,1 @@
+../../../../../../../plugins/filter/reproducer_refspec.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/filter/to_nice_yaml_all.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/filter/to_nice_yaml_all.py
@@ -1,0 +1,1 @@
+../../../../../../../plugins/filter/to_nice_yaml_all.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/module_utils/__init__.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/module_utils/__init__.py
@@ -1,0 +1,1 @@
+../../../../../../../plugins/module_utils/__init__.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/module_utils/encoding/__init__.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/module_utils/encoding/__init__.py
@@ -1,0 +1,1 @@
+../../../../../../../../plugins/module_utils/encoding/__init__.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/module_utils/encoding/ansible_encoding.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/module_utils/encoding/ansible_encoding.py
@@ -1,0 +1,1 @@
+../../../../../../../../plugins/module_utils/encoding/ansible_encoding.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/module_utils/net_map/__init__.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/module_utils/net_map/__init__.py
@@ -1,0 +1,1 @@
+../../../../../../../../plugins/module_utils/net_map/__init__.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/module_utils/net_map/exceptions.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/module_utils/net_map/exceptions.py
@@ -1,0 +1,1 @@
+../../../../../../../../plugins/module_utils/net_map/exceptions.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/module_utils/net_map/ip_pools.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/module_utils/net_map/ip_pools.py
@@ -1,0 +1,1 @@
+../../../../../../../../plugins/module_utils/net_map/ip_pools.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/module_utils/net_map/networking_definition.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/module_utils/net_map/networking_definition.py
@@ -1,0 +1,1 @@
+../../../../../../../../plugins/module_utils/net_map/networking_definition.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/module_utils/net_map/networking_env_definitions.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/module_utils/net_map/networking_env_definitions.py
@@ -1,0 +1,1 @@
+../../../../../../../../plugins/module_utils/net_map/networking_env_definitions.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/module_utils/net_map/networking_mapper.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/module_utils/net_map/networking_mapper.py
@@ -1,0 +1,1 @@
+../../../../../../../../plugins/module_utils/net_map/networking_mapper.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/modules/approve_csr.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/modules/approve_csr.py
@@ -1,0 +1,1 @@
+../../../../../../../plugins/modules/approve_csr.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/modules/bridge_vlan.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/modules/bridge_vlan.py
@@ -1,0 +1,1 @@
+../../../../../../../plugins/modules/bridge_vlan.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/modules/cephx_key.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/modules/cephx_key.py
@@ -1,0 +1,1 @@
+../../../../../../../plugins/modules/cephx_key.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/modules/crawl_n_mask.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/modules/crawl_n_mask.py
@@ -1,0 +1,1 @@
+../../../../../../../plugins/modules/crawl_n_mask.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/modules/generate_make_tasks.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/modules/generate_make_tasks.py
@@ -1,0 +1,1 @@
+../../../../../../../plugins/modules/generate_make_tasks.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/modules/get_makefiles_env.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/modules/get_makefiles_env.py
@@ -1,0 +1,1 @@
+../../../../../../../plugins/modules/get_makefiles_env.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/modules/krb_request.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/modules/krb_request.py
@@ -1,0 +1,1 @@
+../../../../../../../plugins/modules/krb_request.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/modules/pem_read.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/modules/pem_read.py
@@ -1,0 +1,1 @@
+../../../../../../../plugins/modules/pem_read.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/modules/tempest_list_allowed.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/modules/tempest_list_allowed.py
@@ -1,0 +1,1 @@
+../../../../../../../plugins/modules/tempest_list_allowed.py

--- a/playbooks/collections/ansible_collections/cifmw/general/plugins/modules/tempest_list_skipped.py
+++ b/playbooks/collections/ansible_collections/cifmw/general/plugins/modules/tempest_list_skipped.py
@@ -1,0 +1,1 @@
+../../../../../../../plugins/modules/tempest_list_skipped.py


### PR DESCRIPTION
By making the symlink to the plugins, even when Zuul does not have installed the collection, it should take them from the directory.