### PR TITLE
Update check-role-prefix script

### DIFF
--- a/.github/workflows/verify-pr-prefix.yml
+++ b/.github/workflows/verify-pr-prefix.yml
@@ -20,12 +20,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Dump commit message to file
-        run: |
-          git fetch origin ${{ github.event.pull_request.head.sha }}
-          git log -1 --pretty=format:"%B" ${{ github.event.pull_request.head.sha }} | head -n1 > commit-message-file
-
-      - name: Run commit message check
+      - name: Check all commits in PR
         id: prefixcheck
         run: |
-          ./scripts/check-role-prefix.sh commit-message-file
+          ./scripts/check-role-prefix.sh

--- a/scripts/check-role-prefix.sh
+++ b/scripts/check-role-prefix.sh
@@ -1,49 +1,73 @@
 #!/bin/bash
 
-# Get the latest commit message file
-TMP_MSG_FILE="$1"
+# Validate that each commit in the PR has the correct role prefix
+# based on the roles modified in that specific commit.
 
-if [ -z "$TMP_MSG_FILE" ]; then
-    TMP_MSG_FILE=$(mktemp)
-    git log -1 --pretty=format:"%B" | head -n1
-fi
-
-echo "Checking latest commit message:"
-cat "$TMP_MSG_FILE"
-
-if [ -n "$GITHUB_BASE_REF" ]; then
-    CHANGED_ROLES=$(git diff "origin/${GITHUB_BASE_REF}" --name-only || true)
-else
-    CHANGED_ROLES=$(git diff --cached --name-only || true)
-fi
-
-CHANGED_ROLES=$(echo "$CHANGED_ROLES" | grep '^roles/' | cut -d'/' -f2 | sort -u | xargs | sed 's/ /|/g')
-if [ -z "$CHANGED_ROLES" ]; then
-    echo "No roles modified - skipping check..."
+if [ -z "$GITHUB_BASE_REF" ]; then
+    echo "Not running in GitHub Actions - skipping check"
     exit 0
 fi
 
-echo -e "\n\nDetected changes in roles: **$CHANGED_ROLES**"
-MSG=$(head -n 1 "$TMP_MSG_FILE")
-ROLE_COUNT=$(echo "$CHANGED_ROLES" | tr '|' '\n' | wc -l)
+echo "Checking all commits in PR against base: origin/${GITHUB_BASE_REF}"
+echo ""
 
-if [ "$ROLE_COUNT" -eq 1 ]; then
-    # shellcheck disable=SC2016
-    ESCAPED_ROLE=$(printf '%s\n' "$CHANGED_ROLES" | sed 's/[]\.*^$()+?{|]/\\&/g')
-    PATTERN="^[[(]${ESCAPED_ROLE}[])]"
-else
-    PATTERN="^[[(](multiple)[])]"
+# Get all commits in the PR
+COMMITS=$(git rev-list origin/${GITHUB_BASE_REF}..HEAD)
+
+if [ -z "$COMMITS" ]; then
+    echo "No commits to check"
+    exit 0
 fi
 
-if ! grep -qE "$PATTERN" <<<"$MSG"; then
-    echo -e "\n**ERROR: Commit message must start with:**\n"
-    if [ "$ROLE_COUNT" -eq 1 ]; then echo -e "\t[$CHANGED_ROLES]\n"; fi
-    if [ "$ROLE_COUNT" -gt 1 ]; then echo -e "\t(multiple)\n\n"; fi
-    echo -e "Example commit header:\n"
-    echo -e "\t-[reproducer] fix task something\n"
-    echo -e "\t-(cifmw_helpers) improve code\n"
-    echo -e "\t-[multiple] updated default value"
+FAILED=0
+
+# Check each commit individually
+while IFS= read -r COMMIT; do
+    MSG=$(git log -1 --pretty=format:"%s" "$COMMIT")
+    echo "Checking commit ${COMMIT:0:8}: $MSG"
+
+    # Get roles changed in THIS commit only
+    CHANGED_ROLES=$(git diff-tree --no-commit-id --name-only -r "$COMMIT" | grep '^roles/' | cut -d'/' -f2 | sort -u | xargs | sed 's/ /|/g')
+
+    if [ -z "$CHANGED_ROLES" ]; then
+        echo "  No roles modified - skipping"
+        echo ""
+        continue
+    fi
+
+    echo "  Changed roles: $CHANGED_ROLES"
+
+    ROLE_COUNT=$(echo "$CHANGED_ROLES" | tr '|' '\n' | wc -l)
+
+    if [ "$ROLE_COUNT" -eq 1 ]; then
+        # shellcheck disable=SC2016
+        ESCAPED_ROLE=$(printf '%s\n' "$CHANGED_ROLES" | sed 's/[]\.*^$()+?{|]/\\&/g')
+        PATTERN="^[[(]${ESCAPED_ROLE}[])]"
+    else
+        PATTERN="^[[(](multiple)[])]"
+    fi
+
+    if ! grep -qE "$PATTERN" <<<"$MSG"; then
+        echo ""
+        echo "  **ERROR: Commit message must start with:**"
+        if [ "$ROLE_COUNT" -eq 1 ]; then
+            echo "    [$CHANGED_ROLES]"
+        else
+            echo "    (multiple)"
+        fi
+        echo ""
+        FAILED=1
+    else
+        echo "  ✓ Valid prefix"
+    fi
+    echo ""
+done <<< "$COMMITS"
+
+if [ $FAILED -eq 1 ]; then
+    echo "Example commit messages:"
+    echo "  [reproducer] fix task something"
+    echo "  (multiple) updated default value"
     exit 1
 fi
 
-echo "Commit message prefix is valid."
+echo "Each commit message prefix is valid."

--- a/zuul.d/edpm.yaml
+++ b/zuul.d/edpm.yaml
@@ -22,6 +22,7 @@
       - ^CONTRIBUTING.md
       - ^docs/*
       - ^OWNERS*
+      - ^scripts/check-role-prefix.sh
       - roles/.*/molecule/.*
     vars:
       crc_parameters: "--memory 32000 --disk-size 240 --cpus 12"

--- a/zuul.d/edpm_multinode.yaml
+++ b/zuul.d/edpm_multinode.yaml
@@ -323,6 +323,7 @@
       - ^CONTRIBUTING.md
       - ^docs/*
       - ^OWNERS*
+      - ^scripts/check-role-prefix.sh
       - roles/.*/molecule/.*
     vars:
       cifmw_extras:


### PR DESCRIPTION
Now the script can handle a PR containing more than
one commit where each commit might update or not
roles.

Now instead of checking last commit, it checks the whole
commits modified and iterates over them.

Signed-off-by: Enrique Vallespi Gil <evallesp@redhat.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>