### PR TITLE
Add all molecule files to the scope of check_zuul_jobs

### DIFF
--- a/zuul.d/pods.yaml
+++ b/zuul.d/pods.yaml
@@ -34,6 +34,7 @@
       - ^zuul.d/.*
       - ^ci/templates/.*
       - ^ci/config/.*
+      - ^roles/.*/molecule/.*
 
 - job:
     name: cifmw-pod-k8s-snippets-source


### PR DESCRIPTION
check_zuul_jobs take care of multiple zuul related files. It also includes molecule job file. If any change is made to molecule within role definition, this job is not triggered, and it causes manual changes issue for molecule.yml zuul file. This commit ensure this job is run every time when any change is made to molecule file of any role. It will ensure jobs are not broken due to such changes.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3346