### PR TITLE
[libvirt_manager] Add predictable network interface names to EDPM

### DIFF
--- a/roles/libvirt_manager/defaults/main.yml
+++ b/roles/libvirt_manager/defaults/main.yml
@@ -84,6 +84,7 @@ cifmw_libvirt_manager_firewalld_zone_libvirt_forward: true
 cifmw_libvirt_manager_firewalld_default_zone: public
 cifmw_libvirt_manager_firewalld_default_zone_masquerade: true
 cifmw_libvirt_manager_attach_dummy_interface_on_bridges: true
+cifmw_libvirt_manager_predictable_nic_names: false
 cifmw_libvirt_manager_extra_network_configuration: {}
 
 cifmw_libvirt_manager_vm_users: []

--- a/roles/libvirt_manager/tasks/create_vms.yml
+++ b/roles/libvirt_manager/tasks/create_vms.yml
@@ -61,6 +61,14 @@
         xml: "{{ lookup('template', cifmw_libvirt_manager_vm_template) }}"
         uri: "qemu:///system"
 
+    - name: "Disable net.ifnames=0 for {{ vm }}"
+      when:
+        - vm_data.disk_file_name != 'blank'
+        - cifmw_libvirt_manager_predictable_nic_names | default(false) | bool
+        - vm is match('^.*(compute).*$')
+      ansible.builtin.command:
+        cmd: "virt-customize -c qemu:///system --domain cifmw-{{ vm }} --run-command 'grubby --remove-args=net.ifnames=0 --update-kernel=ALL'"
+
 - name: "Attach listed networks to the VMs {{ vm }}"
   vars:
     vm_item: "{{ vm }}"


### PR DESCRIPTION
Enable systemd predictable network interface naming inside guest VMs
by removing `net.ifnames=0` from kernel args via virt-customize. This
gives guests consistent PCI-topology-based names (enp1s0, enp2s0, etc.)
instead of legacy ethN naming. Predictable network interfaces are
requirement for testing Leapp upgrade functionality.

Controlled by cifmw_libvirt_manager_predictable_nic_names (defaults
to false).

Jira: [OSPRH-29381](https://redhat.atlassian.net/browse/OSPRH-29381)