### PR TITLE
[federation] Fix RHSSO OperatorGroup conflict with RHOSO operators

### DIFF
--- a/docs/dictionary/en-custom.txt
+++ b/docs/dictionary/en-custom.txt
@@ -583,6 +583,7 @@ rsa
 rsync
 runtime
 RHCOS
+RHSSO
 scansettingbinding
 scap
 scp

--- a/roles/federation/README.md
+++ b/roles/federation/README.md
@@ -28,6 +28,7 @@ This role supports testing all OIDC authentication methods available in keystone
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `cifmw_federation_operator_namespace` | `keycloak-operators` | Kubernetes namespace for the RHSSO operator |
 | `cifmw_federation_keycloak_namespace` | `openstack` | Kubernetes namespace for Keycloak |
 | `cifmw_federation_run_osp_cmd_namespace` | `openstack` | Kubernetes namespace for openstackclient |
 | `cifmw_federation_domain` | - | Base domain for service URLs |

--- a/roles/federation/defaults/main.yml
+++ b/roles/federation/defaults/main.yml
@@ -12,7 +12,7 @@
 # Basic namespace and domain settings for the federation deployment
 
 # Kubernetes namespaces
-cifmw_federation_operator_namespace: openstack-operators
+cifmw_federation_operator_namespace: keycloak-operators
 cifmw_federation_keycloak_namespace: openstack
 cifmw_federation_run_osp_cmd_namespace: openstack
 

--- a/roles/federation/tasks/run_keycloak_setup.yml
+++ b/roles/federation/tasks/run_keycloak_setup.yml
@@ -28,9 +28,16 @@
     mode: "0640"
   when: cifmw_federation_deploy_type == "crc"
 
-- name: Create namespace
+- name: Create keycloak namespace
   kubernetes.core.k8s:
     name: "{{ cifmw_federation_keycloak_namespace }}"
+    api_version: v1
+    kind: Namespace
+    state: present
+
+- name: Create operator namespace
+  kubernetes.core.k8s:
+    name: "{{ cifmw_federation_operator_namespace }}"
     api_version: v1
     kind: Namespace
     state: present


### PR DESCRIPTION
The federation role was deploying the RHSSO OperatorGroup into openstack-operators, which already has an OperatorGroup from the OpenStack operator. OLM enforces one OperatorGroup per namespace, so the second one triggered TooManyOperatorGroups and blocked InstallPlan creation for the RHSSO subscription.

Change the default cifmw_federation_operator_namespace from openstack-operators to keycloak-operators, and add a task to create that namespace before applying the OLM manifest.