### PR TITLE
[multi-namespace] Skip container image update when primary NS has no overrides

### DIFF
--- a/playbooks/multi-namespace/ns2_update_containers.yaml
+++ b/playbooks/multi-namespace/ns2_update_containers.yaml
@@ -6,6 +6,20 @@
       ansible.builtin.include_vars:
         dir: "{{ cifmw_basedir }}/artifacts/parameters"
 
+    - name: Check if primary namespace has customContainerImages
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.command:
+        cmd: >-
+          oc get openstackversion
+          -n {{ cifmw_openstack_namespace }}
+          -o jsonpath='{.items[0].spec.customContainerImages}'
+      register: _primary_custom_images
+      changed_when: false
+
     - name: "Update containers in {{ cifmw_update_containers_namespace }}"
+      when:
+        - _primary_custom_images.stdout not in ['', '{}']
       ansible.builtin.include_role:
         name: update_containers


### PR DESCRIPTION
The ns2_update_containers playbook unconditionally applies custom container images to the openstack2 namespace using CI parameter variables (registry, org, tag). However, when the primary openstack namespace does not have customContainerImages set on its OpenStackVersion CR, those CI parameters produce incorrect images that override the correct operator defaults.

Add a pre-check that reads the primary namespace's OpenStackVersion customContainerImages. If empty, skip the update_containers role so that openstack2 uses the same operator defaults as openstack.