### PR TITLE
[whitebox_neutron_tempest_jobs] fix update_containers values

### DIFF
--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -19,26 +19,26 @@
       cifmw_test_operator_timeout: 14400
       cifmw_block_device_size: 40G
       cifmw_repo_setup_branch: antelope
-      cifmw_update_containers_org: podified-{{ cifmw_repo_setup_branch }}-centos9
-      cifmw_update_containers_registry: quay.rdoproject.org
-      cifmw_update_containers_tag: "{{ cifmw_repo_setup_full_hash }}"
+      cifmw_update_containers_registry: >-
+        {{
+          content_provider_os_registry_url | default('') | split('/') | first
+          if content_provider_os_registry_url is defined and content_provider_os_registry_url != 'null'
+          else 'quay.rdoproject.org'
+        }}
+      cifmw_update_containers_org: >-
+        {{
+          content_provider_os_registry_url | default('') | split('/') | last
+          if content_provider_os_registry_url is defined and content_provider_os_registry_url != 'null'
+          else 'podified-' + cifmw_repo_setup_branch + '-centos9'
+        }}
+      cifmw_update_containers_tag: "{{ content_provider_dlrn_md5_hash | default(cifmw_repo_setup_full_hash) }}"
       cifmw_test_operator_tempest_concurrency: 6
       cifmw_test_operator_tempest_network_attachments:
         - ctlplane
       cifmw_test_operator_tempest_container: openstack-tempest-all
-      cifmw_test_operator_tempest_registry: >-
-        {{
-          content_provider_os_registry_url | default('') | split('/') | first
-          if content_provider_os_registry_url is defined and content_provider_os_registry_url != 'null'
-          else cifmw_update_containers_registry
-        }}
-      cifmw_test_operator_tempest_namespace: >-
-        {{
-          content_provider_os_registry_url | default('') | split('/') | last
-          if content_provider_os_registry_url is defined and content_provider_os_registry_url != 'null'
-          else cifmw_update_containers_org
-        }}
-      cifmw_test_operator_tempest_image_tag: "{{ content_provider_dlrn_md5_hash | default(cifmw_repo_setup_full_hash) }}"
+      cifmw_test_operator_tempest_registry: "{{ cifmw_update_containers_registry }}"
+      cifmw_test_operator_tempest_namespace: "{{ cifmw_update_containers_org }}"
+      cifmw_test_operator_tempest_image_tag: "{{ cifmw_update_containers_tag }}"
       cifmw_test_operator_tempest_extra_images:
         - URL: "https://github.com/openstack-k8s-operators/openstack-k8s-operators-ci/releases/download/v1.0.0/wntp-custom-v1.0.0.qcow2"
           name: custom_neutron_guest


### PR DESCRIPTION
Values of `cifmw_update_containers_registry`,
`cifmw_update_containers_org` and `cifmw_update_containers_tag` were not properly updated when the job received values for
`content_provider_os_registry_url` and `content_provider_dlrn_md5_hash`, creating wrong OpenstackVersion CR. This patch fixes that issue.