### PR TITLE
Add two dz-storage post-deployment playbooks

### DIFF
--- a/hooks/playbooks/dz_storage_post_deploy_az.yaml
+++ b/hooks/playbooks/dz_storage_post_deploy_az.yaml
@@ -1,0 +1,72 @@
+---
+# Setup Cinder volume types and Nova aggregates for dz-storage DT
+# Based on architecture/examples/dt/dz-storage/validate.md
+
+- name: Setup dz-storage environment
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  tasks:
+    - name: Get service project ID
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig | default('/home/' + ansible_user | default('zuul') + '/.kube/config') }}"
+        PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
+      ansible.builtin.command: >-
+        oc rsh
+        -n openstack
+        openstackclient
+        openstack project show service -c id -f value
+      register: service_project_result
+
+    - name: Set service project ID
+      ansible.builtin.set_fact:
+        service_project_id: "{{ service_project_result.stdout | trim }}"
+
+    - name: Create Cinder volume types for Glance multistore
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig | default('/home/' + ansible_user | default('zuul') + '/.kube/config') }}"
+        PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
+      ansible.builtin.command: >-
+        oc rsh
+        -n openstack
+        openstackclient
+        openstack volume type create --private
+        --project "{{ service_project_id }}"
+        --property "RESKEY:availability_zones={{ item.zone }}"
+        {{ item.name }}
+      loop:
+        - { name: "glance-iscsi-az0", zone: "az0" }
+        - { name: "glance-iscsi-az1", zone: "az1" }
+        - { name: "glance-iscsi-az2", zone: "az2" }
+      failed_when: false  # Types might already exist
+
+    - name: Create Nova aggregates for availability zones
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig | default('/home/' + ansible_user | default('zuul') + '/.kube/config') }}"
+        PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
+      ansible.builtin.command: >-
+        oc rsh
+        -n openstack
+        openstackclient
+        openstack aggregate create {{ item }} --zone {{ item }}
+      loop:
+        - "az0"
+        - "az1"
+        - "az2"
+      failed_when: false  # Aggregates might already exist
+
+    - name: Add compute hosts to availability zone aggregates
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig | default('/home/' + ansible_user | default('zuul') + '/.kube/config') }}"
+        PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
+      ansible.builtin.command: >-
+        oc rsh
+        -n openstack
+        openstackclient
+        openstack aggregate add host {{ item.az }} {{ item.host }}
+      loop:
+        - { az: "az0", host: "r0-compute-0.ctlplane.example.com" }
+        - { az: "az0", host: "r0-compute-1.ctlplane.example.com" }
+        - { az: "az1", host: "r1-compute-0.ctlplane.example.com" }
+        - { az: "az1", host: "r1-compute-1.ctlplane.example.com" }
+        - { az: "az2", host: "r2-compute-0.ctlplane.example.com" }
+        - { az: "az2", host: "r2-compute-1.ctlplane.example.com" }
+      failed_when: false  # Hosts might already be in aggregates

--- a/hooks/playbooks/dz_storage_pre_test_images.yaml
+++ b/hooks/playbooks/dz_storage_pre_test_images.yaml
@@ -1,0 +1,143 @@
+---
+# Create and import images to all Glance stores for dz-storage DT testing
+# Based on DCN pre-test approach in ci-framework-jobs/playbooks/dcn/dcn-pre-tests.yaml
+
+- name: Prepare dz-storage images for multi-zone testing
+  hosts: "{{ cifmw_target_host | default('localhost') }}"
+  vars:
+    cirros_version: "0.6.2"
+    cirros_image_name: "cirros-{{ cirros_version }}-x86_64-disk.img"
+    cirros_download_url: "https://github.com/cirros-dev/cirros/releases/download/{{ cirros_version }}/{{ cirros_image_name }}"
+    openstack_namespace: "{{ cifmw_openstack_namespace | default('openstack') }}"
+  tasks:
+    - name: Check if cirros image already exists
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig | default('/home/' + ansible_user | default('zuul') + '/.kube/config') }}"
+        PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
+      ansible.builtin.command: >-
+        oc rsh
+        -n {{ openstack_namespace }}
+        openstackclient
+        openstack image show {{ cirros_image_name }}
+      register: _image_exists
+      failed_when: false
+
+    - name: Create and import cirros image to all glance stores
+      when: _image_exists.rc != 0
+      block:
+        - name: Get keystone public URL
+          environment:
+            KUBECONFIG: "{{ cifmw_openshift_kubeconfig | default('/home/' + ansible_user | default('zuul') + '/.kube/config') }}"
+            PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
+          ansible.builtin.command: >-
+            oc rsh
+            -n {{ openstack_namespace }}
+            openstackclient
+            openstack endpoint list --service keystone --interface public -f value -c URL
+          register: keystone_url
+
+        - name: Get admin password from secret
+          environment:
+            KUBECONFIG: "{{ cifmw_openshift_kubeconfig | default('/home/' + ansible_user | default('zuul') + '/.kube/config') }}"
+            PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
+          ansible.builtin.command: >-
+            oc get secret osp-secret -n {{ openstack_namespace }} -o jsonpath='{.data.AdminPassword}'
+          register: admin_password_b64
+
+        - name: Decode admin password
+          ansible.builtin.set_fact:
+            admin_password: "{{ admin_password_b64.stdout | b64decode }}"
+
+        - name: Download cirros image to controller
+          ansible.builtin.get_url:
+            url: "{{ cirros_download_url }}"
+            dest: "/tmp/{{ cirros_image_name }}"
+            mode: '0644'
+
+        - name: Copy cirros image to openstackclient pod
+          environment:
+            KUBECONFIG: "{{ cifmw_openshift_kubeconfig | default('/home/' + ansible_user | default('zuul') + '/.kube/config') }}"
+            PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
+          ansible.builtin.command: >-
+            oc cp
+            "/tmp/{{ cirros_image_name }}"
+            "{{ openstack_namespace }}/openstackclient:/home/cloud-admin/{{ cirros_image_name }}"
+
+        - name: Create cirros image in default glance store (az0)
+          environment:
+            KUBECONFIG: "{{ cifmw_openshift_kubeconfig | default('/home/' + ansible_user | default('zuul') + '/.kube/config') }}"
+            PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
+          ansible.builtin.command: >-
+            oc rsh
+            -n {{ openstack_namespace }}
+            openstackclient
+            openstack image create
+            --disk-format qcow2
+            --container-format bare
+            --public
+            --file "/home/cloud-admin/{{ cirros_image_name }}"
+            --import
+            "{{ cirros_image_name }}"
+
+        - name: Wait for image to become active
+          environment:
+            KUBECONFIG: "{{ cifmw_openshift_kubeconfig | default('/home/' + ansible_user | default('zuul') + '/.kube/config') }}"
+            PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
+          ansible.builtin.command: >-
+            oc rsh
+            -n {{ openstack_namespace }}
+            openstackclient
+            openstack image show {{ cirros_image_name }} -f value -c status
+          register: image_status
+          until: "'active' in image_status.stdout"
+          retries: 60
+          delay: 10
+
+        - name: Get image ID for import to other stores
+          environment:
+            KUBECONFIG: "{{ cifmw_openshift_kubeconfig | default('/home/' + ansible_user | default('zuul') + '/.kube/config') }}"
+            PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
+          ansible.builtin.command: >-
+            oc rsh
+            -n {{ openstack_namespace }}
+            openstackclient
+            openstack image show {{ cirros_image_name }} -f value -c id
+          register: image_id
+
+        - name: Import image to all glance stores (az0, az1, az2)
+          environment:
+            KUBECONFIG: "{{ cifmw_openshift_kubeconfig | default('/home/' + ansible_user | default('zuul') + '/.kube/config') }}"
+            PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
+          ansible.builtin.command: >-
+            oc rsh
+            -n {{ openstack_namespace }}
+            openstackclient
+            glance --os-auth-url {{ keystone_url.stdout | trim }}
+            --os-project-name admin
+            --os-username admin
+            --os-password {{ admin_password }}
+            --os-user-domain-name default
+            --os-project-domain-name default
+            image-import {{ image_id.stdout | trim }}
+            --all-stores True
+            --import-method copy-image
+
+        - name: Verify image is available in all stores
+          environment:
+            KUBECONFIG: "{{ cifmw_openshift_kubeconfig | default('/home/' + ansible_user | default('zuul') + '/.kube/config') }}"
+            PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
+          ansible.builtin.command: >-
+            oc rsh
+            -n {{ openstack_namespace }}
+            openstackclient
+            openstack image show {{ image_id.stdout | trim }} -c properties -f value
+          register: image_stores
+
+        - name: Display image store locations
+          ansible.builtin.debug:
+            msg: "Image stores: {{ image_stores.stdout }}"
+
+        - name: Clean up local image file
+          ansible.builtin.file:
+            path: "/tmp/{{ cirros_image_name }}"
+            state: absent


### PR DESCRIPTION
Before tempest can be run in the dz-storage scenario, the following two playbooks need to be run.

1. dz_storage_post_deploy_az.yaml

This playbook creates Cinder volume types (needed by Glance) and Nova aggregates required for the dz-storage topology after EDPM deployment. These types and aggregates are necessary in order for the Tempest tests to pass.

2. dz_storage_pre_test_images.yaml

This playbook downloads a cirros image, creates it in the default store and imports to all stores using --all-stores flag. Tempest cannot handle multi-zone image creation on its own.


Co-authored-by: Claude (AI Assistant) claude@anthropic.com