### PR TITLE
[reproducer] Add cifmw_post_deploy_extra_args for PreMetal

### DIFF
--- a/reproducer.yml
+++ b/reproducer.yml
@@ -147,4 +147,7 @@
       poll: 20
       delegate_to: controller-0
       ansible.builtin.command:
-        cmd: "$HOME/post_deployment.sh {{ cifmw_post_deploy_args | default('') }}"
+        cmd: >-
+          $HOME/post_deployment.sh
+          {{ cifmw_post_deploy_args | default('') }}
+          {{ cifmw_post_deploy_extra_args | default('') }}

--- a/roles/reproducer/tasks/premetal.yml
+++ b/roles/reproducer/tasks/premetal.yml
@@ -43,3 +43,17 @@
   ansible.builtin.debug:
     msg: >
       Current cifmw_deploy_architecture_args {{ cifmw_deploy_architecture_args | default('') }}
+
+- name: Pass extra variable files to post-deployment script
+  ansible.builtin.set_fact:
+    cifmw_post_deploy_extra_args: >
+      {{ cifmw_post_deploy_extra_args | default('') }}
+      -e @{{ extra_variable_file }}
+  loop: "{{ cifmw_post_deploy_extra_variable_files | default([]) }}"
+  loop_control:
+    loop_var: extra_variable_file
+
+- name: Print final cifmw_post_deploy_extra_args
+  ansible.builtin.debug:
+    msg: >
+      Current cifmw_post_deploy_extra_args {{ cifmw_post_deploy_extra_args | default('') }}


### PR DESCRIPTION
On PreMetal, extra_variable_files set at the testing-phase job level do not reach post_deployment.sh, since cifmw_post_deploy_args is passed as a CLI extra-var by ci-framework-jobs and cannot be overridden downstream. Introduce cifmw_post_deploy_extra_variable_files, mirroring the existing cifmw_deploy_architecture_args mechanism, so jobs can inject extra vars files into the post-deployment phase.