### PR TITLE
run_hook: fix the condition which makes an hook valid

### DIFF
--- a/roles/run_hook/tasks/main.yml
+++ b/roles/run_hook/tasks/main.yml
@@ -80,4 +80,3 @@
       when:
         - hook | length > 0
         - hook.type is defined
-        - hook.source is defined


### PR DESCRIPTION
A previous change to make the code more roboust (namely https://github.com/openstack-k8s-operators/ci-framework/pull/3266 ) excluded the case when an hook is a CR, which does not need a source. Remove the playbook-specific condition: only type is relevant from the run_hook point of view, the other attributes are handled by the type-specific code.
