### PR TITLE
Drop labels dedicated to cloud provider

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -27,7 +27,7 @@
 - job:
     name: openstack-k8s-operators-content-provider
     parent: cifmw-base-minimal
-    nodeset: centos-stream-9-vexxhost
+    nodeset: centos-stream-9
     irrelevant-files: &ir_files
       - .*/*.md
       - ^.github/.*$
@@ -235,7 +235,7 @@
     parent: base-extracted-crc-ci-bootstrap-staging
     timeout: 10800
     attempts: 1
-    nodeset: centos-9-medium-centos-9-crc-cloud-ocp-4-18-1-3xl-vexxhost
+    nodeset: centos-9-medium-centos-9-crc-cloud-ocp-4-18-1-3xl
     irrelevant-files: *ir_files
     required-projects: *multinode_edpm_rp
     roles: *multinode_edpm_roles

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -16,18 +16,6 @@
         nodes: []
 
 - nodeset:
-    name: centos-stream-9-vexxhost
-    nodes:
-      - name: controller
-        label: cloud-centos-9-stream-tripleo-vexxhost
-    groups:
-      - name: switch
-        nodes:
-          - controller
-      - name: peers
-        nodes: []
-
-- nodeset:
     name: 4x-centos-9-medium
     nodes:
       - name: controller
@@ -51,10 +39,10 @@
 #  CentOS Stream 10 nodeset
 #
 - nodeset:
-    name: centos-stream-10-vexxhost
+    name: centos-stream-10
     nodes:
       - name: controller
-        label: cloud-centos-10-stream-tripleo-vexxhost
+        label: cloud-centos-10-stream-tripleo
     groups:
       - name: switch
         nodes:
@@ -68,14 +56,14 @@
 
 # Used by watcher-operator
 - nodeset:
-    name: centos-9-medium-2x-centos-9-crc-extracted-2-39-0-3xl-vexxhost
+    name: centos-9-medium-2x-centos-9-crc-extracted-2-39-0-3xl
     nodes:
       - name: controller
-        label: cloud-centos-9-stream-tripleo-vexxhost-medium
+        label: cloud-centos-9-stream-tripleo-medium
       - name: compute-0
-        label: cloud-centos-9-stream-tripleo-vexxhost
+        label: cloud-centos-9-stream-tripleo
       - name: compute-1
-        label: cloud-centos-9-stream-tripleo-vexxhost
+        label: cloud-centos-9-stream-tripleo
       - name: crc
         label: coreos-crc-extracted-2-39-0-3xl
     groups:
@@ -139,26 +127,6 @@
           - crc
 
 - nodeset:
-    name: centos-9-medium-2x-centos-9-crc-cloud-ocp-4-18-1-3xl-vexxhost
-    nodes:
-      - name: controller
-        label: cloud-centos-9-stream-tripleo-vexxhost-medium
-      - name: compute-0
-        label: cloud-centos-9-stream-tripleo-vexxhost
-      - name: compute-1
-        label: cloud-centos-9-stream-tripleo-vexxhost
-      - name: crc
-        label: crc-cloud-ocp-4-18-1-3xl
-    groups:
-      - name: computes
-        nodes:
-          - compute-0
-          - compute-1
-      - name: ocps
-        nodes:
-          - crc
-
-- nodeset:
     name: centos-9-2x-centos-9-xxl-crc-cloud-ocp-4-18-1-xxl
     nodes:
       - name: controller
@@ -206,20 +174,6 @@
     nodes:
       - name: controller
         label: cloud-centos-9-stream-tripleo-medium
-      - name: crc
-        label: crc-cloud-ocp-4-18-1-3xl
-    groups:
-      - name: computes
-        nodes: []
-      - name: ocps
-        nodes:
-          - crc
-
-- nodeset:
-    name: centos-9-medium-crc-cloud-ocp-4-18-1-3xl-vexxhost
-    nodes:
-      - name: controller
-        label: cloud-centos-9-stream-tripleo-vexxhost-medium
       - name: crc
         label: crc-cloud-ocp-4-18-1-3xl
     groups:
@@ -381,24 +335,6 @@
         nodes:
           - crc
 
-# todo: Remove. Temporal. Needed as the credentials used in ci-bootstrap jobs for IBM don't work
-- nodeset:
-    name: centos-9-medium-centos-9-crc-cloud-ocp-4-18-1-3xl-vexxhost
-    nodes:
-      - name: controller
-        label: cloud-centos-9-stream-tripleo-vexxhost-medium
-      - name: compute-0
-        label: cloud-centos-9-stream-tripleo-vexxhost
-      - name: crc
-        label: crc-cloud-ocp-4-18-1-3xl
-    groups:
-      - name: computes
-        nodes:
-          - compute-0
-      - name: ocps
-        nodes:
-          - crc
-
 - nodeset:
     name: centos-9-crc-2-48-0-6xlarge
     nodes:
@@ -463,26 +399,6 @@
           - crc
 
 - nodeset:
-    name: centos-9-medium-2x-centos-9-crc-cloud-ocp-4-20-1-3xl-vexxhost
-    nodes:
-      - name: controller
-        label: cloud-centos-9-stream-tripleo-vexxhost-medium
-      - name: compute-0
-        label: cloud-centos-9-stream-tripleo-vexxhost
-      - name: compute-1
-        label: cloud-centos-9-stream-tripleo-vexxhost
-      - name: crc
-        label: crc-cloud-ocp-4-20-1-3xl
-    groups:
-      - name: computes
-        nodes:
-          - compute-0
-          - compute-1
-      - name: ocps
-        nodes:
-          - crc
-
-- nodeset:
     name: centos-9-2x-centos-9-xxl-crc-cloud-ocp-4-20-1-xxl
     nodes:
       - name: controller
@@ -530,20 +446,6 @@
     nodes:
       - name: controller
         label: cloud-centos-9-stream-tripleo-medium
-      - name: crc
-        label: crc-cloud-ocp-4-20-1-3xl
-    groups:
-      - name: computes
-        nodes: []
-      - name: ocps
-        nodes:
-          - crc
-
-- nodeset:
-    name: centos-9-medium-crc-cloud-ocp-4-20-1-3xl-vexxhost
-    nodes:
-      - name: controller
-        label: cloud-centos-9-stream-tripleo-vexxhost-medium
       - name: crc
         label: crc-cloud-ocp-4-20-1-3xl
     groups:
@@ -701,24 +603,6 @@
           - compute-0
           - compute-1
           - compute-2
-      - name: ocps
-        nodes:
-          - crc
-
-# todo: Remove. Temporal. Needed as the credentials used in ci-bootstrap jobs for IBM don't work
-- nodeset:
-    name: centos-9-medium-centos-9-crc-cloud-ocp-4-20-1-3xl-vexxhost
-    nodes:
-      - name: controller
-        label: cloud-centos-9-stream-tripleo-vexxhost-medium
-      - name: compute-0
-        label: cloud-centos-9-stream-tripleo-vexxhost
-      - name: crc
-        label: crc-cloud-ocp-4-20-1-3xl
-    groups:
-      - name: computes
-        nodes:
-          - compute-0
       - name: ocps
         nodes:
           - crc

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -16,6 +16,18 @@
         nodes: []
 
 - nodeset:
+    name: centos-stream-9-vexxhost
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo
+    groups:
+      - name: switch
+        nodes:
+          - controller
+      - name: peers
+        nodes: []
+
+- nodeset:
     name: 4x-centos-9-medium
     nodes:
       - name: controller
@@ -50,6 +62,18 @@
       - name: peers
         nodes: []
 
+- nodeset:
+    name: centos-stream-10-vexxhost
+    nodes:
+      - name: controller
+        label: cloud-centos-10-stream-tripleo
+    groups:
+      - name: switch
+        nodes:
+          - controller
+      - name: peers
+        nodes: []
+
 #
 # CRC-2.39 (OCP4.16) nodesets
 #
@@ -57,6 +81,26 @@
 # Used by watcher-operator
 - nodeset:
     name: centos-9-medium-2x-centos-9-crc-extracted-2-39-0-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: coreos-crc-extracted-2-39-0-3xl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-medium-2x-centos-9-crc-extracted-2-39-0-3xl-vexxhost
     nodes:
       - name: controller
         label: cloud-centos-9-stream-tripleo-medium
@@ -126,6 +170,27 @@
         nodes:
           - crc
 
+# FIXME: drop nodeset when other project update their config.
+- nodeset:
+    name: centos-9-medium-2x-centos-9-crc-cloud-ocp-4-18-1-3xl-vexxhost
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: crc-cloud-ocp-4-18-1-3xl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+      - name: ocps
+        nodes:
+          - crc
+
 - nodeset:
     name: centos-9-2x-centos-9-xxl-crc-cloud-ocp-4-18-1-xxl
     nodes:
@@ -174,6 +239,20 @@
     nodes:
       - name: controller
         label: cloud-centos-9-stream-tripleo-medium
+      - name: crc
+        label: crc-cloud-ocp-4-18-1-3xl
+    groups:
+      - name: computes
+        nodes: []
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-medium-crc-cloud-ocp-4-18-1-3xl-vexxhost
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-vexxhost-medium
       - name: crc
         label: crc-cloud-ocp-4-18-1-3xl
     groups:

--- a/zuul.d/tcib.yaml
+++ b/zuul.d/tcib.yaml
@@ -3,7 +3,7 @@
     name: cifmw-tcib-base
     parent: container-tcib-build-base
     timeout: 3500
-    nodeset: centos-stream-9-vexxhost
+    nodeset: centos-stream-9
     required-projects:
       - opendev.org/zuul/zuul-jobs
       - github.com/openstack-k8s-operators/ci-framework


### PR DESCRIPTION
When IBM private cloud would be removed, there is no need to keep
nodesets that would force spawning CI jobs on specific cloud
provider.

After merging: https://github.com/openstack-k8s-operators/ci-framework/pull/3851

Depends-On: https://github.com/openstack-k8s-operators/watcher-operator/pull/363