### PR TITLE
[edpm_deploy_baremetal] Check provisionserver readiness based on image type

### DIFF
--- a/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -227,6 +227,8 @@
           --timeout={{ cifmw_edpm_deploy_baremetal_wait_ironic_timeout_mins }}m
 
     - name: Wait for OpenStack Provision Server pod to be created
+      when:
+        - (cifmw_install_yamls_environment.BAREMETAL_OS_IMG_TYPE | default('') | lower) != 'passthrough'
       environment:
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"
@@ -240,6 +242,8 @@
       until: cifmw_edpm_deploy_baremetal_provisionserver_pod_output.stdout != ''
 
     - name: Wait for OpenStack Provision Server deployment to be available
+      when:
+        - (cifmw_install_yamls_environment.BAREMETAL_OS_IMG_TYPE | default('') | lower) != 'passthrough'
       environment:
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
         PATH: "{{ cifmw_path }}"


### PR DESCRIPTION
For passthrough there won't be any provision server. So these checks should be skipped.
