### PR TITLE
[dlrn_report] Set crypto policies when FIPS is enabled

### DIFF
--- a/roles/dlrn_report/tasks/dlrn_report_results.yml
+++ b/roles/dlrn_report/tasks/dlrn_report_results.yml
@@ -14,6 +14,18 @@
   ansible.builtin.include_role:
     name: repo_setup
 
+- name: Check currently enabled crypto policies
+  become: true
+  ansible.builtin.command: >
+    update-crypto-policies --show
+  register: _crypto_policies_status
+
+- name: Update crypto policies when FIPS is set
+  when: "'FIPS' in _crypto_policies_status.stdout"
+  become: true
+  ansible.builtin.command: >
+    update-crypto-policies --set FIPS:AD-SUPPORT
+
 - name: Perform kinit for DLRN kerberos authentication
   ansible.builtin.command:
     cmd: >-


### PR DESCRIPTION
Since some CI jobs are running using the PreMetal tool, and we move the job execution from controller node to hypervisor directly, the crypto policies are different.
For example, when the task was executed on controller:

    update-crypto-policies --show
    DEFAULT

Where, in some case, where uni job require FIPS, output is:

    update-crypto-policies --show
    FIPS

Set the AD-SUPPORT policy when just FIPS is enabled.