### PR TITLE
Bump pidone compute amount to 5

### DIFF
--- a/scenarios/reproducers/va-pidone.yml
+++ b/scenarios/reproducers/va-pidone.yml
@@ -87,7 +87,7 @@ cifmw_libvirt_manager_configuration:
     compute:
       uefi: "{{ cifmw_use_uefi }}"
       root_part_id: "{{ cifmw_root_partition_id }}"
-      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 3] | max }}"
+      amount: "{{ [cifmw_libvirt_manager_compute_amount|int, 5] | max }}"
       image_url: "{{ cifmw_discovered_image_url }}"
       sha256_image_name: "{{ cifmw_discovered_hash }}"
       image_local_dir: "{{ cifmw_basedir }}/images/"


### PR DESCRIPTION
Match the architecture repo change that adds compute-3 and compute-4 to the pidone deployment topology.

Depends-On: https://github.com/openstack-k8s-operators/architecture/pull/765

Signed-off-by: Luca Miccini <lmiccini@redhat.com>