### PR TITLE
Revert "Add read_global_vars.yml in pre-run stage"

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -13,7 +13,6 @@
       and prepare the environment for running ci-framework playbooks.
       Once the job finishes, it will collect necessary logs.
     pre-run:
-      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
     post-run:
@@ -140,7 +139,6 @@
     roles: &multinode_edpm_roles
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run: &multinode_edpm_pre_run
-      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/multinode-customizations.yml
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
@@ -283,7 +281,6 @@
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run:
-      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
     post-run:
@@ -308,7 +305,6 @@
       CRC environment and before running ci-boostrap roles to
       configure networking between nodes.
     pre-run:
-      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
       - ci/playbooks/bootstrap-networking-mapper.yml

--- a/zuul.d/end-to-end.yaml
+++ b/zuul.d/end-to-end.yaml
@@ -9,7 +9,6 @@
       zuul_log_collection: true
       registry_login_enabled: false
     pre-run:
-      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
     post-run:

--- a/zuul.d/kuttl.yaml
+++ b/zuul.d/kuttl.yaml
@@ -9,7 +9,6 @@
       zuul_log_collection: true
     parent: base-simple-crc
     pre-run:
-      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/e2e-prepare.yml
     run:
       - ci/playbooks/dump_zuul_data.yml

--- a/zuul.d/kuttl_multinode.yaml
+++ b/zuul.d/kuttl_multinode.yaml
@@ -41,8 +41,6 @@
                 ip: 172.18.0.5
               tenant:
                 ip: 172.19.0.5
-    pre-run:
-      - ci/playbooks/read_global_vars.yml
     run:
       - ci/playbooks/dump_zuul_data.yml
       - ci/playbooks/kuttl/run.yml

--- a/zuul.d/tcib.yaml
+++ b/zuul.d/tcib.yaml
@@ -11,7 +11,6 @@
       - github.com/openstack-k8s-operators/tcib
       - github.com/openstack-k8s-operators/install_yamls
     pre-run:
-      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/content_provider/pre.yml
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml

--- a/zuul.d/test-job.yaml
+++ b/zuul.d/test-job.yaml
@@ -5,7 +5,6 @@
     nodeset: centos-stream-9
     abstract: true
     pre-run:
-      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
     run:


### PR DESCRIPTION
Reverts openstack-k8s-operators/ci-framework#3258

The reason to remove the playbook from pre-run stage from Zuul is, Zuul is not storing the cached vars that we added in pre-run. Maybe it is possible by some other way, but lets remove this for now.