### PR TITLE
openshift_setup: enable registry.connect.redhat.com too

### DIFF
--- a/roles/openshift_setup/tasks/main.yml
+++ b/roles/openshift_setup/tasks/main.yml
@@ -176,6 +176,7 @@
       - "gcr.io"
       - "registry.k8s.io"
       - "registry.redhat.io"
+      - "registry.connect.redhat.com"
       - "registry-proxy.engineering.redhat.com"
       - "images.paas.redhat.com"
       - "image-registry.openshift-image-registry.svc:5000"


### PR DESCRIPTION
It is the official registry of the 3rd-party container images.