### PR TITLE
[ci_gen_kustomize_values] Add peer_asn to bgp_dt02 network-values tem…

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/bgp_dt02/network-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bgp_dt02/network-values/values.yaml.j2
@@ -47,6 +47,7 @@ data:
                            ansible.utils.ipmath(ip_index) %}
     loopback_ip: {{ loopback_ip }}
     loopback_ipv6: {{ loopback_ipv6 }}
+    peer_asn: {{ original_content.data['node_' ~ ns.ocp_index].peer_asn | default(64999) }}
 {%     if node_bgp_orig_content.routes | default(false) %}
     routes: {{ node_bgp_orig_content.routes }}
 {%     endif %}


### PR DESCRIPTION
```
[ci_gen_kustomize_values] Add peer_asn to bgp_dt02 network-values template

Generate peer_asn in the template so architecture validation gates
can build the dt02 kustomization. Real deployments already work via
the ci_gen_kustomize_values merge pipeline from [1].

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/3900

Related: OSPRH-28085
Assisted-By: Claude Code
Signed-off-by: Maor Blaustein <mblue@redhat.com>
```