### PR TITLE
Include read_global_vars.yml in pre-run: zuul.d/pods.yaml

### DIFF
--- a/zuul.d/pods.yaml
+++ b/zuul.d/pods.yaml
@@ -9,6 +9,8 @@
       Run lightweight jobs in pods
     required-projects:
       - openstack-k8s-operators/ci-framework
+    pre-run:
+      - ci/playbooks/read_global_vars.yml
     run: ci/playbooks/pod-jobs.yml
 
 - job:
@@ -62,6 +64,7 @@
     parent: build-push-container-base
     nodeset: centos-stream-9
     pre-run:
+      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/molecule-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
     run: ci/playbooks/build_push_container_runner.yml


### PR DESCRIPTION
The reason to make the change one file per commit is our flakey jobs. It is pain to get all jobs pass at once