### PR TITLE
Add missing vars for update role

### DIFF
--- a/roles/update/defaults/main.yml
+++ b/roles/update/defaults/main.yml
@@ -67,3 +67,6 @@ cifmw_update_ctl_plane_max_tries: 84
 
 # Resource Monitoring during update
 cifmw_update_resources_monitoring_interval: 10 # in seconds.
+
+cifmw_openshift_kubeconfig: "{{ ansible_user_dir  }}/.crc/machines/crc/kubeconfig"
+cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"


### PR DESCRIPTION
There are some missing variables, so the Ansible is raising an error:

    task path: /home/zuul/src/github.com/openstack-k8s-operators/ci-framework/roles/update/tasks/init_monitoring.yml:29
    fatal: [localhost]: FAILED! =>
        changed: false
        msg: 'AnsibleUndefinedVariable: ''cifmw_path'' is undefined. ''cifmw_path'' is undefined'