### PR TITLE
Revert "Include read_global_vars.yml in pre-run: zuul.d/molecule-base.yaml"

### DIFF
--- a/zuul.d/molecule-base.yaml
+++ b/zuul.d/molecule-base.yaml
@@ -7,7 +7,6 @@
     provides:
       - cifmw-molecule
     pre-run:
-      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/dump_zuul_data.yml
       - ci/playbooks/molecule-prepare.yml
     run: ci/playbooks/molecule-test.yml
@@ -26,7 +25,6 @@
     provides:
       - cifmw-molecule
     pre-run:
-      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/dump_zuul_data.yml
       - ci/playbooks/molecule-prepare.yml
     run: ci/playbooks/molecule-test.yml


### PR DESCRIPTION
Reverts openstack-k8s-operators/ci-framework#3276

The reason to remove the playbook from pre-run stage from Zuul is, Zuul is not storing the cached vars that we added in pre-run. Maybe it is possible by some other way, but lets remove this for now.