### PR TITLE
update: Add optional cleanup of OpenStack resources

### DIFF
--- a/roles/update/README.md
+++ b/roles/update/README.md
@@ -21,5 +21,6 @@ Role to run update
 * `cifmw_update_ansible_ssh_private_key_file`: (String) Define the path to the private key file used for the compute nodes.
 * `cifmw_update_wait_retries_reboot`: (Integer) Number of retries to wait for a compute node reboot. One retry is done every five seconds. Default to 60, so five minutes.
 * `cifmw_update_resources_monitoring_interval`: (Integer) Interval, in seconds, between two resources monitor during update. Default to 10 seconds.
+* `cifmw_update_dont_cleanup`: (Bool) By default we cleanup the resources created on OpenStack during testing. Setting this parameter to `true` prevents it. Useful for debugging. Default to `false`.
 
 ## Examples

--- a/roles/update/defaults/main.yml
+++ b/roles/update/defaults/main.yml
@@ -48,6 +48,7 @@ cifmw_update_openstack_cmd: >-
   oc rsh -n {{ cifmw_update_namespace }} openstackclient openstack
 
 ## User facing
+cifmw_update_dont_cleanup: false
 cifmw_update_reboot_test: false
 cifmw_update_ansible_ssh_private_key_file: >-
   "{{ ansible_ssh_private_key_file | default(ansible_user_dir ~ '/.ssh/id_cifw') }}"

--- a/roles/update/tasks/cleanup.yml
+++ b/roles/update/tasks/cleanup.yml
@@ -14,6 +14,19 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Cleaning the World
-  ansible.builtin.debug:
-    msg: "So here update should clean things up!"
+- name: Cleanup ping test resources
+  block:
+    - name: Cleaning the ping vm if needed
+      ansible.builtin.shell: |
+        set -e
+        set -o pipefail
+        cat {{ cifmw_update_workload_launch_script }} | \
+        podman exec -i lopenstackclient env WKL_MODE=cleanup bash -i 2>&1 \
+        {{ cifmw_update_timestamper_cmd }} | tee {{ cifmw_update_artifacts_basedir }}/workload_cleanup.log
+
+    - name: Get logs from update instance creation
+      ansible.builtin.shell: >
+        podman cp lopenstackclient:{{ cifmw_update_artifacts_basedir_suffix }}/.
+        {{ cifmw_update_artifacts_basedir }}
+  when:
+    - cifmw_update_ping_test | bool

--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -208,3 +208,9 @@
     cmd: >
       {{ cifmw_update_artifacts_basedir }}/update_event.sh
       Update complete
+
+- name: Cleanup ressources used for testing on OpenStack
+  ansible.builtin.include_tasks: cleanup.yml
+  when:
+    - not (cifmw_update_dont_cleanup | bool)
+    - not (cifmw_update_run_dryrun | bool)


### PR DESCRIPTION
This commit introduces tasks that cleans up resources created on
OpenStack during the update test. The cleanup runs by default.

A new boolean variable, `cifmw_update_dont_cleanup`, is added to allow
skipping the cleanup phase. This is useful for debugging purposes when
the created resources need to be inspected.

Closes: [openstack resources created to test update in rhoso 18 are not cleanup](https://issues.redhat.com/browse/OSPRH-20307)