### PR TITLE
fix: skip role prefix check for automated cherry-pick PRs

### DIFF
--- a/scripts/check-role-prefix.sh
+++ b/scripts/check-role-prefix.sh
@@ -8,6 +8,15 @@ if [ -z "$GITHUB_BASE_REF" ]; then
     exit 0
 fi
 
+# Skip prefix check for automated cherry-pick PRs.
+# The Prow cherrypicker robot creates branches matching cherry-pick-*
+# and does not preserve role prefixes in commit messages.
+# The original PR already passed this check.
+if [[ "${GITHUB_HEAD_REF:-}" == cherry-pick-* ]]; then
+    echo "Cherry-pick PR detected (branch: $GITHUB_HEAD_REF) - skipping prefix check"
+    exit 0
+fi
+
 echo "Checking all commits in PR against base: origin/${GITHUB_BASE_REF}"
 echo ""
 


### PR DESCRIPTION
## Problem

The `verify-prefix` check fails on automated cherry-pick PRs created by the Prow cherrypicker robot (`openshift-cherrypick-robot`). The robot creates branches like `cherry-pick-XXXX-to-BRANCH` and does not preserve role prefixes (e.g. `[devscripts]`) in commit messages.

Since the original PR already passed this check, re-validating on the cherry-pick is unnecessary and causes false failures (e.g. #4079).

## Fix

Detect cherry-pick branches by checking `GITHUB_HEAD_REF` for the `cherry-pick-*` pattern and skip the prefix check entirely.

## Testing

After this merges, re-running the `verify-prefix` check on #4079 should pass.

Made with [Cursor](https://cursor.com)