### PR TITLE
Fix bmo01 scenario template generation key

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/bmo01/nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bmo01/nodeset-values/values.yaml.j2
@@ -16,7 +16,7 @@ data:
       rhos-release {{ cifmw_repo_setup_rhos_release_args }}
     nodes:
 {% for host in cifmw_networking_env_definition.instances.keys() if host is match('^leaf0-.*') %}
-{% set idx = host.split('-')[1] %}
+{% set idx = host.split('-')[-1] %}
 {% set compute_name = 'edpm-compute-0-' ~ idx %}
 {% set ip = cifmw_networking_env_definition.instances[host].networks.ctlplane1.ip_v4 %}
 {% set ctlplane_ip = cifmw_networking_env_definition.instances[host].networks.ctlplane.ip_v4 | default(ip) %}
@@ -56,7 +56,7 @@ data:
       rhos-release {{ cifmw_repo_setup_rhos_release_args }}
     nodes:
 {% for host in cifmw_networking_env_definition.instances.keys() if host is match('^leaf1-.*') %}
-{% set idx = host.split('-')[1] %}
+{% set idx = host.split('-')[-1] %}
 {% set compute_name = 'edpm-compute-1-' ~ idx %}
 {% set ip = cifmw_networking_env_definition.instances[host].networks.ctlplane2.ip_v4 %}
 {% set ctlplane_ip = cifmw_networking_env_definition.instances[host].networks.ctlplane.ip_v4 | default(ip) %}


### PR DESCRIPTION
bmo01 scneario template generates duplicate YAML keys when processing multi-ppart inventory hostnames, causing Nodeset deployment timeout.

This bug casues data loss (first host) when adding a misnamed node (duplicate key survivor) This PR tries to fix.

fixes: [OSPRH-32215](https://redhat.atlassian.net/browse/OSPRH-32215)