### PR TITLE
[ansible] Add SSH keepalive to prevent connection drops during long tasks

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -20,4 +20,4 @@ pipelining = True
 any_errors_fatal = True
 jinja2_native = True
 [ssh_connection]
-ssh_args = -o ControlMaster=auto -o ControlPersist=300
+ssh_args = -o ControlMaster=auto -o ControlPersist=300 -o ServerAliveInterval=30 -o ServerAliveCountMax=10


### PR DESCRIPTION
Long-running tasks like `oc adm wait-for-stable-cluster` after certificate rotation can cause SSH connections to be dropped by intermediate network devices (firewalls, NAT) due to inactivity. Add ServerAliveInterval and ServerAliveCountMax to maintain the connection alive.