### PR TITLE
[DNM] [env_op_images] Increase molecule job timeout to 3600s

### DIFF
--- a/ci/config/molecule.yaml
+++ b/ci/config/molecule.yaml
@@ -69,6 +69,7 @@
 - job:
     name: cifmw-molecule-env_op_images
     nodeset: centos-9-crc-2-56-0-xl
+    timeout: 3600
 - job:
     name: cifmw_molecule-pkg_build
     files:

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -399,6 +399,7 @@
     name: cifmw-molecule-env_op_images
     nodeset: centos-9-crc-2-56-0-xl
     parent: cifmw-molecule-base
+    timeout: 3600
     vars:
       TEST_RUN: env_op_images
 - job:


### PR DESCRIPTION
The cifmw-molecule-env_op_images job has been consistently timing out at the default 1800s (30 min) limit. The timeout occurs during CRC startup and the subsequent `oc login` retry loop that handles expired kubelet certificates (retries: 90, delay: 10s in crc_start.yml).

Recent CRC node images and infrastructure changes have increased the time needed for CRC to fully stabilize, pushing the job from its previous ~22-26 min runtime past the 30 min ceiling. The actual role tests complete quickly -- the bottleneck is entirely in the shared CRC setup phase.

Increasing the timeout to 3600s (60 min) provides sufficient headroom for the CRC environment to start and the certificate retry loop to complete, without masking real failures in the role under test.

This also fixes the same timeout seen in cifmw-molecule-ci_local_storage and other CRC-based molecule jobs that share the same infrastructure setup path.