### PR TITLE
feat(artifacts): Replace hardcoded zuul path with configurable variable

### DIFF
--- a/roles/artifacts/tasks/edpm.yml
+++ b/roles/artifacts/tasks/edpm.yml
@@ -75,7 +75,7 @@
           sudo test -d /var/lib/openstack && sudo cp -a /var/lib/openstack /tmp/{{ host_ip }}
           sudo test -d /var/lib/config-data && sudo cp -a /var/lib/config-data /tmp/{{ host_ip }}
           sudo test -d /var/lib/cloud && sudo cp -a /var/lib/cloud /tmp/{{ host_ip }}
-          sudo test -d /home/zuul/compliance-scans && sudo cp -a /home/zuul/compliance-scans /tmp/{{ host_ip }}
+          sudo test -d {{ ansible_user_dir }}/compliance-scans && sudo cp -a {{ ansible_user_dir }}/compliance-scans /tmp/{{ host_ip }}
           sudo find /tmp/{{ host_ip }} -type d -exec chmod ugoa+rx '{}' \;
           sudo find /tmp/{{ host_ip }} -type f -exec chmod ugoa+r '{}' \;
           command -v ovs-vsctl && sudo ovs-vsctl list Open_vSwitch > /tmp/{{ host_ip }}/ovs_vsctl_list_openvswitch.txt


### PR DESCRIPTION
Replace hardcoded /home/zuul/ paths with the configurable `ansible_user_dir` variable in the artifacts edpm.yml task file to remove hardcoded dependencies and align with other roles in the framework.