### PR TITLE
Revert "Include read_global_vars.yml in pre-run: zuul.d/pods.yaml"

### DIFF
--- a/zuul.d/pods.yaml
+++ b/zuul.d/pods.yaml
@@ -9,8 +9,6 @@
       Run lightweight jobs in pods
     required-projects:
       - openstack-k8s-operators/ci-framework
-    pre-run:
-      - ci/playbooks/read_global_vars.yml
     run: ci/playbooks/pod-jobs.yml
 
 - job:
@@ -64,7 +62,6 @@
     parent: build-push-container-base
     nodeset: centos-stream-9
     pre-run:
-      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/molecule-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
     run: ci/playbooks/build_push_container_runner.yml


### PR DESCRIPTION
Reverts openstack-k8s-operators/ci-framework#3277

The reason to remove the playbook from pre-run stage from Zuul is, Zuul is not storing the cached vars that we added in pre-run. Maybe it is possible by some other way, but lets remove this for now.