### PR TITLE
[os_must_gather] Make SOS_DECOMPRESS configurable

### DIFF
--- a/roles/os_must_gather/README.md
+++ b/roles/os_must_gather/README.md
@@ -17,6 +17,7 @@ testing the new changes.
 * `cifmw_os_must_gather_namespaces`: (List) List of namespaces required by the gather task in case of failure
 * `cifmw_os_must_gather_additional_namespaces`: (String) List of comma separated additional namespaces. Defaults to `kuttl,openshift-storage,sushy-emulator`
 * `cifmw_os_must_gather_volume_percentage`: (int) Specify maximum percentage of must-gather pod's allocated volume that can be used. If this limit is exceeded, must-gather will stop gathering, but still copy gathered data. Defaults to `80`
+* `cifmw_os_must_gather_sos_decompress`: (int) Controls whether SOS reports collected from both OCP and EDPM nodes are decompressed after gathering. Set to `1` to decompress (default), or `0` to keep them compressed. Decompressing makes the reports directly readable (useful for CI purposes) but increases usage. Defaults to `1`
 * `cifmw_os_must_gather_omc`: (bool) Enables the full gathering method. When set to false, a lightweight mode is used; when true, it performs a comprehensive data collection, which is more resource-intensive. Defaults to `false`
 
 ## Examples

--- a/roles/os_must_gather/defaults/main.yml
+++ b/roles/os_must_gather/defaults/main.yml
@@ -26,6 +26,7 @@ cifmw_os_must_gather_repo_path: "{{ ansible_user_dir }}/src/github.com/openstack
 cifmw_os_must_gather_sos_edpm: "all"
 cifmw_os_must_gather_timeout: "30m"
 cifmw_os_must_gather_volume_percentage: 80
+cifmw_os_must_gather_sos_decompress: 1
 cifmw_os_must_gather_additional_namespaces: "kuttl,openshift-storage,openshift-marketplace,openshift-operators,sushy-emulator,tobiko"
 cifmw_os_must_gather_namespaces:
   - "{{ operator_namespace }}"

--- a/roles/os_must_gather/tasks/main.yml
+++ b/roles/os_must_gather/tasks/main.yml
@@ -62,7 +62,7 @@
         KUBECONFIG: "{{ cifmw_openshift_kubeconfig | default(cifmw_os_must_gather_kubeconfig) }}"
         PATH: "{{ cifmw_path }}"
         SOS_EDPM: "{{ cifmw_os_must_gather_sos_edpm }}"
-        SOS_DECOMPRESS: "0"
+        SOS_DECOMPRESS: "{{ cifmw_os_must_gather_sos_decompress }}"
         OPENSTACK_DATABASES: "{{ cifmw_os_must_gather_dump_db }}"
         OMC: "{{ cifmw_os_must_gather_omc }}"
       cifmw.general.ci_script:


### PR DESCRIPTION
Expose `SOS_DECOMPRESS` as `cifmw_os_must_gather_sos_decompress` so that `SOS` reports from both `OCP` and `EDPM` nodes are `decompressed` after collection, making them directly readable without extra steps. This keep the original behavior and adapts `cifmw` to the recent changes introduced to `openstack-must-gather`.

Jira: https://redhat.atlassian.net/browse/OSPRH-32765