### PR TITLE
[reproducer] Sync configs directory when PreMetal used

### DIFF
--- a/roles/reproducer/tasks/sync_src_dir.yml
+++ b/roles/reproducer/tasks/sync_src_dir.yml
@@ -14,6 +14,7 @@
     recursive: true
   no_log: "{{ cifmw_nolog | default(true) | bool }}"
   loop:
+    - configs
     - secrets
     - src
   loop_control:


### PR DESCRIPTION
The configs dir was not synchronized to the controller-0, but because we miss some files that contains necessary variables, we also need to sync that dir.