### PR TITLE
[repo_setup] Fix git clone failure when using local filesystem path

### DIFF
--- a/roles/repo_setup/README.md
+++ b/roles/repo_setup/README.md
@@ -19,6 +19,7 @@ using `cifmw_repo_setup_src` role default var.
 * `cifmw_repo_setup_rdo_mirror`: (String) Address from which to install RDO packages. Defaults to `{{ cifmw_repo_setup_dlrn_uri }}`.
 * `cifmw_repo_setup_os_release`: (String) Operating system release. Defaults to `{{ ansible_distribution|lower }}`.
 * `cifmw_repo_setup_src`: (String) repo-setup repository location. Defaults to `https://github.com/openstack-k8s-operators/repo-setup`.
+* `cifmw_repo_setup_git_ref`: (String) Git branch, tag, or commit to checkout when cloning repo-setup repository. Only applies when `cifmw_repo_setup_src` is a git URL. Defaults to `main`.
 * `cifmw_repo_setup_output`: (String) Repository files output. Defaults to `{{ cifmw_repo_setup_basedir }}/artifacts/repositories`.
 * `cifmw_repo_setup_additional_repos`: (String) Additional repos(ceph, deps) to enable. Defaults to `''`.
 * `cifmw_repo_setup_env`: (Dict) Environment variables to be passed to repo_setup cli . Defaults to `'{}'`.

--- a/roles/repo_setup/defaults/main.yml
+++ b/roles/repo_setup/defaults/main.yml
@@ -28,6 +28,7 @@ cifmw_repo_setup_rdo_mirror: "{{ cifmw_repo_setup_dlrn_uri }}"
 cifmw_repo_setup_os_release: "{{ ansible_distribution | lower }}"
 cifmw_repo_setup_dist_major_version: "{{ ansible_distribution_major_version }}"
 cifmw_repo_setup_src: "https://github.com/openstack-k8s-operators/repo-setup"
+cifmw_repo_setup_git_ref: "main"
 cifmw_repo_setup_output: "{{ cifmw_repo_setup_basedir }}/artifacts/repositories"
 cifmw_repo_setup_env: {}
 cifmw_repo_setup_additional_repos: ''

--- a/roles/repo_setup/tasks/install.yml
+++ b/roles/repo_setup/tasks/install.yml
@@ -18,11 +18,21 @@
     - packages
     - bootstrap
 
-- name: Get repo-setup repository # noqa: latest[git]
+- name: Get repo-setup repository (from local path)
+  ansible.builtin.copy:
+    src: "{{ cifmw_repo_setup_src }}/"
+    dest: "{{ cifmw_repo_setup_basedir }}/tmp/repo-setup"
+    remote_src: true
+    mode: preserve
+  when: cifmw_repo_setup_src is match('^/')
+
+- name: Get repo-setup repository (from git URL)
   ansible.builtin.git:
     accept_hostkey: true
     dest: "{{ cifmw_repo_setup_basedir }}/tmp/repo-setup"
     repo: "{{ cifmw_repo_setup_src }}"
+    version: "{{ cifmw_repo_setup_git_ref }}"
+  when: cifmw_repo_setup_src is not match('^/')
 
 - name: Initialize python venv and install requirements
   ansible.builtin.pip:


### PR DESCRIPTION
The git module fails when cifmw_repo_setup_src points to a local path and the source repository is in detached HEAD state. The module tries to resolve 'HEAD' from the source repo and fails with "pathspec 'None' did not match any file(s) known to git".

This fix adds conditional logic to:
- Use ansible.builtin.copy for local filesystem paths (starts with '/')
- Use ansible.builtin.git with proper version parameter for git URLs

This allows the role to work in both, where repos are pre-checked out locally, and manual deployments (where git URLs are used).