### PR TITLE
Add messaging-rabbitmq-4 repo to content provider job

### DIFF
--- a/zuul.d/content_provider.yaml
+++ b/zuul.d/content_provider.yaml
@@ -18,6 +18,8 @@
           centos10:
             - tempest-extras
         master: *exclude
+      cifmw_repo_setup_extra_repos:
+        - "messaging-rabbitmq-4,baseurl=https://mirror.stream.centos.org/SIGs/{{ ansible_distribution_major_version }}-stream/messaging/x86_64/rabbitmq-4/"
     pre-run:
       - ci/playbooks/meta_content_provider/copy_container_files.yaml
     run:


### PR DESCRIPTION
The openstack-rabbitmq container image needs RabbitMQ 4.x from the CentOS Messaging SIG repo. Without this, container builds pick up RabbitMQ 3.9.x from the default repos, causing deployment failures in downstream CI jobs.

Configure cifmw_repo_setup_extra_repos on the
openstack-meta-content-provider job so the messaging-rabbitmq-4 repo is available during container image builds. Uses
ansible_distribution_major_version to support both CentOS 9 and 10.