### PR TITLE
[reproducer] Wait for controller-0 SSH before configuring

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -29,6 +29,11 @@
         default('zuul')
       }}
   block:
+    - name: Wait for controller-0 SSH to be ready
+      ansible.builtin.wait_for_connection:
+        timeout: 300
+        sleep: 5
+
     - name: Ensure directories exist
       ansible.builtin.file:
         path: "{{ cifmw_reproducer_controller_basedir }}/{{ item }}"


### PR DESCRIPTION
After controller-0 reboots, SSH may become transiently unreachable while background system initialization completes. The configure_controller block delegates tasks to controller-0 without verifying connectivity first, causing intermittent UNREACHABLE failures on the install_ca task.

Add wait_for_connection at the start of the delegate_to block to ensure controller-0 is fully accessible before proceeding.