### PR TITLE
[test_operator] Read horizontest admin password from osp-secret

### DIFF
--- a/roles/test_operator/tasks/runners/horizontest_runner.yml
+++ b/roles/test_operator/tasks/runners/horizontest_runner.yml
@@ -1,4 +1,29 @@
 ---
+- name: Fetch admin password from osp-secret
+  no_log: true
+  ansible.builtin.command:
+    cmd: >-
+      oc get secret osp-secret
+      -n {{ cifmw_test_operator_namespace }}
+      -o jsonpath='{.data.AdminPassword}'
+  register: _horizontest_admin_password_b64
+  failed_when: false
+  changed_when: false
+
+- name: Override admin password from osp-secret
+  no_log: true
+  when:
+    - _horizontest_admin_password_b64.rc == 0
+    - _horizontest_admin_password_b64.stdout | length > 0
+  ansible.builtin.set_fact:
+    stage_vars_dict: >-
+      {{
+        stage_vars_dict | combine({
+          'cifmw_test_operator_horizontest_admin_password':
+            _horizontest_admin_password_b64.stdout | b64decode
+        })
+      }}
+
 - name: Run horizontest job
   vars:
     run_test_fw: horizontest


### PR DESCRIPTION
install_yamls PR openstack-k8s-operators/install_yamls#1158 replaced hardcoded passwords with dynamically generated per-service secrets. The horizontest runner defaulted adminPassword to "12345678" which no longer matches the deployed admin password.

Fetch AdminPassword from the osp-secret Secret at runtime and override the default before building the HorizonTest CR.

Jira: [OSPRH-32754](https://redhat.atlassian.net/browse/OSPRH-32754)