### PR TITLE
Dump openstack databases when must-gather is collected

### DIFF
--- a/roles/os_must_gather/defaults/main.yml
+++ b/roles/os_must_gather/defaults/main.yml
@@ -35,3 +35,4 @@ cifmw_os_must_gather_namespaces:
   - metallb-system
   - crc-storage
 cifmw_os_must_gather_host_network: false
+cifmw_os_must_gather_dump_db: "ALL"

--- a/roles/os_must_gather/tasks/main.yml
+++ b/roles/os_must_gather/tasks/main.yml
@@ -58,6 +58,7 @@
         PATH: "{{ cifmw_path }}"
         SOS_EDPM: "all"
         SOS_DECOMPRESS: "0"
+        OPENSTACK_DATABASES: "{{ cifmw_os_must_gather_dump_db }}"
       cifmw.general.ci_script:
         output_dir: "{{ cifmw_os_must_gather_output_dir }}/artifacts"
         script: >-
@@ -66,6 +67,7 @@
           --host-network={{ cifmw_os_must_gather_host_network }}
           --dest-dir {{ cifmw_os_must_gather_output_dir }}/logs
           -- ADDITIONAL_NAMESPACES={{ cifmw_os_must_gather_additional_namespaces }}
+          OPENSTACK_DATABASES=$OPENSTACK_DATABASES
           SOS_EDPM=$SOS_EDPM
           SOS_DECOMPRESS=$SOS_DECOMPRESS
           gather &> {{ cifmw_os_must_gather_output_dir }}/logs/os_must_gather.log


### PR DESCRIPTION
When we collect the `must-gather` info in CI, it would be useful to dump the `openstack` databases for troubleshooting purposes. In addition, this makes sure we properly test the `gather_db` code from `must-gather`.

This patch is required to test https://github.com/openstack-k8s-operators/openstack-must-gather/pull/102

Jira: https://issues.redhat.com/browse/OSPRH-19553