### PR TITLE
Pin ansible-core in pre-commit ansible-lint hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,7 @@ repos:
     hooks:
       - id: ansible-lint
         additional_dependencies:
+          - ansible-core==2.15.13
           - netaddr
           - jmespath
 


### PR DESCRIPTION
ansible-lint 6.22.2 (used by the pre-commit hook) is incompatible with ansible-core >= 2.16 due to removed internal APIs it depends on. Pin ansible-core==2.15.13 in the hook's additional_dependencies to match test-requirements.txt, preventing cryptic import errors when running pre-commit.