### PR TITLE
Add stage override variable to shiftstack role

### DIFF
--- a/roles/shiftstack/README.md
+++ b/roles/shiftstack/README.md
@@ -22,6 +22,7 @@ Role for triggering Openshift on Openstack QA automation (installation and tests
 * `cifmw_shiftstack_qa_gerrithub_change`: (*string*) The gerrithub change to fetch from the `cifmw_shiftstack_qa_repo` repository (i.e. 'refs/changes/29/1188429/50)'. Defaults to ''.
 * `cifmw_shiftstack_qa_repo`: (*string*) The repository containing the Openshift on Openstack QA automation. Defaults to `https://review.gerrithub.io/shiftstack/shiftstack-qa`.
 * `cifmw_shiftstack_run_playbook`: (*string*) The playbook to be run from the `cifmw_shiftstack_qa_repo` repository. Defaults to `ocp_testing.yaml`.
+* `cifmw_shiftstack_stages_override`: (*list*) Optional stage list passed as ansible-navigator `--extra-vars` to override the stages from the testconfig. An empty list leaves the testconfig stages unchanged. Defaults to `[]`.
 * `cifmw_shiftstack_sc`: (*string*) The storage class to be used for PVC for the shiftstackclient pod. Defaults to `local-storage`.
 * `cifmw_shiftstack_shiftstackclient_artifacts_dir`: (*string*) The artifacts directory path for the shiftstackclient pod. Defaults to `/home/cloud-admin/artifacts`.
 * `cifmw_shiftstack_shiftstackclient_incluster_kubeconfig_dir`: (*string*) The directory path in shiftstackclient pod the will hold the RHOSO kubeconfig. Defaults to `/home/cloud-admin/incluster-kubeconfig`.

--- a/roles/shiftstack/defaults/main.yml
+++ b/roles/shiftstack/defaults/main.yml
@@ -53,3 +53,4 @@ cifmw_shiftstack_extra_vars_configmap_name: "shiftstack-extra-vars"
 cifmw_shiftstack_extra_vars_mount_path: "/home/cloud-admin/extra-vars"
 # Optional: name of a Kubernetes Secret containing SSH keys to mount into the pod
 # cifmw_shiftstack_trex_keypair_secret: "trex-keypair"
+cifmw_shiftstack_stages_override: []

--- a/roles/shiftstack/tasks/test_config.yml
+++ b/roles/shiftstack/tasks/test_config.yml
@@ -40,6 +40,7 @@
           -e user_cloud={{ cifmw_shiftstack_project_name }}
           -e hypervisor={{ cifmw_shiftstack_hypervisor }}
           -e rhoso_kubeconfig={{ cifmw_shiftstack_shiftstackclient_incluster_kubeconfig_dir }}/kubeconfig
+          {% if cifmw_shiftstack_stages_override | default([]) | length > 0 %}-e "{\"stages\":{{ cifmw_shiftstack_stages_override | to_json }}}"{% endif %}
       ansible.builtin.include_tasks: exec_command_in_pod.yml
 
   rescue:


### PR DESCRIPTION
The shiftstack role invokes `ocp_testing.yaml` with a testconfig that bundles all stages (install + test) in a single ansible-navigator call. The upcoming phased pipeline needs to run install stages in one Zuul job and test stages in another, using the same testconfig file.

Add `cifmw_shiftstack_stages_override` (default: []) that appends `--extra-vars` to the ansible-navigator command when non-empty, overriding the stages list from the testconfig. This avoids creating per-phase testconfig files in shiftstack-qa and keeps the monolithic job unchanged (empty list = no override = all stages run as before).

Related-Issue: [OSPRH-33128](https://redhat.atlassian.net/browse/OSPRH-33128)