### PR TITLE
Add retry logic to ceph node package installation

### DIFF
--- a/hooks/playbooks/setup_cephnodes.yaml
+++ b/hooks/playbooks/setup_cephnodes.yaml
@@ -52,6 +52,10 @@
           - os-net-config
           - openvswitch
         state: present
+      retries: 5
+      delay: 30
+      register: _ceph_pkgs_install
+      until: _ceph_pkgs_install is success
 
     - name: Generate os-net-config YAML
       ansible.builtin.copy:

--- a/hooks/playbooks/setup_cephnodes_ipv6.yaml
+++ b/hooks/playbooks/setup_cephnodes_ipv6.yaml
@@ -52,6 +52,10 @@
           - os-net-config
           - openvswitch
         state: present
+      retries: 5
+      delay: 30
+      register: _ceph_pkgs_install
+      until: _ceph_pkgs_install is success
 
     - name: Generate os-net-config YAML
       ansible.builtin.copy:


### PR DESCRIPTION
The dnf task installing os-net-config and openvswitch on ceph nodes had no retry, causing transient repo failures to fail the entire job. Added retries: 3 with delay: 10 to both setup_cephnodes.yaml and setup_cephnodes_ipv6.yaml, consistent with other dnf tasks in the playbooks.