### PR TITLE
federation: split controlplane hook into pre- and post-deploy

### DIFF
--- a/hooks/playbooks/federation-controlplane-config-postdeploy.yml
+++ b/hooks/playbooks/federation-controlplane-config-postdeploy.yml
@@ -1,0 +1,18 @@
+---
+- name: Update CA bundle and patch Keystone for Federation (post-deploy)
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  tasks:
+    - name: Set uni domain name var from federation role
+      ansible.builtin.set_fact:
+        cifmw_federation_domain: "apps.ocp.openstack.lab"
+      when: cifmw_federation_deploy_type == "uni"
+
+    - name: Set crc domain name var from federation role
+      ansible.builtin.set_fact:
+        cifmw_federation_domain: "apps-crc.testing"
+      when: cifmw_federation_deploy_type == "crc"
+
+    - name: Run SSO controlplane post-deploy setup
+      ansible.builtin.import_role:
+        name: federation
+        tasks_from: hook_controlplane_config_postdeploy.yml

--- a/roles/federation/tasks/hook_controlplane_config.yml
+++ b/roles/federation/tasks/hook_controlplane_config.yml
@@ -13,121 +13,26 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-
-# ---------------------------------------------------------------------------
-# Step 1 - read the Keycloak CA cert written by federation-pre-deploy
-# ---------------------------------------------------------------------------
-- name: Get ingress operator CA cert
-  ansible.builtin.slurp:
-    src: "{{ [ansible_user_dir, 'ci-framework-data', 'tmp', 'ingress-operator-ca.crt'] | path_join }}"
-  register: federation_sso_ca
-
-# ---------------------------------------------------------------------------
-# Step 2 - read the live OSCP to determine where the CA bundle lives.
 #
-# Priority for the secret name:
-#   1. spec.tls.caBundleSecretName already set on the OSCP  (use it as-is).
-#   2. cifmw_custom_ca_certs_secret_name variable (if set by caller).
-#   3. Hard default: "custom-ca-certs".
+# Pre-deploy hook for the component / CRC pipeline.
 #
-# This makes the hook self-healing: it does not rely on the kustomize having
-# correctly propagated caBundleSecretName, and it works on fresh installs
-# where the secret does not yet exist.
-# ---------------------------------------------------------------------------
-- name: Read current OpenStackControlPlane state
-  kubernetes.core.k8s_info:
-    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
-    api_version: core.openstack.org/v1beta1
-    kind: OpenStackControlPlane
-    name: controlplane
-    namespace: "{{ cifmw_federation_run_osp_cmd_namespace }}"
-  register: _federation_oscp_info
+# Called before kustomize_deploy brings up the OpenStackControlPlane.
+# Creates the required secrets and writes a kustomization file that
+# kustomize_deploy will apply when it deploys the control plane.
+# The OSCP does not exist yet at this point; no direct OSCP patching
+# is performed here.
+#
+# For the post-deploy (architecture / integration / SKMO) pipeline where
+# the OSCP is already running, use hook_controlplane_config_postdeploy.yml
+# instead.
 
-- name: Resolve CA bundle secret name and check if OSCP already references one
-  ansible.builtin.set_fact:
-    _federation_ca_bundle_secret_name: >-
-      {{
-        ((_federation_oscp_info.resources | first).spec.tls | default({})).caBundleSecretName
-        | default(cifmw_custom_ca_certs_secret_name, true)
-        | default('custom-ca-certs', true)
-      }}
-    _federation_oscp_has_ca_bundle: >-
-      {{
-        (
-          ((_federation_oscp_info.resources | first).spec.tls | default({})).caBundleSecretName
-          | default('')
-        ) | length > 0
-      }}
-
-# ---------------------------------------------------------------------------
-# Step 3 - preserve any keys already in the target secret
-# ---------------------------------------------------------------------------
-- name: Look up existing CA bundle secret
-  kubernetes.core.k8s_info:
-    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
-    api_version: v1
-    kind: Secret
-    name: "{{ _federation_ca_bundle_secret_name }}"
-    namespace: "{{ cifmw_federation_run_osp_cmd_namespace }}"
-  register: _federation_existing_ca_bundle
-
-- name: Capture existing CA bundle secret data
-  ansible.builtin.set_fact:
-    _federation_ca_bundle_existing_data: >-
-      {{
-        (_federation_existing_ca_bundle.resources | first).data
-        if _federation_existing_ca_bundle.resources | length > 0
-        else {}
-      }}
-
-# ---------------------------------------------------------------------------
-# Step 4 - create / update the secret, adding keycloak-ca.crt
-# ---------------------------------------------------------------------------
-- name: Create or update CA bundle secret with Keycloak CA cert
-  kubernetes.core.k8s:
-    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
-    state: present
-    definition:
-      apiVersion: v1
-      kind: Secret
-      type: Opaque
-      metadata:
-        name: "{{ _federation_ca_bundle_secret_name }}"
-        namespace: "{{ cifmw_federation_run_osp_cmd_namespace }}"
-      data: >-
-        {{
-          _federation_ca_bundle_existing_data |
-          combine({'keycloak-ca.crt': federation_sso_ca.content})
-        }}
-
-# ---------------------------------------------------------------------------
-# Step 5 - patch the OSCP to reference the secret when not already set
-# ---------------------------------------------------------------------------
-- name: Patch OpenStackControlPlane to set caBundleSecretName (when unset)
-  when: not _federation_oscp_has_ca_bundle | bool
-  kubernetes.core.k8s:
-    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
-    state: patched
-    definition:
-      apiVersion: core.openstack.org/v1beta1
-      kind: OpenStackControlPlane
-      metadata:
-        name: controlplane
-        namespace: "{{ cifmw_federation_run_osp_cmd_namespace }}"
-      spec:
-        tls:
-          caBundleSecretName: "{{ _federation_ca_bundle_secret_name }}"
-
-# ---------------------------------------------------------------------------
-# Step 6 - kustomization for CRC/devscripts flow (not consumed by kustomize_deploy)
-# ---------------------------------------------------------------------------
 - name: Ensure kustomization controlplane directory exists
   ansible.builtin.file:
     path: "{{ cifmw_manifests_dir }}/kustomizations/controlplane"
     state: directory
     mode: "0755"
 
-- name: Create Keystone federation kustomization
+- name: Create file to customize keystone for Federation resources deployed in the control plane
   ansible.builtin.copy:
     dest: "{{ cifmw_manifests_dir }}/kustomizations/controlplane/keystone_federation.yaml"
     mode: "0644"
@@ -141,31 +46,48 @@
           kind: OpenStackControlPlane
           name: .*
         patch: |-
-          apiVersion: core.openstack.org/v1beta1
-          kind: OpenStackControlPlane
-          metadata:
-            name: controlplane
-          spec:
-            tls:
-              caBundleSecretName: {{ _federation_ca_bundle_secret_name }}
-            keystone:
-              template:
-                httpdCustomization:
-                  customConfigSecret: keystone-httpd-override
-                customServiceConfig: |
-                  [DEFAULT]
-                  insecure_debug=true
-                  debug=true
-                  [federation]
-                  trusted_dashboard={{ cifmw_federation_horizon_url }}/dashboard/auth/websso/
-                  [openid]
-                  remote_id_attribute=HTTP_OIDC_ISS
-                  [auth]
-                  methods = password,token,oauth1,mapped,application_credential,openid
+          - op: add
+            path: /spec/tls
+            value: {}
+          - op: add
+            path: /spec/tls/caBundleSecretName
+            value: keycloakca
+          - op: add
+            path: /spec/keystone/template/httpdCustomization
+            value:
+              customConfigSecret: keystone-httpd-override
+          - op: add
+            path: /spec/keystone/template/customServiceConfig
+            value: |
+              [DEFAULT]
+              insecure_debug=true
+              debug=true
+              [federation]
+              trusted_dashboard={{ cifmw_federation_horizon_url }}/dashboard/auth/websso/
+              [openid]
+              remote_id_attribute=HTTP_OIDC_ISS
+              [auth]
+              methods = password,token,oauth1,mapped,application_credential,openid
 
-# ---------------------------------------------------------------------------
-# Step 7 - Keystone httpd override secret (always needed)
-# ---------------------------------------------------------------------------
+- name: Get ingress operator CA cert
+  ansible.builtin.slurp:
+    src: "{{ [ansible_user_dir, 'ci-framework-data', 'tmp', 'ingress-operator-ca.crt'] | path_join }}"
+  register: cifmw_federation_sso_ca
+
+- name: Add Keycloak CA secret
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      type: Opaque
+      metadata:
+        name: keycloakca
+        namespace: "{{ cifmw_federation_run_osp_cmd_namespace }}"
+      data:
+        KeyCloakCA: "{{ cifmw_federation_sso_ca.content }}"
+
 - name: Create Keystone httpd override secret for Federation
   kubernetes.core.k8s:
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
@@ -179,33 +101,3 @@
       type: Opaque
       stringData:
         federation.conf: "{{ lookup('template', 'federation-single.conf.j2') }}"
-
-# ---------------------------------------------------------------------------
-# Step 8 - patch the OSCP for Keystone OIDC settings (kustomize_deploy flow)
-# ---------------------------------------------------------------------------
-- name: Patch OpenStackControlPlane with Keystone federation config
-  when: _federation_oscp_info.resources | length > 0
-  kubernetes.core.k8s:
-    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
-    state: patched
-    definition:
-      apiVersion: core.openstack.org/v1beta1
-      kind: OpenStackControlPlane
-      metadata:
-        name: controlplane
-        namespace: "{{ cifmw_federation_run_osp_cmd_namespace }}"
-      spec:
-        keystone:
-          template:
-            httpdCustomization:
-              customConfigSecret: keystone-httpd-override
-            customServiceConfig: |
-              [DEFAULT]
-              insecure_debug=true
-              debug=true
-              [federation]
-              trusted_dashboard={{ cifmw_federation_horizon_url }}/dashboard/auth/websso/
-              [openid]
-              remote_id_attribute=HTTP_OIDC_ISS
-              [auth]
-              methods = password,token,oauth1,mapped,application_credential,openid

--- a/roles/federation/tasks/hook_controlplane_config_postdeploy.yml
+++ b/roles/federation/tasks/hook_controlplane_config_postdeploy.yml
@@ -1,0 +1,191 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# Post-deploy hook for the architecture / integration / SKMO pipeline.
+#
+# Called after kustomize_deploy has already brought up the
+# OpenStackControlPlane.  Reads the live OSCP to determine the existing
+# CA bundle secret name, preserves any keys already in that secret, merges
+# in the Keycloak CA, and patches the OSCP to reference the secret when it
+# is not already set.
+#
+#
+# For the pre-deploy (component / CRC) pipeline where the OSCP does not
+# yet exist, use hook_controlplane_config.yml instead.
+
+# ---------------------------------------------------------------------------
+# Step 1 - read the Keycloak CA cert written by federation-pre-deploy
+# ---------------------------------------------------------------------------
+- name: Get ingress operator CA cert
+  ansible.builtin.slurp:
+    src: "{{ [ansible_user_dir, 'ci-framework-data', 'tmp', 'ingress-operator-ca.crt'] | path_join }}"
+  register: cifmw_federation_sso_ca
+
+# ---------------------------------------------------------------------------
+# Step 2 - read the live OSCP to determine where the CA bundle lives.
+#
+# Priority for the secret name:
+#   1. spec.tls.caBundleSecretName already set on the OSCP  (use it as-is).
+#   2. cifmw_custom_ca_certs_secret_name variable (if set by caller).
+#   3. Hard default: "custom-ca-certs".
+# ---------------------------------------------------------------------------
+- name: Read current OpenStackControlPlane state
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_version: core.openstack.org/v1beta1
+    kind: OpenStackControlPlane
+    name: controlplane
+    namespace: "{{ cifmw_federation_run_osp_cmd_namespace }}"
+  register: cifmw_federation_oscp_info
+
+- name: Resolve CA bundle secret name and check if OSCP already references one
+  ansible.builtin.set_fact:
+    cifmw_federation_ca_bundle_secret_name: >-
+      {{
+        (cifmw_federation_oscp_info.resources[0].spec.tls | default({})).caBundleSecretName
+        | default(cifmw_custom_ca_certs_secret_name | default('', true), true)
+        | default('custom-ca-certs', true)
+      }}
+    cifmw_federation_oscp_has_ca_bundle: >-
+      {{
+        ((cifmw_federation_oscp_info.resources[0].spec.tls | default({})).caBundleSecretName
+         | default('')) | length > 0
+      }}
+
+# ---------------------------------------------------------------------------
+# Step 3 - preserve any keys already in the target secret
+# ---------------------------------------------------------------------------
+- name: Look up existing CA bundle secret
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_version: v1
+    kind: Secret
+    name: "{{ cifmw_federation_ca_bundle_secret_name }}"
+    namespace: "{{ cifmw_federation_run_osp_cmd_namespace }}"
+  register: cifmw_federation_existing_ca_bundle
+
+- name: Capture existing CA bundle secret data
+  ansible.builtin.set_fact:
+    cifmw_federation_ca_bundle_existing_data: >-
+      {{
+        (cifmw_federation_existing_ca_bundle.resources[0].data | default({}))
+        if cifmw_federation_existing_ca_bundle.resources | length > 0
+        else {}
+      }}
+
+# ---------------------------------------------------------------------------
+# Step 4 - create / update the secret, merging in the Keycloak CA cert
+# ---------------------------------------------------------------------------
+- name: Create or update CA bundle secret with Keycloak CA cert
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      type: Opaque
+      metadata:
+        name: "{{ cifmw_federation_ca_bundle_secret_name }}"
+        namespace: "{{ cifmw_federation_run_osp_cmd_namespace }}"
+      data: >-
+        {{
+          cifmw_federation_ca_bundle_existing_data |
+          combine({'keycloak-ca.crt': cifmw_federation_sso_ca.content})
+        }}
+
+# ---------------------------------------------------------------------------
+# Step 5 - patch the OSCP to reference the secret when not already set.
+# ---------------------------------------------------------------------------
+- name: Patch OpenStackControlPlane to set caBundleSecretName (when unset)
+  when: not cifmw_federation_oscp_has_ca_bundle | bool
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    state: patched
+    definition:
+      apiVersion: core.openstack.org/v1beta1
+      kind: OpenStackControlPlane
+      metadata:
+        name: controlplane
+        namespace: "{{ cifmw_federation_run_osp_cmd_namespace }}"
+      spec:
+        tls:
+          caBundleSecretName: "{{ cifmw_federation_ca_bundle_secret_name }}"
+
+# ---------------------------------------------------------------------------
+# Step 6 - Keystone httpd override secret (always needed)
+# ---------------------------------------------------------------------------
+- name: Create Keystone httpd override secret for Federation
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: keystone-httpd-override
+        namespace: "{{ cifmw_federation_run_osp_cmd_namespace }}"
+      type: Opaque
+      stringData:
+        federation.conf: "{{ lookup('template', 'federation-single.conf.j2') }}"
+
+# ---------------------------------------------------------------------------
+# Step 7 - wire the httpd override secret and federation customServiceConfig
+#          into the live OSCP keystone section.
+# ---------------------------------------------------------------------------
+- name: Patch OpenStackControlPlane to enable keystone federation httpd config and auth methods
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    state: patched
+    definition:
+      apiVersion: core.openstack.org/v1beta1
+      kind: OpenStackControlPlane
+      metadata:
+        name: controlplane
+        namespace: "{{ cifmw_federation_run_osp_cmd_namespace }}"
+      spec:
+        keystone:
+          template:
+            httpdCustomization:
+              customConfigSecret: keystone-httpd-override
+            customServiceConfig: |
+              [DEFAULT]
+              insecure_debug=true
+              debug=true
+              [federation]
+              trusted_dashboard={{ cifmw_federation_horizon_url }}/dashboard/auth/websso/
+              [openid]
+              remote_id_attribute=HTTP_OIDC_ISS
+              [auth]
+              methods = password,token,oauth1,mapped,application_credential,openid
+
+# ---------------------------------------------------------------------------
+# Step 8 - wait for Keystone to reconcile with the new federation config
+# ---------------------------------------------------------------------------
+- name: Wait for Keystone to be Ready with federation config applied
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_version: keystone.openstack.org/v1beta1
+    kind: KeystoneAPI
+    name: keystone
+    namespace: "{{ cifmw_federation_run_osp_cmd_namespace }}"
+  register: _keystone_fed_wait
+  until:
+    - _keystone_fed_wait.resources | length > 0
+    - (_keystone_fed_wait.resources[0].status.conditions | default([]) |
+       selectattr('type', 'equalto', 'Ready') |
+       selectattr('status', 'equalto', 'True') | list | length) > 0
+  retries: 30
+  delay: 10


### PR DESCRIPTION
Recent changes were made to hook_controlplane_config.yml to accomodate adding federation to the SKMO deployment.  This deployment differs though, in that the control plane already exists in the SKMO case.  The changes broke the existing component job.

The cases are sufficiently different that its just cleaner to just use two different playbooks.  That way, we do not have to worry about getting different conditionals right.  This PR just does this - reverting the existing playbook to its original state (for the component job) and adding a new one for the SKMO case.

split into two task files:
  - hook_controlplane_config.yml  (pre-deploy / component pipeline, unchanged)
  - hook_controlplane_config_postdeploy.yml  (post-deploy / SKMO pipeline)

Add a new playbook federation-controlplane-config-postdeploy.yml that wraps the new post-deploy task file.

The architecture/automation/vars/multi-namespace-skmo.yaml is updated separately to call the new post-deploy playbook.

Fix variable names in both task files to use the required cifmw_ prefix so they pass the var-naming[pattern] rule enforced by ansible-lint.

Related-To: [OSPCIX-1321](https://redhat.atlassian.net/browse/OSPCIX-1321)