### PR TITLE
Include read_global_vars.yml in pre-run: zuul.d/tcib.yaml

### DIFF
--- a/zuul.d/tcib.yaml
+++ b/zuul.d/tcib.yaml
@@ -11,6 +11,7 @@
       - github.com/openstack-k8s-operators/tcib
       - github.com/openstack-k8s-operators/install_yamls
     pre-run:
+      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/content_provider/pre.yml
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml


### PR DESCRIPTION
The reason to make the change one file per commit is our flaky jobs. It is pain to get all jobs pass at once.