### PR TITLE
Configure adoption_ironic_post_oc subnet with ipv6

### DIFF
--- a/hooks/playbooks/adoption_ironic_post_oc.yml
+++ b/hooks/playbooks/adoption_ironic_post_oc.yml
@@ -22,6 +22,8 @@
     _subnet_alloc_pool_start: '172.20.1.150'
     _subnet_alloc_pool_end: '172.20.1.199'
     _subnet_ip_version: 4
+    _subnet_ipv6_address_mode: null
+    _subnet_ipv6_ra_mode: null
     _provider_physical_network: ironic
     _provider_network_type: flat
   tasks:
@@ -153,6 +155,13 @@
               openstack subnet show provisioning-subnet &>/dev/null || \
                 openstack subnet create provisioning-subnet \
                   --network provisioning \
+                  --ip-version {{ _subnet_ip_version }} \
+                  {% if _subnet_ipv6_address_mode -%}
+                  --ipv6-address-mode {{ _subnet_ipv6_address_mode }} \
+                  {% endif -%}
+                  {% if _subnet_ipv6_ra_mode -%}
+                  --ipv6-ra-mode {{ _subnet_ipv6_ra_mode }} \
+                  {% endif -%}
                   --subnet-range {{ _subnet_range }} \
                   --gateway {{ _subnet_gateway }} \
                   --allocation-pool start={{ _subnet_alloc_pool_start }},end={{ _subnet_alloc_pool_end }}


### PR DESCRIPTION
We have noticed that uni04delta-ipv6 adoption deploys the OSP17.1 successfully with IPv6 network. But we found out that ironic subnet is configured with IPv4 instead of IPv6.

This PR aims to fix it.

fixes: [OSPRH-20019](https://issues.redhat.com//browse/OSPRH-20019)