### PR TITLE
Un-pin the nat64 CS 9-stream image

### DIFF
--- a/roles/nat64_appliance/tasks/main.yml
+++ b/roles/nat64_appliance/tasks/main.yml
@@ -72,7 +72,6 @@
     ELEMENTS_PATH: "{{ cifmw_nat64_appliance_workdir }}/elements:{{ cifmw_nat64_appliance_workdir }}/edpm-image-builder/dib/"
     DIB_IMAGE_CACHE: "{{ cifmw_nat64_appliance_workdir }}/cache"
     DIB_DEBUG_TRACE: '1'
-    BASE_IMAGE_FILE: CentOS-Stream-GenericCloud-x86_64-9-20250812.1.x86_64.qcow2
   cifmw.general.ci_script:
     chdir: "{{ cifmw_nat64_appliance_workdir }}"
     output_dir: "{{ cifmw_nat64_appliance_basedir }}/artifacts"


### PR DESCRIPTION
Image was pinned for OSPCIX-1020, should be unpinned once CentOS 9-Stream images are good again.

When the nat64 molecule job passes, this should be good to merge.