### PR TITLE
[edpm_prepare] Add cifmw_edpm_prepare_extra_kustomizations var

### DIFF
--- a/roles/edpm_prepare/README.md
+++ b/roles/edpm_prepare/README.md
@@ -19,3 +19,4 @@ This role doesn't need privilege escalation.
 * `cifmw_edpm_prepare_kustomizations`: (List) Kustomizations to apply on top of the controlplane CRs. Defaults to `[]`.
 * `cifmw_edpm_prepare_wait_controplane_status_change_sec`: (Integer) Time, in seconds, to wait before checking
 openstack control plane deployment status. Useful when using the role to only update the control plane resource, scenario where it may be in a `ready` status. Defaults to `30`.
+* `cifmw_edpm_prepare_extra_kustomizations`: (List) Extra Kustomizations to apply on top of the controlplane CRs. Defaults to `[]`.

--- a/roles/edpm_prepare/defaults/main.yml
+++ b/roles/edpm_prepare/defaults/main.yml
@@ -32,3 +32,4 @@ cifmw_edpm_prepare_kustomizations: []
 #  when we are modifying the control plane, since the check status task can get a
 #  false 'ready' status.
 cifmw_edpm_prepare_wait_controplane_status_change_sec: 30
+cifmw_edpm_prepare_extra_kustomizations: []

--- a/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
+++ b/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
@@ -68,7 +68,12 @@
   cifmw.general.ci_kustomize:
     target_path: "{{ cifmw_edpm_prepare_openstack_crs_path }}"
     sort_ascending: false
-    kustomizations: "{{ cifmw_edpm_prepare_kustomizations + _ctlplane_name_kustomizations }}"
+    kustomizations: >-
+      {{
+        cifmw_edpm_prepare_kustomizations +
+        _ctlplane_name_kustomizations +
+        (cifmw_edpm_prepare_extra_kustomizations | default([]))
+      }}
     kustomizations_paths: >-
       {{
         [


### PR DESCRIPTION
We have cifmw_edpm_prepare_kustomizations var to pass kustomize for applying on top of Controlplane deploy. We define them in scenario file and kustomize list is very long.

In order to test different scenario, like enabling few features on top of existing deployment already using cifmw_edpm_prepare_kustomizations var, apart from hook there is no way to pass extra set of kustomize via zuul job vars.
    
 Creating hooks for extra kustomization each time was hard to maintain based on growing number of feature testing.
    
 This pr introduces a new cifmw_edpm_prepare_extra_kustomizations var to pass additional kustomization via zuul jobs allow use to enable/disable certain features easily.
    
 It is needed for watcher operator testing.

Test results:

- master (default config with enabled nova-notifications): [https://logserver.rdoproject.org/609/rdoproject.org/609af4fc1f76408a8ac6a11ce4152863/cont[…]penstack/crs/watchers.watcher.openstack.org/watcher.yaml](https://logserver.rdoproject.org/609/rdoproject.org/609af4fc1f76408a8ac6a11ce4152863/controller/ci-framework-data/logs/openstack-k8s-operators-openstack-must-gather/namespaces/openstack/crs/watchers.watcher.openstack.org/watcher.yaml)
- epoxy (no nova-notifications and model collector set to 60): [https://logserver.rdoproject.org/270/rdoproject.org/27027b40b8174ca0b2340646cee34867/cont[…]penstack/crs/watchers.watcher.openstack.org/watcher.yaml](https://logserver.rdoproject.org/270/rdoproject.org/27027b40b8174ca0b2340646cee34867/controller/ci-framework-data/logs/openstack-k8s-operators-openstack-must-gather/namespaces/openstack/crs/watchers.watcher.openstack.org/watcher.yaml)

