### PR TITLE
Do not wipe Ansible facts in post stage

### DIFF
--- a/roles/cifmw_setup/tasks/run_logs.yml
+++ b/roles/cifmw_setup/tasks/run_logs.yml
@@ -94,8 +94,3 @@
           }}
         mode: "0777"
         remote_src: true
-
-    - name: Clean ansible fact cache
-      ansible.builtin.file:
-        path: "{{ ansible_user_dir }}/ansible_facts_cache"
-        state: absent


### PR DESCRIPTION
Some CI jobs are executing post tasks even when the CI job is not finished yet. Those variables might be required for next ongoing tasks.