### PR TITLE
[devscripts] Preserve host-passthrough CPU in metal3 devscripts

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -464,6 +464,7 @@ ovnkubernetes
 pablintino
 param
 params
+passthrough
 passwd
 passwordless
 pastebin

--- a/roles/devscripts/README.md
+++ b/roles/devscripts/README.md
@@ -56,6 +56,9 @@ networks.
 * `cifmw_devscripts_cinder_volume_pvs` (list) a list of physical disks to be
   used for creating cinder-volumes volume-group. By default, the list contains
   `/dev/vda`.
+* `cifmw_devscripts_cpu_passthrough` (bool) Enable host-passthrough cpu model
+  to virtual machine instead of using QEMU on nested environment. Defaults
+  to `false`.
 
 ### Secrets management
 

--- a/roles/devscripts/defaults/main.yml
+++ b/roles/devscripts/defaults/main.yml
@@ -74,3 +74,4 @@ cifmw_devscripts_config_overrides: {}
 cifmw_devscripts_installer_timeout: 7200  # 2 hours
 cifmw_devscripts_etcd_slow_profile: true
 cifmw_devscripts_disable_console: false
+cifmw_devscripts_cpu_passthrough: false

--- a/roles/devscripts/tasks/135_patch_src.yml
+++ b/roles/devscripts/tasks/135_patch_src.yml
@@ -50,3 +50,12 @@
     owner: "{{ cifmw_devscripts_user }}"
     group: "{{ cifmw_devscripts_user }}"
     mode: "0644"
+
+- name: Force KVM domain type in dev-scripts configure to preserve host-passthrough CPU
+  when:
+    - cifmw_devscripts_cpu_passthrough | bool
+  ansible.builtin.lineinfile:
+    path: "{{ cifmw_devscripts_repo_dir }}/02_configure_host.sh"
+    insertbefore: '.*-b -vvv.*setup-playbook.yml'
+    firstmatch: true
+    line: '    -e "libvirt_domain_type=kvm" \'


### PR DESCRIPTION
The metal3 generates a file in work dir:

    # metal3-dev-env/vm-setup/roles/libvirt/tasks/vm_setup_tasks.yml
    (...)
    - name: Detect virtualization if libvirt_domain_type is not provided
      command: systemd-detect-virt
      ignore_errors: true
      become: true
      register: virt_result

    - name: Default to qemu if inside a VM
      set_fact:
        libvirt_domain_type: qemu
      when: virt_result is succeeded

    - name: Default to kvm if a VM is not detected
      set_fact:
        libvirt_domain_type: kvm
      when: virt_result is failed
    when: libvirt_domain_type is undefined

which generates later in an SNO VM xml:

    <cpu mode='custom' match='exact' check='full'>
      <model fallback='forbid'>EPYC</model>
      <vendor>AMD</vendor>
      <feature policy='require' name='monitor'/>
      <feature policy='require' name='x2apic'/>
      <feature policy='require' name='hypervisor'/>
      <feature policy='require' name='acpi'/>
      <feature policy='require' name='ss'/>
      <feature policy='require' name='erms'/>
      <feature policy='require' name='mpx'/>
      <feature policy='require' name='clwb'/>
      <feature policy='require' name='umip'/>
      <feature policy='require' name='pku'/>
      <feature policy='require' name='vaes'/>
      <feature policy='require' name='la57'/>
      <feature policy='require' name='rdpid'/>
      <feature policy='require' name='pks'/>
      <feature policy='require' name='fsrm'/>
      <feature policy='require' name='cmpccxadd'/>
      <feature policy='require' name='fzrm'/>
      <feature policy='require' name='fsrs'/>
      <feature policy='require' name='fsrc'/>
      <feature policy='require' name='3dnowext'/>
      <feature policy='require' name='3dnow'/>
      <feature policy='require' name='xsaveerptr'/>
      <feature policy='require' name='wbnoinvd'/>
      <feature policy='require' name='npt'/>
      <feature policy='require' name='vgif'/>
      <feature policy='require' name='svme-addr-chk'/>
      <feature policy='require' name='no-nested-data-bp'/>
      <feature policy='require' name='null-sel-clr-base'/>
      <feature policy='disable' name='vme'/>
      <feature policy='disable' name='xsavec'/>
      <feature policy='disable' name='misalignsse'/>
      <feature policy='disable' name='osvw'/>
      <feature policy='disable' name='topoext'/>
      <feature policy='disable' name='fxsr_opt'/>
      <feature policy='disable' name='nrip-save'/>
    </cpu>

instead of host-passthrough. Bypass that behavior and always use
host-passthrough.