### PR TITLE
Fix output of must-gather log

### DIFF
--- a/roles/os_must_gather/tasks/main.yml
+++ b/roles/os_must_gather/tasks/main.yml
@@ -68,7 +68,8 @@
           OPENSTACK_DATABASES=$OPENSTACK_DATABASES
           SOS_EDPM=$SOS_EDPM
           SOS_DECOMPRESS=$SOS_DECOMPRESS
-          gather &> {{ cifmw_os_must_gather_output_dir }}/logs/openstack-k8s-operators-openstack-must-gather/os_must_gather.log
+          gather
+          2>&1
 
   rescue:
     - name: Openstack-must-gather failure


### PR DESCRIPTION
Right now because of &> the output of ci_script task
in collected logs is empty. After the change we will
have the output along other calls of ci_script instead
of relying on the dedicated file.