### PR TITLE
Increase the scope of cifmw-pods-zuul-files job

### DIFF
--- a/zuul.d/pods.yaml
+++ b/zuul.d/pods.yaml
@@ -32,7 +32,7 @@
       - ^zuul.d/.*
       - ^ci/templates/.*
       - ^ci/config/.*
-      - ^roles/.*/molecule/.*
+      - ^roles/.*
 
 - job:
     name: cifmw-pod-k8s-snippets-source


### PR DESCRIPTION
Just checking the changes to molecule files solve only half of our problem. If a user add a new role, even then molecule job definition for that role is not added, and this job starts to fail in future. Though running this job on any change made in roles dir is quite wider scope. But seems like it is not possible to just run the job when new role is added.

Related to: https://github.com/openstack-k8s-operators/ci-framework/pull/3348