### PR TITLE
[libvirt_manager] Add retries to controller SSH key inject tasks

### DIFF
--- a/roles/libvirt_manager/tasks/manage_vms.yml
+++ b/roles/libvirt_manager/tasks/manage_vms.yml
@@ -102,6 +102,10 @@
         owner: "{{ _user }}"
         group: "{{ _user }}"
         mode: "0400"
+      retries: 5
+      delay: 30
+      register: _inject_private_key
+      until: _inject_private_key is not failed
 
     - name: "Inject public key on hosts {{ vm }}"
       delegate_to: "{{ vm_con_name }}"
@@ -112,3 +116,7 @@
         owner: "{{ _user }}"
         group: "{{ _user }}"
         mode: "0444"
+      retries: 5
+      delay: 30
+      register: _inject_public_key
+      until: _inject_public_key is not failed


### PR DESCRIPTION
## Summary

- Adds `retries: 5, delay: 30` to both "Inject private key" and "Inject public key" tasks in `manage_vms.yml`
- Matches the retry pattern already used for OCP SSH access (line 62-75, `retries: 5, delay: 60`)
- Fixes a race condition where cloud-init hasn't written `authorized_keys` before the inject task attempts SSH, causing `Permission denied (publickey)` on controller VMs

## Root cause

SSHD starts independently of cloud-init on RHEL 9. The SSH port opens ~16s after VM boot, but cloud-init may not finish writing SSH keys until 30-60s post-boot. Without retries, the inject task fails immediately on first attempt.

Observed in testproject build `5ac3f032` on devin07 (reused hypervisor, routable IPs through physical bridge), but this is a latent race condition that could affect any environment where cloud-init is slower than usual.

## Test plan

- [ ] Verify via ci-framework-testproject build with `Depends-On:` pointing to this PR
- [ ] Confirm inject tasks succeed with retries on devin07 testproject

Related-Issue: #[OSPRH-32065](https://redhat.atlassian.net/browse/OSPRH-32065)

🤖 Generated with [Claude Code](https://claude.com/claude-code)