### PR TITLE
Add parent_group support for mixed VM type layouts

### DIFF
--- a/roles/libvirt_manager/defaults/main.yml
+++ b/roles/libvirt_manager/defaults/main.yml
@@ -32,6 +32,9 @@ cifmw_libvirt_manager_configuration:
   networks:
     - default
   vms:
+    # VM types support an optional `parent_group` key (string). When set, a parent
+    # group inventory file is generated listing this type's group as a child, so
+    # that Ansible groups['<parent_group>'] includes all members across child types.
     compute:
       start: true
       manage: true

--- a/roles/libvirt_manager/tasks/add_vm_to_inventory.yml
+++ b/roles/libvirt_manager/tasks/add_vm_to_inventory.yml
@@ -2,7 +2,10 @@
 - name: Add host to runtime inventory
   ansible.builtin.add_host:
     name: "{{ _full_host_name }}"
-    groups: "{{ _group }}s"
+    groups: >-
+      {{
+        [_group ~ 's'] + ([_parent_group] if _parent_group | default('') else [])
+      }}
     ansible_ssh_user: "{{ _ssh_user }}"
     ansible_host: "{{ _add_ansible_host | ternary(_ansible_host, omit) }}"
     vm_type: "{{ _group }}"

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -100,6 +100,33 @@
   loop_control:
     label: "{{ item }}"
 
+- name: Create parent group inventories
+  vars:
+    _child_types: >-
+      {{
+        _cifmw_libvirt_manager_layout.vms |
+        dict2items |
+        selectattr('value.parent_group', 'defined') |
+        selectattr('value.parent_group', 'equalto', item) |
+        map(attribute='key') |
+        list
+      }}
+  ansible.builtin.template:
+    dest: "{{ cifmw_libvirt_manager_basedir }}/reproducer-inventory/{{ item }}-group.yml"
+    src: parent_group_inventory.yml.j2
+    mode: "0644"
+  loop: >-
+    {{
+      _cifmw_libvirt_manager_layout.vms |
+      dict2items |
+      selectattr('value.parent_group', 'defined') |
+      map(attribute='value.parent_group') |
+      unique |
+      list
+    }}
+  loop_control:
+    label: "{{ item }}"
+
 - name: Create "all" group inventory file
   ansible.builtin.include_tasks: create_all_group_inventory.yml
 

--- a/roles/libvirt_manager/tasks/generate_networking_data.yml
+++ b/roles/libvirt_manager/tasks/generate_networking_data.yml
@@ -95,6 +95,10 @@
          cifmw_baremetal_hosts[item.key] is defined) |
         ternary('baremetal', _std_group)
       }}
+    _parent_group: >-
+      {{
+        _cifmw_libvirt_manager_layout.vms[_vm_type].parent_group | default('')
+      }}
     _ocp_name: >-
       {{
         item.key | replace('_', '-') |

--- a/roles/libvirt_manager/templates/parent_group_inventory.yml.j2
+++ b/roles/libvirt_manager/templates/parent_group_inventory.yml.j2
@@ -1,0 +1,5 @@
+{{ item }}:
+  children:
+{% for child_type in _child_types %}
+    {{ child_type }}s: {}
+{% endfor %}


### PR DESCRIPTION
Allow VM types to declare a parent_group key. Hosts are added to the parent group at add_host time so that groups like 'computes' are populated before dependent roles check group membership. A parent group inventory file is also written to reproducer-inventory/ for subsequent playbook runs.