### PR TITLE
[libvirt_manager] Add opt-in KVM discard/TRIM support

### DIFF
--- a/roles/libvirt_manager/README.md
+++ b/roles/libvirt_manager/README.md
@@ -91,6 +91,7 @@ cifmw_libvirt_manager_configuration:
       extra_disks_num: (integer, optional. Number of extra disks to be configured.)
       extra_disks_size: (string, optional. Storage capacity to be allocated. Example 1G, 512M)
       extra_disks_bus: (string, optional. Bus type for extra disks. It can be virtio or scsi. Defaults to `virtio`)
+      fstrim_enabled: (boolean, optional. When true, sets discard='unmap' on the primary disk libvirt driver and enables fstrim.timer on a daily schedule in the guest. Defaults to false.)
       user: (string, optional. Username to create on the vm which can becomes root. Defaults to `zuul`)
       password: (string, optional, defaults to fooBar. Root password for console access)
       target: (Hypervisor hostname you want to deploy the family on. Optional)

--- a/roles/libvirt_manager/molecule/deploy_layout/converge.yml
+++ b/roles/libvirt_manager/molecule/deploy_layout/converge.yml
@@ -59,6 +59,7 @@
           disksize: 20
           memory: 1
           cpus: 1
+          fstrim_enabled: true
           nets:
             - public
             - osp_trunk
@@ -266,6 +267,31 @@
             that:
               - expected_count == found_count
           loop: "{{ volume_count.results }}"
+
+    - name: Test discard='unmap' on primary disk for fstrim_enabled VMs
+      block:
+        - name: Get compute-0 XML
+          register: _compute_xml
+          community.libvirt.virt:
+            command: get_xml
+            name: cifmw-compute-0
+            uri: qemu:///system
+
+        - name: Assert discard=unmap on primary disk driver
+          community.general.xml:
+            count: true
+            xmlstring: "{{ _compute_xml.get_xml }}"
+            xpath: "/domain/devices/disk/driver[@discard='unmap']"
+          register: _discard_count
+
+        - name: Verify discard attribute present
+          ansible.builtin.assert:
+            that:
+              - _discard_count.count == 1
+            msg: >-
+              Primary disk driver for cifmw-compute-0 does not have
+              discard='unmap' -- fstrim_enabled may not be wired into
+              domain.xml.j2 correctly
 
     # Redeploying the exact same layout will ensure we
     # are able to run the role multiple time over the

--- a/roles/libvirt_manager/tasks/configure_fstrim_vm.yml
+++ b/roles/libvirt_manager/tasks/configure_fstrim_vm.yml
@@ -1,0 +1,42 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Configure fstrim timer in guest
+  become: true
+  delegate_to: "{{ _fstrim_target }}"
+  remote_user: "{{ _fstrim_user }}"
+  block:
+    - name: Create fstrim.timer drop-in directory
+      ansible.builtin.file:
+        path: /etc/systemd/system/fstrim.timer.d
+        state: directory
+        mode: "0755"
+
+    - name: Write daily fstrim override
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/fstrim.timer.d/override.conf
+        content: |
+          [Timer]
+          OnCalendar=
+          OnCalendar=daily
+        mode: "0644"
+
+    - name: Enable fstrim.timer
+      ansible.builtin.systemd:
+        name: fstrim.timer
+        daemon_reload: true
+        enabled: true
+        state: started

--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -229,6 +229,28 @@
   loop_control:
     loop_var: _vm
 
+- name: Configure fstrim on VMs where enabled
+  ansible.builtin.include_tasks: configure_fstrim_vm.yml
+  vars:
+    _fstrim_enabled_types: >-
+      {{
+        _cifmw_libvirt_manager_layout.vms | dict2items |
+        selectattr('value.fstrim_enabled', 'defined') |
+        selectattr('value.fstrim_enabled', 'equalto', true) |
+        map(attribute='key') | list
+      }}
+    _fstrim_enabled_vms: >-
+      {{
+        cifmw_libvirt_manager_all_vms | dict2items |
+        selectattr('value', 'in', _fstrim_enabled_types) | list
+      }}
+    _fstrim_target: "{{ (_vm.key | replace('ocp-', '')) }}.{{ inventory_hostname }}"
+    _fstrim_user: "{{ 'core' if _vm.key is match('^(crc|ocp).*') else 'zuul' }}"
+  loop: "{{ _fstrim_enabled_vms }}"
+  loop_control:
+    loop_var: _vm
+    label: "{{ _vm.key }}"
+
 - name: Create VBMC entity
   when:
     - _vbmc_available is defined

--- a/roles/libvirt_manager/templates/domain.xml.j2
+++ b/roles/libvirt_manager/templates/domain.xml.j2
@@ -42,7 +42,7 @@
   <devices>
     <emulator>/usr/libexec/qemu-kvm</emulator>
     <disk type='file' device='disk'>
-      <driver name='qemu' type='qcow2'/>
+      <driver name='qemu' type='qcow2'{% if vm_data.fstrim_enabled | default(false) | bool %} discard='unmap'{% endif %}/>
       <source file='{{ _chdir }}/{{ vm }}.qcow2'/>
       {% set disk_bus = vm_data.disk_bus | default('scsi') %}
       {% if disk_bus == 'scsi' %}


### PR DESCRIPTION
Adds fstrim_enabled per-VM-type param. When true, sets discard='unmap' on the primary disk and schedules daily fstrim.timer in the guest via a systemd drop-in over SSH.