### PR TITLE
[ci_gen_kustomize_values] fix: Preserve nodes config from architectur…

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/nfv-ovs-dpdk-sriov-hci/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/nfv-ovs-dpdk-sriov-hci/edpm-nodeset-values/values.yaml.j2
@@ -32,8 +32,9 @@ data:
     nodes:
 {% for instance in instances_names                                                     %}
 {%   set node_name = 'edpm-' + instance                                               %}
+{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance}) %}
       {{ node_name }}:
-{{ _original_nodes[node_name] | default({'hostName': instance}) | to_nice_yaml(indent=2) | indent(8, first=true) }}
+{{ node_config | to_nice_yaml(indent=2) | indent(8, first=true) }}
 {% endfor                                                                              %}
 
 {% if ('repo-setup' not in (_original_nodeset['services'] | default([]))) and

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-2nodesets/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-2nodesets/edpm-nodeset-values/values.yaml.j2
@@ -44,8 +44,10 @@ data:
 {% endif                                                                               %}
     nodes:
 {% for instance in instances_names                                                     %}
-      edpm-{{ instance }}:
-        hostName: {{ instance }}
+{%   set node_name = 'edpm-' + instance                                               %}
+{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance}) %}
+      {{ node_name }}:
+{{ node_config | to_nice_yaml(indent=2) | indent(8, first=true) }}
 {% endfor                                                                              %}
 
 {% if ('repo-setup' not in (_original_nodeset['services'] | default([]))) and

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-2nodesets/edpm-nodeset2-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-2nodesets/edpm-nodeset2-values/values.yaml.j2
@@ -44,8 +44,10 @@ data:
 {% endif                                                                               %}
     nodes:
 {% for instance in instances_names                                                     %}
-      edpm-{{ instance }}:
-        hostName: {{ instance }}
+{%   set node_name = 'edpm-' + instance                                               %}
+{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance}) %}
+      {{ node_name }}:
+{{ node_config | to_nice_yaml(indent=2) | indent(8, first=true) }}
 {% endfor                                                                              %}
 
 {% if ('repo-setup' not in (_original_nodeset['services'] | default([]))) and

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-ipv6-2nodesets/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-ipv6-2nodesets/edpm-nodeset-values/values.yaml.j2
@@ -44,8 +44,10 @@ data:
 {% endif                                                                               %}
     nodes:
 {% for instance in instances_names                                                     %}
-      edpm-{{ instance }}:
-        hostName: {{ instance }}
+{%   set node_name = 'edpm-' + instance                                               %}
+{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance}) %}
+      {{ node_name }}:
+{{ node_config | to_nice_yaml(indent=2) | indent(8, first=true) }}
 {% endfor                                                                              %}
 
 {% if ('repo-setup' not in (_original_nodeset['services'] | default([]))) and

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-ipv6-2nodesets/edpm-nodeset2-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-ipv6-2nodesets/edpm-nodeset2-values/values.yaml.j2
@@ -44,8 +44,10 @@ data:
 {% endif                                                                               %}
     nodes:
 {% for instance in instances_names                                                     %}
-      edpm-{{ instance }}:
-        hostName: {{ instance }}
+{%   set node_name = 'edpm-' + instance                                               %}
+{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance}) %}
+      {{ node_name }}:
+{{ node_config | to_nice_yaml(indent=2) | indent(8, first=true) }}
 {% endfor                                                                              %}
 
 {% if ('repo-setup' not in (_original_nodeset['services'] | default([]))) and

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-ipv6/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-ipv6/edpm-nodeset-values/values.yaml.j2
@@ -31,8 +31,10 @@ data:
 {% endif                                                                               %}
     nodes:
 {% for instance in instances_names                                                     %}
-      edpm-{{ instance }}:
-        hostName: {{ instance }}
+{%   set node_name = 'edpm-' + instance                                               %}
+{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance}) %}
+      {{ node_name }}:
+{{ node_config | to_nice_yaml(indent=2) | indent(8, first=true) }}
 {% endfor                                                                              %}
 
 {% if ('repo-setup' not in (_original_nodeset['services'] | default([]))) and

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-networker/edpm-common-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-networker/edpm-common-nodeset-values/values.yaml.j2
@@ -45,8 +45,10 @@ data:
 {% endif                                                                               %}
     nodes:
 {% for instance in instance_names                                                      %}
-      edpm-{{ instance }}:
-        hostName: {{ instance }}
+{%   set node_name = 'edpm-' + instance                                               %}
+{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance}) %}
+      {{ node_name }}:
+{{ node_config | to_nice_yaml(indent=2) | indent(8, first=true) }}
 {% endfor                                                                              %}
 
 {% if ('repo-setup' not in (_original_nodeset['services'] | default([]))) and

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/edpm-nodeset-values/values.yaml.j2
@@ -31,8 +31,10 @@ data:
 {% endif                                                                               %}
     nodes:
 {% for instance in instances_names                                                     %}
-      edpm-{{ instance }}:
-        hostName: {{ instance }}
+{%   set node_name = 'edpm-' + instance                                               %}
+{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance}) %}
+      {{ node_name }}:
+{{ node_config | to_nice_yaml(indent=2) | indent(8, first=true) }}
 {% endfor                                                                              %}
 
 {% if ('repo-setup' not in (_original_nodeset['services'] | default([]))) and

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk/edpm-nodeset-values/values.yaml.j2
@@ -31,8 +31,10 @@ data:
 {% endif                                                                               %}
     nodes:
 {% for instance in instances_names                                                     %}
-      edpm-{{ instance }}:
-        hostName: {{ instance }}
+{%   set node_name = 'edpm-' + instance                                               %}
+{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance}) %}
+      {{ node_name }}:
+{{ node_config | to_nice_yaml(indent=2) | indent(8, first=true) }}
 {% endfor                                                                              %}
 {% if ('repo-setup' not in (_original_nodeset['services'] | default([]))) and
       ('repo-setup' in ci_gen_kustomize_edpm_nodeset_predeployed_services)             %}

--- a/roles/ci_gen_kustomize_values/templates/sriov/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/sriov/edpm-nodeset-values/values.yaml.j2
@@ -31,8 +31,10 @@ data:
 {% endif                                                                               %}
     nodes:
 {% for instance in instances_names                                                     %}
-      edpm-{{ instance }}:
-        hostName: {{ instance }}
+{%   set node_name = 'edpm-' + instance                                               %}
+{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance}) %}
+      {{ node_name }}:
+{{ node_config | to_nice_yaml(indent=2) | indent(8, first=true) }}
 {% endfor                                                                              %}
 {% if ('repo-setup' not in (_original_nodeset['services'] | default([]))) and
       ('repo-setup' in ci_gen_kustomize_edpm_nodeset_predeployed_services)             %}


### PR DESCRIPTION
Extend the fix from https://github.com/openstack-k8s-operators/ci-framework/commit/fffa7217ddd483f835127ba0c83e5c0271db7b9f (HCI template) to all remaining NFV
templates. Preserve the complete node configuration (ansibleHost,
networks, fixedIP) from the architecture repository instead of
overwriting it with just hostName.

Affected templates: ovs-dpdk, ovs-dpdk-sriov, ovs-dpdk-sriov-ipv6,
sriov, ovs-dpdk-sriov-2nodesets, ovs-dpdk-sriov-ipv6-2nodesets,
and ovs-dpdk-sriov-networker.

Signed-off-by: Miguel Angel Nieto Jimenez <mnietoji@redhat.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>