### PR TITLE
[federation] Remove manual Keycloak Route creation to fix SSL race condition

### DIFF
--- a/roles/federation/tasks/run_keycloak_setup.yml
+++ b/roles/federation/tasks/run_keycloak_setup.yml
@@ -146,30 +146,6 @@
   retries: 30
   delay: 10
 
-- name: Create Route for Keycloak
-  kubernetes.core.k8s:
-    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
-    state: present
-    definition:
-      apiVersion: route.openshift.io/v1
-      kind: Route
-      metadata:
-        name: keycloak
-        namespace: "{{ cifmw_federation_keycloak_namespace }}"
-      spec:
-        host: "keycloak-{{ cifmw_federation_keycloak_namespace }}.{{ cifmw_federation_domain }}"
-        to:
-          kind: Service
-          name: keycloak
-        port:
-          targetPort: 8443
-        tls:
-          termination: passthrough
-  register: _keycloak_route
-  until: _keycloak_route is succeeded
-  retries: 30
-  delay: 10
-
 - name: Grant privileged SCC to namespace default serviceaccount for Keycloak
   environment:
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"


### PR DESCRIPTION
## Problem

The `crc-federation` CI job started failing intermittently with:

    SSL exception connecting to https://keycloak-openstack.apps-crc.testing/...
    SSLCertVerificationError: certificate verify failed: self-signed certificate in certificate chain

No code changes in the federation role between passing and failing builds.

## Root cause

The task "Create Route for Keycloak" in `run_keycloak_setup.yml` creates a
`passthrough` TLS Route right after the Keycloak Service appears. The RHSSO
operator also creates/reconciles a Route for Keycloak (because
`externalAccess.enabled: true` in the Keycloak CR), but as `reencrypt`.

This is a race condition:
- When the operator wins: Route becomes `reencrypt`, ingress CA is the correct
  trust anchor, SSL works.
- When Ansible wins: Route stays `passthrough`, the Keycloak pod serves its own
  self-signed cert, `full-ca-list.crt` (which only has the ingress CA) cannot
  verify it, SSL fails.

## Fix

Remove the manual Route creation entirely. The RHSSO operator handles it
correctly with `reencrypt` and the proper `destinationCACertificate`.

## Testing

Verified on a CRC environment:
1. Deployed RHSSO operator + Keycloak CR (without manual Route)
2. Confirmed the operator created the Route as `reencrypt`
3. Deployed OpenStack control plane with federation configuration
4. Successfully obtained a federated Keystone token via `openstack token issue`
   using OIDC password grant through Keycloak