### PR TITLE
[switch_config] Move paramiko key lookup disable to switches_config p…

### DIFF
--- a/playbooks/switches_config.yml
+++ b/playbooks/switches_config.yml
@@ -18,6 +18,14 @@
           - ncclient
           - xmltodict
 
+    - name: Disable paramiko key lookup for netconf switch connections
+      community.general.ini_file:
+        path: "{{ playbook_dir }}/ansible.cfg"
+        section: paramiko_connection
+        option: look_for_keys
+        value: "False"
+        no_extra_spaces: true
+
 - name: Switches configuration
   hosts: switches
   gather_facts: false


### PR DESCRIPTION
[switch_config] Disable paramiko key lookup for netconf connections
Paramiko discovers SSH keys in ~/.ssh and attempts to use them when
establishing netconf connections to Junos switches. With paramiko 5.0
this causes failures because it tries to negotiate ssh-rsa (SHA-1)
signing with switches running older Junos versions.

Disable look_for_keys in ansible.cfg before running switch
configuration so that paramiko only uses explicitly configured
credentials.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Signed-off-by: Miguel Angel Nieto Jimenez <mnietoji@redhat.com>