### PR TITLE
fix(reproducer): Fix bootstrap and add auto-deploy option

### DIFF
--- a/roles/reproducer/defaults/main.yml
+++ b/roles/reproducer/defaults/main.yml
@@ -34,6 +34,7 @@ cifmw_reproducer_compute_repos: []
 cifmw_reproducer_compute_set_repositories: true
 cifmw_reproducer_repositories_path: "src"
 cifmw_reproducer_play_extravars: []
+cifmw_reproducer_auto_deploy: true
 cifmw_reproducer_provision_net: ocppr
 cifmw_reproducer_supported_hypervisor_os:
   CentOS:

--- a/roles/reproducer/tasks/reuse_main.yaml
+++ b/roles/reproducer/tasks/reuse_main.yaml
@@ -127,16 +127,14 @@
           environment:
             ANSIBLE_LOG_PATH: "{{ ansible_user_dir }}/ansible-bootstrap.log"
           no_log: "{{ cifmw_nolog | default(true) | bool }}"
-          ansible.builtin.import_role:
+          ansible.builtin.include_role:
             name: cifmw_setup
             tasks_from: bootstrap.yml
           vars:
             ansible_extra_vars:
               - "{{ ansible_user_dir }}/ci-framework-data/parameters/reproducer-variables.yml"
               - "scenarios/reproducers/networking-definition.yml"
-          changed_when: false
-          args:
-            chdir: "{{ _cifmw_reproducer_framework_location }}"
+            cifmw_basedir: "{{ _cifmw_reproducer_framework_location }}"
 
         - name: Install dev tools from install_yamls on controller-0
           environment:
@@ -281,3 +279,17 @@
         mode: "0755"
         owner: "{{ cifmw_reproducer_controller_user }}"
         group: "{{ cifmw_reproducer_controller_user }}"
+
+    - name: Execute deployment automatically
+      when:
+        - cifmw_job_uri is undefined
+        - cifmw_reproducer_auto_deploy | default(false) | bool
+      delegate_to: controller-0
+      environment:
+        ANSIBLE_LOG_PATH: "{{ cifmw_reproducer_controller_user_dir }}/ansible-deploy-edpm.log"
+      ansible.builtin.command:
+        cmd: "{{ cifmw_reproducer_controller_user_dir }}/deploy-edpm.sh"
+      async: 7200
+      poll: 60
+      register: _deploy_result
+      changed_when: true


### PR DESCRIPTION
fix(reproducer): Fix bootstrap and add auto-deploy option
Fix two issues introduced in commit https://github.com/openstack-k8s-operators/ci-framework/commit/10121fb1b72c3bdd4da5b82a5c79a23308849f0b:
1. Remove invalid 'args: chdir' parameter (only valid for command/shell)
2. Change import_role to include_role (static vs dynamic execution)

Also add cifmw_reproducer_auto_deploy variable to optionally execute
deployment automatically after bootstrap/cleanup, matching CI behavior.

Fixes: UNREACHABLE error and invalid options for import_role
Introduced-by: https://github.com/openstack-k8s-operators/ci-framework/commit/10121fb1b72c3bdd4da5b82a5c79a23308849f0b ([multiple] Post changes after removing playbooks)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>