### PR TITLE
Drop pre-run and post-run for kuttl_multinode

### DIFF
--- a/zuul.d/kuttl_multinode.yaml
+++ b/zuul.d/kuttl_multinode.yaml
@@ -41,13 +41,9 @@
                 ip: 172.18.0.5
               tenant:
                 ip: 172.19.0.5
-    pre-run:
-      - ci/playbooks/e2e-prepare.yml
     run:
       - ci/playbooks/dump_zuul_data.yml
       - ci/playbooks/kuttl/run.yml
-    post-run:
-      - ci/playbooks/collect-logs.yml
     required-projects:
       - github.com/openstack-k8s-operators/install_yamls
 


### PR DESCRIPTION
The playbook execution is duplicated and it raises complication in some cases.