### PR TITLE
[multiple] Add per-node BMH label for deterministic node assignment

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/common/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/common/edpm-nodeset-values/values.yaml.j2
@@ -46,6 +46,10 @@ data:
     nodes:
 {% for instance in instances_names                                                     %}
       edpm-{{ instance }}:
+{% if not (cifmw_edpm_deploy_pre_provisioned | default(true) | bool)                   %}
+        bmhLabelSelector:
+          nodeName: {{ instance }}
+{% endif                                                                               %}
         ansible:
           ansibleHost: {{ cifmw_networking_env_definition.instances[instance].networks.ctlplane[_ipv.ip_vX] }}
         hostName: {{ instance }}

--- a/roles/deploy_bmh/template/bmh.yml.j2
+++ b/roles/deploy_bmh/template/bmh.yml.j2
@@ -11,6 +11,7 @@ metadata:
   labels:
     app: {{ node_data['label'] | default("openstack") }}
     workload: {{ node_name.split('-')[0] }}
+    nodeName: {{ node_name }}
 {% if 'extra_labels' in node_data %}
 {% for label,key in node_data['extra_labels'].items() %}
     {{ label }}: {{ key }}


### PR DESCRIPTION
When `preProvisioned: false`, the OSDPO's `OpenStackBaremetalSet` assigns BareMetalHost CRs to NodeSet nodes non-deterministically ([OSPRH-10282](https://redhat.atlassian.net/browse/OSPRH-10282)).  This causes hostname shuffling: a node provisioned from BMH `compute-0` may receive the hostname of `compute-2`, breaking services that depend on hostname correctness (e.g. Ceph `orch apply` fails with "hostname does not match expected hostname").

Fix by establishing a 1-to-1 mapping between BMH CRs and NodeSet nodes using per-node `bmhLabelSelector`:

- `deploy_bmh` template: add a `nodeName` label to every BMH CR,
  set to the node's name (e.g. `nodeName: compute-0`).

- `ci_gen_kustomize_values` common edpm-nodeset-values template: when `cifmw_edpm_deploy_pre_provisioned` is `false`, emit a per-node `bmhLabelSelector: {nodeName: <instance>}` so each NodeSet node selects its specific BMH by label.

Pre-provisioned deployments are unaffected (the `bmhLabelSelector` is only emitted when `cifmw_edpm_deploy_pre_provisioned` is false, which defaults to true).

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3884
Depends-On: https://github.com/openstack-k8s-operators/architecture/pull/746
Related-to: [ANVIL-108](https://redhat.atlassian.net/browse/ANVIL-108)