### PR TITLE
[test_operator] Allow to read files from remote hosts

### DIFF
--- a/roles/test_operator/tasks/tempest-tests.yml
+++ b/roles/test_operator/tasks/tempest-tests.yml
@@ -92,6 +92,11 @@
     - stage_vars_dict.cifmw_test_operator_tempest_ssh_key_secret_name is not defined
     - private_key_file.stat.exists
   block:
+    - name: Slurp cifmw private key file
+      ansible.builtin.slurp:
+        path: "{{ cifmw_test_operator_controller_priv_key_file_path }}"
+      register: private_key_file_content
+
     - name: Ensure a secret for the cifmw private key file exists
       kubernetes.core.k8s:
         kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
@@ -107,11 +112,8 @@
             name: "{{ cifmw_test_operator_controller_priv_key_secret_name }}"
             namespace: "{{ stage_vars_dict.cifmw_test_operator_namespace }}"
           data:
-            ssh-privatekey: >-
-              {{
-                  lookup('file', cifmw_test_operator_controller_priv_key_file_path, rstrip=False) |
-                  b64encode
-              }}
+            # b64decode not needed because the text has to be encoded
+            ssh-privatekey: "{{ private_key_file_content.content }}"
 
     - name: Add SSHKeySecretName section to Tempest CR
       ansible.builtin.set_fact:

--- a/roles/test_operator/tasks/tobiko-tests.yml
+++ b/roles/test_operator/tasks/tobiko-tests.yml
@@ -26,15 +26,19 @@
   loop_control:
     loop_var: tobikoconf_section
 
+- name: Slurp tobiko.conf
+  ansible.builtin.slurp:
+    path: "{{ cifmw_test_operator_artifacts_basedir }}/tobiko.conf"
+  register: tobikoconf_content
+
 - name: Add config section to tobiko CR
+  vars:
+    tobikoconf_content_decoded: "{{ tobikoconf_content.content | b64decode }}"
   ansible.builtin.set_fact:
     test_operator_cr: >-
       {{
           test_operator_cr |
-          combine({'spec': {'config':
-                             lookup('file',
-                                    cifmw_test_operator_artifacts_basedir + '/tobiko.conf')
-                  }}, recursive=true)
+          combine({'spec': {'config': tobikoconf_content_decoded}}, recursive=true)
       }}
 
 - name: Add ssh keys used for the VMs that tobiko creates to tobiko CR
@@ -51,22 +55,30 @@
         size: "{{ stage_vars_dict.cifmw_test_operator_tobiko_ssh_keysize }}"
       when: not check_ssh_key.stat.exists
 
+    - name: Slurp key files
+      vars:
+        keyfilename: "id_{{ stage_vars_dict.cifmw_test_operator_tobiko_ssh_keytype }}{{ '.pub' if item == 'public' else '' }}"
+      ansible.builtin.slurp:
+        path: "{{ cifmw_test_operator_artifacts_basedir }}/{{ keyfilename }}"
+      register: key_file_content
+      loop:
+        - private
+        - public
+
     - name: Add private and public keys to tobiko CR
       vars:
         keyname: "{{ item }}Key"
-        keyfilename: "id_{{ stage_vars_dict.cifmw_test_operator_tobiko_ssh_keytype }}{{ '.pub' if item == 'public' else '' }}"
       ansible.builtin.set_fact:
         test_operator_cr: >-
           {{
               test_operator_cr |
-              combine({'spec': {keyname:
-                                lookup('file',
-                                       cifmw_test_operator_artifacts_basedir + '/' + keyfilename)
-                      }}, recursive=true)
+              combine({'spec': {keyname: key_file_content.results[idx].content | b64decode}}, recursive=true)
           }}
-      with_items:
+      loop:
         - private
         - public
+      loop_control:
+        index_var: idx
 
 - name: Add preventCreate if it is defined
   ansible.builtin.set_fact:
@@ -88,6 +100,11 @@
       }}
   when: stage_vars_dict.cifmw_test_operator_tobiko_num_processes is not none
 
+- name: Slurp kubeconfig file
+  ansible.builtin.slurp:
+    path: "{{ cifmw_openshift_kubeconfig }}"
+  register: kubeconfig_file_content
+
 - name: Ensure a secret for the kubeconfig file exists
   kubernetes.core.k8s:
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
@@ -103,5 +120,6 @@
         name: "{{ stage_vars_dict.cifmw_test_operator_tobiko_kubeconfig_secret }}"
         namespace: "{{ stage_vars_dict.cifmw_test_operator_namespace }}"
       data:
-        config: "{{ lookup('file', cifmw_openshift_kubeconfig) | b64encode }}"
+        # b64decode not needed because the text has to be encoded
+        config: "{{ kubeconfig_file_content.content }}"
   when: not cifmw_test_operator_dry_run | bool


### PR DESCRIPTION
Several tasks from the test_operator role only worked when the ansible
playbook was run on localhost, because they used lookup file to read the
file content.
With this change, the file content is obtained with slurp, which allows
to execute the playbook from a different host.

[OSPRH-20268](https://issues.redhat.com//browse/OSPRH-20268)