### PR TITLE
Create group_vars dir in the project dir if does not exist

### DIFF
--- a/ci/playbooks/molecule-test.yml
+++ b/ci/playbooks/molecule-test.yml
@@ -17,6 +17,20 @@
       ansible.builtin.include_vars:
         file: "{{ cifmw_reproducer_molecule_env_file }}"
 
+    - name: Check if group_vars dir exists
+      ansible.builtin.stat:
+        path: "{{ zuul.project.src_dir }}/group_vars"
+      register: group_vars_dir
+
+    - name: Create group_vars dir if does not exist
+      ansible.builtin.file:
+        path: "{{ zuul.project.src_dir }}/group_vars"
+        state: directory
+        owner: zuul
+        group: zuul
+        mode: '0755'
+      when: not group_vars_dir.stat.exists
+
     - name: Run molecule
       environment:
         ANSIBLE_LOG_PATH: "{{ ansible_user_dir }}/zuul-output/logs/ansible-execution.log"


### PR DESCRIPTION
If our molecule job is used from other project, chances are group_vars dir won't be there. Since our molecule config expects group_vars dir to be there, let's create it before running molecule job.