### PR TITLE
fix(devscripts): add molecule group in roles/devscript/check_cluster_status/molecule.yml

### DIFF
--- a/roles/devscripts/molecule/check_cluster_status/molecule.yml
+++ b/roles/devscripts/molecule/check_cluster_status/molecule.yml
@@ -9,6 +9,7 @@ log: true
 platforms:
   - name: instance
     groups:
+      - molecule
       - devscript_molecule
 
 provisioner:


### PR DESCRIPTION
PR [1] ensured our molecule jobs can use group_vars. During this, adding molecule group to one file was missed. This commit adds that.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/3333