### PR TITLE
Add playbook to prepare ceph nodes and create required template for 17.1 job

### DIFF
--- a/hooks/playbooks/create_external_ceph_params.yml
+++ b/hooks/playbooks/create_external_ceph_params.yml
@@ -1,0 +1,36 @@
+---
+# This Playbook runs the shell script that extracts Ceph credentials to create the tht parameter file and copy required ceph conf files on osp-controller
+
+- name: Create external Ceph parameters file and copy ceph client conf files
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Execute external Ceph parameters creation script
+      ansible.builtin.script: "{{ playbook_dir }}/../../scripts/create_external_ceph_params.sh {{ ceph_node }} {{ ceph_mon_host }}"
+      register: script_output
+
+    - name: Display script output
+      ansible.builtin.debug:
+        var: script_output.stdout_lines
+
+    - name: Display script errors if any
+      when: script_output.stderr_lines | length > 0
+      ansible.builtin.debug:
+        msg: "Script stderr: {{ script_output.stderr_lines }}"
+
+    - name: Verify external_ceph_params.yaml was created
+      delegate_to: osp-undercloud-0
+      ansible.builtin.stat:
+        path: "{{ ansible_user_dir }}/external_ceph_params.yaml"
+      register: params_file_stat
+
+    - name: Confirm file creation
+      ansible.builtin.debug:
+        msg: "Successfully created external_ceph_params.yaml on osp-undercloud-0"
+      when: params_file_stat.stat.exists
+
+    - name: Fail if file wasn't created
+      ansible.builtin.fail:
+        msg: "Failed to create external_ceph_params.yaml on osp-undercloud-0"
+      when: not params_file_stat.stat.exists

--- a/hooks/playbooks/setup_cephnodes_ipv6.yaml
+++ b/hooks/playbooks/setup_cephnodes_ipv6.yaml
@@ -1,0 +1,104 @@
+---
+- name: Setup repos, CA and networks on ceph nodes
+  hosts: "{{ cifmw_ceph_target | default('ceph')  }}"
+  gather_facts: true
+  become: true
+  vars:
+    cifmw_adoption_osp_deploy_ntp_server: "pool.ntp.org"
+    cifmw_adoption_osp_deploy_repos:
+      - rhel-9-for-x86_64-baseos-eus-rpms
+      - rhel-9-for-x86_64-appstream-eus-rpms
+      - rhel-9-for-x86_64-highavailability-eus-rpms
+      - openstack-17.1-for-rhel-9-x86_64-rpms
+      - fast-datapath-for-rhel-9-x86_64-rpms
+      - rhceph-7-tools-for-rhel-9-x86_64-rpms
+    common_dns: ["2620:cf:cf:aaaa::1"]
+    base_config: "/etc/os-net-config"
+  tasks:
+    - name: Setup repositories via rhos-release if needed
+      ansible.builtin.import_role:
+        name: repo_setup
+        tasks_from: rhos_release.yml
+
+    - name: Install custom CA if needed
+      ansible.builtin.import_role:
+        name: install_ca
+    - name: Ensure needed logins
+      ansible.builtin.import_role:
+        name: adoption_osp_deploy
+        tasks_from: login_registries.yml
+
+    - name: Ensure repos are setup
+      become: true
+      community.general.rhsm_repository:
+        name: "{{ cifmw_adoption_osp_deploy_repos }}"
+        state: enabled
+
+    - name: Ensure os-net-config folder exists in ceph nodes
+      become: true
+      ansible.builtin.file:
+        path: "/etc/os-net-config"
+        state: directory
+        mode: '0755'
+
+    - name: Ensure os-net-config and openvswitch is installed in ceph nodes
+      become: true
+      ansible.builtin.dnf:
+        name:
+          - os-net-config
+          - openvswitch
+        state: present
+
+    - name: Generate os-net-config YAML
+      ansible.builtin.copy:
+        dest: "{{ base_config }}/network-os-net-config.yaml"
+        mode: '0644'
+        content: |
+          network_config:
+          - type: ovs_bridge
+            name: br-ex
+            mtu: 1500
+            use_dhcp: false
+            dns_servers: {{ common_dns }}
+            addresses:
+            - ip_netmask: "{{ hostvars[inventory_hostname]['bridge_ip'] }}"
+            routes: []
+            members:
+            - type: interface
+              name: nic2
+              mtu: 1500
+              primary: true
+              addresses:
+              - ip_netmask: "{{ hostvars[inventory_hostname]['external_ip'] }}"
+              routes: []
+            - type: vlan
+              vlan_id: 20
+              addresses:
+              - ip_netmask: "{{ hostvars[inventory_hostname]['internalapi_ip'] }}"
+              routes: []
+            - type: vlan
+              vlan_id: 21
+              addresses:
+              - ip_netmask: "{{ hostvars[inventory_hostname]['storage_ip'] }}"
+              routes: []
+            - type: vlan
+              vlan_id: 23
+              addresses:
+              - ip_netmask: "{{ hostvars[inventory_hostname]['storagemgmt_ip'] }}"
+              routes: []
+            - type: vlan
+              vlan_id: 22
+              addresses:
+              - ip_netmask: "{{ hostvars[inventory_hostname]['tenant_ip'] }}"
+              routes: []
+
+    - name: Apply network configuration
+      ansible.builtin.command: >
+        os-net-config -c {{ base_config }}/network-os-net-config.yaml -v
+      changed_when: true
+
+    - name: Set net.ipv6.ip_nonlocal_bind
+      ansible.posix.sysctl:
+        name: net.ipv6.ip_nonlocal_bind
+        value: '1'
+        state: present

--- a/roles/run_hook/README.md
+++ b/roles/run_hook/README.md
@@ -37,6 +37,7 @@ name:
 * `source`: (String) Source of the playbook. If it's a filename, the playbook is expected in `hooks/playbooks`. It can be an absolute path.
 * `type`: (String) Type of the hook. In this case, set it to `playbook`.
 * `extra_vars`: (Dict) Structure listing the extra variables you would like to pass down ([extra_vars explained](#extra_vars-explained))
+* `gathering`: (String) Set the ANSIBLE_GATHERING environment variable. Valid values: `implicit`, `explicit`, `smart`. Defaults to empty string (uses ansible.cfg setting).
 * `hook_retry` (Boolean) Set true, if the hook execution should be retried on failure
 
 ##### About OpenShift namespaces and install_yamls
@@ -56,6 +57,7 @@ Since `install_yamls` might not be initialized, the `run_hook` is exposing two n
 * `source`: (String) Source of the playbook. If it's a filename, the playbook is expected in `hooks/playbooks`. It can be an absolute path.
 * `type`: (String) Type of the hook. In this case, set it to `playbook`.
 * `extra_vars`: (Dict) Structure listing the extra variables you would like to pass down ([extra_vars explained](#extra_vars-explained))
+* `gathering`: (String) Set the ANSIBLE_GATHERING environment variable. Valid values: `implicit`, `explicit`, `smart`. Defaults to empty string (uses ansible.cfg setting).
 * `hook_retry` (Boolean) Set true, if the hook execution should be retried on failure
 
 #### Hook callback
@@ -133,6 +135,7 @@ pre_deploy:
     - name: My hook
       source: ceph-deploy.yml
       type: playbook
+      gathering: implicit
       extra_vars:
         UUID: <some generated UUID>
         file: "ceph_env.yml"

--- a/roles/run_hook/tasks/playbook.yml
+++ b/roles/run_hook/tasks/playbook.yml
@@ -94,9 +94,15 @@
   no_log: "{{ cifmw_nolog | default(true) | bool }}"
   cifmw.general.ci_script:
     output_dir: "{{ cifmw_basedir }}/artifacts"
-    extra_args:
-      ANSIBLE_CONFIG: "{{ hook.config_file | default(ansible_config_file) }}"
-      ANSIBLE_LOG_PATH: "{{ log_path }}"
+    extra_args: >-
+      {{
+        {
+          'ANSIBLE_CONFIG': hook.config_file | default(ansible_config_file),
+          'ANSIBLE_LOG_PATH': log_path
+        } | combine(
+          {'ANSIBLE_GATHERING': hook.gathering} if hook.gathering is defined else {}
+        )
+      }}
     creates: "{{ hook.creates | default(omit) }}"
     script: >-
       ansible-playbook -i {{ hook.inventory | default(inventory_file) }}
@@ -115,9 +121,15 @@
   no_log: "{{ cifmw_nolog | default(true) | bool }}"
   cifmw.general.ci_script:
     output_dir: "{{ cifmw_basedir }}/artifacts"
-    extra_args:
-      ANSIBLE_CONFIG: "{{ hook.config_file | default(ansible_config_file) }}"
-      ANSIBLE_LOG_PATH: "{{ log_path }}"
+    extra_args: >-
+      {{
+        {
+          'ANSIBLE_CONFIG': hook.config_file | default(ansible_config_file),
+          'ANSIBLE_LOG_PATH': log_path
+        } | combine(
+          {'ANSIBLE_GATHERING': hook.gathering} if hook.gathering is defined else {}
+        )
+      }}
     creates: "{{ hook.creates | default(omit) }}"
     script: >-
       ansible-playbook -i {{ hook.inventory | default(inventory_file) }}

--- a/scripts/create_external_ceph_params.sh
+++ b/scripts/create_external_ceph_params.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Create tht external_ceph_params.yaml on undercloud and update ceph_conf files in osp-controller
+
+set -e  # Exit on any error
+
+# Parameters - only Ceph-specific values
+CEPH_NODE=${1}
+CEPH_MON_HOST=${2}
+
+# Validate required parameters
+if [ -z "$CEPH_NODE" ] || [ -z "$CEPH_MON_HOST" ]; then
+    echo "ERROR: Missing required parameters"
+    echo "Usage: $0 <ceph_node> <ceph_mon_host>"
+    echo "  ceph_node: Name of the Ceph node (e.g., osp-ext-ceph-uni04delta-ipv6-0)"
+    echo "  ceph_mon_host: Comma-separated list of Ceph monitor IPs (e.g., 2620:cf:cf:cccc::6a,2620:cf:cf:cccc::6b,2620:cf:cf:cccc::6c)"
+    exit 1
+fi
+
+echo "Creating external Ceph parameters file..."
+echo "Using Ceph node: $CEPH_NODE"
+echo "Using Ceph monitor hosts: $CEPH_MON_HOST"
+
+# Extract Ceph credentials
+echo "Fetching Ceph credentials from $CEPH_NODE..."
+CEPH_OUTPUT=$(ssh "$CEPH_NODE" cat /etc/ceph/ceph.conf /etc/ceph/ceph.client.openstack.keyring)
+
+FSID=$(echo "$CEPH_OUTPUT" | awk '/fsid =/ {print $3}')
+KEY=$(echo "$CEPH_OUTPUT" | awk '/key =/ {print $3}' | tr -d '"')
+
+if [ -z "$FSID" ] || [ -z "$KEY" ]; then
+    echo "ERROR: Failed to extract FSID or KEY from Ceph configuration"
+    exit 1
+fi
+
+echo "Found FSID: $FSID"
+echo "Found Key: $KEY"
+
+# Create the parameter file on undercloud
+echo "Creating ~/external_ceph_params.yaml on osp-undercloud-0..."
+ssh osp-undercloud-0 "cat > ~/external_ceph_params.yaml" <<EOC
+parameter_defaults:
+  CephClusterFSID: '$FSID'
+  CephClientKey: '$KEY'
+  CephManilaClientKey: '$KEY'
+  CephExternalMonHost: '$CEPH_MON_HOST'
+EOC
+
+echo "Successfully created ~/external_ceph_params.yaml on osp-undercloud-0"
+echo ""
+echo "File contents:"
+ssh osp-undercloud-0 "cat ~/external_ceph_params.yaml"
+
+# Below code copies the ceph admin keyring and conf files that are required for adoption pre-requisites
+
+echo "Copying Ceph configuration files from $CEPH_NODE to osp-controller-0..."
+
+echo "Creating directory on controller..."
+ssh osp-controller-0 mkdir -p $HOME/ceph_client
+
+ssh "$CEPH_NODE" sudo cat /etc/ceph/ceph.conf | ssh osp-controller-0 "cat > $HOME/ceph_client/ceph.conf"
+ssh "$CEPH_NODE" sudo cat /etc/ceph/ceph.client.admin.keyring | ssh osp-controller-0 "cat > $HOME/ceph_client/ceph.client.admin.keyring"
+
+echo " Done! Files copied to osp-controller-0:$HOME/ceph_client/"


### PR DESCRIPTION
For ipv6 adoption usecase with external ceph we need additional playbook to prepare ceph nodes before deploying ceph. This patch adds the playbook.