### PR TITLE
[shiftstack] Mount TRex SSH keypair secret into shiftstackclient pod

### DIFF
--- a/roles/shiftstack/defaults/main.yml
+++ b/roles/shiftstack/defaults/main.yml
@@ -51,3 +51,5 @@ cifmw_shiftstack_storage_access_mode:
 cifmw_shiftstack_extra_vars: {}
 cifmw_shiftstack_extra_vars_configmap_name: "shiftstack-extra-vars"
 cifmw_shiftstack_extra_vars_mount_path: "/home/cloud-admin/extra-vars"
+# Optional: name of a Kubernetes Secret containing SSH keys to mount into the pod
+# cifmw_shiftstack_trex_keypair_secret: "trex-keypair"

--- a/roles/shiftstack/templates/shiftstackclient_pod.yml.j2
+++ b/roles/shiftstack/templates/shiftstackclient_pod.yml.j2
@@ -48,6 +48,11 @@ spec:
       mountPath: {{ cifmw_shiftstack_extra_vars_mount_path }}
       readOnly: true
 {% endif %}
+{% if cifmw_shiftstack_trex_keypair_secret is defined %}
+    - name: trex-keypair
+      mountPath: /home/cloud-admin/trex-keypair
+      readOnly: true
+{% endif %}
   dnsPolicy: ClusterFirst
   enableServiceLinks: true
   preemptionPolicy: PreemptLowerPriority
@@ -89,4 +94,10 @@ spec:
     configMap:
       defaultMode: 420
       name: {{ cifmw_shiftstack_extra_vars_configmap_name }}
+{% endif %}
+{% if cifmw_shiftstack_trex_keypair_secret is defined %}
+  - name: trex-keypair
+    secret:
+      defaultMode: 256
+      secretName: {{ cifmw_shiftstack_trex_keypair_secret }}
 {% endif %}


### PR DESCRIPTION
## Summary
- Add optional `cifmw_shiftstack_trex_keypair_secret` variable to mount a Kubernetes Secret containing SSH keys into the shiftstackclient pod
- When set, the secret is mounted read-only at `/home/cloud-admin/trex-keypair/`
- Used by the NFV telco verification job: Terraform creates the TRex keypair as an OCP Secret, which is then available to shiftstack-qa automation inside the pod for SSH connectivity to the TRex traffic generator VM

## Test plan
- [ ] Deploy without `cifmw_shiftstack_trex_keypair_secret` set — verify pod is unchanged
- [ ] Deploy with `cifmw_shiftstack_trex_keypair_secret: "trex-keypair"` and the secret present — verify key is mounted at `/home/cloud-admin/trex-keypair/trex_keypair.key`
- [ ] Run telco NFV verification end-to-end with ansible-nfv performance scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)