### PR TITLE
[env_op_images] Fix expected_pull_basis for direct mirror URLs

### DIFF
--- a/roles/env_op_images/tasks/pulled_images_report.yml
+++ b/roles/env_op_images/tasks/pulled_images_report.yml
@@ -18,8 +18,10 @@
 # - Load cluster ImageContentSourcePolicy + ImageDigestMirrorSet objects via oc.
 # - Flatten them into {source, mirror} pairs (repository prefix -> mirror ref).
 # - For each container/initContainer in selected namespaces, compare the pod
-#   status image string to those prefixes: first matching rule yields
+#   status image string to those prefixes: first matching source rule yields
 #   expected_pull_basis mirror and expected_pull_location from the mirror host;
+#   if no source rule matched, a second pass checks whether the image already
+#   references a known mirror prefix (direct mirror URL in the pod spec);
 #   otherwise basis source and location from the image ref host.
 # Matching uses image (reference string), not imageID; pod status often keeps
 # the upstream registry name even when the runtime used a mirror.

--- a/roles/env_op_images/templates/pulled_images_report.j2
+++ b/roles/env_op_images/templates/pulled_images_report.j2
@@ -25,6 +25,14 @@
 {%         set match.expected_pull_basis = 'mirror' %}
 {%       endif %}
 {%     endfor %}
+{%     if match.expected_pull_basis != 'mirror' %}
+{%       for m in _pulled_report_mirror_mappings if m.mirror is defined and m.mirror and image.startswith(m.mirror) %}
+{%         if loop.first %}
+{%           set match.host = m.mirror.split('/')[0] %}
+{%           set match.expected_pull_basis = 'mirror' %}
+{%         endif %}
+{%       endfor %}
+{%     endif %}
 {%     set _ = entries.append({
          'namespace': pod.metadata.namespace,
          'pod': pod.metadata.name,


### PR DESCRIPTION
The pulled-images report template only checked image references against source registry prefixes from ICSP/IDMS rules. Images already referencing a mirror URL directly (e.g. registry.stage instead of registry.redhat.io) were misclassified as "source". Add a second-pass check against mirror prefixes so these images are correctly labelled expected_pull_basis: mirror.