### PR TITLE
Default fips_mode in BGP leaf-frr template

### DIFF
--- a/playbooks/bgp/templates/leaf-frr.conf.j2
+++ b/playbooks/bgp/templates/leaf-frr.conf.j2
@@ -28,7 +28,7 @@ router bgp 64999
   neighbor downlink bfd
   neighbor downlink bfd profile tripleo
 {# TODO: remove the next if when RHEL-63205 is fixed #}
-{% if not (fips_mode | bool) %}
+{% if not (fips_mode | default(false) | bool) %}
   neighbor downlink password f00barZ
 {% endif %}
   ! neighbor downlink capability extended-nexthop


### PR DESCRIPTION
Without a default value, then the Configure FRR task in the playbook prepare-bgp-spines-leaves.yaml will fail with the following, unless the user knows to override this variable.

'AnsibleUndefinedVariable: ''fips_mode'' is undefined.