### PR TITLE
[multiple] Add LVMS support to dt-vhosts-compact and dt-sharded-compact

### DIFF
--- a/scenarios/reproducers/dt-sharded-compact.yml
+++ b/scenarios/reproducers/dt-sharded-compact.yml
@@ -263,6 +263,8 @@ cifmw_libvirt_manager_configuration:
       image_local_dir: "{{ cifmw_basedir }}/images/"
       disk_file_name: "ocp_master"
       disksize: "100"
+      extra_disks_num: 3
+      extra_disks_size: "50G"
       cpus: 16
       memory: 64
       root_part_id: 4
@@ -320,3 +322,10 @@ cifmw_ceph_daemons_layout:
   ceph_nfs_enabled: true
 
 cifmw_deploy_obs: true
+
+# Set Logical Volume Manager Storage by default for local storage
+cifmw_use_lvms: true
+cifmw_lvms_disk_list:
+  - /dev/vda
+  - /dev/vdb
+  - /dev/vdc

--- a/scenarios/reproducers/dt-vhosts-compact.yml
+++ b/scenarios/reproducers/dt-vhosts-compact.yml
@@ -263,6 +263,8 @@ cifmw_libvirt_manager_configuration:
       image_local_dir: "{{ cifmw_basedir }}/images/"
       disk_file_name: "ocp_master"
       disksize: "100"
+      extra_disks_num: 3
+      extra_disks_size: "50G"
       cpus: 16
       memory: 64
       root_part_id: 4
@@ -320,3 +322,10 @@ cifmw_ceph_daemons_layout:
   ceph_nfs_enabled: true
 
 cifmw_deploy_obs: true
+
+# Set Logical Volume Manager Storage by default for local storage
+cifmw_use_lvms: true
+cifmw_lvms_disk_list:
+  - /dev/vda
+  - /dev/vdb
+  - /dev/vdc


### PR DESCRIPTION
Add 3 extra disks (50G each) to OCP master nodes and configure LVMS using /dev/vda, /dev/vdb, /dev/vdc, following the same pattern used by other compact OCP scenarios (va-multi, dt-nfv-ovs-dpdk-sriov-hci). This replaces the default ci_local_storage with the LVMS operator for dynamic local storage provisioning.