### PR TITLE
Add building Tempest timing data url

### DIFF
--- a/roles/test_operator/tasks/tempest-tests.yml
+++ b/roles/test_operator/tasks/tempest-tests.yml
@@ -210,3 +210,71 @@
               stage_vars_dict |
               combine({'cifmw_test_operator_tempest_workflow': no_resources_workflow})
           }}
+
+- name: Build tempest timing data URL (no workflow)
+  when:
+    - not cifmw_test_operator_dry_run | bool
+    - stage_vars_dict.cifmw_test_operator_tempest_timing_data_url is defined
+    - stage_vars_dict.cifmw_test_operator_tempest_timing_data_url
+    - stage_vars_dict.cifmw_test_operator_tempest_workflow | length == 0
+  vars:
+    final_timing_data_url: >-
+      {{
+        stage_vars_dict.cifmw_test_operator_tempest_timing_data_url +
+        test_operator_instance_name + '/stestr.tar.gz'
+      }}
+  ansible.builtin.set_fact:
+    test_operator_cr: >-
+      {{
+          test_operator_cr |
+          combine({'spec': {'timingDataUrl': final_timing_data_url}}, recursive=true)
+      }}
+    stage_vars_dict: >-
+      {{
+          stage_vars_dict |
+          combine({'cifmw_test_operator_tempest_timing_data_url': final_timing_data_url})
+      }}
+
+- name: Build tempest timing data URL (workflow)
+  when:
+    - not cifmw_test_operator_dry_run | bool
+    - stage_vars_dict.cifmw_test_operator_tempest_workflow | length > 0
+  block:
+    - name: Add the full timing data url to workflow steps
+      vars:
+        base_url: >-
+          {{
+            item.timingDataUrl | default(stage_vars_dict.get('cifmw_test_operator_tempest_timing_data_url', ''))
+          }}
+        final_timing_data_url: >-
+          {{
+            base_url + test_operator_instance_name + '-s' +
+            '%02d' | format(step_number) + '-' + item.stepName + '/stestr.tar.gz'
+          }}
+        _timing_data_url_workflow_step: >-
+          {{
+              (base_url | length > 0)
+              | ternary(
+                  item | combine({'timingDataUrl': final_timing_data_url}, recursive=true),
+                  item
+                )
+          }}
+      ansible.builtin.set_fact:
+        timing_data_url_workflow: "{{ timing_data_url_workflow | default([]) + [_timing_data_url_workflow_step] }}"
+      loop: "{{ stage_vars_dict.cifmw_test_operator_tempest_workflow | list }}"
+      loop_control:
+        index_var: step_number
+
+    - name: Override the Tempest CR workflow
+      when: timing_data_url_workflow is defined
+      ansible.builtin.set_fact:
+        test_operator_cr: >-
+          {{
+              test_operator_cr |
+              combine({'spec': {'workflow': timing_data_url_workflow}}, recursive=true)
+          }}
+        stage_vars_dict: >-
+          {{
+              stage_vars_dict |
+              combine({'cifmw_test_operator_tempest_workflow': timing_data_url_workflow})
+          }}


### PR DESCRIPTION
There is a relatively new parameter added to test-operator, called TimingDataUrl. We are trying to make the parameter work with jobs, but the issue is that there is no variable that stores the final Tempest pod name that will be created. Without it, we cannot build the timing data url, as we are saving the data under job/test-name folder.

This change adds a way to build the final url for both tests with and without workflow.