### PR TITLE
[update] Allow curl to use ipv6 for downloading cirros image.

### DIFF
--- a/roles/update/templates/workload_launch.sh.j2
+++ b/roles/update/templates/workload_launch.sh.j2
@@ -291,7 +291,7 @@ function workload_launch {
     openstack image list | grep ${IMAGE_NAME}
     if [ $? -ne 0 ]; then
         echo "Downloading image ${IMAGE_URL}"
-        curl -4fsSLk --retry 5 -o ${IMAGE_FILE} ${IMAGE_URL}
+        curl -fsSLk --retry 5 -o ${IMAGE_FILE} ${IMAGE_URL}
 
         if [ $? -ne 0 ]; then
             echo "Failed to download ${IMAGE_URL}"


### PR DESCRIPTION
For testing we use a cirros image that is used to create a vm on the
cloud.

We used to force ipv4 on curl, but it fails in ipv6 unidelta job.

Remove the constraint to suit ipv4 and ipv6 jobs.

Closes: [uni04delta-ipv6-update failing to download cirros-cloud.net image
](https://issues.redhat.com/browse/OSPRH-17249)