### PR TITLE
[env_op_images] Replace ICSP with IDMS/ITMS in pulled-images report

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -11,6 +11,7 @@ ICSP
 IDMS
 ImageDigestMirrorSet
 ImageTagMirrorSet
+ITMS
 IMVHO
 IdP
 Idempotency

--- a/roles/env_op_images/README.md
+++ b/roles/env_op_images/README.md
@@ -1,13 +1,13 @@
 # env_op_images
 
-This role collects OpenStack operator image references from the ClusterServiceVersion and running pods into `operator_images.yaml`, builds a **pulled-images policy report** by combining ICSP/IDMS mirror rules with pod status image references, and enriches that report with digest-level **CRI-O pull evidence** from node journals (writing a separate verified YAML artifact).
+This role collects OpenStack operator image references from the ClusterServiceVersion and running pods into `operator_images.yaml`, builds a **pulled-images policy report** by combining IDMS/ITMS mirror rules with pod status image references, and enriches that report with digest-level **CRI-O pull evidence** from node journals (writing a separate verified YAML artifact).
 
 All steps that talk to the cluster require `cifmw_openshift_kubeconfig` to be defined.
 
 ## Workflow
 
 1. **Operator images artifact** — When OpenStack is installed (or when `cifmw_env_op_images_dryrun` is true), collects images from the OpenStack operator CSV/pods and writes `{{ cifmw_env_op_images_dir }}/artifacts/{{ cifmw_env_op_images_file }}`.
-2. **Pulled-images report** (`tasks/pulled_images_report.yml`) — Policy-oriented view (not node-verified): loads `ImageContentSourcePolicy` and `ImageDigestMirrorSet` via `oc`, flattens mirror rules, lists pods in configured namespaces, and emits YAML with a `summary` plus per-container `images` rows (expected pull basis vs. ICSP/IDMS).
+2. **Pulled-images report** (`tasks/pulled_images_report.yml`) — Policy-oriented view (not node-verified): loads `ImageDigestMirrorSet` and `ImageTagMirrorSet` via `oc`, flattens mirror rules, lists pods in configured namespaces, and emits YAML with a `summary` plus per-container `images` rows (expected pull basis vs. IDMS/ITMS).
 3. **CRI-O verification** (`tasks/verify_pulled_report_crio.yml`) — If the pulled report file exists, fetches CRI-O unit logs per node (`oc adm node-logs <node> -u crio --since=-24h`), saves them under `cifmw_env_op_images_crio_logs_dir`, then runs the `verify_pulled_report_crio` module to write the verified report. This include is non-fatal (`ignore_errors: true`) so a failure here does not abort the rest of the play.
 
 ## Parameters
@@ -16,13 +16,13 @@ All steps that talk to the cluster require `cifmw_openshift_kubeconfig` to be de
 * `cifmw_env_op_images_file`: (String) Filename for the operator images YAML under `artifacts/`. Defaults to `operator_images.yaml`.
 * `cifmw_env_op_images_dryrun`: (Boolean) When true, image collection can run even if OpenStack is not reported Ready. Defaults to `false`.
 * `cifmw_env_op_images_pulled_report_namespaces`: (List) Namespaces whose pods are scanned for the pulled report. Defaults to `{{ cifmw_openstack_namespace | default('openstack') }}` and `{{ operator_namespace | default('openstack-operators') }}`.
-* `cifmw_env_op_images_pulled_report_path`: (String) Destination YAML for the pulled report: top-level `summary` (including embedded `mirror_rules` from ICSP/IDMS) and `images`. Defaults to `{{ cifmw_env_op_images_dir }}/artifacts/pulled_images_report.yaml`.
+* `cifmw_env_op_images_pulled_report_path`: (String) Destination YAML for the pulled report: top-level `summary` (including embedded `mirror_rules` from IDMS/ITMS) and `images`. Defaults to `{{ cifmw_env_op_images_dir }}/artifacts/pulled_images_report.yaml`.
 * `cifmw_env_op_images_verified_report_path`: (String) Output YAML after CRI-O enrichment (same structure as the pulled report, with extra fields on rows that could be matched). Defaults to `{{ cifmw_env_op_images_dir }}/artifacts/pulled_images_report_verified.yaml`.
 * `cifmw_env_op_images_crio_logs_dir`: (String) Directory for per-node `*.crio.log` files produced before verification. Defaults to `{{ cifmw_env_op_images_dir }}/artifacts/crio_logs`.
 
 ### Pulled report (`cifmw_env_op_images_pulled_report_path`)
 
-The pulled report prefix-matches each container’s **status `image` string** (from `containerStatuses` / `initContainerStatuses`) against ICSP/IDMS `source` values; it also records `image_id`, but `expected_pull_basis` / `expected_pull_location` come from the `image` string, not from `imageID`. The first matching rule sets `expected_pull_basis` to `mirror` and `expected_pull_location` to the mirror registry host; otherwise the row uses the image reference’s host and `source`. Pod status may still show the upstream registry name even when the runtime pulled via a mirror.
+The pulled report prefix-matches each container’s **status `image` string** (from `containerStatuses` / `initContainerStatuses`) against IDMS/ITMS `source` values; it also records `image_id`, but `expected_pull_basis` / `expected_pull_location` come from the `image` string, not from `imageID`. The first matching rule sets `expected_pull_basis` to `mirror` and `expected_pull_location` to the mirror registry host; otherwise the row uses the image reference’s host and `source`. Pod status may still show the upstream registry name even when the runtime pulled via a mirror.
 
 ### Verified report (`cifmw_env_op_images_verified_report_path`)
 

--- a/roles/env_op_images/tasks/pulled_images_report.yml
+++ b/roles/env_op_images/tasks/pulled_images_report.yml
@@ -15,7 +15,7 @@
 # under the License.
 
 # Pulled-images report (policy view, not node-verified pulls):
-# - Load cluster ImageContentSourcePolicy + ImageDigestMirrorSet objects via oc.
+# - Load cluster ImageDigestMirrorSet + ImageTagMirrorSet objects via oc.
 # - Flatten them into {source, mirror} pairs (repository prefix -> mirror ref).
 # - For each container/initContainer in selected namespaces, compare the pod
 #   status image string to those prefixes: first matching source rule yields
@@ -39,46 +39,35 @@
         state: directory
         mode: "0755"
 
-    - name: Get ICSP mirror rules
-      ansible.builtin.command:
-        cmd: oc get imagecontentsourcepolicy -o json
-      register: _pulled_report_icsp
-      failed_when: false
-
     - name: Get IDMS mirror rules
       ansible.builtin.command:
         cmd: oc get imagedigestmirrorset -o json
       register: _pulled_report_idms
       failed_when: false
 
-    # Flatten ICSP repositoryDigestMirrors and IDMS imageDigestMirrors into
-    # a single list of {source, mirror} pairs.  A source with N mirrors
-    # produces N entries so the Jinja template can prefix-match every
-    # mirror in one loop.
+    - name: Get ITMS mirror rules
+      ansible.builtin.command:
+        cmd: oc get imagetagmirrorset -o json
+      register: _pulled_report_itms
+      failed_when: false
+
+    # Flatten IDMS imageDigestMirrors and ITMS imageTagMirrors into a single
+    # list of {source, mirror} pairs.  A source with N mirrors produces N
+    # entries so the Jinja template can prefix-match every mirror in one loop.
     # Example output (_pulled_report_mirror_mappings):
     #   - source: registry.redhat.io/openstack-k8s-operators
     #     mirror: quay.example.com/rh-osbs/openstack-k8s-operators
     #   - source: registry.redhat.io/openstack-k8s-operators
     #     mirror: internal-registry.corp.net/openstack-k8s-operators
-    - name: Build source-to-mirror mapping from ICSP/IDMS
+    - name: Build source-to-mirror mapping from IDMS/ITMS
       vars:
-        _icsp_items: >-
-          {{ (_pulled_report_icsp.stdout | default('{}', true) | from_json).get('items', []) }}
         _idms_items: >-
           {{ (_pulled_report_idms.stdout | default('{}', true) | from_json).get('items', []) }}
+        _itms_items: >-
+          {{ (_pulled_report_itms.stdout | default('{}', true) | from_json).get('items', []) }}
         _mappings: >-
           {% set maps = [] %}
-          {# ICSP spec.repositoryDigestMirrors: source repo + mirrors[] #}
-          {% for icsp in _icsp_items %}
-          {%   for rdm in icsp.spec.get('repositoryDigestMirrors', []) %}
-          {%     if rdm.source is defined and rdm.source %}
-          {%       for m in rdm.get('mirrors', []) %}
-          {%         set _ = maps.append({'source': rdm.source, 'mirror': m}) %}
-          {%       endfor %}
-          {%     endif %}
-          {%   endfor %}
-          {% endfor %}
-          {# IDMS spec.imageDigestMirrors: same shape for matching purposes #}
+          {# IDMS spec.imageDigestMirrors: digest-based mirror rules #}
           {% for idms in _idms_items %}
           {%   for rdm in idms.spec.get('imageDigestMirrors', []) %}
           {%     if rdm.source is defined and rdm.source %}
@@ -88,15 +77,25 @@
           {%     endif %}
           {%   endfor %}
           {% endfor %}
+          {# ITMS spec.imageTagMirrors: tag-based mirror rules #}
+          {% for itms in _itms_items %}
+          {%   for rtm in itms.spec.get('imageTagMirrors', []) %}
+          {%     if rtm.source is defined and rtm.source %}
+          {%       for m in rtm.get('mirrors', []) %}
+          {%         set _ = maps.append({'source': rtm.source, 'mirror': m}) %}
+          {%       endfor %}
+          {%     endif %}
+          {%   endfor %}
+          {% endfor %}
           {{ maps }}
       ansible.builtin.set_fact:
         _pulled_report_mirror_mappings: "{{ _mappings | trim | from_yaml }}"
 
-    - name: Warn if no ICSP/IDMS mirror rules found
+    - name: Warn if no IDMS/ITMS mirror rules found
       when: _pulled_report_mirror_mappings | length == 0
       ansible.builtin.debug:
         msg: >-
-          No ICSP or IDMS mirror rules found on the cluster.
+          No IDMS or ITMS mirror rules found on the cluster.
           All rows will have expected_pull_basis: source and expected_pull_location from the image ref.
 
     # Namespaces come from role default / caller; failed namespaces skip via failed_when: false.


### PR DESCRIPTION
PR #3865 replaced deprecated ImageContentSourcePolicy with ImageDigestMirrorSet and added ImageTagMirrorSet in the openshift_setup role. 

Aligning the pulled-images report accordingly:
- Remove ICSP lookup (oc get imagecontentsourcepolicy)
- Add ITMS lookup (oc get imagetagmirrorset)
- Update mirror mapping builder to flatten IDMS imageDigestMirrors and ITMS imageTagMirrors
- Update README to reflect IDMS/ITMS terminology

