### PR TITLE
Adjusts to test eBGP (different ASN values)

### DIFF
--- a/playbooks/bgp/prepare-bgp-spines-leaves.yaml
+++ b/playbooks/bgp/prepare-bgp-spines-leaves.yaml
@@ -440,6 +440,11 @@
     leaf_id: "{{ (ansible_hostname.split('-')[-1] | int) % 2 }}"  # always 2 leaves per rack
     rack_id: "{{ (ansible_hostname.split('-')[-1] | int) // 2 }}"  # always 2 leaves per rack
     _ip_version: "{{ ip_version | default(4) | int }}"
+    # ebgp_racks: comma-separated rack IDs that use eBGP (e.g. "1,2")
+    # ebgp_leaf_asn: base ASN for eBGP leaves (default: 64999 - rack_id)
+    _is_ebgp_rack: "{{ (rack_id | int) in (ebgp_racks | default('') | split(',') | select | map('int') | list) }}"
+    downlink_remote_as: "{{ 'external' if _is_ebgp_rack else 'internal' }}"
+    leaf_asn: "{{ ebgp_leaf_asn | default(64999 - (rack_id | int)) if _is_ebgp_rack else 64999 }}"
   tasks:
     - name: Obtain the connection for the eth0 interface
       ansible.builtin.command:

--- a/playbooks/bgp/prepare-bgp-spines-leaves.yaml
+++ b/playbooks/bgp/prepare-bgp-spines-leaves.yaml
@@ -544,6 +544,8 @@
           become: true
           vars:
             downlink_interfaces: "{{ downlink_ifs_rack3 if (rack_id | int) == 3 else leaf_downlink_ifs }}"
+            downlink_remote_as: "{{ 'external' if (rack_id | int) in (ebgp_racks | default([]) | map('int') | list) else 'internal' }}"
+            leaf_asn: "{{ ebgp_leaf_asn | default(64999) if (rack_id | int) in (ebgp_racks | default([]) | map('int') | list) else 64999 }}"
             _router_id: ''
           ansible.builtin.template:
             src: templates/leaf-frr.conf.j2
@@ -599,6 +601,8 @@
         - name: Configure FRR
           become: true
           vars:
+            downlink_remote_as: "{{ 'external' if (rack_id | int) in (ebgp_racks | default([]) | map('int') | list) else 'internal' }}"
+            leaf_asn: "{{ ebgp_leaf_asn | default(64999) if (rack_id | int) in (ebgp_racks | default([]) | map('int') | list) else 64999 }}"
             _router_id: "{{ '1.1.1.20' + ansible_hostname.split('-')[-1] }}"
           ansible.builtin.template:
             src: templates/leaf-frr.conf.j2

--- a/playbooks/bgp/templates/leaf-frr.conf.j2
+++ b/playbooks/bgp/templates/leaf-frr.conf.j2
@@ -13,7 +13,8 @@ debug bgp neighbor-events
 debug bgp updates
 debug bgp update-groups
 
-router bgp 64999
+{% set _downlink_as_mode = downlink_remote_as | default('internal') %}
+router bgp {{ leaf_asn | default(64999) }}
 {% if _router_id %}
   bgp router-id {{_router_id}}
 {% endif %}
@@ -27,7 +28,7 @@ router bgp 64999
   ! bgp long-lived-graceful-restart stale-time 15
 
   neighbor downlink peer-group
-  neighbor downlink remote-as internal
+  neighbor downlink remote-as {{ _downlink_as_mode }}
   neighbor downlink bfd
   neighbor downlink bfd profile tripleo
 {# TODO: remove the next if when RHEL-63205 is fixed #}
@@ -53,9 +54,11 @@ router bgp 64999
 
   address-family ipv4 unicast
     redistribute connected
-    neighbor downlink route-reflector-client
     neighbor downlink default-originate
     neighbor downlink next-hop-self
+{% if _downlink_as_mode == 'internal' %}
+    neighbor downlink route-reflector-client
+{% endif %}
     neighbor downlink prefix-list only-host-prefixes out
     neighbor uplink allowas-in origin
     neighbor uplink prefix-list only-default-host-prefixes in
@@ -64,9 +67,11 @@ router bgp 64999
   address-family ipv6 unicast
     redistribute connected
     neighbor downlink activate
-    neighbor downlink route-reflector-client
     neighbor downlink default-originate
     neighbor downlink next-hop-self
+{% if _downlink_as_mode == 'internal' %}
+    neighbor downlink route-reflector-client
+{% endif %}
     neighbor uplink activate
     neighbor uplink allowas-in origin
     neighbor uplink prefix-list only-default-host-prefixes in
@@ -76,7 +81,9 @@ router bgp 64999
     neighbor uplink activate
     neighbor uplink allowas-in origin
     neighbor downlink activate
+{% if _downlink_as_mode == 'internal' %}
     neighbor downlink route-reflector-client
+{% endif %}
   exit-address-family
 
 ip prefix-list only-default-host-prefixes permit 0.0.0.0/0

--- a/playbooks/bgp/templates/leaf-frr.conf.j2
+++ b/playbooks/bgp/templates/leaf-frr.conf.j2
@@ -13,12 +13,15 @@ debug bgp neighbor-events
 debug bgp updates
 debug bgp update-groups
 
-router bgp 64999
+{% set _downlink_as_mode = downlink_remote_as | default('internal') %}
+router bgp {{ leaf_asn | default(64999) }}
 {% if _router_id %}
   bgp router-id {{_router_id}}
 {% endif %}
   bgp log-neighbor-changes
+{% if _downlink_as_mode == 'internal' %}
   bgp graceful-shutdown
+{% endif %}
 
   bgp graceful-restart
   bgp graceful-restart notification
@@ -27,7 +30,7 @@ router bgp 64999
   ! bgp long-lived-graceful-restart stale-time 15
 
   neighbor downlink peer-group
-  neighbor downlink remote-as internal
+  neighbor downlink remote-as {{ _downlink_as_mode }}
   neighbor downlink bfd
   neighbor downlink bfd profile tripleo
 {# TODO: remove the next if when RHEL-63205 is fixed #}
@@ -53,9 +56,11 @@ router bgp 64999
 
   address-family ipv4 unicast
     redistribute connected
-    neighbor downlink route-reflector-client
     neighbor downlink default-originate
     neighbor downlink next-hop-self
+{% if _downlink_as_mode == 'internal' %}
+    neighbor downlink route-reflector-client
+{% endif %}
     neighbor downlink prefix-list only-host-prefixes out
     neighbor uplink allowas-in origin
     neighbor uplink prefix-list only-default-host-prefixes in
@@ -64,9 +69,11 @@ router bgp 64999
   address-family ipv6 unicast
     redistribute connected
     neighbor downlink activate
-    neighbor downlink route-reflector-client
     neighbor downlink default-originate
     neighbor downlink next-hop-self
+{% if _downlink_as_mode == 'internal' %}
+    neighbor downlink route-reflector-client
+{% endif %}
     neighbor uplink activate
     neighbor uplink allowas-in origin
     neighbor uplink prefix-list only-default-host-prefixes in
@@ -76,7 +83,9 @@ router bgp 64999
     neighbor uplink activate
     neighbor uplink allowas-in origin
     neighbor downlink activate
+{% if _downlink_as_mode == 'internal' %}
     neighbor downlink route-reflector-client
+{% endif %}
   exit-address-family
 
 ip prefix-list only-default-host-prefixes permit 0.0.0.0/0

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt02/OWNERS
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt02/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://www.kubernetes.dev/docs/guide/owners/
+
+approvers:
+  - bgp-team
+
+reviewers:
+  - bgp-team

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt02/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt02/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2
@@ -1,0 +1,68 @@
+# source: bgp_dt02/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2
+{% set instances_names = []                                                            %}
+{% set rack = 'r' ~ rack_number                                                        %}
+{% for _inst in cifmw_networking_env_definition.instances.keys()                       %}
+{%   if _inst.startswith('-'.join([rack, node_type]))                                  %}
+{%     set _ = instances_names.append(_inst)                                           %}
+{%   endif                                                                             %}
+{% endfor                                                                              %}
+data:
+  ssh_keys:
+    authorized: {{ cifmw_ci_gen_kustomize_values_ssh_authorizedkeys | b64encode }}
+    private: {{ cifmw_ci_gen_kustomize_values_ssh_private_key | b64encode }}
+    public: {{ cifmw_ci_gen_kustomize_values_ssh_public_key | b64encode }}
+  nova:
+    migration:
+      ssh_keys:
+        private: {{ cifmw_ci_gen_kustomize_values_migration_priv_key | b64encode }}
+        public: {{ cifmw_ci_gen_kustomize_values_migration_pub_key | b64encode }}
+  nodeset:
+    ansible:
+      ansibleUser: "zuul"
+      ansibleVars:
+        edpm_fips_mode: "{{ 'enabled' if cifmw_fips_enabled|default(false)|bool else 'check' }}"
+        timesync_ntp_servers:
+          - hostname: "{{ cifmw_ci_gen_kustomize_values_ntp_srv | default('pool.ntp.org') }}"
+        edpm_sshd_allowed_ranges:
+{% set sshd_allowed_range = cifmw_ci_gen_kustomize_values_sshd_ranges | default([])    %}
+{% for rack in ['r0', 'r1', 'r2']                                                      %}
+{%   set _ = sshd_allowed_range.append(cifmw_networking_env_definition.networks['ctlplane' + rack].network_v4) %}
+{% endfor                                                                              %}
+{% for range in sshd_allowed_range                                                     %}
+          - "{{ range }}"
+{% endfor                                                                              %}
+    nodes:
+{% for instance in instances_names                                                     %}
+      {{ instance }}:
+        ansible:
+{%   set ctlplane_rack = 'ctlplane' + rack                                             %}
+          ansibleHost: {{ cifmw_networking_env_definition.instances[instance].networks[ctlplane_rack].ip_v4 }}
+{%   if original_content.data.nodeset.nodes['edpm-' ~ instance].ansible.ansibleVars is defined %}
+          ansibleVars: {{ original_content.data.nodeset.nodes['edpm-' ~ instance].ansible.ansibleVars }}
+{%   endif                                                                                                          %}
+        hostName: {{ instance }}
+        networks:
+{%      for net in cifmw_networking_env_definition.instances[instance].networks.keys() %}
+{%        if 'storagemgmt' not in net                                                  %}
+          - name: {{ net if net != ctlplane_rack else 'ctlplane' }}
+            subnetName: {{ 'subnet1' if net != ctlplane_rack else 'subnet' ~ rack_number }}
+{%          if 'ctlplane' in net                                                       %}
+            defaultRoute: true
+            fixedIP: {{ cifmw_networking_env_definition.instances[instance].networks[ctlplane_rack].ip_v4 }}
+{%          endif                                                                      %}
+{%        endif                                                                        %}
+{%      endfor                                                                         %}
+{%        set peer_suffix = 1 if 'compute' in instance else 5                          %}
+          - name: BgpNet0
+            subnetName: subnet{{ rack_number }}
+            fixedIP: 100.64.{{ rack_number }}.{{ peer_suffix + 1 }}
+          - name: BgpNet1
+            subnetName: subnet{{ rack_number }}
+            fixedIP: 100.65.{{ rack_number }}.{{ peer_suffix + 1 }}
+          - name: BgpMainNet
+            subnetName: subnet{{ rack_number }}
+            fixedIP: 99.99.{{ rack_number }}.{{ peer_suffix + 1 }}
+          - name: BgpMainNetV6
+            subnetName: subnet{{ rack_number }}
+            fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:00{{ (rack_number | int) + 1 }}{{ 2 if 'compute' in instance else 3 }}
+{% endfor                                                                              %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt02/edpm-r0-compute-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt02/edpm-r0-compute-nodeset-values/values.yaml.j2
@@ -1,0 +1,5 @@
+---
+# source: bgp_dt02/edpm-r0-compute-nodeset-values/values.yaml.j2
+{% set node_type = "compute"                                                              %}
+{% set rack_number = 0                                                                    %}
+{% include 'templates/bgp_dt02/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt02/edpm-r0-networker-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt02/edpm-r0-networker-nodeset-values/values.yaml.j2
@@ -1,0 +1,5 @@
+---
+# source: bgp_dt02/edpm-r0-networker-nodeset-values/values.yaml.j2
+{% set node_type = "networker"                                                            %}
+{% set rack_number = 0                                                                    %}
+{% include 'templates/bgp_dt02/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt02/edpm-r1-compute-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt02/edpm-r1-compute-nodeset-values/values.yaml.j2
@@ -1,0 +1,5 @@
+---
+# source: bgp_dt02/edpm-r1-compute-nodeset-values/values.yaml.j2
+{% set node_type = "compute"                                                              %}
+{% set rack_number = 1                                                                    %}
+{% include 'templates/bgp_dt02/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt02/edpm-r1-networker-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt02/edpm-r1-networker-nodeset-values/values.yaml.j2
@@ -1,0 +1,5 @@
+---
+# source: bgp_dt02/edpm-r1-networker-nodeset-values/values.yaml.j2
+{% set node_type = "networker"                                                            %}
+{% set rack_number = 1                                                                    %}
+{% include 'templates/bgp_dt02/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt02/edpm-r2-compute-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt02/edpm-r2-compute-nodeset-values/values.yaml.j2
@@ -1,0 +1,5 @@
+---
+# source: bgp_dt02/edpm-r2-compute-nodeset-values/values.yaml.j2
+{% set node_type = "compute"                                                              %}
+{% set rack_number = 2                                                                    %}
+{% include 'templates/bgp_dt02/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt02/edpm-r2-networker-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt02/edpm-r2-networker-nodeset-values/values.yaml.j2
@@ -1,0 +1,5 @@
+---
+# source: bgp_dt02/edpm-r2-networker-nodeset-values/values.yaml.j2
+{% set node_type = "networker"                                                            %}
+{% set rack_number = 2                                                                    %}
+{% include 'templates/bgp_dt02/edpm-common-nodeset-values/common-bgp-edpm-values.yaml.j2' %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt02/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt02/network-values/values.yaml.j2
@@ -1,0 +1,202 @@
+---
+# source: bgp_dt02/network-values/values.yaml.j2
+{% set ns = namespace(interfaces={},
+                      ocp_index=0,
+                      lb_tools={}) %}
+
+data:
+{% set node_groups = groups if 'rhoso-architecture-validate' not in ((zuul | default({})).job | default('')) else test_groups %}
+{% for host in cifmw_networking_env_definition.instances.keys() -%}
+{%   set hostname = cifmw_networking_env_definition.instances[host]['hostname'] %}
+{%   if host is match('^(ocp|crc).*') %}
+{%     if 'ocp_workers' not in node_groups or host in node_groups.ocp_workers %}
+  node_{{ ns.ocp_index }}:
+    name: {{ hostname }}
+{%     for network in cifmw_networking_env_definition.instances[host]['networks'].values() %}
+{%       set ns.interfaces = ns.interfaces |
+                             combine({network.network_name: (network.parent_interface |
+                                                             default(network.interface_name)
+                                                            )
+                                     },
+                                     recursive=true) %}
+    {{ network.network_name }}_ip: {{ network.ip_v4 }}
+{%       if 'ctlplane' == network.network_name %}
+    base_if: {{ network.interface_name }}
+{%       endif %}
+{%     endfor %}
+{%     set node_bgp_orig_content = original_content.data.bgp.bgpdefs['node' ~ ns.ocp_index] %}
+{%     set node_bgp_net0 = node_bgp_orig_content.bgpnet0 %}
+{%     if 'worker-3' != hostname %}
+{%       set node_bgp_net1 = node_bgp_orig_content.bgpnet1 %}
+{%     endif %}
+    bgp_peers:
+      - {{ node_bgp_net0.bgp_peer }}
+{%     if 'worker-3' != hostname %}
+      - {{ node_bgp_net1.bgp_peer }}
+{%     endif %}
+    bgp_ip:
+      - {{ node_bgp_net0.bgp_ip }}
+{%     if 'worker-3' != hostname %}
+      - {{ node_bgp_net1.bgp_ip }}
+{%     endif %}
+{%     set subnet_index = (hostname | split('-'))[-1] | int %}
+{%     set ip_index = 1 if ('master-' in hostname or 'worker-3' == hostname) else 2  %}
+{%     set loopback_ip = original_content.data.bgp.subnets.bgpmainnet[subnet_index].allocationRanges[0].start |
+                         ansible.utils.ipmath(ip_index) %}
+{%     set loopback_ipv6 = original_content.data.bgp.subnets.bgpmainnetv6[subnet_index].allocationRanges[0].start |
+                           ansible.utils.ipmath(ip_index) %}
+    loopback_ip: {{ loopback_ip }}
+    loopback_ipv6: {{ loopback_ipv6 }}
+{%     if node_bgp_orig_content.routes | default(false) %}
+    routes: {{ node_bgp_orig_content.routes }}
+{%     endif %}
+{%     endif %}
+{%     set ns.ocp_index = ns.ocp_index+1 %}
+{%   endif %}
+{% endfor %}
+
+{% for network in cifmw_networking_env_definition.networks.values() %}
+{% if network.network_name != 'ctlplane_ocp_nad' %}
+{%  set ns.lb_tools = {} %}
+  {{ network.network_name }}:
+    dnsDomain: {{ network.search_domain }}
+{%  if network.tools is defined and network.tools.keys() | length > 0 %}
+    subnets:
+{%    for tool in network.tools.keys() %}
+{%      if tool is match('.*lb$') %}
+{%        set _ = ns.lb_tools.update({tool: []}) %}
+{%      endif %}
+{%    endfor %}
+{%    if network.network_name != 'ctlplane' and network.tools.netconfig is defined %}
+      - allocationRanges:
+{%      for range in network.tools.netconfig.ipv4_ranges %}
+        - end: {{ range.end }}
+          start: {{ range.start }}
+{%      endfor %}
+        cidr: {{ network.network_v4 }}
+{%      if network.gw_v4 is defined %}
+        gateway: {{ network.gw_v4 }}
+{%      endif %}
+        name: subnet1
+{%      if network.vlan_id is defined  %}
+        vlan: {{ network.vlan_id }}
+{%      endif %}
+{%    elif network.network_name == 'ctlplane' %}
+{%      for rack in ['r0', 'r1', 'r2'] %}
+{%        set rack_subnet = cifmw_networking_env_definition.networks[network.network_name + rack] %}
+      - allocationRanges:
+{%        for range in rack_subnet.tools.netconfig.ipv4_ranges %}
+        - end: {{ range.end }}
+          start: {{ range.start }}
+{%        endfor %}
+        cidr: {{ rack_subnet.network_v4 }}
+{%        if rack_subnet.gw_v4 is defined %}
+        gateway: {{ rack_subnet.gw_v4 }}
+{%        endif %}
+        name: {{ 'subnet' ~ loop.index0 }}
+{%        if rack_subnet.vlan_id is defined  %}
+        vlan: {{ rack_subnet.vlan_id }}
+{%        endif %}
+{%      endfor %}
+{%    endif %}
+{%    if ns.lb_tools | length > 0 %}
+    lb_addresses:
+{%      for tool in ns.lb_tools.keys() %}
+{%      set lb_range_network = network if network.network_name != "ctlplane" else cifmw_networking_env_definition.networks.ctlplane_ocp_nad %}
+{%        for lb_range in lb_range_network.tools[tool].ipv4_ranges %}
+      - {{ lb_range.start }}-{{ lb_range.end }}
+{%          set _ = ns.lb_tools[tool].append(lb_range.start) %}
+{%        endfor %}
+    endpoint_annotations:
+      {{ tool }}.universe.tf/address-pool: {{ network.network_name }}
+      {{ tool }}.universe.tf/allow-shared-ip: {{ network.network_name }}
+      {{ tool }}.universe.tf/loadBalancerIPs: {{ ','.join(ns.lb_tools[tool]) }}
+{%      endfor %}
+{%    endif %}
+{%  endif %}
+    prefix-length: {{ network.network_v4 | ansible.utils.ipaddr('prefix') }}
+    mtu: {{ network.mtu | default(1500) }}
+{%  if network.vlan_id is defined  %}
+    vlan: {{ network.vlan_id }}
+{%    if ns.interfaces[network.network_name] is defined %}
+    iface: {{ network.network_name }}
+    base_iface: {{ ns.interfaces[network.network_name] }}
+{%    endif %}
+{%  elif network.network_name == "ctlplane" %}
+    iface: {{ ns.interfaces[network.network_name] }}
+{%  elif ns.interfaces[network.network_name] is defined %}
+    iface: {{ network.network_name }}
+{%  endif %}
+{%  if network.tools.multus is defined %}
+    net-attach-def: |
+      {
+        "cniVersion": "0.3.1",
+        "name": "{{ network.network_name }}",
+        "type": "bridge",
+        "isDefaultGateway": true,
+        "isGateway": true,
+        "forceAddress": false,
+{%  if network.network_name == "ctlplane" %}
+        "ipMasq": true,
+{%  else %}
+        "ipMasq": false,
+{%  endif %}
+        "hairpinMode": true,
+{%  if network.network_name == "ctlplane" %}
+        "bridge": "ospbr",
+{%  else %}
+        "bridge": "{{ network.network_name }}",
+{%  endif %}
+        "ipam": {
+          "type": "whereabouts",
+{%  if network.network_name == "octavia" and network.tools.multus.ipv4_routes | default([]) | length > 0 %}
+          "routes": [
+{%    for route in network.tools.multus.ipv4_routes %}
+             {
+               "dst": "{{ route.destination }}",
+               "gw": "{{ route.gateway }}"
+             }{% if not loop.last %},{% endif %}
+{%    endfor %}
+           ],
+{%  endif %}
+{%  set range_network = network if network.network_name != "ctlplane" else cifmw_networking_env_definition.networks.ctlplane_ocp_nad %}
+          "range": "{{ range_network.network_v4 }}",
+          "range_start": "{{ range_network.tools.multus.ipv4_ranges.0.start }}",
+          "range_end": "{{ range_network.tools.multus.ipv4_ranges.0.end }}",
+          "gateway": "{{ range_network.network_v4 |ansible.utils.nthhost(1) }}"
+        }
+      }
+{%  endif %}
+{% endif %}
+{% endfor %}
+
+  dns-resolver:
+    config:
+      server:
+        - "{{ cifmw_networking_env_definition.networks.ctlplane.gw_v4 }}"
+      search: []
+    options:
+      - key: server
+        values:
+          - {{ cifmw_networking_env_definition.networks.ctlplane.gw_v4 }}
+{% for nameserver in cifmw_ci_gen_kustomize_values_nameservers %}
+      - key: server
+        values:
+          - {{ nameserver }}
+{% endfor %}
+
+  routes:
+    config: []
+
+# Hardcoding the last IP bit since we don't have support for endpoint_annotations in the networking_mapper output
+  rabbitmq:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(85) }}
+  rabbitmq-cell1:
+    endpoint_annotations:
+      metallb.universe.tf/address-pool: internalapi
+      metallb.universe.tf/loadBalancerIPs: {{ cifmw_networking_env_definition.networks['internalapi'].network_v4 | ansible.utils.ipmath(86) }}
+
+  lbServiceType: LoadBalancer
+  storageClass: local-storage


### PR DESCRIPTION
Allow parameterized ASN (leaf_asn), downlink mode (downlink_remote_as). Conditional route-reflector-client for iBGP only.

Sets downlink_remote_as and leaf_asn according to destined ebgp_racks and ebgp_leaf_asn variables (changes both IPv4 and IPv6 renders).

Related: [OSPRH-28085](https://redhat.atlassian.net/browse/OSPRH-28085)
Assisted-By: Claude Code