### PR TITLE
[update] Add optional cleanup of OpenStack resources

### DIFF
--- a/roles/update/README.md
+++ b/roles/update/README.md
@@ -23,5 +23,6 @@ Role to run update
 * `cifmw_update_resources_monitoring_interval`: (Integer) Interval, in seconds, between two resources monitor during update. Default to 10 seconds.
 * `cifmw_update_wait_controplane_status_change_sec`: (Integer) Time, in seconds, to wait before checking openstack control plane deployment status. Used when need to wait to allow the control plane's ready condition to transition from its initial state, preventing premature completion while the control plane is still reconciling the operator changes. Defaults to `60`.
 * `cifmw_update_openstack_update_kpatch`: (Boolean) Activate `kpatch` during update. Default to false.
+* `cifmw_update_cleanup`: (Bool) Cleanup resources created on OpenStack during update testing. Set to `false` to skip cleanup for debugging. Default to `true`.
 
 ## Examples

--- a/roles/update/defaults/main.yml
+++ b/roles/update/defaults/main.yml
@@ -48,6 +48,7 @@ cifmw_update_openstack_cmd: >-
   oc rsh -n {{ cifmw_update_namespace }} openstackclient openstack
 
 ## User facing
+cifmw_update_cleanup: true
 cifmw_update_openstack_update_kpatch: false
 
 cifmw_update_reboot_test: false

--- a/roles/update/tasks/cleanup.yml
+++ b/roles/update/tasks/cleanup.yml
@@ -14,6 +14,20 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Cleaning the World
-  ansible.builtin.debug:
-    msg: "So here update should clean things up!"
+- name: Cleanup ping test resources
+  when:
+    - cifmw_update_ping_test | bool
+  block:
+    - name: Cleaning the ping vm if needed
+      ansible.builtin.shell: |
+        set -e
+        set -o pipefail
+        cat {{ cifmw_update_workload_launch_script }} | \
+        podman exec -i lopenstackclient env WKL_MODE=cleanup bash -i 2>&1 \
+        {{ cifmw_update_timestamper_cmd }} | tee {{ cifmw_update_artifacts_basedir }}/workload_cleanup.log
+
+    - name: Get logs from update instance cleanup
+      ansible.builtin.command:
+        cmd: >
+          podman cp lopenstackclient:{{ cifmw_update_artifacts_basedir_suffix }}/.
+          {{ cifmw_update_artifacts_basedir }}

--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -266,3 +266,9 @@
     cmd: >
       {{ cifmw_update_artifacts_basedir }}/update_event.sh
       Update complete
+
+- name: Cleanup resources used for testing on OpenStack
+  ansible.builtin.include_tasks: cleanup.yml
+  when:
+    - cifmw_update_cleanup | bool
+    - not (cifmw_update_run_dryrun | bool)

--- a/roles/update/templates/workload_launch.sh.j2
+++ b/roles/update/templates/workload_launch.sh.j2
@@ -635,6 +635,7 @@ if [[ "${MODE}" == "workload_traffic" ]]; then
 fi
 
 if [[ "${MODE}" == "cleanup" ]]; then
+    export WORKLOAD_FILE="${HOME}/{{ cifmw_update_artifacts_basedir_suffix }}/workload_suffix"
     # obtain SUFFIX value generated during workload_launch
     source "${WORKLOAD_FILE}"
     prepare_env


### PR DESCRIPTION
The update role creates test workloads (ping test VM, ports) on OpenStack during the update procedure but never cleans them up. This leaves ports allocated on the external network, which blocks subsequent test jobs from recreating subnets.

Add a cleanup step at the end of the update role that runs the workload_launch.sh script in cleanup mode to delete the test VM and associated ports. The cleanup runs by default and can be disabled with cifmw_update_dont_cleanup for debugging.

Based on the work from #3335 by Sofer Athlan-Guyot which was closed by the stale bot before merging.

Related-Issue: #[OSPRH-20307](https://redhat.atlassian.net/browse/OSPRH-20307)