### PR TITLE
[jobs] Add override checkout to ci-framework and repo-setup

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -76,7 +76,8 @@
     required-projects:
       - opendev.org/zuul/zuul-jobs
       - openstack-k8s-operators/barbican-operator
-      - openstack-k8s-operators/ci-framework
+      - name: openstack-k8s-operators/ci-framework
+        override-checkout: main
       - openstack-k8s-operators/cinder-operator
       - openstack-k8s-operators/designate-operator
       - openstack-k8s-operators/glance-operator
@@ -96,7 +97,8 @@
       - openstack-k8s-operators/openstack-operator
       - openstack-k8s-operators/ovn-operator
       - openstack-k8s-operators/placement-operator
-      - openstack-k8s-operators/repo-setup
+      - name: openstack-k8s-operators/repo-setup
+        override-checkout: main
       - openstack-k8s-operators/swift-operator
       - openstack-k8s-operators/tcib
       - openstack-k8s-operators/telemetry-operator
@@ -128,13 +130,15 @@
     nodeset: centos-9-medium-centos-9-crc-cloud-ocp-4-18-1-3xl
     irrelevant-files: *ir_files
     required-projects: &multinode_edpm_rp
-      - openstack-k8s-operators/ci-framework
+      - name: openstack-k8s-operators/ci-framework
+        override-checkout: main
       - openstack-k8s-operators/install_yamls
       - openstack-k8s-operators/infra-operator
       - openstack-k8s-operators/openstack-baremetal-operator
       - openstack-k8s-operators/openstack-must-gather
       - openstack-k8s-operators/openstack-operator
-      - openstack-k8s-operators/repo-setup
+      - name: openstack-k8s-operators/repo-setup
+        override-checkout: main
       - openstack-k8s-operators/edpm-ansible
     roles: &multinode_edpm_roles
       - zuul: github.com/openstack-k8s-operators/ci-framework
@@ -270,13 +274,15 @@
     abstract: true
     irrelevant-files: *ir_files
     required-projects:
-      - openstack-k8s-operators/ci-framework
+      - name: openstack-k8s-operators/ci-framework
+        override-checkout: main
       - openstack-k8s-operators/install_yamls
       - openstack-k8s-operators/infra-operator
       - openstack-k8s-operators/openstack-baremetal-operator
       - openstack-k8s-operators/openstack-must-gather
       - openstack-k8s-operators/openstack-operator
-      - openstack-k8s-operators/repo-setup
+      - name: openstack-k8s-operators/repo-setup
+        override-checkout: main
       - openstack-k8s-operators/edpm-ansible
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework

--- a/zuul.d/edpm_build_images_content_provider.yaml
+++ b/zuul.d/edpm_build_images_content_provider.yaml
@@ -7,7 +7,8 @@
     required-projects:
       - opendev.org/zuul/zuul-jobs
       - github.com/openstack-k8s-operators/edpm-image-builder
-      - github.com/openstack-k8s-operators/ci-framework
+      - name: github.com/openstack-k8s-operators/ci-framework
+        override-checkout: main
     pre-run:
       - ci/playbooks/content_provider/pre.yml
     run:

--- a/zuul.d/pods.yaml
+++ b/zuul.d/pods.yaml
@@ -8,7 +8,8 @@
     description: |
       Run lightweight jobs in pods
     required-projects:
-      - openstack-k8s-operators/ci-framework
+      - name: openstack-k8s-operators/ci-framework
+        override-checkout: main
     run: ci/playbooks/pod-jobs.yml
 
 - job:

--- a/zuul.d/tcib.yaml
+++ b/zuul.d/tcib.yaml
@@ -6,8 +6,10 @@
     nodeset: centos-stream-9-vexxhost
     required-projects:
       - opendev.org/zuul/zuul-jobs
-      - github.com/openstack-k8s-operators/ci-framework
-      - github.com/openstack-k8s-operators/repo-setup
+      - name: github.com/openstack-k8s-operators/ci-framework
+        override-checkout: main
+      - name: github.com/openstack-k8s-operators/repo-setup
+        override-checkout: main
       - github.com/openstack-k8s-operators/tcib
       - github.com/openstack-k8s-operators/install_yamls
     pre-run:

--- a/zuul.d/tempest_multinode.yaml
+++ b/zuul.d/tempest_multinode.yaml
@@ -58,11 +58,13 @@
       - ci/playbooks/e2e-run.yml
     required-projects:
       - github.com/openstack-k8s-operators/install_yamls
-      - openstack-k8s-operators/ci-framework
+      - name: openstack-k8s-operators/ci-framework
+        override-checkout: main
       - openstack-k8s-operators/infra-operator
       - openstack-k8s-operators/openstack-baremetal-operator
       - openstack-k8s-operators/openstack-operator
-      - openstack-k8s-operators/repo-setup
+      - name: openstack-k8s-operators/repo-setup
+        override-checkout: main
       - openstack-k8s-operators/edpm-ansible
 
 - job:


### PR DESCRIPTION
All of our jobs running in operator main or stable branches are centralized in ci-framework. ci-framework since stopped preparing branches similar to operator repos i.e 18.0-fr* this resulted into jobs not running in stable operator branches without any per repo changes.

With this patch adding explicit override-check in all the jobs.

Related-Issue: https://issues.redhat.com/browse/OSPNW-998
Related-Issue: https://issues.redhat.com/browse/OSPCIX-1033