### PR TITLE
[cifmw_backup_restore] Add Swift data verification to e2e workflow

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -233,6 +233,7 @@ fultonj
 fusco
 fwcybtb
 Galera
+GaleraBackup
 gapped
 genericcloud
 genindex
@@ -369,6 +370,8 @@ maxdepth
 mcs
 mellanox
 metallb
+MiB
+MinIO
 metalsmith
 mgmt
 minclient
@@ -680,6 +683,7 @@ wljewmjozmzawlzasdje
 wljewmtozmzawlzasdje
 workstream
 xargs
+xattr
 xdg
 xoc
 xpath

--- a/roles/cifmw_backup_restore/README.md
+++ b/roles/cifmw_backup_restore/README.md
@@ -53,6 +53,19 @@ OpenShift cluster.
 * `cifmw_backup_restore_pin_pvcs`: (Boolean) Enable PVC-to-node pinning during restore for WaitForFirstConsumer storage classes. Defaults to `false`.
 * Post-EDPM **Neutron–OVN** steps follow [user guide Step 12](https://github.com/openstack-k8s-operators/dev-docs/blob/main/backup-restore/user-guide.md#step-12-verify-and-sync-neutron-to-ovn): run `neutron-ovn-db-sync-util` in `log` mode first (`neutron-dist.conf`, `neutron.conf`, `neutron.conf.d`). **Repair** runs if `cifmw_backup_restore_ovn_db` is `false` (no OVN NB/SB file backup was taken), or if log-mode stdout/stderr contains a `WARNING` line—Neutron reports drift that way while still exiting 0. If OVN file backup/restore was enabled and log output has no `WARNING` lines, repair is skipped as redundant.
 
+### End-to-end orchestration (e2e.yml)
+
+* `cifmw_backup_restore_install_deps`: (Boolean) Install MinIO, OADP, and GaleraBackup CRs. Defaults to `true`.
+* `cifmw_backup_restore_create_workload`: (Boolean) Create a test VM with floating IP before backup. Defaults to `true`.
+* `cifmw_backup_restore_run_backup`: (Boolean) Run the backup step. Defaults to `true`.
+* `cifmw_backup_restore_run_cleanup`: (Boolean) Run the cleanup step. Defaults to `true`.
+* `cifmw_backup_restore_run_restore`: (Boolean) Run the restore step. Defaults to `true`.
+* `cifmw_backup_restore_run_post_tempest`: (Boolean) Run tempest validation after restore. Defaults to `false`.
+* `cifmw_backup_restore_test_swift_data`: (Boolean) Upload a random file to Swift before backup and verify it can be downloaded after restore. Catches Swift data loss caused by xattr issues (OSPRH-29818). Defaults to `true`.
+* `cifmw_backup_restore_swift_test_container`: (String) Swift container name for the test object. Defaults to `backup-test-container`.
+* `cifmw_backup_restore_swift_test_object`: (String) Object name for the test file. Defaults to `backup-test-object`.
+* `cifmw_backup_restore_swift_test_file_size_bytes`: (Integer) Size of the random test file in bytes. Defaults to `1048576` (1 MiB).
+
 ### Cleanup
 
 * `cifmw_backup_restore_cleanup_ctlplane`: (Boolean) Delete control-plane resources during cleanup. Defaults to `true`.

--- a/roles/cifmw_backup_restore/defaults/main.yml
+++ b/roles/cifmw_backup_restore/defaults/main.yml
@@ -33,6 +33,10 @@ cifmw_backup_restore_run_backup: true
 cifmw_backup_restore_run_cleanup: true
 cifmw_backup_restore_run_restore: true
 cifmw_backup_restore_run_post_tempest: false
+cifmw_backup_restore_test_swift_data: true
+cifmw_backup_restore_swift_test_container: "backup-test-container"
+cifmw_backup_restore_swift_test_object: "backup-test-object"
+cifmw_backup_restore_swift_test_file_size_bytes: 1048576
 
 # Passthrough to update role when creating the test workload (prefix matches update role, not this role)
 cifmw_update_ping_test: true

--- a/roles/cifmw_backup_restore/tasks/e2e.yml
+++ b/roles/cifmw_backup_restore/tasks/e2e.yml
@@ -76,6 +76,13 @@
         tasks_from: create_instance.yml
 
 # ========================================
+# Step 2.5: Upload Swift test data
+# ========================================
+- name: Upload Swift test data before backup
+  ansible.builtin.include_tasks: swift_data_upload.yml
+  when: cifmw_backup_restore_test_swift_data | bool
+
+# ========================================
 # Step 3: Create backup
 # ========================================
 - name: Create backup
@@ -238,6 +245,15 @@
         msg: >-
           Workload validation passed: instance reachable via FIP {{ _instance_fip.stdout }},
           stop/start successful, ping after restart OK
+
+# ========================================
+# Step 6.5: Validate Swift data after restore
+# ========================================
+- name: Validate Swift data after restore
+  ansible.builtin.include_tasks: swift_data_verify.yml
+  when:
+    - cifmw_backup_restore_test_swift_data | bool
+    - cifmw_backup_restore_run_restore | bool
 
 # ========================================
 # Step 7: Post-restore tempest validation

--- a/roles/cifmw_backup_restore/tasks/swift_data_upload.yml
+++ b/roles/cifmw_backup_restore/tasks/swift_data_upload.yml
@@ -1,0 +1,75 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Upload a random test file to Swift before backup.
+# After restore, swift_data_verify.yml downloads the file and checks its
+# checksum to confirm Swift data survived the backup/restore cycle.
+
+- name: Set openstackclient exec prefix
+  ansible.builtin.set_fact:
+    _os_exec: >-
+      oc exec -t openstackclient -n {{ cifmw_backup_restore_namespace }} --
+
+- name: Generate random test file in openstackclient pod
+  ansible.builtin.shell: |
+    {{ _os_exec }} dd if=/dev/urandom of=/tmp/{{ cifmw_backup_restore_swift_test_object }} \
+      bs=1 count={{ cifmw_backup_restore_swift_test_file_size_bytes }} 2>/dev/null
+  changed_when: true
+
+- name: Calculate checksum of test file
+  ansible.builtin.shell: |
+    set -o pipefail
+    {{ _os_exec }} md5sum /tmp/{{ cifmw_backup_restore_swift_test_object }} | awk '{print $1}'
+  register: _swift_test_checksum_result
+  changed_when: false
+
+- name: Store checksum for post-restore verification
+  ansible.builtin.set_fact:
+    _swift_test_checksum: "{{ _swift_test_checksum_result.stdout }}"
+
+- name: Create Swift container
+  ansible.builtin.shell: |
+    {{ _os_exec }} openstack container create {{ cifmw_backup_restore_swift_test_container }}
+  changed_when: true
+
+- name: Upload test object to Swift
+  ansible.builtin.shell: |
+    {{ _os_exec }} openstack object create {{ cifmw_backup_restore_swift_test_container }} \
+      /tmp/{{ cifmw_backup_restore_swift_test_object }} \
+      --name {{ cifmw_backup_restore_swift_test_object }}
+  changed_when: true
+
+- name: Verify upload succeeded
+  ansible.builtin.shell: |
+    set -o pipefail
+    {{ _os_exec }} openstack object show \
+      {{ cifmw_backup_restore_swift_test_container }} \
+      {{ cifmw_backup_restore_swift_test_object }} -f json | jq -r '."content-length"'
+  register: _swift_upload_check
+  changed_when: false
+
+- name: Display Swift test data info
+  ansible.builtin.debug:
+    msg: >-
+      Swift test data uploaded: container={{ cifmw_backup_restore_swift_test_container }},
+      object={{ cifmw_backup_restore_swift_test_object }},
+      size={{ _swift_upload_check.stdout }} bytes,
+      md5={{ _swift_test_checksum }}
+
+- name: Remove local temp file from pod
+  ansible.builtin.shell: |
+    {{ _os_exec }} rm -f /tmp/{{ cifmw_backup_restore_swift_test_object }}
+  changed_when: true

--- a/roles/cifmw_backup_restore/tasks/swift_data_verify.yml
+++ b/roles/cifmw_backup_restore/tasks/swift_data_verify.yml
@@ -1,0 +1,70 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Verify Swift test data survived the backup/restore cycle.
+# Downloads the object uploaded by swift_data_upload.yml and compares
+# its checksum against the value recorded before backup.
+
+- name: Set openstackclient exec prefix
+  ansible.builtin.set_fact:
+    _os_exec: >-
+      oc exec -t openstackclient -n {{ cifmw_backup_restore_namespace }} --
+
+- name: Verify Swift container exists after restore
+  ansible.builtin.shell: |
+    {{ _os_exec }} openstack container show {{ cifmw_backup_restore_swift_test_container }}
+  changed_when: false
+
+- name: Download test object from Swift
+  ansible.builtin.shell: |
+    {{ _os_exec }} openstack object save \
+      {{ cifmw_backup_restore_swift_test_container }} \
+      {{ cifmw_backup_restore_swift_test_object }} \
+      --file /tmp/{{ cifmw_backup_restore_swift_test_object }}.restored
+  changed_when: true
+
+- name: Calculate checksum of restored file
+  ansible.builtin.shell: |
+    set -o pipefail
+    {{ _os_exec }} md5sum /tmp/{{ cifmw_backup_restore_swift_test_object }}.restored | awk '{print $1}'
+  register: _swift_restored_checksum
+  changed_when: false
+
+- name: Verify checksum matches
+  ansible.builtin.assert:
+    that:
+      - _swift_restored_checksum.stdout == _swift_test_checksum
+    fail_msg: >-
+      Swift data verification FAILED: checksum mismatch.
+      Expected {{ _swift_test_checksum }}, got {{ _swift_restored_checksum.stdout }}.
+      This indicates Swift data was lost or corrupted during backup/restore
+      (possibly due to xattr loss — see OSPRH-29818).
+    success_msg: >-
+      Swift data verification PASSED: checksum {{ _swift_test_checksum }} matches.
+
+- name: Clean up Swift test data
+  ansible.builtin.shell: |
+    {{ _os_exec }} openstack object delete \
+      {{ cifmw_backup_restore_swift_test_container }} \
+      {{ cifmw_backup_restore_swift_test_object }}
+    {{ _os_exec }} openstack container delete {{ cifmw_backup_restore_swift_test_container }}
+  changed_when: true
+  failed_when: false
+
+- name: Remove restored temp file from pod
+  ansible.builtin.shell: |
+    {{ _os_exec }} rm -f /tmp/{{ cifmw_backup_restore_swift_test_object }}.restored
+  changed_when: true


### PR DESCRIPTION
Upload a random file to Swift before backup and verify it can be downloaded with a matching checksum after restore. This catches Swift data loss caused by xattr issues during OADP DataMover/kopia PVC backup and restore cycles.

Closes: [OSPRH-30250](https://redhat.atlassian.net/browse/OSPRH-30250)
Related-Issue: [OSPRH-29818](https://redhat.atlassian.net/browse/OSPRH-29818)

Signed-off-by: Andrew Bays <abays@redhat.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>