### PR TITLE
[cifmw_cephadm] Fix log path when post.yml delegates to localhost

### DIFF
--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -110,7 +110,7 @@ cifmw_cephadm_urischeme: "http"
 cifmw_cephadm_config_key_set_ssl_option: no_sslv2:sslv3:no_tlsv1:no_tlsv1_1
 # Deployment logs variables
 cifmw_cephadm_log_dump: true
-cifmw_cephadm_log_path: "{{ ansible_user_dir ~ '/ci-framework-data/logs/ceph' }}"
+cifmw_cephadm_log_path: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}/logs/ceph"
 cifmw_cephadm_log_commands:
   # Get deployed Ceph daemons
   - type: "daemons"


### PR DESCRIPTION
`cifmw_cephadm_log_path` uses `ansible_user_dir` which resolves to `/root` on compute nodes running with become: true. The post.yml and logs.yml tasks `delegate_to: localhost` to write log files, but on the controller the zuul user cannot create directories under /root.

Use cifmw_basedir (always /home/zuul/ci-framework-data in CI) with a fallback to the original expression for non-CI contexts.

Related-Issue: ANVIL-109