### PR TITLE
[BGP+AmphoraLBs] Fix network configuration

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/network-values/values.yaml.j2
@@ -130,11 +130,9 @@ data:
         "isDefaultGateway": true,
         "isGateway": true,
         "forceAddress": false,
-        "ipMasq": true,
+        "ipMasq": false,
         "hairpinMode": true,
-{%  if network.network_name == "octavia" %}
-        "bridge": "octbr",
-{%  elif network.network_name == "ctlplane" %}
+{%  if network.network_name == "ctlplane" %}
         "bridge": "ospbr",
 {%  else %}
         "bridge": "{{ network.network_name }}",


### PR DESCRIPTION
Amphora LBs did not work properly with BGP.
With this change, network configuration is modified to configure properly octavia NAD.

OSPRH-10768