### PR TITLE
Enable SOS reports when needed

### DIFF
--- a/roles/os_must_gather/README.md
+++ b/roles/os_must_gather/README.md
@@ -15,6 +15,7 @@ testing the new changes.
 * `cifmw_os_must_gather_host_network`: (Bool) Flag to gather host network data
 * `cifmw_os_must_gather_namespaces`: (List) List of namespaces required by the gather task in case of failure
 * `cifmw_os_must_gather_additional_namespaces`: (String) List of comma separated additional namespaces. Defaults to `kuttl,openshift-storage,sushy-emulator`
+* `cifmw_os_must_gather_sos`: (Bool) Enable SOS reports
 
 ## Examples
 ```

--- a/roles/os_must_gather/tasks/main.yml
+++ b/roles/os_must_gather/tasks/main.yml
@@ -68,8 +68,10 @@
           --dest-dir {{ cifmw_os_must_gather_output_dir }}/logs
           -- ADDITIONAL_NAMESPACES={{ cifmw_os_must_gather_additional_namespaces }}
           OPENSTACK_DATABASES=$OPENSTACK_DATABASES
+          {% if cifmw_os_must_gather_sos is defined and cifmw_os_must_gather_sos -%}
           SOS_EDPM=$SOS_EDPM
           SOS_DECOMPRESS=$SOS_DECOMPRESS
+          {% endif -%}
           gather &> {{ cifmw_os_must_gather_output_dir }}/logs/os_must_gather.log
 
     # directory name will be generated starting from cifmw_os_must_gather_image

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -160,6 +160,7 @@
       cifmw_openshift_api: api.crc.testing:6443
       cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
       cifmw_openshift_skip_tls_verify: true
+      cifmw_os_must_gather_sos: true
       cifmw_use_libvirt: false
       cifmw_zuul_target_host: controller
       crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -7,6 +7,7 @@
     vars:
       cifmw_extras:
         - '@scenarios/centos-9/nested_virt.yml'
+      cifmw_os_must_gather_sos: true
     files:
       - '^hooks/playbooks/ceph.yml'
 
@@ -20,6 +21,7 @@
       crc_parameters: "--memory 32000 --disk-size 240 --cpus 12"
       cifmw_manage_secrets_pullsecret_content: '{}'
       cifmw_rhol_crc_binary_folder: "/usr/local/bin"
+      cifmw_os_must_gather_sos: true
 
 # Podified galera job
 - job:


### PR DESCRIPTION
There is no need to collect each time SOS report.
Let's collect them when there is a need by setting the parameter: cifmw_os_must_gather_sos.