### PR TITLE
Allow to add metadata labels to BMH

### DIFF
--- a/roles/deploy_bmh/template/bmh.yml.j2
+++ b/roles/deploy_bmh/template/bmh.yml.j2
@@ -11,6 +11,11 @@ metadata:
   labels:
     app: {{ node_data['label'] | default("openstack") }}
     workload: {{ node_name.split('-')[0] }}
+{% if 'extra_labels' in node_data %}
+{% for label,key in node_data['extra_labels'].items() %}
+    {{ label }}: {{ key }}
+{% endfor %}
+{% endif %}
 spec:
   bmc:
     address: {{ node_data['connection'] }}


### PR DESCRIPTION
This change adds the ability to add additional metadata labels in the BareMetalHost CR.

For example, having an input like this:

```
cifmw_baremetal_hosts:
  compute-0:
    ...
    extra_labels:
      server: tigon23
```

will result in a CR like this (`app` and `workload` added by default):
```
apiVersion: metal3.io/v1alpha1
kind: BareMetalHost
metadata:
    labels:
        app: openstack
        workload: compute
        server: tigon23
...
```

which in turn will allow the compute to be bound with a specific server by adding the `bmhLabelSelector` attribute under spec/nodes in the OpenStackDataPlaneNodeSet CR [0]:
```
apiVersion: dataplane.openstack.org/v1beta1
kind: OpenStackDataPlaneNodeSet
metadata:
  name: openstack-edpm
  namespace: openstack
spec:
...
  nodes:
    edpm-compute-0:
      hostName: compute-0
      bmhLabelSelector:
        server: tigon23
```

[0] https://issues.redhat.com/browse/OSPRH-13226?focusedId=26446283&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-26446283