### PR TITLE
[multiple] Remove unnecessary registries from defaults

### DIFF
--- a/hooks/playbooks/config_cluster_for_disconnected_deployment.yml
+++ b/hooks/playbooks/config_cluster_for_disconnected_deployment.yml
@@ -1,17 +1,7 @@
 ---
 # This is a pre_infra ci-framework hook that will configure the cluster for
 # disconnected deployment. The variable: cifmw_ci_gen_kustomize_values_ooi_image
-# must be specified. These examples for that variable are supported:
-#
-# registry-proxy.engineering.redhat.com/rh-osbs/iib:1125611
-# registry.redhat.io/redhat/redhat-operator-index:v4.18
-#
-# Due to being in deprecated sqlite format this is unsupported:
-# images.paas.redhat.com/podified-main-rhos-18-rhel-9/openstack-operator-index:trunk-patches-latest
-#
-# sqlite requires deprecated v1 oc-mirror workflow instead of the supported v2
-# oc-mirror workflow
-#
+# must be specified with a valid operator index image URL.
 #
 - name: Update cluster for disconnected deployment
   hosts: "{{ cifmw_target_host | default('localhost') }}"

--- a/roles/openshift_setup/defaults/main.yml
+++ b/roles/openshift_setup/defaults/main.yml
@@ -36,8 +36,4 @@ cifmw_openshift_setup_allowed_registries:
   - "registry.k8s.io"
   - "registry.redhat.io"
   - "registry.connect.redhat.com"
-  - "registry-proxy.engineering.redhat.com"
-  - "registry.stage.redhat.io"
-  - "images.paas.redhat.com"
-  - "image-registry.openshift-image-registry.svc:5000"
 cifmw_openshift_setup_allowed_extra_registries: []

--- a/roles/set_openstack_containers/README.md
+++ b/roles/set_openstack_containers/README.md
@@ -99,7 +99,7 @@ It is used in edpm-ansible job to update the `ANSIBLEEE_IMAGE_URL_DEFAULT`.
 
 ### Update an image which doesn't have openstack- in its name
 
-For instance `RELATED_IMAGE_IRONIC_PYTHON_AGENT_IMAGE_URL_DEFAULT` has this kind of url `registry-proxy.engineering.redhat.com/rh-osbs/rhoso18-ironic-python-agent:18.0` where the usual `openstack-` prefix is absent.
+For instance `RELATED_IMAGE_IRONIC_PYTHON_AGENT_IMAGE_URL_DEFAULT` has this kind of url `example.registry.com/rh-osbs/rhoso18-ironic-python-agent:18.0` where the usual `openstack-` prefix is absent.
 
 Setting `cifmw_set_openstack_containers_overrides_transform` will enable the transformation to happen.
 
@@ -118,7 +118,7 @@ Setting `cifmw_set_openstack_containers_overrides_transform` will enable the tra
         name: set_openstack_containers
 ```
 
-Will transform `registry-proxy.engineering.redhat.com/rh-osbs/rhoso18-ironic-python-agent:18.0` into `quay.io/test-namespace/ironic-python-agent:test-tag`
+Will transform `example.registry.com/rh-osbs/rhoso18-ironic-python-agent:18.0` into `quay.io/test-namespace/ironic-python-agent:test-tag`
 
 ### Update all openstack services containers env vars in meta operator with tag from delorean and set OPENSTACK_RELEASE_VERSION env
 


### PR DESCRIPTION
## Summary
Remove registries that are not needed in upstream defaults from the `openshift_setup` role.
A mechanism already exists to supply additional registries at the job level via `cifmw_openshift_setup_allowed_extra_registries`, which is consumed in `roles/openshift_setup/tasks/configure_registries.yml` and merged into the final `allowedRegistries` list.

## Note
A hardcoded registry reference was found in `hooks/playbooks/config_cluster_for_disconnected_deployment.yml`. This needs to be investigated and removed in a dedicated follow-up task.