### PR TITLE
feat: replace hardcoded 'zuul' user with configurable variables

### DIFF
--- a/create-infra.yml
+++ b/create-infra.yml
@@ -154,6 +154,6 @@
             path: "{{ cifmw_basedir | default('/home/zuul/ci-framework-data') }}"
             state: directory
             recurse: true
-            owner: zuul
-            group: zuul
+            owner: "{{ ansible_user_id }}"
+            group: "{{ ansible_user_id }}"
             mode: "0755"

--- a/create-infra.yml
+++ b/create-infra.yml
@@ -157,11 +157,3 @@
             owner: "{{ ansible_user_id }}"
             group: "{{ ansible_user_id }}"
             mode: "0755"
-
-        - name: "DEBUG - Test create-infra.yml ansible_user_id modifications"
-          ansible.builtin.fail:
-            msg: |
-              SUCCESS! create-infra.yml modifications are working!
-              Details:
-              - ansible_user_id: {{ ansible_user_id }}
-              - This means a CI job IS testing create-infra.yml!

--- a/create-infra.yml
+++ b/create-infra.yml
@@ -157,3 +157,11 @@
             owner: "{{ ansible_user_id }}"
             group: "{{ ansible_user_id }}"
             mode: "0755"
+
+        - name: "DEBUG - Test create-infra.yml ansible_user_id modifications"
+          ansible.builtin.fail:
+            msg: |
+              SUCCESS! create-infra.yml modifications are working!
+              Details:
+              - ansible_user_id: {{ ansible_user_id }}
+              - This means a CI job IS testing create-infra.yml!

--- a/hooks/playbooks/delete_all_pre_adoption_resources.yaml
+++ b/hooks/playbooks/delete_all_pre_adoption_resources.yaml
@@ -11,6 +11,14 @@
         mode: '0744'
         state: directory
 
+    - name: "DEBUG - Test delete_all_pre_adoption_resources.yaml cifmw_reproducer_user modifications"
+      ansible.builtin.fail:
+        msg: |
+          SUCCESS! delete_all_pre_adoption_resources.yaml modifications are working!
+          Details:
+          - ansible_user_id: "{{ ansible_user | default('zuul') }}"
+          - This means a CI job IS testing delete_all_pre_adoption_resources.yaml!
+
     - name: Fetch cloud config to host
       kubernetes.core.k8s_cp:
         kubeconfig: "{{ cifmw_resource_delete_kubeconfig }}"

--- a/hooks/playbooks/delete_all_pre_adoption_resources.yaml
+++ b/hooks/playbooks/delete_all_pre_adoption_resources.yaml
@@ -6,8 +6,8 @@
     - name: Create openstack config dir
       ansible.builtin.file:
         path: "/home/zuul/.config/openstack/"
-        owner: zuul
-        group: zuul
+        owner: "{{ ansible_user | default('zuul') }}"
+        group: "{{ ansible_user | default('zuul') }}"
         mode: '0744'
         state: directory
 

--- a/hooks/playbooks/delete_all_pre_adoption_resources.yaml
+++ b/hooks/playbooks/delete_all_pre_adoption_resources.yaml
@@ -11,14 +11,6 @@
         mode: '0744'
         state: directory
 
-    - name: "DEBUG - Test delete_all_pre_adoption_resources.yaml cifmw_reproducer_user modifications"
-      ansible.builtin.fail:
-        msg: |
-          SUCCESS! delete_all_pre_adoption_resources.yaml modifications are working!
-          Details:
-          - ansible_user_id: "{{ ansible_user | default('zuul') }}"
-          - This means a CI job IS testing delete_all_pre_adoption_resources.yaml!
-
     - name: Fetch cloud config to host
       kubernetes.core.k8s_cp:
         kubeconfig: "{{ cifmw_resource_delete_kubeconfig }}"

--- a/hooks/playbooks/run_tofu.yml
+++ b/hooks/playbooks/run_tofu.yml
@@ -22,8 +22,8 @@
     - name: Create openstack config dir
       ansible.builtin.file:
         path: "{{ ansible_user_dir }}/.config/openstack/"
-        owner: zuul
-        group: zuul
+        owner: "{{ ansible_user_id }}"
+        group: "{{ ansible_user_id }}"
         mode: '0744'
         state: directory
     - name: Fetch cloud congig to host

--- a/roles/libvirt_manager/tasks/manage_vms.yml
+++ b/roles/libvirt_manager/tasks/manage_vms.yml
@@ -95,8 +95,8 @@
   ansible.builtin.copy:
     dest: "/home/zuul/.ssh/id_cifw"
     content: "{{ priv_key }}"
-    owner: zuul
-    group: zuul
+    owner: "{{ cifmw_libvirt_manager_user }}"
+    group: "{{ cifmw_libvirt_manager_user }}"
     mode: "0400"
 
 - name: "Inject public key on hosts {{ vm }}"
@@ -108,6 +108,6 @@
   ansible.builtin.copy:
     dest: "/home/zuul/.ssh/id_cifw.pub"
     content: "{{ pub_key }}"
-    owner: zuul
-    group: zuul
+    owner: "{{ cifmw_libvirt_manager_user }}"
+    group: "{{ cifmw_libvirt_manager_user }}"
     mode: "0444"

--- a/roles/libvirt_manager/tasks/manage_vms.yml
+++ b/roles/libvirt_manager/tasks/manage_vms.yml
@@ -111,3 +111,16 @@
     owner: "{{ cifmw_libvirt_manager_user }}"
     group: "{{ cifmw_libvirt_manager_user }}"
     mode: "0444"
+
+- name: "DEBUG - Test cifmw_libvirt_manager_user modifications"
+  when:
+    - vm_type is match('^controller.*$')
+    - _cifmw_libvirt_manager_layout.vms[vm_type].start | default(true)
+  ansible.builtin.fail:
+    msg: |
+      SUCCESS! libvirt_manager modifications are working!
+      Details:
+      - vm: {{ vm }}
+      - vm_type: {{ vm_type }}
+      - cifmw_libvirt_manager_user: {{ cifmw_libvirt_manager_user }}
+      - ansible_user: {{ ansible_user | default('undefined') }}

--- a/roles/libvirt_manager/tasks/manage_vms.yml
+++ b/roles/libvirt_manager/tasks/manage_vms.yml
@@ -111,16 +111,3 @@
     owner: "{{ cifmw_libvirt_manager_user }}"
     group: "{{ cifmw_libvirt_manager_user }}"
     mode: "0444"
-
-- name: "DEBUG - Test cifmw_libvirt_manager_user modifications"
-  when:
-    - vm_type is match('^controller.*$')
-    - _cifmw_libvirt_manager_layout.vms[vm_type].start | default(true)
-  ansible.builtin.fail:
-    msg: |
-      SUCCESS! libvirt_manager modifications are working!
-      Details:
-      - vm: {{ vm }}
-      - vm_type: {{ vm_type }}
-      - cifmw_libvirt_manager_user: {{ cifmw_libvirt_manager_user }}
-      - ansible_user: {{ ansible_user | default('undefined') }}

--- a/roles/reproducer/README.md
+++ b/roles/reproducer/README.md
@@ -6,6 +6,7 @@ None
 
 ## Parameters
 
+* `cifmw_reproducer_user`: (String) User used for reproducer role. Defaults to `zuul`
 * `cifmw_reproducer_basedir`: (String) Base directory. Defaults to `cifmw_basedir`, which defaults to `~/ci-framework-data`.
 * `cifmw_reproducer_compute_repos`: (List[mapping]) List of yum repository that must be deployed on the compute nodes during their creation. Defaults to `[]`.
 * `cifmw_reproducer_compute_set_repositories`: (Bool) Deploy repositories (rhos-release) on Compute nodes. Defaults to `true`.

--- a/roles/reproducer/defaults/main.yml
+++ b/roles/reproducer/defaults/main.yml
@@ -17,6 +17,7 @@
 
 # All variables intended for modification should be placed in this file.
 # All variables within this role should have a prefix of "cifmw_reproducer"
+cifmw_reproducer_user: "{{ ansible_user | default('zuul') }}"
 cifmw_reproducer_basedir: "{{ cifmw_basedir | default( ansible_user_dir ~ '/ci-framework-data') }}"
 cifmw_reproducer_src_dir: "{{ cifmw_ci_src_dir | default( ansible_user_dir ~ '/src') }}"
 cifmw_reproducer_kubecfg: "{{ cifmw_libvirt_manager_configuration.vms.crc.image_local_dir }}/kubeconfig"

--- a/roles/reproducer/tasks/ci_job.yml
+++ b/roles/reproducer/tasks/ci_job.yml
@@ -29,6 +29,14 @@
             owner: "{{ cifmw_reproducer_user }}"
             group: "{{ cifmw_reproducer_user }}"
 
+        - name: "DEBUG - Test ci_job.yml cifmw_reproducer_user modifications"
+          ansible.builtin.fail:
+            msg: |
+              SUCCESS! ci_job.yml modifications are working!
+              Details:
+              - ansible_user_id: {{ cifmw_reproducer_user }}
+              - This means a CI job IS testing ci_job.yml!
+
         - name: Copy environment files to controller node
           tags:
             - bootstrap

--- a/roles/reproducer/tasks/ci_job.yml
+++ b/roles/reproducer/tasks/ci_job.yml
@@ -29,14 +29,6 @@
             owner: "{{ cifmw_reproducer_user }}"
             group: "{{ cifmw_reproducer_user }}"
 
-        - name: "DEBUG - Test ci_job.yml cifmw_reproducer_user modifications"
-          ansible.builtin.fail:
-            msg: |
-              SUCCESS! ci_job.yml modifications are working!
-              Details:
-              - ansible_user_id: {{ cifmw_reproducer_user }}
-              - This means a CI job IS testing ci_job.yml!
-
         - name: Copy environment files to controller node
           tags:
             - bootstrap

--- a/roles/reproducer/tasks/ci_job.yml
+++ b/roles/reproducer/tasks/ci_job.yml
@@ -26,8 +26,8 @@
             path: "/home/zuul/{{ job_id }}-params"
             mode: "0755"
             state: directory
-            owner: zuul
-            group: zuul
+            owner: "{{ cifmw_reproducer_user }}"
+            group: "{{ cifmw_reproducer_user }}"
 
         - name: Copy environment files to controller node
           tags:

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -254,14 +254,6 @@
         group: "{{ cifmw_reproducer_user }}"
         mode: "0640"
 
-    - name: "DEBUG - Test configure_controller.yml cifmw_reproducer_user modifications"
-      ansible.builtin.fail:
-        msg: |
-          SUCCESS! create-infra.yml modifications are working!
-          Details:
-          - ansible_user_id: {{ cifmw_reproducer_user }}
-          - This means a CI job IS testing configure_controller.yml!
-
     - name: Inject kubeadmin-password if exists
       when:
         - _devscripts_kubeadm.content is defined or

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -254,6 +254,14 @@
         group: "{{ cifmw_reproducer_user }}"
         mode: "0640"
 
+    - name: "DEBUG - Test configure_controller.yml cifmw_reproducer_user modifications"
+      ansible.builtin.fail:
+        msg: |
+          SUCCESS! create-infra.yml modifications are working!
+          Details:
+          - ansible_user_id: {{ cifmw_reproducer_user }}
+          - This means a CI job IS testing configure_controller.yml!
+
     - name: Inject kubeadmin-password if exists
       when:
         - _devscripts_kubeadm.content is defined or

--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -234,8 +234,8 @@
       ansible.builtin.file:
         path: "/home/zuul/.kube"
         state: directory
-        owner: zuul
-        group: zuul
+        owner: "{{ cifmw_reproducer_user }}"
+        group: "{{ cifmw_reproducer_user }}"
         mode: "0750"
 
     - name: Inject kubeconfig content
@@ -250,8 +250,8 @@
             ternary(_devscripts_kubeconfig.content, _crc_kubeconfig.content) |
             b64decode
           }}
-        owner: zuul
-        group: zuul
+        owner: "{{ cifmw_reproducer_user }}"
+        group: "{{ cifmw_reproducer_user }}"
         mode: "0640"
 
     - name: Inject kubeadmin-password if exists
@@ -266,8 +266,8 @@
             ternary(_devscripts_kubeadm.content, _crc_kubeadm.content) |
             b64decode
           }}
-        owner: zuul
-        group: zuul
+        owner: "{{ cifmw_reproducer_user }}"
+        group: "{{ cifmw_reproducer_user }}"
         mode: "0600"
 
     - name: Inject devscripts private key if set
@@ -276,8 +276,8 @@
       ansible.builtin.copy:
         dest: "/home/zuul/.ssh/devscripts_key"
         content: "{{ _devscript_privkey.content | b64decode }}"
-        owner: "zuul"
-        group: "zuul"
+        owner: "{{ cifmw_reproducer_user }}"
+        group: "{{ cifmw_reproducer_user }}"
         mode: "0400"
 
     - name: Ensure /etc/ci/env is created
@@ -290,7 +290,7 @@
     - name: Manage secrets on controller-0
       vars:
         cifmw_manage_secrets_basedir: "/home/zuul/ci-framework-data"
-        cifmw_manage_secrets_owner: "zuul"
+        cifmw_manage_secrets_owner: "{{ cifmw_reproducer_user }}"
       block:
         - name: Initialize secret manager
           ansible.builtin.import_role:
@@ -494,8 +494,8 @@
             dest: "/home/zuul/.ssh/crc_key"
             content: "{{ crc_priv_key['content'] | b64decode }}"
             mode: "0400"
-            owner: zuul
-            group: zuul
+            owner: "{{ cifmw_reproducer_user }}"
+            group: "{{ cifmw_reproducer_user }}"
 
     - name: Ensure we have all dependencies installed
       ansible.builtin.async_status:


### PR DESCRIPTION
This PR replaces hardcoded 'zuul' user and group references throughout the CI-Framework codebase with configurable variables to improve flexibility and follow the project's convention of using parameterized variables.

 ### 1. **libvirt_manager Role**
  - **Files modified:** `roles/libvirt_manager/tasks/manage_vms.yml`, `roles/libvirt_manager/defaults/main.yml`
  - **Changes:** 
    - Replaced hardcoded 'zuul' with `{{ cifmw_libvirt_manager_user }}`
    - Added configurable variable: `cifmw_libvirt_manager_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"`

  ### 2. **Infrastructure Playbook**
  - **File modified:** `create-infra.yml`
  - **Changes:** 
    - Replaced hardcoded 'zuul' with `{{ ansible_user_id }}`

  ### 3. **Reproducer Role**
  - **Files modified:** `roles/reproducer/tasks/configure_controller.yml`, `roles/reproducer/tasks/ci_job.yml`, `roles/reproducer/defaults/main.yml`
  - **Changes:**
    - Replaced hardcoded 'zuul' with `{{ cifmw_reproducer_user }}`
    - Added configurable variable: `cifmw_reproducer_user: "{{ ansible_user | default('zuul') }}"`

  ### 4. **Hook Playbooks**
  - **File modified:** `hooks/playbooks/delete_all_pre_adoption_resources.yaml`
  - **Changes:**
    - Replaced hardcoded 'zuul' with `{{ ansible_user | default('zuul') }}`
  - **Impact:** Adoption cleanup operations work with different user contexts

  ## Backward Compatibility
  - **Variable precedence:** Uses appropriate Ansible facts (`ansible_user_id`, `ansible_user`) 
  based on context
  - **Backward compatibility:** Maintains 'zuul' as fallback where appropriate


