### PR TITLE
[build_openstack_packages] Removing whitebox-n-t-p and tempest from branchless dict

### DIFF
--- a/roles/build_openstack_packages/defaults/main.yml
+++ b/roles/build_openstack_packages/defaults/main.yml
@@ -62,8 +62,6 @@ cifmw_bop_timestamper_cmd: >-
 cifmw_bop_branchless_projects:
   - openstack-k8s-operators/tcib
   - os-net-config/os-net-config
-  - x/whitebox-neutron-tempest-plugin
-  - openstack/tempest
 
 cifmw_bop_change_list: []
 


### PR DESCRIPTION
So we want them to be actually checkout to antelope code instead
of master

Signed-off-by: Enrique Vallespi Gil <evallesp@redhat.com>