### PR TITLE
DNM: Add cifmw-extracted-crc-pre-bootstrap-no-mapper job

### DIFF
--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -311,3 +311,18 @@
       - ci/playbooks/e2e-prepare.yml
       - ci/playbooks/dump_zuul_data.yml
       - ci/playbooks/bootstrap-networking-mapper.yml
+
+- job:
+    name: cifmw-extracted-crc-pre-bootstrap-no-mapper
+    parent: base-extracted-crc-wo-networks
+    abstract: true
+    pre-run:
+      - ci/playbooks/e2e-prepare.yml
+      - ci/playbooks/dump_zuul_data.yml
+
+- job:
+    name: cifmw-extracted-crc-no-mapper-edpm
+    parent: cifmw-extracted-crc-pre-bootstrap-no-mapper
+    abstract: true
+    run:
+      - ci/playbooks/edpm/run.yml


### PR DESCRIPTION
Same as cifmw-extracted-crc-pre-bootstrap but without bootstrap-networking-mapper.yml.

Generated-By: Claude Opus 4.6 <noreply@anthropic.com>