### PR TITLE
Add post_infra hook processing to create-infra.yml

### DIFF
--- a/create-infra.yml
+++ b/create-infra.yml
@@ -79,6 +79,12 @@
         name: "libvirt_manager"
         tasks_from: "deploy_layout.yml"
 
+    - name: Run post_infra hooks
+      vars:
+        step: post_infra
+      ansible.builtin.import_role:
+        name: run_hook
+
     - name: Gather ansible_user_id
       ansible.builtin.setup:
         gather_subset:


### PR DESCRIPTION
The adoption deploy-infra job uses create-infra.yml which did not process post_infra hooks. This meant hooks like vlanprovider_mtu (which sets the hypervisor trunk bridge MTU) only ran in greenfield via cifmw_setup but never in adoption. Adding run_hook after deploy_layout ensures the trunk bridge MTU is set before VMs boot.

Assisted-by: Claude Code Opus 4.6
Related-to: [OSPRH-30634](https://redhat.atlassian.net/browse/OSPRH-30634)