### PR TITLE
update ceph var for ipv6

### DIFF
--- a/hooks/playbooks/ceph.yml
+++ b/hooks/playbooks/ceph.yml
@@ -163,7 +163,7 @@
     - name: Set IPv4 facts
       when:
         - ansible_all_ipv4_addresses | length > 0
-        - not ceph_ipv6 | default(false)
+        - not cifmw_ceph_ipv6 | default(false)
       ansible.builtin.set_fact:
         ssh_network_range: 192.168.122.0/24
         # storage_network_range: 172.18.0.0/24
@@ -175,7 +175,7 @@
     - name: Set IPv6 facts
       when:
         - ansible_all_ipv6_addresses | length > 0
-        - ceph_ipv6 | default(false)
+        - cifmw_ceph_ipv6 | default(false)
       ansible.builtin.set_fact:
         ssh_network_range: "2620:cf:cf:aaaa::/64"
         # storage_network_range: "2620:cf:cf:cccc::/64"
@@ -214,7 +214,7 @@
           when:
             - cifmw_networking_env_definition is defined
             - ansible_all_ipv4_addresses | length > 0
-            - not ceph_ipv6 | default(false)
+            - not cifmw_ceph_ipv6 | default(false)
           ansible.builtin.set_fact:
             storage_network_range: >-
               {{
@@ -229,7 +229,7 @@
           when:
             - cifmw_networking_env_definition is defined
             - ansible_all_ipv6_addresses | length > 0
-            - ceph_ipv6 | default(false)
+            - cifmw_ceph_ipv6 | default(false)
           ansible.builtin.set_fact:
             storage_network_range: >-
               {{
@@ -318,7 +318,7 @@
     - name: Set IPv4 facts
       when:
         - ansible_all_ipv4_addresses | length > 0
-        - not ceph_ipv6 | default(false)
+        - not cifmw_ceph_ipv6 | default(false)
       ansible.builtin.set_fact:
         all_addresses: ansible_all_ipv4_addresses
         cidr: 24
@@ -326,7 +326,7 @@
     - name: Set IPv6 facts
       when:
         - ansible_all_ipv6_addresses | length > 0
-        - ceph_ipv6 | default(false)
+        - cifmw_ceph_ipv6 | default(false)
       ansible.builtin.set_fact:
         all_addresses: ansible_all_ipv6_addresses
         cidr: 64


### PR DESCRIPTION
cifmw filters vars only with prefix cifmw- so
updating the var so that it can be propogated
duirng job execution.