### PR TITLE
[ci_gen_kustomize_values] Co-locate provisionserver with metal3 to prevent DHCP failures

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -183,6 +183,7 @@ dlrnapi
 dlrnrepo
 dm
 dnf
+DPDK
 dns
 dnsdata
 dnsmasq
@@ -283,6 +284,7 @@ ipmi
 ips
 iptables
 ipv
+IOV
 iscsi
 isdir
 itldwuw
@@ -391,6 +393,7 @@ networker
 networkmanager
 networktype
 nfs
+NFV
 nftables
 nhc
 nic
@@ -461,6 +464,7 @@ ovirt
 ovirtmgmt
 ovn
 ovnkubernetes
+OVS
 pablintino
 param
 params

--- a/roles/ci_gen_kustomize_values/README.md
+++ b/roles/ci_gen_kustomize_values/README.md
@@ -35,6 +35,7 @@ with a message.
 * `ci_gen_kustomize_fetch_ocp_state`: (Boolean) If true it enables generating CI templates based on the OCP state. Defaults to `true`.
 * `cifmw_ci_gen_kustomize_values_storage_class_prefix`: (String) Prefix for `storageClass` in generated values.yaml files. Defaults to `"lvms-"` only if `cifmw_use_lvms` is True, otherwise it defaults to `""`. The prefix is prepended to the `cifmw_ci_gen_kustomize_values_storage_class`. It is not recommended to override this value, instead set `cifmw_use_lvms` True or False.
 * `cifmw_ci_gen_kustomize_values_storage_class`: (String) Value for `storageClass` in generated values.yaml files. Defaults to `"lvms-local-storage"` only if `cifmw_use_lvms` is True, otherwise it defaults to `"local-storage"`.
+* `cifmw_ci_gen_kustomize_values_detect_metal3`: (Boolean) Enable metal3 node detection for baremetal nodeset provisioning. When enabled, detects the node where metal3 pod is running and sets `provisionServerNodeSelector` in `baremetalSetTemplate` to co-locate the provision server with metal3. This prevents DHCP conflicts during baremetal provisioning. Defaults to `false`. Set to `true` for baremetal deployment scenarios (NFV, OVS-DPDK, SR-IOV).
 * `cifmw_ci_gen_kustomize_values_remove_keys_expressions*`: (List) Remove keys matching the regular expressions from source ConfigMaps (values.yaml).
   Defaults to `["^nodes$", "^node(_[0-9]+)?$"]`. Accepts passing additional expressions by passing variables that matches `cifmw_ci_gen_kustomize_values_remove_keys_expressions.+`.
 

--- a/roles/ci_gen_kustomize_values/defaults/main.yml
+++ b/roles/ci_gen_kustomize_values/defaults/main.yml
@@ -67,6 +67,9 @@ ci_gen_kustomize_fetch_ocp_state: true
 cifmw_ci_gen_kustomize_values_storage_class_prefix: "{{ 'lvms-' if cifmw_use_lvms | default(false) | bool else '' }}"
 cifmw_ci_gen_kustomize_values_storage_class: "{{ cifmw_ci_gen_kustomize_values_storage_class_prefix }}local-storage"
 
+# Enable metal3 node detection for baremetal provisioning
+cifmw_ci_gen_kustomize_values_detect_metal3: false
+
 cifmw_ci_gen_kustomize_values_primary_ip_version: 4
 cifmw_ci_gen_kustomize_values_remove_keys_expressions:
   - ^nodes$

--- a/roles/ci_gen_kustomize_values/tasks/detect_metal3_node.yml
+++ b/roles/ci_gen_kustomize_values/tasks/detect_metal3_node.yml
@@ -14,14 +14,18 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Detect metal3 node for baremetal nodeset provisioning
+- name: Get metal3 pod information
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    kind: Pod
+    namespace: openshift-machine-api
+    label_selectors:
+      - k8s-app=metal3
+  register: _cifmw_kustomize_deploy_metal3_pod_info
+
+- name: Set metal3 node for provisionserver nodeSelector
+  ansible.builtin.set_fact:
+    cifmw_kustomize_deploy_metal3_node: "{{ _cifmw_kustomize_deploy_metal3_pod_info.resources[0].spec.nodeName }}"
+    cacheable: true
   when:
-    - (cifmw_ci_gen_kustomize_values_detect_metal3 | default(false) | bool) and (cifmw_kustomize_deploy_metal3_node is not defined)
-    - ('nodeset' in (cifmw_ci_gen_kustomize_values_dest_fname_prefix | default(cifmw_ci_gen_kustomize_values_name, true) | default('')))
-  ansible.builtin.include_tasks: detect_metal3_node.yml
-
-- name: Generate snippets files
-  ansible.builtin.include_tasks: generate_snippets.yml
-
-- name: Generate values file
-  ansible.builtin.include_tasks: generate_values.yml
+    - _cifmw_kustomize_deploy_metal3_pod_info.resources | default([]) | length > 0

--- a/roles/ci_gen_kustomize_values/templates/nfv-ovs-dpdk-sriov-hci/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/nfv-ovs-dpdk-sriov-hci/edpm-nodeset-values/values.yaml.j2
@@ -44,3 +44,9 @@ data:
       - "{{ svc }}"
 {%   endfor                                                                            %}
 {% endif                                                                               %}
+{% if cifmw_kustomize_deploy_metal3_node is defined                                    %}
+  baremetalSetTemplate:
+{{ original_content.data.baremetalSetTemplate | default({}) | to_nice_yaml(indent=2) | indent(4, first=true) }}
+    provisionServerNodeSelector:
+      kubernetes.io/hostname: "{{ cifmw_kustomize_deploy_metal3_node }}"
+{% endif                                                                               %}

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-2nodesets/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-2nodesets/edpm-nodeset-values/values.yaml.j2
@@ -56,3 +56,9 @@ data:
       - "{{ svc }}"
 {%   endfor                                                                            %}
 {% endif                                                                               %}
+{% if cifmw_kustomize_deploy_metal3_node is defined                                    %}
+  baremetalSetTemplate:
+{{ original_content.data.baremetalSetTemplate | default({}) | to_nice_yaml(indent=2) | indent(4, first=true) }}
+    provisionServerNodeSelector:
+      kubernetes.io/hostname: "{{ cifmw_kustomize_deploy_metal3_node }}"
+{% endif                                                                               %}

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-ipv6-2nodesets/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-ipv6-2nodesets/edpm-nodeset-values/values.yaml.j2
@@ -56,3 +56,9 @@ data:
       - "{{ svc }}"
 {%   endfor                                                                            %}
 {% endif                                                                               %}
+{% if cifmw_kustomize_deploy_metal3_node is defined                                    %}
+  baremetalSetTemplate:
+{{ original_content.data.baremetalSetTemplate | default({}) | to_nice_yaml(indent=2) | indent(4, first=true) }}
+    provisionServerNodeSelector:
+      kubernetes.io/hostname: "{{ cifmw_kustomize_deploy_metal3_node }}"
+{% endif                                                                               %}

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-ipv6/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-ipv6/edpm-nodeset-values/values.yaml.j2
@@ -43,3 +43,9 @@ data:
       - "{{ svc }}"
 {%   endfor                                                                            %}
 {% endif                                                                               %}
+{% if cifmw_kustomize_deploy_metal3_node is defined                                    %}
+  baremetalSetTemplate:
+{{ original_content.data.baremetalSetTemplate | default({}) | to_nice_yaml(indent=2) | indent(4, first=true) }}
+    provisionServerNodeSelector:
+      kubernetes.io/hostname: "{{ cifmw_kustomize_deploy_metal3_node }}"
+{% endif                                                                               %}

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/edpm-nodeset-values/values.yaml.j2
@@ -43,3 +43,9 @@ data:
       - "{{ svc }}"
 {%   endfor                                                                            %}
 {% endif                                                                               %}
+{% if cifmw_kustomize_deploy_metal3_node is defined                                    %}
+  baremetalSetTemplate:
+{{ original_content.data.baremetalSetTemplate | default({}) | to_nice_yaml(indent=2) | indent(4, first=true) }}
+    provisionServerNodeSelector:
+      kubernetes.io/hostname: "{{ cifmw_kustomize_deploy_metal3_node }}"
+{% endif                                                                               %}

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk/edpm-nodeset-values/values.yaml.j2
@@ -42,3 +42,9 @@ data:
       - "{{ svc }}"
 {%   endfor                                                                            %}
 {% endif                                                                               %}
+{% if cifmw_kustomize_deploy_metal3_node is defined                                    %}
+  baremetalSetTemplate:
+{{ original_content.data.baremetalSetTemplate | default({}) | to_nice_yaml(indent=2) | indent(4, first=true) }}
+    provisionServerNodeSelector:
+      kubernetes.io/hostname: "{{ cifmw_kustomize_deploy_metal3_node }}"
+{% endif                                                                               %}

--- a/roles/ci_gen_kustomize_values/templates/sriov/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/sriov/edpm-nodeset-values/values.yaml.j2
@@ -42,3 +42,9 @@ data:
       - "{{ svc }}"
 {%   endfor                                                                            %}
 {% endif                                                                               %}
+{% if cifmw_kustomize_deploy_metal3_node is defined                                    %}
+  baremetalSetTemplate:
+{{ original_content.data.baremetalSetTemplate | default({}) | to_nice_yaml(indent=2) | indent(4, first=true) }}
+    provisionServerNodeSelector:
+      kubernetes.io/hostname: "{{ cifmw_kustomize_deploy_metal3_node }}"
+{% endif                                                                               %}

--- a/scenarios/reproducers/dt-nfv-ovs-dpdk-sriov-2nodesets.yml
+++ b/scenarios/reproducers/dt-nfv-ovs-dpdk-sriov-2nodesets.yml
@@ -1,5 +1,6 @@
 ---
 cifmw_architecture_scenario: "ovs-dpdk-sriov-2nodesets"
+cifmw_ci_gen_kustomize_values_detect_metal3: true
 
 # Automation section. Most of those parameters will be passed to the
 # controller-0 as-is and be consumed by the `deploy-va.sh` script.

--- a/scenarios/reproducers/dt-nfv-ovs-dpdk-sriov-hci.yml
+++ b/scenarios/reproducers/dt-nfv-ovs-dpdk-sriov-hci.yml
@@ -1,5 +1,6 @@
 ---
 cifmw_architecture_scenario: "nfv-ovs-dpdk-sriov-hci"
+cifmw_ci_gen_kustomize_values_detect_metal3: true
 
 # Automation section. Most of those parameters will be passed to the
 # controller-0 as-is and be consumed by the `deploy-va.sh` script.

--- a/scenarios/reproducers/dt-nfv-ovs-dpdk-sriov-ipv6-2nodesets.yml
+++ b/scenarios/reproducers/dt-nfv-ovs-dpdk-sriov-ipv6-2nodesets.yml
@@ -3,6 +3,7 @@
 # This reproducer configures NFV OVS-DPDK SR-IOV with 2 different nodesets using IPv6 as primary IP
 
 cifmw_architecture_scenario: "ovs-dpdk-sriov-ipv6-2nodesets"
+cifmw_ci_gen_kustomize_values_detect_metal3: true
 
 # Automation section. Most of those parameters will be passed to the
 # controller-0 as-is and be consumed by the `deploy-va.sh` script.

--- a/scenarios/reproducers/dt-nfv-ovs-dpdk-sriov-networker.yml
+++ b/scenarios/reproducers/dt-nfv-ovs-dpdk-sriov-networker.yml
@@ -1,5 +1,6 @@
 ---
 cifmw_architecture_scenario: "ovs-dpdk-sriov-networker"
+cifmw_ci_gen_kustomize_values_detect_metal3: true
 
 # Automation section. Most of those parameters will be passed to the
 # controller-0 as-is and be consumed by the `deploy-va.sh` script.

--- a/scenarios/reproducers/va-nfv-ovs-dpdk-sriov-ipv6.yml
+++ b/scenarios/reproducers/va-nfv-ovs-dpdk-sriov-ipv6.yml
@@ -3,6 +3,7 @@
 # This reproducer configures NFV OVS-DPDK SR-IOV with 1 nodeset using IPv6 as primary IP
 
 cifmw_architecture_scenario: "ovs-dpdk-sriov-ipv6"
+cifmw_ci_gen_kustomize_values_detect_metal3: true
 
 # Automation section. Most of those parameters will be passed to the
 # controller-0 as-is and be consumed by the `deploy-va.sh` script.

--- a/scenarios/reproducers/va-nfv-ovs-dpdk-sriov.yml
+++ b/scenarios/reproducers/va-nfv-ovs-dpdk-sriov.yml
@@ -1,5 +1,6 @@
 ---
 cifmw_architecture_scenario: "ovs-dpdk-sriov"
+cifmw_ci_gen_kustomize_values_detect_metal3: true
 
 # Automation section. Most of those parameters will be passed to the
 # controller-0 as-is and be consumed by the `deploy-va.sh` script.

--- a/scenarios/reproducers/va-nfv-ovs-dpdk.yml
+++ b/scenarios/reproducers/va-nfv-ovs-dpdk.yml
@@ -1,5 +1,6 @@
 ---
 cifmw_architecture_scenario: "ovs-dpdk"
+cifmw_ci_gen_kustomize_values_detect_metal3: true
 
 # Automation section. Most of those parameters will be passed to the
 # controller-0 as-is and be consumed by the `deploy-va.sh` script.

--- a/scenarios/reproducers/va-nfv-ovs-sriov.yml
+++ b/scenarios/reproducers/va-nfv-ovs-sriov.yml
@@ -1,5 +1,6 @@
 ---
 cifmw_architecture_scenario: "ovs-sriov"
+cifmw_ci_gen_kustomize_values_detect_metal3: true
 
 # Automation section. Most of those parameters will be passed to the
 # controller-0 as-is and be consumed by the `deploy-va.sh` script.


### PR DESCRIPTION
…ures

When metal3-dnsmasq pod restarts during a node's DHCP lease renewal on the provisioning network (172.23.0.0/24), NetworkManager fails to renew and sets ipv4.method=disabled. NMState operator then preserves this disabled state, causing permanent loss of provisioning network connectivity on that node.

The issue occurs when OpenStackProvisionServer and metal3 pods run on different nodes. If metal3 restarts while a node is attempting DHCP renewal, the temporary unavailability of metal3-dnsmasq causes the renewal to fail.

Solution:
Automatically detect the node running metal3 pod (via k8s-app=metal3 label) and configure provisionServerNodeSelector in baremetalSetTemplate to schedule OpenStackProvisionServer on the same node. This ensures provisioning network connectivity is maintained because metal3-static-ip-manager maintains a static IP (172.23.0.3) on the metal3 node regardless of dnsmasq restarts.