### PR TITLE
Add post_ceph var for deploying Ceph in edpm ceph scenario

### DIFF
--- a/scenarios/centos-9/ceph_backends.yml
+++ b/scenarios/centos-9/ceph_backends.yml
@@ -1,5 +1,6 @@
 ---
 cifmw_control_plane_ceph_backend_include_vars: "{{ cifmw_basedir }}/artifacts/pre_deploy_61_ceph_deploy.yml"
+cifmw_cephadm_log_path: "{{ cifmw_basedir }}/logs"
 
 cifmw_install_yamls_vars:
   BMO_SETUP: false
@@ -10,6 +11,11 @@ cifmw_edpm_prepare_skip_crc_storage_creation: true
 cifmw_make_ceph_environment:
   CEPH_TIMEOUT: 120
   CEPH_DATASIZE: "10Gi"
+
+post_ceph:
+  - name: 80 Run Ceph hook playbook
+    type: playbook
+    source: ceph.yml
 
 pre_deploy:
   - name: 61 Ceph deploy

--- a/scenarios/centos-9/hci_ceph_backends.yml
+++ b/scenarios/centos-9/hci_ceph_backends.yml
@@ -1,4 +1,6 @@
 ---
+cifmw_cephadm_log_path: "{{ cifmw_basedir }}/logs"
+
 cifmw_install_yamls_vars:
   BMO_SETUP: false
   INSTALL_CERT_MANAGER: false
@@ -16,8 +18,6 @@ post_ceph:
   - name: 80 Run Ceph hook playbook
     type: playbook
     source: ceph.yml
-
-cifmw_cephadm_log_path: /home/zuul/ci-framework-data/logs
 
 post_deploy:
   - name: 81 Kustomize OpenStack CR with Ceph


### PR DESCRIPTION
The variable was missing, so the post_ceph hook was not executed.