### PR TITLE
Include read_global_vars.yml in pre-run: zuul.d/base.yaml

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -13,6 +13,7 @@
       and prepare the environment for running ci-framework playbooks.
       Once the job finishes, it will collect necessary logs.
     pre-run:
+      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
     post-run:
@@ -139,6 +140,7 @@
     roles: &multinode_edpm_roles
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run: &multinode_edpm_pre_run
+      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/multinode-customizations.yml
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
@@ -281,6 +283,7 @@
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run:
+      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
     post-run:
@@ -305,6 +308,7 @@
       CRC environment and before running ci-boostrap roles to
       configure networking between nodes.
     pre-run:
+      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
       - ci/playbooks/bootstrap-networking-mapper.yml


### PR DESCRIPTION
The reason to make the change one file per commit is our flakey jobs. It is pain to get all jobs pass at once.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3280