### PR TITLE
Add hook_retry parameter for run_hook role

### DIFF
--- a/roles/run_hook/README.md
+++ b/roles/run_hook/README.md
@@ -37,6 +37,7 @@ name:
 * `source`: (String) Source of the playbook. If it's a filename, the playbook is expected in `hooks/playbooks`. It can be an absolute path.
 * `type`: (String) Type of the hook. In this case, set it to `playbook`.
 * `extra_vars`: (Dict) Structure listing the extra variables you would like to pass down ([extra_vars explained](#extra_vars-explained))
+* `hook_retry` (Boolean) Set true, if the hook execution should be retried on failure
 
 ##### About OpenShift namespaces and install_yamls
 
@@ -55,6 +56,7 @@ Since `install_yamls` might not be initialized, the `run_hook` is exposing two n
 * `source`: (String) Source of the playbook. If it's a filename, the playbook is expected in `hooks/playbooks`. It can be an absolute path.
 * `type`: (String) Type of the hook. In this case, set it to `playbook`.
 * `extra_vars`: (Dict) Structure listing the extra variables you would like to pass down ([extra_vars explained](#extra_vars-explained))
+* `hook_retry` (Boolean) Set true, if the hook execution should be retried on failure
 
 #### Hook callback
 

--- a/roles/run_hook/molecule/default/converge.yml
+++ b/roles/run_hook/molecule/default/converge.yml
@@ -103,3 +103,26 @@
         that:
           - test_list is defined
           - test_list | length == 2
+
+    - name: Hooks with retry
+      block:
+        - name: Run hook with retry
+          vars:
+            step: retry_hook
+          ansible.builtin.include_role:
+            name: run_hook
+
+        - name: Check if fake file exists for retry playbook
+          ansible.builtin.stat:
+            path: /tmp/molecule-retry-fake-file
+          register: _molecule_fake_file
+
+        - name: Ensure file exists and was created on retry
+          ansible.builtin.assert:
+            that:
+              - _molecule_fake_file.stat.exists
+      always:
+        - name: Remove generated file
+          ansible.builtin.file:
+            path: /tmp/molecule-retry-fake-file
+            state: absent

--- a/roles/run_hook/molecule/default/molecule.yml
+++ b/roles/run_hook/molecule/default/molecule.yml
@@ -50,3 +50,9 @@ provisioner:
           extra_vars:
             foo: bar
             file: "/tmp/dummy-env.yml"
+
+        retry_hook:
+          - name: Run hook with retry
+            source: "/tmp/dummy-retry.yml"
+            type: playbook
+            retry_hook: true

--- a/roles/run_hook/molecule/default/prepare.yml
+++ b/roles/run_hook/molecule/default/prepare.yml
@@ -42,3 +42,14 @@
         - dummy-4.yml
         - dummy-5.yml
         - dummy-6.yml
+
+    - name: Remove dummy file for retry playbook test
+      ansible.builtin.file:
+        path: /tmp/molecule-retry-fake-file
+        state: absent
+
+    - name: Create dummy retry playbook
+      ansible.builtin.template:
+        dest: "/tmp/dummy-retry.yml"
+        src: "dummy-retry.yml.j2"
+        mode: "0644"

--- a/roles/run_hook/molecule/default/templates/dummy-retry.yml.j2
+++ b/roles/run_hook/molecule/default/templates/dummy-retry.yml.j2
@@ -1,0 +1,25 @@
+---
+- hosts: localhost
+  gather_facts: true
+  tasks:
+{% raw %}
+    - name: Check if fake file exists
+      ansible.builtin.stat:
+        path: /tmp/molecule-retry-fake-file
+      register: _molecule_fake_file
+
+    - name: Create a file, if it does not exists
+      when: not _molecule_fake_file.stat.exists
+      ansible.builtin.file:
+        path: /tmp/molecule-retry-fake-file
+        state: touch
+
+    - name: Finish if file does not exists
+      when: not _molecule_fake_file.stat.exists
+      ansible.builtin.meta: end_play
+
+    - name: Print Hello world if file exists
+      when: _molecule_fake_file.stat.exists
+      ansible.builtin.debug:
+        msg: 'Hello retry world'
+{% endraw %}

--- a/roles/run_hook/tasks/playbook.yml
+++ b/roles/run_hook/tasks/playbook.yml
@@ -89,7 +89,8 @@
 # even less from a task. So the way to run a playbook from within a playbook
 # is to call a command. Though we may lose some of the data passed to the
 # "main" play.
-- name: "Run {{ hook.name }}"
+- name: "Run hook without retry - {{ hook.name }}"
+  when: not hook.hook_retry | default(false)
   no_log: "{{ cifmw_nolog | default(true) | bool }}"
   cifmw.general.ci_script:
     output_dir: "{{ cifmw_basedir }}/artifacts"
@@ -108,6 +109,31 @@
       -e "hook_name={{ hook_name }}"
       -e "playbook_dir={{ playbook_path | dirname }}"
       {{ playbook_path }}
+
+- name: "Run hook with retry - {{ hook.name }}"
+  when: hook.hook_retry | default(false)
+  no_log: "{{ cifmw_nolog | default(true) | bool }}"
+  cifmw.general.ci_script:
+    output_dir: "{{ cifmw_basedir }}/artifacts"
+    extra_args:
+      ANSIBLE_CONFIG: "{{ hook.config_file | default(ansible_config_file) }}"
+      ANSIBLE_LOG_PATH: "{{ log_path }}"
+    creates: "{{ hook.creates | default(omit) }}"
+    script: >-
+      ansible-playbook -i {{ hook.inventory | default(inventory_file) }}
+      {% if hook.connection is defined -%}
+      -c {{ hook.connection }}
+      {% endif -%}
+      {{ extra_vars }}
+      -e "cifmw_basedir={{ cifmw_basedir }}"
+      -e "step={{ step }}"
+      -e "hook_name={{ hook_name }}"
+      -e "playbook_dir={{ playbook_path | dirname }}"
+      {{ playbook_path }}
+  register: hook_result
+  retries: 3
+  delay: 10
+  until: hook_result is not failed
 
 - name: Load generated content if any
   block:


### PR DESCRIPTION
Sometimes, some hooks fails like on downloading tools. Let's add a new parameter: hook_retry that will make a retry on those hooks, where the parameter `hook_retry` is set to true.