### PR TITLE
[ci_gen_kustomize_values] BGP: generate gateway IP for network bridges from CIDR

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/bgp-l3-xl/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp-l3-xl/network-values/values.yaml.j2
@@ -108,6 +108,7 @@ data:
 {%       endfor %}
 {%     endif %}
 {%   endif %}
+    gateway: {{ network.network_v4 | ansible.utils.nthhost(1) }}
     prefix-length: {{ network.network_v4 | ansible.utils.ipaddr('prefix') }}
     mtu: {{ network.mtu | default(1500) }}
 {%   if network.vlan_id is defined  %}

--- a/roles/ci_gen_kustomize_values/templates/bgp_dt01/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt01/network-values/values.yaml.j2
@@ -114,6 +114,7 @@ data:
 {%      endfor %}
 {%    endif %}
 {%  endif %}
+    gateway: {{ network.network_v4 | ansible.utils.nthhost(1) }}
     prefix-length: {{ network.network_v4 | ansible.utils.ipaddr('prefix') }}
     mtu: {{ network.mtu | default(1500) }}
 {%  if network.vlan_id is defined  %}


### PR DESCRIPTION
## Summary

- BGP deployments (`bgp_dt01`, `bgp-l3-xl`) use `isGateway: true` in the internalapi and storage NetworkAttachmentDefinitions, which causes the bridge CNI plugin to assign a gateway IP (e.g. `172.17.0.1/24`) to the bridge when the first pod starts on the node.
- Without this IP being explicitly set in the NNCP desired state, NMState periodically removes it during reconciliation, causing `ovn-controller` to lose connectivity to the OVN SB DB pods (typically after 24+ hours).
- This change uses `ansible.utils.nthhost(1)` to derive the gateway IP directly from the network CIDR when generating `values.yaml`, so the `architecture` repo NNCP templates can include it in the desired state without requiring a hardcoded value.

This is the ci-framework counterpart to the fix in [openstack-k8s-operators/architecture#783](https://github.com/openstack-k8s-operators/architecture/pull/783).

Related-Issue: #[OSPRH-32725](https://redhat.atlassian.net/browse/OSPRH-32725)

**AI attribution**: commit message and PR description drafted with assistance from Claude Sonnet 4.6.

## Test plan

- [X] Verify generated `values.yaml` contains correct `gateway` field for `internalapi` and `storage` networks in BGP deployments
- [X] Deploy a BGP environment and confirm `internalapi`/`storage` bridge gateway IPs are preserved after NMState reconciliation
- [X] Verify OVN SB DB pods remain reachable from compute/networker nodes after 24+ hours

**Depends-On**: https://github.com/openstack-k8s-operators/architecture/pull/783

🤖 Generated with [Claude Code](https://claude.com/claude-code)