### PR TITLE
shiftstack: Support passing extra vars into shiftstackclient pod

### DIFF
--- a/roles/shiftstack/defaults/main.yml
+++ b/roles/shiftstack/defaults/main.yml
@@ -48,3 +48,6 @@ cifmw_shiftstack_storage_access_mode:
   - ReadWriteOnce
   - ReadWriteMany
   - ReadOnlyMany
+cifmw_shiftstack_extra_vars: {}
+cifmw_shiftstack_extra_vars_configmap_name: "shiftstack-extra-vars"
+cifmw_shiftstack_extra_vars_mount_path: "/home/cloud-admin/extra-vars"

--- a/roles/shiftstack/tasks/deploy_shiftstackclient_pod.yml
+++ b/roles/shiftstack/tasks/deploy_shiftstackclient_pod.yml
@@ -48,6 +48,21 @@
     src: "{{ (cifmw_shiftstack_manifests_dir, cifmw_shiftstack_client_pvc_manifest) | path_join }}"
     proxy: "{{ cifmw_shiftstack_proxy | default(omit) }}"
 
+- name: Create ConfigMap with extra vars for the shiftstackclient pod
+  when: cifmw_shiftstack_extra_vars | length > 0
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    definition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: "{{ cifmw_shiftstack_extra_vars_configmap_name }}"
+        namespace: "{{ cifmw_shiftstack_client_pod_namespace }}"
+      data:
+        extra-vars.yaml: "{{ cifmw_shiftstack_extra_vars | to_nice_yaml }}"
+    proxy: "{{ cifmw_shiftstack_proxy | default(omit) }}"
+
 - name: Render the pod manifest from a template
   ansible.builtin.template:
     src: "templates/shiftstackclient_pod.yml.j2"

--- a/roles/shiftstack/tasks/test_config.yml
+++ b/roles/shiftstack/tasks/test_config.yml
@@ -35,6 +35,7 @@
           cd shiftstack-qa &&
           ansible-navigator run playbooks/{{ cifmw_shiftstack_run_playbook }}
           -e @jobs_definitions/{{ testconfig }}
+          {% if cifmw_shiftstack_extra_vars | length > 0 %}-e @{{ cifmw_shiftstack_extra_vars_mount_path }}/extra-vars.yaml{% endif %}
           -e ocp_cluster_name={{ cifmw_shiftstack_cluster_name }}
           -e user_cloud={{ cifmw_shiftstack_project_name }}
           -e hypervisor={{ cifmw_shiftstack_hypervisor }}

--- a/roles/shiftstack/templates/shiftstackclient_pod.yml.j2
+++ b/roles/shiftstack/templates/shiftstackclient_pod.yml.j2
@@ -43,6 +43,11 @@ spec:
     - name: {{ cifmw_shiftstack_client_incluster_secret_name }}-volume
       mountPath: {{ cifmw_shiftstack_shiftstackclient_incluster_kubeconfig_dir }}
       readOnly: true
+{% if cifmw_shiftstack_extra_vars | length > 0 %}
+    - name: extra-vars
+      mountPath: {{ cifmw_shiftstack_extra_vars_mount_path }}
+      readOnly: true
+{% endif %}
   dnsPolicy: ClusterFirst
   enableServiceLinks: true
   preemptionPolicy: PreemptLowerPriority
@@ -79,3 +84,9 @@ spec:
   - name: installation-volume
     persistentVolumeClaim:
       claimName: {{ cifmw_shiftstack_client_pod_name }}-pvc
+{% if cifmw_shiftstack_extra_vars | length > 0 %}
+  - name: extra-vars
+    configMap:
+      defaultMode: 420
+      name: {{ cifmw_shiftstack_extra_vars_configmap_name }}
+{% endif %}


### PR DESCRIPTION
## Summary
- Add `cifmw_shiftstack_extra_vars` variable support to inject environment-specific configuration into the shiftstackclient pod
- When set, creates a ConfigMap with the vars, mounts it as a volume, and passes it to `ansible-navigator` with `-e @extra-vars.yaml`
- Enables telco/NFV verification jobs to keep environment-specific config (network names, flavors, CIDRs) in ci-framework-jobs while the generic job definition stays in shiftstack-qa

## Test plan
- [ ] Deploy with `cifmw_shiftstack_extra_vars: {}` (empty, default) — verify no ConfigMap created, pod unchanged, no extra `-e` flag
- [ ] Deploy with `cifmw_shiftstack_extra_vars` containing telco_env config — verify ConfigMap created, mounted in pod, vars accessible inside pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)