### PR TITLE
[reproducer] Fix MAC address corruption in bm_info

### DIFF
--- a/roles/reproducer/tasks/generate_bm_info.yml
+++ b/roles/reproducer/tasks/generate_bm_info.yml
@@ -108,7 +108,7 @@
     libvirt_manager_bm_info_data: >-
       {{
         libvirt_manager_bm_info_data | default({}) |
-        combine((_with_nics | from_yaml), recursive=true) |
+        combine(_with_nics, recursive=true) |
         combine((_oringal_cifmw_baremetal_hosts | default({}) | from_yaml), recursive=true)
       }}
   loop: "{{ cifmw_libvirt_manager_uuids | dict2items }}"


### PR DESCRIPTION
The `_with_nics` variable already evaluates to a Python dict from the `combine()` call. Piping it through `| from_yaml` caused Ansible to serialize it as a YAML string and re-parse it.

PyYAML's YAML 1.1 sexagesimal rule then corrupted **all-numeric** MAC addresses (e.g. `41:13:61:22:00:02`) into integers (`41136122002`).

Remove the redundant `| from_yaml` to prevent the lossy round-trip.

Closes: [OSPRH-31852](https://redhat.atlassian.net/browse/OSPRH-31852)
Assisted-By: Claude (claude-4.6-sonnet-medium)