### PR TITLE
[reproducer] Remove invalid import_role options

### DIFF
--- a/roles/reproducer/tasks/reuse_main.yaml
+++ b/roles/reproducer/tasks/reuse_main.yaml
@@ -144,9 +144,6 @@
             ansible_extra_vars:
               - "{{ ansible_user_dir }}/ci-framework-data/parameters/reproducer-variables.yml"
               - "scenarios/reproducers/networking-definition.yml"
-          changed_when: false
-          args:
-            chdir: "{{ _cifmw_reproducer_framework_location }}"
 
         - name: Install dev tools from install_yamls on controller-0
           environment:


### PR DESCRIPTION
The "Bootstrap environment on controller-0" task was refactored from ansible.builtin.command to ansible.builtin.import_role (712ef7db) but the args/chdir and changed_when directives were left behind. These are only valid for command/shell modules. ansible-core 2.15 now strictly validates import_role options and rejects chdir at parse time.

Generated-by: claude-4.6-opus-high