### PR TITLE
Include read_global_vars.yml in pre-run: zuul.d/test-job.yaml

### DIFF
--- a/zuul.d/test-job.yaml
+++ b/zuul.d/test-job.yaml
@@ -5,6 +5,7 @@
     nodeset: centos-stream-9
     abstract: true
     pre-run:
+      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
     run:


### PR DESCRIPTION
The reason to make the change one file per commit is our flaky jobs. It is pain to get all jobs pass at once.