### PR TITLE
Run nova-manage discover_hosts in ci_script

### DIFF
--- a/roles/edpm_deploy/tasks/main.yml
+++ b/roles/edpm_deploy/tasks/main.yml
@@ -173,11 +173,12 @@
   environment:
     PATH: "{{ cifmw_path }}"
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-  ansible.builtin.command:
-    cmd: >-
-      oc rsh
-      --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }}
-      nova-cell0-conductor-0 nova-manage cell_v2 discover_hosts --verbose
+  cifmw.general.ci_script:
+    output_dir: "{{ cifmw_basedir }}/artifacts"
+    executable: "/bin/bash"
+    script: |
+      set -xe
+      oc rsh --namespace={{ cifmw_install_yamls_defaults['NAMESPACE'] }} nova-cell0-conductor-0 nova-manage cell_v2 discover_hosts --verbose
 
 - name: Validate EDPM
   when: cifmw_edpm_deploy_run_validation | bool


### PR DESCRIPTION
Run the discover_hosts hosts command in a ci_script instead of a plain
ansible command to enable debugging the output from the logs.
