### PR TITLE
Fix openshift_adm role context when kubeconfig has multiple clusters

### DIFF
--- a/roles/openshift_adm/README.md
+++ b/roles/openshift_adm/README.md
@@ -16,7 +16,6 @@ This role requires the following parameters to be configured.
 
 * `cifmw_openshift_adm_basedir` (str) Framework base directory, defaults to `cifmw_basedir` or
   `~/ci-framework-data`.
-* `cifmw_openshift_api` (str) Cluster endpoint to be used for communication.
 * `cifmw_openshift_user` (str) Name of the user to be used for authentication.
 * `cifmw_openshift_password` (str) Password of the provided user.
 * `cifmw_openshift_kubeconfig` (str) Absolute path to the kubeconfig file.
@@ -30,6 +29,11 @@ This role requires the following parameters to be configured.
   performed on the cluster.
 * `cifmw_openshift_adm_retry_count` (int) The maximum number of attempts to be
   made for a command to succeed. Default is `100`.
+* `cifmw_openshift_adm_context` (str) The kubeconfig context to use for cluster operations. Default is `admin`.
+
+## Obsolete Parameters
+
+* `cifmw_openshift_api` (str) Previously required cluster endpoint URL. Removed in favor of dynamic API server URL detection from kubeconfig context to ensure correct cluster targeting.
 
 ## Reference
 

--- a/roles/openshift_adm/defaults/main.yml
+++ b/roles/openshift_adm/defaults/main.yml
@@ -29,3 +29,4 @@ cifmw_openshift_adm_op: ""
 cifmw_openshift_adm_dry_run: false
 cifmw_openshift_adm_retry_count: 100
 cifmw_openshift_adm_stable_period: 3m
+cifmw_openshift_adm_context: admin

--- a/roles/openshift_adm/tasks/_get_api_server.yml
+++ b/roles/openshift_adm/tasks/_get_api_server.yml
@@ -1,0 +1,46 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# Gets the API server URL from the current context in the kubeconfig
+
+- name: Get current context
+  ansible.builtin.command: |
+    oc config current-context
+  register: _current_context
+  changed_when: false
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+
+- name: Get cluster name from current context
+  ansible.builtin.command: |
+    oc config view -o jsonpath='{.contexts[?(@.name=="{{ _current_context.stdout }}")].context.cluster}'
+  register: _current_cluster
+  changed_when: false
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+
+- name: Get API server URL from cluster
+  ansible.builtin.command: |
+    oc config view -o jsonpath='{.clusters[?(@.name=="{{ _current_cluster.stdout }}")].cluster.server}'
+  register: _context_api_server
+  changed_when: false
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+
+- name: Set API server URL from context
+  ansible.builtin.set_fact:
+    _current_api_server: "{{ _context_api_server.stdout }}"

--- a/roles/openshift_adm/tasks/_get_nodes.yml
+++ b/roles/openshift_adm/tasks/_get_nodes.yml
@@ -4,6 +4,7 @@
   kubernetes.core.k8s_info:
     kind: Node
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    context: "{{ cifmw_openshift_adm_context }}"
     validate_certs: false
     wait_condition:
       reason: KubeletReady

--- a/roles/openshift_adm/tasks/api_cert.yml
+++ b/roles/openshift_adm/tasks/api_cert.yml
@@ -37,6 +37,7 @@
     name: "{{ item }}"
     state: absent
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    context: "{{ cifmw_openshift_adm_context }}"
     validate_certs: false
   loop:
     - csr-signer-signer
@@ -60,6 +61,7 @@
     namespace: openshift-kube-controller-manager-operator
     name: csr-signer-signer
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    context: "{{ cifmw_openshift_adm_context }}"
     validate_certs: false
   register: _api_cert
 

--- a/roles/openshift_adm/tasks/main.yml
+++ b/roles/openshift_adm/tasks/main.yml
@@ -20,7 +20,6 @@
     that:
       - cifmw_basedir is defined
       - cifmw_path is defined
-      - cifmw_openshift_api is defined
       - cifmw_openshift_user is defined
       - cifmw_openshift_password is defined
       - cifmw_openshift_kubeconfig is defined

--- a/roles/openshift_adm/tasks/shutdown.yml
+++ b/roles/openshift_adm/tasks/shutdown.yml
@@ -57,6 +57,7 @@
         name: "{{ item }}"
         state: cordon
         kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        context: "{{ cifmw_openshift_adm_context }}"
         validate_certs: false
       loop: "{{ _node_names }}"
 

--- a/roles/openshift_adm/tasks/wait_for_cluster.yml
+++ b/roles/openshift_adm/tasks/wait_for_cluster.yml
@@ -18,16 +18,19 @@
 # We would wait till forbidden error is received. It indicates the endpoint
 # is reachable.
 
+- name: Get API server URL from current context
+  ansible.builtin.include_tasks: _get_api_server.yml
+
 - name: Wait until the OCP API endpoint is reachable.
   ansible.builtin.uri:
-    url: "{{ cifmw_openshift_api }}"
+    url: "{{ _current_api_server }}"
     return_content: true
     validate_certs: false
     status_code: 403
   register: ocp_api_result
   until: ocp_api_result.status == 403
   retries: "{{ cifmw_openshift_adm_retry_count }}"
-  delay: 5
+  delay: 30
 
 - name: Get nodes list
   ansible.builtin.import_tasks: _get_nodes.yml
@@ -39,25 +42,32 @@
     name: "{{ item }}"
     state: uncordon
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    context: "{{ cifmw_openshift_adm_context }}"
     validate_certs: false
   loop: "{{ _nodes.resources | map(attribute='metadata.name') | list }}"
   register: _node_status
   until: _node_status.result is defined
   retries: "{{ cifmw_openshift_adm_retry_count }}"
-  delay: 5
+  delay: 30
 
 - name: Check for pending certificate approval.
   when:
     - _openshift_adm_check_cert_approve | default(false) | bool
-  register: _approve_csr
-  approve_csr:
-    k8s_config: "{{ cifmw_openshift_kubeconfig }}"
-  retries: 30
-  delay: 10
-  until:
-    - _approve_csr is defined
-    - _approve_csr.rc is defined
-    - _approve_csr.rc == 0
+  block:
+    - name: Set current context to admin for CSR approval
+      ansible.builtin.shell: |
+        KUBECONFIG="{{ cifmw_openshift_kubeconfig }}" oc config use-context "{{ cifmw_openshift_adm_context }}"
+
+    - name: Approve pending certificate requests
+      register: _approve_csr
+      approve_csr:
+        k8s_config: "{{ cifmw_openshift_kubeconfig }}"
+      retries: 10
+      delay: 30
+      until:
+        - _approve_csr is defined
+        - _approve_csr.rc is defined
+        - _approve_csr.rc == 0
 
 - name: Wait until the OpenShift cluster is stable.
   environment:
@@ -68,13 +78,24 @@
       oc adm wait-for-stable-cluster --minimum-stable-period=5s --timeout=30m
 
 - name: Wait until OCP login succeeds.
-  community.okd.openshift_auth:
-    host: "{{ cifmw_openshift_api }}"
-    password: "{{ cifmw_openshift_password }}"
-    state: present
-    username: "{{ cifmw_openshift_user }}"
-    validate_certs: false
-  register: _oc_login_result
-  until: _oc_login_result.k8s_auth is defined
-  retries: "{{ cifmw_openshift_adm_retry_count }}"
-  delay: 2
+  block:
+    - name: Ensure admin context is set for login
+      ansible.builtin.shell: |
+        KUBECONFIG="{{ cifmw_openshift_kubeconfig }}" oc config use-context "{{ cifmw_openshift_adm_context }}"
+
+    # Re-get API server URL since admin context may point to a different
+    # cluster than the initial context used for reachability check above
+    - name: Get API server URL from admin context
+      ansible.builtin.include_tasks: _get_api_server.yml
+
+    - name: Authenticate to OpenShift cluster
+      community.okd.openshift_auth:
+        host: "{{ _current_api_server }}"
+        password: "{{ cifmw_openshift_password }}"
+        state: present
+        username: "{{ cifmw_openshift_user }}"
+        validate_certs: false
+      register: _oc_login_result
+      until: _oc_login_result.k8s_auth is defined
+      retries: "{{ cifmw_openshift_adm_retry_count }}"
+      delay: 30


### PR DESCRIPTION
Add configurable context parameter to openshift_adm role to explicitly target the deployed OpenShift cluster instead of relying on current-context.

- Add cifmw_openshift_adm_context variable defaulting to 'admin'

- Update all kubernetes.core tasks to use the specified context:
  - _get_nodes.yml: k8s_info task
  - wait_for_cluster.yml: k8s_drain task
  - api_cert.yml: k8s and k8s_info tasks
  - shutdown.yml: k8s_drain task

- Add context switching for custom modules that don't support context:
  - approve_csr module: switch context before CSR approval
  - openshift_auth module: switch context before authentication

- Replace static cifmw_openshift_api parameter with dynamic API server URL detection:
  - Add _get_api_server.yml task to retrieve URL from current context
  - Update URI check and authentication to use context-based URL

- Fixes issue where tasks fail with 403 Forbidden when current-context points to CI cluster where user lacks permissions

Jira: https://issues.redhat.com/browse/OSPRH-20252
Co-Authored-By: Claude <noreply@anthropic.com>
Signed-off-by: John Fulton <fulton@redhat.com>