### PR TITLE
[tempest] Cap Manila API microversion to 2.78 in tempest overrides

### DIFF
--- a/scenarios/centos-9/ceph_backends.yml
+++ b/scenarios/centos-9/ceph_backends.yml
@@ -43,5 +43,6 @@ cifmw_test_operator_tempest_tempestconf_config:
     share.run_share_group_tests false
     share.capability_storage_protocol cephfs
     share.suppress_errors_in_cleanup true
+    share.max_api_microversion 2.78
     service_available.swift false
     service_available.cinder true

--- a/scenarios/centos-9/hci_ceph_backends.yml
+++ b/scenarios/centos-9/hci_ceph_backends.yml
@@ -59,3 +59,4 @@ cifmw_test_operator_tempest_tempestconf_config:
     share.run_share_group_tests false
     share.capability_storage_protocol cephfs
     share.suppress_errors_in_cleanup true
+    share.max_api_microversion 2.78


### PR DESCRIPTION
The `manila-tempest-tests` `plugin` in `openstack-tempest-all:current-podified` `auto-discovers` its max supported `microversion` (2.85), but the Manila API server (`Antelope`) only supports up to `2.78`. This causes all tests using the `v2` client to fail with `HTTP 406` during `setUpClass/create_share_type`.