### PR TITLE
[cifmw_helpers] Fix CRC certificate renewal wait using kubeconfig

### DIFF
--- a/roles/cifmw_helpers/tasks/crc_start.yml
+++ b/roles/cifmw_helpers/tasks/crc_start.yml
@@ -6,15 +6,13 @@
   register: _crc_output
   ignore_errors: true  # noqa: ignore-errors
 
-- name: Login to the OpenShift when certificate is expired
+- name: Wait for cluster to stabilize after certificate renewal
   when: "'Kubelet serving certificate has expired' in _crc_output.stderr"
   ansible.builtin.command: >
-    oc login
-    -u kubeadmin
-    https://api.crc.testing:6443
-    --insecure-skip-tls-verify
-  register: _openshift_login
-  until: _openshift_login.rc == 0
-  retries: 90
+    oc get nodes
+    --kubeconfig={{ ansible_user_dir }}/.crc/machines/crc/kubeconfig
+  register: _cluster_check
+  until: _cluster_check.rc == 0
+  retries: 150
   delay: 10
   changed_when: false


### PR DESCRIPTION
## Problem
Since ~2026-06-03, all CRC-based molecule jobs (`ci_local_storage`, `env_op_images`, etc.) fail consistently during the prepare phase, stuck on `TASK [cifmw_helpers : Login to the OpenShift when certificate is expired]` for 15 minutes before timing out with 401 Unauthorized.

## Root cause
The `oc login -u kubeadmin` command in `crc_start.yml` never included the p flag. In non-interactive CI the empty password always returns 401, regardless of cluster state.

## Fix
- Replace `oc login` with `oc get nodes --kubeconfig=...` which uses  the CRC kubeconfig file directly, avoiding the OAuth dependency and the need for credentials during certificate renewal.
- Increase retries from 90 to 150 (~25 min) to cover the observed cluster recovery time.
  
Refs:
 - https://gateway-cloud-softwarefactory.apps.ocp.cloud.ci.centos.org/zuul/t/rdoproject.org/build/4d4440cfa7f44ab59da90c14c51d8bd4 
 -  https://gateway-cloud-softwarefactory.apps.ocp.cloud.ci.centos.org/logs//4d4/rdoproject.org/4d4440cfa7f44ab59da90c14c51d8bd4/ci-framework-data/logs/molecule-execution.log
