### PR TITLE
[DNM] [ipa role] Wait until IDM route exists in run_ipa_setup stage

### DIFF
--- a/roles/ipa/tasks/run_ipa_setup.yml
+++ b/roles/ipa/tasks/run_ipa_setup.yml
@@ -119,6 +119,18 @@
     wait: true
     wait_timeout: 300
 
+- name: Wait until IDM route exists
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: idm
+    namespace: "{{ cifmw_ipa_namespace }}"
+  register: idm_route
+  until: idm_route.resources | length > 0
+  retries: 20
+  delay: 15
+
 - name: Get ipa route
   kubernetes.core.k8s_info:
     kubeconfig: "{{ cifmw_openshift_kubeconfig }}"


### PR DESCRIPTION
The IPA pod itself came up fine, but the Route object lagged behind
and there is no retry/wait guard before the URL is used.

This PR add task preceding task that waits for the Route to exist before querying it.

Signed-off-by: Bhagyashri Shewale bshewale@redhat.com