### PR TITLE
Set cifmw_ceph_ipv6 var in uni04delta-ipv6 scenario

### DIFF
--- a/scenarios/adoption/uni04delta-ipv6.yml
+++ b/scenarios/adoption/uni04delta-ipv6.yml
@@ -1,2 +1,4 @@
+---
 libvirt_manager_patch_layout: {}
 networking_mapper_definition_patch: {}
+cifmw_ceph_ipv6: true


### PR DESCRIPTION
The variable have default value set to false, so the Ceph deployment is raising an issue:

    The task includes an option with an undefined variable. The error was: ''all_addresses'' is undefined.