### PR TITLE
[cert_manager] Add retry when installing cert_manager

### DIFF
--- a/roles/cert_manager/tasks/main.yml
+++ b/roles/cert_manager/tasks/main.yml
@@ -20,7 +20,7 @@
     state: directory
     mode: "0755"
 
-- name: Create the cifmw_cert_manager_operator_namespace namespace"
+- name: Create the cifmw_cert_manager_operator_namespace namespace
   kubernetes.core.k8s:
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
     api_key: "{{ cifmw_openshift_token | default(omit)}}"
@@ -28,6 +28,10 @@
     name: "{{ cifmw_cert_manager_operator_namespace }}"
     kind: Namespace
     state: present
+  register: _cm_operator_ns
+  until: _cm_operator_ns is succeeded
+  retries: 5
+  delay: 10
 
 - name: Install from Release Manifest
   when: cifmw_cert_manager_install_from_release_manifest | bool
@@ -37,7 +41,7 @@
   when: not cifmw_cert_manager_install_from_release_manifest | bool
   ansible.builtin.include_tasks: olm_manifest.yml
 
-- name: Check for cert-manager namspeace existance
+- name: Check for cert-manager namespace existence
   kubernetes.core.k8s_info:
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
     api_key: "{{ cifmw_openshift_token | default(omit)}}"
@@ -46,6 +50,10 @@
     kind: Namespace
     field_selectors:
       - status.phase=Active
+  register: _cm_ns_info
+  until: _cm_ns_info is succeeded
+  retries: 5
+  delay: 10
 
 - name: Wait for cert-manager pods to be ready
   kubernetes.core.k8s_info:
@@ -66,6 +74,10 @@
     - cainjector
     - webhook
     - cert-manager
+  register: _cm_pods_ready
+  until: _cm_pods_ready is succeeded
+  retries: 5
+  delay: 10
 
 - name: Validate cert-manager installation
   when: cifmw_cert_manager_validate | bool

--- a/roles/cert_manager/tasks/olm_manifest.yml
+++ b/roles/cert_manager/tasks/olm_manifest.yml
@@ -22,6 +22,10 @@
     - "{{ cifmw_cert_manager_olm_subscription }}"
   loop_control:
     label: "{{ item.metadata.name }}"
+  register: _cm_olm_sub
+  until: _cm_olm_sub is succeeded
+  retries: 5
+  delay: 10
 
 - name: Get the operator name
   ansible.builtin.set_fact:
@@ -40,6 +44,10 @@
     wait_condition:
       type: Ready
       status: "True"
+  register: _cm_operator_deployment
+  until: _cm_operator_deployment is succeeded
+  retries: 5
+  delay: 10
 
 - name: Wait for the cert-manager operator csv to be installed
   environment:

--- a/roles/cert_manager/tasks/release_manifest.yml
+++ b/roles/cert_manager/tasks/release_manifest.yml
@@ -4,6 +4,10 @@
     url: "{{ cifmw_cert_manager_release_manifest }}"
     dest: "{{ cifmw_cert_manager_manifests_dir }}/cert_manager_manifest.yml"
     mode: '0664'
+  register: _release_manifest
+  until: _release_manifest is succeeded
+  retries: 5
+  delay: 10
 
 - name: Install cert-manager from release manifest
   kubernetes.core.k8s:
@@ -12,3 +16,7 @@
     context: "{{ cifmw_openshift_context | default(omit) }}"
     state: present
     src: "{{ cifmw_cert_manager_manifests_dir }}/cert_manager_manifest.yml"
+  register: _cm_release_manifest
+  until: _cm_release_manifest is succeeded
+  retries: 5
+  delay: 10

--- a/roles/cert_manager/tasks/validate_certs.yml
+++ b/roles/cert_manager/tasks/validate_certs.yml
@@ -32,6 +32,10 @@
     url: "https://github.com/cert-manager/cmctl/releases/{{ cifmw_cert_manager_version }}/download/cmctl_{{ _os }}_{{ _arch }}"
     dest: "{{ ansible_user_dir }}/bin/cmctl"
     mode: "0755"
+  register: _cmctl_cli
+  until: _cmctl_cli is succeeded
+  retries: 5
+  delay: 10
 
 - name: Verify cert_manager api
   environment:


### PR DESCRIPTION
In some cases, the CI if failing on various issues not related to the cert manager, but more related to OpenShift cluster that can be unstable.
Example error:

    TASK [cert_manager : Create the cifmw_cert_manager_operator_namespace namespace
    (...)
    File "/usr/lib/python3.9/site-packages/urllib3/util/retry.py", line 576, in increment
      raise MaxRetryError(_pool, url, error or ResponseError(cause))
  urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='api.crc.testing', port=6443): Max retries exceeded with url: /api/v1/namespaces/cert-manager-operator (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f551ceaba00>: Failed to establish a new connection: [Errno 111] Connection refused'))
  (...)

Retry with delay should avoid potential issues when installing cert manager.