### PR TITLE
.githooks/pre-push: Use /usr/bin/env sh instead of /usr/bin/sh

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/usr/bin/env sh
 
 set -e
 


### PR DESCRIPTION
While /usr/bin/sh runs fine on linux, it is better to use env to lookup sh from path, as macOS did not have sh in /usr/bin (It was in /bin).