### PR TITLE
Remove danpawlik from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,7 +5,6 @@ aliases:
     - rebtoor
     - fultonj
     - dasm
-    - danpawlik
     - Valkyrie00
     - yorabl
     - tosky


### PR DESCRIPTION
I recently changed the team, so to save time related to checking email box for notifications related to changes in CI Framework project where I was not called directly, I would like to be removed from that group.