### PR TITLE
Switch to OCP 4.20 for periodic-whitebox-neutron-tempest-plugin CI job

### DIFF
--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -5,7 +5,7 @@
 - job:
     name: whitebox-neutron-tempest-plugin-podified-multinode-edpm-deployment-crc-2comp
     parent: podified-multinode-edpm-deployment-crc-2comp
-    nodeset: centos-9-2x-centos-9-xxl-crc-cloud-ocp-4-18-1-xxl
+    nodeset: centos-9-2x-centos-9-xxl-crc-cloud-ocp-4-20-1-xxl
     timeout: 14400
     override-checkout: main
     description: |

--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -5,7 +5,7 @@
 - job:
     name: whitebox-neutron-tempest-plugin-podified-multinode-edpm-deployment-crc-2comp
     parent: podified-multinode-edpm-deployment-crc-2comp
-    nodeset: centos-9-2x-centos-9-xxl-crc-cloud-ocp-4-18-1-xxl
+    nodeset: centos-9-2x-centos-9-xxl-crc-cloud-ocp-4-20-1-xxl
     timeout: 18000
     override-checkout: main
     description: |


### PR DESCRIPTION
This PR switched the whitebox-neutron-tempest-plugin-podified-multinode-edpm-deployment job to OCP- 4.20

Jobs:
whitebox-neutron-tempest-plugin-podified-multinode-edpm-deployment-crc-2comp

Signed-off-by: Bhagyashri Shewale bshewale@redhat.com