### PR TITLE
[edpm_prepare] Fall back to quay.io bootc OS image

### DIFF
--- a/roles/edpm_prepare/README.md
+++ b/roles/edpm_prepare/README.md
@@ -20,3 +20,4 @@ This role doesn't need privilege escalation.
 * `cifmw_edpm_prepare_wait_controplane_status_change_sec`: (Integer) Time, in seconds, to wait before checking
 openstack control plane deployment status. Useful when using the role to only update the control plane resource, scenario where it may be in a `ready` status. Defaults to `30`.
 * `cifmw_edpm_prepare_extra_kustomizations`: (List) Extra Kustomizations to apply on top of the controlplane CRs. Defaults to `[]`.
+* `cifmw_edpm_prepare_bootc_os_image_url`: (String) Default bootc OS container image used when content-provider did not build one. Defaults to `quay.io/openstack-k8s-operators/edpm-bootc:latest-qcow2`.

--- a/roles/edpm_prepare/defaults/main.yml
+++ b/roles/edpm_prepare/defaults/main.yml
@@ -34,3 +34,6 @@ cifmw_edpm_prepare_kustomizations: []
 cifmw_edpm_prepare_wait_controplane_status_change_sec: 30
 cifmw_edpm_prepare_extra_kustomizations: []
 cifmw_prepare_openstackversion: true
+# Default bootc OS image when content-provider did not build one.
+cifmw_edpm_prepare_bootc_os_image_url: >-
+  quay.io/openstack-k8s-operators/edpm-bootc:latest-qcow2

--- a/roles/edpm_prepare/tasks/main.yml
+++ b/roles/edpm_prepare/tasks/main.yml
@@ -170,7 +170,6 @@
       }}
     cacheable: true
   when:
-    - cifmw_update_containers_edpm_image_url is not defined
     - cifmw_build_images_output is defined
     - "'images' in cifmw_build_images_output"
     - >-
@@ -181,6 +180,14 @@
         not (cifmw_edpm_deploy_baremetal_bootc | default(false) | bool) and
         'edpm-hardened-uefi' in cifmw_build_images_output['images']
       )
+
+- name: Set default bootc OS image url when not built by content provider
+  ansible.builtin.set_fact:
+    cifmw_update_containers_edpm_image_url: "{{ cifmw_edpm_prepare_bootc_os_image_url }}"
+    cacheable: true
+  when:
+    - cifmw_edpm_deploy_baremetal_bootc | default(false) | bool
+    - cifmw_update_containers_edpm_image_url is not defined
 
 # Prepare and kustomize the OpenStackControlPlane CR
 - name: Prepare OpenStack control plane CR


### PR DESCRIPTION
Default bootc OS images to quay.io/openstack-k8s-operators/edpm-bootc:latest-qcow2 when content-provider does not build them. CP output overrides that default.