### PR TITLE
[cifmw_cephadm] Add fallback when cifmw_cephadm_rpm_url 404s

### DIFF
--- a/roles/cifmw_cephadm/tasks/ensure_cifmw_cephadm_rpm_url.yml
+++ b/roles/cifmw_cephadm/tasks/ensure_cifmw_cephadm_rpm_url.yml
@@ -1,0 +1,61 @@
+---
+# Copyright 2026 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Check if cifmw_cephadm_rpm_url is reachable
+  ansible.builtin.uri:
+    url: "{{ cifmw_cephadm_rpm_url }}"
+    method: HEAD
+    status_code: [200, 404]
+  register: cifmw_cephadm_rpm_url_check
+
+- name: Search index page for cephadm RPM if URL returned 404
+  when:
+    - cifmw_cephadm_rpm_url_check.status | default(0) | int is equalto 404
+  block:
+    - name: Fetch the parent directory index page
+      ansible.builtin.uri:
+        url: "{{ cifmw_cephadm_rpm_url | regex_replace('/[^/]+$', '/') }}"
+        return_content: true
+      register: cifmw_ceph_repo_index
+
+    - name: Search index page for cephadm RPM
+      ansible.builtin.set_fact:
+        cifmw_cephadm_rpm_candidates: >-
+          {{ cifmw_ceph_repo_index.content |
+             regex_findall('cephadm-\d[^\s"<>]+\.rpm') |
+             unique | list }}
+
+    - name: Fail if no cephadm RPM found on index page
+      when:
+        - cifmw_cephadm_rpm_candidates | length < 1
+      ansible.builtin.fail:
+        msg: >-
+          cifmw_cephadm_rpm_url '{{ cifmw_cephadm_rpm_url }}'
+          returned 404 and no cephadm RPM was found on the
+          index page.
+
+    - name: Update cifmw_cephadm_rpm_url with discovered RPM
+      ansible.builtin.set_fact:
+        cifmw_cephadm_rpm_url: >-
+          {{ (cifmw_cephadm_rpm_url | regex_replace('/[^/]+$', '/')) +
+             cifmw_cephadm_rpm_candidates[0] }}
+
+    - name: Warn about cifmw_cephadm_rpm_url fallback
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: cifmw_cephadm_rpm_url 404'd. Using
+          '{{ cifmw_cephadm_rpm_url }}' discovered from
+          the index page instead.

--- a/roles/cifmw_cephadm/tasks/install_cephadm.yml
+++ b/roles/cifmw_cephadm/tasks/install_cephadm.yml
@@ -37,17 +37,22 @@
   until: task_result is success
 
 - name: Install cephadm package from URL
-  become: true
   when:
     - cifmw_cephadm_rpm_url | length > 0
-  ansible.builtin.dnf:
-    name: "{{ cifmw_cephadm_rpm_url }}"
-    state: present
-    disable_gpg_check: true
-  register: task_result
-  retries: "{{ cifmw_cephadm_wait_install_retries }}"
-  delay: "{{ cifmw_cephadm_wait_install_delay }}"
-  until: task_result is success
+  block:
+    - name: Ensure cifmw_cephadm_rpm_url is valid
+      ansible.builtin.include_tasks: ensure_cifmw_cephadm_rpm_url.yml
+
+    - name: Install cephadm from URL
+      become: true
+      ansible.builtin.dnf:
+        name: "{{ cifmw_cephadm_rpm_url }}"
+        state: present
+        disable_gpg_check: true
+      register: task_result
+      retries: "{{ cifmw_cephadm_wait_install_retries }}"
+      delay: "{{ cifmw_cephadm_wait_install_delay }}"
+      until: task_result is success
 
 - name: Stat cephadm file
   ansible.builtin.stat:


### PR DESCRIPTION
If `cifmw_cephadm_rpm_url` returns a 404, strip the filename from the URL to get the parent directory, fetch the index page, and search it for a cephadm RPM. If one is found, warn and update `cifmw_cephadm_rpm_url` to the discovered URL. If none is found, fail with a descriptive error.

This handles cases where the exact RPM version in the URL has changed (e.g. a compose rebuild with a new NVR) but a valid cephadm package still exists in the same directory.

Related-Issue: [OSPRH-31757](https://redhat.atlassian.net/browse/OSPRH-31757)