### PR TITLE
[adoption] Enable network service on OSP17

### DIFF
--- a/roles/adoption_osp_deploy/tasks/prepare_overcloud.yml
+++ b/roles/adoption_osp_deploy/tasks/prepare_overcloud.yml
@@ -340,6 +340,17 @@
       loop_control:
         loop_var: overcloud_vm
 
+    - name: Enable and start network service for overcloud nodes
+      become: true
+      delegate_to: "{{ overcloud_vm }}"
+      ansible.builtin.systemd:
+        name: network
+        enabled: true
+        state: started
+      loop: "{{ _tripleo_nodes_stack[_overcloud_name] }}"
+      loop_control:
+        loop_var: overcloud_vm
+
     - name: Slurp undercloud public key for ssh access to overcloud nodes
       delegate_to: "osp-undercloud-0"
       ansible.builtin.slurp:


### PR DESCRIPTION
OSP17 requires network service running as ifcfg is used as backend for os-net-config. Without it nodes loose network connection on reboot or ifcfg to nmstate migration.

Resolves: [OSPRH-31307](https://redhat.atlassian.net/browse/OSPRH-31307)