### PR TITLE
[adoption_osp_deploy] Add enable_keystone_ldap setting in adoption role

### DIFF
--- a/roles/adoption_osp_deploy/templates/adoption_vars.yaml.j2
+++ b/roles/adoption_osp_deploy/templates/adoption_vars.yaml.j2
@@ -220,3 +220,7 @@ edpm_{{ site }}_routes:
   {% endfor %}
 {% endif %}
 {% endfor %}
+
+{% if cifmw_adoption_osp_deploy_scenario.enable_keystone_ldap | default(false) %}
+enable_keystone_ldap: true
+{% endif %}


### PR DESCRIPTION
This will work with the following data plane adoption patch to add ldap users to keystone in uni03gamma deploys.

https://github.com/openstack-k8s-operators/data-plane-adoption/pull/1386