### PR TITLE
[pcp_metrics] Make target hosts configurable via cifmw_pcp_metrics_hosts

### DIFF
--- a/hooks/playbooks/pcp-metrics-post.yml
+++ b/hooks/playbooks/pcp-metrics-post.yml
@@ -7,7 +7,7 @@
 # The best place to call this hook is under post_tests actions.
 #
 - name: Collect performance metrics
-  hosts: all,!localhost
+  hosts: "{{ cifmw_pcp_metrics_hosts }}"
   gather_facts: false
   tasks:
     - name: Gather metrics

--- a/hooks/playbooks/pcp-metrics-pre.yml
+++ b/hooks/playbooks/pcp-metrics-pre.yml
@@ -24,7 +24,7 @@
         tasks_from: repo
 
 - name: Start collecting performance metrics
-  hosts: all,!localhost
+  hosts: "{{ cifmw_pcp_metrics_hosts }}"
   gather_facts: false
   tasks:
     - name: Setup PCP

--- a/roles/pcp_metrics/defaults/main.yaml
+++ b/roles/pcp_metrics/defaults/main.yaml
@@ -4,6 +4,9 @@ pcp_metrics_setup: false
 pcp_metrics_gather: false
 pcp_metrics_plot: false
 
+# Host pattern for PCP hook playbooks (setup and gather)
+cifmw_pcp_metrics_hosts: "all,!localhost"
+
 # Setup-related variables
 pcp_metrics_packages:
   - pcp  # for pmlogger


### PR DESCRIPTION
PCP hook playbooks hardcode hosts: all,!localhost, which causes
ansible-playbook to exit rc=2 when compute nodes are unreachable
(e.g. not yet provisioned or already torn down). This kills the
CI job for a metrics side-effect.

Introduce cifmw_pcp_metrics_hosts (default: all,!localhost) so that
downstream jobs can exclude host groups that are expected to be
unavailable. By not targeting those hosts at all, Ansible never
encounters UNREACHABLE errors and exits cleanly.
