### PR TITLE
[reproducer] Remove add_host that breaks reuse_ocp SSH connectivity

### DIFF
--- a/roles/reproducer/tasks/reuse_main.yaml
+++ b/roles/reproducer/tasks/reuse_main.yaml
@@ -126,13 +126,6 @@
           loop:
             - "{{ cifmw_reproducer_controller_user_dir }}/ansible-bootstrap.log"
 
-        - name: Read inventory file and add it using add_host module
-          vars:
-            include_inventory_file: "{{ ansible_user_dir }}/ci-framework-data/artifacts/zuul_inventory.yml"
-          ansible.builtin.include_role:
-            name: cifmw_helpers
-            tasks_from: inventory_file.yml
-
         - name: Bootstrap environment on controller-0
           environment:
             ANSIBLE_LOG_PATH: "{{ ansible_user_dir }}/ansible-bootstrap.log"


### PR DESCRIPTION
[reproducer] Remove add_host that breaks reuse_ocp SSH connectivity
The add_host task in reuse_main.yaml reads the inventory from
controller-0 and re-registers hosts with ansible_host set to
controller-0.utility. This hostname only resolves from the
hypervisor, not from the Zuul executor. The add_host also
overwrites the existing SSH ProxyJump configuration, causing
all subsequent delegated tasks to fail with UNREACHABLE because
the executor tries to connect directly to controller-0.utility.

This task was introduced in https://github.com/openstack-k8s-operators/ci-framework/commit/10121fb1b72c3bdd4da5b82a5c79a23308849f0b as part of the refactor
from command-based to role-based bootstrap execution.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Signed-off-by: Miguel Angel Nieto Jimenez <mnietoji@redhat.com>