### PR TITLE
[ci_dcn_site] Add retry logic to Nova aggregate creation

### DIFF
--- a/roles/ci_dcn_site/tasks/az.yml
+++ b/roles/ci_dcn_site/tasks/az.yml
@@ -34,12 +34,27 @@
 - name: Create AZ if it does not exist
   when:
     - az_hosts.rc == 1
+  ignore_errors: true
   kubernetes.core.k8s_exec:
     api_key: "{{ _auth_results.openshift_auth.api_key }}"
     namespace: "{{ cifmw_openstack_namespace }}"
     pod: openstackclient
     command: >-
       openstack aggregate create {{ _az }} --zone {{ _az }}
+
+- name: Verify AZ aggregate exists
+  when:
+    - az_hosts.rc == 1
+  register: az_verify
+  retries: 10
+  delay: 30
+  until: az_verify.rc == 0
+  kubernetes.core.k8s_exec:
+    api_key: "{{ _auth_results.openshift_auth.api_key }}"
+    namespace: "{{ cifmw_openstack_namespace }}"
+    pod: openstackclient
+    command: >-
+      openstack aggregate show {{ _az }} -c name -f value
 
 - name: Add only the missing edpm hosts to AZ
   ignore_errors: true


### PR DESCRIPTION
Add retry logic (10 attempts, 30s delay) to the Nova aggregate creation task to handle transient MessageDeliveryFailure errors during RabbitMQ restarts or queue rebalancing.

This aligns with the existing defensive coding pattern used throughout the ci_dcn_site role, where similar k8s_exec and Kubernetes API operations already include retry logic (see pre-ceph.yml, post-ceph.yml, etc.).

Root cause: DataPlaneDeployment triggers RabbitMQ queue rebalance during DCN deployment, causing rolling restarts. Nova aggregate creation can fail with MessageDeliveryFailure if attempted during this window.

This patch provides reactive recovery through retries. Total retry time is up to 5 minutes (10 × 30s), which covers typical RabbitMQ restart windows observed in CI.



Related-Issue: DCN deployment failure with MessageDeliveryFailure