### PR TITLE
Switch edpm-multinode github-check jobs to OCP - 4.20

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -127,7 +127,7 @@
     parent: base-crc-cloud
     timeout: 10800
     attempts: 1
-    nodeset: centos-9-medium-centos-9-crc-cloud-ocp-4-18-1-3xl
+    nodeset: centos-9-medium-centos-9-crc-cloud-ocp-4-20-1-3xl
     irrelevant-files: *ir_files
     required-projects: &multinode_edpm_rp
       - openstack-k8s-operators/ci-framework
@@ -215,7 +215,7 @@
     parent: base-extracted-crc-ci-bootstrap
     timeout: 10800
     attempts: 1
-    nodeset: centos-9-medium-centos-9-crc-cloud-ocp-4-18-1-3xl
+    nodeset: centos-9-medium-centos-9-crc-cloud-ocp-4-20-1-3xl
     irrelevant-files: *ir_files
     required-projects: *multinode_edpm_rp
     roles: *multinode_edpm_roles
@@ -235,7 +235,7 @@
     parent: base-extracted-crc-ci-bootstrap-staging
     timeout: 10800
     attempts: 1
-    nodeset: centos-9-medium-centos-9-crc-cloud-ocp-4-18-1-3xl
+    nodeset: centos-9-medium-centos-9-crc-cloud-ocp-4-20-1-3xl
     irrelevant-files: *ir_files
     required-projects: *multinode_edpm_rp
     roles: *multinode_edpm_roles
@@ -254,7 +254,7 @@
 #
 - job:
     name: cifmw-base-crc
-    nodeset: centos-9-crc-2-48-0-3xl
+    nodeset: centos-9-crc-2-56-0-3xl
     timeout: 10800
     abstract: true
     parent: base-simple-crc

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -2,7 +2,7 @@
 - job:
     name: podified-multinode-edpm-deployment-crc-2comp
     parent: podified-multinode-edpm-deployment-crc
-    nodeset: centos-9-medium-2x-centos-9-crc-cloud-ocp-4-18-1-xxl
+    nodeset: centos-9-medium-2x-centos-9-crc-cloud-ocp-4-20-1-xxl
     description: |
       A multinode EDPM Zuul job which has one controller, one extracted crc
       and two compute nodes. It is used in whitebox neutron tempest plugin testing.
@@ -69,7 +69,7 @@
 - job:
     name: podified-multinode-edpm-deployment-crc-3comp
     parent: podified-multinode-edpm-deployment-crc
-    nodeset: centos-9-medium-3x-centos-9-crc-cloud-ocp-4-18-1-3xl
+    nodeset: centos-9-medium-3x-centos-9-crc-cloud-ocp-4-20-1-3xl
     vars:
       crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"
       crc_ci_bootstrap_networking:
@@ -146,7 +146,7 @@
 - job:
     name: podified-multinode-hci-deployment-crc-3comp
     parent: podified-multinode-edpm-deployment-crc
-    nodeset: centos-9-medium-3x-centos-9-crc-cloud-ocp-4-18-1-xxl
+    nodeset: centos-9-medium-3x-centos-9-crc-cloud-ocp-4-20-1-xxl
     vars:
       cifmw_edpm_deploy_hci: true
       crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"
@@ -238,7 +238,7 @@
 - job:
     name: podified-multinode-hci-deployment-crc-1comp
     parent: podified-multinode-edpm-deployment-crc
-    nodeset: centos-9-medium-centos-9-crc-cloud-ocp-4-18-1-3xl
+    nodeset: centos-9-medium-centos-9-crc-cloud-ocp-4-20-1-3xl
     vars:
       cifmw_edpm_deploy_hci: true
       cifmw_cephadm_single_host_defaults: true

--- a/zuul.d/kuttl_multinode.yaml
+++ b/zuul.d/kuttl_multinode.yaml
@@ -4,7 +4,7 @@
     parent: cifmw-podified-multinode-edpm-base-crc
     timeout: 7200
     abstract: true
-    nodeset: centos-9-medium-crc-cloud-ocp-4-18-1-3xl
+    nodeset: centos-9-medium-crc-cloud-ocp-4-20-1-3xl
     vars:
       zuul_log_collection: true
     extra-vars:

--- a/zuul.d/podified_multinode.yaml
+++ b/zuul.d/podified_multinode.yaml
@@ -12,7 +12,7 @@
     parent: cifmw-podified-multinode-edpm-base-crc
     timeout: 5400
     abstract: true
-    nodeset: centos-9-medium-crc-cloud-ocp-4-18-1-3xl
+    nodeset: centos-9-medium-crc-cloud-ocp-4-20-1-3xl
     run:
       - ci/playbooks/edpm/run.yml
     extra-vars:

--- a/zuul.d/tempest_multinode.yaml
+++ b/zuul.d/tempest_multinode.yaml
@@ -4,7 +4,7 @@
     parent: cifmw-podified-multinode-edpm-base-crc
     timeout: 5400
     abstract: true
-    nodeset: centos-9-medium-crc-cloud-ocp-4-18-1-3xl
+    nodeset: centos-9-medium-crc-cloud-ocp-4-20-1-3xl
     description: |
       Base multinode job definition for running test-operator.
     vars:


### PR DESCRIPTION
This PR switched the edpm multinode github-check jobs to OCP- 4.20

Jobs:
base, edpm_multinode, kuttl_multinode, podified_multinode and tempest_multinode.

Signed-off-by: Bhagyashri Shewale bshewale@redhat.com