### PR TITLE
[copy_container] Fix zuul api url for the ci to pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ![CIFMW Logo](docs/source/images/logo_cifmw_64.png) CI-Framework
 
 [![CodeQL](https://github.com/openstack-k8s-operators/ci-framework/actions/workflows/codeql.yml/badge.svg)](https://github.com/openstack-k8s-operators/ci-framework/actions/workflows/codeql.yml)
-[![Zuul](https://review.rdoproject.org/zuul/api/badge?project=openstack-k8s-operators/ci-framework&pipeline=github-check&branch=main)](https://review.rdoproject.org/zuul/api/badge?project=openstack-k8s-operators/ci-framework&pipeline=github-check&branch=main)
+[![Zuul](https://gateway-cloud-softwarefactory.apps.ocp.cloud.ci.centos.org/zuul/api/badge?project=openstack-k8s-operators/ci-framework&pipeline=github-check&branch=main)](https://gateway-cloud-softwarefactory.apps.ocp.cloud.ci.centos.org/zuul/api/badge?project=openstack-k8s-operators/ci-framework&pipeline=github-check&branch=main)
 [![Documentation Status](https://readthedocs.org/projects/ci-framework/badge/?version=latest)](https://ci-framework.readthedocs.io/en/latest/?badge=latest)
 
 ## Documentation

--- a/roles/copy_container/files/copy-quay/config.yaml
+++ b/roles/copy_container/files/copy-quay/config.yaml
@@ -1,5 +1,5 @@
 ---
-zuul_api: "https://review.rdoproject.org/zuul/api/"
+zuul_api: "https://gateway-cloud-softwarefactory.apps.ocp.cloud.ci.centos.org/zuul/api/"
 pull_registry: "quay.rdoproject.org"
 push_registry: "{{ cifmw_default_registry }}"
 quay_api_base_url: "https://quay.io/api/v1"

--- a/roles/copy_container/molecule/default/converge.yml
+++ b/roles/copy_container/molecule/default/converge.yml
@@ -30,7 +30,7 @@
       vars:
         _data: |
           ---
-          zuul_api: "https://review.rdoproject.org/zuul/api/"
+          zuul_api: "https://gateway-cloud-softwarefactory.apps.ocp.cloud.ci.centos.org/zuul/api/"
           pull_registry: "quay.rdoproject.org"
           push_registry: "127.0.0.1:5001"
           entries:


### PR DESCRIPTION
This PR fix the zuul api url.

old url: https://review.rdoproject.org/zuul/api
new url: https://gateway-cloud-softwarefactory.apps.ocp.cloud.ci.centos.org/zuul/api

Signed-off-by: Bhagyashri Shewale bshewale@redhat.com