### PR TITLE
Increase timeout for cifmw-molecule-openshift_obs job

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -1,5 +1,8 @@
 ---
 - job:
+    name: cifmw-molecule-openshift_obs
+    timeout: 3600
+- job:
     name: cifmw-molecule-libvirt_manager
     files:
       - ^roles/dnsmasq/.*

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -545,6 +545,7 @@
     name: cifmw-molecule-openshift_obs
     nodeset: centos-9-crc-2-48-0-xxl-ibm
     parent: cifmw-molecule-base
+    timeout: 3600
     vars:
       TEST_RUN: openshift_obs
 - job:


### PR DESCRIPTION
cifmw-molecule-openshift_obs job is failing sometimes due to timeout. Trying to increase tiemout to fix this issue.