### PR TITLE
[openshift_setup] Replace ICSP with IDMS/ITMS for modern mirror confi…

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -9,6 +9,8 @@ FreeIPA
 IDM
 ICSP
 IDMS
+ImageDigestMirrorSet
+ImageTagMirrorSet
 IMVHO
 IdP
 Idempotency

--- a/roles/openshift_setup/README.md
+++ b/roles/openshift_setup/README.md
@@ -15,7 +15,7 @@ should be configured for in an OCP/CRC cluster.
 * `cifmw_openshift_setup_ca_bundle_path`: (String) Path to the CA bundle.
 Defaults to `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`. Only has an
 effect if `cifmw_openshift_setup_ca_registry_to_add` is set.
-* `cifmw_openshift_setup_digest_mirrors`: (List) List of alternative mirrored repository locations. Defaults to `[]`.
+* `cifmw_openshift_setup_digest_mirrors`: (List) List of alternative mirrored repository locations for digest-based image pulls. Used to create ImageDigestMirrorSet resources. Defaults to `[]`.
     * Example:
         ```yaml
         cifmw_openshift_setup_digest_mirrors:
@@ -25,6 +25,17 @@ effect if `cifmw_openshift_setup_ca_registry_to_add` is set.
           - source: quay.rdoproject.org
             mirrors:
               - mirror.quay.rdoproject.org
+        ```
+* `cifmw_openshift_setup_tag_mirrors`: (List) List of alternative mirrored repository locations for tag-based image pulls. Used to create ImageTagMirrorSet resources. When both digest and tag mirrors are configured, digest mirrors take precedence for digest-based pulls, while tag mirrors act as a fallback for tag-based pulls. Defaults to `[]`.
+    * Example:
+        ```yaml
+        cifmw_openshift_setup_tag_mirrors:
+          - source: quay.io
+            mirrors:
+              - mirror.quay.io
+          - source: registry.redhat.io
+            mirrors:
+              - my-mirror.example.com
         ```
 * `cifmw_openshift_setup_allowed_registries`: (List) List of allowed registries when setting up insecure registry configuration. Used in conjunction with `cifmw_update_containers_registry`. Defaults to common registries.
     * Example:

--- a/roles/openshift_setup/defaults/main.yml
+++ b/roles/openshift_setup/defaults/main.yml
@@ -24,6 +24,7 @@ cifmw_openshift_setup_skip_internal_registry: false
 cifmw_openshift_setup_skip_internal_registry_tls_verify: false
 cifmw_openshift_setup_ca_bundle_path: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
 cifmw_openshift_setup_digest_mirrors: []
+cifmw_openshift_setup_tag_mirrors: []
 cifmw_openshift_setup_operator_override_catalog_name: "redhat-operators-4.17"
 cifmw_openshift_setup_operator_override_catalog_namespace: "openshift-marketplace"
 cifmw_openshift_setup_operator_override_catalog_image: "registry.redhat.io/redhat/redhat-operator-index:v4.17"

--- a/roles/openshift_setup/molecule/default/converge.yml
+++ b/roles/openshift_setup/molecule/default/converge.yml
@@ -28,6 +28,10 @@
       - source: quay.rdoproject.org
         mirrors:
           - mirror.quay.rdoproject.org
+    cifmw_openshift_setup_tag_mirrors:
+      - source: registry.redhat.io
+        mirrors:
+          - mirror.registry.redhat.io
   roles:
     - role: "openshift_setup"
   tasks:
@@ -66,13 +70,29 @@
         kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
         api_key: "{{ cifmw_openshift_token | default(omit)}}"
         context: "{{ cifmw_openshift_context | default(omit)}}"
-        api_version: operator.openshift.io/v1alpha1
-        kind: ImageContentSourcePolicy
+        api_version: config.openshift.io/v1
+        kind: ImageDigestMirrorSet
         name: registry-digest-mirrors
       register: _registry_mirror
 
     - name: Assert that digest mirrors are correct
       ansible.builtin.assert:
         that:
-          - _registry_mirror.resources[0].spec.repositoryDigestMirrors[0].source == "quay.rdoproject.org"
-          - _registry_mirror.resources[0].spec.repositoryDigestMirrors[0].mirrors[0] == "mirror.quay.rdoproject.org"
+          - _registry_mirror.resources[0].spec.imageDigestMirrors[0].source == "quay.rdoproject.org"
+          - _registry_mirror.resources[0].spec.imageDigestMirrors[0].mirrors[0] == "mirror.quay.rdoproject.org"
+
+    - name: Check that tag mirror resource is created
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit)}}"
+        context: "{{ cifmw_openshift_context | default(omit)}}"
+        api_version: config.openshift.io/v1
+        kind: ImageTagMirrorSet
+        name: registry-tag-mirrors
+      register: _tag_mirror
+
+    - name: Assert that tag mirrors are correct
+      ansible.builtin.assert:
+        that:
+          - _tag_mirror.resources[0].spec.imageTagMirrors[0].source == "registry.redhat.io"
+          - _tag_mirror.resources[0].spec.imageTagMirrors[0].mirrors[0] == "mirror.registry.redhat.io"

--- a/roles/openshift_setup/molecule/default/converge.yml
+++ b/roles/openshift_setup/molecule/default/converge.yml
@@ -66,13 +66,13 @@
         kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
         api_key: "{{ cifmw_openshift_token | default(omit)}}"
         context: "{{ cifmw_openshift_context | default(omit)}}"
-        api_version: operator.openshift.io/v1alpha1
-        kind: ImageContentSourcePolicy
+        api_version: config.openshift.io/v1
+        kind: ImageDigestMirrorSet
         name: registry-digest-mirrors
       register: _registry_mirror
 
     - name: Assert that digest mirrors are correct
       ansible.builtin.assert:
         that:
-          - _registry_mirror.resources[0].spec.repositoryDigestMirrors[0].source == "quay.rdoproject.org"
-          - _registry_mirror.resources[0].spec.repositoryDigestMirrors[0].mirrors[0] == "mirror.quay.rdoproject.org"
+          - _registry_mirror.resources[0].spec.imageDigestMirrors[0].source == "quay.rdoproject.org"
+          - _registry_mirror.resources[0].spec.imageDigestMirrors[0].mirrors[0] == "mirror.quay.rdoproject.org"

--- a/roles/openshift_setup/tasks/configure_registries.yml
+++ b/roles/openshift_setup/tasks/configure_registries.yml
@@ -37,7 +37,7 @@
             - "{{ cifmw_update_containers_registry }}"
           allowedRegistries: "{{ all_registries }}"
 
-- name: Create a ICSP with repository digest mirrors
+- name: Create ImageDigestMirrorSet repository digest mirrors
   when:
     - cifmw_openshift_setup_digest_mirrors is defined
     - cifmw_openshift_setup_digest_mirrors | length > 0
@@ -46,9 +46,28 @@
     api_key: "{{ cifmw_openshift_token | default(omit)}}"
     context: "{{ cifmw_openshift_context | default(omit)}}"
     definition:
-      apiVersion: operator.openshift.io/v1alpha1
-      kind: ImageContentSourcePolicy
+      apiVersion: config.openshift.io/v1
+      kind: ImageDigestMirrorSet
       metadata:
         name: registry-digest-mirrors
       spec:
-        repositoryDigestMirrors: "{{ cifmw_openshift_setup_digest_mirrors }}"
+        imageDigestMirrors: "{{ cifmw_openshift_setup_digest_mirrors }}"
+
+#  If both ImageDigestMirrorSet and ImageTagMirrorSet are applied to the registries,
+# ITMS acts as a fallback for tag-based pulls, while IDMS provides the primary
+# secure source for digests
+- name: Create ImageTagMirrorSet for tag-based pulls
+  when:
+    - cifmw_openshift_setup_tag_mirrors is defined
+    - cifmw_openshift_setup_tag_mirrors | length > 0
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    definition:
+      apiVersion: config.openshift.io/v1
+      kind: ImageTagMirrorSet
+      metadata:
+        name: registry-tag-mirrors
+      spec:
+        imageTagMirrors: "{{ cifmw_openshift_setup_tag_mirrors }}"

--- a/roles/openshift_setup/tasks/configure_registries.yml
+++ b/roles/openshift_setup/tasks/configure_registries.yml
@@ -14,7 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-# This task file configures insecure registries and ImageContentSourcePolicy
+# This task file configures insecure registries and ImageDigestMirrorSet/ImageTagMirrorSet
 # Can be used standalone from playbooks that don't need the full openshift_setup role
 
 - name: Add insecure registry
@@ -37,7 +37,7 @@
             - "{{ cifmw_update_containers_registry }}"
           allowedRegistries: "{{ all_registries }}"
 
-- name: Create a ICSP with repository digest mirrors
+- name: Create ImageDigestMirrorSet repository digest mirrors
   when:
     - cifmw_openshift_setup_digest_mirrors is defined
     - cifmw_openshift_setup_digest_mirrors | length > 0
@@ -46,9 +46,28 @@
     api_key: "{{ cifmw_openshift_token | default(omit)}}"
     context: "{{ cifmw_openshift_context | default(omit)}}"
     definition:
-      apiVersion: operator.openshift.io/v1alpha1
-      kind: ImageContentSourcePolicy
+      apiVersion: config.openshift.io/v1
+      kind: ImageDigestMirrorSet
       metadata:
         name: registry-digest-mirrors
       spec:
-        repositoryDigestMirrors: "{{ cifmw_openshift_setup_digest_mirrors }}"
+        imageDigestMirrors: "{{ cifmw_openshift_setup_digest_mirrors }}"
+
+#  If both ImageDigestMirrorSet and ImageTagMirrorSet are applied to the registries,
+# ITMS acts as a fallback for tag-based pulls, while IDMS provides the primary
+# secure source for digests
+- name: Create ImageTagMirrorSet for tag-based pulls
+  when:
+    - cifmw_openshift_setup_tag_mirrors is defined
+    - cifmw_openshift_setup_tag_mirrors | length > 0
+  kubernetes.core.k8s:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_key: "{{ cifmw_openshift_token | default(omit)}}"
+    context: "{{ cifmw_openshift_context | default(omit)}}"
+    definition:
+      apiVersion: config.openshift.io/v1
+      kind: ImageTagMirrorSet
+      metadata:
+        name: registry-tag-mirrors
+      spec:
+        imageTagMirrors: "{{ cifmw_openshift_setup_tag_mirrors }}"


### PR DESCRIPTION
[openshift_setup] Replace ICSP with IDMS/ITMS for modern mirror configuration


- Migrate from deprecated ImageContentSourcePolicy to ImageDigestMirrorSet
- Add ImageTagMirrorSet for tag-based image pulls
- Support both digest and tag-based image resolution
- Enable NeverContactSource in the corresponding downstream patch that contains rbac-proxy registry
- Improve granular control over mirror selection order

Signed-off-by: David Sariel <dsariel@redhat.com>

[1]
https://docs.redhat.com/en/documentation/openshift_container_platform/4.14/html/config_apis/imagetagmirrorset-config-openshift-io-v1

[2]
https://docs.redhat.com/en/documentation/openshift_container_platform/4.14/html/config_apis/imagedigestmirrorset-config-openshift-io-v1

[ANVIL-58](https://redhat.atlassian.net/browse/ANVIL-58)