### PR TITLE
Remove.*-ibm nodesets

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -11,16 +11,16 @@
     timeout: 3600
 - job:
     name: cifmw-molecule-openshift_login
-    nodeset: centos-9-crc-2-48-0-xl-ibm
+    nodeset: centos-9-crc-2-48-0-xl
 - job:
     name: cifmw-molecule-openshift_provisioner_node
-    nodeset: centos-9-crc-2-48-0-xl-ibm
+    nodeset: centos-9-crc-2-48-0-xl
 - job:
     name: cifmw-molecule-openshift_setup
-    nodeset: centos-9-crc-2-48-0-xl-ibm
+    nodeset: centos-9-crc-2-48-0-xl
 - job:
     name: cifmw-molecule-rhol_crc
-    nodeset: centos-9-crc-2-48-0-xxl-ibm
+    nodeset: centos-9-crc-2-48-0-xxl
     timeout: 5400
 - job:
     name: cifmw-molecule-operator_deploy
@@ -48,13 +48,13 @@
 - job:
     name: cifmw-molecule-install_openstack_ca
     parent: cifmw-molecule-base-crc
-    nodeset: centos-9-crc-2-48-0-3xl-ibm
+    nodeset: centos-9-crc-2-48-0-3xl
     timeout: 5400
     extra-vars:
       crc_parameters: "--memory 29000 --disk-size 100 --cpus 8"
 - job:
     name: cifmw-molecule-reproducer
-    nodeset: centos-9-crc-2-48-0-xxl-ibm
+    nodeset: centos-9-crc-2-48-0-xxl
     timeout: 5400
     files:
       - ^roles/dnsmasq/.*
@@ -65,10 +65,10 @@
       - ^roles/rhol_crc/.*
 - job:
     name: cifmw-molecule-cert_manager
-    nodeset: centos-9-crc-2-48-0-xxl-ibm
+    nodeset: centos-9-crc-2-48-0-xxl
 - job:
     name: cifmw-molecule-env_op_images
-    nodeset: centos-9-crc-2-48-0-xl-ibm
+    nodeset: centos-9-crc-2-48-0-xl
 - job:
     name: cifmw_molecule-pkg_build
     files:
@@ -85,22 +85,22 @@
       - ^roles/repo_setup/.*
 - job:
     name: cifmw-molecule-manage_secrets
-    nodeset: centos-9-crc-2-48-0-xl-ibm
+    nodeset: centos-9-crc-2-48-0-xl
 - job:
     name: cifmw-molecule-ci_local_storage
-    nodeset: centos-9-crc-2-48-0-xl-ibm
+    nodeset: centos-9-crc-2-48-0-xl
 - job:
     name: cifmw-molecule-networking_mapper
     nodeset: 4x-centos-9-medium
 - job:
     name: cifmw-molecule-openshift_obs
-    nodeset: centos-9-crc-2-48-0-xxl-ibm
+    nodeset: centos-9-crc-2-48-0-xxl
 - job:
     name: cifmw-molecule-sushy_emulator
-    nodeset: centos-9-crc-2-48-0-xl-ibm
+    nodeset: centos-9-crc-2-48-0-xl
 - job:
     name: cifmw-molecule-shiftstack
-    nodeset: centos-9-crc-2-48-0-xl-ibm
+    nodeset: centos-9-crc-2-48-0-xl
 - job:
     name: cifmw-molecule-tofu
     nodeset: centos-9-crc-2-48-0-xl

--- a/zuul.d/molecule-base.yaml
+++ b/zuul.d/molecule-base.yaml
@@ -2,7 +2,7 @@
 # one, and be listed in the "molecule.yaml" file.
 - job:
     name: cifmw-molecule-base
-    nodeset: centos-stream-9-ibm
+    nodeset: centos-stream-9
     parent: base-ci-framework
     semaphore: semaphore-molecule
     provides:

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -52,7 +52,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-cert_manager
-    nodeset: centos-9-crc-2-48-0-xxl-ibm
+    nodeset: centos-9-crc-2-48-0-xxl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: cert_manager
@@ -77,7 +77,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-ci_local_storage
-    nodeset: centos-9-crc-2-48-0-xl-ibm
+    nodeset: centos-9-crc-2-48-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: ci_local_storage
@@ -386,7 +386,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-env_op_images
-    nodeset: centos-9-crc-2-48-0-xl-ibm
+    nodeset: centos-9-crc-2-48-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: env_op_images
@@ -444,7 +444,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-install_openstack_ca
-    nodeset: centos-9-crc-2-48-0-3xl-ibm
+    nodeset: centos-9-crc-2-48-0-3xl
     parent: cifmw-molecule-base-crc
     timeout: 5400
     vars:
@@ -496,7 +496,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-manage_secrets
-    nodeset: centos-9-crc-2-48-0-xl-ibm
+    nodeset: centos-9-crc-2-48-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: manage_secrets
@@ -542,7 +542,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_login
-    nodeset: centos-9-crc-2-48-0-xl-ibm
+    nodeset: centos-9-crc-2-48-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: openshift_login
@@ -554,7 +554,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_obs
-    nodeset: centos-9-crc-2-48-0-xxl-ibm
+    nodeset: centos-9-crc-2-48-0-xxl
     parent: cifmw-molecule-base
     timeout: 3600
     vars:
@@ -567,7 +567,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_provisioner_node
-    nodeset: centos-9-crc-2-48-0-xl-ibm
+    nodeset: centos-9-crc-2-48-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: openshift_provisioner_node
@@ -579,7 +579,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-openshift_setup
-    nodeset: centos-9-crc-2-48-0-xl-ibm
+    nodeset: centos-9-crc-2-48-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: openshift_setup
@@ -708,7 +708,7 @@
     - ^roles/sushy_emulator/.*
     - ^roles/rhol_crc/.*
     name: cifmw-molecule-reproducer
-    nodeset: centos-9-crc-2-48-0-xxl-ibm
+    nodeset: centos-9-crc-2-48-0-xxl
     parent: cifmw-molecule-base
     timeout: 5400
     vars:
@@ -721,7 +721,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-rhol_crc
-    nodeset: centos-9-crc-2-48-0-xxl-ibm
+    nodeset: centos-9-crc-2-48-0-xxl
     parent: cifmw-molecule-base
     timeout: 5400
     vars:
@@ -756,7 +756,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-shiftstack
-    nodeset: centos-9-crc-2-48-0-xl-ibm
+    nodeset: centos-9-crc-2-48-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: shiftstack
@@ -779,7 +779,7 @@
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*
     name: cifmw-molecule-sushy_emulator
-    nodeset: centos-9-crc-2-48-0-xl-ibm
+    nodeset: centos-9-crc-2-48-0-xl
     parent: cifmw-molecule-base
     vars:
       TEST_RUN: sushy_emulator

--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -28,18 +28,6 @@
         nodes: []
 
 - nodeset:
-    name: centos-stream-9-ibm
-    nodes:
-      - name: controller
-        label: cloud-centos-9-stream-tripleo-ibm
-    groups:
-      - name: switch
-        nodes:
-          - controller
-      - name: peers
-        nodes: []
-
-- nodeset:
     name: 4x-centos-9-medium
     nodes:
       - name: controller
@@ -423,31 +411,6 @@
       - name: controller
         label: centos-9-stream-crc-2-48-0-xl
 
-### Molecule jobs - force use IBM hosts ###
-- nodeset:
-    name: centos-9-crc-2-48-0-xl-ibm
-    nodes:
-      - name: controller
-        label: centos-9-stream-crc-2-48-0-xl-ibm
-
-- nodeset:
-    name: centos-9-crc-2-48-0-xxl-ibm
-    nodes:
-      - name: controller
-        label: centos-9-stream-crc-2-48-0-xxl-ibm
-
-- nodeset:
-    name: centos-9-crc-2-48-0-3xl-ibm
-    nodes:
-      - name: controller
-        label: centos-9-stream-crc-2-48-0-3xl-ibm
-
-- nodeset:
-    name: centos-9-crc-2-48-0-6xlarge-ibm
-    nodes:
-      - name: controller
-        label: centos-9-stream-crc-2-48-0-6xlarge-ibm
-
 #
 # CRC CLOUD (OCP 4.20) (CRC 2.56.0) nodesets
 #
@@ -771,28 +734,3 @@
     nodes:
       - name: controller
         label: centos-9-stream-crc-2-56-0-xl
-
-### Molecule jobs - force use IBM hosts ###
-- nodeset:
-    name: centos-9-crc-2-56-0-xl-ibm
-    nodes:
-      - name: controller
-        label: centos-9-stream-crc-2-56-0-xl-ibm
-
-- nodeset:
-    name: centos-9-crc-2-56-0-xxl-ibm
-    nodes:
-      - name: controller
-        label: centos-9-stream-crc-2-56-0-xxl-ibm
-
-- nodeset:
-    name: centos-9-crc-2-56-0-3xl-ibm
-    nodes:
-      - name: controller
-        label: centos-9-stream-crc-2-56-0-3xl-ibm
-
-- nodeset:
-    name: centos-9-crc-2-56-0-6xlarge-ibm
-    nodes:
-      - name: controller
-        label: centos-9-stream-crc-2-56-0-6xlarge-ibm


### PR DESCRIPTION
the ibm clouds are decommissioned today, jobs running on resources exclusive to these clouds will fail.