### PR TITLE
[kustomize_deploy] Make metal3 node fact cacheable

### DIFF
--- a/roles/kustomize_deploy/tasks/execute_step.yml
+++ b/roles/kustomize_deploy/tasks/execute_step.yml
@@ -143,7 +143,7 @@
         - name: Set metal3 node for provisionserver nodeSelector
           ansible.builtin.set_fact:
             cifmw_kustomize_deploy_metal3_node: "{{ _cifmw_kustomize_deploy_metal3_pod_info.resources[0].spec.nodeName }}"
-            cacheable: false
+            cacheable: true
           when:
             - _cifmw_kustomize_deploy_metal3_pod_info.resources is defined
             - _cifmw_kustomize_deploy_metal3_pod_info.resources | length > 0


### PR DESCRIPTION
    [kustomize_deploy] Make metal3 node fact cacheable
    
    Enable caching for cifmw_kustomize_deploy_metal3_node fact to persist
    the node selection across playbook runs.
    
    Signed-off-by: Miguel Angel Nieto Jimenez <mnietoji@redhat.com>
    Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
