### PR TITLE
libvirt_manager: allow users to specify per-VM devices

### DIFF
--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -96,6 +96,7 @@ cifmw_libvirt_manager_configuration:
       uefi: (boolean, toggle UEFI boot. Optional, defaults to false)
       bootmenu_enable: (string, toggle bootmenu. Optional, defaults to "no")
       networkconfig: (dict or list[dict], [network-config](https://cloudinit.readthedocs.io/en/latest/reference/network-config-format-v2.html#network-config-v2) v2 config, needed if a static ip address should be defined at boot time in absence of a dhcp server in special scenarios. Optional)
+      devices: (dict, optional, defaults to {}. The keys are the VMs of that type that needs devices to be attached, and the values are lists of strings, where each string must contain a valid <hostdev/> libvirt XML element that will be passed to virsh attach-device)
   networks:
     net_name: <XML definition of the network to create>
 ```
@@ -140,6 +141,13 @@ cifmw_libvirt_manager_configuration:
         - osp_trunk
       extra_disks_num: 5
       extra_disks_size: '1G'
+      devices:
+        "0": >-
+          <hostdev mode='subsystem' type='pci' managed='yes'>
+            <source>
+              <address domain='0x0000' bus='0x17' slot='0x00' function='0x0'/>
+            </source>
+          </hostdev>
     controller:
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"

--- a/roles/libvirt_manager/tasks/attach_devices.yml
+++ b/roles/libvirt_manager/tasks/attach_devices.yml
@@ -1,0 +1,19 @@
+---
+- name: Create a temporary file to hold the device configuration
+  ansible.builtin.tempfile:
+    state: file
+    prefix: "{{ _vm_name }}_device_"
+  register: vm_devices_file
+
+- name: Copy the device configuration requested for the VM to a temporary file
+  ansible.builtin.copy:
+    content: "{{ _vm_device }}"
+    dest: "{{ vm_devices_file.path }}"
+    mode: '0660'
+
+- name: Attach the device configuration to the VM
+  ansible.builtin.shell:
+    cmd: >-
+      set -o pipefail;
+      virsh -c qemu:///system attach-device {{ _vm_name }} {{ vm_devices_file.path }}
+      --persistent;

--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -180,3 +180,25 @@
           --type cdrom
           --mode readonly
           --persistent
+
+- name: "Attach additional devices if specified"
+  when:
+    - vm_data.devices is defined
+    - vm_data.devices[_vm_specific_index] is defined
+  vars:
+    _vm_name: "cifmw-{{ vm }}"
+    _vm_all_devices: "{{ vm_data.devices[_vm_specific_index] }}"
+    # This is the index of the VM for its type.
+    # For example '1' if the VM is 'compute-1', or '2' if it is 'ocp-master-2'
+    _vm_specific_index: "{{ vm | regex_search('^.+-([0-9]+)','\\1') | first | default('0') | string }}"
+    # Make sure the value is always a list
+    _vm_devices_content: >-
+      {{
+        _vm_all_devices
+        if (_vm_all_devices | type_debug == "list")
+        else [_vm_all_devices]
+      }}
+  ansible.builtin.include_tasks: attach_devices.yml
+  loop: "{{ _vm_devices_content }}"
+  loop_control:
+    loop_var: _vm_device


### PR DESCRIPTION
Add a new parameter 'devices' to the definition of virtual machine
types in cifmw_libvirt_manager_configuration.
The parameter is optional. If set, it contains a dictionary
where the keys are the VMs of that type that needs devices
to be attached, and the values are lists of strings,
where each string must contain a valid <hostdev/> libvirt XML
element that will be passed to `virsh attach-device`.

This is useful to expose for example passthrough devices
to the virtual machines.