### PR TITLE
Use gzip with best parameter to make logs size smaller

### DIFF
--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -147,7 +147,7 @@
             ! -name "*.gz"
             ! -name "*.xz"
             -size +2M
-            -exec gzip "{}" +
+            -exec gzip --best "{}" +
 
         - name: Copy files from workspace on node
           vars:


### PR DESCRIPTION
With the best parameter, the logs should be even smaller than before.