### PR TITLE
Add default('') to discovered image vars

### DIFF
--- a/scenarios/reproducers/va-hci.yml
+++ b/scenarios/reproducers/va-hci.yml
@@ -70,8 +70,8 @@ cifmw_libvirt_manager_configuration:
       uefi: "{{ cifmw_use_uefi }}"
       root_part_id: "{{ cifmw_root_partition_id }}"
       amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 3] | max }}"
-      image_url: "{{ cifmw_discovered_image_url }}"
-      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_url: "{{ cifmw_discovered_image_url | default('') }}"
+      sha256_image_name: "{{ cifmw_discovered_hash | default('') }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"
       disk_file_name: "compute-base-os.qcow2"
       disksize: "{{ [cifmw_libvirt_manager_compute_disksize|int, 50] | max }}"
@@ -85,8 +85,8 @@ cifmw_libvirt_manager_configuration:
     controller:
       uefi: "{{ cifmw_use_uefi }}"
       root_part_id: "{{ cifmw_root_partition_id }}"
-      image_url: "{{ cifmw_discovered_image_url }}"
-      sha256_image_name: "{{ cifmw_discovered_hash }}"
+      image_url: "{{ cifmw_discovered_image_url | default('') }}"
+      sha256_image_name: "{{ cifmw_discovered_hash | default('') }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"
       disk_file_name: "base-os.qcow2"
       disksize: 50


### PR DESCRIPTION
`cifmw_discovered_image_url` and `cifmw_discovered_hash` are set dynamically by the `discover_latest_image` role. When `networking_mapper` serializes hostvars early in the play, these variables are not yet defined, causing a fatal undefined variable error. Add `| default('')` so serialization succeeds; the real values are populated later when `discover_latest_image` runs.

Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>