### PR TITLE
[cifmw_cephadm] Add cifmw_cephadm_auth_allowed_ciphers parameter

### DIFF
--- a/roles/cifmw_cephadm/README.md
+++ b/roles/cifmw_cephadm/README.md
@@ -117,6 +117,11 @@ that they do not need to be changed for a typical EDPM deployment.
   releases prior to Tentacle, this option is not required, as both `NFSv3`
   and `NFSv4` are enabled by default.
 
+* `cifmw_cephadm_auth_allowed_ciphers`: (String) When set, runs
+  `ceph mon set auth_allowed_ciphers <value>` during cluster configuration.
+   Example values are `"aes,aes256k"` or `"aes256k"` or `"aes"`.
+   Defaults to `""` (unset, no command is run).
+
 Use the `cifmw_cephadm_pools` list of dictionaries to define pools for
 Nova (vms), Cinder (volumes), Cinder-backups (backups), and Glance (images).
 ```

--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -53,6 +53,7 @@ cifmw_cephadm_internal_tls_enabled: false
 cifmw_cephadm_certs: /etc/pki/tls
 cifmw_cephadm_debug: false
 cifmw_cephadm_min_compat_client: "mimic"
+cifmw_cephadm_auth_allowed_ciphers: ""
 cifmw_cephadm_deployed_ceph: false
 cifmw_cephadm_backend: ''
 cifmw_cephadm_action: disable

--- a/roles/cifmw_cephadm/tasks/cephadm_config_set.yml
+++ b/roles/cifmw_cephadm/tasks/cephadm_config_set.yml
@@ -52,6 +52,16 @@
     {{ cifmw_cephadm_min_compat_client }}
   changed_when: false
 
+- name: Set Ceph auth_allowed_ciphers
+  become: true
+  when:
+    - cifmw_cephadm_auth_allowed_ciphers is defined
+    - cifmw_cephadm_auth_allowed_ciphers | length > 0
+  ansible.builtin.command: |
+    {{ cifmw_cephadm_ceph_cli }} mon set auth_allowed_ciphers \
+    {{ cifmw_cephadm_auth_allowed_ciphers }}
+  changed_when: false
+
 - name: Set container image base in ceph configuration
   become: true
   when:


### PR DESCRIPTION
Add a new optional string parameter cifmw_cephadm_auth_allowed_ciphers to the cifmw_cephadm role. When set, the role runs the fullowing during cluster configuration (cephadm_config_set.yml)

  ceph mon set auth_allowed_ciphers <value>

The parameter defaults to "" and is a no-op when unset, so existing deployments are unaffected. Document the parameter and its use cases in the role README.

Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Jira: [OSPRH-29668](https://redhat.atlassian.net/browse/OSPRH-29668)