### PR TITLE
Include read_global_vars.yml in pre-run: zuul.d/molecule-base.yaml

### DIFF
--- a/zuul.d/molecule-base.yaml
+++ b/zuul.d/molecule-base.yaml
@@ -7,6 +7,7 @@
     provides:
       - cifmw-molecule
     pre-run:
+      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/dump_zuul_data.yml
       - ci/playbooks/molecule-prepare.yml
     run: ci/playbooks/molecule-test.yml
@@ -25,6 +26,7 @@
     provides:
       - cifmw-molecule
     pre-run:
+      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/dump_zuul_data.yml
       - ci/playbooks/molecule-prepare.yml
     run: ci/playbooks/molecule-test.yml


### PR DESCRIPTION
The reason to make the change one file per commit is our flakey jobs. It is pain to get all jobs pass at once