### PR TITLE
[openshift_setup] Add retry and delay on getting OpenShift info

### DIFF
--- a/roles/openshift_setup/tasks/patch_samples_registry.yml
+++ b/roles/openshift_setup/tasks/patch_samples_registry.yml
@@ -13,3 +13,7 @@
       - op: replace
         path: /spec/samplesRegistry
         value: "{{ cifmw_openshift_setup_samples_registry }}"
+  register: _samples_registry_config
+  until: _samples_registry_config is succeeded
+  retries: 5
+  delay: 10


### PR DESCRIPTION
Tasks executed before patch_samples_registry.yml triggers OpenShift API to rollback, so when the hypervisor is overloaded it fails with error:

    urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='api.crc.testing', port=6443): Max retries exceeded with url: /apis/samples.operator.openshift.io/v1/configs/cluster (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7fdd6e714280>: Failed to establish a new connection: [Errno 111] Connection refused'))

Add retry to prevent such error.