### PR TITLE
[test_operator] Support merging skiplist with exclude list

### DIFF
--- a/roles/test_operator/README.md
+++ b/roles/test_operator/README.md
@@ -55,6 +55,7 @@ Execute tests via the [test-operator](https://openstack-k8s-operators.github.io/
 * `cifmw_test_operator_tempest_container`: (String) Name of the tempest container. Default value: `openstack-tempest-all`
 * `cifmw_test_operator_tempest_debug`: (Bool) Run Tempest in debug mode, it keeps the operator pod sleeping infinity (it must only set to `true`only for debugging purposes). Default value: `false`
 * `cifmw_test_operator_tempest_exclude_list`: (String) List of tests to be skipped. Setting this will not use the `list_skipped` plugin. Default value: `''`
+* `cifmw_test_operator_tempest_exclude_list_merge`: (Bool) When set to true, merges tests from both `list_skipped.yml` and `cifmw_test_operator_tempest_exclude_list` into a single combined exclusion list. Default value: `false`
 * `cifmw_test_operator_tempest_expected_failures_list`: (String) List of tests for which failures will be ignored. Default value: `''`
 * `cifmw_test_operator_tempest_external_plugin`: (List) List of dicts describing any external plugin to be installed. The dictionary contains a repository, changeRepository (optional) and changeRefspec (optional). Default value: `[]`
 * `cifmw_test_operator_tempest_extra_configmaps_mounts`: WARNING: This parameter will be deprecated! Please use `cifmw_test_operator_tempest_extra_mounts` parameter instead. (List) A list of configmaps that should be mounted into the tempest test pods. Default value: `[]`

--- a/roles/test_operator/defaults/main.yml
+++ b/roles/test_operator/defaults/main.yml
@@ -75,6 +75,7 @@ cifmw_test_operator_tempest_image_tag: "{{ cifmw_test_operator_default_image_tag
 cifmw_test_operator_tempest_network_attachments: []
 cifmw_test_operator_tempest_tests_include_override_scenario: false
 cifmw_test_operator_tempest_tests_exclude_override_scenario: false
+cifmw_test_operator_tempest_exclude_list_merge: false
 cifmw_test_operator_tempest_workflow: []
 cifmw_test_operator_tempest_cleanup: false
 cifmw_test_operator_tempest_rerun_failed_tests: false

--- a/roles/test_operator/tasks/tempest-tests.yml
+++ b/roles/test_operator/tasks/tempest-tests.yml
@@ -51,6 +51,7 @@
 - name: Configuring tests to be skipped via skiplist
   when: >
     stage_vars_dict.cifmw_test_operator_tempest_exclude_list is not defined or
+    stage_vars_dict.cifmw_test_operator_tempest_exclude_list_merge | bool or
     stage_vars_dict.cifmw_test_operator_tempest_tests_exclude_override_scenario | bool
   block:
     - name: Copy list_skipped to artifacts dir
@@ -66,10 +67,19 @@
       register:
         list_skipped
 
-    - name: Set variable
+    - name: Merge tests from exclude list when merge is enabled
+      when:
+        - stage_vars_dict.cifmw_test_operator_tempest_exclude_list_merge | bool
+        - stage_vars_dict.cifmw_test_operator_tempest_exclude_list is defined
+        - stage_vars_dict.cifmw_test_operator_tempest_exclude_list | trim | length > 0
+      ansible.builtin.set_fact:
+        test_names: "{{ test_names | default(list_skipped.skipped_tests) + [item] }}"
+      loop: "{{ stage_vars_dict.cifmw_test_operator_tempest_exclude_list | trim | split('\n') }}"
+
+    - name: Convert list of tests to string to pass to test-operator
       vars:
         skipped_tests: |
-          {% for item in list_skipped.skipped_tests %}
+          {% for item in test_names | default(list_skipped.skipped_tests) %}
           {{ item }}
           {% endfor %}
       ansible.builtin.set_fact:


### PR DESCRIPTION
Adding cifmw_test_operator_tempest_exclude_list_merge variable to enable combining list_skipped.yml with
cifmw_test_operator_tempest_exclude_list. When set to true, both sources are merged into a single exclude list, which helps to later remove workarounds that merged these lists manually.

Signed-off-by: Katarina Strenkova kstrenko@redhat.com