### PR TITLE
[adoption_osp_deploy] Allow overriding scenario stack CLI args

### DIFF
--- a/roles/adoption_osp_deploy/README.md
+++ b/roles/adoption_osp_deploy/README.md
@@ -28,6 +28,13 @@ configure the OSP17.1 deployment.
 * `cifmw_adoption_osp_deploy_overcloud_extra_args`: (String) The content of a
   file which will be used with the -e option in the overcloud deploy command.
   This is useful to specify private/restricted parameters.
+* `cifmw_adoption_osp_deploy_stack_args_remove`: (List) List of CLI argument
+  strings to remove from the scenario's `stack.args` before running overcloud
+  deploy. Each entry must exactly match an element in `stack.args`. Defaults
+  to `[]`.
+* `cifmw_adoption_osp_deploy_stack_args_add`: (List) List of CLI argument
+  strings to append to the scenario's `stack.args` after removals are applied.
+  Defaults to `[]`.
 * `cifmw_adoption_osp_deploy_bgp`: (Boolean) Enable BGP support for the OSP
   deployment. When enabled, uses BGP-specific network configurations and
   templates. Defaults to `false`.

--- a/roles/adoption_osp_deploy/defaults/main.yml
+++ b/roles/adoption_osp_deploy/defaults/main.yml
@@ -31,6 +31,9 @@ cifmw_adoption_osp_deploy_adoption_vars_exclude_nets:
 
 cifmw_adoption_osp_deploy_overcloud_extra_args: ''
 
+cifmw_adoption_osp_deploy_stack_args_remove: []
+cifmw_adoption_osp_deploy_stack_args_add: []
+
 cifmw_adoption_osp_deploy_bgp: false
 
 cifmw_adoption_osp_deploy_freeipa_admin_password: "nomoresecrets"

--- a/roles/adoption_osp_deploy/molecule/default/converge.yml
+++ b/roles/adoption_osp_deploy/molecule/default/converge.yml
@@ -33,3 +33,90 @@
             cacheable: true
           vars:
             ip_version: ip_v4
+    - name: Test stack args override logic
+      vars:
+        _mock_args:
+          - "--override-ansible-cfg /home/zuul/ansible_config.cfg"
+          - "--templates /usr/share/openstack-tripleo-heat-templates"
+          - "--libvirt-type qemu"
+          - "--timeout 90"
+          - "--deployed-server"
+      block:
+        - name: Test default (no remove, no add) preserves args
+          ansible.builtin.set_fact:
+            _result_default: >-
+              {{
+                ((_mock_args |
+                 reject('in', []) |
+                 list) +
+                 []) |
+                join(' ')
+              }}
+
+        - name: Test removing a single arg
+          ansible.builtin.set_fact:
+            _result_remove: >-
+              {{
+                ((_mock_args |
+                 reject('in', ['--libvirt-type qemu']) |
+                 list) +
+                 []) |
+                join(' ')
+              }}
+
+        - name: Test adding an arg
+          ansible.builtin.set_fact:
+            _result_add: >-
+              {{
+                ((_mock_args |
+                 reject('in', []) |
+                 list) +
+                 ['--libvirt-type kvm']) |
+                join(' ')
+              }}
+
+        - name: Test removing and adding (replace pattern)
+          ansible.builtin.set_fact:
+            _result_replace: >-
+              {{
+                ((_mock_args |
+                 reject('in', ['--libvirt-type qemu']) |
+                 list) +
+                 ['--libvirt-type kvm']) |
+                join(' ')
+              }}
+
+        - name: Test removing multiple args
+          ansible.builtin.set_fact:
+            _result_remove_multi: >-
+              {{
+                ((_mock_args |
+                 reject('in', ['--libvirt-type qemu',
+                               '--timeout 90']) |
+                 list) +
+                 []) |
+                join(' ')
+              }}
+
+        - name: Test removing non-existent arg is a no-op
+          ansible.builtin.set_fact:
+            _result_remove_noop: >-
+              {{
+                ((_mock_args |
+                 reject('in', ['--nonexistent-flag']) |
+                 list) +
+                 []) |
+                join(' ')
+              }}
+
+        - name: Store args override results for verification
+          ansible.builtin.set_fact:
+            args_override_results:
+              mock_args_joined: "{{ _mock_args | join(' ') }}"
+              default: "{{ _result_default }}"
+              remove: "{{ _result_remove }}"
+              add: "{{ _result_add }}"
+              replace: "{{ _result_replace }}"
+              remove_multi: "{{ _result_remove_multi }}"
+              remove_noop: "{{ _result_remove_noop }}"
+            cacheable: true

--- a/roles/adoption_osp_deploy/molecule/default/verify.yml
+++ b/roles/adoption_osp_deploy/molecule/default/verify.yml
@@ -42,3 +42,49 @@
           - "adoption_vars.edpm_nodes.cell2['cell2-osp-compute-uni05epsilon-0'].ansible.ansibleHost == '192.168.122.120'"
         fail_msg: "Multi-cell edpm_nodes structure is incorrect"
         success_msg: "Successfully verified multi-cell edpm_nodes structure"
+    - name: "Load args override results"
+      ansible.builtin.set_fact:
+        args_override_results: "{{ hostvars[inventory_hostname].args_override_results }}"
+
+    - name: "Assert default args are preserved when no overrides"
+      ansible.builtin.assert:
+        that:
+          - "args_override_results.default == args_override_results.mock_args_joined"
+        fail_msg: >-
+          Default args mismatch.
+          Got: '{{ args_override_results.default }}'
+          Expected: '{{ args_override_results.mock_args_joined }}'
+
+    - name: "Assert removing an arg works"
+      ansible.builtin.assert:
+        that:
+          - "'--libvirt-type qemu' not in args_override_results.remove"
+          - "'--timeout 90' in args_override_results.remove"
+          - "'--deployed-server' in args_override_results.remove"
+
+    - name: "Assert adding an arg appends it"
+      ansible.builtin.assert:
+        that:
+          - "'--libvirt-type kvm' in args_override_results.add"
+          - "'--libvirt-type qemu' in args_override_results.add"
+          - "args_override_results.add.endswith('--libvirt-type kvm')"
+
+    - name: "Assert replace pattern (remove + add)"
+      ansible.builtin.assert:
+        that:
+          - "'--libvirt-type qemu' not in args_override_results.replace"
+          - "'--libvirt-type kvm' in args_override_results.replace"
+          - "args_override_results.replace.endswith('--libvirt-type kvm')"
+          - "'--timeout 90' in args_override_results.replace"
+
+    - name: "Assert removing multiple args works"
+      ansible.builtin.assert:
+        that:
+          - "'--libvirt-type qemu' not in args_override_results.remove_multi"
+          - "'--timeout 90' not in args_override_results.remove_multi"
+          - "'--deployed-server' in args_override_results.remove_multi"
+
+    - name: "Assert removing non-existent arg is a no-op"
+      ansible.builtin.assert:
+        that:
+          - "args_override_results.remove_noop == args_override_results.default"

--- a/roles/adoption_osp_deploy/tasks/deploy_overcloud.yml
+++ b/roles/adoption_osp_deploy/tasks/deploy_overcloud.yml
@@ -38,7 +38,11 @@
     _network_data_file_dest: "{{ ansible_user_dir }}/network_data_{{ _overcloud_name }}.yaml"
     _overcloud_args: >-
       {{
-        _stack.args | join(' ')
+        ((_stack.args |
+         reject('in', cifmw_adoption_osp_deploy_stack_args_remove) |
+         list) +
+         cifmw_adoption_osp_deploy_stack_args_add) |
+        join(' ')
       }}
     _overcloud_vars: >-
       {{

--- a/roles/adoption_osp_deploy/tasks/validate_scenario.yml
+++ b/roles/adoption_osp_deploy/tasks/validate_scenario.yml
@@ -14,6 +14,19 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Validate stack args override variables
+  ansible.builtin.assert:
+    that:
+      - cifmw_adoption_osp_deploy_stack_args_remove is not string
+      - cifmw_adoption_osp_deploy_stack_args_remove is not mapping
+      - cifmw_adoption_osp_deploy_stack_args_remove is iterable
+      - cifmw_adoption_osp_deploy_stack_args_add is not string
+      - cifmw_adoption_osp_deploy_stack_args_add is not mapping
+      - cifmw_adoption_osp_deploy_stack_args_add is iterable
+    msg: >-
+      cifmw_adoption_osp_deploy_stack_args_remove and
+      cifmw_adoption_osp_deploy_stack_args_add must be lists.
+
 - name: Validate scenario format
   ansible.builtin.assert:
     that:


### PR DESCRIPTION
TripleO CLI arguments like `--libvirt-type` generate internal heat
environments that are applied *after* all user-provided `-e` files
in the [`overcloud deploy` command](https://github.com/openstack-k8s-operators/ci-framework/blob/main/roles/adoption_osp_deploy/tasks/deploy_overcloud.yml#L80-L92).
This means `cifmw_adoption_osp_deploy_overcloud_extra_args` (which
creates `internal-configuration.yaml` as the last `-e` file) cannot
override them - the CLI arg wins because TripleO processes it
separately from `-e` file stacking.

For shiftstack adoption on baremetal, we need `--libvirt-type kvm`
instead of `--libvirt-type qemu` (nested virt requires KVM), but
the existing override mechanism has no effect. See the
[TripleO hiera hierarchy](https://github.com/openstack/tripleo-heat-templates/blob/16b0e650ca838995894a8552f5070bb3e40f1984/overcloud.j2.yaml#L677-L700)
for the full priority chain.

This adds two variables to `adoption_osp_deploy`:
- `cifmw_adoption_osp_deploy_stack_args_remove` - filter out args
  from the scenario's `stack.args` using Ansible's `reject('in', ...)`
  (preserves order, unlike `difference()` which uses sets)
- `cifmw_adoption_osp_deploy_stack_args_add` - append new args after
  removals

Both default to `[]`, so existing jobs produce identical output.
Input validation ensures both are lists (not string/mapping) before
the Jinja2 expression runs.

Usage in ci-framework-jobs ([shiftstack adoption deploy-osp](https://github.com/openstack-k8s-operators/ci-framework-jobs/blob/main/zuul.d/adoption-uni-jobs.yaml)):
```yaml
cifmw_adoption_osp_deploy_stack_args_remove:
  - '--libvirt-type qemu'
cifmw_adoption_osp_deploy_stack_args_add:
  - '--libvirt-type kvm'
```

Companion PR: [data-plane-adoption #1292](https://github.com/openstack-k8s-operators/data-plane-adoption/pull/1292) -
removes redundant ExtraConfig virt_type entries that would otherwise
still override at [hiera priority 7 vs 11](https://github.com/openstack/tripleo-heat-templates/blob/16b0e650ca838995894a8552f5070bb3e40f1984/overcloud.j2.yaml#L684-L688).

Molecule tests cover 6 scenarios: default (no-op), remove, add,
replace, multi-remove, non-existent removal. Full adoption pipeline
passed (7/7 stages) via [testproject buildset](https://sf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/zuul/t/components-integration/buildset/9821f411e5284656bd82c9ba00a9135d).

Related-Issue: [OSPRH-27919](https://redhat.atlassian.net/browse/OSPRH-27919)

Assisted-By: Claude Code