### PR TITLE
DNM Print some variables before executing run_logs.yml

### DIFF
--- a/ci/playbooks/e2e-collect-logs.yml
+++ b/ci/playbooks/e2e-collect-logs.yml
@@ -29,6 +29,49 @@
         name: cifmw_helpers
         tasks_from: var_file.yml
 
+    - name: Get vars
+      copy:
+        content: |
+          {{ vars }}
+        dest: /tmp/vars
+
+    - name: Get environment
+      copy:
+        content: |
+          {{ environment }}
+        dest: /tmp/environment
+
+    - name: Get group_names
+      copy:
+        content: |
+          {{ group_names }}
+        dest: /tmp/group_names
+
+    - name: Get groups
+      copy:
+        content: |
+          {{ groups }}
+        dest: /tmp/groups
+
+    - name: Get hostvars
+      copy:
+        content: |
+          {{ hostvars }}
+        dest: /tmp/hostvars
+
+    - name: Print all
+      shell: |
+        echo "vars";
+        cat /tmp/vars;
+        echo "environment";
+        cat /tmp/environment;
+        echo "group_names";
+        cat /tmp/group_names;
+        echo "groups";
+        cat /tmp/groups;
+        echo "hostvars";
+        cat /tmp/hostvars;
+
     - name: Run log collection
       ansible.builtin.import_role:
         name: cifmw_setup


### PR DESCRIPTION
In some CI env, ansible_user_dir is different and it is poiting to zuul executor dir.