### PR TITLE
[devscripts] Disable remember_owner

### DIFF
--- a/roles/devscripts/README.md
+++ b/roles/devscripts/README.md
@@ -56,6 +56,9 @@ networks.
 * `cifmw_devscripts_cinder_volume_pvs` (list) a list of physical disks to be
   used for creating cinder-volumes volume-group. By default, the list contains
   `/dev/vda`.
+* `cifmw_devscripts_disable_remember_owner` (bool), Disable the remember_owner
+  feature which in some cases might raise unexpected issues on starting the
+  VM. Defaults to `true`.
 
 ### Secrets management
 

--- a/roles/devscripts/defaults/main.yml
+++ b/roles/devscripts/defaults/main.yml
@@ -74,3 +74,4 @@ cifmw_devscripts_config_overrides: {}
 cifmw_devscripts_installer_timeout: 7200  # 2 hours
 cifmw_devscripts_etcd_slow_profile: true
 cifmw_devscripts_disable_console: false
+cifmw_devscripts_disable_remember_owner: true

--- a/roles/devscripts/handlers/main.yml
+++ b/roles/devscripts/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: restart libvirt
+  become: true
+  ansible.builtin.systemd_service:
+    name: virtqemud
+    state: restarted

--- a/roles/devscripts/tasks/300_post.yml
+++ b/roles/devscripts/tasks/300_post.yml
@@ -53,3 +53,7 @@
   tags:
     - devscripts_deploy
   ansible.builtin.include_tasks: 310_prepare_overlay.yml
+
+- name: Disable Qemu remember_owner option
+  when: cifmw_devscripts_disable_remember_owner
+  ansible.builtin.include_tasks: 350_disable_remember_owner.yml

--- a/roles/devscripts/tasks/350_disable_remember_owner.yml
+++ b/roles/devscripts/tasks/350_disable_remember_owner.yml
@@ -1,0 +1,7 @@
+---
+- name: Disable libvirt owner remembering
+  ansible.builtin.lineinfile:
+    path: /etc/libvirt/qemu.conf
+    regexp: '^#?remember_owner\s*='
+    line: 'remember_owner = 0'
+  notify: restart libvirt


### PR DESCRIPTION
In some CI, there is an error:

    error: Failed to start domain 'somevm'
    error: Requested operation is not valid:
    Setting different SELinux label on /home/zuul/ci-framework-data/some.qcow2 which is already in use

where later there is an error:

    TASK [libvirt_manager : Start vm name=cifmw-{{ vm }}, state=running, uri=qemu:///system] ***
    ...
    task path: /home/zuul/src/github.com/openstack-k8s-operators/ci-framework/roles/libvirt_manager/tasks/start_one_vm.yml:2
    fatal: [localhost -> hypervisor(somehost)]: FAILED! =>
        attempts: 5
        changed: false
        msg: 'Cannot open log file: ''/var/log/libvirt/qemu/somevm.log'':
          Device or resource busy'

Disable the the feature as it is not needed in the CI.