### PR TITLE
Include read_global_vars.yml in pre-run: zuul.d/end-to-end.yaml

### DIFF
--- a/zuul.d/end-to-end.yaml
+++ b/zuul.d/end-to-end.yaml
@@ -9,6 +9,7 @@
       zuul_log_collection: true
       registry_login_enabled: false
     pre-run:
+      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
     post-run:


### PR DESCRIPTION
The reason to make the change one file per commit is our flaky jobs. It is pain to get all jobs pass at once.