### PR TITLE
Remove deprecated cifmw_tempest_tempestconf_config

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -92,7 +92,6 @@ cifmw_test_operator_stages:
 * `cifmw_test_operator_tempest_rerun_override_status`: (Bool) Allow override of exit status with the tempest re-run feature. When activated, the original return value of the tempest run will be overridden with a result of the tempest run on the set of failed tests. Default value: `false`
 * `cifmw_test_operator_tempest_timing_data_url`: (String) An URL pointing to an archive that contains the saved timing data. This data is used to optimize the test order and reduce Tempest execution time. Default value: `''`
 * `cifmw_test_operator_tempest_resources`: (Dict) A dictionary that specifies resources (cpu, memory) for the test pods. When untouched it clears the default values set on the test-operator side. This means that the tempest test pods run with unspecified resource limits. Default value: `{requests: {}, limits: {}}`
-* `cifmw_tempest_tempestconf_config`: Deprecated, please use `cifmw_test_operator_tempest_tempestconf_config` instead
 * `cifmw_test_operator_tempest_tempestconf_config`: (Dict) This parameter can be used to customize the execution of the `discover-tempest-config` run. Please consult the test-operator documentation. For example, to pass a custom configuration for `tempest.conf`, use the `overrides` section:
 ```
 cifmw_test_operator_tempest_tempestconf_config:

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -78,7 +78,6 @@ cifmw_test_operator_tempest_workflow: []
 cifmw_test_operator_tempest_cleanup: false
 cifmw_test_operator_tempest_rerun_failed_tests: false
 cifmw_test_operator_tempest_rerun_override_status: false
-cifmw_test_operator_tempest_tempestconf_config: "{{ cifmw_tempest_tempestconf_config }}"
 
 # TODO: The default value of this parameter should be changed to {} once this fix
 #       for tempest reaches the upstream build of the openstack-tempest-all image:


### PR DESCRIPTION
This parameter has been deprecated for some time, so we should use the new variant cifmw_test_operator_tempest_tempestconf_config. All mentions of this parameter have been removed both from downstream and upstream, so this patch is the last step to removing the parameter.