### PR TITLE
Update pre-commit requirements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -20,7 +20,7 @@ repos:
   # Ignores the following rules:
   # SC2071: todo(Lewis): Will fix in a follow up patch
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
         verbose: true
@@ -33,13 +33,13 @@ repos:
 
   # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.8.0
+    rev: 25.1.0
     hooks:
       - id: black
 
   # todo(Lewis): Update version when we bump to python>=3.10
   - repo: https://github.com/ansible/ansible-lint
-    rev: v6.22.2
+    rev: v25.8.2
     hooks:
       - id: ansible-lint
         additional_dependencies:


### PR DESCRIPTION
On some envs, the 'pre-commit' command fails wit error:

    Traceback (most recent call last):
      File "<frozen runpy>", line 198, in _run_module_as_main
      File "<frozen runpy>", line 88, in _run_code
      File "/home/user/.cache/pre-commit/repotz759v_i/py_env-python3/lib/python3.13/site-packages/ansiblelint/__main__.py", line 50, in <module>
        from ansiblelint import cli
      File "/home/user/.cache/pre-commit/repotz759v_i/py_env-python3/lib/python3.13/site-packages/ansiblelint/cli.py", line 29, in <module>
        from ansiblelint.yaml_utils import clean_json
      File "/home/user/.cache/pre-commit/repotz759v_i/py_env-python3/lib/python3.13/site-packages/ansiblelint/yaml_utils.py", line 33, in <module>
        from ansiblelint.utils import Task
      File "/home/user/.cache/pre-commit/repotz759v_i/py_env-python3/lib/python3.13/site-packages/ansiblelint/utils.py", line 44, in <module>
        from ansible.parsing.yaml.constructor import AnsibleConstructor, AnsibleMapping
    ModuleNotFoundError: No module named 'ansible.parsing.yaml.constructor'

Updating modules to newer version by using command:

    pre-commit autoupdate

Seems to help.