### PR TITLE
Add parsing external inventory file and add host

### DIFF
--- a/roles/cifmw_helpers/README.md
+++ b/roles/cifmw_helpers/README.md
@@ -190,3 +190,22 @@ To parse them and set as a fact, use `various_vars.yml` task file.
           "Value for file is: {{ cifmw_repo_setup_os_release }}"
           "Value for dict is: {{ test }}"
 ```
+
+#### Parse inventory file and add it to inventory
+
+Sometimes, the VMs on which action would be done are not available when the
+main Ansible playbook is executed. In that case, to parse the new inventory file
+use `inventory_file.yml` task, then you would be able to use delegation to
+execute tasks on new host.
+
+```yaml
+- name: Test parsing additional inventory file
+  hosts: localhost
+  tasks:
+    - name: Read inventory file and add it using add_host module
+      vars:
+        include_inventory_file: vms-inventory.yml
+      ansible.builtin.include_role:
+        name: cifmw_helpers
+        tasks_from: inventory_file.yml
+```

--- a/roles/cifmw_helpers/tasks/inventory_file.yml
+++ b/roles/cifmw_helpers/tasks/inventory_file.yml
@@ -1,0 +1,16 @@
+---
+- name: Read inventory file
+  ansible.builtin.slurp:
+    src: "{{ include_inventory_file }}"
+  register: _inventory_file
+
+- name: Parse inventory file content
+  ansible.builtin.set_fact:
+    inventory_data: "{{ _inventory_file.content | b64decode | from_yaml }}"
+
+- name: Process each group with hosts
+  ansible.builtin.include_tasks:
+    file: parse_inventory.yml
+  loop: "{{ inventory_data | dict2items | selectattr('value.hosts', 'defined') | list }}"
+  loop_control:
+    loop_var: group_item

--- a/roles/cifmw_helpers/tasks/parse_inventory.yml
+++ b/roles/cifmw_helpers/tasks/parse_inventory.yml
@@ -1,0 +1,14 @@
+---
+- name: "Add hosts for group {{ group_item.key }}"
+  ansible.builtin.add_host:
+    name: "{{ host_item.key }}"
+    groups: "{{ group_item.key }}"
+    ansible_host: "{{ host_item.value.ansible_host | default(omit) }}"
+    ansible_ssh_common_args: "{{ host_item.value.ansible_ssh_common_args | default(omit) }}"
+    ansible_ssh_private_key_file: "{{ host_item.value.ansible_ssh_private_key_file | default(omit) }}"
+    ansible_user: "{{ host_item.value.ansible_user | default(omit) }}"
+    ansible_connection: "{{ host_item.value.ansible_connection | default(omit) }}"
+    cifmw_hypervisor_host: "{{ host_item.value.cifmw_hypervisor_host | default(omit) }}"
+  loop: "{{ group_item.value.hosts | dict2items }}"
+  loop_control:
+    loop_var: host_item


### PR DESCRIPTION
Sometimes, the VMs on which action would be done are not available when the main Ansible playbook is executed. In that case, to parse the new inventory file use `inventory_file.yml` task, then you would be able to use delegation to execute tasks on new host.