### PR TITLE
Add cifmw_crc_additional_insecure_registries support

### DIFF
--- a/ci/playbooks/multinode-customizations.yml
+++ b/ci/playbooks/multinode-customizations.yml
@@ -213,7 +213,10 @@
 
     - name: Set insecure registry on crc node
       ansible.builtin.include_tasks: tasks/set_crc_insecure_registry.yml
-      when: content_provider_registry_ip is defined or cifmw_crc_registry_mirror_content is defined
+      when: >-
+        content_provider_registry_ip is defined or
+        cifmw_crc_registry_mirror_content is defined or
+        cifmw_crc_additional_insecure_registries is defined
 
 - hosts: controller
   name: "Tweak Controller"

--- a/ci/playbooks/tasks/set_crc_insecure_registry.yml
+++ b/ci/playbooks/tasks/set_crc_insecure_registry.yml
@@ -38,6 +38,14 @@
     image.config.openshift.io/cluster
   loop: "{{ cifmw_crc_additional_allowed_registries }}"
 
+- name: Add additional insecure registries
+  when: cifmw_crc_additional_insecure_registries is defined
+  ansible.builtin.shell: |
+    oc patch --type=json \
+    --patch='[{"op": "add", "path": "/spec/registrySources/insecureRegistries/-", "value": "{{ item }}"}]' \
+    image.config.openshift.io/cluster
+  loop: "{{ cifmw_crc_additional_insecure_registries }}"
+
 - name: Ensure registries.conf.d exists
   become: true
   when: cifmw_crc_registry_mirror_content is defined or content_provider_registry_ip is defined
@@ -61,6 +69,24 @@
       mirror-by-digest-only = false
       prefix = ""
 
+- name: Set insecure registry in crio for additional registries
+  become: true
+  when: cifmw_crc_additional_insecure_registries is defined
+  ansible.builtin.blockinfile:
+    state: present
+    insertafter: EOF
+    marker: "# ANSIBLE MANAGED BLOCK - additional insecure registry: {{ item }}"
+    dest: /etc/containers/registries.conf.d/99-insecure-registry.conf
+    create: true
+    content: |-
+      [[registry]]
+      location = "{{ item }}"
+      insecure = true
+      blocked = false
+      mirror-by-digest-only = false
+      prefix = ""
+  loop: "{{ cifmw_crc_additional_insecure_registries }}"
+
 - name: Set registry mirror override
   when: cifmw_crc_registry_mirror_content is defined
   become: true
@@ -72,7 +98,10 @@
     content: "{{ cifmw_crc_registry_mirror_content }}"
 
 - name: Restart crio
-  when: cifmw_crc_registry_mirror_content is defined or content_provider_registry_ip is defined
+  when: >-
+    cifmw_crc_registry_mirror_content is defined or
+    content_provider_registry_ip is defined or
+    cifmw_crc_additional_insecure_registries is defined
   become: true
   ansible.builtin.service:
     name: crio

--- a/hooks/playbooks/fetch_compute_facts.yml
+++ b/hooks/playbooks/fetch_compute_facts.yml
@@ -256,10 +256,16 @@
                       - "{{ dns_server }}"
               {% endfor %}
 
-              {% if content_provider_registry_ip is defined %}
+              {% if content_provider_registry_ip is defined or cifmw_crc_additional_insecure_registries is defined %}
                   - op: add
                     path: /spec/nodeTemplate/ansible/ansibleVars/edpm_container_registry_insecure_registries
-                    value: ["{{ content_provider_registry_ip }}:5001"]
+                    value:
+              {% if content_provider_registry_ip is defined %}
+                      - "{{ content_provider_registry_ip }}:5001"
+              {% endif %}
+              {% for reg in cifmw_crc_additional_insecure_registries | default([]) %}
+                      - "{{ reg }}"
+              {% endfor %}
               {% endif %}
 
                   - op: add

--- a/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -127,10 +127,16 @@
             - target:
                 kind: OpenStackDataPlaneNodeSet
               patch: |-
-          {% if content_provider_registry_ip is defined %}
+          {% if content_provider_registry_ip is defined or cifmw_crc_additional_insecure_registries is defined %}
                 - op: add
                   path: /spec/nodeTemplate/ansible/ansibleVars/edpm_container_registry_insecure_registries
-                  value: ["{{ content_provider_registry_ip }}:5001"]
+                  value:
+          {% if content_provider_registry_ip is defined %}
+                    - "{{ content_provider_registry_ip }}:5001"
+          {% endif %}
+          {% for reg in cifmw_crc_additional_insecure_registries | default([]) %}
+                    - "{{ reg }}"
+          {% endfor %}
           {% endif %}
 
           {% if not cifmw_edpm_deploy_baremetal_bootc and not cifmw_edpm_deploy_baremetal_custom_bootstrap %}


### PR DESCRIPTION
Allow content-provider jobs to register additional insecure registries on the CRC node. This patches insecureRegistries in image.config.openshift.io/cluster and configures crio, paralleling the existing cifmw_crc_additional_allowed_registries mechanism.

This will be used with a custom content-provider job, which will build and provide images of sg-core, mysqld_exporter and prometheus-podman-exporter. The mechanism is generic and can be used with other custom content-provider jobs providing other non-operator, non-openstack-service images in the future.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/4003

Generated-By: Claude-Code claude-opus-4-6