### PR TITLE
[ci_gen_kustomize_values] Add per-node bmhLabelSelector to prevent BM…

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/nfv-ovs-dpdk-sriov-hci/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/nfv-ovs-dpdk-sriov-hci/edpm-nodeset-values/values.yaml.j2
@@ -32,7 +32,7 @@ data:
     nodes:
 {% for instance in instances_names                                                     %}
 {%   set node_name = 'edpm-' + instance                                               %}
-{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance}) %}
+{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance, 'bmhLabelSelector': {'nodeName': instance}}) %}
       {{ node_name }}:
 {{ node_config | to_nice_yaml(indent=2) | indent(8, first=true) }}
 {% endfor                                                                              %}

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-2nodesets/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-2nodesets/edpm-nodeset-values/values.yaml.j2
@@ -45,7 +45,7 @@ data:
     nodes:
 {% for instance in instances_names                                                     %}
 {%   set node_name = 'edpm-' + instance                                               %}
-{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance}) %}
+{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance, 'bmhLabelSelector': {'nodeName': instance}}) %}
       {{ node_name }}:
 {{ node_config | to_nice_yaml(indent=2) | indent(8, first=true) }}
 {% endfor                                                                              %}

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-2nodesets/edpm-nodeset2-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-2nodesets/edpm-nodeset2-values/values.yaml.j2
@@ -45,7 +45,7 @@ data:
     nodes:
 {% for instance in instances_names                                                     %}
 {%   set node_name = 'edpm-' + instance                                               %}
-{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance}) %}
+{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance, 'bmhLabelSelector': {'nodeName': instance}}) %}
       {{ node_name }}:
 {{ node_config | to_nice_yaml(indent=2) | indent(8, first=true) }}
 {% endfor                                                                              %}

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-ipv6-2nodesets/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-ipv6-2nodesets/edpm-nodeset-values/values.yaml.j2
@@ -45,7 +45,7 @@ data:
     nodes:
 {% for instance in instances_names                                                     %}
 {%   set node_name = 'edpm-' + instance                                               %}
-{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance}) %}
+{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance, 'bmhLabelSelector': {'nodeName': instance}}) %}
       {{ node_name }}:
 {{ node_config | to_nice_yaml(indent=2) | indent(8, first=true) }}
 {% endfor                                                                              %}

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-ipv6-2nodesets/edpm-nodeset2-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-ipv6-2nodesets/edpm-nodeset2-values/values.yaml.j2
@@ -45,7 +45,7 @@ data:
     nodes:
 {% for instance in instances_names                                                     %}
 {%   set node_name = 'edpm-' + instance                                               %}
-{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance}) %}
+{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance, 'bmhLabelSelector': {'nodeName': instance}}) %}
       {{ node_name }}:
 {{ node_config | to_nice_yaml(indent=2) | indent(8, first=true) }}
 {% endfor                                                                              %}

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-ipv6/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-ipv6/edpm-nodeset-values/values.yaml.j2
@@ -32,7 +32,7 @@ data:
     nodes:
 {% for instance in instances_names                                                     %}
 {%   set node_name = 'edpm-' + instance                                               %}
-{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance}) %}
+{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance, 'bmhLabelSelector': {'nodeName': instance}}) %}
       {{ node_name }}:
 {{ node_config | to_nice_yaml(indent=2) | indent(8, first=true) }}
 {% endfor                                                                              %}

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-networker/edpm-common-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov-networker/edpm-common-nodeset-values/values.yaml.j2
@@ -46,7 +46,7 @@ data:
     nodes:
 {% for instance in instance_names                                                      %}
 {%   set node_name = 'edpm-' + instance                                               %}
-{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance}) %}
+{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance, 'bmhLabelSelector': {'nodeName': instance}}) %}
       {{ node_name }}:
 {{ node_config | to_nice_yaml(indent=2) | indent(8, first=true) }}
 {% endfor                                                                              %}

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk-sriov/edpm-nodeset-values/values.yaml.j2
@@ -32,7 +32,7 @@ data:
     nodes:
 {% for instance in instances_names                                                     %}
 {%   set node_name = 'edpm-' + instance                                               %}
-{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance}) %}
+{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance, 'bmhLabelSelector': {'nodeName': instance}}) %}
       {{ node_name }}:
 {{ node_config | to_nice_yaml(indent=2) | indent(8, first=true) }}
 {% endfor                                                                              %}

--- a/roles/ci_gen_kustomize_values/templates/ovs-dpdk/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/ovs-dpdk/edpm-nodeset-values/values.yaml.j2
@@ -32,7 +32,7 @@ data:
     nodes:
 {% for instance in instances_names                                                     %}
 {%   set node_name = 'edpm-' + instance                                               %}
-{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance}) %}
+{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance, 'bmhLabelSelector': {'nodeName': instance}}) %}
       {{ node_name }}:
 {{ node_config | to_nice_yaml(indent=2) | indent(8, first=true) }}
 {% endfor                                                                              %}

--- a/roles/ci_gen_kustomize_values/templates/sriov/edpm-nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/sriov/edpm-nodeset-values/values.yaml.j2
@@ -32,7 +32,7 @@ data:
     nodes:
 {% for instance in instances_names                                                     %}
 {%   set node_name = 'edpm-' + instance                                               %}
-{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance}) %}
+{%   set node_config = _original_nodes[node_name] | default({}) | combine({'hostName': instance, 'bmhLabelSelector': {'nodeName': instance}}) %}
       {{ node_name }}:
 {{ node_config | to_nice_yaml(indent=2) | indent(8, first=true) }}
 {% endfor                                                                              %}


### PR DESCRIPTION
[ci_gen_kustomize_values] Add per-node bmhLabelSelector to prevent BMH shuffling
The OpenStackBaremetalSet operator assigns BMHs to nodeset hostnames
non-deterministically ([OSPRH-10282](https://redhat.atlassian.net/browse/OSPRH-10282)), causing compute-0 to get the
network config of compute-1 and vice versa. Add bmhLabelSelector
with nodeName per node so each edpm-compute-X is deterministically
bound to the BMH named compute-X.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>