### PR TITLE
[reproducer] Enable CSR auto-approval when waiting for OCP stability

### DIFF
--- a/roles/reproducer/tasks/main.yml
+++ b/roles/reproducer/tasks/main.yml
@@ -474,6 +474,7 @@
     cifmw_openshift_adm_op: "stable"
     cifmw_openshift_kubeconfig: >-
       {{ (_auth_path, 'kubeconfig') | ansible.builtin.path_join }}
+    _openshift_adm_check_cert_approve: true
   ansible.builtin.include_role:
     name: openshift_adm
 

--- a/roles/reproducer/tasks/reuse_main.yaml
+++ b/roles/reproducer/tasks/reuse_main.yaml
@@ -179,6 +179,7 @@
     cifmw_openshift_adm_op: "stable"
     cifmw_openshift_kubeconfig: >-
       {{ (_auth_path, 'kubeconfig') | ansible.builtin.path_join }}
+    _openshift_adm_check_cert_approve: true
   ansible.builtin.include_role:
     name: openshift_adm
 


### PR DESCRIPTION
When reusing an existing OpenShift cluster (e.g. after `reproducer-clean.yml` without `--tags deepscrub`), the reproducer calls `openshift_adm` with `op: stable` to wait for the cluster to come back.  The `wait_for_cluster.yml` task file already contains a block that auto-approves pending certificate signing requests via the `cifmw.general.approve_csr` module, but that block is gated by `_openshift_adm_check_cert_approve`, which defaults to `false`.

The `devscripts` role sets this flag during its own golden-image verification flow, but the reproducer role calls `openshift_adm` directly — bypassing that path entirely.  As a result, CSRs that appear after a cluster restart (kubelet client/server certs) are never approved, causing the MachineConfigPool wait to hang indefinitely.

Pass `_openshift_adm_check_cert_approve: true` from both reproducer entry points (`main.yml` and `reuse_main.yaml`) so that pending CSRs are automatically approved during the cluster stability wait.

Co-authored-by: Cursor <cursoragent@cursor.com>
Signed-off-by: Andrew Bays <abays@redhat.com>