### PR TITLE
[openshift_setup] Extract insecure registry logic

### DIFF
--- a/roles/openshift_setup/README.md
+++ b/roles/openshift_setup/README.md
@@ -26,5 +26,14 @@ effect if `cifmw_openshift_setup_ca_registry_to_add` is set.
             mirrors:
               - mirror.quay.rdoproject.org
         ```
+* `cifmw_openshift_setup_allowed_registries`: (List) List of allowed registries when setting up insecure registry configuration. Used in conjunction with `cifmw_update_containers_registry`. Defaults to common registries.
+    * Example:
+        ```yaml
+        cifmw_openshift_setup_allowed_registries:
+          - "quay.io"
+          - "registry.redhat.io"
+          - "my-internal-registry.example.com"
+        ```
+* `cifmw_openshift_setup_allowed_extra_registries`: (List) List of extra registries we want to allow. Intended to be by CI jobs using the framework.
 * `cifmw_openshift_setup_apply_marketplace_fix`: (Boolean) Apply openshift-marketplace workaround which is recreating all pods in the namespace. NOTE: same step is done in `base` job.
 * `cifmw_openshift_setup_samples_registry`: (String) Registry sample

--- a/roles/openshift_setup/defaults/main.yml
+++ b/roles/openshift_setup/defaults/main.yml
@@ -29,3 +29,14 @@ cifmw_openshift_setup_operator_override_catalog_namespace: "openshift-marketplac
 cifmw_openshift_setup_operator_override_catalog_image: "registry.redhat.io/redhat/redhat-operator-index:v4.17"
 cifmw_openshift_setup_apply_marketplace_fix: false
 cifmw_openshift_setup_samples_registry: "registry.redhat.io"
+cifmw_openshift_setup_allowed_registries:
+  - "quay.io"
+  - "gcr.io"
+  - "registry.k8s.io"
+  - "registry.redhat.io"
+  - "registry.connect.redhat.com"
+  - "registry-proxy.engineering.redhat.com"
+  - "registry.stage.redhat.io"
+  - "images.paas.redhat.com"
+  - "image-registry.openshift-image-registry.svc:5000"
+cifmw_openshift_setup_allowed_extra_registries: []

--- a/roles/openshift_setup/tasks/configure_registries.yml
+++ b/roles/openshift_setup/tasks/configure_registries.yml
@@ -1,0 +1,54 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# This task file configures insecure registries and ImageContentSourcePolicy
+# Can be used standalone from playbooks that don't need the full openshift_setup role
+
+- name: Add insecure registry
+  when: cifmw_update_containers_registry is defined
+  vars:
+    all_registries: "{{ ([cifmw_update_containers_registry] + cifmw_openshift_setup_allowed_registries + cifmw_openshift_setup_allowed_extra_registries) | unique }}"
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    merge_type: "merge"
+    definition:
+      apiVersion: config.openshift.io/v1
+      kind: Image
+      metadata:
+        name: cluster
+      spec:
+        registrySources:
+          insecureRegistries:
+            - "{{ cifmw_update_containers_registry }}"
+          allowedRegistries: "{{ all_registries }}"
+
+- name: Create a ICSP with repository digest mirrors
+  when:
+    - cifmw_openshift_setup_digest_mirrors is defined
+    - cifmw_openshift_setup_digest_mirrors | length > 0
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    definition:
+      apiVersion: operator.openshift.io/v1alpha1
+      kind: ImageContentSourcePolicy
+      metadata:
+        name: registry-digest-mirrors
+      spec:
+        repositoryDigestMirrors: "{{ cifmw_openshift_setup_digest_mirrors }}"

--- a/roles/openshift_setup/tasks/main.yml
+++ b/roles/openshift_setup/tasks/main.yml
@@ -168,51 +168,8 @@
             additionalTrustedCA:
               name: "registry-cas"
 
-- name: Add insecure registry
-  when: cifmw_update_containers_registry is defined
-  vars:
-    default_allowed_registries:
-      - "quay.io"
-      - "gcr.io"
-      - "registry.k8s.io"
-      - "registry.redhat.io"
-      - "registry.connect.redhat.com"
-      - "registry-proxy.engineering.redhat.com"
-      - "registry.stage.redhat.io"
-      - "images.paas.redhat.com"
-      - "image-registry.openshift-image-registry.svc:5000"
-    all_registries: "{{ [cifmw_update_containers_registry] + default_allowed_registries | unique }}"
-  kubernetes.core.k8s:
-    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
-    api_key: "{{ cifmw_openshift_token | default(omit)}}"
-    context: "{{ cifmw_openshift_context | default(omit)}}"
-    merge_type: "merge"
-    definition:
-      apiVersion: config.openshift.io/v1
-      kind: Image
-      metadata:
-        name: cluster
-      spec:
-        registrySources:
-          insecureRegistries:
-            - "{{ cifmw_update_containers_registry }}"
-          allowedRegistries: "{{ all_registries }}"
-
-- name: Create a ICSP with repository digest mirrors
-  when:
-    - cifmw_openshift_setup_digest_mirrors is defined
-    - cifmw_openshift_setup_digest_mirrors | length > 0
-  kubernetes.core.k8s:
-    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
-    api_key: "{{ cifmw_openshift_token | default(omit)}}"
-    context: "{{ cifmw_openshift_context | default(omit)}}"
-    definition:
-      apiVersion: operator.openshift.io/v1alpha1
-      kind: ImageContentSourcePolicy
-      metadata:
-        name: registry-digest-mirrors
-      spec:
-        repositoryDigestMirrors: "{{ cifmw_openshift_setup_digest_mirrors }}"
+- name: Configure insecure registries and ICSP
+  ansible.builtin.import_tasks: configure_registries.yml
 
 - name: Patch network operator when using OVNKubernetes backend
   ansible.builtin.import_tasks: patch_network_operator.yml


### PR DESCRIPTION
We're extracting the logic behind allowing insecure registries. With this, we can use directly this code from other projects that uses parts of ci-framework