### PR TITLE
Add feature to exclude updating certain packages

### DIFF
--- a/ci/playbooks/multinode-customizations.yml
+++ b/ci/playbooks/multinode-customizations.yml
@@ -1,4 +1,23 @@
 ---
+- name: Exclude updating certain packages
+  hosts: all
+  tasks:
+    - name: Check if yum conf exists
+      become: true
+      ansible.builtin.stat:
+        path: "/etc/yum.conf"
+      register: _yum_conf
+
+    - name: Exclude packages for being upgraded
+      when:
+        - _yum_conf.stat.exists
+        - cifmw_excluded_updating_rpm | default([]) | length > 0
+      become: true
+      ansible.builtin.lineinfile:
+        dest: "/etc/yum.conf"
+        regexp: "^exclude="
+        line: "exclude={{ cifmw_excluded_updating_rpm | join(' ') | default([]) }}"
+
 - hosts: crc
   name: "Tweak CRC node"
   gather_facts: false


### PR DESCRIPTION
In some CI jobs, especially where some systems are based on RHEL and there are additional repositories provided, where packages belongs to CentOS, it can be a situation where the SSHd service would raise an issue:

    kex_exchange_identification: read: Connection reset by peer

Where on the host, sshd service raises a message:

    OpenSSL version mismatch. Built against 30000070, you have 30500010

With that way, we are able to add into the Zuul job vars and exclude the packages like 'openssl-libs*' (in that case) for being updated.