### PR TITLE
[test_operator] Fix test_operator_results overwrite for multi-stage runs

### DIFF
--- a/roles/test_operator/tasks/run-test-operator-job.yml
+++ b/roles/test_operator/tasks/run-test-operator-job.yml
@@ -122,12 +122,12 @@
       ansible.builtin.assert:
         that: successful_execution
 
-    - name: Save result - {{ run_test_fw }}
+    - name: Save result - {{ run_test_fw + '-' + _stage_vars.name }}
       ansible.builtin.set_fact:
         test_operator_results: >-
           {{
               test_operator_results | default({}) |
-              combine({run_test_fw: successful_execution})
+              combine({run_test_fw + '-' + _stage_vars.name: successful_execution})
           }}
 
     - name: Delete test resources


### PR DESCRIPTION
When cifmw_test_operator_stages contains multiple stages of the same type, the results dict key was just the framework name. Each stage overwrote the previous result, so a failing middle stage was silently masked if the final stage succeeded.

Include the stage name in the dict key so each stage gets its own entry. The assert at the end of main.yml iterates dict2items, so it checks all entries without further changes.