### PR TITLE
kustomize_deploy: Add retry logic for transient auth failures

### DIFF
--- a/roles/kustomize_deploy/defaults/main.yml
+++ b/roles/kustomize_deploy/defaults/main.yml
@@ -219,7 +219,11 @@ cifmw_kustomize_deploy_dp_dest_file: >-
     ] | path_join
   }}
 
-# timeouts
+# timeouts and retry configuration
 
 cifmw_kustomize_deploy_delay: 10
 cifmw_kustomize_deploy_retries_install_plan: 60
+
+# Default retry settings for k8s_info operations to handle transient auth failures
+cifmw_kustomize_deploy_k8s_retries: 5
+cifmw_kustomize_deploy_k8s_delay: 30

--- a/roles/kustomize_deploy/tasks/install_operators.yml
+++ b/roles/kustomize_deploy/tasks/install_operators.yml
@@ -395,7 +395,10 @@
     context: "{{ cifmw_openshift_context | default(omit) }}"
     kind: CustomResourceDefinition
     name: openstacks.operator.openstack.org
+  retries: "{{ cifmw_kustomize_deploy_k8s_retries }}"
+  delay: "{{ cifmw_kustomize_deploy_k8s_delay }}"
   register: _cifmw_kustomize_deploy_olm_osp_operator_openstack_crd_out
+  until: _cifmw_kustomize_deploy_olm_osp_operator_openstack_crd_out is success
 
 - name: Handle OpenStack initialization, if necessary
   when: (_cifmw_kustomize_deploy_olm_osp_operator_openstack_crd_out.resources | length) > 0
@@ -447,6 +450,10 @@
           cifmw_kustomize_deploy_check_mode |
           default(false, true)
         }}
+      retries: "{{ cifmw_kustomize_deploy_k8s_retries }}"
+      delay: "{{ cifmw_kustomize_deploy_k8s_delay }}"
+      register: _openstack_operators_ready
+      until: _openstack_operators_ready is success
 
 - name: Wait until OpenStack operators are deployed and ready (old install paradigm)
   when:
@@ -468,6 +475,10 @@
       cifmw_kustomize_deploy_check_mode |
       default(false, true)
     }}
+  retries: "{{ cifmw_kustomize_deploy_k8s_retries }}"
+  delay: "{{ cifmw_kustomize_deploy_k8s_delay }}"
+  register: _openstack_operators_old_ready
+  until: _openstack_operators_old_ready is success
   with_items:
     - openstack.org/operator-name
     # The RabbitMQ operator does not share our openstack.org/operator-name label


### PR DESCRIPTION
Add configurable retry logic to kubernetes.core.k8s_info tasks that lack resilience against transient OpenShift API authentication failures.

When OpenShift is under load, API authentication can temporarily fail with HTTP 401 errors, causing the kustomize_deploy role to abort entire deployments. This change adds retry logic to the 3 vulnerable tasks:

- Wait until OpenStack operators are deployed and ready (new install paradigm)
- Wait until OpenStack operators are deployed and ready (old install paradigm)
- Check if the OpenStack initialization CRD exists

Changes:
- Add cifmw_kustomize_deploy_k8s_retries (default: 5) and cifmw_kustomize_deploy_k8s_delay (default: 30s) configuration
- Apply consistent retry pattern using retries/delay/until logic
- Aligns with existing retry patterns used by other tasks in same file

This prevents costly deployment restarts when experiencing temporary OpenShift API authentication issues.

Jira: https://issues.redhat.com/browse/OSPRH-19853