### PR TITLE
fix(ci_gen_kustomize_values): add MTU to uni07eta net-attach-def JSON

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/uni07eta/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/uni07eta/network-values/values.yaml.j2
@@ -139,6 +139,7 @@ data:
         "name": "{{ network.network_name }}",
         "type": "macvlan",
         "master": "{{ network.network_name if network.vlan_id is defined else ns.interfaces[network.network_name] }}",
+        "mtu": {{ network.mtu | default(1500) }},
         "ipam": {
           "type": "whereabouts",
           "range": "{{ network[_ipv.network_vX] }}",


### PR DESCRIPTION
Include "mtu": {{ network.mtu | default(1500) }} in the generic macvlan net-attach-def.

Assisted-By: Cursor-composer-2-fast