### PR TITLE
[libvirt_manager] Create DNS/DHCP records when mac_map is pre-defined

### DIFF
--- a/roles/libvirt_manager/tasks/deploy_layout.yml
+++ b/roles/libvirt_manager/tasks/deploy_layout.yml
@@ -118,6 +118,30 @@
     - cifmw_libvirt_manager_mac_map is undefined
   ansible.builtin.include_tasks: generate_networking_data.yml
 
+- name: Ensure DNS/DHCP records exist when mac_map is pre-defined
+  when:
+    - cifmw_libvirt_manager_mac_map is defined
+  block:
+    - name: Load networking env definition if not already set
+      when:
+        - cifmw_networking_env_definition is not defined or
+          (cifmw_networking_env_definition.instances | default({}) | length == 0)
+      block:
+        - name: Read networking environment definition file
+          ansible.builtin.slurp:
+            path: "{{ cifmw_networking_mapper_networking_env_def_path | default('/etc/ci/env/networking-environment-definition.yml') }}"
+          register: _net_env_def_file
+
+        - name: Set networking env definition fact
+          ansible.builtin.set_fact:
+            cifmw_networking_env_definition: "{{ _net_env_def_file.content | b64decode | from_yaml }}"
+
+    - name: Create DNS/DHCP records
+      when:
+        - cifmw_networking_env_definition is defined
+        - cifmw_networking_env_definition.instances | default({}) | length > 0
+      ansible.builtin.include_tasks: create_dns_records.yml
+
 - name: Create group inventories
   when:
     - _cifmw_libvirt_manager_layout.vms[item].manage | default(true)


### PR DESCRIPTION
When `cifmw_libvirt_manager_mac_map` is defined (baremetal deploy-bm
flow), `generate_networking_data.yml` is skipped because MAC addresses
are already known. However, this also skips the DNS/DHCP record
creation (`create_dns_records.yml`) which is called at the end of
that file.

Without DHCP reservations, compute VMs provisioned by Ironic never
get a ctlplane IP, leaving them unreachable for EDPM bootstrap.

This adds a separate path that loads `cifmw_networking_env_definition`
from the infra environment file (`/etc/ci/env/networking-environment-definition.yml`)
and creates DNS/DHCP records when `mac_map` is pre-defined.

Related-Issue: [ANVIL-109](https://redhat.atlassian.net/browse/ANVIL-109)