### PR TITLE
Fix: search openstack-operator-index in all namespaces

### DIFF
--- a/roles/env_op_images/tasks/main.yml
+++ b/roles/env_op_images/tasks/main.yml
@@ -77,6 +77,24 @@
       ansible.builtin.set_fact:
         cifmw_openstack_service_images_content: "{{ _sa_images_content.stdout | from_json }}"
 
+    - name: Get all pods from all namespaces to find openstack-operator-index
+      kubernetes.core.k8s_info:
+        kind: Pod
+        api_version: v1
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit)}}"
+        context: "{{ cifmw_openshift_context | default(omit)}}"
+        field_selectors:
+          - status.phase=Running
+      register: all_pods_list
+
+    - name: Retrieve openstack-operator-index pod
+      vars:
+        selected_pod: "{{ all_pods_list.resources | selectattr('metadata.generateName', 'defined') | selectattr('metadata.generateName', 'search', 'openstack-operator-index-') | list | first }}"
+      ansible.builtin.set_fact:
+        cifmw_install_yamls_vars_content:
+          OPENSTACK_IMG: "{{ selected_pod.status.containerStatuses[0].imageID }}"
+
     - name: Get all the pods in openstack-operator namespace
       vars:
         csv_items: "{{ (_csvs_out.stdout | from_yaml)['items'] }}"
@@ -93,13 +111,6 @@
         field_selectors:
           - status.phase=Running
       register: pod_list
-
-    - name: Retrieve openstack-operator-index pod
-      vars:
-        selected_pod: "{{ pod_list.resources| selectattr('metadata.generateName', 'equalto', 'openstack-operator-index-') | list | first }}"
-      ansible.builtin.set_fact:
-        cifmw_install_yamls_vars_content:
-          OPENSTACK_IMG: "{{ selected_pod.status.containerStatuses[0].imageID }}"
 
     - name: Get operator images and pods
       when: not cifmw_env_op_images_dryrun | bool


### PR DESCRIPTION
Currently it is looking for it in openstack-operator-index, but it is configured by default in openshift-marketplace. Task will look for it in any namespace