### PR TITLE
Update Cinder volume backend naming to use sequential identifiers

### DIFF
--- a/roles/ci_dcn_site/templates/service-values.yaml.j2
+++ b/roles/ci_dcn_site/templates/service-values.yaml.j2
@@ -28,10 +28,10 @@ data:
     {{ _ceph.cifmw_ceph_client_cluster }}:
       customServiceConfig: |
         [DEFAULT]
-        enabled_backends = ceph
+        enabled_backends = ceph{{ loop.index }}
         glance_api_servers = https://glance-{{ _ceph.cifmw_ceph_client_cluster }}-internal.openstack.svc:9292
-        [ceph]
-        volume_backend_name = ceph
+        [ceph{{ loop.index }}]
+        volume_backend_name = ceph{{ loop.index }}
         volume_driver = cinder.volume.drivers.rbd.RBDDriver
         rbd_ceph_conf = /etc/ceph/{{ _ceph.cifmw_ceph_client_cluster }}.conf
         rbd_user = openstack


### PR DESCRIPTION
Change Cinder volume backend configuration from using cluster names to sequential naming (ceph1, ceph2, etc.) to ensure unique backend names across all deployments.