### PR TITLE
(multiple) Set test_operator as default test role

### DIFF
--- a/docs/source/usage/01_usage.md
+++ b/docs/source/usage/01_usage.md
@@ -53,7 +53,7 @@ are shared among multiple roles:
 - `cifmw_ceph_target`: (String) The Ansible inventory group where ceph is deployed. Defaults to `computes`.
 - `cifmw_run_tests`: (Bool) Specifies whether tests should be executed.
   Defaults to false.
-- `cifmw_run_test_role`: (String) Specifies which ci-framework role will be used to run tests. Allowed options are `test_operator`, `tempest` and `shiftstack`. Defaults to `tempest`.
+- `cifmw_run_test_role`: (String) Specifies which ci-framework role will be used to run tests. Allowed options are `test_operator` and `shiftstack`. Defaults to `test_operator`.
 - `cifmw_edpm_deploy_nfs`: (Bool) Specifies whether an nfs server should be deployed.
 - `cifmw_nfs_target`: (String) The Ansible inventory group where the nfs server is deployed. Defaults to `computes`. Only has an effect if `cifmw_edpm_deploy_nfs` is set to `true`.
 - `cifmw_nfs_network`: (String) The network the deployed nfs server will be accessible from. Defaults to `storage`. Only has an effect if `cifmw_edpm_deploy_nfs` is set to `true`.

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -44,6 +44,9 @@ cifmw_default_container_image_tag: "current-podified"
 cifmw_master_container_image_namespace: "podified-master-centos9"
 cifmw_openstack_k8s_operators_org_url: "https://github.com/openstack-k8s-operators"
 
+# Default test role
+cifmw_run_test_role: test_operator
+
 #### Pinned external projects dependencies ####
 #
 # These variables define the source URL and version for

--- a/playbooks/08-run-tests.yml
+++ b/playbooks/08-run-tests.yml
@@ -23,7 +23,7 @@
       tags:
         - tests
       ansible.builtin.import_role:
-        name: "{{ cifmw_run_test_role | default('tempest') }}"
+        name: "{{ cifmw_run_test_role | default('test_operator') }}"
 
     - name: Run post_tests hooks
       vars:

--- a/playbooks/multi-namespace/ns2_validation.yaml
+++ b/playbooks/multi-namespace/ns2_validation.yaml
@@ -6,4 +6,4 @@
       tags:
         - tests
       ansible.builtin.import_role:
-        name: "{{ cifmw_run_test_role | default('tempest') }}"
+        name: "{{ cifmw_run_test_role | default('test_operator') }}"

--- a/roles/cifmw_setup/tasks/run_tests.yml
+++ b/roles/cifmw_setup/tasks/run_tests.yml
@@ -9,7 +9,7 @@
   tags:
     - tests
   ansible.builtin.import_role:
-    name: "{{ cifmw_run_test_role | default('tempest') }}"
+    name: "{{ cifmw_run_test_role | default('test_operator') }}"
   when: cifmw_run_tests | default(false) | bool
 
 - name: Run post_tests hooks

--- a/roles/polarion/README.md
+++ b/roles/polarion/README.md
@@ -4,7 +4,7 @@ Role to setup jump tool and upload XML test results to Polarion.
 ## Parameters
 * `cifmw_polarion_basedir`: (String) Base directory. Defaults to `cifmw_basedir` which defaults to `~/ci-framework-data`.
 * `cifmw_polarion_jump_repo_dir`: (String) Jump repo directory. Defaults to `~/ci-framework-data/polarion-jump`.
-* `cifmw_polarion_jump_result_dir`: (String) Test results directory. Based on `cifmw_run_test_role` defaults to `~/ci-framework-data/tests/tempest/` or `~/ci-framework-data/tests/test_operator/`.
+* `cifmw_polarion_jump_result_dir`: (String) Test results directory. Based on `cifmw_run_test_role` defaults to `~/ci-framework-data/tests/test_operator/`.
 * `cifmw_polarion_jump_repo_url`: (String) URL of jump repository.
 * `cifmw_polarion_testrun_title`: (String) A name of the test run under which the test results will be uploaded to polarion. The role appends an index number to the name to distinguish multiple test runs apart.
 * `cifmw_polarion_testrun_id`: (String) A test run identification provided by Polarion test case or `create-new-test-run` if polarion should generate a random test run ID. A value other than `create-new-test-run` will force this role to upload all test results found in all directories under `cifmw_polarion_jump_repo_url` to one test run identified by the given ID. The default behavior of this role is to treat the directories in `cifmw_polarion_jump_repo_url` as separate test runs.

--- a/roles/polarion/defaults/main.yml
+++ b/roles/polarion/defaults/main.yml
@@ -21,7 +21,7 @@
 cifmw_polarion_basedir: "{{ cifmw_basedir }}"
 cifmw_polarion_jump_custom_fields: {}
 cifmw_polarion_jump_repo_dir: "{{ cifmw_polarion_basedir }}/polarion-jump"
-cifmw_polarion_jump_result_dir: "{{ cifmw_polarion_basedir }}/tests/{{ cifmw_run_test_role | default('tempest') }}/"
+cifmw_polarion_jump_result_dir: "{{ cifmw_polarion_basedir }}/tests/{{ cifmw_run_test_role }}/"
 cifmw_polarion_jump_repo_branch: "master"
 cifmw_polarion_testrun_title: "testrun-name"
 cifmw_polarion_use_stage: false

--- a/roles/reportportal/README.md
+++ b/roles/reportportal/README.md
@@ -7,11 +7,11 @@ The `reportportal` role uses Data Router tool for uploading XML test results to 
 * `cifmw_reportportal_droute_client_url`: (String) URL of Data router client repository (mandatory).
 * `cifmw_reportportal_datarouter_username`: (String) username for Data router client (mandatory).
 * `cifmw_reportportal_datarouter_password`: (String) password for Data router client (mandatory).
-* `cifmw_reportportal_datarouter_result_dir`: (String) Test results directory. Based on `cifmw_run_test_role` defaults to `~/ci-framework-data/tests/tempest/` or `~/ci-framework-data/tests/test_operator/`. One or more properly formatted xml results files are expected to be found in this directory.
+* `cifmw_reportportal_results_dir`: (String) Test results directory. Based on `cifmw_run_test_role` defaults to `~/ci-framework-data/tests/test_operator/`. One or more properly formatted xml results files are expected to be found in this directory.
 * `cifmw_reportportal_project`: (String) Report portal project for uploading results (mandatory).
 * `cifmw_reportportal_launch_name`: (String) Name of the Report portal launch defaults to `Dummy launch`.
 * `cifmw_reportportal_launch_description`: (String) Description of the Report portal launch defaults to `Test results sent via Data router`.
-* `cifmw_reportportal_droute_version`: (String) Data router client version defaults to `1.2.1`.
+* `cifmw_reportportal_droute_version`: (String) Data router client version defaults to `latest`.
 * `cifmw_reportportal_droute_binary`: (String) Data router binary name defaults to `droute-linux-amd64`.
 
 ## Examples

--- a/roles/reportportal/defaults/main.yml
+++ b/roles/reportportal/defaults/main.yml
@@ -14,7 +14,7 @@ cifmw_reportportal_results_dir: >-
   {{
     (cifmw_reportportal_basedir,
      'tests',
-     cifmw_run_test_role | default('tempest')) |
+     cifmw_run_test_role) |
     path_join
   }}
 

--- a/scenarios/centos-9/multinode-ci.yml
+++ b/scenarios/centos-9/multinode-ci.yml
@@ -31,6 +31,5 @@ cifmw_install_yamls_vars:
 cifmw_deploy_edpm: true
 
 # Tempest vars
-cifmw_run_test_role: test_operator
 cifmw_test_operator_tempest_include_list: |
   tempest.scenario.test_network_basic_ops.TestNetworkBasicOps

--- a/scenarios/reproducers/bgp-4-racks-3-ocps.yml
+++ b/scenarios/reproducers/bgp-4-racks-3-ocps.yml
@@ -1,6 +1,5 @@
 ---
 cifmw_run_tests: true
-cifmw_run_test_role: test_operator
 cifmw_test_operator_timeout: 7200
 cifmw_test_operator_tempest_include_list: |
   tempest.scenario.test_network_basic_ops.TestNetworkBasicOps

--- a/scenarios/reproducers/va-common.yml
+++ b/scenarios/reproducers/va-common.yml
@@ -28,7 +28,6 @@ cifmw_libvirt_manager_pub_net: ocpbm
 
 # Run tests
 cifmw_run_tests: true
-cifmw_run_test_role: test_operator
 cifmw_test_operator_timeout: 7200
 cifmw_test_operator_tempest_include_list: |
   tempest.scenario.test_network_basic_ops.TestNetworkBasicOps

--- a/zuul.d/tempest_multinode.yaml
+++ b/zuul.d/tempest_multinode.yaml
@@ -13,7 +13,6 @@
       # disable operator build
       cifmw_operator_build_meta_build: false
       cifmw_operator_build_operators: []
-      cifmw_run_test_role: test_operator
       cifmw_test_operator_tempest_tests_include_override_scenario: true
     extra-vars:
       crc_ci_bootstrap_cloud_name: "{{ nodepool.cloud | replace('-nodepool-tripleo','') }}"

--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -14,7 +14,6 @@
       whitebox-neutron-tempest-plugin opendev patches. It will validate the
       deployment by running whitebox-neutron-tempest-plugin tests.
     vars:
-      cifmw_run_test_role: test_operator
       cifmw_os_must_gather_timeout: "30m"
       cifmw_test_operator_timeout: 14400
       cifmw_block_device_size: 40G


### PR DESCRIPTION
Set cifmw_run_test_role to test_operator as a default and remove redundant explicit settings from scenarios. This is an effort to deprecate the tempest role and to reduce repetition of setting this variable to test_operator almost every time.

Signed-off-by: Katarina Strenkova <kstrenko@redhat.com>