### PR TITLE
[test_operator] Add RBAC for test pod exec

### DIFF
--- a/roles/test_operator/tasks/run-test-operator-job.yml
+++ b/roles/test_operator/tasks/run-test-operator-job.yml
@@ -42,6 +42,40 @@
         dest: "{{ cifmw_test_operator_crs_path }}/{{ test_operator_instance_name }}.yaml"
         mode: '0644'
 
+    - name: Ensure RBAC for test pod exec - {{ run_test_fw }}
+      kubernetes.core.k8s:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit) }}"
+        context: "{{ cifmw_openshift_context | default(omit) }}"
+        state: present
+        definition: "{{ item }}"
+      loop:
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            name: test-pods-exec
+            namespace: "{{ stage_vars_dict.cifmw_test_operator_namespace }}"
+          rules:
+            - apiGroups: [""]
+              resources: ["pods/exec"]
+              verbs: ["get", "create"]
+            - apiGroups: [""]
+              resources: ["pods"]
+              verbs: ["get", "list"]
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            name: test-pods-exec
+            namespace: "{{ stage_vars_dict.cifmw_test_operator_namespace }}"
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: test-pods-exec
+          subjects:
+            - kind: ServiceAccount
+              name: default
+              namespace: "{{ stage_vars_dict.cifmw_test_operator_namespace }}"
+
     - name: Start tests - {{ run_test_fw }}
       kubernetes.core.k8s:
         kubeconfig: "{{ cifmw_openshift_kubeconfig }}"


### PR DESCRIPTION
Test plugins like `nfv-tempest-plugin` use the Kubernetes Python client to exec into other pods (e.g. `openstackclient`) via `connect_get_namespaced_pod_exec`. The default service account in the test namespace lacks `pods/exec` permissions, causing 403 Forbidden errors during test execution.

Create a Role and RoleBinding granting `get`/`create` on `pods/exec` and `get`/`list` on `pods` to the default service account before starting the test CR.

Assisted-By: Claude Code (Anthropic)