### PR TITLE
[ci_gen_kustomize_values] fix bmhlabelselector mismatch

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/bmo01/nodeset-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bmo01/nodeset-values/values.yaml.j2
@@ -16,6 +16,11 @@ data:
       rhos-release {{ cifmw_repo_setup_rhos_release_args }}
     nodes:
 {% for host in cifmw_networking_env_definition.instances.keys() if host is match('^leaf0-.*') %}
+{% if cifmw_run_id is defined %}
+{% set _host = host | replace('-' + cifmw_run_id, '') %}
+{% else %}
+{% set _host = host %}
+{% endif %}
 {% set idx = host.split('-')[-1] %}
 {% set compute_name = 'edpm-compute-0-' ~ idx %}
 {% set ip = cifmw_networking_env_definition.instances[host].networks.ctlplane1.ip_v4 %}
@@ -24,7 +29,7 @@ data:
         ansible:
           ansibleHost: {{ ctlplane_ip }}
         bmhLabelSelector:
-          nodeName: {{ host }}
+          nodeName: {{ _host }}
         hostName: {{ compute_name }}
         networkData:
           name: {{ compute_name }}-network-data
@@ -56,6 +61,11 @@ data:
       rhos-release {{ cifmw_repo_setup_rhos_release_args }}
     nodes:
 {% for host in cifmw_networking_env_definition.instances.keys() if host is match('^leaf1-.*') %}
+{% if cifmw_run_id is defined %}
+{% set _host = host | replace('-' + cifmw_run_id, '') %}
+{% else %}
+{% set _host = host %}
+{% endif %}
 {% set idx = host.split('-')[-1] %}
 {% set compute_name = 'edpm-compute-1-' ~ idx %}
 {% set ip = cifmw_networking_env_definition.instances[host].networks.ctlplane2.ip_v4 %}
@@ -64,7 +74,7 @@ data:
         ansible:
           ansibleHost: {{ ctlplane_ip }}
         bmhLabelSelector:
-          nodeName: {{ host }}
+          nodeName: {{ _host }}
         hostName: {{ compute_name }}
         networkData:
           name: {{ compute_name }}-network-data


### PR DESCRIPTION
A label mismatch between BareMetalHost resources and OpenStackDataPlaneNodeSet selectors:

- BareMetalHosts were created with name leaf0-0 and label nodeName: leaf0-0 (without run_id)
- NodeSets were looking for nodeName: leaf0-5g3gib85-0 (with run_id)

BareMetalHosts are created without this suffix in their labels.root cause is a template bug where OpenStackDataPlaneNodeSet resources reference BareMetalHost labels that include the cifmw_run_id suffix, but the actual BareMetalHosts are created without this suffix in their labels.

fixes: [OSPRH-32525](https://redhat.atlassian.net/browse/OSPRH-32525)