### PR TITLE
[bm_sno] Discover VirtualMedia member at runtime

### DIFF
--- a/roles/bm_sno/README.md
+++ b/roles/bm_sno/README.md
@@ -63,6 +63,7 @@ provision IP via `/etc/hosts` entries managed by the role.
 | `cifmw_bm_agent_live_debug` | bool | `false` | Patch the agent ISO with password, autologin, and systemd debug shell on `tty6` for discovery-phase console access (requires `cifmw_bm_agent_core_password`) |
 | `cifmw_bm_agent_disabled_ifaces` | list | `[]` | Extra NIC names to disable IPv4/IPv6 on during agent-based install. Prevents overlapping-subnet validation failures when multiple NICs share a native VLAN (e.g. `[eno2]`). The interfaces stay link-up but get no IP address; post-install NNCP configures them. |
 | `cifmw_bm_agent_lvms_partition` | dict | `{}` | When set, creates an Ignition partition at install time to cap CoreOS rootfs growth and leave unallocated space for the LVMS StorageClass. Keys: `device` (required, e.g. `/dev/nvme0n1`), `rootfs_mib` (default `150000`), `size_mib` (default `0` = rest of disk), `label` (default `lvmstorage`). See [LVMS partition](#lvms-partition). |
+| `cifmw_bm_agent_iso_server_ip` | str | `""` | IP address the iDRAC uses to fetch the agent ISO. When empty, the role auto-detects the controller's IP from nodepool metadata or `ansible_default_ipv4.address`. Set this when the auto-detected IP is not reachable by the iDRAC — for example, when running over VPN where the VPN interface IP must be used instead of the default-route IP. |
 
 ## Secrets management
 

--- a/roles/bm_sno/defaults/main.yml
+++ b/roles/bm_sno/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 cifmw_bm_agent_iso_http_port: 80
+cifmw_bm_agent_iso_server_ip: ""
 cifmw_bm_agent_installer_timeout: 7200
 cifmw_bm_agent_openshift_version: "4.18.3"
 cifmw_bm_agent_core_password: "redhat"

--- a/roles/bm_sno/tasks/bm_discover_vmedia_member.yml
+++ b/roles/bm_sno/tasks/bm_discover_vmedia_member.yml
@@ -1,0 +1,112 @@
+---
+# Discover the correct VirtualMedia member URI for CD/DVD on this iDRAC.
+# The member name varies across firmware versions (CD, RemovableDisk, 1, 2, …).
+# On iDRAC 10+ the Managers VirtualMedia path requires NumericDynamicSegmentsEnable;
+# the Systems path works without it and is tried as a fallback.
+# You can manually set it with racadm set Redfish.1.NumericDynamicSegmentsEnable Enabled.
+# Sets _vmedia_member_uri, _vmedia_insert_action, _vmedia_eject_action.
+# Requires: _bmc_host, _bmc_creds, _redfish_headers
+
+- name: Fetch VirtualMedia collection (Managers path)
+  no_log: false
+  ansible.builtin.uri:
+    url: "https://{{ _bmc_host }}/redfish/v1/Managers/iDRAC.Embedded.1/VirtualMedia"
+    method: GET
+    headers: "{{ _redfish_headers }}"
+    user: "{{ _bmc_creds.username }}"
+    password: "{{ _bmc_creds.password }}"
+    validate_certs: false
+    force_basic_auth: true
+    return_content: true
+    status_code: [200, 404]
+  register: _vmedia_collection_mgr
+
+- name: Fetch VirtualMedia collection (Systems path fallback)
+  when: _vmedia_collection_mgr.status == 404
+  no_log: false
+  ansible.builtin.uri:
+    url: "https://{{ _bmc_host }}/redfish/v1/Systems/System.Embedded.1/VirtualMedia"
+    method: GET
+    headers: "{{ _redfish_headers }}"
+    user: "{{ _bmc_creds.username }}"
+    password: "{{ _bmc_creds.password }}"
+    validate_certs: false
+    force_basic_auth: true
+    return_content: true
+    status_code: [200]
+  register: _vmedia_collection_sys
+
+- name: Set active VirtualMedia collection result
+  ansible.builtin.set_fact:
+    _vmedia_collection: >-
+      {{ _vmedia_collection_sys
+         if (_vmedia_collection_mgr.status == 404)
+         else _vmedia_collection_mgr }}
+
+- name: Show VirtualMedia collection source
+  ansible.builtin.debug:
+    msg: >-
+      VirtualMedia collection from
+      {{ '/redfish/v1/Systems/System.Embedded.1/VirtualMedia'
+         if (_vmedia_collection_mgr.status == 404)
+         else '/redfish/v1/Managers/iDRAC.Embedded.1/VirtualMedia' }}
+      ({{ _vmedia_collection.json.Members | length }} members)
+
+- name: Fetch each VirtualMedia member detail
+  no_log: false
+  ansible.builtin.uri:
+    url: "https://{{ _bmc_host }}{{ item['@odata.id'] }}"
+    method: GET
+    headers: "{{ _redfish_headers }}"
+    user: "{{ _bmc_creds.username }}"
+    password: "{{ _bmc_creds.password }}"
+    validate_certs: false
+    force_basic_auth: true
+    return_content: true
+    status_code: [200]
+  register: _vmedia_members
+  loop: "{{ _vmedia_collection.json.Members }}"
+  loop_control:
+    label: "{{ item['@odata.id'] | basename }}"
+
+- name: Pick the first member that supports CD or DVD media types
+  ansible.builtin.set_fact:
+    _vmedia_member_uri: "{{ item.json['@odata.id'] }}"
+    _vmedia_insert_action: >-
+      {{ item.json.Actions['#VirtualMedia.InsertMedia'].target }}
+    _vmedia_eject_action: >-
+      {{ item.json.Actions['#VirtualMedia.EjectMedia'].target }}
+  when:
+    - _vmedia_member_uri is not defined
+    - item.json.MediaTypes is defined
+    - item.json.MediaTypes | intersect(['CD', 'DVD']) | length > 0
+  loop: "{{ _vmedia_members.results }}"
+  loop_control:
+    label: "{{ item.json['@odata.id'] | basename }}"
+
+- name: Fall back to first member with an InsertMedia action
+  ansible.builtin.set_fact:
+    _vmedia_member_uri: "{{ item.json['@odata.id'] }}"
+    _vmedia_insert_action: >-
+      {{ item.json.Actions['#VirtualMedia.InsertMedia'].target }}
+    _vmedia_eject_action: >-
+      {{ item.json.Actions['#VirtualMedia.EjectMedia'].target }}
+  when:
+    - _vmedia_member_uri is not defined
+    - item.json.Actions is defined
+    - "'#VirtualMedia.InsertMedia' in item.json.Actions"
+  loop: "{{ _vmedia_members.results }}"
+  loop_control:
+    label: "{{ item.json['@odata.id'] | basename }}"
+
+- name: Fail if no usable VirtualMedia member found
+  when: _vmedia_member_uri is not defined
+  ansible.builtin.fail:
+    msg: >-
+      No VirtualMedia member with InsertMedia support found.
+      Members: {{ _vmedia_members.results |
+        map(attribute='json') | map(attribute='@odata.id') | list | join(', ') }}
+
+- name: Show discovered VirtualMedia member
+  ansible.builtin.debug:
+    msg: "VirtualMedia member: {{ _vmedia_member_uri }} — insert: {{ _vmedia_insert_action }}"

--- a/roles/bm_sno/tasks/bm_discover_vmedia_target.yml
+++ b/roles/bm_sno/tasks/bm_discover_vmedia_target.yml
@@ -175,7 +175,7 @@
 - name: Verify VirtualMedia is still inserted
   no_log: true
   ansible.builtin.uri:
-    url: "https://{{ _bmc_host }}/redfish/v1/Managers/iDRAC.Embedded.1/VirtualMedia/CD"
+    url: "https://{{ _bmc_host }}{{ _vmedia_member_uri }}"
     method: GET
     headers: "{{ _redfish_headers }}"
     user: "{{ _bmc_creds.username }}"

--- a/roles/bm_sno/tasks/bm_eject_vmedia.yml
+++ b/roles/bm_sno/tasks/bm_eject_vmedia.yml
@@ -5,10 +5,49 @@
 # Neither Redfish PATCH (405), vmdisconnect (vConsole-only), nor
 # remoteimage -d reliably release it. A racreset is the only way to
 # guarantee the stale RFS is fully torn down.
+# On iDRAC 10, stale Redfish sessions holding a VirtualMedia device cause
+# VRM0021 ("already in use") on the next InsertMedia call. Delete all
+# sessions created by prior runs before ejecting.
 # Requires: _bmc_host, _bmc_creds, _redfish_headers
+
+- name: Fetch active iDRAC sessions
+  no_log: true
+  ansible.builtin.uri:
+    url: "https://{{ _bmc_host }}/redfish/v1/SessionService/Sessions"
+    method: GET
+    headers: "{{ _redfish_headers }}"
+    user: "{{ _bmc_creds.username }}"
+    password: "{{ _bmc_creds.password }}"
+    validate_certs: false
+    force_basic_auth: true
+    status_code: [200, 404]
+  register: _idrac_sessions
+  failed_when: false
+
+- name: Delete stale iDRAC sessions
+  no_log: true
+  ansible.builtin.uri:
+    url: "https://{{ _bmc_host }}{{ item['@odata.id'] }}"
+    method: DELETE
+    headers: "{{ _redfish_headers }}"
+    user: "{{ _bmc_creds.username }}"
+    password: "{{ _bmc_creds.password }}"
+    validate_certs: false
+    force_basic_auth: true
+    status_code: [200, 204, 404]
+  loop: "{{ _idrac_sessions.json.Members | default([]) }}"
+  loop_control:
+    label: "{{ item['@odata.id'] | basename }}"
+  failed_when: false
+  when: _idrac_sessions.status == 200
+
+- name: Discover VirtualMedia member URI (if not already known)
+  when: _vmedia_eject_action is not defined
+  ansible.builtin.include_tasks: bm_discover_vmedia_member.yml
+
 - name: Eject VirtualMedia
   ansible.builtin.uri:
-    url: "https://{{ _bmc_host }}/redfish/v1/Managers/iDRAC.Embedded.1/VirtualMedia/CD/Actions/VirtualMedia.EjectMedia"
+    url: "https://{{ _bmc_host }}{{ _vmedia_eject_action }}"
     method: POST
     headers: "{{ _redfish_headers }}"
     body_format: json

--- a/roles/bm_sno/tasks/main.yml
+++ b/roles/bm_sno/tasks/main.yml
@@ -265,9 +265,11 @@
 - name: Set controller IP fact
   ansible.builtin.set_fact:
     _controller_ip: >-
-      {{ hostvars[inventory_hostname]['nodepool']['interface_ip'] |
-        default(ansible_default_ipv4.address |
-        default(ansible_host)) }}
+      {{ cifmw_bm_agent_iso_server_ip
+         if cifmw_bm_agent_iso_server_ip | length > 0
+         else (hostvars[inventory_hostname]['nodepool']['interface_ip'] |
+           default(ansible_default_ipv4.address |
+           default(ansible_host))) }}
 
 - name: Show ISO URL that iDRAC will fetch
   ansible.builtin.debug:
@@ -310,13 +312,16 @@
   delay: 3
   until: _http_check.status == 200
 
+- name: Discover VirtualMedia member URI
+  ansible.builtin.include_tasks: bm_discover_vmedia_member.yml
+
 - name: Eject any existing VirtualMedia before insert
   ansible.builtin.include_tasks: bm_eject_vmedia.yml
 
 - name: Insert agent ISO via VirtualMedia
   no_log: true
   ansible.builtin.uri:
-    url: "https://{{ _bmc_host }}/redfish/v1/Managers/iDRAC.Embedded.1/VirtualMedia/CD/Actions/VirtualMedia.InsertMedia"
+    url: "https://{{ _bmc_host }}{{ _vmedia_insert_action }}"
     method: POST
     headers: "{{ _redfish_headers }}"
     body_format: json


### PR DESCRIPTION
The InsertMedia and EjectMedia action URLs were hardcoded as
VirtualMedia/CD, which is only valid on older iDRAC firmware.

Newer firmware versions expose the virtual optical drive under
a different member name (e.g. RemovableDisk, 1, 2), causing a
404 ResourceNotFound error on the InsertMedia call.

Add bm_discover_vmedia_member.yml that GETs the VirtualMedia
collection, selects the first member whose MediaTypes includes
CD or DVD (fallback: first member with an InsertMedia action),
and exposes _vmedia_member_uri, _vmedia_insert_action, and
_vmedia_eject_action for use by other tasks.

Update main.yml to run discovery before the eject+insert
sequence and use the discovered action URLs.

Update bm_eject_vmedia.yml to trigger lazy discovery when
the action variable is not already set.

Delete stale iDRAC sessions as well.

Fix bm_discover_vmedia_target.yml to verify the inserted ISO                                                                                                                                                    
against the discovered member URI rather than the hardcoded
VirtualMedia/CD path.

Add cifmw_bm_agent_iso_server_ip to override the IP the iDRAC uses
to fetch the agent ISO. Auto-detection picks the default-route
address, which is unreachable by iDRAC when the controller runs
over VPN.

Generated-By: cursor-agent (claude-4.6-sonnet-medium)