### PR TITLE
ipa: fix kube-rbac-proxy image pull failure

### DIFF
--- a/roles/ipa/tasks/run_ipa_setup.yml
+++ b/roles/ipa/tasks/run_ipa_setup.yml
@@ -65,6 +65,7 @@
       oc create -f config/rbac/scc.yaml
       (cd config/default && kustomize edit set namespace "{{ cifmw_ipa_namespace }}")
       (cd config/manager && kustomize edit set image controller=quay.io/freeipa/freeipa-operator:nightly)
+      (cd config/default && kustomize edit set image gcr.io/kubebuilder/kube-rbac-proxy=registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0)
       kustomize build config/default | kubectl apply -f -
 
 - name: Wait for it to be deployed


### PR DESCRIPTION
## Summary

Fixes the LDAP CI job failure in the keystone component pipeline.

- **Job:** `component-keystone-edpm-rhel9-rhoso18.0-crc-ldap`
- **Error:** `ErrImagePull` / `ImagePullBackOff` for `gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0`
- **Root cause:** The `freeipa-operator` Deployment includes a `kube-rbac-proxy` sidecar referencing `gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0` which is no longer available (Google Container Registry deprecation)
- **Fix:** Override the sidecar image to `registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0` via `kustomize edit set image` during IPA operator installation

## Test plan

- [x] `component-keystone-edpm-rhel9-rhoso18.0-crc-ldap` passes (verified 2x on [testproject MR !2210](https://gitlab.cee.redhat.com/ci-framework/ci-framework-testproject/-/merge_requests/2210))

## Related

- [OSPCIX-1321](https://redhat.atlassian.net/browse/OSPCIX-1321)
- [OSPRH-28983](https://redhat.atlassian.net/browse/OSPRH-28983)
- Federation fix (separate): #3847

Assisted-by: Claude Opus 4 (Anthropic)