### PR TITLE
Allow merging all stages result xml

### DIFF
--- a/roles/polarion/README.md
+++ b/roles/polarion/README.md
@@ -12,6 +12,7 @@ Role to setup jump tool and upload XML test results to Polarion.
 * `cifmw_polarion_jump_extra_vars`: (String) A list of extra_vars that are being passed to the jump script. Defaults to empty.
 * `cifmw_polarion_jump_custom_fields`: (Dict) Structure listing the fields for --custom-fields argument of jump tool.
 * `cifmw_polarion_use_stage`: (Bool) Flag for using the staging instance of Polarion. Default is False meaning the production instance gets updated. Don't forget to change for testing on stage instance.
+* `cifmw_polarion_aggregate_test_results`: (Bool) Flag for merging all results into a single file instead of uploading multiple results. Default: False
 
 
 ## Examples

--- a/roles/polarion/defaults/main.yml
+++ b/roles/polarion/defaults/main.yml
@@ -27,3 +27,4 @@ cifmw_polarion_testrun_title: "testrun-name"
 cifmw_polarion_use_stage: false
 cifmw_zuul_project: "tripleo-ci-internal"
 cifmw_zuul_url: "https://sf.hosted.upshift.rdu2.redhat.com/zuul/t/{{ cifmw_zuul_project }}/build"
+cifmw_polarion_aggregate_test_results: false

--- a/roles/polarion/tasks/main.yml
+++ b/roles/polarion/tasks/main.yml
@@ -94,6 +94,20 @@
       ansible.builtin.debug:
         var: pylero_output.stdout_lines
 
+    - name: Cppy all xml to the same directory
+      ansible.builtin.copy:
+        src: '{{ item.path }}'
+        dest: '{{ cifmw_polarion_jump_result_dir }}'
+        mode: "0755"
+      when: cifmw_polarion_aggregate_test_results
+
+    - name: Override xml_files var if cifmw_polarion_aggregate_test_results
+      ansible.builtin.find:
+        paths: "{{ cifmw_polarion_jump_result_dir }}"
+        patterns: "*.xml"
+      register: xml_files
+      when: cifmw_polarion_aggregate_test_results
+
     - name: Merge result XML files of each directory
       ansible.builtin.shell:
         chdir: "{{ cifmw_polarion_jump_result_dir }}"


### PR DESCRIPTION
Polarion shows stages results as different test run which makes it
harder to manage. Allow merging all stages results if required

Solves: https://issues.redhat.com/browse/NFV-3317