### PR TITLE
Add molecule jobs from edpm-ansible

### DIFF
--- a/ci/playbooks/molecule-test.yml
+++ b/ci/playbooks/molecule-test.yml
@@ -49,6 +49,5 @@
         chdir: "{{ roles_dir }}"
         cmd: >-
           set -o pipefail;
-          mkdir -p {{ roles_dir }}/../../group_vars ;
           molecule -c {{ mol_config_dir }} test --all |
           tee {{ ansible_user_dir }}/ci-framework-data/logs/molecule-execution.log

--- a/scripts/create_role_molecule.py
+++ b/scripts/create_role_molecule.py
@@ -21,7 +21,6 @@ import logging
 from jinja2 import Environment, FileSystemLoader
 
 additional_molecule_jobs = [
-    "edpm-ansible-molecule-edpm_kernel",
     "edpm-ansible-molecule-edpm_podman",
     "edpm-ansible-molecule-edpm_ovs",
 ]

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -104,7 +104,6 @@
       - cifmw-molecule-update_containers
       - cifmw-molecule-validations
       - cifmw-molecule-virtualbmc
-      - edpm-ansible-molecule-edpm_kernel
       - edpm-ansible-molecule-edpm_podman
       - edpm-ansible-molecule-edpm_ovs
     github-post:


### PR DESCRIPTION
The edpm-ansible folks would like to run own job also when our changes are related to molecule job.
Let's trigger some of they jobs here.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3385