### PR TITLE
[validations] Restore original image after hotfix

### DIFF
--- a/roles/validations/tasks/edpm/hotfix.yml
+++ b/roles/validations/tasks/edpm/hotfix.yml
@@ -16,6 +16,15 @@
       oc get osdpns -n {{ cifmw_validations_namespace }} --no-headers -o custom-columns=":metadata.name"
   register: deployed_nodeset_name
 
+# Collect running image before the hotfix is applied
+- name: Collect the image currently used by nova_compute on the edpm node
+  become: true
+  ansible.builtin.shell:
+    cmd: >-
+      set -o pipefail && podman inspect nova_compute | jq '.[].ImageName' | tr -d '"'
+  delegate_to: "{{ cifmw_validations_edpm_check_node }}"
+  register: original_nova_compute_image
+
 # Simulate hotfixed image by update edpm_nova_compute_image to a different, non-default value
 - name: Update edpm_nova_compute_image value
   environment:
@@ -89,6 +98,83 @@
   ansible.builtin.assert:
     that:
       - cifmw_validations_hotfixed_edpm_nova_compute_image == post_change_nova_compute_image.stdout
+
+# Restore hot fixed image to original value
+- name: Update edpm_nova_compute_image value
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  cifmw.general.ci_script:
+    output_dir: "{{ cifmw_validations_basedir }}/artifacts"
+    script: >-
+      oc patch -n {{ cifmw_validations_namespace }}
+      osdpns/"{{ deployed_nodeset_name.stdout | trim }}"
+      --type=merge -p '{"spec": {"nodeTemplate": {"ansible": {"ansibleVars": {"edpm_nova_compute_image": "{{ original_nova_compute_image.stdout }}"}}}}}'
+
+# loop check the status of the openstackdataplanenodeset until it is either SetupReady,
+# or reaches a defined timeout value.
+- name: Wait for nodeset to be SetupReady again
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  cifmw.general.ci_script:
+    output_dir: "{{ cifmw_validations_basedir }}/artifacts"
+    script: >-
+      oc wait osdpns "{{ deployed_nodeset_name.stdout | trim }}"
+      --namespace={{ cifmw_validations_namespace }}
+      --for=condition=SetupReady
+      --timeout={{ cifmw_validations_timeout }}m
+
+# Create a new OpenStackDataPlaneDeployment to restore the original image
+- name: Create openstackdataplanedeployment to rollout changes
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  cifmw.general.ci_script:
+    output_dir: "{{ cifmw_validations_basedir }}/artifacts"
+    script: |
+      oc apply -f - <<EOF
+      apiVersion: dataplane.openstack.org/v1beta1
+      kind: OpenStackDataPlaneDeployment
+      metadata:
+        name: remove-edpm-hotfix
+        namespace: {{ cifmw_validations_namespace }}
+      spec:
+        nodeSets:
+          - "{{ deployed_nodeset_name.stdout | trim }}"
+        servicesOverride:
+          - "{{ cifmw_validations_custom_nova_service }}"
+      EOF
+
+# loop check the status of the openstackdataplanedeployment until it is either completed,
+# or reaches a defined timeout value.
+- name: Wait for deployment to be complete
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  cifmw.general.ci_script:
+    output_dir: "{{ cifmw_validations_basedir }}/artifacts"
+    script: >-
+      oc wait openstackdataplanedeployment remove-edpm-hotfix
+      --namespace={{ cifmw_validations_namespace }}
+      --for=condition=ready
+      --timeout={{ cifmw_validations_timeout }}m
+
+# Collect running image to assert the hotfix was removed
+- name: Collect the image currently used by nova_compute on the edpm node
+  become: true
+  ansible.builtin.shell:
+    cmd: >-
+      set -o pipefail && podman inspect nova_compute | jq '.[].ImageName' | tr -d '"'
+  delegate_to: "{{ cifmw_validations_edpm_check_node }}"
+  register: post_remove_nova_compute_image
+
+# these assertions will determine whether this job has ultimately been successful or not.
+# here, we should list all of the assertions required to satisfy our feature requirements.
+- name: Assert state change reflects our requirements
+  ansible.builtin.assert:
+    that:
+      - original_nova_compute_image.stdout == post_remove_nova_compute_image.stdout
 
 - name: Wait for all nova-compute services to be up after hotfix rollout
   cifmw.general.ci_script:


### PR DESCRIPTION
Restore original image after simulated hotfix test. This leaves compute nodes in a known state and prevents failures in subsequent tests.