### PR TITLE
[edpm_deploy_baremetal] Allow overriding edpm_bootstrap_command

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -51,6 +51,7 @@ bmo
 bool
 booleans
 boostrap
+bootc
 bootmacaddress
 bootmode
 buildah

--- a/roles/edpm_deploy_baremetal/README.md
+++ b/roles/edpm_deploy_baremetal/README.md
@@ -19,6 +19,8 @@ This role doesn't need privilege escalation.
 * `cifmw_edpm_deploy_baremetal_repo_setup_override`: (Boolean) Override the repo-setup service in OpenStackDataPlane with repo-setup-downstream. Default: `false`
 * `cifmw_edpm_deploy_baremetal_create_vms`: (Boolean) If enabled, compute nodes are pre-provisioned using Ironic else OpenStackProvisioner. Default: `true`
 * `cifmw_edpm_deploy_baremetal_nova_compute_extra_config`: (String) Oslo config snippet defining extra configuration for the nova-compute services. Defaults to an empty string.
+* `cifmw_edpm_deploy_baremetal_custom_bootstrap`: (Boolean) When true, skips the inline `edpm_bootstrap_command` kustomization patch so that a file-based kustomization can provide a custom bootstrap command instead. Default: `false`
+* `cifmw_edpm_deploy_baremetal_bootc`: (Boolean) Disables the inline `edpm_bootstrap_command` patch and `dnf update` for bootc-based immutable nodes. Default: `false`
 
 ## Examples
 

--- a/roles/edpm_deploy_baremetal/defaults/main.yml
+++ b/roles/edpm_deploy_baremetal/defaults/main.yml
@@ -29,4 +29,5 @@ cifmw_edpm_deploy_baremetal_update_os_containers: false
 cifmw_edpm_deploy_baremetal_repo_setup_override: false
 cifmw_edpm_deploy_baremetal_create_vms: true
 cifmw_edpm_deploy_baremetal_nova_compute_extra_config: ""
+cifmw_edpm_deploy_baremetal_custom_bootstrap: false
 cifmw_edpm_deploy_baremetal_bootc: false

--- a/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -120,7 +120,7 @@
         target_path: "{{ cifmw_edpm_deploy_openstack_crs_path }}"
         sort_ascending: false
         kustomizations: |-
-          {% if content_provider_registry_ip is defined or not cifmw_edpm_deploy_baremetal_bootc %}
+          {% if content_provider_registry_ip is defined or (not cifmw_edpm_deploy_baremetal_bootc and not cifmw_edpm_deploy_baremetal_custom_bootstrap) %}
           apiVersion: kustomize.config.k8s.io/v1beta1
           kind: Kustomization
           patches:
@@ -133,7 +133,7 @@
                   value: ["{{ content_provider_registry_ip }}:5001"]
           {% endif %}
 
-          {% if not cifmw_edpm_deploy_baremetal_bootc %}
+          {% if not cifmw_edpm_deploy_baremetal_bootc and not cifmw_edpm_deploy_baremetal_custom_bootstrap %}
                 - op: add
                   path: /spec/nodeTemplate/ansible/ansibleVars/edpm_bootstrap_command
                   value: sudo dnf -y update


### PR DESCRIPTION
The inline kustomization hardcodes edpm_bootstrap_command to "sudo dnf -y update", preventing downstream jobs from customizing the bootstrap command via file-based kustomizations (which are applied first and get overwritten).
Use a configurable variable with the same default so existing jobs are unaffected, while jobs that need a custom bootstrap command can set cifmw_edpm_deploy_baremetal_bootstrap_command.