### PR TITLE
Check if hook is properly defined for execution

### DIFF
--- a/roles/run_hook/tasks/main.yml
+++ b/roles/run_hook/tasks/main.yml
@@ -77,3 +77,7 @@
       loop: "{{ _hooks }}"
       loop_control:
         loop_var: 'hook'
+      when:
+        - hook | length > 0
+        - hook.type is defined
+        - hook.source is defined


### PR DESCRIPTION
Adding the additional `when` conditions make it possible to override the named hooks in job definitions with empty mappings (i.e. `{}`) in order to skip specific ones.

Unfortunately, because `set_fact` tasks are involved we cannot simply use the `undef()` to achieve that (it raises `Mandatory variable has not been overridden.` [1]).

[1] https://stackoverflow.com/questions/73427379/how-to-unset-a-variable-in-ansible#comment138144412_78351300

// Verified in testproject 1450