### PR TITLE
[federation] Replace jq with python3 in get-keycloak-token.sh

### DIFF
--- a/roles/federation/templates/get-keycloak-token.sh.j2
+++ b/roles/federation/templates/get-keycloak-token.sh.j2
@@ -28,7 +28,7 @@ get_access_token() {
         -d "client_secret=${CLIENT_SECRET}" \
         -d "username=${username}" \
         -d "password=${password}" \
-        -d "scope=openid profile email" | jq -r '.access_token // empty'
+        -d "scope=openid profile email" | python3 -c "import sys, json; print(json.load(sys.stdin).get('access_token', ''))"
 }
 
 get_auth_code() {
@@ -77,7 +77,7 @@ get_admin_token() {
         -d "grant_type=password" \
         -d "client_id=admin-cli" \
         -d "username={{ cifmw_federation_keycloak_admin_username }}" \
-        -d "password={{ cifmw_federation_keycloak_admin_password }}" | jq -r '.access_token // empty'
+        -d "password={{ cifmw_federation_keycloak_admin_password }}" | python3 -c "import sys, json; print(json.load(sys.stdin).get('access_token', ''))"
 }
 
 case "$1" in


### PR DESCRIPTION
[OSPRH-31571](https://redhat.atlassian.net/browse/OSPRH-31571): https://issues.redhat.com/browse/OSPRH-31571

The openstackclient pod does not ship \`jq\`, causing the \`access_token\`
and \`admin_token\` commands in \`get-keycloak-token.sh\` to fail with
\`jq: command not found\`.

Regression introduced by 8a15a5fa71 (\`[federation] Add OIDC authentication flows tests\`).

Replace both \`jq\` invocations with an equivalent \`python3\` one-liner,
which is always present in the openstackclient pod.

Testproject: https://gitlab.cee.redhat.com/ci-framework/ci-framework-testproject/-/merge_requests/2440

Assisted-by: Claude Sonnet 4.6