### PR TITLE
[env_op_images] Improve CRI-O image origin verification accuracy

### DIFF
--- a/plugins/modules/verify_pulled_report_crio.py
+++ b/plugins/modules/verify_pulled_report_crio.py
@@ -27,7 +27,13 @@ short_description: Enrich pulled_images_report with CRI-O pull evidence
 
 description:
   - Reads the YAML produced by the env_op_images pulled-images report role task.
-  - "Parses CRI-O journal lines for C(msg=\"Pulled image: ...@sha256:...\")."
+  - "Parses CRI-O journal lines for both C(msg=\"Trying to access\") and
+    C(msg=\"Pulled image: ...@sha256:...\") entries."
+  - "CRI-O always reports the canonical source registry in C(Pulled image)
+    lines even when the image was fetched from a mirror.  The
+    C(Trying to access) lines show which registries CRI-O actually
+    contacted.  This module uses the last C(Trying to access) URI for
+    a given digest as the authoritative pull-source evidence."
   - Adds per-row verification fields using trusted mirror domains from
     C(summary.mirror_rules).
   - When images carry a C(node) field, evidence is matched against the
@@ -105,7 +111,8 @@ cross_node_entries:
   returned: always
 nodes_with_evidence:
   description: >-
-    Node names that had at least one C(Pulled image) log entry.
+    Node names that had at least one C(Trying to access) or
+    C(Pulled image) log entry.
   type: list
   elements: str
   returned: always
@@ -118,8 +125,11 @@ import re
 import yaml
 from ansible.module_utils.basic import AnsibleModule
 
-LOG_PATTERN = re.compile(
-    r'msg="Pulled image: (?P<actual_uri>[^@\s]+)@(?P<id>sha256:[a-f0-9]+)"'
+PULLED_PATTERN = re.compile(
+    r'msg="Pulled image: (?P<pulled_uri>[^@\s]+)@(?P<id>sha256:[a-f0-9]+)"'
+)
+TRYING_PATTERN = re.compile(
+    r'msg="Trying to access \\"(?P<tried_uri>[^@\s]+)@(?P<id>sha256:[a-f0-9]+)\\"'
 )
 SHA256_PATTERN = re.compile(r"sha256:[a-f0-9]+")
 
@@ -138,24 +148,58 @@ def _domain_from_uri(uri):
     return uri.split("/")[0].strip()
 
 
-def _apply_evidence(img, actual_uri, evidence_node, trusted_mirrors):
-    """Set common verification fields on an image row that has log evidence."""
-    actual_domain = _domain_from_uri(actual_uri)
-    img["node_verified_image_origin"] = (
-        "mirror" if actual_domain in trusted_mirrors else "source"
-    )
-    img["log_evidence_uri"] = actual_uri
+def _apply_evidence(img, evidence, evidence_node, trusted_mirrors):
+    """Set verification fields on an image row that has log evidence.
+
+    The *evidence* dict carries ``tried_uri`` (from "Trying to access") and/or
+    ``pulled_uri`` (from "Pulled image").  The tried URI is authoritative for
+    determining origin because CRI-O always reports the canonical source name
+    in "Pulled image" even when it fetched from a mirror.
+
+    When only ``tried_uri`` exists without a ``pulled_uri``, the pull was
+    attempted but never confirmed successful -- origin is ``pull_failed``.
+    """
+    tried_uri = evidence.get("tried_uri")
+    pulled_uri = evidence.get("pulled_uri")
+
+    if tried_uri and not pulled_uri:
+        img["node_verified_image_origin"] = "pull_failed"
+        img["verification_reason"] = "CRI-O tried registries but pull never succeeded"
+        img["image_fetched_from"] = None
+        img["image_canonical_name"] = None
+        img["log_evidence_node"] = evidence_node
+        return None
+
+    authoritative_uri = tried_uri or pulled_uri
+    actual_domain = _domain_from_uri(authoritative_uri)
+    origin = "mirror" if actual_domain in trusted_mirrors else "source"
+    img["node_verified_image_origin"] = origin
+
+    if tried_uri:
+        img["verification_reason"] = "CRI-O contacted {0} and pull succeeded".format(
+            origin
+        )
+    else:
+        img["verification_reason"] = (
+            "Pull confirmed via Pulled image log only"
+            " (no registry contact attempt logged)"
+        )
+
+    img["image_fetched_from"] = tried_uri
+    img["image_canonical_name"] = pulled_uri
     img["log_evidence_node"] = evidence_node
-    return actual_domain
 
 
 def _collect_log_evidence(paths, module):
     """Parse CRI-O logs into per-node and global evidence dicts.
 
+    Each digest maps to ``{"tried_uri": ..., "pulled_uri": ...}``.
+    "Trying to access" is the authoritative source for which registry was
+    contacted; "Pulled image" always carries the canonical name.
+
     Returns:
-        per_node: ``{node_name: {sha256_digest: pull_uri}}``
-        global_evidence: ``{sha256_digest: (pull_uri, node_name)}``
-            (last writer wins across nodes for the global dict)
+        per_node: ``{node_name: {digest: {"tried_uri": str|None, "pulled_uri": str|None}}}``
+        global_evidence: ``{digest: (evidence_dict, node_name)}``
     """
     per_node = {}
     global_evidence = {}
@@ -165,12 +209,33 @@ def _collect_log_evidence(paths, module):
         try:
             with open(path, "r") as f:
                 for line in f:
-                    match = LOG_PATTERN.search(line)
-                    if match:
-                        digest = match.group("id")
-                        uri = match.group("actual_uri")
-                        node_ev[digest] = uri
-                        global_evidence[digest] = (uri, node)
+                    trying = TRYING_PATTERN.search(line)
+                    if trying:
+                        digest = trying.group("id")
+                        node_entry = node_ev.setdefault(
+                            digest, {"tried_uri": None, "pulled_uri": None}
+                        )
+                        node_entry["tried_uri"] = trying.group("tried_uri")
+                        global_entry = global_evidence.setdefault(
+                            digest, [{"tried_uri": None, "pulled_uri": None}, node]
+                        )
+                        global_entry[0]["tried_uri"] = trying.group("tried_uri")
+                        global_entry[1] = node
+                        continue
+
+                    pulled = PULLED_PATTERN.search(line)
+                    if pulled:
+                        digest = pulled.group("id")
+                        node_entry = node_ev.setdefault(
+                            digest, {"tried_uri": None, "pulled_uri": None}
+                        )
+                        node_entry["pulled_uri"] = pulled.group("pulled_uri")
+                        global_entry = global_evidence.setdefault(
+                            digest, [{"tried_uri": None, "pulled_uri": None}, node]
+                        )
+                        global_entry[0]["pulled_uri"] = pulled.group("pulled_uri")
+                        if global_entry[1] is None:
+                            global_entry[1] = node
         except IOError as exc:
             module.fail_json(
                 msg="Cannot read CRI-O log file {0}: {1}".format(path, str(exc))
@@ -251,16 +316,18 @@ def run_module():
         )
 
         if node_local_hit:
-            actual_uri = per_node_evidence[img_node][img_sha]
-            _apply_evidence(img, actual_uri, img_node, trusted_mirrors)
+            evidence = per_node_evidence[img_node][img_sha]
+            _apply_evidence(img, evidence, img_node, trusted_mirrors)
         elif img_sha in global_evidence:
-            actual_uri, evidence_node = global_evidence[img_sha]
-            _apply_evidence(img, actual_uri, evidence_node, trusted_mirrors)
+            evidence, evidence_node = global_evidence[img_sha]
+            _apply_evidence(img, evidence, evidence_node, trusted_mirrors)
             if img_node:
                 cross_node_entries += 1
         else:
             img["node_verified_image_origin"] = "cached/unknown"
-            img["log_evidence_uri"] = None
+            img["verification_reason"] = "No CRI-O log evidence found for this digest"
+            img["image_fetched_from"] = None
+            img["image_canonical_name"] = None
             img["log_evidence_node"] = None
 
     nodes_with_evidence = sorted(n for n, ev in per_node_evidence.items() if ev)

--- a/tests/unit/modules/test_verify_pulled_report_crio.py
+++ b/tests/unit/modules/test_verify_pulled_report_crio.py
@@ -27,11 +27,13 @@ class TestVerifyPulledReportCrio(ModuleBaseTestCase):
     def test_enriches_report_and_counts_cross_node(self):
         """
         GIVEN a pulled-images report with two digest entries across two nodes
-              and CRI-O logs showing each image pulled on its own node
+              and CRI-O logs with "Trying to access" + "Pulled image" lines
         WHEN  the module processes the report against the logs
-        THEN  it enriches every image with log evidence, identifies trusted
-              mirrors, and reports zero cross-node entries
+        THEN  it uses the "Trying to access" URI for origin verification,
+              identifies trusted mirrors, and reports zero cross-node entries
         """
+        _sha_a = "a" * 64
+        _sha_b = "b" * 64
         report_data = {
             "summary": {
                 "mirror_rules": [
@@ -41,17 +43,11 @@ class TestVerifyPulledReportCrio(ModuleBaseTestCase):
             },
             "images": [
                 {
-                    "image_id": (
-                        "quay.io/demo/app@sha256:"
-                        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                    ),
+                    "image_id": "quay.io/demo/app@sha256:" + _sha_a,
                     "node": "node-a",
                 },
                 {
-                    "image_id": (
-                        "quay.io/demo/other@sha256:"
-                        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-                    ),
+                    "image_id": "quay.io/demo/other@sha256:" + _sha_b,
                     "node": "node-b",
                 },
                 {"image_id": "no-digest-here", "node": "node-a"},
@@ -71,18 +67,16 @@ class TestVerifyPulledReportCrio(ModuleBaseTestCase):
 
             with open(log_a, "w") as f:
                 f.write(
+                    'level=info msg="Trying to access \\"'
+                    "mirror.registry.example:5000/ns/app@sha256:" + _sha_a + '\\""\n'
                     'level=info msg="Pulled image: '
-                    "mirror.registry.example:5000/ns/app@sha256:"
-                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                    '"\n'
+                    "quay.io/demo/app@sha256:" + _sha_a + '"\n'
                 )
 
             with open(log_b, "w") as f:
                 f.write(
                     'level=info msg="Pulled image: '
-                    "quay.io/demo/other@sha256:"
-                    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-                    '"\n'
+                    "quay.io/demo/other@sha256:" + _sha_b + '"\n'
                 )
 
             set_module_args(
@@ -111,15 +105,29 @@ class TestVerifyPulledReportCrio(ModuleBaseTestCase):
             img0 = enriched["images"][0]
             self.assertEqual(img0["log_evidence_node"], "node-a")
             self.assertEqual(
-                img0["log_evidence_uri"],
+                img0["image_fetched_from"],
                 "mirror.registry.example:5000/ns/app",
             )
+            self.assertEqual(
+                img0["image_canonical_name"],
+                "quay.io/demo/app",
+            )
             self.assertEqual(img0["node_verified_image_origin"], "mirror")
+            self.assertEqual(
+                img0["verification_reason"],
+                "CRI-O contacted mirror and pull succeeded",
+            )
 
             img1 = enriched["images"][1]
             self.assertEqual(img1["log_evidence_node"], "node-b")
-            self.assertEqual(img1["log_evidence_uri"], "quay.io/demo/other")
+            self.assertIsNone(img1["image_fetched_from"])
+            self.assertEqual(img1["image_canonical_name"], "quay.io/demo/other")
             self.assertEqual(img1["node_verified_image_origin"], "source")
+            self.assertEqual(
+                img1["verification_reason"],
+                "Pull confirmed via Pulled image log only"
+                " (no registry contact attempt logged)",
+            )
 
     def test_cross_node_match_increments_counter(self):
         """
@@ -129,14 +137,12 @@ class TestVerifyPulledReportCrio(ModuleBaseTestCase):
         THEN  the cross_node_entries counter is incremented and the
               evidence node is set to the log's node (node-b)
         """
+        _sha_c = "c" * 64
         report_data = {
             "summary": {"mirror_rules": [{"mirror": "mirror.example/ns"}]},
             "images": [
                 {
-                    "image_id": (
-                        "quay.io/demo/app@sha256:"
-                        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-                    ),
+                    "image_id": "quay.io/demo/app@sha256:" + _sha_c,
                     "node": "node-a",
                 }
             ],
@@ -154,10 +160,10 @@ class TestVerifyPulledReportCrio(ModuleBaseTestCase):
 
             with open(log_b, "w") as f:
                 f.write(
+                    'level=info msg="Trying to access \\"'
+                    "mirror.example/ns/app@sha256:" + _sha_c + '\\""\n'
                     'level=info msg="Pulled image: '
-                    "mirror.example/ns/app@sha256:"
-                    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-                    '"\n'
+                    "quay.io/demo/app@sha256:" + _sha_c + '"\n'
                 )
 
             set_module_args(
@@ -181,6 +187,313 @@ class TestVerifyPulledReportCrio(ModuleBaseTestCase):
             img0 = enriched["images"][0]
             self.assertEqual(img0["log_evidence_node"], "node-b")
             self.assertEqual(img0["node_verified_image_origin"], "mirror")
+
+    def test_trying_to_access_overrides_pulled_image_for_origin(self):
+        """
+        GIVEN CRI-O logs where "Trying to access" shows a mirror URI but
+              "Pulled image" shows the canonical source URI (normal CRI-O
+              behaviour with ICSP/IDMS mirror rules)
+        WHEN  the module processes the report
+        THEN  node_verified_image_origin is "mirror" (from "Trying to access"),
+              not "source" (which "Pulled image" alone would yield)
+        """
+        _sha = "d" * 64
+        report_data = {
+            "summary": {
+                "mirror_rules": [
+                    {
+                        "source": "registry.redhat.io/rhoso-operators",
+                        "mirror": (
+                            "image-rbac-proxy.apps.example.com"
+                            "/redhat-user-workloads/openstack-tenant"
+                            "/openstack-18-0-21"
+                        ),
+                    }
+                ]
+            },
+            "images": [
+                {
+                    "image_id": (
+                        "registry.redhat.io/rhoso-operators"
+                        "/swift-rhel9-operator@sha256:" + _sha
+                    ),
+                    "node": "master-1",
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            report_path = os.path.join(td, "pulled_images_report.yaml")
+            output_path = os.path.join(td, "verified.yaml")
+            log_m1 = os.path.join(td, "master-1.crio.log")
+
+            with open(report_path, "w") as f:
+                yaml.safe_dump(
+                    report_data, f, default_flow_style=False, sort_keys=False
+                )
+
+            with open(log_m1, "w") as f:
+                f.write(
+                    'level=info msg="Trying to access \\"'
+                    "image-rbac-proxy.apps.example.com"
+                    "/redhat-user-workloads/openstack-tenant"
+                    "/openstack-18-0-21"
+                    "/swift-operator@sha256:" + _sha + '\\""\n'
+                    'level=info msg="Pulled image: '
+                    "registry.redhat.io/rhoso-operators"
+                    "/swift-rhel9-operator@sha256:" + _sha + '"\n'
+                )
+
+            set_module_args(
+                dict(
+                    report_path=report_path,
+                    output_path=output_path,
+                    log_paths=[log_m1],
+                )
+            )
+
+            with self.assertRaises(AnsibleExitJson) as rst:
+                verify_pulled_report_crio.run_module()
+
+            result = rst.exception.args[0]
+            self.assertEqual(result["entries_with_digest"], 1)
+            self.assertEqual(result["cross_node_entries"], 0)
+            self.assertIn(
+                "image-rbac-proxy.apps.example.com", result["trusted_mirrors"]
+            )
+
+            with open(output_path, "r") as f:
+                enriched = yaml.safe_load(f)
+
+            img0 = enriched["images"][0]
+            self.assertEqual(img0["node_verified_image_origin"], "mirror")
+            self.assertEqual(
+                img0["image_fetched_from"],
+                "image-rbac-proxy.apps.example.com"
+                "/redhat-user-workloads/openstack-tenant"
+                "/openstack-18-0-21"
+                "/swift-operator",
+            )
+            self.assertEqual(
+                img0["image_canonical_name"],
+                "registry.redhat.io/rhoso-operators/swift-rhel9-operator",
+            )
+            self.assertEqual(img0["log_evidence_node"], "master-1")
+            self.assertEqual(
+                img0["verification_reason"],
+                "CRI-O contacted mirror and pull succeeded",
+            )
+
+    def test_fallback_to_pulled_image_when_no_trying_lines(self):
+        """
+        GIVEN CRI-O logs with only "Pulled image" lines (no "Trying to access")
+        WHEN  the module processes the report
+        THEN  it falls back to using the "Pulled image" URI for origin and
+              sets log_evidence_tried_uri to None
+        """
+        _sha = "e" * 64
+        report_data = {
+            "summary": {"mirror_rules": [{"mirror": "mirror.example/ns"}]},
+            "images": [
+                {
+                    "image_id": "quay.io/demo/app@sha256:" + _sha,
+                    "node": "node-a",
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            report_path = os.path.join(td, "pulled_images_report.yaml")
+            output_path = os.path.join(td, "verified.yaml")
+            log_a = os.path.join(td, "node-a.crio.log")
+
+            with open(report_path, "w") as f:
+                yaml.safe_dump(
+                    report_data, f, default_flow_style=False, sort_keys=False
+                )
+
+            with open(log_a, "w") as f:
+                f.write(
+                    'level=info msg="Pulled image: '
+                    "quay.io/demo/app@sha256:" + _sha + '"\n'
+                )
+
+            set_module_args(
+                dict(
+                    report_path=report_path,
+                    output_path=output_path,
+                    log_paths=[log_a],
+                )
+            )
+
+            with self.assertRaises(AnsibleExitJson) as rst:
+                verify_pulled_report_crio.run_module()
+
+            with open(output_path, "r") as f:
+                enriched = yaml.safe_load(f)
+
+            img0 = enriched["images"][0]
+            self.assertEqual(img0["node_verified_image_origin"], "source")
+            self.assertIsNone(img0["image_fetched_from"])
+            self.assertEqual(img0["image_canonical_name"], "quay.io/demo/app")
+            self.assertEqual(img0["log_evidence_node"], "node-a")
+            self.assertEqual(
+                img0["verification_reason"],
+                "Pull confirmed via Pulled image log only"
+                " (no registry contact attempt logged)",
+            )
+
+    def test_mirror_unavailable_fallback_to_source(self):
+        """
+        GIVEN CRI-O logs where "Trying to access" shows the source registry
+              (not a mirror) because the mirror was unavailable and CRI-O
+              fell back to contacting the source directly
+        WHEN  the module processes the report
+        THEN  node_verified_image_origin is "source" (the tried URI domain
+              is not in trusted_mirrors)
+        """
+        _sha = "ab" * 32
+        report_data = {
+            "summary": {"mirror_rules": [{"mirror": "mirror.unavailable.example/ns"}]},
+            "images": [
+                {
+                    "image_id": "registry.redhat.io/rhoso/app@sha256:" + _sha,
+                    "node": "node-a",
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            report_path = os.path.join(td, "pulled_images_report.yaml")
+            output_path = os.path.join(td, "verified.yaml")
+            log_a = os.path.join(td, "node-a.crio.log")
+
+            with open(report_path, "w") as f:
+                yaml.safe_dump(
+                    report_data, f, default_flow_style=False, sort_keys=False
+                )
+
+            with open(log_a, "w") as f:
+                f.write(
+                    'level=info msg="Trying to access \\"'
+                    "registry.redhat.io/rhoso/app@sha256:" + _sha + '\\""\n'
+                    'level=info msg="Pulled image: '
+                    "registry.redhat.io/rhoso/app@sha256:" + _sha + '"\n'
+                )
+
+            set_module_args(
+                dict(
+                    report_path=report_path,
+                    output_path=output_path,
+                    log_paths=[log_a],
+                )
+            )
+
+            with self.assertRaises(AnsibleExitJson) as rst:
+                verify_pulled_report_crio.run_module()
+
+            result = rst.exception.args[0]
+            self.assertEqual(result["entries_with_digest"], 1)
+            self.assertEqual(result["cross_node_entries"], 0)
+
+            with open(output_path, "r") as f:
+                enriched = yaml.safe_load(f)
+
+            img0 = enriched["images"][0]
+            self.assertEqual(img0["node_verified_image_origin"], "source")
+            self.assertEqual(
+                img0["image_fetched_from"],
+                "registry.redhat.io/rhoso/app",
+            )
+            self.assertEqual(
+                img0["image_canonical_name"],
+                "registry.redhat.io/rhoso/app",
+            )
+            self.assertEqual(img0["log_evidence_node"], "node-a")
+            self.assertEqual(
+                img0["verification_reason"],
+                "CRI-O contacted source and pull succeeded",
+            )
+
+    def test_pull_failed_when_trying_without_pulled(self):
+        """
+        GIVEN CRI-O logs with multiple "Trying to access" lines for a digest
+              but no "Pulled image" line (all pull attempts failed)
+        WHEN  the module processes the report
+        THEN  node_verified_image_origin is "pull_failed" and
+              image_fetched_from is None
+        """
+        _sha = "f" * 64
+        report_data = {
+            "summary": {
+                "mirror_rules": [
+                    {
+                        "source": "registry.redhat.io/rhoso",
+                        "mirror": (
+                            "image-rbac-proxy.apps.example.com"
+                            "/redhat-user-workloads/openstack-tenant"
+                            "/openstack-18-0-21"
+                        ),
+                    }
+                ]
+            },
+            "images": [
+                {
+                    "image_id": (
+                        "registry.redhat.io/rhoso"
+                        "/openstack-rsyslog-rhel9@sha256:" + _sha
+                    ),
+                    "node": "master-0",
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            report_path = os.path.join(td, "pulled_images_report.yaml")
+            output_path = os.path.join(td, "verified.yaml")
+            log_m0 = os.path.join(td, "master-0.crio.log")
+
+            with open(report_path, "w") as f:
+                yaml.safe_dump(
+                    report_data, f, default_flow_style=False, sort_keys=False
+                )
+
+            with open(log_m0, "w") as f:
+                for _attempt in range(4):
+                    f.write(
+                        'level=info msg="Trying to access \\"'
+                        "image-rbac-proxy.apps.example.com"
+                        "/redhat-user-workloads/openstack-tenant"
+                        "/openstack-18-0-21"
+                        "/openstack-rsyslog@sha256:" + _sha + '\\""\n'
+                        'level=info msg="Trying to access \\"'
+                        "registry.redhat.io/rhoso"
+                        "/openstack-rsyslog-rhel9@sha256:" + _sha + '\\""\n'
+                    )
+
+            set_module_args(
+                dict(
+                    report_path=report_path,
+                    output_path=output_path,
+                    log_paths=[log_m0],
+                )
+            )
+
+            with self.assertRaises(AnsibleExitJson) as rst:
+                verify_pulled_report_crio.run_module()
+
+            with open(output_path, "r") as f:
+                enriched = yaml.safe_load(f)
+
+            img0 = enriched["images"][0]
+            self.assertEqual(img0["node_verified_image_origin"], "pull_failed")
+            self.assertEqual(
+                img0["verification_reason"],
+                "CRI-O tried registries but pull never succeeded",
+            )
+            self.assertIsNone(img0["image_fetched_from"])
+            self.assertIsNone(img0["image_canonical_name"])
+            self.assertEqual(img0["log_evidence_node"], "master-0")
 
     def test_fails_when_no_log_files(self):
         """


### PR DESCRIPTION
CRI-O always reports the canonical source registry (e.g. registry.redhat.io) in "Pulled image" log lines, even when the image was actually fetched from a mirror. This made node_verified_image_origin unreliable -- it nearly always reported "source" for mirrored images.

This MR switches to using "Trying to access" log lines as the authoritative evidence for determining image origin, since those show the actual registry CRI-O contacted.

Unit tests were added covering mirror-override, fallback, and pull_failed scenarios.