### PR TITLE
[DNM] [update] Restrict post-services split update tests to tempest only

### DIFF
--- a/roles/update/tasks/update_variant_split.yml
+++ b/roles/update/tasks/update_variant_split.yml
@@ -24,6 +24,9 @@
   vars:
     cifmw_test_operator_artifacts_basedir: "{{ cifmw_basedir }}/tests/test_operator_update"
     cifmw_test_operator_tempest_name: "post-services-update-tempest-tests"
+    cifmw_test_operator_stages:
+      - name: tempest
+        type: tempest
   ansible.builtin.include_role:
     name: cifmw_setup
     tasks_from: run_tests.yml


### PR DESCRIPTION
## Summary

During a split update (`cifmw_update_variant: split`), the "Run tests after Services update" task in `update_variant_split.yml` runs the full `cifmw_test_operator_stages` (tobiko + tempest) while the continuous control
plane check is still active in the background.
The control plane check continuously creates and deletes VMs, which can collide with tobiko's `action_on_all_instances('active')` call, causing non-deterministic failures when tobiko encounters VMs in `BUILD` state.

This PR overrides `cifmw_test_operator_stages` in the intermediate post-services test task to only include tempest. Tobiko continues to run as before in the final post-update stage (`update-edpm.yml`), where the control plane check has already been stopped.

## Context
This is an alternative approach to #3978, which stops and restarts the control plane check around the intermediate tests. This approach was suggested during review as a cleaner solution that preserves uninterrupted control plane monitoring throughout the entire update.

Closes: [OSPCIX-1381](https://redhat.atlassian.net/browse/OSPCIX-1381)
Assisted-By: Cursor