### PR TITLE
Include read_global_vars.yml in pre-run: zuul.d/kuttl.yaml & zuul.d/k…

### DIFF
--- a/zuul.d/kuttl.yaml
+++ b/zuul.d/kuttl.yaml
@@ -9,6 +9,7 @@
       zuul_log_collection: true
     parent: base-simple-crc
     pre-run:
+      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/e2e-prepare.yml
     run:
       - ci/playbooks/dump_zuul_data.yml

--- a/zuul.d/kuttl_multinode.yaml
+++ b/zuul.d/kuttl_multinode.yaml
@@ -41,6 +41,8 @@
                 ip: 172.18.0.5
               tenant:
                 ip: 172.19.0.5
+    pre-run:
+      - ci/playbooks/read_global_vars.yml
     run:
       - ci/playbooks/dump_zuul_data.yml
       - ci/playbooks/kuttl/run.yml


### PR DESCRIPTION
…uttl_multinode.yaml

The reason to make the change one file per commit is our flaky jobs. It is pain to get all jobs pass at once.