### PR TITLE
[libvirt_manager] Register workload dir as libvirt storage pool

### DIFF
--- a/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/roles/libvirt_manager/tasks/clean_layout.yml
@@ -242,6 +242,15 @@
         pool_action: "delete"
       ansible.builtin.include_tasks: storage_pool.yml
 
+    - name: Remove workload storage pool
+      vars:
+        pool_action: "delete"
+        cifmw_libvirt_manager_storage_pool: >-
+          {{ cifmw_libvirt_manager_workload_pool }}
+        cifmw_libvirt_manager_pool_dir: >-
+          {{ cifmw_libvirt_manager_basedir }}/workload
+      ansible.builtin.include_tasks: storage_pool.yml
+
     - name: Remove overlay images from ocp_volume pools if exists
       when:
         - item is not match('^base-.*$')

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -76,6 +76,15 @@
     - workload
     - volumes
 
+- name: Ensure workload storage pool is present
+  vars:
+    pool_action: "create"
+    cifmw_libvirt_manager_storage_pool: >-
+      {{ cifmw_libvirt_manager_workload_pool }}
+    cifmw_libvirt_manager_pool_dir: >-
+      {{ cifmw_libvirt_manager_basedir }}/workload
+  ansible.builtin.include_tasks: storage_pool.yml
+
 - name: Generate networking data
   when:
     - cifmw_libvirt_manager_mac_map is undefined

--- a/roles/libvirt_manager/vars/main.yml
+++ b/roles/libvirt_manager/vars/main.yml
@@ -39,6 +39,7 @@ cifmw_libvirt_manager_polkit_rules_dir: /etc/polkit-1/rules.d
 cifmw_libvirt_manager_polkit_rules_file: "{{ cifmw_libvirt_manager_polkit_rules_dir }}/80-libvirt-manage.rules"
 
 cifmw_libvirt_manager_storage_pool: "cifmw-pool"
+cifmw_libvirt_manager_workload_pool: "cifmw-workload"
 cifmw_libvirt_manager_fixed_networks_defaults:
   - ocpbm
   - ocppr


### PR DESCRIPTION
The `workload/` directory holds primary VM boot disks but was not registered as a libvirt storage pool. This caused sushy-emulator's libvirt driver to fail `storageVolLookupByPath()` calls when querying VM disk information.

Define a `cifmw-workload` pool for `workload/` alongside the existing `cifmw-pool` for `volumes/`, and clean it up on teardown.