### PR TITLE
[multiple] Publish native bootc content provider images

### DIFF
--- a/roles/edpm_build_images/tasks/bootc.yml
+++ b/roles/edpm_build_images/tasks/bootc.yml
@@ -33,6 +33,7 @@
   ansible.builtin.shell: >-
     buildah bud
     --network host
+    --format oci
     --build-arg EDPM_BASE_IMAGE={{ cifmw_edpm_build_images_bootc_base_image }}
     --build-arg RHSM_SCRIPT={{ cifmw_edpm_build_images_bootc_rhsm_script }}
     --build-arg FIPS={{ cifmw_edpm_build_images_bootc_fips }}
@@ -117,6 +118,8 @@
   ansible.builtin.set_fact:
     cifmw_edpm_build_images_bootc_output:
       images:
+        edpm-bootc:
+          image: "oci://{{ cifmw_edpm_build_images_bootc_repo }}:{{ cifmw_edpm_build_images_tag }}"
         edpm-bootc-qcow2:
           image: "{{ cifmw_edpm_build_images_bootc_repo }}:{{ cifmw_edpm_build_images_tag }}-qcow2"
     cacheable: true

--- a/roles/edpm_build_images/tasks/post.yaml
+++ b/roles/edpm_build_images/tasks/post.yaml
@@ -101,6 +101,18 @@
   delay: 5
   until: _cifmw_edpm_build_images_ipa_manifest_check.status == 200
 
+- name: Push bootc image to registry with tag {{ cifmw_edpm_build_images_tag }}
+  when: cifmw_edpm_build_images_bootc | bool
+  become: true
+  containers.podman.podman_image:
+    name: edpm-bootc
+    tag: "{{ cifmw_edpm_build_images_tag }}"
+    pull: false
+    push: true
+    push_args:
+      dest: >-
+        {{ cifmw_edpm_build_images_bootc_repo }}:{{ cifmw_edpm_build_images_tag }}
+
 - name: Push bootc qcow2 image to registry with tag {{ cifmw_edpm_build_images_tag }}
   when: cifmw_edpm_build_images_bootc | bool
   become: true
@@ -120,6 +132,22 @@
       {{ cifmw_edpm_build_images_bootc_repo | split('/', 1) | first }}
     _cifmw_edpm_build_images_bootc_repository: >-
       {{ cifmw_edpm_build_images_bootc_repo | split('/', 1) | last }}
+
+- name: Verify bootc image manifest is available in registry
+  when: cifmw_edpm_build_images_bootc | bool
+  ansible.builtin.uri:
+    url: >-
+      http://{{ _cifmw_edpm_build_images_bootc_registry }}/v2/{{
+      _cifmw_edpm_build_images_bootc_repository
+      }}/manifests/{{ cifmw_edpm_build_images_tag }}
+    method: GET
+    headers:
+      Accept: "application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json"
+    status_code: 200
+  register: _cifmw_edpm_build_images_bootc_native_manifest_check
+  retries: 12
+  delay: 5
+  until: _cifmw_edpm_build_images_bootc_native_manifest_check.status == 200
 
 - name: Verify bootc qcow2 image manifest is available in registry
   when: cifmw_edpm_build_images_bootc | bool

--- a/roles/edpm_prepare/README.md
+++ b/roles/edpm_prepare/README.md
@@ -20,4 +20,5 @@ This role doesn't need privilege escalation.
 * `cifmw_edpm_prepare_wait_controplane_status_change_sec`: (Integer) Time, in seconds, to wait before checking
 openstack control plane deployment status. Useful when using the role to only update the control plane resource, scenario where it may be in a `ready` status. Defaults to `30`.
 * `cifmw_edpm_prepare_extra_kustomizations`: (List) Extra Kustomizations to apply on top of the controlplane CRs. Defaults to `[]`.
-* `cifmw_edpm_prepare_bootc_os_image_url`: (String) Default bootc OS container image used when content-provider did not build one. Defaults to `quay.io/openstack-k8s-operators/edpm-bootc:latest-qcow2`.
+* `cifmw_edpm_prepare_bootc_os_image_url`: (String) Default bootc qcow2 OS container image used when content-provider did not build one. Defaults to `quay.io/openstack-k8s-operators/edpm-bootc:latest-qcow2`.
+* `cifmw_edpm_prepare_bootc_passthrough_os_image_url`: (String) Default bootc PassThrough OS container image used when content-provider did not build one. Defaults to `oci://quay.io/openstack-k8s-operators/edpm-bootc:latest`.

--- a/roles/edpm_prepare/defaults/main.yml
+++ b/roles/edpm_prepare/defaults/main.yml
@@ -37,3 +37,6 @@ cifmw_prepare_openstackversion: true
 # Default bootc OS image when content-provider did not build one.
 cifmw_edpm_prepare_bootc_os_image_url: >-
   quay.io/openstack-k8s-operators/edpm-bootc:latest-qcow2
+# Default bootc OS image for PassThrough when content-provider did not build one.
+cifmw_edpm_prepare_bootc_passthrough_os_image_url: >-
+  oci://quay.io/openstack-k8s-operators/edpm-bootc:latest

--- a/roles/edpm_prepare/tasks/main.yml
+++ b/roles/edpm_prepare/tasks/main.yml
@@ -163,9 +163,18 @@
     cifmw_update_containers_edpm_image_url: >-
       {{
         cifmw_build_images_output['images'][
-          'edpm-bootc-qcow2'
-          if (cifmw_edpm_deploy_baremetal_bootc | default(false) | bool)
-          else 'edpm-hardened-uefi'
+          (
+            'edpm-bootc'
+            if (
+              (cifmw_edpm_deploy_baremetal_bootc | default(false) | bool) and
+              (((cifmw_install_yamls_environment | default({})).BAREMETAL_OS_IMG_TYPE | default('') | lower) == 'passthrough')
+            )
+            else (
+              'edpm-bootc-qcow2'
+              if (cifmw_edpm_deploy_baremetal_bootc | default(false) | bool)
+              else 'edpm-hardened-uefi'
+            )
+          )
         ]['image']
       }}
     cacheable: true
@@ -175,7 +184,15 @@
     - >-
       (
         cifmw_edpm_deploy_baremetal_bootc | default(false) | bool and
-        'edpm-bootc-qcow2' in cifmw_build_images_output['images']
+        (
+          (
+            (((cifmw_install_yamls_environment | default({})).BAREMETAL_OS_IMG_TYPE | default('') | lower) == 'passthrough') and
+            'edpm-bootc' in cifmw_build_images_output['images']
+          ) or (
+            (((cifmw_install_yamls_environment | default({})).BAREMETAL_OS_IMG_TYPE | default('') | lower) != 'passthrough') and
+            'edpm-bootc-qcow2' in cifmw_build_images_output['images']
+          )
+        )
       ) or (
         not (cifmw_edpm_deploy_baremetal_bootc | default(false) | bool) and
         'edpm-hardened-uefi' in cifmw_build_images_output['images']
@@ -183,7 +200,12 @@
 
 - name: Set default bootc OS image url when not built by content provider
   ansible.builtin.set_fact:
-    cifmw_update_containers_edpm_image_url: "{{ cifmw_edpm_prepare_bootc_os_image_url }}"
+    cifmw_update_containers_edpm_image_url: >-
+      {{
+        cifmw_edpm_prepare_bootc_passthrough_os_image_url
+        if (((cifmw_install_yamls_environment | default({})).BAREMETAL_OS_IMG_TYPE | default('') | lower) == 'passthrough')
+        else cifmw_edpm_prepare_bootc_os_image_url
+      }}
     cacheable: true
   when:
     - cifmw_edpm_deploy_baremetal_bootc | default(false) | bool

--- a/zuul.d/content_provider.yaml
+++ b/zuul.d/content_provider.yaml
@@ -7,8 +7,8 @@
     name: openstack-k8s-operators-content-provider-bootc
     parent: openstack-k8s-operators-content-provider
     description: |
-      A zuul job to build and publish bootc qcow2 and ironic-python-agent
-      content for dependent jobs.
+      A zuul job to build and publish bootc, bootc qcow2, and
+      ironic-python-agent content for dependent jobs.
     vars:
       cifmw_edpm_build_images_all: false
       cifmw_edpm_build_images_hardened_uefi: false


### PR DESCRIPTION
Push the native bootc image alongside the qcow2 wrapper, expose the oci:// image in the content provider output, and use it for PassThrough bootc jobs. Keep the existing qcow2 bootc path and fallback for non-PassThrough jobs.