### PR TITLE
Add periodic bootc jobs

### DIFF
--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -31,8 +31,10 @@
       crc_parameters: "--memory 32000 --disk-size 240 --cpus 12"
       cifmw_manage_secrets_pullsecret_content: '{}'
       cifmw_rhol_crc_binary_folder: "/usr/local/bin"
+      # This needs to be updated later to not use hardcoded image url but the one pushed by
+      # the periodic job for pushing the bootc images to the registry 
+      cifmw_update_containers_edpm_image_url: quay.io/openstack-k8s-operators/edpm-bootc:latest-qcow2
       cifmw_install_yamls_vars:
-        BAREMETAL_OS_CONTAINER_IMG: quay.io/openstack-k8s-operators/edpm-bootc:latest-qcow2
         BAREMETAL_OS_IMG: edpm-bootc.qcow2
       cifmw_edpm_deploy_baremetal_bootc: true
 

--- a/zuul.d/edpm_periodic.yaml
+++ b/zuul.d/edpm_periodic.yaml
@@ -20,6 +20,23 @@
       cifmw_tempest_container: openstack-tempest-all
       cifmw_tempest_image_tag: "{{ cifmw_repo_setup_full_hash }}"
 
+- job:
+    name: periodic-podified-edpm-baremetal-bootc-master-ocp-crc
+    parent: cifmw-crc-podified-edpm-baremetal-bootc
+    vars:
+      cifmw_repo_setup_branch: master
+      cifmw_repo_setup_promotion: podified-ci-testing
+      cifmw_dlrn_report_result: true
+      cifmw_tempest_registry: quay.rdoproject.org
+      cifmw_tempest_namespace: podified-{{ cifmw_repo_setup_branch }}-centos9
+      cifmw_tempest_container: openstack-tempest-all
+      cifmw_tempest_image_tag: "{{ cifmw_repo_setup_full_hash }}"
+      cifmw_update_containers_registry: quay.rdoproject.org
+      cifmw_update_containers_org: "podified-master-centos9"
+      cifmw_update_containers_tag: "{{ cifmw_repo_setup_full_hash }}"
+      cifmw_update_containers_openstack: true
+      cifmw_extras:
+        - '@scenarios/centos-9/nested_virt.yml'
 
 - job:
     name: periodic-podified-multinode-edpm-deployment-master-ocp-crc-cs9


### PR DESCRIPTION
Also use cifmw_update_containers_edpm_image_url to patch openstackversion CR.

We can also remove BAREMETAL_OS_IMG var when we use the same qcow image name for bootc images.