### PR TITLE
Add cifmw-crc-edpm-podified-baremetal-bootc job

### DIFF
--- a/roles/edpm_deploy_baremetal/defaults/main.yml
+++ b/roles/edpm_deploy_baremetal/defaults/main.yml
@@ -29,3 +29,4 @@ cifmw_edpm_deploy_baremetal_update_os_containers: false
 cifmw_edpm_deploy_baremetal_repo_setup_override: false
 cifmw_edpm_deploy_baremetal_create_vms: true
 cifmw_edpm_deploy_baremetal_nova_compute_extra_config: ""
+cifmw_edpm_deploy_baremetal_bootc: false

--- a/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -132,9 +132,11 @@
                   value: ["{{ content_provider_registry_ip }}:5001"]
           {% endif %}
 
+          {% if not cifmw_edpm_deploy_baremetal_bootc %}
                 - op: add
                   path: /spec/nodeTemplate/ansible/ansibleVars/edpm_bootstrap_command
                   value: sudo dnf -y update
+          {% endif %}
         kustomizations_paths: >-
           {{
             [

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -21,6 +21,21 @@
       cifmw_manage_secrets_pullsecret_content: '{}'
       cifmw_rhol_crc_binary_folder: "/usr/local/bin"
 
+# Virtual Baremetal job with CRC and single bootc compute node.
+- job:
+    name: cifmw-crc-podified-edpm-baremetal-bootc
+    nodeset: centos-9-crc-2-48-0-6xlarge
+    parent: cifmw-base-crc-openstack
+    run: ci/playbooks/edpm_baremetal_deployment/run.yml
+    vars:
+      crc_parameters: "--memory 32000 --disk-size 240 --cpus 12"
+      cifmw_manage_secrets_pullsecret_content: '{}'
+      cifmw_rhol_crc_binary_folder: "/usr/local/bin"
+      cifmw_install_yamls_vars:
+        BAREMETAL_OS_CONTAINER_IMG: quay.io/openstack-k8s-operators/edpm-bootc:latest-qcow2
+        BAREMETAL_OS_IMG: edpm-bootc.qcow2
+      cifmw_edpm_deploy_baremetal_bootc: true
+
 # Podified galera job
 - job:
     name: cifmw-crc-podified-galera-deployment

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -15,6 +15,15 @@
         - cifmw-pod-zuul-files
 
 - project-template:
+    name: podified-multinode-edpm-baremetal-bootc-pipeline
+    description: |
+      Project template to run content provider with EDPM with bootc and
+      baremetal job.
+    github-check:
+      jobs:
+        - cifmw-crc-podified-edpm-baremetal-bootc: *content_provider
+
+- project-template:
     name: podified-multinode-edpm-pipeline
     description: |
       Project template to run content provider with EDPM job.


### PR DESCRIPTION
Add cifmw-crc-edpm-podified-baremetal-bootc job

The job uses bootc as the base OS for the edpm baremetal compute node.
Adds a new podified-multinode-edpm-baremetal-bootc-pipeline which will
run the new job.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/1091
Signed-off-by: James Slagle <jslagle@redhat.com>
