### PR TITLE
[Feature] unused vars: cifmw_build_containers_tcib_src

### DIFF
--- a/scenarios/centos-9/meta_content_provider.yml
+++ b/scenarios/centos-9/meta_content_provider.yml
@@ -8,7 +8,6 @@ cifmw_operator_build_local_registry: 1
 cifmw_operator_build_push_registry_tls_verify: false
 
 # build_containers vars
-cifmw_build_containers_tcib_src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/tcib"
 cifmw_repo_setup_src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/repo-setup"
 cifmw_build_containers_repo_dir: "{{ cifmw_basedir }}/artifacts/repositories"
 cifmw_build_containers_push_registry: "{{ cifmw_rp_registry_ip }}:{{ cifmw_rp_registry_port }}"

--- a/scenarios/centos-9/tcib.yml
+++ b/scenarios/centos-9/tcib.yml
@@ -1,5 +1,4 @@
 ---
-cifmw_build_containers_tcib_src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/tcib"
 cifmw_repo_setup_src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/repo-setup"
 cifmw_build_containers_repo_dir: "{{ cifmw_basedir }}/artifacts/repositories"
 cifmw_build_containers_push_registry: "{{ cifmw_rp_registry_ip }}:{{ cifmw_rp_registry_port }}"


### PR DESCRIPTION
- removes these vars which are unusued in centos-9 scenario files
- Jira Reference: [OSPRH-22054](https://redhat.atlassian.net/browse/OSPRH-22054)