### PR TITLE
Include read_global_vars.yml in pre-run: zuul.d/edpm_build_images.yam…

### DIFF
--- a/zuul.d/edpm_build_images.yaml
+++ b/zuul.d/edpm_build_images.yaml
@@ -8,6 +8,7 @@
     required-projects:
       - github.com/openstack-k8s-operators/edpm-image-builder
     pre-run:
+      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/molecule-prepare.yml
     run:
       - ci/playbooks/dump_zuul_data.yml

--- a/zuul.d/edpm_build_images_content_provider.yaml
+++ b/zuul.d/edpm_build_images_content_provider.yaml
@@ -9,6 +9,7 @@
       - github.com/openstack-k8s-operators/edpm-image-builder
       - github.com/openstack-k8s-operators/ci-framework
     pre-run:
+      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/content_provider/pre.yml
     run:
       - ci/playbooks/e2e-prepare.yml


### PR DESCRIPTION
…l & edpm_build_images_content_provider.yaml

The reason to make the change one file per commit is our flaky jobs. It is pain to get all jobs pass at once.