### PR TITLE
DNM Checking reading group_vars until Zuul is not upgraded

### DIFF
--- a/ci/playbooks/content_provider/pre.yml
+++ b/ci/playbooks/content_provider/pre.yml
@@ -1,4 +1,12 @@
 ---
+- name: Get all repos on all hosts
+  hosts: all
+  gather_facts: true
+  tasks:
+    - name: Clone repos in the job workspace
+      ansible.builtin.include_role:
+        name: prepare-workspace
+
 - name: "Run ci/playbooks/content_provider/pre.yml"
   hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   tasks:
@@ -8,10 +16,6 @@
         - cifmw_zuul_target_host != 'all'
         - inventory_hostname != cifmw_zuul_target_host
       ansible.builtin.meta: end_host
-
-    - name: Clone repos in the job workspace
-      ansible.builtin.include_role:
-        name: prepare-workspace
 
     - name: Install ansible-core
       become: true

--- a/ci/playbooks/e2e-prepare.yml
+++ b/ci/playbooks/e2e-prepare.yml
@@ -1,12 +1,16 @@
 ---
-- name: "Run ci/playbooks/e2e-prepare.yml"
-  hosts: controller, primary
+- name: Get all repos on all hosts
+  hosts: all
   gather_facts: true
   tasks:
     - name: Clone repos in the job workspace
       ansible.builtin.include_role:
         name: prepare-workspace
 
+- name: "Run ci/playbooks/e2e-prepare.yml"
+  hosts: controller, primary
+  gather_facts: true
+  tasks:
     - name: Create zuul-output directory
       ansible.builtin.file:
         path: "{{ ansible_user_dir }}/zuul-output/logs"

--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -9,6 +9,19 @@
 - name: Remove status flag
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   tasks:
+
+    - name: Read group_vars
+      vars:
+        provided_dir: >
+          {{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/group_vars
+      ansible.builtin.include_role:
+        name: cifmw_helpers
+        tasks_from: var_dir.yml
+
+    - name: Print test text
+      ansible.builtin.debug:
+        msg: "{{ daniel }}"
+
     - name: Delete success flag if exists
       ansible.builtin.file:
         path: "{{ ansible_user_dir }}/cifmw-success"
@@ -34,6 +47,20 @@
 - name: Prepare host virtualization
   hosts: "{{ ('virthosts' in groups) | ternary('virthosts', cifmw_target_host | default('localhost') ) }}"
   tasks:
+
+    - name: Read group_vars
+      vars:
+        provided_dir: >
+          {{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/group_vars
+      ansible.builtin.include_role:
+        name: cifmw_helpers
+        tasks_from: var_dir.yml
+
+    - name: Print test text
+      ansible.builtin.debug:
+        msg: "{{ daniel }}"
+
+
     - name: Run prepare host virtualization
       vars:
         step: pre_infra
@@ -46,6 +73,12 @@
 - name: Run cifmw_setup infra, build package, container and operators, deploy EDPM
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   tasks:
+
+
+    - name: Print test text
+      ansible.builtin.debug:
+        msg: "{{ daniel }}"
+
     - name: Prepare the platform
       vars:
         step: pre_infra
@@ -89,6 +122,19 @@
   become: true
   hosts: "{{ groups[cifmw_nfs_target | default('computes')][0] | default([]) }}"
   tasks:
+
+    - name: Read group_vars
+      vars:
+        provided_dir: >
+          {{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/group_vars
+      ansible.builtin.include_role:
+        name: cifmw_helpers
+        tasks_from: var_dir.yml
+
+    - name: Print test text
+      ansible.builtin.debug:
+        msg: "{{ daniel }}"
+
     - name: Run cifmw_nfs role
       vars:
         nftables_path: /etc/nftables
@@ -101,6 +147,19 @@
 - name: Clear ceph target hosts facts to force refreshing in HCI deployments
   hosts: "{{ cifmw_ceph_target | default('computes')  }}"
   tasks:
+
+    - name: Read group_vars
+      vars:
+        provided_dir: >
+          {{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/group_vars
+      ansible.builtin.include_role:
+        name: cifmw_helpers
+        tasks_from: var_dir.yml
+
+    - name: Print test text
+      ansible.builtin.debug:
+        msg: "{{ daniel }}"
+
     # end_play will end only current play, not the main edpm-deploy.yml
     - name: Early end if architecture deploy
       when:
@@ -131,6 +190,12 @@
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
+
+
+    - name: Print test text
+      ansible.builtin.debug:
+        msg: "{{ daniel }}"
+
     - name: Continue HCI deploy
       ansible.builtin.import_role:
         name: cifmw_setup

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -2,3 +2,6 @@
 # This file contains all repeating variables, that can be set
 # globaly instead of parse Zuul inventory file to get proper value.
 #### GLOBAL VARS ####
+
+
+daniel: test


### PR DESCRIPTION
We can not set in zuul job definition path to the dir or file [1] that should be readded before Zuul executor starts the CI. It makes troubles on "merging" common vars into the group_vars/all. This PR shows if we can read the vars using cifmw_helpers role to make it work.

[1] https://zuul-ci.org/docs/zuul/latest/config/job.html#attr-job.include-vars.name