### PR TITLE
Remove ovn-egress-iface=true workaround for br-ex physical NIC

### DIFF
--- a/hooks/playbooks/fetch_compute_facts.yml
+++ b/hooks/playbooks/fetch_compute_facts.yml
@@ -234,11 +234,6 @@
                             mtu: {{ min_viable_mtu }}
                             # force the MAC address of the bridge to this interface
                             primary: true
-                        {% if edpm_network_config_nmstate | bool %}
-                            # this ovs_extra configuration fixes OSPRH-17551, but it will be not needed when FDP-1472 is resolved
-                            ovs_extra:
-                              - "set interface eth1 external-ids:ovn-egress-iface=true"
-                        {% endif %}
                         {% for network in nodeset_networks %}
                           - type: vlan
                             mtu: {{ lookup('vars', networks_lower[network] ~ '_mtu') }}


### PR DESCRIPTION
The nmstate conditional block setting ovn-egress-iface=true on eth1 is no longer needed since the OVN fix is included in ovn24.03-24.03.6-7 and later.

Related-to: [OSPRH-29270](https://redhat.atlassian.net/browse/OSPRH-29270)