### PR TITLE
[cifmw_setup] Fix deploy-edpm.yml crash on unpreprovisioned baremetal computes

### DIFF
--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -87,21 +87,30 @@
 
 - name: Deploy NFS server on target nodes
   become: true
+  gather_facts: false
   hosts: "{{ groups[cifmw_nfs_target | default('computes')][0] | default([]) }}"
   tasks:
+    - name: End play early for architecture deploys
+      when:
+        - cifmw_architecture_scenario is defined
+      ansible.builtin.meta: end_play
+
+    - name: Gather facts for NFS deployment
+      ansible.builtin.setup:
+
     - name: Run cifmw_nfs role
       vars:
         nftables_path: /etc/nftables
         nftables_conf: /etc/sysconfig/nftables.conf
       when:
         - cifmw_edpm_deploy_nfs | default(false) | bool
-      ansible.builtin.import_role:
+      ansible.builtin.include_role:
         name: cifmw_nfs
 
 - name: Clear ceph target hosts facts to force refreshing in HCI deployments
+  gather_facts: false
   hosts: "{{ cifmw_ceph_target | default('computes')  }}"
   tasks:
-    # end_play will end only current play, not the main edpm-deploy.yml
     - name: Early end if architecture deploy
       when:
         - cifmw_architecture_scenario is defined

--- a/roles/cifmw_setup/tasks/deploy_architecture.yml
+++ b/roles/cifmw_setup/tasks/deploy_architecture.yml
@@ -11,6 +11,10 @@
     - always
   when:
     - "not item.startswith('ocp-')"
+    - >-
+      (item not in groups.get('computes', []) and
+       not item.startswith('compute-')) or
+      (cifmw_edpm_deploy_pre_provisioned | default(true) | bool)
   ansible.builtin.setup:
     gather_subset: network
   delegate_facts: true


### PR DESCRIPTION
The NFS and Ceph plays in deploy-edpm.yml target the computes
group with gather_facts enabled (the default). In architecture
deployments with preProvisioned=false, compute nodes are bare
libvirt domains with no OS until Ironic provisions them during
the kustomize_deploy stages. Ansible's implicit fact gathering
tries to SSH into these unreachable hosts, aborting the entire
playbook before the architecture deployment can run.

Add gather_facts: false to both the NFS and Ceph plays. For the
NFS play, insert an end_play guard when cifmw_architecture_scenario
is defined and move fact gathering after that guard. The Ceph play
already had an end_play guard but Ansible was crashing on fact
gathering before reaching it.

Similarly, the "Fetch network facts" task in deploy_architecture.yml
delegates setup to every host in the inventory, including
unprovisioned computes. Skip computes when
cifmw_edpm_deploy_pre_provisioned is false.

This fixes all architecture-uni03gamma-deploy-bm-* jobs which have
been consistently failing since the deploy-bm variant was introduced.

Related-Issue: [ANVIL-109](https://redhat.atlassian.net/browse/ANVIL-109)
Co-authored-by: Cursor <cursoragent@cursor.com>