### PR TITLE
[manage_secrets] Add no_log to debug task printing secret content

### DIFF
--- a/roles/manage_secrets/tasks/_push_secret.yml
+++ b/roles/manage_secrets/tasks/_push_secret.yml
@@ -23,6 +23,7 @@
     var: _secret_file
 
 - name: Debug _secret_content
+  no_log: "{{ cifmw_nolog | default(true) | bool }}"
   ansible.builtin.debug:
     var: _secret_content
 


### PR DESCRIPTION
The debug task for _secret_content prints sensitive values (pull secrets, CI tokens, kubeconfig) to stdout and ansible.log without no_log. The copy task in the same file correctly uses no_log — the debug task was missed.

Uses the same cifmw_nolog pattern as the rest of the role to allow disabling for debugging when needed.

Jira: [OSPRH-31754](https://redhat.atlassian.net/browse/OSPRH-31754)