### PR TITLE
Adjusts to test eBGP (different ASN values)

### DIFF
--- a/playbooks/bgp/prepare-bgp-spines-leaves.yaml
+++ b/playbooks/bgp/prepare-bgp-spines-leaves.yaml
@@ -544,6 +544,8 @@
           become: true
           vars:
             downlink_interfaces: "{{ downlink_ifs_rack3 if (rack_id | int) == 3 else leaf_downlink_ifs }}"
+            downlink_remote_as: "{{ 'external' if (rack_id | int) in (ebgp_racks | default([]) | map('int') | list) else 'internal' }}"
+            leaf_asn: "{{ ebgp_leaf_asn | default(64999) if (rack_id | int) in (ebgp_racks | default([]) | map('int') | list) else 64999 }}"
             _router_id: ''
           ansible.builtin.template:
             src: templates/leaf-frr.conf.j2
@@ -599,6 +601,8 @@
         - name: Configure FRR
           become: true
           vars:
+            downlink_remote_as: "{{ 'external' if (rack_id | int) in (ebgp_racks | default([]) | map('int') | list) else 'internal' }}"
+            leaf_asn: "{{ ebgp_leaf_asn | default(64999) if (rack_id | int) in (ebgp_racks | default([]) | map('int') | list) else 64999 }}"
             _router_id: "{{ '1.1.1.20' + ansible_hostname.split('-')[-1] }}"
           ansible.builtin.template:
             src: templates/leaf-frr.conf.j2

--- a/playbooks/bgp/templates/leaf-frr.conf.j2
+++ b/playbooks/bgp/templates/leaf-frr.conf.j2
@@ -13,7 +13,8 @@ debug bgp neighbor-events
 debug bgp updates
 debug bgp update-groups
 
-router bgp 64999
+{% set _downlink_as_mode = downlink_remote_as | default('internal') %}
+router bgp {{ leaf_asn | default(64999) }}
 {% if _router_id %}
   bgp router-id {{_router_id}}
 {% endif %}
@@ -27,7 +28,7 @@ router bgp 64999
   ! bgp long-lived-graceful-restart stale-time 15
 
   neighbor downlink peer-group
-  neighbor downlink remote-as internal
+  neighbor downlink remote-as {{ _downlink_as_mode }}
   neighbor downlink bfd
   neighbor downlink bfd profile tripleo
 {# TODO: remove the next if when RHEL-63205 is fixed #}
@@ -53,9 +54,11 @@ router bgp 64999
 
   address-family ipv4 unicast
     redistribute connected
-    neighbor downlink route-reflector-client
     neighbor downlink default-originate
     neighbor downlink next-hop-self
+{% if _downlink_as_mode == 'internal' %}
+    neighbor downlink route-reflector-client
+{% endif %}
     neighbor downlink prefix-list only-host-prefixes out
     neighbor uplink allowas-in origin
     neighbor uplink prefix-list only-default-host-prefixes in
@@ -64,9 +67,11 @@ router bgp 64999
   address-family ipv6 unicast
     redistribute connected
     neighbor downlink activate
-    neighbor downlink route-reflector-client
     neighbor downlink default-originate
     neighbor downlink next-hop-self
+{% if _downlink_as_mode == 'internal' %}
+    neighbor downlink route-reflector-client
+{% endif %}
     neighbor uplink activate
     neighbor uplink allowas-in origin
     neighbor uplink prefix-list only-default-host-prefixes in
@@ -76,7 +81,9 @@ router bgp 64999
     neighbor uplink activate
     neighbor uplink allowas-in origin
     neighbor downlink activate
+{% if _downlink_as_mode == 'internal' %}
     neighbor downlink route-reflector-client
+{% endif %}
   exit-address-family
 
 ip prefix-list only-default-host-prefixes permit 0.0.0.0/0


### PR DESCRIPTION
Allow parameterized ASN (leaf_asn), downlink mode (downlink_remote_as). Conditional route-reflector-client for iBGP only.

Sets downlink_remote_as and leaf_asn according to destined ebgp_racks and ebgp_leaf_asn variables (changes both IPv4 and IPv6 renders).

Related: [OSPRH-28085](https://redhat.atlassian.net/browse/OSPRH-28085)
Assisted-By: Claude Code

(cherry picked from commit 0308fa980c03e9e02c3773bed8f0063009cd8894)