### PR TITLE
Make a symlink of os_must_gather dir to static name dir

### DIFF
--- a/roles/os_must_gather/defaults/main.yml
+++ b/roles/os_must_gather/defaults/main.yml
@@ -21,6 +21,7 @@ cifmw_os_must_gather_image: "quay.io/openstack-k8s-operators/openstack-must-gath
 cifmw_os_must_gather_image_push: true
 cifmw_os_must_gather_image_registry: "quay.rdoproject.org/openstack-k8s-operators"
 cifmw_os_must_gather_output_dir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+cifmw_os_must_gather_output_log_dir: "{{ cifmw_os_must_gather_output_dir }}/logs/openstack-must-gather"
 cifmw_os_must_gather_repo_path: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/openstack-must-gather"
 cifmw_os_must_gather_timeout: "10m"
 cifmw_os_must_gather_additional_namespaces: "kuttl,openshift-storage,openshift-marketplace,openshift-operators,sushy-emulator,tobiko"

--- a/roles/os_must_gather/tasks/main.yml
+++ b/roles/os_must_gather/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: Ensure directories are present
   ansible.builtin.file:
-    path: "{{ cifmw_os_must_gather_output_dir }}/logs/openstack-k8s-operators-openstack-must-gather"
+    path: "{{ cifmw_os_must_gather_output_log_dir }}"
     state: directory
     mode: "0755"
 
@@ -63,13 +63,26 @@
           oc adm must-gather --image {{ cifmw_os_must_gather_image }}
           --timeout {{ cifmw_os_must_gather_timeout }}
           --host-network={{ cifmw_os_must_gather_host_network }}
-          --dest-dir {{ cifmw_os_must_gather_output_dir }}/logs/openstack-k8s-operators-openstack-must-gather
+          --dest-dir {{ cifmw_os_must_gather_output_log_dir }}
           -- ADDITIONAL_NAMESPACES={{ cifmw_os_must_gather_additional_namespaces }}
           OPENSTACK_DATABASES=$OPENSTACK_DATABASES
           SOS_EDPM=$SOS_EDPM
           SOS_DECOMPRESS=$SOS_DECOMPRESS
           gather
           2>&1
+
+    - name: Find existing os-must-gather directories
+      ansible.builtin.find:
+        paths: "{{ cifmw_os_must_gather_output_log_dir }}"
+        file_type: directory
+        depth: 1
+      register: _os_gather_latest_dir
+
+    - name: Create a symlink to newest os-must-gather directory
+      ansible.builtin.file:
+        src: "{{ (_os_gather_latest_dir.files | sort(attribute='mtime', reverse=True) | first).path | basename }}"
+        dest: "{{ cifmw_os_must_gather_output_log_dir }}/latest"
+        state: link
 
   rescue:
     - name: Openstack-must-gather failure


### PR DESCRIPTION
Some teams are using static directory to grab latest CI job results. Let's help them and create a symlink to latest dir.