### PR TITLE
[switch_config] Disable paramiko key lookup for netconf connections

### DIFF
--- a/playbooks/switches_config.yml
+++ b/playbooks/switches_config.yml
@@ -21,6 +21,8 @@
 - name: Switches configuration
   hosts: switches
   gather_facts: false
+  environment:
+    ANSIBLE_PARAMIKO_LOOK_FOR_KEYS: "False"
   pre_tasks:
     - name: Early playbook stop
       when:


### PR DESCRIPTION
Paramiko 5.0 refuses to negotiate ssh-rsa (SHA-1) signing, which breaks netconf connections to Junos switches when the Zuul build RSA key is present in ~/.ssh/. The netconf plugin does not honor the inventory variable ansible_paramiko_look_for_keys, so we set it via the ANSIBLE_PARAMIKO_LOOK_FOR_KEYS environment variable at the play level.