### PR TITLE
[cifmw_setup] Use cifmw_helpers role to read variable files

### DIFF
--- a/roles/cifmw_setup/tasks/host_virtualization.yml
+++ b/roles/cifmw_setup/tasks/host_virtualization.yml
@@ -1,7 +1,10 @@
 ---
 - name: Load parameters files
-  ansible.builtin.include_vars:
-    dir: "{{ cifmw_basedir }}/artifacts/parameters"
+  vars:
+    included_dir: "{{ cifmw_basedir }}/artifacts/parameters"
+  ansible.builtin.include_role:
+    name: cifmw_helpers
+    tasks_from: include_dir.yml
 
 - name: Ensure libvirt is present/configured
   when:

--- a/roles/cifmw_setup/tasks/infra.yml
+++ b/roles/cifmw_setup/tasks/infra.yml
@@ -1,7 +1,10 @@
 ---
 - name: Load parameters files
-  ansible.builtin.include_vars:
-    dir: "{{ cifmw_basedir }}/artifacts/parameters"
+  vars:
+    included_dir: "{{ cifmw_basedir }}/artifacts/parameters"
+  ansible.builtin.include_role:
+    name: cifmw_helpers
+    tasks_from: include_dir.yml
 
 - name: Load Networking Environment Definition
   vars:


### PR DESCRIPTION
In the CI job, where the nested Ansible execution was removed, there is an issue to read the variables using include_vars module, because that module is searching the files on the host where the Ansible was executed. It means that if the nested Ansible was dropped, the Ansible bin was called from the Zuul executor, on which the /home/zuul does not exists.