### PR TITLE
[libvirt_manager] generate unique MAC per interface in generate_macs

### DIFF
--- a/roles/libvirt_manager/tasks/generate_macs.yml
+++ b/roles/libvirt_manager/tasks/generate_macs.yml
@@ -11,7 +11,6 @@
     vm: "{{ _vm.key }}"
     _vm_type: "{{ _vm.value }}"
     _mac_seed: "{{ '52:54:%02i' % vm_id }}"
-    _fixed_mac: "{{ _mac_seed | community.general.random_mac }}"
     # We don't generate MAC for spineleafnets - if that one is set
     # we won't get "nets" entry. Just use an empty list in that case.
     _nets_list: >-
@@ -25,6 +24,7 @@
       {%   set _macs = cifmw_libvirt_manager_mac_map[vm] -%}
       {% endif -%}
       {% for network in _nets_list -%}
+      {%   set _net_mac = ('52:54:%02i:%02i' % (vm_id, loop.index0)) | community.general.random_mac -%}
       {%   if cifmw_libvirt_manager_mac_map |
               dict2items | selectattr('key', 'equalto', vm) |
               map(attribute='value') | first | default([]) |
@@ -32,7 +32,7 @@
               dict2items | map(attribute='key') |
               select('equalto', network) | length == 0 -%}
       {%     set _ = _macs.append({'network': network,
-                                   'mac': _fixed_mac }) -%}
+                                   'mac': _net_mac }) -%}
       {%   endif -%}
       {% endfor -%}
       {% if _macs | length != 0 -%}


### PR DESCRIPTION
Previously, a single MAC address (_fixed_mac) was generated once per VM and assigned to all its network interfaces. For OCP master VMs with multiple networks (e.g. ocppr, ocpbm, osp_trunk, osp_trunk), all interfaces shared the same MAC.

This caused the networking_mapper to always resolve to the first interface (enp5s0, on the ocppr bridge) when looking up any network by MAC, since all MACs matched equally. The incorrect interface name then flowed into ci_gen_kustomize_values, setting enp5s0 as the macvlan master in the ctlplane NetworkAttachmentDefinition. Bootstrap pods sent ARP on the wrong bridge and never reached compute nodes, causing wait_for_connection to time out.

Fix: generate a unique MAC per (VM, network-index) pair by incorporating loop.index0 into the seed, ensuring each interface gets a distinct MAC. The networking_mapper can then correctly identify enp7s0 (on cifmw-osp_trunk) as the ctlplane interface.

Fixes: [OSPRH-28297](https://redhat.atlassian.net/browse/OSPRH-28297)

Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>