### PR TITLE
Disable crio stats by default

### DIFF
--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -85,7 +85,7 @@
           loop: "{{ files_to_copy.files }}"
 
         - name: Copy crio stats log file
-          when: cifmw_openshift_crio_stats | default(true)
+          when: cifmw_openshift_crio_stats | default(false)
           ignore_errors: true  # noqa: ignore-errors
           ansible.builtin.copy:
             src: /tmp/crio-stats.log

--- a/ci/playbooks/e2e-prepare.yml
+++ b/ci/playbooks/e2e-prepare.yml
@@ -39,7 +39,7 @@
           /usr/bin/date >> /tmp/crio-stats.log;
           {{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/scripts/get-stats.sh >>
           /tmp/crio-stats.log
-      when: cifmw_openshift_crio_stats | default(true)
+      when: cifmw_openshift_crio_stats | default(false)
 
     - name: Construct project change list
       ansible.builtin.set_fact:


### PR DESCRIPTION
The stats require some resource to utilize each minute and it might affect CI job result.
Let's enable it when it is needed.