### PR TITLE
Add mysqld_exporter and podman-exporter image overrides

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -207,6 +207,7 @@ edecb
 edploy
 edpm
 edpmnodeexporter
+edpmpodmanexporter
 ee
 encodings
 eno
@@ -394,6 +395,7 @@ multinode
 multipath
 multus
 myorg
+mysqld
 mytest
 nad
 namespace
@@ -495,6 +497,7 @@ pki
 png
 podified
 podman
+podmanexporter
 polarion
 polkit
 pragadeeswaran

--- a/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
+++ b/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
@@ -38,7 +38,10 @@
       (cifmw_update_containers_openstack is defined and
       cifmw_update_containers_openstack | bool) or
       (cifmw_update_containers_watcher is defined and
-      cifmw_update_containers_watcher | bool))
+      cifmw_update_containers_watcher | bool) or
+      (cifmw_update_containers_ceilometersgcoreImage is defined) or
+      (cifmw_update_containers_ceilometermysqldexporterImage is defined) or
+      (cifmw_update_containers_edpmpodmanexporterImage is defined))
   vars:
     cifmw_update_containers_metadata: "{{ _ctlplane_name }}"
   ansible.builtin.include_role:

--- a/roles/update_containers/README.md
+++ b/roles/update_containers/README.md
@@ -21,7 +21,9 @@ If apply, please explain the privilege escalation done in this role.
 * `cifmw_update_containers_manilashares`: The names of the manila shares prefix. Default to `[]`.
 * `cifmw_update_containers_agentimage`: Full Agent Image url for updating Agent Image.
 * `cifmw_update_containers_ceilometersgcoreImage`: Full Ceilometersgcore Image url for updating Ceilometersgcore Image.
+* `cifmw_update_containers_ceilometermysqldexporterImage`: Full Ceilometer mysqld_exporter Image url for updating Ceilometer mysqld_exporter Image.
 * `cifmw_update_containers_edpmnodeexporterimage`: Fill EdpmNodeExporter Image url for update Nodeexporter Image.
+* `cifmw_update_containers_edpmpodmanexporterImage`: Fill EdpmPodmanExporter Image url for update PodmanExporter Image.
 * `cifmw_update_containers_openstack`: Whether to generate CR for updating openstack containers. Default to `false`.
 * `cifmw_update_containers_ansibleee_image_url`: Full Ansibleee Image url for updating Ansibleee Image.
 * `cifmw_update_containers_edpm_image_url`: Full EDPM Image url for updating EDPM OS image.

--- a/roles/update_containers/templates/update_containers.j2
+++ b/roles/update_containers/templates/update_containers.j2
@@ -116,6 +116,12 @@ spec:
 {% if cifmw_update_containers_edpmnodeexporterimage is defined %}
     edpmNodeExporterImage: {{ cifmw_update_containers_edpmnodeexporterimage }}
 {% endif %}
+{% if cifmw_update_containers_ceilometermysqldexporterImage is defined %}
+    ceilometerMysqldExporterImage: {{ cifmw_update_containers_ceilometermysqldexporterImage }}
+{% endif %}
+{% if cifmw_update_containers_edpmpodmanexporterImage is defined %}
+    edpmPodmanExporterImage: {{ cifmw_update_containers_edpmpodmanexporterImage }}
+{% endif %}
 {% if cifmw_update_containers_agentimage is defined %}
 	    agentImage: {{ cifmw_update_containers_registry }}/{{ cifmw_update_containers_org }}/{{ cifmw_update_containers_name_prefix }}-baremetal-operator-agent:{{ cifmw_update_containers_tag }}
 {% endif %}


### PR DESCRIPTION
Add ceilometerMysqldExporterImage and edpmPodmanExporterImage fields to the update_containers template. This allows Zuul content-provider jobs for mysqld_exporter and prometheus-podman-exporter to override the container images used in functional tests via the OpenStackVersion custom resource.

Generated-By: Claude-Code claude-opus-4-6