### PR TITLE
[devscripts] Export SNO resource overrides in config template

### DIFF
--- a/roles/devscripts/templates/conf_ciuser.j2
+++ b/roles/devscripts/templates/conf_ciuser.j2
@@ -14,8 +14,10 @@ set -x
 {% for item in ['working_dir', 'assets_extra_folder', 'openshift_release_type',
     'openshift_version', 'cluster_name', 'base_domain', 'ntp_servers',
     'external_subnet_v4', 'ip_stack', 'agent_e2e_test_scenario',
-    'agent_platform_type'] %}
+    'agent_platform_type', 'master_memory', 'master_disk', 'master_vcpu'] %}
+{% if item in cifmw_devscripts_config %}
 export {{ item.upper() }}="{{ cifmw_devscripts_config[item] }}"
+{% endif %}
 {% endfor %}
 export NUM_MASTERS=1
 export NUM_WORKERS=0


### PR DESCRIPTION
The `conf_ciuser.j2` has missing fields like `master_memory`, `master_disk`, and `master_vcpu` that should be possible to parametrize.