### PR TITLE
[reproducer] Support overwriting zuul vars when job runner differs from hypervisor

### DIFF
--- a/roles/reproducer/tasks/overwrite_zuul_vars.yml
+++ b/roles/reproducer/tasks/overwrite_zuul_vars.yml
@@ -27,6 +27,13 @@
       delegate_to: controller-0
       no_log: "{{ cifmw_nolog | default(true) | bool }}"
 
+    - name: Copy reproducer-variables.yml to hypervisor
+      ansible.builtin.copy:
+        src: "{{ temp_reproducer_var_path }}"
+        dest: "{{ temp_reproducer_var_path }}"
+        mode: "0640"
+      no_log: "{{ cifmw_nolog | default(true) | bool }}"
+
     - name: Copy merge yamls script
       become: true
       ansible.builtin.copy:
@@ -55,6 +62,13 @@
       loop_control:
         loop_var: extra_variable_file
         label: "{{ extra_variable_file | basename }}"
+      no_log: "{{ cifmw_nolog | default(true) | bool }}"
+
+    - name: Fetch merged reproducer-variables.yml from hypervisor
+      ansible.builtin.fetch:
+        src: "{{ temp_merged_reproducer_var_path }}"
+        dest: "{{ temp_merged_reproducer_var_path }}"
+        flat: true
       no_log: "{{ cifmw_nolog | default(true) | bool }}"
 
     - name: Write back merged reproducer-variables.yml


### PR DESCRIPTION
This allows us to have these required files when job runner and hypervisor
are different machines

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/4049


More info: [OSPRH-32137](https://redhat.atlassian.net/browse/OSPRH-32137)