### PR TITLE
[reproducer] Pin OpenSSL to 3.5.5 for ASN1: NOT_ENOUGH_DATA error

### DIFF
--- a/roles/reproducer/tasks/configure_controller.yml
+++ b/roles/reproducer/tasks/configure_controller.yml
@@ -323,6 +323,22 @@
           retries: 100
           delay: 5
 
+    - name: Pin OpenSSL to 3.5.5
+      become: true
+      register: _cifmw_pin_openssl
+      changed_when: >-
+        _cifmw_pin_openssl.rc == 0 and
+        "Nothing to do." not in (_cifmw_pin_openssl.stdout | default(""))
+      failed_when: false
+      ansible.builtin.command:
+        argv:
+          - dnf
+          - downgrade
+          - --allowerasing
+          - -y
+          - openssl-3.5.5
+          - openssl-libs-3.5.5
+
     # Deploy Sushy Emulator on the Ansible controller,
     - name: Deploy Sushy Emulator service container
       tags:


### PR DESCRIPTION
There is an already solution in place:
https://github.com/openstack-k8s-operators/ci-framework/pull/4042/changes/984a8118c5071026bcc7ee54cf7ff3238ded70ee https://github.com/openstack-k8s-operators/ci-framework/pull/4042/changes/c6fae872236d07d9ff72a7142c8540a6bc05e47c

This change fixes cifmw-molecule-reproducer job.

This jobs creates mid-test compute and controller VMs, coming from latest centos image. These has no the pin version constraint.