### PR TITLE
[DCN] Add tests for cinderBackups

### DIFF
--- a/playbooks/dcn.yml
+++ b/playbooks/dcn.yml
@@ -64,6 +64,15 @@
       ansible.builtin.include_role:
         name: ci_dcn_site
 
+    - name: Verify cinder backups across AZs
+      when: cifmw_dcn_test_cinder_backups | default(true) | bool
+      cifmw.general.ci_script:
+        output_dir: "{{ cifmw_basedir }}/artifacts"
+        extra_args:
+          ANSIBLE_LOG_PATH: "{{ cifmw_basedir }}/logs/cinder_backups_test.log"
+        script: |
+          ansible-playbook -i {{ inventory_file }} {{ cifmw_repo }}/hooks/playbooks/cinder_backups.yaml
+
     - name: The map for az0 contains all AZ backends
       ansible.builtin.set_fact:
         az_to_group_map:

--- a/roles/ci_dcn_site/templates/service-values.yaml.j2
+++ b/roles/ci_dcn_site/templates/service-values.yaml.j2
@@ -15,13 +15,28 @@ data:
   cinderAPI:
     replicas: 3
   cinderBackup:
-    replicas: 3
+    replicas: 0
     customServiceConfig: |
       [DEFAULT]
-      backup_driver = cinder.backup.drivers.ceph.CephBackupDriver
-      backup_ceph_conf = /etc/ceph/az0.conf
-      backup_ceph_pool = backups
-      backup_ceph_user = openstack
+      # cinderBackup (singular) is deprecated; use cinderBackups (plural)
+  cinderBackups:
+{% for _ceph in _ceph_vars_list %}
+    {{ _ceph.cifmw_ceph_client_cluster }}:
+      customServiceConfig: |
+        [DEFAULT]
+        storage_availability_zone = {{ _ceph.cifmw_ceph_client_cluster }}
+        backup_driver = cinder.backup.drivers.ceph.CephBackupDriver
+        backup_ceph_conf = /etc/ceph/{{ _ceph.cifmw_ceph_client_cluster }}.conf
+        backup_ceph_pool = backups
+        backup_ceph_user = openstack
+      networkAttachments:
+        - storage
+{% if _ceph.cifmw_ceph_client_cluster == _az_to_scaledown %}
+      replicas: 0
+{% else %}
+      replicas: 2
+{% endif %}
+{% endfor %}
   cinderVolumes:
 {% for _ceph in _ceph_vars_list %}
 {% if _ceph.cifmw_ceph_client_cluster != _az_to_scaledown %}


### PR DESCRIPTION
spec.cinder.template.cinderBackup (singluar) in DCN DT is
replaced with cinderBackups (plural) to deploy multiple cinder backups per edge sites.
Invoking hooks/playbooks/cinder_backups.yaml playbook to validates the behaviour of cinderBackups in DCN scenario.

The playbook tests different scenarios of cinder backup creation
and restoring the backups across availability zones.

Jira: [OSPRH-28343]
Signed-off-by: Gais Ameer <gameer@redhat.com>