### PR TITLE
[reproducer] Use include_role for install_ca in delegated block

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -54,7 +54,7 @@
         loop_var: 'config'
 
     - name: Install custom CA if needed
-      ansible.builtin.import_role:
+      ansible.builtin.include_role:
         name: install_ca
 
     - name: RHEL repository setup for ansible-controller


### PR DESCRIPTION
When import_role is used inside a delegate_to block, Ansible triggers Python interpreter discovery on the original host (hypervisor) rather than the delegate target (controller-0). If the SSH connection to the hypervisor is unavailable at that point, the task fails with UNREACHABLE.

Switch to include_role which loads tasks dynamically within the delegated execution context, avoiding the interpreter discovery on the original host.