### PR TITLE
Remove KRB5_TRACE to avoid trace logging output

### DIFF
--- a/roles/dlrn_report/tasks/dlrn_report_results.yml
+++ b/roles/dlrn_report/tasks/dlrn_report_results.yml
@@ -20,8 +20,6 @@
       kinit
       {{ cifmw_dlrn_report_krb_user_realm }}
       -k -t {{ cifmw_dlrn_report_keytab }}
-  environment:
-    KRB5_TRACE: /dev/stdout
   retries: 5
   delay: 60
   register: _kinit_status


### PR DESCRIPTION
We can remove the trace since [OSPCIX-936](https://issues.redhat.com//browse/OSPCIX-936) has been resolved