### PR TITLE
[devscripts] Exclude qemu-kvm and libvirt for being upgraded

### DIFF
--- a/roles/devscripts/README.md
+++ b/roles/devscripts/README.md
@@ -56,6 +56,10 @@ networks.
 * `cifmw_devscripts_cinder_volume_pvs` (list) a list of physical disks to be
   used for creating cinder-volumes volume-group. By default, the list contains
   `/dev/vda`.
+* `cifmw_devscripts_exclude_qemu_libvirt` (bool) Exclude package qemu-kvm and
+  libvirt for being updated to newer version that might be broken.
+  When value is set to "true", it will add into /etc/dnf/dnf.conf `exclude`
+  parameter.
 
 ### Secrets management
 

--- a/roles/devscripts/defaults/main.yml
+++ b/roles/devscripts/defaults/main.yml
@@ -74,3 +74,4 @@ cifmw_devscripts_config_overrides: {}
 cifmw_devscripts_installer_timeout: 7200  # 2 hours
 cifmw_devscripts_etcd_slow_profile: true
 cifmw_devscripts_disable_console: false
+cifmw_devscripts_exclude_qemu_libvirt: false

--- a/roles/devscripts/tasks/300_post.yml
+++ b/roles/devscripts/tasks/300_post.yml
@@ -14,6 +14,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Pin libvirt and Qemu packages
+  when: cifmw_devscripts_exclude_qemu_libvirt
+  ansible.builtin.import_tasks: pin_libvirt_qemu.yml
 
 # The layout is prepared and deployed when there exists no overlay. Irrespective
 # of the running state of the cluster.

--- a/roles/devscripts/tasks/pin_libvirt_qemu.yml
+++ b/roles/devscripts/tasks/pin_libvirt_qemu.yml
@@ -1,0 +1,8 @@
+---
+- name: Exclude qemu-kvm and libvirt for being upgraded
+  become: true
+  ansible.builtin.lineinfile:
+    path: /etc/dnf/dnf.conf
+    regexp: '^exclude='
+    line: 'exclude=qemu-kvm,libvirt*'
+    state: present


### PR DESCRIPTION
In some cases, excluding qemu-kvm and libvirt package to avoid upgrade might be very helpful.