### PR TITLE
Add logging to a file for os must gather task

### DIFF
--- a/ci/playbooks/e2e-collect-logs.yml
+++ b/ci/playbooks/e2e-collect-logs.yml
@@ -32,6 +32,8 @@
         -e "@scenarios/centos-9/base.yml"
       args:
         chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework"
+      environment:
+        ANSIBLE_LOG_PATH: "{{ ansible_user_dir }}/ci-framework-data/logs/e2e-collect-logs-must-gather.log"
 
 - name: "Run ci/playbooks/collect-logs.yml on CRC host"
   hosts: crc

--- a/roles/cifmw_setup/tasks/run_logs.yml
+++ b/roles/cifmw_setup/tasks/run_logs.yml
@@ -6,7 +6,7 @@
 
 - name: Try to load parameters files
   block:
-    - name: Check directory availabilty
+    - name: Check directory availability
       register: param_dir
       ansible.builtin.stat:
         path: "{{ cifmw_basedir }}/artifacts/parameters"


### PR DESCRIPTION
After we drop executing Ansible playbook and we move temporary to Ansible command directly, there is an issue that some tasks are not executed properly.
Add ANSIBLE_LOG_PATH for that task for now, to make clear view what is executed.