### PR TITLE
refactor(scenarios): replace hardcoded /home/zuul paths in va-multi.yml

### DIFF
--- a/scenarios/reproducers/va-multi.yml
+++ b/scenarios/reproducers/va-multi.yml
@@ -381,7 +381,7 @@ cifmw_networking_definition:
 post_deploy:
   - name: Discover hypervisors for openstack2 namespace
     type: playbook
-    source: "/home/zuul/src/github.com/openstack-k8s-operators/ci-framework/hooks/playbooks/nova_manage_discover_hosts.yml"
+    source: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/hooks/playbooks/nova_manage_discover_hosts.yml"
     extra_vars:
       namespace: openstack2
       _cell_conductors: nova-cell0-conductor-0
@@ -389,7 +389,7 @@ post_deploy:
 pre_admin_setup:
   - name: Prepare OSP networks in openstack2 namespace
     type: playbook
-    source: "/home/zuul/src/github.com/openstack-k8s-operators/ci-framework/playbooks/multi-namespace/ns2_osp_networks.yaml"
+    source: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/playbooks/multi-namespace/ns2_osp_networks.yaml"
     extra_vars:
       cifmw_os_net_setup_namespace: openstack2
       cifmw_os_net_setup_public_cidr: "192.168.133.0/24"
@@ -400,7 +400,7 @@ pre_admin_setup:
 post_tests:
   - name: Run tempest against openstack2 namespace
     type: playbook
-    source: "/home/zuul/src/github.com/openstack-k8s-operators/ci-framework/playbooks/multi-namespace/ns2_validation.yaml"
+    source: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/ci-framework/playbooks/multi-namespace/ns2_validation.yaml"
     extra_vars:
       cifmw_test_operator_tempest_name: tempest-tests2
       cifmw_test_operator_namespace: openstack2


### PR DESCRIPTION
  ## Description
Replace hardcoded /home/zuul/ paths with ansible_user_dir variable  in hook source paths to support different user environments and improve consistency with configurable user variables pattern.

  ## Changes
  Updated hook source paths in `scenarios/reproducers/va-multi.yml`:
  - `post_deploy`: nova_manage_discover_hosts.yml hook
  - `pre_admin_setup`: ns2_osp_networks.yaml hook
  - `post_tests`: ns2_validation.yaml hook
