### PR TITLE
Fix multi-cell edpm_nodes generation in adoption_vars template

### DIFF
--- a/roles/adoption_osp_deploy/molecule/default/converge.yml
+++ b/roles/adoption_osp_deploy/molecule/default/converge.yml
@@ -24,3 +24,12 @@
       ansible.builtin.set_fact:
         tripleo_nodes_stack: "{{ _tripleo_nodes_stack }}"
         cacheable: true
+
+    - name: Test edpm_nodes template generation for multi-cell
+      block:
+        - name: Render and parse adoption_vars template
+          ansible.builtin.set_fact:
+            parsed_adoption_vars: "{{ lookup('template', '../../templates/adoption_vars.yaml.j2') | from_yaml }}"
+            cacheable: true
+          vars:
+            ip_version: ip_v4

--- a/roles/adoption_osp_deploy/molecule/default/vars.yaml
+++ b/roles/adoption_osp_deploy/molecule/default/vars.yaml
@@ -28,6 +28,16 @@ expected_nodes:
     - cell2-osp-controller-uni05epsilon-0
 
 cifmw_adoption_osp_deploy_scenario:
+  stacks:
+    - stackname: overcloud
+    - stackname: cell1
+    - stackname: cell2
+  cloud_domain: example.com
+  network_tripleo_network_map:
+    ctlplane: ctlplane
+    internalapi: internalapi
+    storage: storage
+    tenant: tenant
   hostname_groups_map:
     cell1-osp-computes: cell1-novacompute
     cell1-osp-controllers: cell1-controller
@@ -60,3 +70,50 @@ _vm_groups:
     - osp-controller-uni05epsilon-0
   osp-underclouds:
     - osp-undercloud-uni05epsilon-0
+
+_stack_names:
+  - overcloud
+  - cell1
+  - cell2
+
+_default_cell_name: default
+
+# Expected edpm_nodes structure for multi-cell scenario
+expected_edpm_nodes:
+  cell1:
+    - cell1-osp-compute-uni05epsilon-0
+  cell2:
+    - cell2-osp-compute-uni05epsilon-0
+
+cifmw_adoption_osp_deploy_adoption_vars_exclude_nets: []
+
+# Variables needed by template
+_controller_1_internalapi_ip: 172.17.0.100
+_compute_1_name: cell1-osp-compute-uni05epsilon-0
+_compute_1_ip: 192.168.122.110
+_undercloud_ip: 192.168.122.1
+
+cifmw_networking_env_definition:
+  networks:
+    ctlplane:
+      dns_v4:
+        - 8.8.8.8
+  instances:
+    osp-controller-uni05epsilon-0:
+      networks:
+        ctlplane:
+          ip_v4: 192.168.122.100
+        internalapi:
+          ip_v4: 172.17.0.100
+    cell1-osp-compute-uni05epsilon-0:
+      networks:
+        ctlplane:
+          ip_v4: 192.168.122.110
+        internalapi:
+          ip_v4: 172.17.0.110
+    cell2-osp-compute-uni05epsilon-0:
+      networks:
+        ctlplane:
+          ip_v4: 192.168.122.120
+        internalapi:
+          ip_v4: 172.17.0.120

--- a/roles/adoption_osp_deploy/molecule/default/verify.yml
+++ b/roles/adoption_osp_deploy/molecule/default/verify.yml
@@ -21,3 +21,24 @@
       loop: "{{ stacks }}"
       loop_control:
         loop_var: _stack
+
+    - name: "Get parsed adoption vars from persistent fact"
+      ansible.builtin.set_fact:
+        adoption_vars: "{{ hostvars[inventory_hostname].parsed_adoption_vars }}"
+      when: hostvars[inventory_hostname].parsed_adoption_vars is defined
+
+    - name: "Assert edpm_nodes has correct multi-cell structure"
+      ansible.builtin.assert:
+        that:
+          - "adoption_vars.edpm_nodes is defined"
+          - "adoption_vars.edpm_nodes is mapping"
+          - "adoption_vars.edpm_nodes.cell1 is defined"
+          - "adoption_vars.edpm_nodes.cell2 is defined"
+          - "'cell1-osp-compute-uni05epsilon-0' in adoption_vars.edpm_nodes.cell1"
+          - "'cell2-osp-compute-uni05epsilon-0' in adoption_vars.edpm_nodes.cell2"
+          - "adoption_vars.edpm_nodes.cell1['cell1-osp-compute-uni05epsilon-0'].hostName == 'cell1-osp-compute-uni05epsilon-0.example.com'"
+          - "adoption_vars.edpm_nodes.cell1['cell1-osp-compute-uni05epsilon-0'].ansible.ansibleHost == '192.168.122.110'"
+          - "adoption_vars.edpm_nodes.cell2['cell2-osp-compute-uni05epsilon-0'].hostName == 'cell2-osp-compute-uni05epsilon-0.example.com'"
+          - "adoption_vars.edpm_nodes.cell2['cell2-osp-compute-uni05epsilon-0'].ansible.ansibleHost == '192.168.122.120'"
+        fail_msg: "Multi-cell edpm_nodes structure is incorrect"
+        success_msg: "Successfully verified multi-cell edpm_nodes structure"

--- a/roles/adoption_osp_deploy/templates/adoption_vars.yaml.j2
+++ b/roles/adoption_osp_deploy/templates/adoption_vars.yaml.j2
@@ -76,28 +76,41 @@ source_galera_members: |
   {% endfor %}
 {%+ endif +%}
 
-{% if _vm_groups['osp-computes'] | default([]) | length > 0 %}
+# Generate edpm_nodes using _stack_names-driven approach
+# - Single-cell: _stack_names=['overcloud'] → looks for 'osp-computes' → creates edpm_nodes.<default_cell_name>
+# - Multi-cell: _stack_names=['overcloud','cell1','cell2'] → looks for 'cell1-osp-computes', 'cell2-osp-computes' → creates edpm_nodes.cell1, edpm_nodes.cell2
 edpm_nodes:
-  {% for compute in _vm_groups['osp-computes'] %}
-  {% set node_nets = cifmw_networking_env_definition.instances[compute] %}
-  {{ compute }}:
-    hostName: {{ compute }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}
-    {% for net in node_nets.networks.keys() if cifmw_adoption_osp_deploy_scenario.network_tripleo_network_map[net]|default(net) == "ctlplane" %}
-    ansible:
-      ansibleHost: {{ node_nets.networks[net][ip_version|default('ip_v4')] }}
-    {% endfor %}
-    networks:
-    {% for net in node_nets.networks.keys() if net not in cifmw_adoption_osp_deploy_adoption_vars_exclude_nets %}
+{% for stack in _stack_names %}
+  {% if stack == 'overcloud' %}
+    {% set cell = _default_cell_name %}
+    {% set prefix = '' %}
+  {% else %}
+    {% set cell = stack %}
+    {% set prefix = stack ~ '-' %}
+  {% endif %}
+  {% if _vm_groups[prefix ~ 'osp-computes'] | default([]) | length > 0 %}
+  {{ cell }}:
+    {% for compute in _vm_groups[prefix ~ 'osp-computes'] %}
+    {% set node_nets = cifmw_networking_env_definition.instances[compute] %}
+    {{ compute }}:
+      hostName: {{ compute }}.{{ cifmw_adoption_osp_deploy_scenario.cloud_domain }}
+      {% for net in node_nets.networks.keys() if cifmw_adoption_osp_deploy_scenario.network_tripleo_network_map[net]|default(net) == "ctlplane" %}
+      ansible:
+        ansibleHost: {{ node_nets.networks[net][ip_version|default('ip_v4')] }}
+      {% endfor %}
+      networks:
+      {% for net in node_nets.networks.keys() if net not in cifmw_adoption_osp_deploy_adoption_vars_exclude_nets %}
 {% set net_name = cifmw_adoption_osp_deploy_scenario.network_tripleo_network_map[net]|default(net) %}
-      - fixedIP: {{ node_nets.networks[net][ip_version|default('ip_v4')] }}
-        name: {{ net_name }}
-        subnetName: {{ "subnet1" if net_name == net else net}}
+        - fixedIP: {{ node_nets.networks[net][ip_version|default('ip_v4')] }}
+          name: {{ net_name }}
+          subnetName: {{ "subnet1" if net_name == net else net}}
 {% if net_name == 'ctlplane' %}
-        defaultRoute: true
+          defaultRoute: true
 {% endif %}
+      {% endfor %}
     {% endfor %}
-    {% endfor %}
-{% endif %}
+  {% endif %}
+{% endfor %}
 
 {% if _vm_groups['osp-dcn1-compute-az1s'] | default([]) | length > 0 %}
 edpm_nodes_dcn1:


### PR DESCRIPTION
[adoption_osp_deploy] Fix multi-cell edpm_nodes generation in adoption_vars template

The template logic was broken for multi-cell scenarios since commit 78bf394d,
which replaced the multi-cell-aware loop with single-cell-only logic that only
checked for 'osp-computes' group.

This fix restores the original _stack_names-driven approach that:
- Loops through stacks (overcloud, cell1, cell2, etc.)
- Uses appropriate prefix for each stack ('' for overcloud, 'cell1-' for cell1)
- Generates edpm_nodes with correct structure based on deployment type
- Works for both single-cell and multi-cell scenarios

Backward compatibility:
- Single-cell deployments (only overcloud): edpm_nodes.<node-name>
- Multi-cell deployments: edpm_nodes.<cell-name>.<node-name>
- Preserves existing adoption job behavior for single-cell scenarios

Also adds molecule test for multi-cell fixtures to 
verify the logic and prevent future breakages.


Resolves : https://redhat.atlassian.net/browse/OSPCIX-1325
Resolves: https://redhat.atlassian.net/browse/OSPRH-28982