### PR TITLE
[env_op_images] Add pulled images report to env_op_images role

### DIFF
--- a/ci/playbooks/collect-logs.yml
+++ b/ci/playbooks/collect-logs.yml
@@ -1,4 +1,15 @@
 ---
+- name: Ensure ci-framework-data base directories exist on all nodes
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Create ci-framework-data/logs directory if missing
+      ansible.builtin.file:
+        path: "{{ ansible_user_dir }}/ci-framework-data/logs"
+        state: directory
+        mode: "0755"
+      ignore_errors: true  # noqa: ignore-errors
+
 - name: "Run ci/playbooks/collect-logs.yml"
   hosts: "{{ cifmw_zuul_target_host | default('all') }}"
   gather_facts: true

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -6,6 +6,8 @@ CPython
 ClusterServiceVersion
 FreeIPA
 IDM
+ICSP
+IDMS
 IMVHO
 IdP
 Idempotency

--- a/roles/env_op_images/README.md
+++ b/roles/env_op_images/README.md
@@ -4,6 +4,9 @@ A role to gather the container images used in the openstack deployment with spec
 ## Parameters
 * `cifmw_env_op_images_dir`: (String) Directory where the operator_images.yaml will be stored. Defaults to `~/ci-framework-data/artifacts`
 * `cifmw_env_op_images_file`: (String) Name of the file storing the operator images and tags. Defaults to `operator_images.yaml`
+* `cifmw_env_op_images_pulled_report_path`: Pulled-images policy report (ICSP/IDMS + pod image refs).
+* `cifmw_env_op_images_verified_report_path`: Output path for the CRI-O-enriched report. After the pulled report runs, fetches `oc adm node-logs NODE -u crio` per node, then writes this file with digest-level CRI-O fields (`node_verified_image_origin`, `log_evidence_uri`, `log_evidence_node`).
+* `cifmw_env_op_images_crio_logs_dir`: Directory for per-node `*.crio.log` files used during verification.
 
 ## Examples
 ```YAML

--- a/roles/env_op_images/defaults/main.yml
+++ b/roles/env_op_images/defaults/main.yml
@@ -21,3 +21,8 @@
 cifmw_env_op_images_dir: "{{ cifmw_basedir }}"
 cifmw_env_op_images_file: operator_images.yaml
 cifmw_env_op_images_dryrun: false
+
+cifmw_env_op_images_pulled_report_file: pulled_images_report.yaml
+cifmw_env_op_images_pulled_report_namespaces:
+  - "{{ cifmw_openstack_namespace | default('openstack') }}"
+  - "{{ operator_namespace | default('openstack-operators') }}"

--- a/roles/env_op_images/defaults/main.yml
+++ b/roles/env_op_images/defaults/main.yml
@@ -22,7 +22,20 @@ cifmw_env_op_images_dir: "{{ cifmw_basedir }}"
 cifmw_env_op_images_file: operator_images.yaml
 cifmw_env_op_images_dryrun: false
 
-cifmw_env_op_images_pulled_report_file: pulled_images_report.yaml
+cifmw_env_op_images_pulled_report_path: >-
+  {{
+    (cifmw_env_op_images_dir, 'artifacts', 'pulled_images_report.yaml')
+    | path_join
+  }}
+
+cifmw_env_op_images_verified_report_path: >-
+  {{
+    (cifmw_env_op_images_dir, 'artifacts', 'pulled_images_report_verified.yaml')
+    | path_join
+  }}
+cifmw_env_op_images_crio_logs_dir: >-
+  {{ (cifmw_env_op_images_dir, 'artifacts', 'crio_logs') | path_join }}
+
 cifmw_env_op_images_pulled_report_namespaces:
   - "{{ cifmw_openstack_namespace | default('openstack') }}"
   - "{{ operator_namespace | default('openstack-operators') }}"

--- a/roles/env_op_images/library/verify_pulled_report_crio.py
+++ b/roles/env_op_images/library/verify_pulled_report_crio.py
@@ -1,0 +1,297 @@
+#!/usr/bin/python
+
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: verify_pulled_report_crio
+
+short_description: Enrich pulled_images_report with CRI-O pull evidence
+
+description:
+  - Reads the YAML produced by the env_op_images pulled-images report role task.
+  - "Parses CRI-O journal lines for C(msg=\"Pulled image: ...@sha256:...\")."
+  - Adds per-row verification fields using trusted mirror domains from
+    C(summary.mirror_rules).
+  - When images carry a C(node) field, evidence is matched against the
+    specific node's CRI-O log first.  If the digest is only found on a
+    different node the entry is counted as a cross-node mismatch.
+  - Log files are expected to follow the C(<node-name>.crio.log) naming
+    convention produced by the role task.
+
+options:
+  report_path:
+    description: Path to C(pulled_images_report.yaml) (input).
+    required: true
+    type: str
+  output_path:
+    description: Path for the enriched YAML report (output).
+    required: true
+    type: str
+  log_paths:
+    description:
+      - Explicit list of log files to parse (e.g. per-node CRI-O logs).
+      - Combined with files found under I(log_dir) when set.
+    required: false
+    type: list
+    elements: str
+    default: []
+  log_dir:
+    description:
+      - Directory containing CRI-O log files matching I(log_glob).
+    required: false
+    type: str
+  log_glob:
+    description: Glob under I(log_dir). Used only when I(log_dir) is set.
+    required: false
+    default: "*.crio.log"
+    type: str
+
+author:
+  - Nemanja Marjanovic (@nemarjan)
+
+notes:
+  - Requires PyYAML on the controller (same as other cifmw.general modules).
+"""
+
+EXAMPLES = r"""
+- name: Enrich pulled report using fetched node logs
+  cifmw.general.verify_pulled_report_crio:
+    report_path: "{{ cifmw_env_op_images_pulled_report_path }}"
+    log_dir: "{{ cifmw_env_op_images_crio_logs_dir }}"
+    output_path: "{{ cifmw_env_op_images_verified_report_path }}"
+"""
+
+RETURN = r"""
+changed:
+  description: Whether the output file was written.
+  type: bool
+  returned: always
+trusted_mirrors:
+  description: Hostnames extracted from mirror rules in the report summary.
+  type: list
+  elements: str
+  returned: always
+log_files:
+  description: Number of log files read.
+  type: int
+  returned: always
+entries_with_digest:
+  description: Image rows that had a sha256 digest in C(image_id).
+  type: int
+  returned: always
+cross_node_entries:
+  description: >-
+    Image rows where evidence was found only on a different node
+    than where the pod ran.
+  type: int
+  returned: always
+nodes_with_evidence:
+  description: >-
+    Node names that had at least one C(Pulled image) log entry.
+  type: list
+  elements: str
+  returned: always
+"""
+
+import glob
+import os
+import re
+
+import yaml
+from ansible.module_utils.basic import AnsibleModule
+
+LOG_PATTERN = re.compile(
+    r'msg="Pulled image: (?P<actual_uri>[^@\s]+)@(?P<id>sha256:[a-f0-9]+)"'
+)
+SHA256_PATTERN = re.compile(r"sha256:[a-f0-9]+")
+
+
+def _node_from_path(path):
+    """Derive node name from the ``<node>.crio.log`` naming convention."""
+    basename = os.path.basename(path)
+    suffix_pos = basename.find(".crio.log")
+    if suffix_pos > 0:
+        return basename[:suffix_pos]
+    return os.path.splitext(basename)[0]
+
+
+def _domain_from_uri(uri):
+    """Return the registry host (+ optional port) from an image URI."""
+    return uri.split("/")[0].strip()
+
+
+def _apply_evidence(img, actual_uri, evidence_node, trusted_mirrors):
+    """Set common verification fields on an image row that has log evidence."""
+    actual_domain = _domain_from_uri(actual_uri)
+    img["node_verified_image_origin"] = (
+        "mirror" if actual_domain in trusted_mirrors else "source"
+    )
+    img["log_evidence_uri"] = actual_uri
+    img["log_evidence_node"] = evidence_node
+    return actual_domain
+
+
+def _collect_log_evidence(paths, module):
+    """Parse CRI-O logs into per-node and global evidence dicts.
+
+    Returns:
+        per_node: ``{node_name: {sha256_digest: pull_uri}}``
+        global_evidence: ``{sha256_digest: (pull_uri, node_name)}``
+            (last writer wins across nodes for the global dict)
+    """
+    per_node = {}
+    global_evidence = {}
+    for path in paths:
+        node = _node_from_path(path)
+        node_ev = per_node.setdefault(node, {})
+        try:
+            with open(path, "r") as f:
+                for line in f:
+                    match = LOG_PATTERN.search(line)
+                    if match:
+                        digest = match.group("id")
+                        uri = match.group("actual_uri")
+                        node_ev[digest] = uri
+                        global_evidence[digest] = (uri, node)
+        except IOError as exc:
+            module.fail_json(
+                msg="Cannot read CRI-O log file {0}: {1}".format(path, str(exc))
+            )
+    return per_node, global_evidence
+
+
+def run_module():
+    module_args = dict(
+        report_path=dict(type="str", required=True),
+        output_path=dict(type="str", required=True),
+        log_paths=dict(type="list", required=False, elements="str", default=[]),
+        log_dir=dict(type="str", required=False),
+        log_glob=dict(type="str", required=False, default="*.crio.log"),
+    )
+
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+
+    report_path = module.params["report_path"]
+    output_path = module.params["output_path"]
+    log_paths = module.params["log_paths"] or []
+    log_dir = module.params["log_dir"]
+    log_glob = module.params["log_glob"]
+
+    paths = list(log_paths)
+    if log_dir:
+        paths.extend(sorted(glob.glob(os.path.join(log_dir, log_glob))))
+
+    if not paths:
+        module.fail_json(
+            msg="No CRI-O log files: set log_paths and/or log_dir with matching files."
+        )
+
+    try:
+        with open(report_path, "r") as f:
+            data = yaml.safe_load(f)
+    except IOError as exc:
+        module.fail_json(
+            msg="Cannot read report {0}: {1}".format(report_path, str(exc))
+        )
+    except yaml.YAMLError as exc:
+        module.fail_json(msg="Invalid YAML in report: {0}".format(str(exc)))
+
+    if not isinstance(data, dict):
+        module.fail_json(msg="Report root must be a mapping (dict).")
+
+    trusted_mirrors = set()
+    summary_section = data.get("summary") or {}
+    for rule in summary_section.get("mirror_rules") or []:
+        if not isinstance(rule, dict):
+            continue
+        mirror_url = rule.get("mirror")
+        if mirror_url:
+            domain = _domain_from_uri(mirror_url)
+            if domain:
+                trusted_mirrors.add(domain)
+
+    per_node_evidence, global_evidence = _collect_log_evidence(paths, module)
+
+    images_list = data.get("images") or []
+    entries_with_digest = 0
+    cross_node_entries = 0
+    for img in images_list:
+        if not isinstance(img, dict):
+            continue
+        image_id = img.get("image_id") or ""
+        sha_match = SHA256_PATTERN.search(image_id)
+        if not sha_match:
+            continue
+        entries_with_digest += 1
+        img_sha = sha_match.group(0)
+        img_node = img.get("node") or ""
+
+        node_local_hit = (
+            img_node
+            and img_node in per_node_evidence
+            and img_sha in per_node_evidence[img_node]
+        )
+
+        if node_local_hit:
+            actual_uri = per_node_evidence[img_node][img_sha]
+            _apply_evidence(img, actual_uri, img_node, trusted_mirrors)
+        elif img_sha in global_evidence:
+            actual_uri, evidence_node = global_evidence[img_sha]
+            _apply_evidence(img, actual_uri, evidence_node, trusted_mirrors)
+            if img_node:
+                cross_node_entries += 1
+        else:
+            img["node_verified_image_origin"] = "cached/unknown"
+            img["log_evidence_uri"] = None
+            img["log_evidence_node"] = None
+
+    nodes_with_evidence = sorted(n for n, ev in per_node_evidence.items() if ev)
+    result = dict(
+        changed=False,
+        trusted_mirrors=sorted(trusted_mirrors),
+        log_files=len(paths),
+        entries_with_digest=entries_with_digest,
+        cross_node_entries=cross_node_entries,
+        nodes_with_evidence=nodes_with_evidence,
+    )
+
+    if module.check_mode:
+        result["changed"] = True
+        module.exit_json(**result)
+
+    try:
+        with open(output_path, "w") as f:
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+    except IOError as exc:
+        module.fail_json(
+            msg="Cannot write verified report {0}: {1}".format(output_path, str(exc))
+        )
+
+    result["changed"] = True
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/env_op_images/tasks/main.yml
+++ b/roles/env_op_images/tasks/main.yml
@@ -158,3 +158,7 @@
 
 - name: Generate pulled images registry report
   ansible.builtin.include_tasks: pulled_images_report.yml
+
+- name: Verify pulled report against CRI-O node logs
+  ansible.builtin.include_tasks: verify_pulled_report_crio.yml
+  ignore_errors: true  # noqa: ignore-errors

--- a/roles/env_op_images/tasks/main.yml
+++ b/roles/env_op_images/tasks/main.yml
@@ -155,3 +155,6 @@
         dest: "{{ cifmw_env_op_images_dir }}/artifacts/{{ cifmw_env_op_images_file }}"
         content: "{{ _content | to_nice_yaml }}"
         mode: "0644"
+
+- name: Generate pulled images registry report
+  ansible.builtin.include_tasks: pulled_images_report.yml

--- a/roles/env_op_images/tasks/pulled_images_report.yml
+++ b/roles/env_op_images/tasks/pulled_images_report.yml
@@ -1,0 +1,230 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Pulled-images report (policy view, not node-verified pulls):
+# - Load cluster ImageContentSourcePolicy + ImageDigestMirrorSet objects via oc.
+# - Flatten them into {source, mirror} pairs (repository prefix -> mirror ref).
+# - For each container/initContainer in selected namespaces, compare the pod
+#   status image string to those prefixes: first matching rule yields
+#   expected_pull_basis mirror and expected_pull_location from the mirror host;
+#   otherwise basis source and location from the image ref host.
+# Matching uses image (reference string), not imageID; pod status often keeps
+# the upstream registry name even when the runtime used a mirror.
+
+- name: Report pulled image registries per pod
+  when:
+    - cifmw_openshift_kubeconfig is defined
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  block:
+    - name: Ensure artifacts directory exists
+      ansible.builtin.file:
+        path: "{{ cifmw_env_op_images_dir }}/artifacts"
+        state: directory
+        mode: "0755"
+
+    # Legacy OpenShift mirror CRD; empty or error is OK (parsed as no items).
+    - name: Get ICSP mirror rules
+      ansible.builtin.command:
+        cmd: oc get imagecontentsourcepolicy -o json
+      register: _pulled_report_icsp
+      failed_when: false
+
+    # Preferred / current mirror CRD alongside ICSP.
+    - name: Get IDMS mirror rules
+      ansible.builtin.command:
+        cmd: oc get imagedigestmirrorset -o json
+      register: _pulled_report_idms
+      failed_when: false
+
+    # One flat list of rules for templating: each mirror list entry becomes
+    # its own row so prefix matching can use the same loop for all mirrors.
+    - name: Build source-to-mirror mapping from ICSP/IDMS
+      vars:
+        _icsp_items: >-
+          {{ (_pulled_report_icsp.stdout | default('{}') | from_json).get('items', []) }}
+        _idms_items: >-
+          {{ (_pulled_report_idms.stdout | default('{}') | from_json).get('items', []) }}
+        _mappings: >-
+          {% set maps = [] %}
+          {# ICSP spec.repositoryDigestMirrors: source repo + mirrors[] #}
+          {% for icsp in _icsp_items %}
+          {%   for rdm in icsp.spec.get('repositoryDigestMirrors', []) %}
+          {%     if rdm.source is defined and rdm.source %}
+          {%       for m in rdm.get('mirrors', []) %}
+          {%         set _ = maps.append({'source': rdm.source, 'mirror': m}) %}
+          {%       endfor %}
+          {%     endif %}
+          {%   endfor %}
+          {% endfor %}
+          {# IDMS spec.imageDigestMirrors: same shape for matching purposes #}
+          {% for idms in _idms_items %}
+          {%   for rdm in idms.spec.get('imageDigestMirrors', []) %}
+          {%     if rdm.source is defined and rdm.source %}
+          {%       for m in rdm.get('mirrors', []) %}
+          {%         set _ = maps.append({'source': rdm.source, 'mirror': m}) %}
+          {%       endfor %}
+          {%     endif %}
+          {%   endfor %}
+          {% endfor %}
+          {{ maps }}
+      ansible.builtin.set_fact:
+        _pulled_report_mirror_mappings: "{{ _mappings | trim | from_yaml }}"
+
+    - name: Report ICSP/IDMS mirror rules found
+      when: _pulled_report_mirror_mappings | length > 0
+      ansible.builtin.debug:
+        msg: >-
+          {{ item.source }} -> {{ item.mirror }}
+      loop: "{{ _pulled_report_mirror_mappings }}"
+      loop_control:
+        label: "{{ item.source }}"
+
+    - name: Warn if no ICSP/IDMS mirror rules found
+      when: _pulled_report_mirror_mappings | length == 0
+      ansible.builtin.debug:
+        msg: >-
+          No ICSP or IDMS mirror rules found on the cluster.
+          All rows will have expected_pull_basis: source and expected_pull_location from the image ref.
+
+    # Namespaces come from role default / caller; failed namespaces skip via failed_when: false.
+    - name: Get pods per namespace
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit) }}"
+        context: "{{ cifmw_openshift_context | default(omit) }}"
+        kind: Pod
+        namespace: "{{ item }}"
+      register: _pulled_report_pods
+      loop: "{{ cifmw_env_op_images_pulled_report_namespaces | unique }}"
+      loop_control:
+        label: "{{ item }}"
+      failed_when: false
+
+    # Flatten all loop results, then one report row per container + initContainer.
+    - name: Build per-pod pulled images report
+      vars:
+        _report: >-
+          {% set entries = [] %}
+          {% set all_pods = _pulled_report_pods.results |
+                            map(attribute='resources', default=[]) | flatten %}
+          {% for pod in all_pods %}
+          {%   set pod_labels = pod.metadata.labels | default({}) %}
+          {%   set operator_name = pod_labels.get('openstack.org/operator-name', '') %}
+          {%   set app_label = pod_labels.get('app', pod_labels.get('app.kubernetes.io/name', '')) %}
+          {# Build a single list so regular and init containers share one loop #}
+          {%   set image_statuses = [] %}
+          {%   for cs in pod.status.containerStatuses | default([]) %}
+          {%     set _ = image_statuses.append({'cs': cs, 'type': 'container'}) %}
+          {%   endfor %}
+          {%   for cs in pod.status.initContainerStatuses | default([]) %}
+          {%     set _ = image_statuses.append({'cs': cs, 'type': 'init_container'}) %}
+          {%   endfor %}
+          {%   for entry in image_statuses %}
+          {%     set cs = entry.cs %}
+          {%     set image = cs.image | default('unknown') %}
+          {%     set image_id = cs.imageID | default('') %}
+          {%     set image_repo = image.split('@')[0].split(':')[0] %}
+          {%     set image_name = image_repo.split('/')[-1] %}
+          {# Default: host = first path segment of image ref; basis = source #}
+          {%     set match = namespace(host=image.split('/')[0], expected_pull_basis='source') %}
+          {# First mapping where image startswith source: use mirror registry host #}
+          {%     for m in _pulled_report_mirror_mappings if m.source is defined and m.source and image.startswith(m.source) %}
+          {%       if loop.first %}
+          {%         set match.host = m.mirror.split('/')[0] %}
+          {%         set match.expected_pull_basis = 'mirror' %}
+          {%       endif %}
+          {%     endfor %}
+          {%     set _ = entries.append({
+                   'namespace': pod.metadata.namespace,
+                   'pod': pod.metadata.name,
+                   'container': cs.name,
+                   'container_type': entry.type,
+                   'operator': operator_name if operator_name else 'N/A',
+                   'app': app_label if app_label else image_name,
+                   'image': image,
+                   'image_id': image_id,
+                   'expected_pull_location': match.host,
+                   'expected_pull_basis': match.expected_pull_basis
+                 }) %}
+          {%   endfor %}
+          {% endfor %}
+          {{ entries }}
+      ansible.builtin.set_fact:
+        _pulled_images_report: "{{ _report | trim | from_yaml }}"
+
+    # Counts for the YAML artifact summary section.
+    - name: Build report summary
+      vars:
+        _total: "{{ _pulled_images_report | length }}"
+        _basis_mirror: >-
+          {{ _pulled_images_report |
+             selectattr('expected_pull_basis', 'equalto', 'mirror') | list | length }}
+        _basis_source: >-
+          {{ _pulled_images_report |
+             selectattr('expected_pull_basis', 'equalto', 'source') | list | length }}
+        _mirror_rules: "{{ _pulled_report_mirror_mappings | length }}"
+      ansible.builtin.set_fact:
+        _pulled_report_summary:
+          mirror_rules_found: "{{ _mirror_rules | int }}"
+          mirror_rules: "{{ _pulled_report_mirror_mappings }}"
+          total_containers: "{{ _total | int }}"
+          containers_expected_basis_source: "{{ _basis_source | int }}"
+          containers_expected_basis_mirror: "{{ _basis_mirror | int }}"
+
+    - name: Save pulled images report to artifacts
+      vars:
+        _full_report:
+          summary: "{{ _pulled_report_summary }}"
+          images: "{{ _pulled_images_report }}"
+      ansible.builtin.copy:
+        dest: >-
+          {{
+            (cifmw_env_op_images_dir, 'artifacts',
+             cifmw_env_op_images_pulled_report_file) | path_join
+          }}
+        content: "{{ _full_report | to_nice_yaml }}"
+        mode: "0644"
+
+    # Console visibility: split rows by how ICSP/IDMS classification turned out.
+    - name: Images with expected_pull_basis source
+      ansible.builtin.debug:
+        msg: >-
+          [{{ item.app }}] {{ item.image }} ->
+          expected pull location {{ item.expected_pull_location }}
+          ({{ item.container_type }}: {{ item.container }}
+          | operator: {{ item.operator }}
+          | pod: {{ item.namespace }}/{{ item.pod }})
+      loop: >-
+        {{ _pulled_images_report |
+           selectattr('expected_pull_basis', 'equalto', 'source') | list }}
+      loop_control:
+        label: "{{ item.app }}/{{ item.container }}"
+
+    - name: Images with expected_pull_basis mirror
+      ansible.builtin.debug:
+        msg: >-
+          [{{ item.app }}] {{ item.image }} ->
+          expected pull location {{ item.expected_pull_location }}
+          ({{ item.container_type }}: {{ item.container }}
+          | operator: {{ item.operator }}
+          | pod: {{ item.namespace }}/{{ item.pod }})
+      loop: >-
+        {{ _pulled_images_report |
+           selectattr('expected_pull_basis', 'equalto', 'mirror') | list }}
+      loop_control:
+        label: "{{ item.app }}/{{ item.container }}"

--- a/roles/env_op_images/tasks/pulled_images_report.yml
+++ b/roles/env_op_images/tasks/pulled_images_report.yml
@@ -37,28 +37,33 @@
         state: directory
         mode: "0755"
 
-    # Legacy OpenShift mirror CRD; empty or error is OK (parsed as no items).
     - name: Get ICSP mirror rules
       ansible.builtin.command:
         cmd: oc get imagecontentsourcepolicy -o json
       register: _pulled_report_icsp
       failed_when: false
 
-    # Preferred / current mirror CRD alongside ICSP.
     - name: Get IDMS mirror rules
       ansible.builtin.command:
         cmd: oc get imagedigestmirrorset -o json
       register: _pulled_report_idms
       failed_when: false
 
-    # One flat list of rules for templating: each mirror list entry becomes
-    # its own row so prefix matching can use the same loop for all mirrors.
+    # Flatten ICSP repositoryDigestMirrors and IDMS imageDigestMirrors into
+    # a single list of {source, mirror} pairs.  A source with N mirrors
+    # produces N entries so the Jinja template can prefix-match every
+    # mirror in one loop.
+    # Example output (_pulled_report_mirror_mappings):
+    #   - source: registry.redhat.io/openstack-k8s-operators
+    #     mirror: quay.example.com/rh-osbs/openstack-k8s-operators
+    #   - source: registry.redhat.io/openstack-k8s-operators
+    #     mirror: internal-registry.corp.net/openstack-k8s-operators
     - name: Build source-to-mirror mapping from ICSP/IDMS
       vars:
         _icsp_items: >-
-          {{ (_pulled_report_icsp.stdout | default('{}') | from_json).get('items', []) }}
+          {{ (_pulled_report_icsp.stdout | default('{}', true) | from_json).get('items', []) }}
         _idms_items: >-
-          {{ (_pulled_report_idms.stdout | default('{}') | from_json).get('items', []) }}
+          {{ (_pulled_report_idms.stdout | default('{}', true) | from_json).get('items', []) }}
         _mappings: >-
           {% set maps = [] %}
           {# ICSP spec.repositoryDigestMirrors: source repo + mirrors[] #}
@@ -85,15 +90,6 @@
       ansible.builtin.set_fact:
         _pulled_report_mirror_mappings: "{{ _mappings | trim | from_yaml }}"
 
-    - name: Report ICSP/IDMS mirror rules found
-      when: _pulled_report_mirror_mappings | length > 0
-      ansible.builtin.debug:
-        msg: >-
-          {{ item.source }} -> {{ item.mirror }}
-      loop: "{{ _pulled_report_mirror_mappings }}"
-      loop_control:
-        label: "{{ item.source }}"
-
     - name: Warn if no ICSP/IDMS mirror rules found
       when: _pulled_report_mirror_mappings | length == 0
       ansible.builtin.debug:
@@ -115,57 +111,10 @@
         label: "{{ item }}"
       failed_when: false
 
-    # Flatten all loop results, then one report row per container + initContainer.
     - name: Build per-pod pulled images report
-      vars:
-        _report: >-
-          {% set entries = [] %}
-          {% set all_pods = _pulled_report_pods.results |
-                            map(attribute='resources', default=[]) | flatten %}
-          {% for pod in all_pods %}
-          {%   set pod_labels = pod.metadata.labels | default({}) %}
-          {%   set operator_name = pod_labels.get('openstack.org/operator-name', '') %}
-          {%   set app_label = pod_labels.get('app', pod_labels.get('app.kubernetes.io/name', '')) %}
-          {# Build a single list so regular and init containers share one loop #}
-          {%   set image_statuses = [] %}
-          {%   for cs in pod.status.containerStatuses | default([]) %}
-          {%     set _ = image_statuses.append({'cs': cs, 'type': 'container'}) %}
-          {%   endfor %}
-          {%   for cs in pod.status.initContainerStatuses | default([]) %}
-          {%     set _ = image_statuses.append({'cs': cs, 'type': 'init_container'}) %}
-          {%   endfor %}
-          {%   for entry in image_statuses %}
-          {%     set cs = entry.cs %}
-          {%     set image = cs.image | default('unknown') %}
-          {%     set image_id = cs.imageID | default('') %}
-          {%     set image_repo = image.split('@')[0].split(':')[0] %}
-          {%     set image_name = image_repo.split('/')[-1] %}
-          {# Default: host = first path segment of image ref; basis = source #}
-          {%     set match = namespace(host=image.split('/')[0], expected_pull_basis='source') %}
-          {# First mapping where image startswith source: use mirror registry host #}
-          {%     for m in _pulled_report_mirror_mappings if m.source is defined and m.source and image.startswith(m.source) %}
-          {%       if loop.first %}
-          {%         set match.host = m.mirror.split('/')[0] %}
-          {%         set match.expected_pull_basis = 'mirror' %}
-          {%       endif %}
-          {%     endfor %}
-          {%     set _ = entries.append({
-                   'namespace': pod.metadata.namespace,
-                   'pod': pod.metadata.name,
-                   'container': cs.name,
-                   'container_type': entry.type,
-                   'operator': operator_name if operator_name else 'N/A',
-                   'app': app_label if app_label else image_name,
-                   'image': image,
-                   'image_id': image_id,
-                   'expected_pull_location': match.host,
-                   'expected_pull_basis': match.expected_pull_basis
-                 }) %}
-          {%   endfor %}
-          {% endfor %}
-          {{ entries }}
       ansible.builtin.set_fact:
-        _pulled_images_report: "{{ _report | trim | from_yaml }}"
+        _pulled_images_report: >-
+          {{ lookup('template', 'pulled_images_report.j2') | trim | from_yaml }}
 
     # Counts for the YAML artifact summary section.
     - name: Build report summary
@@ -192,39 +141,15 @@
           summary: "{{ _pulled_report_summary }}"
           images: "{{ _pulled_images_report }}"
       ansible.builtin.copy:
-        dest: >-
-          {{
-            (cifmw_env_op_images_dir, 'artifacts',
-             cifmw_env_op_images_pulled_report_file) | path_join
-          }}
+        dest: "{{ cifmw_env_op_images_pulled_report_path }}"
         content: "{{ _full_report | to_nice_yaml }}"
         mode: "0644"
 
-    # Console visibility: split rows by how ICSP/IDMS classification turned out.
-    - name: Images with expected_pull_basis source
+    - name: Pulled images report summary
       ansible.builtin.debug:
         msg: >-
-          [{{ item.app }}] {{ item.image }} ->
-          expected pull location {{ item.expected_pull_location }}
-          ({{ item.container_type }}: {{ item.container }}
-          | operator: {{ item.operator }}
-          | pod: {{ item.namespace }}/{{ item.pod }})
-      loop: >-
-        {{ _pulled_images_report |
-           selectattr('expected_pull_basis', 'equalto', 'source') | list }}
-      loop_control:
-        label: "{{ item.app }}/{{ item.container }}"
-
-    - name: Images with expected_pull_basis mirror
-      ansible.builtin.debug:
-        msg: >-
-          [{{ item.app }}] {{ item.image }} ->
-          expected pull location {{ item.expected_pull_location }}
-          ({{ item.container_type }}: {{ item.container }}
-          | operator: {{ item.operator }}
-          | pod: {{ item.namespace }}/{{ item.pod }})
-      loop: >-
-        {{ _pulled_images_report |
-           selectattr('expected_pull_basis', 'equalto', 'mirror') | list }}
-      loop_control:
-        label: "{{ item.app }}/{{ item.container }}"
+          Pulled images report: {{ _pulled_report_summary.total_containers }} containers
+          ({{ _pulled_report_summary.containers_expected_basis_mirror }} mirror,
+          {{ _pulled_report_summary.containers_expected_basis_source }} source),
+          {{ _pulled_report_summary.mirror_rules_found }} mirror rules.
+          Full report: {{ cifmw_env_op_images_pulled_report_path }}

--- a/roles/env_op_images/tasks/verify_pulled_report_crio.yml
+++ b/roles/env_op_images/tasks/verify_pulled_report_crio.yml
@@ -1,0 +1,112 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Cross-reference the pulled-images report (from pulled_images_report.yml)
+# with CRI-O journal logs from every cluster node to confirm which images
+# were actually pulled by the container runtime.
+#
+# This file runs during POST-RUN log collection so it must NEVER use
+# ansible.builtin.fail -- a failure here would abort the entire
+# log-collection phase and lose all other diagnostic artifacts.
+
+- name: Verify pulled report against CRI-O node logs
+  when:
+    - cifmw_openshift_kubeconfig is defined
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  block:
+    - name: Check pulled images report exists
+      ansible.builtin.stat:
+        path: "{{ cifmw_env_op_images_pulled_report_path }}"
+      register: _verify_crio_pulled_stat
+
+    - name: Collect CRI-O logs and verify
+      when: _verify_crio_pulled_stat.stat.exists
+      block:
+        - name: Ensure CRI-O logs directory exists
+          ansible.builtin.file:
+            path: "{{ cifmw_env_op_images_crio_logs_dir }}"
+            state: directory
+            mode: "0755"
+
+        - name: List cluster nodes
+          ansible.builtin.command:
+            cmd: oc get nodes -o json
+          register: _verify_crio_nodes_json
+          changed_when: false
+          failed_when: false
+
+        - name: Warn when oc get nodes did not succeed
+          when: _verify_crio_nodes_json.rc != 0
+          ansible.builtin.debug:
+            msg: >-
+              oc get nodes failed (rc={{ _verify_crio_nodes_json.rc }});
+              cannot fetch CRI-O logs. Skipping verification.
+
+        - name: Fetch and verify CRI-O logs
+          when: _verify_crio_nodes_json.rc == 0
+          block:
+            - name: Extract node names
+              ansible.builtin.set_fact:
+                _verify_crio_node_names: >-
+                  {{
+                    (_verify_crio_nodes_json.stdout | from_json).get('items', [])
+                    | map(attribute='metadata.name') | list
+                  }}
+
+            - name: Fetch CRI-O unit logs per node
+              ansible.builtin.command:
+                cmd: >-
+                  oc adm node-logs "{{ item }}" -u crio
+                  --since=-24h
+              loop: "{{ _verify_crio_node_names | default([]) }}"
+              timeout: 120
+              failed_when: false
+              register: _verify_crio_fetch
+
+            # Filename is sanitised to avoid path-traversal with unusual node names.
+            - name: Write CRI-O logs to files per node
+              ansible.builtin.copy:
+                dest: "{{ cifmw_env_op_images_crio_logs_dir }}/{{ item.item | regex_replace('[^A-Za-z0-9._-]+', '_') }}.crio.log"
+                content: "{{ item.stdout }}"
+                mode: "0644"
+              loop: "{{ _verify_crio_fetch.results | default([]) }}"
+              loop_control:
+                label: "{{ item.item | default('') }}"
+              when: item.rc | default(1) == 0
+
+            # Non-fatal: some nodes may be unreachable (e.g. NotReady).
+            - name: Warn when node log fetch failed for a node
+              when: item.rc | default(0) != 0
+              ansible.builtin.debug:
+                msg: "oc adm node-logs failed for node (rc={{ item.rc | default('n/a') }}): {{ item.item | default('unknown') }}"
+              loop: "{{ _verify_crio_fetch.results | default([]) }}"
+              loop_control:
+                label: "{{ item.item | default('') }}"
+
+            - name: Find fetched CRI-O log files
+              ansible.builtin.find:
+                paths: "{{ cifmw_env_op_images_crio_logs_dir }}"
+                patterns: "*.crio.log"
+              register: _verify_crio_log_files
+
+            - name: Enrich pulled report with CRI-O evidence
+              when: _verify_crio_log_files.matched | int > 0
+              verify_pulled_report_crio:
+                report_path: "{{ cifmw_env_op_images_pulled_report_path }}"
+                log_dir: "{{ cifmw_env_op_images_crio_logs_dir }}"
+                output_path: "{{ cifmw_env_op_images_verified_report_path }}"

--- a/roles/env_op_images/templates/pulled_images_report.j2
+++ b/roles/env_op_images/templates/pulled_images_report.j2
@@ -1,0 +1,40 @@
+{# Produces a YAML list of per-container image entries.
+   Inputs (Ansible facts):
+     _pulled_report_pods            – register from k8s_info pod queries
+     _pulled_report_mirror_mappings – flat list of {source, mirror} dicts
+#}
+{% set entries = [] %}
+{% set all_pods = _pulled_report_pods.results |
+                  map(attribute='resources', default=[]) | flatten %}
+{% for pod in all_pods %}
+{%   set image_statuses = [] %}
+{%   for cs in pod.status.containerStatuses | default([]) %}
+{%     set _ = image_statuses.append({'cs': cs, 'type': 'container'}) %}
+{%   endfor %}
+{%   for cs in pod.status.initContainerStatuses | default([]) %}
+{%     set _ = image_statuses.append({'cs': cs, 'type': 'init_container'}) %}
+{%   endfor %}
+{%   for entry in image_statuses %}
+{%     set cs = entry.cs %}
+{%     set image = cs.image | default('unknown') %}
+{%     set image_id = cs.imageID | default('') %}
+{%     set match = namespace(host=image.split('/')[0], expected_pull_basis='source') %}
+{%     for m in _pulled_report_mirror_mappings if m.source is defined and m.source and image.startswith(m.source) %}
+{%       if loop.first %}
+{%         set match.host = m.mirror.split('/')[0] %}
+{%         set match.expected_pull_basis = 'mirror' %}
+{%       endif %}
+{%     endfor %}
+{%     set _ = entries.append({
+         'namespace': pod.metadata.namespace,
+         'pod': pod.metadata.name,
+         'node': pod.spec.get('nodeName', 'unknown'),
+         'container': cs.name,
+         'image': image,
+         'image_id': image_id,
+         'expected_pull_location': match.host,
+         'expected_pull_basis': match.expected_pull_basis
+       }) %}
+{%   endfor %}
+{% endfor %}
+{{ entries }}

--- a/tests/sanity/ignore.txt
+++ b/tests/sanity/ignore.txt
@@ -5,3 +5,4 @@ plugins/modules/tempest_list_skipped.py validate-modules:missing-gplv3-license #
 plugins/modules/cephx_key.py validate-modules:missing-gplv3-license # ignore license check
 plugins/modules/krb_request.py validate-modules:missing-gplv3-license # ignore license check
 plugins/modules/pem_read.py validate-modules:missing-gplv3-license # ignore license check
+plugins/modules/verify_pulled_report_crio.py validate-modules:missing-gplv3-license # ignore license check


### PR DESCRIPTION
Builds a pulled_images_report which was created by cross-referencing pod images against ICSP/IDMS mirror rules to report which images have a mirror configured and which pull directly from the original registry. As this is a what "should happen" report we need to verify via CRIO logs on node.

To verify a updated report is created which cross-references the pulled-images report with CRI-O journal logs
from cluster nodes to confirm which images were actually pulled by
the container runtime