### PR TITLE
[bgp] Fix native OVN BGP CI workarounds

### DIFF
--- a/playbooks/bgp/prepare-bgp-computes.yaml
+++ b/playbooks/bgp/prepare-bgp-computes.yaml
@@ -59,3 +59,51 @@
           iptables -t filter -I LIBVIRT_FWI -s 100.64.10.0/24 -i ocpbm -j ACCEPT &&
           iptables -t filter -I LIBVIRT_FWI -d 100.64.10.0/24 -o ocpbm -j ACCEPT
       changed_when: false
+
+# Workaround for OSPRH-30900 - should be removed when the bug is fixed
+- name: Restart neutron pods due to OSPRH-30900
+  hosts: controller-0
+  tasks:
+    - name: Get current neutron pod names
+      ansible.builtin.command:
+        cmd: >-
+          oc get pod -n openstack -l service=neutron
+          -o jsonpath='{.items[*].metadata.name}'
+      register: _neutron_pod_names
+      changed_when: false
+
+    - name: Delete all neutron pods
+      ansible.builtin.command:
+        cmd: >-
+          oc delete pod -n openstack -l service=neutron
+      changed_when: true
+
+    - name: Wait for old neutron pods to terminate
+      ansible.builtin.command:
+        cmd: >-
+          oc wait pod -n openstack {{ item }}
+          --for=delete --timeout=120s
+      changed_when: false
+      failed_when: false
+      loop: "{{ _neutron_pod_names.stdout.split() }}"
+
+    - name: Wait for new neutron pods to be ready
+      ansible.builtin.command:
+        cmd: >-
+          oc wait pod -n openstack
+          -l service=neutron
+          --for=condition=Ready
+          --timeout=300s
+      changed_when: false
+      retries: 4
+      delay: 10
+      register: _neutron_pods_ready
+      until: _neutron_pods_ready.rc == 0
+
+    - name: Wait for OpenStackControlPlane to reconcile
+      ansible.builtin.command:
+        cmd: >-
+          oc wait --for=condition=Ready
+          openstackcontrolplane/controlplane
+          -n openstack --timeout=1200s
+      changed_when: false

--- a/playbooks/bgp/prepare-bgp-spines-leaves.yaml
+++ b/playbooks/bgp/prepare-bgp-spines-leaves.yaml
@@ -272,19 +272,6 @@
         state: present
       when: _ip_version == 6
 
-    - name: Add provider network gateway IP to router loopback
-      become: true
-      community.general.nmcli:
-        autoconnect: true
-        conn_name: lo
-        ip4:
-          - 127.0.0.1/8
-          - 192.168.133.1/32
-        method4: manual
-        ip6: "::1/128"
-        method6: manual
-        state: present
-
     - name: Configure FRR
       vars:
         _router_id: "{{ '' if _ip_version == 4 else '1.1.1.1' }}"


### PR DESCRIPTION
## Summary

- Remove the provider network gateway IP (`192.168.133.1`) from the
  router loopback in `prepare-bgp-spines-leaves.yaml`. This IP was
  needed with `ovn-bgp-agent`, but with native OVN BGP the ping reply
  is dropped by an OVN anti-loop flow in `lr_in_ip_input`. BGP routing
  does not depend on this loopback entry.
- Add a play to restart neutron pods after BGP compute configuration in
  `prepare-bgp-computes.yaml`. After a fresh deployment the BGP
  reconciler's `full_sync()` can be skipped if the OVSDB lock is not
  yet held, leaving `arp_proxy` unset on interconnect LSPs. A pod
  restart triggers a new `full_sync()`. This workaround should be
  removed once the bug is fixed in neutron.

Related-Issue: #[OSPRH-30905](https://redhat.atlassian.net/browse/OSPRH-30905)
Related-Issue: #[OSPRH-30900](https://redhat.atlassian.net/browse/OSPRH-30900)

## Test plan

- [X] Deploy a BGP environment with native OVN BGP
- [X] Verify that the spines/leaves playbook completes without the
      loopback gateway IP task
- [X] Verify that neutron pods are restarted and reach Ready state
- [X] Verify that `OpenStackControlPlane` reconciles successfully
- [X] Confirm `arp_proxy` is set on interconnect LSPs after the restart

Assisted-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>