### PR TITLE
[reproducer] Skip compute configuration when preProvisioned is false

### DIFF
--- a/roles/reproducer/tasks/libvirt_layout.yml
+++ b/roles/reproducer/tasks/libvirt_layout.yml
@@ -95,6 +95,7 @@
 # environment file, and filter on all known edpm node types.
 - name: Configure EDPM based nodes ctlplane network
   when:
+    - cifmw_edpm_deploy_pre_provisioned | default(true) | bool
     - >-
       (compute.key in (groups['computes'] | default([]))) or
       (compute.key in (groups['cephs'] | default([]))) or


### PR DESCRIPTION
The "Configure EDPM based nodes ctlplane network" task in libvirt_layout.yml delegates SSH to all compute hosts. In baremetal deployments with `preProvisioned=false`, Ironic-provisioned computes do not accept SSH from the hypervisor, causing the reproducer to fail with Permission denied.

The task's own comment states it configures pre-provisioned nodes. Add the matching condition to enforce that.

Related-Issue: [ANVIL-109](https://redhat.atlassian.net/browse/ANVIL-109)