### PR TITLE
[rally] Add Rally role

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -78,6 +78,7 @@ baseimg
 baseurl
 bashrc
 bd
+benchmarking
 bgp
 blockquote
 bmaas
@@ -328,6 +329,7 @@ kerberos
 keycloak
 keypair
 keyring
+keystoneapi
 keystoneauth
 keystoneauth1
 keytab

--- a/hooks/playbooks/manila_create_default_resources.yml
+++ b/hooks/playbooks/manila_create_default_resources.yml
@@ -21,14 +21,17 @@
         ( ( _manila_share_creation.rc | int ) != 0 )
         and not ( "HTTP 409" in _manila_share_creation.stderr )
 
+    - name: Prepare extra spec options string
+      when: extra_specs is mapping and extra_specs | length > 0
+      ansible.builtin.set_fact:
+        # convert dict to 'k=v ...' format; guard against extra_specs being passed as a string
+        extra_spec_opt: "{%- for k, v in extra_specs.items() -%}{{ k }}={{ v }} {% endfor -%}"
+
     - name: Update default share type properties
+      when: extra_spec_opt is defined
       environment:
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
-      vars:
-        # convert dict to 'k=v ...' format
-        extra_spec_opt: "{%- for k, v in extra_specs.items() -%}{{ k }}={{ v }} {% endfor -%}"
-      when: extra_spec_opt | length > 0
       ansible.builtin.command: |
         oc -n {{ namespace }} exec -it pod/openstackclient \
           -- openstack share type set {{ share_type_name }} --extra-specs {{ extra_spec_opt }}

--- a/hooks/playbooks/rally_cinder_prerequisites.yaml
+++ b/hooks/playbooks/rally_cinder_prerequisites.yaml
@@ -1,0 +1,83 @@
+---
+- name: Ensure Cinder Rally prerequisites exist
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  vars:
+    _openstackclient_pod: openstackclient
+  tasks:
+    - name: Check m1.tiny flavor
+      kubernetes.core.k8s_exec:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        namespace: "{{ namespace }}"
+        pod: "{{ _openstackclient_pod }}"
+        command: openstack flavor show m1.tiny
+      register: _flavor_show
+      failed_when: false
+      changed_when: false
+
+    - name: Create m1.tiny flavor if missing
+      when: _flavor_show.rc != 0
+      kubernetes.core.k8s_exec:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        namespace: "{{ namespace }}"
+        pod: "{{ _openstackclient_pod }}"
+        command: >-
+          openstack flavor create m1.tiny
+          --ram 512 --disk 1 --vcpus 1 --public
+
+    - name: Check lvmdriver-1 volume type
+      kubernetes.core.k8s_exec:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        namespace: "{{ namespace }}"
+        pod: "{{ _openstackclient_pod }}"
+        command: openstack volume type show lvmdriver-1
+      register: _volume_type_show
+      failed_when: false
+      changed_when: false
+
+    - name: Create lvmdriver-1 volume type if missing
+      when: _volume_type_show.rc != 0
+      kubernetes.core.k8s_exec:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        namespace: "{{ namespace }}"
+        pod: "{{ _openstackclient_pod }}"
+        command: openstack volume type create lvmdriver-1 --public
+
+    - name: Check if cirros image already exists
+      kubernetes.core.k8s_exec:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        namespace: "{{ namespace }}"
+        pod: "{{ _openstackclient_pod }}"
+        command: openstack image show cirros-0.6.2-x86_64-disk
+      register: _cirros_image_exists
+      failed_when: false
+      changed_when: false
+
+    - name: Download cirros image to hypervisor
+      when: _cirros_image_exists.rc != 0
+      ansible.builtin.get_url:
+        url: "https://github.com/cirros-dev/cirros/releases/download/0.6.2/cirros-0.6.2-x86_64-disk.img"
+        dest: "/tmp/cirros-0.6.2-x86_64-disk.img"
+        mode: "0644"
+
+    - name: Copy cirros image to openstackclient pod
+      when: _cirros_image_exists.rc != 0
+      environment:
+        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+        PATH: "{{ cifmw_path }}"
+      ansible.builtin.command: >-
+        oc cp /tmp/cirros-0.6.2-x86_64-disk.img
+        {{ namespace }}/openstackclient:/home/cloud-admin/cirros-0.6.2-x86_64-disk.img
+
+    - name: Upload cirros image for Rally if missing
+      when: _cirros_image_exists.rc != 0
+      kubernetes.core.k8s_exec:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        namespace: "{{ namespace }}"
+        pod: "{{ _openstackclient_pod }}"
+        command: >-
+          openstack image create cirros-0.6.2-x86_64-disk
+          --disk-format qcow2
+          --container-format bare
+          --file /home/cloud-admin/cirros-0.6.2-x86_64-disk.img
+          --public

--- a/hooks/playbooks/rally_run.yaml
+++ b/hooks/playbooks/rally_run.yaml
@@ -1,0 +1,11 @@
+---
+- name: Run Rally benchmarks
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  tasks:
+    - name: Run rally role
+      ansible.builtin.include_role:
+        name: rally

--- a/roles/rally/OWNERS
+++ b/roles/rally/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://www.kubernetes.dev/docs/guide/owners/
+
+approvers:
+  - ciops-team
+
+reviewers:
+  - ciops-team

--- a/roles/rally/README.md
+++ b/roles/rally/README.md
@@ -1,0 +1,95 @@
+# rally
+Role to setup and run Rally benchmarking tests against an OpenStack deployment.
+
+Rally is run inside the `quay.io/airshipit/xrally-openstack` container via podman.
+OpenStack credentials are discovered automatically from the Kubernetes KeystoneAPI resource,
+or can be supplied directly via `cifmw_rally_os_*` variables.
+
+## Prerequisites
+- `oc` CLI available and pointing to the target OpenStack cluster (used for credential and CA discovery).
+- `cifmw_openstack_namespace` must be set to the OpenStack namespace (typically `openstack`).
+
+### Manila prerequisites
+
+If running Manila benchmarks, the `dhss_true` share type must exist before Rally runs.
+Use `manila_create_default_resources.yml` with `share_type_name` and `extra_specs` overrides:
+
+```yaml
+pre_tests_80_manila_share_type:
+  type: playbook
+  source: manila_create_default_resources.yml
+  extra_vars:
+    share_type_name: dhss_true
+    extra_specs: {}
+```
+
+## Privilege escalation
+become - Required to install podman and fix artifact directory ownership after the container run.
+
+## Parameters
+
+* `cifmw_rally_artifacts_basedir`: (String) Directory where all Rally artifacts are stored.
+  Default: `{{ cifmw_basedir }}/tests/rally`
+* `cifmw_rally_registry`: (String) Container registry. Default: `quay.io`
+* `cifmw_rally_namespace`: (String) Registry namespace. Default: `airshipit`
+* `cifmw_rally_container`: (String) Container image name. Default: `xrally-openstack`
+* `cifmw_rally_image`: (String) Full image reference. Composed from registry/namespace/container.
+* `cifmw_rally_image_tag`: (String) Container image tag. Default: `3.0.0`
+* `cifmw_rally_dry_run`: (Boolean) Skip actual container execution. Default: `false`
+* `cifmw_rally_remove_container`: (Boolean) Remove container after run. Default: `true`
+* `cifmw_rally_fail_on_task_failure`: (Boolean) Fail the play if Rally exits non-zero. Default: `true`
+* `cifmw_rally_deployment_name`: (String) Rally deployment name. Default: `cifmw`
+* `cifmw_rally_concurrency`: (Integer) Concurrency passed to the Rally task via `--task-args`. Default: `1`
+* `cifmw_rally_task_file`: (String) Absolute path to a custom Rally task YAML on the host.
+  Mutually exclusive with `cifmw_rally_openstack_tests`. Default: `""`
+* `cifmw_rally_task_extra_args`: (String) Extra arguments passed verbatim to `rally task start`. Default: `""`
+* `cifmw_rally_dns_servers`: (List) DNS servers used inside the Rally container. Default: `["192.168.122.10"]`
+* `cifmw_rally_os_auth_url`: (String) OpenStack auth URL. Auto-discovered from KeystoneAPI if unset.
+* `cifmw_rally_os_username`: (String) OpenStack username. Default: `admin`
+* `cifmw_rally_os_password`: (String) OpenStack password. Auto-discovered from Kubernetes secret if unset.
+* `cifmw_rally_os_project_name`: (String) OpenStack project. Default: `admin`
+* `cifmw_rally_os_user_domain_name`: (String) User domain. Default: `Default`
+* `cifmw_rally_os_project_domain_name`: (String) Project domain. Default: `Default`
+* `cifmw_rally_os_region_name`: (String) OpenStack region. Default: `regionOne`
+* `cifmw_rally_runs`: (List) List of run definitions for sequential multi-run mode.
+  When empty (default), the role runs once using the top-level `cifmw_rally_*` variables.
+  When non-empty, the role loops over the list; each entry may override any `cifmw_rally_*`
+  variable for that run and **must** include a `name` key used to namespace artifacts.
+  Default: `[]`
+
+## Standalone usage (single run)
+
+```yaml
+- hosts: hypervisor
+  roles:
+    - role: rally
+      vars:
+        cifmw_rally_openstack_tests: "cinder"
+        cifmw_rally_concurrency: 2
+        cifmw_rally_fail_on_task_failure: false
+```
+
+## Usage via hook (multiple runs)
+
+Add a `post_tests_*` hook in your job vars and define `cifmw_rally_runs`:
+
+```yaml
+post_tests_90_rally_run:
+  type: playbook
+  source: rally_run.yaml
+cifmw_rally_runs:
+  - name: cinder
+    cifmw_rally_openstack_tests: "cinder"
+    cifmw_rally_concurrency: 1
+  - name: nova
+    cifmw_rally_openstack_tests: "nova"
+    cifmw_rally_concurrency: 2
+    cifmw_rally_fail_on_task_failure: false
+```
+
+Each run stores its artifacts under `cifmw_rally_artifacts_basedir/<name>/`.
+
+## Custom task files
+
+To use a custom Rally task file, set `cifmw_rally_task_file` to the absolute path of the
+YAML on the hypervisor host (pre-stage it via an earlier hook if needed).

--- a/roles/rally/defaults/main.yml
+++ b/roles/rally/defaults/main.yml
@@ -1,0 +1,36 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+# All variables within this role should have a prefix of "cifmw_rally"
+cifmw_rally_artifacts_basedir: "{{ cifmw_basedir }}/tests/rally"
+cifmw_rally_registry: "quay.io"
+cifmw_rally_namespace: "airshipit"
+cifmw_rally_container: "xrally-openstack"
+cifmw_rally_image: "{{ cifmw_rally_registry }}/{{ cifmw_rally_namespace }}/{{ cifmw_rally_container }}"
+cifmw_rally_image_tag: "3.0.0"
+cifmw_rally_dry_run: false
+cifmw_rally_remove_container: true
+cifmw_rally_fail_on_task_failure: true
+cifmw_rally_deployment_name: "cifmw"
+cifmw_rally_concurrency: 1
+cifmw_rally_task_file: ""
+cifmw_rally_openstack_tests: ""
+cifmw_rally_task_extra_args: ""
+cifmw_rally_dns_servers:
+  - "192.168.122.10"
+cifmw_rally_runs: []

--- a/roles/rally/meta/main.yml
+++ b/roles/rally/meta/main.yml
@@ -1,0 +1,29 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: CI Framework
+  description: CI Framework Role -- rally
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: "2.14"
+  namespace: cifmw
+  galaxy_tags:
+    - cifmw
+    - rally
+
+dependencies: []

--- a/roles/rally/molecule/default/converge.yml
+++ b/roles/rally/molecule/default/converge.yml
@@ -1,0 +1,24 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  vars:
+    cifmw_rally_dry_run: true
+    cifmw_rally_openstack_tests: "cinder"
+  roles:
+    - role: "rally"

--- a/roles/rally/molecule/default/molecule.yml
+++ b/roles/rally/molecule/default/molecule.yml
@@ -1,0 +1,9 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true

--- a/roles/rally/molecule/default/prepare.yml
+++ b/roles/rally/molecule/default/prepare.yml
@@ -1,0 +1,28 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Prepare
+  hosts: all
+  vars:
+    cifmw_basedir: "{{ ansible_user_dir }}/ci-framework-data"
+    cifmw_install_yamls_tasks_out: "{{ ansible_user_dir }}/zuul-jobs/roles/install_yamls_makes/tasks"
+    cifmw_install_yamls_defaults:
+      NAMESPACE: openstack
+  roles:
+    - role: test_deps
+    - role: ci_setup
+    - role: install_yamls

--- a/roles/rally/tasks/main.yml
+++ b/roles/rally/tasks/main.yml
@@ -1,0 +1,64 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Ensure podman is installed
+  become: true
+  ansible.builtin.package:
+    name: podman
+    state: present
+
+- name: Create rally base artifacts directory
+  ansible.builtin.file:
+    path: "{{ cifmw_rally_artifacts_basedir }}"
+    state: directory
+    mode: "0755"
+
+- name: Prepare Rally OpenStack credentials
+  ansible.builtin.include_tasks: prepare-rally-credentials.yaml
+  when: not cifmw_rally_dry_run | bool
+
+- name: Get OpenStack public CA secret
+  kubernetes.core.k8s_info:
+    kind: Secret
+    name: rootca-public
+    namespace: "{{ cifmw_openstack_namespace }}"
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+  register: _cifmw_rally_rootca_secret
+  failed_when: false
+  when: not cifmw_rally_dry_run | bool
+
+- name: Ensure we have rally container image
+  register: _cifmw_rally_fetch_img
+  containers.podman.podman_image:
+    name: "{{ cifmw_rally_image }}:{{ cifmw_rally_image_tag }}"
+  retries: 5
+  delay: 5
+  until: _cifmw_rally_fetch_img is success
+
+- name: Run rally (single run)
+  when: cifmw_rally_runs | length == 0
+  ansible.builtin.include_tasks: run_once.yml
+  vars:
+    _cifmw_rally_run_name: ""
+    _cifmw_rally_run_vars: {}
+
+- name: Run rally (multiple runs)
+  when: cifmw_rally_runs | length > 0
+  ansible.builtin.include_tasks: run_once.yml
+  vars:
+    _cifmw_rally_run_name: "{{ item.name }}"
+    _cifmw_rally_run_vars: "{{ item }}"
+  loop: "{{ cifmw_rally_runs }}"

--- a/roles/rally/tasks/prepare-rally-credentials.yaml
+++ b/roles/rally/tasks/prepare-rally-credentials.yaml
@@ -1,0 +1,53 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Discover credentials from Kubernetes when not overridden
+  when: cifmw_rally_os_auth_url is not defined
+  block:
+    - name: Get keystone data
+      kubernetes.core.k8s_info:
+        api_version: keystone.openstack.org/v1beta1
+        kind: KeystoneAPI
+        name: keystone
+        namespace: "{{ cifmw_openstack_namespace }}"
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+      register: _cifmw_rally_keystone_data
+
+    - name: Set keystone vars
+      vars:
+        _keystone: "{{ _cifmw_rally_keystone_data.resources[0] }}"
+      ansible.builtin.set_fact:
+        _cifmw_rally_keystone_secret_name: "{{ _keystone['spec']['secret'] }}"
+        _cifmw_rally_keystone_passwd_select: "{{ _keystone['spec']['passwordSelectors']['admin'] }}"
+        _cifmw_rally_keystone_api: "{{ _keystone['status']['apiEndpoints']['public'] }}"
+
+    - name: Get credentials data
+      kubernetes.core.k8s_info:
+        kind: Secret
+        name: "{{ _cifmw_rally_keystone_secret_name }}"
+        namespace: "{{ cifmw_openstack_namespace }}"
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+      register: _cifmw_rally_os_password_data
+
+    - name: Set OpenStack credentials facts
+      no_log: "{{ cifmw_nolog | default(true) | bool }}"
+      ansible.builtin.set_fact:
+        cifmw_rally_os_auth_url: "{{ _cifmw_rally_keystone_api }}"
+        cifmw_rally_os_password: >-
+          {{
+            _cifmw_rally_os_password_data.resources[0].data[_cifmw_rally_keystone_passwd_select] |
+            ansible.builtin.b64decode
+          }}

--- a/roles/rally/tasks/run_once.yml
+++ b/roles/rally/tasks/run_once.yml
@@ -1,0 +1,170 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Set effective variables for this run
+  ansible.builtin.set_fact:
+    _cifmw_rally_effective_basedir: >-
+      {{ (cifmw_rally_artifacts_basedir ~ '/' ~ _cifmw_rally_run_name)
+         if _cifmw_rally_run_name | length > 0
+         else cifmw_rally_artifacts_basedir }}
+    _cifmw_rally_effective_openstack_tests: >-
+      {{ _cifmw_rally_run_vars.cifmw_rally_openstack_tests
+         | default(cifmw_rally_openstack_tests) }}
+    _cifmw_rally_effective_task_file: >-
+      {{ _cifmw_rally_run_vars.cifmw_rally_task_file
+         | default(cifmw_rally_task_file) }}
+    _cifmw_rally_effective_concurrency: >-
+      {{ _cifmw_rally_run_vars.cifmw_rally_concurrency
+         | default(cifmw_rally_concurrency) }}
+    _cifmw_rally_effective_fail_on_task_failure: >-
+      {{ _cifmw_rally_run_vars.cifmw_rally_fail_on_task_failure
+         | default(cifmw_rally_fail_on_task_failure) }}
+    _cifmw_rally_effective_task_extra_args: >-
+      {{ _cifmw_rally_run_vars.cifmw_rally_task_extra_args
+         | default(cifmw_rally_task_extra_args) }}
+    _cifmw_rally_effective_container_name: >-
+      {{ 'rally-' ~ _cifmw_rally_run_name
+         if _cifmw_rally_run_name | length > 0
+         else 'rally' }}
+
+- name: Assert that a workload source is specified for this run
+  ansible.builtin.assert:
+    that:
+      - >-
+        _cifmw_rally_effective_task_file | length > 0 or
+        _cifmw_rally_effective_openstack_tests | length > 0
+    fail_msg: >-
+      Either cifmw_rally_task_file (absolute path to a custom YAML on the host)
+      or cifmw_rally_openstack_tests (name of a bundled workload, e.g. 'cinder',
+      'nova') must be set for run
+      '{{ _cifmw_rally_run_name | default("default") }}'.
+
+- name: Create per-run directories
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    mode: "{{ item.mode }}"
+  loop:
+    - {path: "{{ _cifmw_rally_effective_basedir }}", mode: "0755"}
+    - {path: "{{ _cifmw_rally_effective_basedir }}/tasks", mode: "0755"}
+    - {path: "{{ _cifmw_rally_effective_basedir }}/reports", mode: "0777"}
+
+- name: Copy custom task file to run tasks directory
+  when: _cifmw_rally_effective_task_file | length > 0
+  ansible.builtin.copy:
+    src: "{{ _cifmw_rally_effective_task_file }}"
+    dest: >-
+      {{ _cifmw_rally_effective_basedir }}/tasks/{{
+         _cifmw_rally_effective_task_file | basename }}
+    mode: "0644"
+    remote_src: true
+
+- name: Copy CA bundle to run artifacts directory
+  ansible.builtin.copy:
+    src: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+    dest: "{{ _cifmw_rally_effective_basedir }}/tls-ca-bundle.pem"
+    mode: "0644"
+    owner: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+    group: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+    remote_src: true
+    force: true
+  when: not cifmw_rally_dry_run | bool
+
+- name: Append OpenStack public CA to tls-ca-bundle
+  when:
+    - not cifmw_rally_dry_run | bool
+    - _cifmw_rally_rootca_secret.resources is defined
+    - _cifmw_rally_rootca_secret.resources | length > 0
+  vars:
+    _rootca_pem: >-
+      {{ _cifmw_rally_rootca_secret.resources[0].data['ca.crt'] | b64decode }}
+  ansible.builtin.shell:
+    cmd: >-
+      cat >> {{ _cifmw_rally_effective_basedir }}/tls-ca-bundle.pem
+    stdin: "{{ _rootca_pem }}"
+
+- name: Create rally run script
+  ansible.builtin.template:
+    src: rally-run.sh.j2
+    dest: "{{ _cifmw_rally_effective_basedir }}/tasks/rally-run.sh"
+    mode: "0755"
+  vars:
+    cifmw_rally_task_file: "{{ _cifmw_rally_effective_task_file }}"
+    cifmw_rally_openstack_tests: "{{ _cifmw_rally_effective_openstack_tests }}"
+    cifmw_rally_concurrency: "{{ _cifmw_rally_effective_concurrency }}"
+    cifmw_rally_task_extra_args: "{{ _cifmw_rally_effective_task_extra_args }}"
+  when: not cifmw_rally_dry_run | bool
+
+- name: Run rally
+  ignore_errors: true
+  containers.podman.podman_container:
+    name: "{{ _cifmw_rally_effective_container_name }}"
+    image: "{{ cifmw_rally_image }}:{{ cifmw_rally_image_tag }}"
+    state: started
+    auto_remove: "{{ cifmw_rally_remove_container }}"
+    network: host
+    dns: "{{ cifmw_rally_dns_servers }}"
+    volume:
+      - "{{ _cifmw_rally_effective_basedir }}/tasks:{{ _cifmw_rally_container_tasks_dir }}:Z"
+      - "{{ _cifmw_rally_effective_basedir }}/reports:{{ _cifmw_rally_container_reports_dir }}:Z"
+      - "{{ _cifmw_rally_effective_basedir }}/tls-ca-bundle.pem:\
+         /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:Z"
+    detach: false
+    entrypoint: "/bin/bash"
+    command: "{{ _cifmw_rally_container_tasks_dir }}/rally-run.sh"
+    env:
+      OS_AUTH_URL: "{{ cifmw_rally_os_auth_url | default('') }}"
+      OS_USERNAME: "{{ cifmw_rally_os_username | default('admin') }}"
+      OS_PASSWORD: "{{ cifmw_rally_os_password | default('') }}"
+      OS_PROJECT_NAME: "{{ cifmw_rally_os_project_name | default('admin') }}"
+      OS_USER_DOMAIN_NAME: "{{ cifmw_rally_os_user_domain_name | default('Default') }}"
+      OS_PROJECT_DOMAIN_NAME: "{{ cifmw_rally_os_project_domain_name | default('Default') }}"
+      OS_REGION_NAME: "{{ cifmw_rally_os_region_name | default('regionOne') }}"
+      OS_IDENTITY_API_VERSION: "3"
+      OS_CACERT: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+      REQUESTS_CA_BUNDLE: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+  when: not cifmw_rally_dry_run | bool
+  register: _cifmw_rally_run_output
+
+- name: Restore ownership of run artifacts directory
+  become: true
+  ansible.builtin.file:
+    path: "{{ _cifmw_rally_effective_basedir }}"
+    state: directory
+    recurse: true
+    owner: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+    group: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+  when: not cifmw_rally_dry_run | bool
+
+- name: Save logs from podman
+  when: not cifmw_rally_dry_run | bool
+  ansible.builtin.copy:
+    mode: "0644"
+    dest: "{{ _cifmw_rally_effective_basedir }}/podman_rally.log"
+    content: "{{ _cifmw_rally_run_output.stdout }}"
+
+- name: Fail if podman container did not succeed
+  when:
+    - not cifmw_rally_dry_run | bool
+    - _cifmw_rally_effective_fail_on_task_failure | bool
+  ansible.builtin.assert:
+    that:
+      - "_cifmw_rally_run_output.failed == false"
+    fail_msg: >-
+      Rally task execution failed for run
+      '{{ _cifmw_rally_run_name | default("default") }}'.
+      Check logs at {{ _cifmw_rally_effective_basedir }}/podman_rally.log
+      and reports at {{ _cifmw_rally_effective_basedir }}/reports/

--- a/roles/rally/templates/rally-run.sh.j2
+++ b/roles/rally/templates/rally-run.sh.j2
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+RALLY_TASK_RC=0
+rally db ensure
+rally deployment create --fromenv --name {{ cifmw_rally_deployment_name }}
+{% if cifmw_rally_task_file | length > 0 %}
+rally task start {{ _cifmw_rally_container_tasks_dir }}/{{ cifmw_rally_task_file | basename }} \
+{% else %}
+rally task start /rally/xrally_openstack/rally-jobs/{{ cifmw_rally_openstack_tests }}.yaml \
+{% endif %}
+  --task-args '{"concurrency": {{ cifmw_rally_concurrency }}}' \
+  {{ cifmw_rally_task_extra_args }} || RALLY_TASK_RC=$?
+rally task report --out {{ _cifmw_rally_container_reports_dir }}/rally-report.html || true
+rally task report --json \
+  --out {{ _cifmw_rally_container_reports_dir }}/rally-report.json || true
+exit $RALLY_TASK_RC

--- a/roles/rally/vars/main.yml
+++ b/roles/rally/vars/main.yml
@@ -1,0 +1,18 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+_cifmw_rally_container_tasks_dir: "/var/lib/rally/tasks"
+_cifmw_rally_container_reports_dir: "/var/lib/rally/reports"

--- a/zuul.d/molecule.yaml
+++ b/zuul.d/molecule.yaml
@@ -676,6 +676,17 @@
     files:
     - ^common-requirements.txt
     - ^test-requirements.txt
+    - ^roles/rally/.*
+    - ^ci/playbooks/molecule.*
+    - ^.config/molecule/.*
+    name: cifmw-molecule-rally
+    parent: cifmw-molecule-base
+    vars:
+      TEST_RUN: rally
+- job:
+    files:
+    - ^common-requirements.txt
+    - ^test-requirements.txt
     - ^roles/registry_deploy/.*
     - ^ci/playbooks/molecule.*
     - ^.config/molecule/.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -99,6 +99,7 @@
       - cifmw-molecule-podman
       - cifmw-molecule-polarion
       - cifmw-molecule-radvd
+      - cifmw-molecule-rally
       - cifmw-molecule-recognize_ssh_keypair
       - cifmw-molecule-registry_deploy
       - cifmw-molecule-repo_setup


### PR DESCRIPTION
Add a new \`rally\` Ansible role that runs OpenStack Rally benchmarks inside a podman
container (\`quay.io/airshipit/xrally-openstack:3.0.0\`). The role auto-discovers OpenStack
credentials from the cluster's KeystoneAPI resource and appends the deployment CA to the
trust bundle so SSL verification works without any manual configuration.

The role supports two execution modes:
- **Single run** (default): uses top-level \`cifmw_rally_*\` variables; artifacts stored
  under \`cifmw_rally_artifacts_basedir/\`.
- **Multi-run**: set \`cifmw_rally_runs\` to a list of dicts, each with a \`name\` key and
  optional \`cifmw_rally_*\` overrides. Artifacts are namespaced under
  \`cifmw_rally_artifacts_basedir/<name>/\`.

Jobs invoke Rally via the ci-framework hooks system using \`hooks/playbooks/rally_run.yaml\`:

    post_tests_90_rally_run:
      type: playbook
      source: rally_run.yaml

Key design decisions:
- Podman container (no Kubernetes CRD exists for Rally)
- Shell script templated to disk to avoid YAML/JSON quoting issues
- \`--fromenv\` deployment creation — no JSON config file needed
- \`rootca-public\` CA from the \`openstack\` namespace appended to the CA bundle so the
  container can verify the Keystone TLS endpoint

Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>