### PR TITLE
Treat various files vars as template

### DIFF
--- a/roles/cifmw_helpers/tasks/various_vars.yml
+++ b/roles/cifmw_helpers/tasks/various_vars.yml
@@ -1,8 +1,21 @@
 ---
 # various_vars
-- name: Filter Ansible variable files and set as fact
+- name: Create temporary to store templated files
+  ansible.builtin.tempfile:
+    state: directory
+    suffix: various
+  register: _various_tmp
+
+- name: Filter Ansible variable files and parse as template
+  ansible.builtin.template:
+    src: "{{ item | replace('@','') }}"
+    dest: "{{ _various_tmp.path }}/{{ item | replace('@','') | basename }}"
+  loop: "{{ various_vars | select('match', '^@.*\\.(yml|yaml)$') | list }}"
+  no_log: "{{ cifmw_helpers_no_log }}"
+
+- name: Read templated vars and set as fact
   vars:
-    provided_file: "{{ item | replace('@','') }}"
+    provided_file: "{{ _various_tmp.path }}/{{ item | replace('@','') | basename }}"
   ansible.builtin.include_tasks: var_file.yml
   loop: "{{ various_vars | select('match', '^@.*\\.(yml|yaml)$') | list }}"
 
@@ -11,3 +24,10 @@
     "{{ item.key }}": "{{ item.value }}"
     cacheable: true
   loop: "{{ (various_vars | select('mapping') | list) | map('dict2items') | flatten }}"
+  no_log: "{{ cifmw_helpers_no_log }}"
+
+- name: Remove temporary directory
+  ansible.builtin.file:
+    path: "{{ _various_tmp.path }}"
+    state: absent
+  when: _various_tmp.path is defined


### PR DESCRIPTION
The Ansible set fact does not lookup to resolve the name if it got a jinja2 template. It is an issue that in some cases, where the variable files are like a template, for example:

    cifmw_repo_setup_basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework') }}"

Instead of resolving the name correctly, value is:

    {{ ansible_user_dir }}/ci-framework-data

It is an error, due later the modules are not "resolving" the name, but raise an error:

    fatal: [localhost]: FAILED! =>
        changed: false
        cmd: /usr/bin/git ls-remote '{{' ansible_user_dir '}}/src/github.com/openstack-k8s-operators/repo-setup'
          -h refs/heads/HEAD
        msg: |-
          fatal: '{{' does not appear to be a git repository
          fatal: Could not read from remote repository.

          Please make sure you have the correct access rights
          and the repository exists.
        rc: 128

Parse the files as a template first, then read and set as fact.