### PR TITLE
[pcp_metrics] Fix broken hosts selection

### DIFF
--- a/hooks/playbooks/pcp-metrics-post.yml
+++ b/hooks/playbooks/pcp-metrics-post.yml
@@ -7,7 +7,7 @@
 # The best place to call this hook is under post_tests actions.
 #
 - name: Collect performance metrics
-  hosts: "{{ cifmw_pcp_metrics_hosts }}"
+  hosts: "{{ cifmw_pcp_metrics_hosts | default('all,!localhost') }}"
   gather_facts: false
   tasks:
     - name: Gather metrics

--- a/hooks/playbooks/pcp-metrics-pre.yml
+++ b/hooks/playbooks/pcp-metrics-pre.yml
@@ -24,7 +24,7 @@
         tasks_from: repo
 
 - name: Start collecting performance metrics
-  hosts: "{{ cifmw_pcp_metrics_hosts }}"
+  hosts: "{{ cifmw_pcp_metrics_hosts | default('all,!localhost') }}"
   gather_facts: false
   tasks:
     - name: Setup PCP

--- a/roles/pcp_metrics/defaults/main.yaml
+++ b/roles/pcp_metrics/defaults/main.yaml
@@ -4,9 +4,6 @@ pcp_metrics_setup: false
 pcp_metrics_gather: false
 pcp_metrics_plot: false
 
-# Host pattern for PCP hook playbooks (setup and gather)
-cifmw_pcp_metrics_hosts: "all,!localhost"
-
 # Setup-related variables
 pcp_metrics_packages:
   - pcp  # for pmlogger


### PR DESCRIPTION
Because `cifmw_pcp_metrics_hosts` was defined in the pcp_metrics role's defaults file, the `pcp-metrics-pre.yml` playbook was trying to use this var before it was imported, leading to `'cifmw_pcp_metrics_hosts' is undefined` errors