### PR TITLE
[setup_molecule] Workaround OpenSSL 3.5.x breaking Ansible url lookups

### DIFF
--- a/scripts/setup_molecule
+++ b/scripts/setup_molecule
@@ -25,6 +25,12 @@ export PROJECT_DIR="$(dirname $(dirname $(readlink -f ${BASH_SOURCE[0]})))"
 #                  system ansible may be installed.
 export ANSIBLE_SKIP_CONFLICT_CHECK=1
 
+# Workaround: OpenSSL >= 3.5.6 introduced strict DER validation that rejects
+# some real-world CA root certs (openssl/openssl#25023), breaking Ansible's
+# url lookup plugin. Pin to 3.5.5 until the issue is resolved upstream.
+# Remove this block once openssl/openssl#25023 is fixed.
+sudo dnf downgrade --allowerasing -y openssl-3.5.5 openssl-libs-3.5.5 2>/dev/null || true
+
 PIP_INSTALL_ARGUMENTS="-U -r ${PROJECT_DIR}/test-requirements.txt"
 case ${USE_VENV-'yes'} in
     y|yes|true)


### PR DESCRIPTION
OpenSSL >= 3.5.6 introduced strict DER validation that rejects some real-world CA root certificates with non-standard encoding (openssl/openssl#25023). This causes Ansible 2.15's url lookup plugin to fail with "ASN1: NOT_ENOUGH_DATA" when load_verify_locations is called with DER-encoded cadata.

Pin openssl to 3.5.5 until the issue is resolved upstream.