### PR TITLE
Drop suffix in the nodeset name

### DIFF
--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -16,18 +16,6 @@
         nodes: []
 
 - nodeset:
-    name: centos-stream-9-vexxhost
-    nodes:
-      - name: controller
-        label: cloud-centos-9-stream-tripleo
-    groups:
-      - name: switch
-        nodes:
-          - controller
-      - name: peers
-        nodes: []
-
-- nodeset:
     name: 4x-centos-9-medium
     nodes:
       - name: controller
@@ -61,19 +49,6 @@
           - controller
       - name: peers
         nodes: []
-
-- nodeset:
-    name: centos-stream-10-vexxhost
-    nodes:
-      - name: controller
-        label: cloud-centos-10-stream-tripleo
-    groups:
-      - name: switch
-        nodes:
-          - controller
-      - name: peers
-        nodes: []
-
 #
 # CRC-2.39 (OCP4.16) nodesets
 #
@@ -81,26 +56,6 @@
 # Used by watcher-operator
 - nodeset:
     name: centos-9-medium-2x-centos-9-crc-extracted-2-39-0-3xl
-    nodes:
-      - name: controller
-        label: cloud-centos-9-stream-tripleo-medium
-      - name: compute-0
-        label: cloud-centos-9-stream-tripleo
-      - name: compute-1
-        label: cloud-centos-9-stream-tripleo
-      - name: crc
-        label: coreos-crc-extracted-2-39-0-3xl
-    groups:
-      - name: computes
-        nodes:
-          - compute-0
-          - compute-1
-      - name: ocps
-        nodes:
-          - crc
-
-- nodeset:
-    name: centos-9-medium-2x-centos-9-crc-extracted-2-39-0-3xl-vexxhost
     nodes:
       - name: controller
         label: cloud-centos-9-stream-tripleo-medium
@@ -170,27 +125,6 @@
         nodes:
           - crc
 
-# FIXME: drop nodeset when other project update their config.
-- nodeset:
-    name: centos-9-medium-2x-centos-9-crc-cloud-ocp-4-18-1-3xl-vexxhost
-    nodes:
-      - name: controller
-        label: cloud-centos-9-stream-tripleo-medium
-      - name: compute-0
-        label: cloud-centos-9-stream-tripleo
-      - name: compute-1
-        label: cloud-centos-9-stream-tripleo
-      - name: crc
-        label: crc-cloud-ocp-4-18-1-3xl
-    groups:
-      - name: computes
-        nodes:
-          - compute-0
-          - compute-1
-      - name: ocps
-        nodes:
-          - crc
-
 - nodeset:
     name: centos-9-2x-centos-9-xxl-crc-cloud-ocp-4-18-1-xxl
     nodes:
@@ -239,20 +173,6 @@
     nodes:
       - name: controller
         label: cloud-centos-9-stream-tripleo-medium
-      - name: crc
-        label: crc-cloud-ocp-4-18-1-3xl
-    groups:
-      - name: computes
-        nodes: []
-      - name: ocps
-        nodes:
-          - crc
-
-- nodeset:
-    name: centos-9-medium-crc-cloud-ocp-4-18-1-3xl-vexxhost
-    nodes:
-      - name: controller
-        label: cloud-centos-9-stream-tripleo-vexxhost-medium
       - name: crc
         label: crc-cloud-ocp-4-18-1-3xl
     groups:


### PR DESCRIPTION
All related projects already switch to use nodeset without suffix that indicates cloud provider.

Depends-On: https://github.com/openstack-k8s-operators/watcher-operator/pull/366
Depends-On: https://github.com/openstack-k8s-operators/edpm-image-builder/pull/96
Depends-On: https://github.com/openstack-k8s-operators/watcher-operator/pull/367