### PR TITLE
Set fail-fast to true in upstream zuul project

### DIFF
--- a/ci/templates/projects.yaml
+++ b/ci/templates/projects.yaml
@@ -9,6 +9,7 @@
       - podified-multinode-edpm-ci-framework-pipeline
       - data-plane-adoption-ci-framework-pipeline
     github-check:
+      fail-fast: true
       jobs:
         - noop
         - cifmw-pod-ansible-test

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,5 +1,6 @@
 - project:
     github-check:
+      fail-fast: true
       jobs:
       - noop
       - cifmw-pod-ansible-test


### PR DESCRIPTION
fail-fast allows us to fail the entire pipeline the moment any job from the pipeline fails. Currently, we have to wait for all jobs to return their status for the pipeline to get complete. It wastes compute resoures as well as time.