### PR TITLE
Revert "Include read_global_vars.yml in pre-run: zuul.d/edpm_build_images.yam…"

### DIFF
--- a/zuul.d/edpm_build_images.yaml
+++ b/zuul.d/edpm_build_images.yaml
@@ -8,7 +8,6 @@
     required-projects:
       - github.com/openstack-k8s-operators/edpm-image-builder
     pre-run:
-      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/molecule-prepare.yml
     run:
       - ci/playbooks/dump_zuul_data.yml

--- a/zuul.d/edpm_build_images_content_provider.yaml
+++ b/zuul.d/edpm_build_images_content_provider.yaml
@@ -9,7 +9,6 @@
       - github.com/openstack-k8s-operators/edpm-image-builder
       - github.com/openstack-k8s-operators/ci-framework
     pre-run:
-      - ci/playbooks/read_global_vars.yml
       - ci/playbooks/content_provider/pre.yml
     run:
       - ci/playbooks/e2e-prepare.yml


### PR DESCRIPTION
Reverts openstack-k8s-operators/ci-framework#3279

The reason to remove the playbook from pre-run stage from Zuul is, Zuul is not storing the cached vars that we added in pre-run. Maybe it is possible by some other way, but lets remove this for now.