### PR TITLE
Add parse ansible argument string to variables

### DIFF
--- a/roles/cifmw_helpers/tasks/parse_ansible_args_string.yml
+++ b/roles/cifmw_helpers/tasks/parse_ansible_args_string.yml
@@ -1,0 +1,34 @@
+---
+# This would help to parse variables, that
+# are called in nested ansible execution using shell/command
+# module.
+# For example:
+#
+#     cifmw_cmd_args: "-e@somefile.yml -e @/tmp/someotherfile.yml -e myvar=test"
+#
+# to:
+#
+#     cifmw_cmd_args_vars: [{'myvar': 'test'}]
+#     cifmw_cmd_args_files: ['somefile.yml', '/tmp/someotherfile.yml']
+#
+
+- name: Split string of arguments into the lists of vars and files
+  when: cifmw_cmd_args | length > 1
+  ansible.builtin.set_fact:
+    cifmw_cmd_args_vars: "{{ cifmw_cmd_args
+         | split(' -e ')
+         | reject('search', '@')
+         | reject('equalto', '')
+         | map('regex_replace', '^(.*?)=(.*)$', '{\"\\1\": \"\\2\"}')
+         | map('from_yaml')
+         | list
+      }}"
+    cifmw_cmd_args_files: "{{ cifmw_cmd_args
+         | split('-e')
+         | select()
+         | map('trim')
+         | select('match', '^@.*\\.(yml|yaml)$')
+         | list
+         | replace('@', '')
+      }}"
+  no_log: "{{ cifmw_helpers_no_log }}"


### PR DESCRIPTION
In some playbook, when nested Ansible is executed via shell/command module, there is a string which contains arguments to parse by the ansible-playbook binary. If nested Ansible can be removed, it would be required to parse such variables.
This helper task can help to parse properly variables, that later can be read properly by tasks without using nested Ansible execution.