### PR TITLE
Fix IPSet hostname lookup regression

### DIFF
--- a/deploy-edpm.yml
+++ b/deploy-edpm.yml
@@ -95,16 +95,13 @@
         - cifmw_architecture_scenario is defined
       ansible.builtin.meta: end_play
 
-    - name: Gather facts for NFS deployment
-      ansible.builtin.setup:
-
     - name: Run cifmw_nfs role
       vars:
         nftables_path: /etc/nftables
         nftables_conf: /etc/sysconfig/nftables.conf
       when:
         - cifmw_edpm_deploy_nfs | default(false) | bool
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: cifmw_nfs
 
 - name: Clear ceph target hosts facts to force refreshing in HCI deployments


### PR DESCRIPTION
PR #3930 added an explicit `ansible.builtin.setup` task before the `cifmw_nfs` role invocation and changed `import_role` to `include_role`. Both changes cause `ansible_domain` to resolve incorrectly in the `_nfs_host` variable:

- The explicit `setup` gathers fresh facts **after** EDPM deployment has configured the compute's hostname with a domain suffix (`ctlplane.example.com`), causing the IPSet lookup to use `compute-0.ctlplane.example.com` instead of `compute-0`.
- `include_role` alters variable scoping so `ansible_domain` no longer resolves from the play target host's facts.

**Fix:**

- Remove the explicit `setup` task. With `gather_facts: false` and no manual fact gathering, `ansible_domain` remains undefined. The `select()` filter in `_nfs_host` drops it, producing the correct short hostname matching the IPSet name.
- Revert `include_role` back to `import_role` to restore play-level variable scoping.

Fixes: `component-watcher` and other NFS-based jobs broken after PR #3930 merged.

Related-Issue: [ANVIL-109](https://redhat.atlassian.net/browse/ANVIL-109)

Closes: [OSPCIX-1394](https://redhat.atlassian.net/browse/OSPCIX-1394)