### PR TITLE
update_containers: allow to set full URIs for volume containers

### DIFF
--- a/roles/update_containers/README.md
+++ b/roles/update_containers/README.md
@@ -17,6 +17,7 @@ If apply, please explain the privilege escalation done in this role.
 * `cifmw_update_containers_org`: The container registry namespace to pull container from. Default to `podified-antelope-centos9`
 * `cifmw_update_containers_tag`: The container tag. Default to "current-podified".
 * `cifmw_update_containers_cindervolumes`: The names of the cinder volumes prefix. Default to `[]`.
+* `cifmw_update_containers_cindervolumes_extra`: Additional cinder volumes containers, meaning names and container URIs. Default to `{}`.
 * `cifmw_update_containers_manilashares`: The names of the manila shares prefix. Default to `[]`.
 * `cifmw_update_containers_agentimage`: Full Agent Image url for updating Agent Image.
 * `cifmw_update_containers_ceilometersgcoreImage`: Full Ceilometersgcore Image url for updating Ceilometersgcore Image.

--- a/roles/update_containers/defaults/main.yml
+++ b/roles/update_containers/defaults/main.yml
@@ -42,6 +42,7 @@ cifmw_update_containers_openstack: false
 cifmw_update_containers_rollback: false
 cifmw_update_containers_cindervolumes:
   - default
+cifmw_update_containers_cindervolumes_extra: {}
 cifmw_update_containers_manilashares:
   - default
 cifmw_update_containers_watcher: false

--- a/roles/update_containers/templates/update_containers.j2
+++ b/roles/update_containers/templates/update_containers.j2
@@ -77,12 +77,21 @@ spec:
     swiftObjectImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-swift-object:{{ cifmw_update_containers_tag }}
     swiftProxyImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-swift-proxy-server:{{ cifmw_update_containers_tag }}
     testTempestImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-tempest-all:{{ cifmw_update_containers_tag }}
-{% if cifmw_update_containers_cindervolumes | length > 0     %}
+{% if (cifmw_update_containers_cindervolumes | length > 0  or
+       (cifmw_update_containers_cindervolumes_extra is defined and cifmw_update_containers_cindervolumes_extra is mapping)) %}
     cinderVolumeImages:
+{% endif %}
+{% if cifmw_update_containers_cindervolumes | length > 0     %}
 {% for vol in cifmw_update_containers_cindervolumes          %}
       {{ vol }}: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-cinder-volume:{{ cifmw_update_containers_tag }}
 {% endfor                                                    %}
 {% endif                                                     %}
+{% if (cifmw_update_containers_cindervolumes_extra is defined and
+       cifmw_update_containers_cindervolumes_extra is mapping) %}
+{% for container_name, container_uri in cifmw_update_containers_cindervolumes_extra.items() %}
+      {{ container_name }}: {{ container_uri }}
+{% endfor %}
+{% endif %}
 {% if cifmw_update_containers_manilashares | length > 0      %}
     manilaShareImages:
 {% for shares in cifmw_update_containers_manilashares        %}


### PR DESCRIPTION
Sometimes the container used for cinder-volume needs to be fetched from a 3rd-party container registry.
Thanks to cifmw_update_containers_cindervolumes_extra it is now possible to configure such containers.