### PR TITLE
Revert "Include read_global_vars.yml in pre-run: zuul.d/adoption.yaml"

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -11,7 +11,6 @@
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run:
-      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/multinode-customizations.yml
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
@@ -209,7 +208,6 @@
     roles: &multinode-roles
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run: &multinode-prerun
-      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/multinode-customizations.yml
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml


### PR DESCRIPTION
Reverts openstack-k8s-operators/ci-framework#3278

The reason to remove the playbook from pre-run stage from Zuul is, Zuul is not storing the cached vars that we added in pre-run. Maybe it is possible by some other way, but lets remove this for now.