### PR TITLE
Add EVPN support to BGP spine-leaf playbook

### DIFF
--- a/playbooks/bgp/prepare-bgp-spines-leaves.yaml
+++ b/playbooks/bgp/prepare-bgp-spines-leaves.yaml
@@ -296,6 +296,51 @@
         group: frr
         mode: '640'
 
+    - name: Create EVPN VXLAN and bridge on the router
+      become: true
+      when: enable_evpn | default(false) | bool
+      block:
+        - name: Load VRF kernel module
+          ansible.builtin.shell: |
+            modprobe vrf
+
+        - name: Persist VRF module load on boot
+          ansible.builtin.copy:
+            dest: /etc/modules-load.d/vrf.conf
+            content: |
+              vrf
+            mode: "0644"
+
+        - name: Create VRF for EVPN
+          ansible.builtin.shell: |
+            ip link add evpnvrf-{{ evpn_vni | default(1) }} type vrf table {{ evpn_vni | default(1) }}
+            ip link set evpnvrf-{{ evpn_vni | default(1) }} up
+
+        - name: Create VXLAN interface for EVPN
+          ansible.builtin.shell: |
+            ip link add vxlan-{{ evpn_vni | default(1) }} type vxlan id {{ evpn_vni | default(1) }} local 192.168.133.1 dstport {{ evpn_vxlan_port | default(4789) }} nolearning
+
+        - name: Create bridge for EVPN
+          ansible.builtin.shell: |
+            ip link add br-evpn type bridge
+
+        - name: Attach VXLAN to bridge
+          ansible.builtin.shell: |
+            ip link set vxlan-{{ evpn_vni | default(1) }} master br-evpn
+
+        - name: Enable ARP/ND suppression on the VXLAN port
+          ansible.builtin.shell: |
+            bridge link set dev vxlan-{{ evpn_vni | default(1) }} neigh_suppress on
+
+        - name: Master bridge to VRF
+          ansible.builtin.shell: |
+            ip link set br-evpn master evpnvrf-{{ evpn_vni | default(1) }}
+
+        - name: Bring up EVPN interfaces
+          ansible.builtin.shell: |
+            ip link set br-evpn up
+            ip link set vxlan-{{ evpn_vni | default(1) }} up
+
     - name: Enable and start FRR
       become: true
       ansible.builtin.service:

--- a/playbooks/bgp/templates/leaf-frr.conf.j2
+++ b/playbooks/bgp/templates/leaf-frr.conf.j2
@@ -31,7 +31,7 @@ router bgp 64999
   neighbor downlink bfd
   neighbor downlink bfd profile tripleo
 {# TODO: remove the next if when RHEL-63205 is fixed #}
-{% if not (fips_mode | default(false) | bool) %}
+{% if not (fips_mode | default(false) | bool) and not (enable_evpn | default(false) | bool) %}
   neighbor downlink password f00barZ
 {% endif %}
   ! neighbor downlink capability extended-nexthop
@@ -77,6 +77,7 @@ router bgp 64999
     neighbor uplink allowas-in origin
     neighbor downlink activate
     neighbor downlink route-reflector-client
+    advertise-all-vni
   exit-address-family
 
 ip prefix-list only-default-host-prefixes permit 0.0.0.0/0

--- a/playbooks/bgp/templates/router-frr.conf.j2
+++ b/playbooks/bgp/templates/router-frr.conf.j2
@@ -55,6 +55,27 @@ router bgp 65000
     neighbor downlink activate
     neighbor downlink route-reflector-client
   exit-address-family
+{% if enable_evpn | default(false) | bool %}
+
+vrf evpnvrf-{{ evpn_vni | default(1) }}
+ vni {{ evpn_vni | default(1) }}
+exit-vrf
+
+router bgp 65000 vrf evpnvrf-{{ evpn_vni | default(1) }}
+ no bgp ebgp-requires-policy
+ address-family ipv4 unicast
+  redistribute kernel
+  redistribute connected
+ exit-address-family
+ address-family ipv6 unicast
+  redistribute kernel
+  redistribute connected
+ exit-address-family
+ address-family l2vpn evpn
+  advertise ipv4 unicast
+  advertise ipv6 unicast
+ exit-address-family
+{% endif %}
 
 ip prefix-list only-default-host-prefixes permit 0.0.0.0/0
 ip prefix-list only-default-host-prefixes permit 0.0.0.0/0 ge 32


### PR DESCRIPTION
Add EVPN-specific configuration to the existing BGP spine-leaf setup, gated by an enable_evpn variable:

- Leaf FRR: skip BGP password when EVPN is enabled (the EVPN extension does not configure one), add advertise-all-vni
- Router FRR: add VRF with VNI and BGP VRF instance for EVPN Type-5 route import/export
- Router play: create VXLAN interface, bridge, and VRF device so the router can reach VMs on the EVPN overlay

Configurable variables: enable_evpn (bool), evpn_vni (int, default 1), evpn_vxlan_port (int, default 4789).


Assisted-By: Claude Opus 4.6