### PR TITLE
[edpm_build_images] Enable bootc image publish in periodic push

### DIFF
--- a/roles/edpm_build_images/README.md
+++ b/roles/edpm_build_images/README.md
@@ -20,7 +20,7 @@ None
 * `cifmw_edpm_build_images_bootc`: (Boolean) Build the bootc image workflow. Default to false.
 * `cifmw_edpm_build_images_hardened_uefi_package`: (Boolean) Packaged `edpm-hardened-uefi` image inside a container image for distribution. Default to false.
 * `cifmw_edpm_build_images_ironic_python_agent_package`: (Boolean) Packaged  `ironic-python-agent-builder` image inside a container image for distribution. Default to false.
-* `cifmw_edpm_build_images_bootc_repo`: (String) Repository used to push the bootc container image. Default: `{{ cifmw_edpm_build_images_push_registry }}/edpm-bootc`.
+* `cifmw_edpm_build_images_bootc_repo`: (String) Repository used to push the bootc container image. Default: `{{ cifmw_edpm_build_images_push_registry }}/[{{ cifmw_edpm_build_images_push_registry_namespace }}/]edpm-bootc`.
 * `cifmw_edpm_build_images_bootc_repo_path`: (String) Path to the bootc content within `edpm-image-builder`.
 * `cifmw_edpm_build_images_bootc_base_image`: (String) Base bootc image used for the build. Default: `quay.io/centos-bootc/centos-bootc:stream9`.
 * `cifmw_edpm_build_images_bootc_builder_image`: (String) Bootc builder image used to produce the qcow2 artifact. Default: `quay.io/centos-bootc/bootc-image-builder:latest`.

--- a/roles/edpm_build_images/defaults/main.yml
+++ b/roles/edpm_build_images/defaults/main.yml
@@ -39,7 +39,16 @@ cifmw_edpm_build_images_ironic_python_agent: false
 cifmw_edpm_build_images_bootc: false
 cifmw_edpm_build_images_hardened_uefi_package: true
 cifmw_edpm_build_images_ironic_python_agent_package: true
-cifmw_edpm_build_images_bootc_repo: "{{ cifmw_edpm_build_images_push_registry }}/edpm-bootc"
+cifmw_edpm_build_images_bootc_repo: >-
+  {{
+    cifmw_edpm_build_images_push_registry ~
+    (
+      '/' ~ cifmw_edpm_build_images_push_registry_namespace
+      if (cifmw_edpm_build_images_push_registry_namespace | default('') | length) > 0
+      else ''
+    ) ~
+    '/edpm-bootc'
+  }}
 cifmw_edpm_build_images_bootc_repo_path: "{{ cifmw_edpm_image_builder_repo_path }}/bootc"
 cifmw_edpm_build_images_bootc_base_image: "quay.io/centos-bootc/centos-bootc:stream9"
 cifmw_edpm_build_images_bootc_builder_image: "quay.io/centos-bootc/bootc-image-builder:latest"

--- a/zuul.d/edpm_periodic.yaml
+++ b/zuul.d/edpm_periodic.yaml
@@ -38,6 +38,7 @@
       cifmw_repo_setup_branch: master
       cifmw_repo_setup_promotion: podified-ci-testing
       openstack_release: master
+      cifmw_edpm_build_images_bootc: true
       cifmw_edpm_build_images_push_container_images: true
       registry_login_enabled: true
       cifmw_dlrn_report_result: true


### PR DESCRIPTION
Build and push bootc images from periodic-edpm-build-push-images jobs.