### PR TITLE
[reproducer] Update config vars in reproducer_variables

### DIFF
--- a/roles/reproducer/files/merge_yaml_override.py
+++ b/roles/reproducer/files/merge_yaml_override.py
@@ -19,9 +19,21 @@
 # recursively for nested mappings; non-dict values (scalars, lists) are
 # replaced entirely by OVERRIDE. Requires PyYAML (python3-pyyaml / python3-yaml
 # on RPM systems).
+#
+# Optional key filtering (applied to the merged result):
+#   --allow REGEX       keep only top-level keys matching this pattern
+#   --reject REGEX      drop top-level keys matching this pattern
+#   --reject-key KEY    drop this exact top-level key
+#   --update-only       only update keys already present in BASE; ignore new
+#                       keys from OVERRIDE entirely
+#
+# Filters are applied in order: allow first (if any), then reject patterns,
+# then reject exact keys.  Multiple --reject / --reject-key flags are accepted.
 
 from __future__ import annotations
 
+import argparse
+import re
 import sys
 
 try:
@@ -54,9 +66,14 @@ def _str_representer(dumper, data):
 DoubleQuoteDumper.add_representer(str, _str_representer)
 
 
-def deep_merge(base: object, override: object) -> object:
+def deep_merge(
+    base: object, override: object, update_only: bool = False
+) -> object:
     """Take two parsed values;
-    return merge where both are dicts (recursive), else override wins."""
+    return merge where both are dicts (recursive), else override wins.
+
+    When update_only is True, only keys already present in base are
+    updated; new keys from override are silently ignored."""
     if base is None:
         return override
     if override is None:
@@ -65,31 +82,103 @@ def deep_merge(base: object, override: object) -> object:
         out = dict(base)
         for key, val in override.items():
             if key in out:
-                out[key] = deep_merge(out[key], val)
-            else:
+                out[key] = deep_merge(out[key], val, update_only=update_only)
+            elif not update_only:
                 out[key] = val
         return out
     return override
 
 
+def filter_keys(
+    data: dict,
+    allow: str | None = None,
+    reject_patterns: list[str] | None = None,
+    reject_keys: list[str] | None = None,
+) -> dict:
+    """Filter top-level keys from a dict.
+
+    Args:
+        data: mapping to filter.
+        allow: if set, only keys matching this regex survive.
+        reject_patterns: list of regexes; matching keys are dropped.
+        reject_keys: list of exact key names to drop.
+
+    Returns:
+        filtered dict (new object, data is not mutated).
+    """
+    out = dict(data)
+
+    if allow is not None:
+        allow_re = re.compile(allow)
+        out = {k: v for k, v in out.items() if allow_re.search(k)}
+
+    if reject_patterns:
+        combined_re = re.compile("|".join(reject_patterns))
+        out = {k: v for k, v in out.items() if not combined_re.search(k)}
+
+    if reject_keys:
+        reject_set = set(reject_keys)
+        out = {k: v for k, v in out.items() if k not in reject_set}
+
+    return out
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Deep-merge two YAML mappings with optional key filtering. "
+            "FILE2 wins on duplicate keys (nested dicts merged). "
+            "Scalars and lists from FILE2 replace FILE1."
+        ),
+    )
+    parser.add_argument("base", metavar="FILE1_BASE.yml", help="base YAML file")
+    parser.add_argument(
+        "override", metavar="FILE2_OVERRIDE.yml", help="override YAML file"
+    )
+    parser.add_argument(
+        "output",
+        metavar="MERGED_OUT.yml",
+        nargs="?",
+        default=None,
+        help="output file (default: stdout)",
+    )
+    parser.add_argument(
+        "--allow",
+        metavar="REGEX",
+        default=None,
+        help="keep only top-level keys matching this pattern",
+    )
+    parser.add_argument(
+        "--reject",
+        metavar="REGEX",
+        action="append",
+        default=[],
+        help="drop top-level keys matching this pattern (repeatable)",
+    )
+    parser.add_argument(
+        "--reject-key",
+        metavar="KEY",
+        action="append",
+        default=[],
+        help="drop this exact top-level key (repeatable)",
+    )
+    parser.add_argument(
+        "--update-only",
+        action="store_true",
+        default=False,
+        help="only update keys already present in BASE; ignore new keys",
+    )
+    return parser.parse_args()
+
+
 def main() -> None:
-    """Read CLI paths (two or three args),
-    merge YAML mappings, write stdout or MERGED_OUT; exit on error."""
-    argc = len(sys.argv)
-    if argc not in (3, 4):
-        sys.stderr.write(
-            f"usage: {sys.argv[0]} FILE1_BASE.yml FILE2_OVERRIDE.yml [MERGED_OUT.yml]\n"
-            "  Deep-merge two YAML mappings: FILE2 wins on duplicate keys (nested dicts merged).\n"
-            "  Scalars and lists from FILE2 replace FILE1. If MERGED_OUT is omitted, print to stdout.\n"
-        )
-        sys.exit(2)
+    """Merge YAML files, optionally filter keys, write output."""
+    args = parse_args()
 
-    base_path, override_path = sys.argv[1], sys.argv[2]
-    out_path = sys.argv[3] if argc == 4 else None
-
-    with open(base_path, encoding="utf-8") as f:
+    with open(args.base, encoding="utf-8") as f:
         base = yaml.safe_load(f)
-    with open(override_path, encoding="utf-8") as f:
+    with open(args.override, encoding="utf-8") as f:
         override = yaml.safe_load(f)
 
     if base is None:
@@ -99,25 +188,35 @@ def main() -> None:
 
     if not isinstance(base, dict):
         sys.stderr.write(
-            f"{base_path}: root must be a mapping, got {type(base).__name__}\n"
+            f"{args.base}: root must be a mapping, got {type(base).__name__}\n"
         )
         sys.exit(3)
     if not isinstance(override, dict):
         sys.stderr.write(
-            f"{override_path}: root must be a mapping, got {type(override).__name__}\n"
+            f"{args.override}: root must be a mapping, got {type(override).__name__}\n"
         )
         sys.exit(3)
 
-    merged = deep_merge(base, override)
+    merged = deep_merge(base, override, update_only=args.update_only)
+
+    has_filters = args.allow or args.reject or args.reject_key
+    if has_filters:
+        merged = filter_keys(
+            merged,
+            allow=args.allow,
+            reject_patterns=args.reject or None,
+            reject_keys=args.reject_key or None,
+        )
+
     dump_options = dict(
         default_flow_style=False,
         sort_keys=False,
         allow_unicode=True,
     )
-    if out_path is None:
+    if args.output is None:
         yaml.dump(merged, sys.stdout, Dumper=DoubleQuoteDumper, **dump_options)
     else:
-        with open(out_path, "w", encoding="utf-8") as out_f:
+        with open(args.output, "w", encoding="utf-8") as out_f:
             yaml.dump(merged, out_f, Dumper=DoubleQuoteDumper, **dump_options)
 
 

--- a/roles/reproducer/tasks/overwrite_zuul_vars.yml
+++ b/roles/reproducer/tasks/overwrite_zuul_vars.yml
@@ -1,72 +1,104 @@
 ---
-# NOTE(dpawlik): Earlier, our idea was to dump vars as
-# it is roles/cifmw_setup/tasks/bootstrap.yml and read it,
-# then dump it and replace reproducer-variables.yml.
-# Normally it make sense, but since we dump zuul_vars in
-# run.yml, we don't need to make such combination, which is
-# more safe - on making host variable dump, some variables
-# might not be defined, so later we can have an issue like:
-#     'cifmw_discovered_image_url' is undefined.
+# Update reproducer-variables.yml on controller-0 with the current
+# hypervisor hostvars.  At premetal pickup time the hypervisor has
+# all config files loaded as extra vars (via run-uni-reproducer.sh),
+# so hostvars contains every variable fully resolved -- no raw Jinja2.
+#
+# We dump the filtered hostvars to a temp file, fetch the existing
+# reproducer-variables.yml from controller-0, deep-merge (fresh dump
+# wins), and write back.  The merge preserves any controller-0-only
+# state from the bootstrap dump while picking up new/changed values.
+#
+# The filter chain matches configure_bm_ocp_controller.yml and
+# configure_controller.yml -- only (pre|post|cifmw)_ keys survive,
+# minus hypervisor-specific vars that must not reach controller-0.
 
 - name: Check if zuul_vars.yaml file is available
   ansible.builtin.stat:
     path: "{{ ansible_user_dir }}/configs/zuul_vars.yaml"
   register: _current_zuul_vars
 
-- name: Overwrite reproducer-variables.yml when PreMetal used
+- name: Copy merge yamls script
+  when: _current_zuul_vars.stat.exists
+  become: true
+  ansible.builtin.copy:
+    src: merge_yaml_override.py
+    dest: /usr/local/bin/merge_yaml_override
+    mode: "0755"
+
+- name: Update reproducer-variables.yml from resolved hostvars
   when: _current_zuul_vars.stat.exists
   vars:
-    temp_reproducer_var_path: /tmp/reproducer-variables.yml
-    temp_merged_reproducer_var_path: /tmp/merged-reproducer-variables.yml
+    _temp_dir: /tmp/reproducer-merge
+    _dump_path: /tmp/reproducer-merge/hypervisor-dump.yml
+    _existing_path: /tmp/reproducer-merge/existing.yml
+    _merged_path: /tmp/reproducer-merge/merged.yml
+    _filtered_vars: >-
+      {{
+        hostvars[inventory_hostname] | default({}) |
+        dict2items |
+        selectattr('key', 'match',
+                   '^(pre|post|cifmw)_(?!install_yamls|devscripts).*') |
+        rejectattr('key', 'equalto', 'cifmw_target_host') |
+        rejectattr('key', 'equalto', 'cifmw_basedir') |
+        rejectattr('key', 'equalto', 'cifmw_path') |
+        rejectattr('key', 'equalto', 'cifmw_extras') |
+        rejectattr('key', 'equalto', 'cifmw_openshift_kubeconfig') |
+        rejectattr('key', 'equalto', 'cifmw_openshift_token') |
+        rejectattr('key', 'equalto', 'cifmw_networking_env_definition') |
+        rejectattr('key', 'match', '^cifmw_use_(?!lvms).*') |
+        rejectattr('key', 'match', '^cifmw_reproducer.*') |
+        rejectattr('key', 'match', '^cifmw_rhol.*') |
+        rejectattr('key', 'match', '^cifmw_discover.*') |
+        rejectattr('key', 'match', '^cifmw_libvirt_manager.*') |
+        rejectattr('key', 'match', '^cifmw_manage_secrets_(pullsecret|citoken).*') |
+        items2dict
+      }}
   block:
-    - name: Slurp reproducer-variables.yml to hypervisor
-      ansible.builtin.slurp:
-        src: "{{ cifmw_basedir }}/parameters/reproducer-variables.yml"
-      register: reproducer_original
-      delegate_to: controller-0
-      no_log: "{{ cifmw_nolog | default(true) | bool }}"
+    - name: Create temp working directory
+      ansible.builtin.file:
+        path: "{{ _temp_dir }}"
+        state: directory
+        mode: "0755"
 
-    - name: Create temp file reproducer-variables.yml on hypervisor
+    - name: Dump filtered hostvars to temp file
       ansible.builtin.copy:
-        content: "{{ reproducer_original.content | b64decode }}"
-        dest: "{{ temp_reproducer_var_path }}"
+        content: "{{ _filtered_vars | to_nice_yaml }}"
+        dest: "{{ _dump_path }}"
         mode: "0664"
       no_log: "{{ cifmw_nolog | default(true) | bool }}"
 
-    - name: Copy merge yamls script
-      become: true
-      ansible.builtin.copy:
-        src: merge_yaml_override.py
-        dest: /usr/local/bin/merge_yaml_override
-        mode: "0755"
+    - name: Fetch existing reproducer-variables.yml from controller-0
+      ansible.builtin.fetch:
+        src: "{{ cifmw_basedir }}/parameters/reproducer-variables.yml"
+        dest: "{{ _existing_path }}"
+        flat: true
+      delegate_to: controller-0
 
-    - name: Execute merge script
-      ansible.builtin.shell: >
+    - name: Merge existing as base with fresh dump as override
+      ansible.builtin.command: >
         python3 /usr/local/bin/merge_yaml_override
-        {{ temp_reproducer_var_path }}
-        {{ ansible_user_dir }}/configs/zuul_vars.yaml >
-        {{ temp_merged_reproducer_var_path }}
-      no_log: "{{ cifmw_nolog | default(true) | bool }}"
+        {{ _existing_path }}
+        {{ _dump_path }}
+        {{ _merged_path }}
 
-    - name: Slurp merged reproducer-variables.yml from hypervisor
-      ansible.builtin.slurp:
-        src: "{{ temp_merged_reproducer_var_path }}"
-      register: merged_reproducer_slurp
-      no_log: "{{ cifmw_nolog | default(true) | bool }}"
-
-    - name: Write back merged reproducer-variables.yml
+    - name: Write merged reproducer-variables.yml to controller-0
       ansible.builtin.copy:
-        content: "{{ merged_reproducer_slurp.content | b64decode }}"
+        src: "{{ _merged_path }}"
         dest: "{{ cifmw_basedir }}/parameters/reproducer-variables.yml"
         mode: "0664"
         backup: true
-      no_log: "{{ cifmw_nolog | default(true) | bool }}"
       delegate_to: controller-0
 
     - name: Overwrite custom-params.yml
       ansible.builtin.copy:
-        content: "{{ merged_reproducer_slurp.content | b64decode }}"
+        src: "{{ _merged_path }}"
         dest: "{{ cifmw_basedir }}/artifacts/parameters/custom-params.yml"
         mode: "0664"
-      no_log: "{{ cifmw_nolog | default(true) | bool }}"
       delegate_to: controller-0
+
+  always:
+    - name: Clean up temp working directory
+      ansible.builtin.file:
+        path: "{{ _temp_dir }}"
+        state: absent


### PR DESCRIPTION
In premetal deployments, if a job's config variables were updated between the initial bootstrap and the job resuming, those updates would not be reflected in the reproducer-variables.yml file.