### PR TITLE
[DNM][TEST][operator_build] Use local path replace for go.mod in meta operator

### DIFF
--- a/roles/operator_build/tasks/build.yml
+++ b/roles/operator_build/tasks/build.yml
@@ -38,14 +38,30 @@
       ansible.builtin.set_fact:
         operator_api_path: "github.com/{{ cifmw_operator_build_org }}/{{ operator.name }}/{{ operator_base_module_name }}"
 
+- name: "{{ operator.name }} - Build pseudo-version from commit metadata"  # noqa: name[template]
+  ansible.builtin.shell: |
+    set -e
+    commit_date=$(TZ=UTC git log -1 --format='%cd' --date=format:'%Y%m%d%H%M%S' {{ operator.pr_sha }})
+    short_hash=$(echo "{{ operator.pr_sha }}" | cut -c1-12)
+    echo "v0.0.0-${commit_date}-${short_hash}"
+  args:
+    chdir: "{{ operator.src }}"
+  register: pseudo_version_out
+  when:
+    - cifmw_operator_build_meta_build
+    - operator.name != cifmw_operator_build_meta_name
+    - operator.pr_owner is defined
+    - operator.pr_sha is defined
+    - operator_base_module
+
 - name: "{{ operator.name }} - Update the go.mod file in meta operator for provided PR_SHA"  # noqa: name[template]
   ansible.builtin.shell: |
     set -e
-    go mod edit -replace {{ operator_api_path }}={{ operator.src }}/{{ operator_base_module_name }}
+    go mod edit -replace {{ operator_api_path }}=github.com/{{ operator.pr_owner }}/{{ operator_base_module_name }}@{{ pseudo_version_out.stdout | trim }}
     go mod tidy
     if [ -d ./apis ]; then
       pushd ./apis/
-      go mod edit -replace {{ operator_api_path }}={{ operator.src }}/{{ operator_base_module_name }}
+      go mod edit -replace {{ operator_api_path }}=github.com/{{ operator.pr_owner }}/{{ operator_base_module_name }}@{{ pseudo_version_out.stdout | trim }}
       go mod tidy
       popd
     fi
@@ -68,14 +84,29 @@
   ansible.builtin.set_fact:
     pr_sha: "{{ operator.pr_sha | default(git_head_out.stdout | trim) }}"
 
+- name: "{{ operator.name }} - Build pseudo-version from HEAD commit"  # noqa: name[template]
+  ansible.builtin.shell: |
+    set -e
+    commit_date=$(TZ=UTC git log -1 --format='%cd' --date=format:'%Y%m%d%H%M%S' HEAD)
+    short_hash=$(git log -1 --format='%H' HEAD | cut -c1-12)
+    echo "v0.0.0-${commit_date}-${short_hash}"
+  args:
+    chdir: "{{ operator.src }}"
+  register: pseudo_version_out
+  when:
+    - cifmw_operator_build_meta_build
+    - operator.name != cifmw_operator_build_meta_name
+    - operator.pr_owner is not defined
+    - operator_base_module
+
 - name: "{{ operator.name }} - Update the go.mod file using latest commit if no PR is provided"  # noqa: name[template]
   ansible.builtin.shell: |
     set -e
-    go mod edit -replace {{ operator_api_path }}={{ operator.src }}/{{ operator_base_module_name }}
+    go mod edit -replace {{ operator_api_path }}={{ operator_api_path }}@{{ pseudo_version_out.stdout | trim }}
     go mod tidy
     if [ -d ./apis ]; then
       pushd ./apis/
-      go mod edit -replace {{ operator_api_path }}={{ operator.src }}/{{ operator_base_module_name }}
+      go mod edit -replace {{ operator_api_path }}={{ operator_api_path }}@{{ pseudo_version_out.stdout | trim }}
       go mod tidy
       popd
     fi

--- a/roles/operator_build/tasks/build.yml
+++ b/roles/operator_build/tasks/build.yml
@@ -38,30 +38,14 @@
       ansible.builtin.set_fact:
         operator_api_path: "github.com/{{ cifmw_operator_build_org }}/{{ operator.name }}/{{ operator_base_module_name }}"
 
-- name: "{{ operator.name }} - Build pseudo-version from commit metadata"  # noqa: name[template]
-  ansible.builtin.shell: |
-    set -e
-    commit_date=$(TZ=UTC git log -1 --format='%cd' --date=format-local:'%Y%m%d%H%M%S' {{ operator.pr_sha }})
-    short_hash=$(echo "{{ operator.pr_sha }}" | cut -c1-12)
-    echo "v0.0.0-${commit_date}-${short_hash}"
-  args:
-    chdir: "{{ operator.src }}"
-  register: pseudo_version_out
-  when:
-    - cifmw_operator_build_meta_build
-    - operator.name != cifmw_operator_build_meta_name
-    - operator.pr_owner is defined
-    - operator.pr_sha is defined
-    - operator_base_module
-
 - name: "{{ operator.name }} - Update the go.mod file in meta operator for provided PR_SHA"  # noqa: name[template]
   ansible.builtin.shell: |
     set -e
-    go mod edit -replace {{ operator_api_path }}=github.com/{{ operator.pr_owner }}/{{ operator_base_module_name }}@{{ pseudo_version_out.stdout | trim }}
+    go mod edit -replace {{ operator_api_path }}=github.com/{{ operator.pr_owner }}/{{ operator_base_module_name }}@{{ operator.pr_sha }}
     go mod tidy
     if [ -d ./apis ]; then
       pushd ./apis/
-      go mod edit -replace {{ operator_api_path }}=github.com/{{ operator.pr_owner }}/{{ operator_base_module_name }}@{{ pseudo_version_out.stdout | trim }}
+      go mod edit -replace {{ operator_api_path }}=github.com/{{ operator.pr_owner }}/{{ operator_base_module_name }}@{{ operator.pr_sha }}
       go mod tidy
       popd
     fi
@@ -84,29 +68,14 @@
   ansible.builtin.set_fact:
     pr_sha: "{{ operator.pr_sha | default(git_head_out.stdout | trim) }}"
 
-- name: "{{ operator.name }} - Build pseudo-version from HEAD commit"  # noqa: name[template]
-  ansible.builtin.shell: |
-    set -e
-    commit_date=$(TZ=UTC git log -1 --format='%cd' --date=format-local:'%Y%m%d%H%M%S' HEAD)
-    short_hash=$(git log -1 --format='%H' HEAD | cut -c1-12)
-    echo "v0.0.0-${commit_date}-${short_hash}"
-  args:
-    chdir: "{{ operator.src }}"
-  register: pseudo_version_out
-  when:
-    - cifmw_operator_build_meta_build
-    - operator.name != cifmw_operator_build_meta_name
-    - operator.pr_owner is not defined
-    - operator_base_module
-
 - name: "{{ operator.name }} - Update the go.mod file using latest commit if no PR is provided"  # noqa: name[template]
   ansible.builtin.shell: |
     set -e
-    go mod edit -replace {{ operator_api_path }}={{ operator_api_path }}@{{ pseudo_version_out.stdout | trim }}
+    go mod edit -replace {{ operator_api_path }}={{ operator_api_path }}@{{ pr_sha }}
     go mod tidy
     if [ -d ./apis ]; then
       pushd ./apis/
-      go mod edit -replace {{ operator_api_path }}={{ operator_api_path }}@{{ pseudo_version_out.stdout | trim }}
+      go mod edit -replace {{ operator_api_path }}={{ operator_api_path }}@{{ pr_sha }}
       go mod tidy
       popd
     fi

--- a/roles/operator_build/tasks/build.yml
+++ b/roles/operator_build/tasks/build.yml
@@ -40,11 +40,12 @@
 
 - name: "{{ operator.name }} - Update the go.mod file in meta operator for provided PR_SHA"  # noqa: name[template]
   ansible.builtin.shell: |
-    go mod edit -replace {{ operator_api_path }}=github.com/{{ operator.pr_owner }}/{{ operator_base_module_name }}@{{ operator.pr_sha }}
+    set -e
+    go mod edit -replace {{ operator_api_path }}={{ operator.src }}/{{ operator_base_module_name }}
     go mod tidy
     if [ -d ./apis ]; then
       pushd ./apis/
-      go mod edit -replace {{ operator_api_path }}=github.com/{{ operator.pr_owner }}/{{ operator_base_module_name }}@{{ operator.pr_sha }}
+      go mod edit -replace {{ operator_api_path }}={{ operator.src }}/{{ operator_base_module_name }}
       go mod tidy
       popd
     fi
@@ -69,11 +70,12 @@
 
 - name: "{{ operator.name }} - Update the go.mod file using latest commit if no PR is provided"  # noqa: name[template]
   ansible.builtin.shell: |
-    go mod edit -replace {{ operator_api_path }}={{ operator_api_path }}@{{ pr_sha }}
+    set -e
+    go mod edit -replace {{ operator_api_path }}={{ operator.src }}/{{ operator_base_module_name }}
     go mod tidy
     if [ -d ./apis ]; then
       pushd ./apis/
-      go mod edit -replace {{ operator_api_path }}={{ operator_api_path }}@{{ pr_sha }}
+      go mod edit -replace {{ operator_api_path }}={{ operator.src }}/{{ operator_base_module_name }}
       go mod tidy
       popd
     fi

--- a/roles/operator_build/tasks/build.yml
+++ b/roles/operator_build/tasks/build.yml
@@ -41,7 +41,7 @@
 - name: "{{ operator.name }} - Build pseudo-version from commit metadata"  # noqa: name[template]
   ansible.builtin.shell: |
     set -e
-    commit_date=$(TZ=UTC git log -1 --format='%cd' --date=format:'%Y%m%d%H%M%S' {{ operator.pr_sha }})
+    commit_date=$(TZ=UTC git log -1 --format='%cd' --date=format-local:'%Y%m%d%H%M%S' {{ operator.pr_sha }})
     short_hash=$(echo "{{ operator.pr_sha }}" | cut -c1-12)
     echo "v0.0.0-${commit_date}-${short_hash}"
   args:
@@ -87,7 +87,7 @@
 - name: "{{ operator.name }} - Build pseudo-version from HEAD commit"  # noqa: name[template]
   ansible.builtin.shell: |
     set -e
-    commit_date=$(TZ=UTC git log -1 --format='%cd' --date=format:'%Y%m%d%H%M%S' HEAD)
+    commit_date=$(TZ=UTC git log -1 --format='%cd' --date=format-local:'%Y%m%d%H%M%S' HEAD)
     short_hash=$(git log -1 --format='%H' HEAD | cut -c1-12)
     echo "v0.0.0-${commit_date}-${short_hash}"
   args:


### PR DESCRIPTION
The go mod edit -replace command was using a remote module reference with a raw commit SHA (e.g. github.com/user/repo@sha), which requires go mod tidy to resolve the SHA to a pseudo-version via the Go module proxy. In CI environments where the proxy cannot reach fork repositories, go mod tidy silently fails (no set -e), leaving the raw SHA in go.mod. The subsequent go work use then fails with "version must be of the form v1.2.3".

Fix by using local path replaces instead — the operator source is already checked out at {{ operator.src }}, so no network access or version resolution is needed. Also add set -e to surface any future failures immediately.