### PR TITLE
Wait for stable cluster after openshift_setup configuration changes

### DIFF
--- a/roles/cifmw_setup/tasks/infra.yml
+++ b/roles/cifmw_setup/tasks/infra.yml
@@ -46,6 +46,15 @@
   ansible.builtin.import_role:
     name: openshift_setup
 
+- name: Wait for cluster to stabilize after openshift_setup changes
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  ansible.builtin.command:
+    cmd: >-
+      oc adm wait-for-stable-cluster --minimum-stable-period=5s --timeout=30m
+  changed_when: false
+
 - name: Deploy Observability operator.
   when:
     - cifmw_deploy_obs is defined


### PR DESCRIPTION
The openshift_setup role modifies cluster-wide resources (Image/cluster additionalTrustedCA, registrySources, ImageContentSourcePolicy, Network operator config) that trigger rolling updates of the API server and other control plane components. Without waiting for these rollouts to complete, subsequent tasks (e.g. kustomize_deploy) fail with 401 Unauthorized because the API server pods are being recycled.