### PR TITLE
federation: skip OperatorGroup creation when one already exists

### DIFF
--- a/roles/federation/tasks/run_keycloak_setup.yml
+++ b/roles/federation/tasks/run_keycloak_setup.yml
@@ -35,6 +35,13 @@
     kind: Namespace
     state: present
 
+- name: Check for existing OperatorGroup in namespace
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1
+    kind: OperatorGroup
+    namespace: "{{ cifmw_federation_operator_namespace }}"
+  register: _existing_operator_groups
+
 - name: Read federation rhsso operator template
   ansible.builtin.template:
     src: rhsso-operator-olm.yaml.j2

--- a/roles/federation/templates/rhsso-operator-olm.yaml.j2
+++ b/roles/federation/templates/rhsso-operator-olm.yaml.j2
@@ -1,3 +1,4 @@
+{% if (_existing_operator_groups.resources | default([])) | length == 0 %}
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -7,6 +8,7 @@ spec:
   targetNamespaces:
   - {{ cifmw_federation_keycloak_namespace }}
 ---
+{% endif %}
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:


### PR DESCRIPTION
OLM enforces a single OperatorGroup per namespace. When deploying on OpenShift with the architecture repo, the namespace already has an OperatorGroup, and creating a second one prevents InstallPlan generation for all Subscriptions in that namespace.

Check for an existing OperatorGroup before rendering the template and conditionally skip creation. This fixes multiregion deployments while preserving CRC support where no OperatorGroup pre-exists.