### PR TITLE
[multiple] Fix host filtering and MAC address handling

### DIFF
--- a/roles/cleanup_openstack/tasks/main.yaml
+++ b/roles/cleanup_openstack/tasks/main.yaml
@@ -28,7 +28,7 @@
     _cifmw_deploy_bmh_bm_hosts: >-
       {{
         cifmw_baremetal_hosts | default({}) | dict2items |
-        rejectattr('key', 'in', ['crc', 'controller', 'ocp']) |
+        rejectattr('key', 'match', '^(crc|controller|ocp)') |
         items2dict
       }}
   ansible.builtin.set_fact:

--- a/roles/deploy_bmh/tasks/main.yml
+++ b/roles/deploy_bmh/tasks/main.yml
@@ -14,19 +14,27 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Load baremetal hosts information from file
+- name: Load baremetal hosts from file for type-safe MAC handling
   when:
     - cifmw_deploy_bmh_parameters_file is file
     - cifmw_baremetal_hosts is not defined
   ansible.builtin.include_vars:
     file: "{{ cifmw_deploy_bmh_parameters_file }}"
+    name: _deploy_bmh_file_data
 
 - name: Set baremetal hosts facts
+  vars:
+    _bmh_source: >-
+      {{
+        (_deploy_bmh_file_data | default({})).cifmw_baremetal_hosts |
+        default(cifmw_baremetal_hosts) |
+        default({})
+      }}
   ansible.builtin.set_fact:
     cifmw_deploy_bmh_bm_hosts: >-
       {{
-        cifmw_baremetal_hosts | default({}) | dict2items |
-        rejectattr('key', 'in', ['crc', 'controller', 'ocp']) |
+        _bmh_source | dict2items |
+        rejectattr('key', 'match', '^(crc|controller|ocp)') |
         items2dict
       }}
 

--- a/roles/deploy_bmh/template/bmh.yml.j2
+++ b/roles/deploy_bmh/template/bmh.yml.j2
@@ -22,7 +22,7 @@ spec:
     credentialsName: {{ node_name }}-bmc-secret
     disableCertificateVerification: {{ cifmw_deploy_bmh_disable_certificate_validation }}
 {% for nic in (node_data['nics'] | default([])) if nic['network'] == cifmw_deploy_bmh_boot_interface %}
-  bootMACAddress: {{ nic.mac }}
+  bootMACAddress: "{{ nic.mac }}"
 {% endfor                                                                            %}
   bootMode: {{ node_data['boot_mode'] }}
   online: {{ 'true' if node_data['status'] | default("") == "running" else 'false' }}


### PR DESCRIPTION
Two issues in the `deploy_bmh` role:

**1. Host filter misses numbered suffixes**

The host filter used exact string matching (`in` test) to exclude
infrastructure hosts. This missed hosts like `controller-0`, causing
BMH CRs to be created for the Ansible controller VM.

Switch to regex prefix matching (`match`) so `controller-0`, `crc-0`,
`ocp-worker-0`, etc. are all properly excluded. Apply the same fix in
`cleanup_openstack` for consistency.

**2. MAC addresses corrupted by `jinja2_native`**

MAC addresses containing only decimal digits (e.g. `52:54:05:00:32:17`)
are silently converted to integers by Ansible's `jinja2_native` mode
(YAML 1.1 sexagesimal parsing). When `cifmw_baremetal_hosts` is set
via extra vars (`-e @reproducer-variables.yml`), the MAC string passes
through Jinja2 native evaluation and becomes an integer (`41136121937`).

Load `baremetal-info.yml` into a namespaced variable via `include_vars`
(which uses `yaml.safe_load` and preserves string types) and prefer it
as the data source. Also quote `bootMACAddress` in the BMH template
for defensive output.

Co-authored-by: Claude <noreply@anthropic.com>