### PR TITLE
ci_gen_kustomize_values: Add bmo01 nodes generation to nodeset-values

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/bmo01/nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bmo01/nodeset-values/values.yaml.j2
@@ -14,6 +14,33 @@ data:
       # install rhos-release repos
       dnf --nogpgcheck install -y {{ cifmw_repo_setup_rhos_release_rpm }}
       rhos-release {{ cifmw_repo_setup_rhos_release_args }}
+    nodes:
+{% for host in cifmw_networking_env_definition.instances.keys() if host is match('^leaf0-.*') %}
+{% set idx = host.split('-')[1] %}
+{% set compute_name = 'edpm-compute-0-' ~ idx %}
+{% set ip = cifmw_networking_env_definition.instances[host].networks.ctlplane1.ip_v4 %}
+{% set ctlplane_ip = cifmw_networking_env_definition.instances[host].networks.ctlplane.ip_v4 | default(ip) %}
+      {{ compute_name }}:
+        ansible:
+          ansibleHost: {{ ctlplane_ip }}
+        bmhLabelSelector:
+          nodeName: {{ host }}
+        hostName: {{ compute_name }}
+        networkData:
+          name: {{ compute_name }}-network-data
+          namespace: openstack
+        networks:
+          - defaultRoute: true
+            fixedIP: {{ ip }}
+            name: ctlplane
+            subnetName: subnet2
+          - name: internalapi
+            subnetName: subnet2
+          - name: storage
+            subnetName: subnet2
+          - name: tenant
+            subnetName: subnet2
+{% endfor %}
   nodeset1:
     timesync_ntp_servers:
       - hostname: "{{ cifmw_ci_gen_kustomize_values_ntp_srv | default('pool.ntp.org') }}"
@@ -27,3 +54,30 @@ data:
       # install rhos-release repos
       dnf --nogpgcheck install -y {{ cifmw_repo_setup_rhos_release_rpm }}
       rhos-release {{ cifmw_repo_setup_rhos_release_args }}
+    nodes:
+{% for host in cifmw_networking_env_definition.instances.keys() if host is match('^leaf1-.*') %}
+{% set idx = host.split('-')[1] %}
+{% set compute_name = 'edpm-compute-1-' ~ idx %}
+{% set ip = cifmw_networking_env_definition.instances[host].networks.ctlplane2.ip_v4 %}
+{% set ctlplane_ip = cifmw_networking_env_definition.instances[host].networks.ctlplane.ip_v4 | default(ip) %}
+      {{ compute_name }}:
+        ansible:
+          ansibleHost: {{ ctlplane_ip }}
+        bmhLabelSelector:
+          nodeName: {{ host }}
+        hostName: {{ compute_name }}
+        networkData:
+          name: {{ compute_name }}-network-data
+          namespace: openstack
+        networks:
+          - defaultRoute: true
+            fixedIP: {{ ip }}
+            name: ctlplane
+            subnetName: subnet3
+          - name: internalapi
+            subnetName: subnet3
+          - name: storage
+            subnetName: subnet3
+          - name: tenant
+            subnetName: subnet3
+{% endfor %}


### PR DESCRIPTION
The bmo01 dataplane nodesets now require `data.nodeset0.nodes` and `data.nodeset1.nodes` in the `nodeset-values` ConfigMap. Without these fields, kustomize replacements fail when generating the OpenStackDataPlaneNodeSet resources.

Add Jinja2 loops that iterate over `leaf0-*` and `leaf1-*` instances from `cifmw_networking_env_definition` to generate the per-nodeset `nodes` blocks with `ansibleHost`, `bmhLabelSelector`, `hostName`, `networkData`, and network definitions for each compute node.