### PR TITLE
Increase semaphore for molecule job

### DIFF
--- a/zuul.d/semaphores.yaml
+++ b/zuul.d/semaphores.yaml
@@ -1,4 +1,4 @@
 ---
 - semaphore:
     name: semaphore-molecule
-    max: 15
+    max: 40


### PR DESCRIPTION
We thought that some molecule CI test will fail less often if less molecule jobs would be computed in the same amount of time. Max server for IBM cloud provider is 25 per host, which means that maximum value is 50. For sure the host would handle that, but let's have some resource reservation to avoid potential problems.