### PR TITLE
[ci_local_storage] Fall back to oc debug for PV dir creation

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -21,6 +21,7 @@ Marjanovic
 Nemanja
 NICs
 NodeHealthCheck
+PV
 PyYAML
 RHCOS
 SNO

--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -19,6 +19,7 @@ Marjanovic
 Nemanja
 NICs
 NodeHealthCheck
+PV
 PyYAML
 RHCOS
 SNO

--- a/roles/ci_local_storage/README.md
+++ b/roles/ci_local_storage/README.md
@@ -17,9 +17,12 @@ If apply, please explain the privilege escalation done in this role.
 * `cifmw_cls_create_ee_storage`: (Bool) Param to create ee_storage. Defaults to `false`.
 * `cifmw_cls_namespace`: (String) The namespace where OCP resources will be installed. Defaults to `openstack`.
 * `cifmw_cls_action`: (String) Action to perform, can be `create` or `clean`. Defaults to `create`.
+* `cifmw_cls_oc_debug_fallback`: (Bool) Use `oc debug node/` to create PV directories on k8s nodes that are not reachable via SSH from the Ansible inventory. When enabled, the role computes which k8s nodes have no matching SSH-reachable inventory host and falls back to `oc debug` for those nodes. Applies to both create and cleanup. Defaults to `false`. Use it with an SNO BM setup.
 * `cifmw_cls_storage_manifest`:  (Dict) The storage manifest resource to be used to initiate storage class.
 
 ## Examples
+
+### Standard (CRC / VM-based)
 ```YAML
     - hosts: localhost
       vars:
@@ -28,6 +31,21 @@ If apply, please explain the privilege escalation done in this role.
         cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.crc/machines/crc/kubeconfig"
         ansible_user_dir: "{{ lookup('env', 'HOME') }}"
         cifmw_path: "{{ ansible_user_dir }}/.crc/bin:{{ ansible_user_dir }}/.crc/bin/oc:{{ ansible_user_dir }}/bin:{{ ansible_env.PATH }}"
+      tasks:
+        - ansible.builtin.include_role:
+            name: ci_local_storage
+```
+
+### Baremetal SNO
+On bare-metal Single Node OpenShift the k8s node is typically not present
+in the Ansible inventory for SSH access. Enable `cifmw_cls_oc_debug_fallback`
+so the role uses `oc debug node/` to manage PV directories instead:
+```YAML
+    - hosts: localhost
+      vars:
+        cifmw_openshift_kubeconfig: "{{ ansible_user_dir }}/.kube/kubeconfig"
+        cifmw_cls_pv_count: 20
+        cifmw_cls_oc_debug_fallback: true
       tasks:
         - ansible.builtin.include_role:
             name: ci_local_storage

--- a/roles/ci_local_storage/defaults/main.yml
+++ b/roles/ci_local_storage/defaults/main.yml
@@ -28,6 +28,7 @@ cifmw_cls_storage_provisioner: cifmw
 cifmw_cls_create_ee_storage: false
 cifmw_cls_namespace: openstack
 cifmw_cls_action: create
+cifmw_cls_oc_debug_fallback: false
 
 cifmw_cls_storage_manifest:
   kind: StorageClass

--- a/roles/ci_local_storage/molecule/default/converge.yml
+++ b/roles/ci_local_storage/molecule/default/converge.yml
@@ -137,3 +137,65 @@
           }}
       ansible.builtin.assert:
         that: "cifmw_cls_namespace not in ns_names"
+
+    - name: Test oc-debug fallback path (uncovered_node_dirs.yml)
+      vars:
+        cifmw_cls_pv_count: 3
+        cifmw_cls_local_storage_name: /mnt/openstack-fallback
+        cifmw_cls_oc_debug_fallback: true
+      block:
+        - name: Get k8s node names for fallback test
+          kubernetes.core.k8s_info:
+            kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+            kind: Node
+          register: _fb_k8s_nodes
+
+        - name: Simulate no SSH-reachable hosts matching k8s nodes
+          ansible.builtin.set_fact:
+            cifmw_ci_local_storage_k8s_hostnames:
+              - "{{ _fb_k8s_nodes.resources[0].metadata.name }}"
+            _hostnames:
+              results: []
+
+        - name: Run uncovered_node_dirs.yml (create)
+          vars:
+            cifmw_cls_action: create
+          ansible.builtin.include_tasks:
+            file: "{{ playbook_dir }}/../../tasks/uncovered_node_dirs.yml"
+
+        - name: Assert uncovered nodes were identified
+          ansible.builtin.assert:
+            that:
+              - _cls_uncovered_nodes | length == 1
+
+        - name: Verify directories created on node
+          delegate_to: crc
+          become: true
+          register: _fb_check
+          ansible.builtin.stat:
+            path: "/mnt/openstack-fallback/pv{{ '%02d' | format(item | int) }}"
+          loop: "{{ range(1, 4) }}"
+
+        - name: Assert all fallback directories exist
+          ansible.builtin.assert:
+            that: item.stat.exists
+          loop: "{{ _fb_check.results }}"
+          loop_control:
+            label: "{{ item.invocation.module_args.path }}"
+
+        - name: Run uncovered_node_dirs.yml (cleanup)
+          vars:
+            cifmw_cls_action: clean
+          ansible.builtin.include_tasks:
+            file: "{{ playbook_dir }}/../../tasks/uncovered_node_dirs.yml"
+
+        - name: Verify fallback directories removed
+          delegate_to: crc
+          become: true
+          register: _fb_removed
+          ansible.builtin.stat:
+            path: "/mnt/openstack-fallback"
+
+        - name: Assert fallback directory tree is gone
+          ansible.builtin.assert:
+            that: not _fb_removed.stat.exists

--- a/roles/ci_local_storage/tasks/cleanup.yml
+++ b/roles/ci_local_storage/tasks/cleanup.yml
@@ -55,6 +55,11 @@
   loop_control:
     loop_var: host
 
+- name: Delete PV directories on nodes unreachable via SSH
+  when:
+    - cifmw_cls_oc_debug_fallback | bool
+  ansible.builtin.include_tasks: uncovered_node_dirs.yml
+
 - name: Remove the cifmw_cls_namespace namespace
   kubernetes.core.k8s:
     state: absent

--- a/roles/ci_local_storage/tasks/cleanup.yml
+++ b/roles/ci_local_storage/tasks/cleanup.yml
@@ -55,6 +55,13 @@
   loop_control:
     loop_var: host
 
+- name: Delete PV directories on nodes unreachable via SSH
+  vars:
+    cifmw_cls_action: "clean"
+  when:
+    - cifmw_cls_oc_debug_fallback | bool
+  ansible.builtin.include_tasks: uncovered_node_dirs.yml
+
 - name: Remove the cifmw_cls_namespace namespace
   kubernetes.core.k8s:
     state: absent

--- a/roles/ci_local_storage/tasks/main.yml
+++ b/roles/ci_local_storage/tasks/main.yml
@@ -52,6 +52,11 @@
   loop_control:
     loop_var: host
 
+- name: Manage PV directories on nodes unreachable via SSH
+  when:
+    - cifmw_cls_oc_debug_fallback | bool
+  ansible.builtin.include_tasks: uncovered_node_dirs.yml
+
 - name: Generate pv related storage manifest file
   ansible.builtin.template:
     src: storage.yaml.j2

--- a/roles/ci_local_storage/tasks/uncovered_node_dirs.yml
+++ b/roles/ci_local_storage/tasks/uncovered_node_dirs.yml
@@ -1,0 +1,44 @@
+---
+- name: Identify k8s nodes not reachable via SSH (SNO BM)
+  vars:
+    _ssh_covered: >-
+      {{
+        _hostnames.results |
+        default([]) |
+        selectattr('stdout', 'defined') |
+        map(attribute='stdout') |
+        list
+      }}
+  ansible.builtin.set_fact:
+    _cls_uncovered_nodes: >-
+      {{
+        cifmw_ci_local_storage_k8s_hostnames |
+        difference(_ssh_covered)
+      }}
+
+- name: Manage PV directories via oc debug for unreachable nodes
+  when:
+    - _cls_uncovered_nodes | length > 0
+  vars:
+    _action_script: >-
+      {% if cifmw_cls_action == 'create' %}
+      for i in $(seq 1 {{ cifmw_cls_pv_count | int }});
+      do d=$(printf '%02d' "$i");
+      mkdir -p '{{ cifmw_cls_local_storage_name }}'/pv$d &&
+      chmod 0775 '{{ cifmw_cls_local_storage_name }}'/pv$d; done
+      {% else %}
+      rm -rf '{{ cifmw_cls_local_storage_name }}'
+      {% endif %}
+  ansible.builtin.command:
+    cmd: >-
+      oc debug node/{{ node_name }}
+      --kubeconfig={{ cifmw_openshift_kubeconfig }}
+      -- chroot /host bash -c "{{ _action_script }}"
+  changed_when: false
+  register: _cls_oc_debug
+  retries: 3
+  delay: 10
+  until: _cls_oc_debug.rc == 0
+  loop: "{{ _cls_uncovered_nodes }}"
+  loop_control:
+    loop_var: node_name

--- a/roles/ci_local_storage/tasks/uncovered_node_dirs.yml
+++ b/roles/ci_local_storage/tasks/uncovered_node_dirs.yml
@@ -1,0 +1,43 @@
+---
+- name: Identify k8s nodes not reachable via SSH (SNO BM)
+  vars:
+    _ssh_covered: >-
+      {{
+        _hostnames.results |
+        default([]) |
+        selectattr('stdout', 'defined') |
+        map(attribute='stdout') |
+        list
+      }}
+  ansible.builtin.set_fact:
+    _cls_uncovered_nodes: >-
+      {{
+        cifmw_ci_local_storage_k8s_hostnames |
+        difference(_ssh_covered)
+      }}
+
+- name: Manage PV directories via oc debug for unreachable nodes
+  when:
+    - _cls_uncovered_nodes | length > 0
+  vars:
+    _action_script: >-
+      {% if cifmw_cls_action == 'create' %}
+      for i in $(seq 1 {{ cifmw_cls_pv_count | int }});
+      do d=$(printf '%02d' "$i");
+      mkdir -p '{{ cifmw_cls_local_storage_name }}'/pv$d &&
+      chmod 0775 '{{ cifmw_cls_local_storage_name }}'/pv$d; done
+      {% else %}
+      rm -rf '{{ cifmw_cls_local_storage_name }}'
+      {% endif %}
+  ansible.builtin.command:
+    cmd: >-
+      oc debug node/{{ node_name }}
+      --kubeconfig={{ cifmw_openshift_kubeconfig }}
+      -- chroot /host bash -c "{{ _action_script }}"
+  register: _cls_oc_debug
+  retries: 3
+  delay: 10
+  until: _cls_oc_debug.rc == 0
+  loop: "{{ _cls_uncovered_nodes }}"
+  loop_control:
+    loop_var: node_name


### PR DESCRIPTION
When no Ansible inventory host matches a k8s node hostname (e.g. bare metal SNO where the node is not SSH-accessible), the role silently skips directory creation while still creating PVs that reference non-existent paths. Add an oc debug fallback that creates directories on each node via a debug pod.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3989

Required-by:  https://github.com/openstack-k8s-operators/ci-framework/pull/3739
Jira: [OSPRH-26767](https://issues.redhat.com/browse/OSPRH-26767)
Generated-by: claude-4.6-opus-high