### PR TITLE
Update nodeset for whitebox neutron tempest plugin

### DIFF
--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -418,6 +418,26 @@
           - crc
 
 - nodeset:
+    name: centos-9-2x-centos-9-xxl-crc-cloud-ocp-4-20-1-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo-xxl
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo-xxl
+      - name: crc
+        label: crc-cloud-ocp-4-20-1-3xl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
     name: centos-9-medium-3x-centos-9-crc-cloud-ocp-4-20-1-xxl
     nodes:
       - name: controller

--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -5,7 +5,7 @@
 - job:
     name: whitebox-neutron-tempest-plugin-podified-multinode-edpm-deployment-crc-2comp
     parent: podified-multinode-edpm-deployment-crc-2comp
-    nodeset: centos-9-2x-centos-9-xxl-crc-cloud-ocp-4-20-1-xxl
+    nodeset: centos-9-2x-centos-9-xxl-crc-cloud-ocp-4-20-1-3xl
     timeout: 18000
     override-checkout: main
     description: |


### PR DESCRIPTION
After changing the OCP to 4.20 (from 4.18), the CI job does not have enough resources to pass the CI as the newer OCP is more resource hungry. It means, that the CI job is more likely to fail, than to pass.

Increase the nodeset to bigger to avoid such errors.