### PR TITLE
[devscripts] Create empty REGISTRY_CREDS file for baremetal platform

### DIFF
--- a/roles/devscripts/tasks/main.yml
+++ b/roles/devscripts/tasks/main.yml
@@ -47,6 +47,18 @@
         (cifmw_devscripts_repo_dir, 'logs' ) | path_join
       }}
   block:
+    - name: Ensure REGISTRY_CREDS file exists for baremetal platform
+      vars:
+        _cluster_name: >-
+          {{ cifmw_devscripts_config.cluster_name | default('ocp') }}
+      ansible.builtin.copy:
+        content: "{}"
+        dest: "{{ ansible_user_dir }}/private-mirror-{{ _cluster_name }}.json"
+        mode: "0644"
+        force: false
+      when:
+        - cifmw_devscripts_config.nodes_platform | default('') == 'baremetal'
+
     - name: Run devscripts make all
       cifmw.general.ci_script:
         chdir: "{{ cifmw_devscripts_repo_dir }}"


### PR DESCRIPTION
## Summary

When `nodes_platform=baremetal`, dev-scripts `02_configure_host.sh` exits early (since upstream PR openshift-metal3/dev-scripts#1922) before creating `private-mirror-<cluster>.json`. The subsequent `03_build_installer.sh` unconditionally reads this file via `write_pull_secret()`, causing all baremetal CI jobs to fail.

Create an empty `{}` JSON file at `~/private-mirror-<cluster>.json` before `make all` when `nodes_platform=baremetal`, so the jq merge in `write_pull_secret()` succeeds.

## Test plan

- [x] testproject MR on serval66 with Depends-On this PR

Made with [Cursor](https://cursor.com)