### PR TITLE
[libvirt_manager] Add parent_group key for libvirt layouts

### DIFF
--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -100,6 +100,7 @@ cifmw_libvirt_manager_configuration:
       networkconfig: (dict or list[dict], [network-config](https://cloudinit.readthedocs.io/en/latest/reference/network-config-format-v2.html#network-config-v2) v2 config, needed if a static ip address should be defined at boot time in absence of a dhcp server in special scenarios. Optional)
       devices: (dict, optional, defaults to {}. The keys are the VMs of that type that needs devices to be attached, and the values are lists of strings, where each string must contain a valid <hostdev/> libvirt XML element that will be passed to virsh attach-device)
       dhcp_options: (list, optional, defaults to []. List of DHCP options to apply to all VMs of this type. Format: ["option_number,value", ...])
+      parent_ansible_group: (string, optional. The full Ansible inventory group name to use as a parent for this VM type's group. Multiple VM types sharing the same parent_ansible_group are addressable both individually and via the parent group. The value must be the complete group name including any suffix (e.g. "computes", not "compute"). Example: two types "compute1" and "compute2" with parent_ansible_group "computes" creates groups "compute1s", "compute2s", and "computes" containing both. The parent group should be considered abstract and must not match any VM type's own group name. The role will fail if a collision is detected.)
   networks:
     net_name: <XML definition of the network to create>
 ```

--- a/roles/libvirt_manager/molecule/parent_group/cleanup.yml
+++ b/roles/libvirt_manager/molecule/parent_group/cleanup.yml
@@ -1,0 +1,9 @@
+---
+- name: Cleanup
+  hosts: instance
+  tasks:
+    - name: Remove basedir
+      become: true
+      ansible.builtin.file:
+        path: "/opt/basedir"
+        state: absent

--- a/roles/libvirt_manager/molecule/parent_group/converge.yml
+++ b/roles/libvirt_manager/molecule/parent_group/converge.yml
@@ -1,0 +1,144 @@
+---
+- name: Parent group inventory test
+  hosts: instance
+  gather_facts: true
+  vars:
+    cifmw_basedir: "/opt/basedir"
+    _cifmw_libvirt_manager_layout:
+      vms:
+        compute1:
+          parent_ansible_group: computes
+          amount: 1
+          disk_file_name: "blank"
+          disksize: 5
+          memory: 1
+          cpus: 1
+          nets: []
+        compute2:
+          parent_ansible_group: computes
+          amount: 1
+          disk_file_name: "blank"
+          disksize: 5
+          memory: 1
+          cpus: 1
+          nets: []
+        controller:
+          amount: 1
+          disk_file_name: "blank"
+          disksize: 5
+          memory: 1
+          cpus: 1
+          nets: []
+  tasks:
+    - name: Create reproducer-inventory directory
+      become: true
+      ansible.builtin.file:
+        path: "{{ cifmw_basedir }}/reproducer-inventory"
+        state: directory
+        owner: "{{ ansible_user_id }}"
+        group: "{{ ansible_user_id }}"
+        mode: "0755"
+
+    - name: Set all_vms fact
+      ansible.builtin.set_fact:
+        cifmw_libvirt_manager_all_vms:
+          compute1-0: compute1
+          compute2-0: compute2
+          controller-0: controller
+
+    - name: Add VMs to inventory
+      vars:
+        _full_host_name: "{{ item.key }}"
+        _group: "{{ item.value }}"
+        _parent_group: >-
+          {{
+            _cifmw_libvirt_manager_layout.vms[item.value].parent_ansible_group |
+            default('')
+          }}
+        _ssh_user: "zuul"
+        _add_ansible_host: false
+        _ansible_host: ""
+        _ini_line: "{{ item.key }} ansible_user=zuul vm_type={{ item.value }}"
+      ansible.builtin.include_role:
+        name: libvirt_manager
+        tasks_from: add_vm_to_inventory.yml
+      loop: "{{ cifmw_libvirt_manager_all_vms | dict2items }}"
+
+    - name: Create all group inventory
+      ansible.builtin.include_role:
+        name: libvirt_manager
+        tasks_from: create_all_group_inventory.yml
+
+    # --- Assertions ---
+
+    - name: Assert runtime inventory has child and parent groups
+      ansible.builtin.assert:
+        that:
+          - "'compute1-0' in groups['compute1s']"
+          - "'compute2-0' in groups['compute2s']"
+          - "'compute1-0' in groups['computes']"
+          - "'compute2-0' in groups['computes']"
+          - "'controller-0' in groups['controllers']"
+          - "'controller-0' not in groups.get('computes', [])"
+
+    - name: Slurp all-group.yml
+      ansible.builtin.slurp:
+        path: "{{ cifmw_basedir }}/reproducer-inventory/all-group.yml"
+      register: _all_group_content
+
+    - name: Assert all-group.yml has parent and child groups
+      vars:
+        _ag: "{{ _all_group_content.content | b64decode | from_yaml }}"
+      ansible.builtin.assert:
+        that:
+          - "'compute1s' in _ag.all.children"
+          - "'compute2s' in _ag.all.children"
+          - "'controllers' in _ag.all.children"
+          - "'computes' in _ag.all.children"
+          - "'compute1s' in _ag.all.children.computes.children"
+          - "'compute2s' in _ag.all.children.computes.children"
+          - "'controllers' not in _ag.all.children.computes.children"
+
+- name: Parent group collision validation test
+  hosts: instance
+  gather_facts: false
+  vars:
+    _cifmw_libvirt_manager_layout:
+      vms:
+        compute:
+          parent_ansible_group: computes
+          amount: 1
+          disk_file_name: "blank"
+          disksize: 5
+          memory: 1
+          cpus: 1
+          nets: []
+        computes:
+          parent_ansible_group: bigcomputes
+          amount: 1
+          disk_file_name: "blank"
+          disksize: 5
+          memory: 1
+          cpus: 1
+          nets: []
+  tasks:
+    - name: Verify collision detection rejects overlapping names
+      block:
+        - name: Run deploy_layout validation with colliding layout
+          ansible.builtin.include_role:
+            name: libvirt_manager
+            tasks_from: deploy_layout.yml
+
+        - name: Fail if validation did not catch collision
+          ansible.builtin.fail:
+            msg: >-
+              deploy_layout.yml should have failed due to
+              'computes' colliding with compute's parent_ansible_group
+
+      rescue:
+        - name: Assert failure message mentions collision
+          ansible.builtin.assert:
+            that:
+              - >-
+                ansible_failed_result.msg is defined and
+                'Collisions' in ansible_failed_result.msg

--- a/roles/libvirt_manager/molecule/parent_group/molecule.yml
+++ b/roles/libvirt_manager/molecule/parent_group/molecule.yml
@@ -1,0 +1,6 @@
+---
+log: true
+
+provisioner:
+  name: ansible
+  log: true

--- a/roles/libvirt_manager/molecule/parent_group/prepare.yml
+++ b/roles/libvirt_manager/molecule/parent_group/prepare.yml
@@ -1,0 +1,12 @@
+---
+- name: Prepare
+  hosts: instance
+  tasks:
+    - name: Create basedir
+      become: true
+      ansible.builtin.file:
+        path: "/opt/basedir"
+        state: directory
+        owner: "{{ ansible_user_id }}"
+        group: "{{ ansible_user_id }}"
+        mode: "0755"

--- a/roles/libvirt_manager/tasks/add_vm_to_inventory.yml
+++ b/roles/libvirt_manager/tasks/add_vm_to_inventory.yml
@@ -1,24 +1,51 @@
 ---
-- name: Add host to runtime inventory
-  ansible.builtin.add_host:
-    name: "{{ _full_host_name }}"
-    groups: "{{ _group }}s"
-    ansible_ssh_user: "{{ _ssh_user }}"
-    ansible_host: "{{ _add_ansible_host | ternary(_ansible_host, omit) }}"
-    vm_type: "{{ _group }}"
+- name: Build group list for host
+  vars:
+    _has_parent: "{{ _parent_group | default('') | length > 0 }}"
+    _groups_list: >-
+      {{
+        [_group ~ 's'] +
+        (_has_parent | ternary([_parent_group], []))
+      }}
+  block:
+    - name: Add host to runtime inventory
+      ansible.builtin.add_host:
+        name: "{{ _full_host_name }}"
+        groups: "{{ _groups_list }}"
+        ansible_ssh_user: "{{ _ssh_user }}"
+        ansible_host: "{{ _add_ansible_host | ternary(_ansible_host, omit) }}"
+        vm_type: "{{ _group }}"
 
-- name: Ensure group section exists
-  ansible.builtin.lineinfile:
-    path: "{{ cifmw_libvirt_manager_tmp_inv_file }}"
-    create: true
-    line: "[{{ _group }}s]"
-    regexp: "^\\[{{ _group }}s\\]$"
-    state: present
-    mode: "0644"
+    - name: Ensure group section exists in INI inventory
+      ansible.builtin.lineinfile:
+        path: "{{ cifmw_libvirt_manager_tmp_inv_file }}"
+        create: true
+        line: "[{{ _group }}s]"
+        regexp: "^\\[{{ _group }}s\\]$"
+        state: present
+        mode: "0644"
 
-- name: Append host under proper group
-  ansible.builtin.lineinfile:
-    path: "{{ cifmw_libvirt_manager_tmp_inv_file }}"
-    insertafter: "^\\[{{ _group }}s\\]$"
-    line: "{{ _ini_line }}"
-    regexp: "^{{ _full_host_name | regex_escape() }} "
+    - name: Append host under its group in INI inventory
+      ansible.builtin.lineinfile:
+        path: "{{ cifmw_libvirt_manager_tmp_inv_file }}"
+        insertafter: "^\\[{{ _group }}s\\]$"
+        line: "{{ _ini_line }}"
+        regexp: "^{{ _full_host_name | regex_escape() }} "
+
+    - name: Ensure parent group children section exists in INI inventory
+      when: _has_parent
+      ansible.builtin.lineinfile:
+        path: "{{ cifmw_libvirt_manager_tmp_inv_file }}"
+        create: true
+        line: "[{{ _parent_group }}:children]"
+        regexp: "^\\[{{ _parent_group }}:children\\]$"
+        state: present
+        mode: "0644"
+
+    - name: Add child group to parent in INI inventory
+      when: _has_parent
+      ansible.builtin.lineinfile:
+        path: "{{ cifmw_libvirt_manager_tmp_inv_file }}"
+        insertafter: "^\\[{{ _parent_group }}:children\\]$"
+        line: "{{ _group }}s"
+        regexp: "^{{ _group }}s$"

--- a/roles/libvirt_manager/tasks/add_vm_to_inventory.yml
+++ b/roles/libvirt_manager/tasks/add_vm_to_inventory.yml
@@ -2,7 +2,7 @@
 - name: Add host to runtime inventory
   ansible.builtin.add_host:
     name: "{{ _full_host_name }}"
-    groups: "{{ _group }}s"
+    groups: "{{ _inventory_groups }}"
     ansible_ssh_user: "{{ _ssh_user }}"
     ansible_host: "{{ _add_ansible_host | ternary(_ansible_host, omit) }}"
     vm_type: "{{ _group }}"
@@ -11,14 +11,20 @@
   ansible.builtin.lineinfile:
     path: "{{ cifmw_libvirt_manager_tmp_inv_file }}"
     create: true
-    line: "[{{ _group }}s]"
-    regexp: "^\\[{{ _group }}s\\]$"
+    line: "[{{ _inv_group }}]"
+    regexp: "^\\[{{ _inv_group }}\\]$"
     state: present
     mode: "0644"
+  loop: "{{ _inventory_groups }}"
+  loop_control:
+    loop_var: _inv_group
 
 - name: Append host under proper group
   ansible.builtin.lineinfile:
     path: "{{ cifmw_libvirt_manager_tmp_inv_file }}"
-    insertafter: "^\\[{{ _group }}s\\]$"
+    insertafter: "^\\[{{ _inv_group }}\\]$"
     line: "{{ _ini_line }}"
     regexp: "^{{ _full_host_name | regex_escape() }} "
+  loop: "{{ _inventory_groups }}"
+  loop_control:
+    loop_var: _inv_group

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -4,6 +4,34 @@
     - _cifmw_libvirt_manager_layout is not defined
   ansible.builtin.include_tasks: generate_layout.yml
 
+- name: Validate no VM group name collides with a parent_ansible_group
+  vars:
+    _vm_group_names: >-
+      {% set _names = [] -%}
+      {% for _k in _cifmw_libvirt_manager_layout.vms.keys() -%}
+      {%   set _ = _names.append(((_k == 'crc') | ternary('ocp', _k)) ~ 's') -%}
+      {% endfor -%}
+      {{ _names }}
+    _reserved_groups:
+      - hypervisors
+      - localhosts
+    _parent_groups: >-
+      {{
+        _cifmw_libvirt_manager_layout.vms.values() |
+        selectattr('parent_ansible_group', 'defined') |
+        map(attribute='parent_ansible_group') |
+        unique | list
+      }}
+    _disallowed_groups: "{{ _vm_group_names + _reserved_groups }}"
+    _collisions: "{{ _disallowed_groups | intersect(_parent_groups) }}"
+  when: _collisions | length > 0
+  ansible.builtin.fail:
+    msg: >-
+      A VM type's own inventory group cannot match a parent_ansible_group value.
+      Collisions: {{ _collisions | join(', ') }}.
+      Set parent_ansible_group to an abstract name not used by any VM type
+      (e.g. computes, not compute1s).
+
 # TODO(hjensas): We should have a dedicated role for firewall
 - name: Enable forwarding in the libvirt zone
   when: cifmw_libvirt_manager_firewalld_zone_libvirt_forward | default(true) | bool

--- a/roles/libvirt_manager/tasks/generate_networking_data.yml
+++ b/roles/libvirt_manager/tasks/generate_networking_data.yml
@@ -95,6 +95,13 @@
          cifmw_baremetal_hosts[item.key] is defined) |
         ternary('baremetal', _std_group)
       }}
+    _subtype_group: "{{ _group }}s"
+    _parent_group: "{{ _cifmw_libvirt_manager_layout.vms[_vm_type].parent_group | default('') }}"
+    _inventory_groups: >-
+      {{
+        [_subtype_group] +
+        ([_parent_group] if _parent_group | length > 0 else [])
+      }}
     _ocp_name: >-
       {{
         item.key | replace('_', '-') |
@@ -198,7 +205,6 @@
         selectattr('name', 'match', _match) | first
       }}
     _dataset: |
-      {% set ns = namespace(ip_start=30) %}
       networks:
         {{ _lnet_data.name | replace('cifmw_', '') }}:
       {% if _lnet_data.ranges[0].start_v4 is defined and _lnet_data.ranges[0].start_v4                                  %}
@@ -210,28 +216,43 @@
           network-v6: '{{ net_6 }}'
       {% endif %}
       group-templates:
+      {% set ns = namespace(ip_start=30, rendered=[]) %}
       {% for group in _cifmw_libvirt_manager_layout.vms.keys() if group != 'controller' and
           ((_cifmw_libvirt_manager_layout.vms[group].amount is defined and
             (_cifmw_libvirt_manager_layout.vms[group].amount | int) > 0) or
           _cifmw_libvirt_manager_layout.vms[group].amount is undefined) %}
-      {% set _gr = (group == 'crc') | ternary('ocp', group)                                                             %}
-      {%   if _lnet_data.name | replace('cifmw_', '') in _cifmw_libvirt_manager_layout.vms[group].nets                  %}
-        {{ _gr }}s:
+      {% set _gr = (group == 'crc') | ternary('ocp', group)                                                            %}
+      {% set _effective_group = _cifmw_libvirt_manager_layout.vms[group].parent_group | default(_gr ~ 's')             %}
+      {% set _group_networks = _cifmw_libvirt_manager_layout.vms[group].nets | default([])                             %}
+      {% if _effective_group not in ns.rendered and _lnet_data.name | replace('cifmw_', '') in _group_networks         %}
+      {%   set _shared_length = namespace(total=0) %}
+      {%   for _candidate in _cifmw_libvirt_manager_layout.vms | dict2items
+             if _candidate.key != 'controller' and
+                ((_candidate.value.amount is defined and (_candidate.value.amount | int) > 0) or
+                 _candidate.value.amount is undefined) %}
+      {%     set _candidate_group = _candidate.value.parent_group | default((((_candidate.key == 'crc') | ternary('ocp', _candidate.key)) ~ 's')) %}
+      {%     if _candidate_group == _effective_group and
+                (_lnet_data.name | replace('cifmw_', '') in (_candidate.value.nets | default([]))) %}
+      {%       set _shared_length.total = _shared_length.total + (_candidate.value.amount | default(1) | int) %}
+      {%     endif %}
+      {%   endfor %}
+        {{ _effective_group }}:
           networks:
             {{ _lnet_data.name | replace('cifmw_', '') }}:
-      {%     if cifmw_networking_definition['group-templates'][_gr ~ 's']['network-template'] is undefined %}
+      {%     if cifmw_networking_definition['group-templates'][_effective_group]['network-template'] is undefined %}
       {%       if net_4 is defined %}
               range-v4:
                 start: '{{  net_4 | ansible.utils.nthhost(ns.ip_start | int ) }}'
-                length: {{ _cifmw_libvirt_manager_layout.vms[group].amount | default(1) }}
+                length: {{ _shared_length.total }}
       {%       endif %}
       {%       if net_6 is defined %}
               range-v6:
                 start: '{{  net_6 | ansible.utils.nthhost(ns.ip_start | int) }}'
-                length: {{ _cifmw_libvirt_manager_layout.vms[group].amount | default(1) }}
+                length: {{ _shared_length.total }}
       {%       endif %}
-      {%   set ns.ip_start = ns.ip_start|int + (_cifmw_libvirt_manager_layout.vms[group].amount | default(1) | int ) + 1 %}
+      {%       set ns.ip_start = ns.ip_start|int + (_shared_length.total | int ) + 1 %}
       {%     endif %}
+      {%     set _ = ns.rendered.append(_effective_group) %}
       {%   endif %}
       {% endfor %}
       {% if cifmw_baremetal_hosts is defined and cifmw_baremetal_hosts | length > 0 %}

--- a/roles/libvirt_manager/tasks/generate_networking_data.yml
+++ b/roles/libvirt_manager/tasks/generate_networking_data.yml
@@ -112,6 +112,11 @@
         default(_cifmw_libvirt_manager_layout.vms[_vm_type].user) |
         default('zuul')
       }}
+    _parent_group: >-
+      {{
+        _cifmw_libvirt_manager_layout.vms[_vm_type].parent_ansible_group |
+        default('')
+      }}
     _add_ansible_host: >-
       {{
         _cifmw_libvirt_manager_layout.vms[_vm_type].manage | default(true) and

--- a/roles/libvirt_manager/templates/all-inventory.yml.j2
+++ b/roles/libvirt_manager/templates/all-inventory.yml.j2
@@ -1,9 +1,18 @@
+{% set ns = namespace(parent_groups=[]) %}
+{% for vm_name, vm_data in _cifmw_libvirt_manager_layout.vms.items()
+     if vm_data.manage | default(true) and
+        vm_data.amount | default(1) | int > 0 %}
+{%   if vm_data.parent_group is defined and vm_data.parent_group not in ns.parent_groups %}
+{%     set _ = ns.parent_groups.append(vm_data.parent_group) %}
+{%   endif %}
+{% endfor %}
 all:
   children:
 {% for vm in _cifmw_libvirt_manager_layout.vms.keys() if
     (_cifmw_libvirt_manager_layout.vms[vm].manage | default(true) and
      _cifmw_libvirt_manager_layout.vms[vm].amount | default(1) | int > 0) %}
-    {{ (vm == 'crc') | ternary('ocp', vm) }}s:
+{% set _group = ((vm == 'crc') | ternary('ocp', vm)) ~ 's' %}
+    {{ _group }}:
       vars:
 {% if _cifmw_libvirt_manager_layout.vms[vm].target is defined %}
 {% set _target = _cifmw_libvirt_manager_layout.vms[vm].target %}
@@ -19,6 +28,16 @@ virtual machines.
         ansible_ssh_private_key_file: "~/.ssh/ssh_{{ _hostname }}"
         ansible_ssh_common_args: "-o StrictHostKeyChecking=no -J {{ ansible_user | default(ansible_user_id) }}@{{ _hostname }}"
 {% endif %}
+{% endfor %}
+{% for parent in ns.parent_groups %}
+    {{ parent }}:
+      children:
+{%   for child_name, child_data in _cifmw_libvirt_manager_layout.vms.items()
+       if child_data.manage | default(true) and
+          child_data.amount | default(1) | int > 0 and
+          child_data.parent_group | default('') == parent %}
+        {{ ((child_name == 'crc') | ternary('ocp', child_name)) ~ 's' }}: {}
+{%   endfor %}
 {% endfor %}
 hypervisors:
   hosts:

--- a/roles/libvirt_manager/templates/all-inventory.yml.j2
+++ b/roles/libvirt_manager/templates/all-inventory.yml.j2
@@ -1,5 +1,16 @@
 all:
   children:
+{% set _parent_map = {} -%}
+{% for vm in _cifmw_libvirt_manager_layout.vms.keys() if
+    (_cifmw_libvirt_manager_layout.vms[vm].manage | default(true) and
+     _cifmw_libvirt_manager_layout.vms[vm].amount | default(1) | int > 0 and
+     _cifmw_libvirt_manager_layout.vms[vm].parent_ansible_group is defined) -%}
+{%   set _pg = _cifmw_libvirt_manager_layout.vms[vm].parent_ansible_group -%}
+{%   if _pg not in _parent_map -%}
+{%     set _ = _parent_map.update({_pg: []}) -%}
+{%   endif -%}
+{%   set _ = _parent_map[_pg].append(vm) -%}
+{% endfor -%}
 {% for vm in _cifmw_libvirt_manager_layout.vms.keys() if
     (_cifmw_libvirt_manager_layout.vms[vm].manage | default(true) and
      _cifmw_libvirt_manager_layout.vms[vm].amount | default(1) | int > 0) %}
@@ -19,6 +30,13 @@ virtual machines.
         ansible_ssh_private_key_file: "~/.ssh/ssh_{{ _hostname }}"
         ansible_ssh_common_args: "-o StrictHostKeyChecking=no -J {{ ansible_user | default(ansible_user_id) }}@{{ _hostname }}"
 {% endif %}
+{% endfor %}
+{% for pg, children in _parent_map.items() %}
+    {{ pg }}:
+      children:
+{%   for vm in children %}
+        {{ (vm == 'crc') | ternary('ocp', vm) }}s: {}
+{%   endfor %}
 {% endfor %}
 hypervisors:
   hosts:


### PR DESCRIPTION
Allow VM types to declare a parent_group so that multiple subgroups (e.g. compute1, compute2) are independently addressable while also being reachable via a shared parent inventory group (e.g. computes).