### PR TITLE
[cifmw_cephadm] Support different ceph server and client versions

### DIFF
--- a/roles/cifmw_cephadm/README.md
+++ b/roles/cifmw_cephadm/README.md
@@ -122,6 +122,30 @@ that they do not need to be changed for a typical EDPM deployment.
    Example values are `"aes,aes256k"` or `"aes256k"` or `"aes"`.
    Defaults to `""` (unset, no command is run).
 
+* `cifmw_cephadm_server_version`: (String) Optional override for Ceph server
+  version during cephadm installation. Both this and `cifmw_cephadm_client_version`
+  must be set (and different) to activate version override logic. When activated,
+  temporarily switches repos to install cephadm at this version, then restores
+  to client version. Example: `"7.1"` or `"9.1"`. Defaults to `""` (empty),
+  which uses `cifmw_repo_setup_rhos_release_args` for everything.
+
+* `cifmw_cephadm_client_version`: (String) Optional client package version,
+  used with `cifmw_cephadm_server_version`. Both must be set (and different)
+  to activate version override logic. Example: `"9.1"`. Defaults to `""` (empty),
+  which uses `cifmw_repo_setup_rhos_release_args` for everything.
+
+The `cifmw_cephadm_server_version` and `cifmw_cephadm_client_version` are
+only used for testing a corner case where the ceph clients and ceph server
+are of different versions. Usually the `repo_setup` role's parameter
+`cifmw_repo_setup_rhos_release_args` determines which ceph repository is
+enabled and the same repository is enabled for both clients and servers.
+If the server version and client version differ, then the repository
+from the server version is temporarily enabled, when cephadm is installed
+(so that cephadm will install that version of the ceph server), and then
+the repository from `cifmw_repo_setup_rhos_release_args` is enabled again.
+If `cifmw_repo_setup_rhos_release_args` is not the same as the client
+version, a warning is printed.
+
 Use the `cifmw_cephadm_pools` list of dictionaries to define pools for
 Nova (vms), Cinder (volumes), Cinder-backups (backups), and Glance (images).
 ```

--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -148,6 +148,16 @@ cifmw_cephadm_repository_override: false
 # we usually support N+1 Ceph version: Adding Squid here because Reef is the
 # default version installed in a greenfield scenario
 cifmw_cephadm_version: "squid"
+# Optional: Override Ceph server version for cephadm installation
+# Both server_version and client_version must be set (and different) to activate
+# version override logic. Will temporarily switch repos to install cephadm at
+# server_version, then restore to client_version. Example: "7.1" or "9.1"
+# Leave empty (default) to use cifmw_repo_setup_rhos_release_args for everything
+cifmw_cephadm_server_version: ""
+# Optional: Client package version (used with server_version)
+# Must be set along with server_version (and different) to activate override logic
+# Leave empty (default) to use cifmw_repo_setup_rhos_release_args for everything
+cifmw_cephadm_client_version: ""
 # bug in cephadm: if you skip "prepare host" it will fail
 cifmw_cephadm_prepare_host: false
 cifmw_cephadm_wait_install_retries: 8

--- a/roles/cifmw_cephadm/tasks/install_cephadm.yml
+++ b/roles/cifmw_cephadm/tasks/install_cephadm.yml
@@ -14,6 +14,45 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Check if server/client version override is configured
+  ansible.builtin.set_fact:
+    _cifmw_cephadm_version_override: >-
+      {{
+        (cifmw_cephadm_server_version | length > 0) and
+        (cifmw_cephadm_client_version | length > 0) and
+        (cifmw_cephadm_server_version != cifmw_cephadm_client_version)
+      }}
+
+- name: Handle version override for cephadm installation
+  when: _cifmw_cephadm_version_override | bool
+  become: true
+  block:
+    - name: Parse version from cifmw_repo_setup_rhos_release_args
+      ansible.builtin.set_fact:
+        _cifmw_cephadm_default_version: "{{ cifmw_repo_setup_rhos_release_args | regex_search('ceph-([0-9.]+)') | regex_replace('^ceph-', '') }}"
+
+    - name: Display version configuration
+      ansible.builtin.debug:
+        msg:
+          - "Default: {{ _cifmw_cephadm_default_version }}"
+          - "Server: {{ cifmw_cephadm_server_version }}"
+          - "Client: {{ cifmw_cephadm_client_version }}"
+          - "{{ 'WARNING: Client version differs from default rhos-release version' if (_cifmw_cephadm_default_version | trim) != (cifmw_cephadm_client_version | trim) else 'Client version matches default' }}"
+
+    - name: Disable default ceph repository
+      when: cifmw_cephadm_server_version != _cifmw_cephadm_default_version
+      ansible.builtin.replace:
+        path: "/etc/yum.repos.d/rhos-release-ceph-{{ _cifmw_cephadm_default_version }}.repo"
+        regexp: '^enabled=1'
+        replace: 'enabled=0'
+
+    - name: Switch to server version repository
+      when: cifmw_cephadm_server_version != _cifmw_cephadm_default_version
+      ansible.builtin.command:
+        cmd: "rhos-release {{ cifmw_repo_setup_rhos_release_args | regex_replace('ceph-[0-9.]+', 'ceph-' + cifmw_cephadm_server_version) }}"
+      register: _cifmw_cephadm_server_repo
+      changed_when: "'Installed' in _cifmw_cephadm_server_repo.stdout"
+
 - name: Enabled ceph Tools Repository
   when:
     - cifmw_cephadm_repository_override | bool
@@ -34,6 +73,22 @@
   retries: "{{ cifmw_cephadm_wait_install_retries }}"
   delay: "{{ cifmw_cephadm_wait_install_delay }}"
   until: task_result is success
+
+- name: Disable server ceph repository before restore
+  when: _cifmw_cephadm_version_override | bool
+  become: true
+  ansible.builtin.replace:
+    path: "/etc/yum.repos.d/rhos-release-ceph-{{ cifmw_cephadm_server_version }}.repo"
+    regexp: '^enabled=1'
+    replace: 'enabled=0'
+
+- name: Restore cifmw_repo_setup_rhos_release_args
+  when: _cifmw_cephadm_version_override | bool
+  become: true
+  ansible.builtin.command:
+    cmd: "rhos-release {{ cifmw_repo_setup_rhos_release_args }}"
+  register: _cifmw_cephadm_restore_repo
+  changed_when: "'Installed' in _cifmw_cephadm_restore_repo.stdout"
 
 - name: Stat cephadm file
   ansible.builtin.stat:


### PR DESCRIPTION
Add optional parameters to cifmw_cephadm role to support installing cephadm at one version while using client packages at another version. This enables testing scenarios where RHCSv9 clients connect to RHCSv7 servers, or vice versa.

Changes:
- Add cifmw_cephadm_server_version and cifmw_cephadm_client_version variables (both default to empty string)
- When both are set and different, temporarily switch to server version repository during cephadm installation, then restore to original cifmw_repo_setup_rhos_release_args
- Version override logic only activates when both variables are set AND different, ensuring no impact on existing jobs
- Add warning when client version differs from rhos-release default

The implementation uses regex_replace to swap only the ceph version number in cifmw_repo_setup_rhos_release_args, preserving all other flags like -r for RHEL version.

Example usage for gamma scenario (v7 server + v9 clients):
```yaml
  cifmw_repo_setup_rhos_release_args: "ceph-9.1-rhel-9 -r 9.4"
  cifmw_cephadm_server_version: "7.1"
  cifmw_cephadm_client_version: "9.1"
```

This temporarily switches to ceph-7.1 for cephadm installation, then restores to ceph-9.1 for client packages.

Related-Issue: [OSPRH-31757](https://redhat.atlassian.net/browse/OSPRH-31757)


Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>