### PR TITLE
Add cifmw_hci_prepare_extra_services parameter

### DIFF
--- a/roles/hci_prepare/README.md
+++ b/roles/hci_prepare/README.md
@@ -15,6 +15,7 @@ None.
 * `cifmw_hci_prepare_storage_mgmt_mtu`: (Int) Storage-Management network MTU. Defaults to `1500`.
 * `cifmw_hci_prepare_storage_mgmt_vlan`: (Int) Storage-Management network VLAn. Defaults to `23`.
 * `cifmw_hci_prepare_namespace`: (String) Namespace to use to apply resources if install-yamls is not used. Defaults to `openstack`.
+* `cifmw_hci_prepare_extra_services`: (List) List of additional services to add to the OpenStackDataPlaneNodeSet `services` list during HCI deployment. This allows you to customize which extra services are enabled on the EDPM nodes beyond the default set. Defaults to an empty list.
 
 ## Examples
 ### 1 - How to deploy HCI using hci_prepare and edpm_deploy

--- a/roles/hci_prepare/defaults/main.yml
+++ b/roles/hci_prepare/defaults/main.yml
@@ -24,3 +24,4 @@ cifmw_hci_prepare_enable_repo_setup_service: true
 cifmw_hci_prepare_storage_mgmt_mtu: 1500
 cifmw_hci_prepare_storage_mgmt_vlan: 23
 cifmw_hci_prepare_namespace: openstack
+cifmw_hci_prepare_extra_services: []

--- a/roles/hci_prepare/tasks/phase2.yml
+++ b/roles/hci_prepare/tasks/phase2.yml
@@ -116,6 +116,12 @@
               - neutron-metadata
               - libvirt
               - nova-custom-ceph
+      {% if cifmw_hci_prepare_extra_services | length > 0 %}
+      {%   for svc in cifmw_hci_prepare_extra_services %}
+              - {{ svc }}
+      {%   endfor %}
+      {% endif %}
+
 
 - name: Enabled nova discover_hosts after deployment
   ansible.builtin.set_fact:


### PR DESCRIPTION
Add cifmw_hci_prepare_extra_services parameter to hci_prepare role. This
parameter allows the user to specify extra services in the dataplane
when deploying using hci, for example, adding the telemetry service. By
default, the parameter is empty and will do nothing.
