### PR TITLE
[edpm_deploy_baremetal] Introduce a new hook step

### DIFF
--- a/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -267,6 +267,12 @@
       ansible.builtin.debug:
         var: compute_nodes_output.stdout_lines
 
+- name: Run post_baremetal_provision hooks
+  vars:
+    step: post_baremetal_provision
+  ansible.builtin.import_role:
+    name: run_hook
+
 - name: Wait for OpenStackDataPlaneNodeSet to be deployed
   when: not cifmw_edpm_deploy_baremetal_dry_run
   vars:


### PR DESCRIPTION
This patch defines a new point to include hooks. This is useful for downstream jobs that may need to run some commands on the provisioned baremetal nodes immediately after they are finished provisioning