### PR TITLE
Fix molecule jobs find group_vars file

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -26,9 +26,6 @@ platforms:
 
 provisioner:
   name: ansible
-  inventory:
-    links:
-      group_vars: ../../../../group_vars/
   config_options:
     defaults:
       fact_caching: jsonfile

--- a/.config/molecule/config_local.yml
+++ b/.config/molecule/config_local.yml
@@ -25,9 +25,6 @@ provisioner:
   #     all:
   #       cifmw_discover_latest_image_qcow_prefix: "CentOS-Stream-GenericCloud-9-20240506"
 
-  inventory:
-    links:
-      group_vars: ../../../../group_vars/
   config_options:
     defaults:
       fact_caching: jsonfile

--- a/.config/molecule/config_podman.yml
+++ b/.config/molecule/config_podman.yml
@@ -25,8 +25,6 @@ provisioner:
         hosts:
           instance:
             ansible_python_interpreter: /usr/bin/python3
-    links:
-      group_vars: ../../../../group_vars/
   name: ansible
   log: true
   env:

--- a/roles/ci_multus/molecule/default/molecule.yml
+++ b/roles/ci_multus/molecule/default/molecule.yml
@@ -12,6 +12,8 @@ provisioner:
   inventory:
     links:
       host_vars: ./host_vars/
+      group_vars: ../../../../group_vars/
+
 prerun: false
 scenario:
   test_sequence:

--- a/roles/ci_multus/molecule/local/molecule.yml
+++ b/roles/ci_multus/molecule/local/molecule.yml
@@ -12,6 +12,7 @@ provisioner:
   inventory:
     links:
       host_vars: ./host_vars/
+      group_vars: ../../../../group_vars/
 
 prerun: false
 scenario:

--- a/roles/ci_multus/molecule/local_ipv6/molecule.yml
+++ b/roles/ci_multus/molecule/local_ipv6/molecule.yml
@@ -12,6 +12,7 @@ provisioner:
   inventory:
     links:
       host_vars: ./host_vars/
+      group_vars: ../../../../group_vars/
 
 prerun: false
 scenario:

--- a/roles/cifmw_snr_nhc/molecule/default/molecule.yml
+++ b/roles/cifmw_snr_nhc/molecule/default/molecule.yml
@@ -27,6 +27,9 @@ platforms:
 
 provisioner:
   name: ansible
+  inventory:
+    links:
+      group_vars: ../../../../group_vars/
 
 verifier:
   name: ansible

--- a/roles/devscripts/molecule/check_cluster_status/molecule.yml
+++ b/roles/devscripts/molecule/check_cluster_status/molecule.yml
@@ -14,4 +14,7 @@ platforms:
 
 provisioner:
   name: ansible
+  inventory:
+    links:
+      group_vars: ../../../../group_vars/
   log: true

--- a/roles/devscripts/molecule/default/molecule.yml
+++ b/roles/devscripts/molecule/default/molecule.yml
@@ -14,4 +14,7 @@ platforms:
 
 provisioner:
   name: ansible
+  inventory:
+    links:
+      group_vars: ../../../../group_vars/
   log: true

--- a/roles/libvirt_manager/molecule/check_dns/molecule.yml
+++ b/roles/libvirt_manager/molecule/check_dns/molecule.yml
@@ -7,3 +7,4 @@ provisioner:
   inventory:
     links:
       host_vars: ./host_vars/
+      group_vars: ../../../../group_vars/

--- a/roles/libvirt_manager/molecule/deploy_layout/molecule.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/molecule.yml
@@ -7,3 +7,4 @@ provisioner:
   inventory:
     links:
       host_vars: ./host_vars/
+      group_vars: ../../../../group_vars/

--- a/roles/libvirt_manager/molecule/generate_network_data/molecule.yml
+++ b/roles/libvirt_manager/molecule/generate_network_data/molecule.yml
@@ -7,3 +7,4 @@ provisioner:
   inventory:
     links:
       host_vars: ./host_vars/
+      group_vars: ../../../../group_vars/

--- a/roles/libvirt_manager/molecule/ocp_layout/molecule.yml
+++ b/roles/libvirt_manager/molecule/ocp_layout/molecule.yml
@@ -7,3 +7,4 @@ provisioner:
   inventory:
     links:
       host_vars: ./host_vars/
+      group_vars: ../../../../group_vars/

--- a/roles/libvirt_manager/molecule/spine_leaf/molecule.yml
+++ b/roles/libvirt_manager/molecule/spine_leaf/molecule.yml
@@ -4,3 +4,6 @@ log: true
 provisioner:
   name: ansible
   log: true
+  inventory:
+    links:
+      group_vars: ../../../../group_vars/

--- a/roles/networking_mapper/molecule/default/molecule.yml
+++ b/roles/networking_mapper/molecule/default/molecule.yml
@@ -12,3 +12,4 @@ provisioner:
   inventory:
     link:
       host_vars: ./host_vars/
+      group_vars: ../../../../group_vars/

--- a/roles/rhol_crc/molecule/add_crc_creds/molecule.yml
+++ b/roles/rhol_crc/molecule/add_crc_creds/molecule.yml
@@ -10,6 +10,9 @@ platforms:
 provisioner:
   name: ansible
   log: true
+  inventory:
+    link:
+      group_vars: ../../../../group_vars/
 
 # Enforce scenario steps to NOT
 # run "verify" as a standalone play

--- a/roles/rhol_crc/molecule/binary/molecule.yml
+++ b/roles/rhol_crc/molecule/binary/molecule.yml
@@ -10,6 +10,9 @@ platforms:
 provisioner:
   name: ansible
   log: true
+  inventory:
+    link:
+      group_vars: ../../../../group_vars/
 
 # Enforce scenario steps to NOT
 # run "verify" as a standalone play

--- a/roles/rhol_crc/molecule/default/molecule.yml
+++ b/roles/rhol_crc/molecule/default/molecule.yml
@@ -10,6 +10,9 @@ platforms:
 provisioner:
   name: ansible
   log: true
+  inventory:
+    link:
+      group_vars: ../../../../group_vars/
 
 # Enforce scenario steps to NOT
 # run "verify" as a standalone play

--- a/roles/rhol_crc/molecule/find_crc/molecule.yml
+++ b/roles/rhol_crc/molecule/find_crc/molecule.yml
@@ -10,6 +10,9 @@ platforms:
 provisioner:
   name: ansible
   log: true
+  inventory:
+    link:
+      group_vars: ../../../../group_vars/
 
 # Enforce scenario steps to NOT
 # run "verify" as a standalone play

--- a/roles/rhol_crc/molecule/get_versions/molecule.yml
+++ b/roles/rhol_crc/molecule/get_versions/molecule.yml
@@ -10,6 +10,9 @@ platforms:
 provisioner:
   name: ansible
   log: true
+  inventory:
+    link:
+      group_vars: ../../../../group_vars/
 
 # Enforce scenario steps to NOT
 # run "verify" as a standalone play

--- a/roles/run_hook/molecule/default/molecule.yml
+++ b/roles/run_hook/molecule/default/molecule.yml
@@ -11,3 +11,4 @@ provisioner:
   inventory:
     links:
       host_vars: ./host_vars/
+      group_vars: ../../../../group_vars/


### PR DESCRIPTION
We've found a problem that molecule jobs are not finding from the molecule parent config files the group_vars, so we need to move them into each of them molecule.yml files per each molecule scenario