### PR TITLE
[build_openstack_packages] Revert Removing whitebox-n-t-p and tempest from branchless dict

### DIFF
--- a/roles/build_openstack_packages/defaults/main.yml
+++ b/roles/build_openstack_packages/defaults/main.yml
@@ -62,6 +62,8 @@ cifmw_bop_timestamper_cmd: >-
 cifmw_bop_branchless_projects:
   - openstack-k8s-operators/tcib
   - os-net-config/os-net-config
+  - x/whitebox-neutron-tempest-plugin
+  - openstack/tempest
 
 cifmw_bop_change_list: []
 


### PR DESCRIPTION
Reverts openstack-k8s-operators/ci-framework#3831

tempest and whitebox-neutron are branchless projects so these need to be
kept in the list. Without it those projects are not processed in meta content provider
job i.e reviews are not tested in CI. Example:-
https://softwarefactory-project.io/zuul/t/rdoproject.org/buildset/a6e4b8d96b7f48738656dc05b6d2957b