### PR TITLE
Add various_vars cifmw_helpers tasks

### DIFF
--- a/roles/cifmw_helpers/README.md
+++ b/roles/cifmw_helpers/README.md
@@ -132,7 +132,24 @@ That code, can be replaced by:
     - logs
 ```
 
+#### Read var file and set as fact
+
+Example task execution:
+
+```yaml
+- name: Read base centos-9 scenarios
+  vars:
+    provided_file: >
+      {{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/
+      ci-framework/scenarios/centos-9/base.yml
+  ansible.builtin.include_role:
+    name: cifmw_helpers
+    tasks_from: var_file.yml
+```
+
 Of course, before Zuul execute the playbook, it is mandatory to call `playbooks/cifmw_collection_zuul_executor.yml`.
+
+#### Read directory and parse all files and then set as fact
 
 For setting all files in the directory as fact, use `var_dir.yml` tasks.
 Example:
@@ -146,4 +163,30 @@ Example:
   ansible.builtin.include_role:
     name: cifmw_helpers
     tasks_from: var_dir.yml
+```
+
+#### Set as fact various variables
+
+In some places in our workflow, we can have a list that contains
+various variables like files: "@some_file.yml" or dictionaries like "some: var".
+To parse them and set as a fact, use `various_vars.yml` task file.
+
+```yaml
+- name: Example
+  hosts: localhost
+  tasks:
+    - name: Test various vars
+      vars:
+        various_vars:
+          - "@scenarios/centos-9/base.yml"
+          - test: ok
+      ansible.builtin.include_role:
+        name: cifmw_helpers
+        tasks_from: various_vars.yml
+
+    - name: Print parsed variables
+      ansible.builtin.debug:
+        msg: |
+          "Value for file is: {{ cifmw_repo_setup_os_release }}"
+          "Value for dict is: {{ test }}"
 ```

--- a/roles/cifmw_helpers/tasks/various_vars.yml
+++ b/roles/cifmw_helpers/tasks/various_vars.yml
@@ -1,0 +1,13 @@
+---
+# various_vars
+- name: Filter Ansible variable files and set as fact
+  vars:
+    provided_file: "{{ item | replace('@','') }}"
+  ansible.builtin.include_tasks: var_file.yml
+  loop: "{{ various_vars | select('match', '^@.*\\.(yml|yaml)$') | list }}"
+
+- name: Filter just dict and set as fact
+  ansible.builtin.set_fact:
+    "{{ item.key }}": "{{ item.value }}"
+    cacheable: true
+  loop: "{{ (various_vars | select('mapping') | list) | map('dict2items') | flatten }}"


### PR DESCRIPTION
In some places, we used to have variables like: cifmw_extras which can have files or dictionaries.
Let's parse these variables and set as fact correctly.