### PR TITLE
Increase SSH ControlPersist to survive long cleanup phases

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -20,4 +20,4 @@ pipelining = True
 any_errors_fatal = True
 jinja2_native = True
 [ssh_connection]
-ssh_args = -o ControlMaster=auto -o ControlPersist=300
+ssh_args = -o ControlMaster=auto -o ControlPersist=900 -o ServerAliveInterval=30


### PR DESCRIPTION
The SSH control socket was expiring during the OpenStack cleanup phase (~9 min) because ControlPersist was set to 300s (5 min). This caused UNREACHABLE errors when the post-cleanup reproducer tried to reconnect to the hypervisor for Python interpreter discovery in configure_controller.yml (install_ca role).

Increase ControlPersist to 900s (15 min) and add ServerAliveInterval to keep connections alive during long delegate_to blocks.