### PR TITLE
[scenarios] Fix cifmw_ceph_target value in nfv-ovs-dpdk-sriov-hci

### DIFF
--- a/scenarios/reproducers/dt-nfv-ovs-dpdk-sriov-hci.yml
+++ b/scenarios/reproducers/dt-nfv-ovs-dpdk-sriov-hci.yml
@@ -118,7 +118,7 @@ cifmw_lvms_disk_list:
   - /dev/vdb
   - /dev/vdc
 
-cifmw_ceph_target: edpms
+cifmw_ceph_target: computes
 cifmw_ceph_client_vars: /tmp/ceph_client.yml
 cifmw_ceph_client_values_post_ceph_path_src: >-
   {{ _arch_repo }}/examples/dt/nfv/nfv-ovs-dpdk-sriov-hci/values.yaml


### PR DESCRIPTION
Compute nodes are named starting with "compute", not "edpm". Update cifmw_ceph_target from "edpms" to "computes" so it matches the actual node naming convention.