### PR TITLE
[ci_gen_kustomize_values] fix: Preserve nodes config from architecture repo in HCI template

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/nfv-ovs-dpdk-sriov-hci/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/nfv-ovs-dpdk-sriov-hci/edpm-nodeset-values/values.yaml.j2
@@ -31,8 +31,9 @@ data:
 {% endif                                                                               %}
     nodes:
 {% for instance in instances_names                                                     %}
-      edpm-{{ instance }}:
-        hostName: {{ instance }}
+{%   set node_name = 'edpm-' + instance                                               %}
+      {{ node_name }}:
+{{ _original_nodes[node_name] | default({'hostName': instance}) | to_nice_yaml(indent=2) | indent(8, first=true) }}
 {% endfor                                                                              %}
 
 {% if ('repo-setup' not in (_original_nodeset['services'] | default([]))) and

--- a/scenarios/reproducers/dt-nfv-ovs-dpdk-sriov-hci.yml
+++ b/scenarios/reproducers/dt-nfv-ovs-dpdk-sriov-hci.yml
@@ -117,6 +117,7 @@ cifmw_lvms_disk_list:
   - /dev/vdb
   - /dev/vdc
 
+cifmw_ceph_target: edpms
 cifmw_ceph_client_vars: /tmp/ceph_client.yml
 cifmw_ceph_client_values_post_ceph_path_src: >-
   {{ _arch_repo }}/examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/values.yaml


### PR DESCRIPTION
When generating kustomize values for HCI deployments, preserve the complete node configuration (ansibleHost, networks, fixedIP) from the architecture repository instead of overwriting it with just hostName.

This fixes the issue where pre-ceph nodeset correctly had fixedIP but post-ceph nodeset lost it because ci-framework template was overwriting the nodes section from architecture repo.