### PR TITLE
[adoption_osp_deploy] Recognize dcn-scenario-defined central stack name

### DIFF
--- a/roles/adoption_osp_deploy/templates/adoption_vars.yaml.j2
+++ b/roles/adoption_osp_deploy/templates/adoption_vars.yaml.j2
@@ -81,7 +81,7 @@ source_galera_members: |
 # - Multi-cell: _stack_names=['overcloud','cell1','cell2'] → looks for 'cell1-osp-computes', 'cell2-osp-computes' → creates edpm_nodes.cell1, edpm_nodes.cell2
 edpm_nodes:
 {% for stack in _stack_names %}
-  {% if stack == 'overcloud' %}
+  {% if stack in ['overcloud', 'central'] %}
     {% set cell = _default_cell_name %}
     {% set prefix = '' %}
   {% else %}


### PR DESCRIPTION
`edpm_nodes:` generates only special-cased stack name `overcloud`, but
 `dcn_storage.yaml` names its central stack `central`, so `edpm_nodes`
rendered empty for that scenario. Widening the check to 
`stack in ['overcloud', 'central']` to cover the `dcn` scenario.