### PR TITLE
[reproducer] Add remove top-level keys from a YAML file

### DIFF
--- a/plugins/modules/strip_dict_keys.py
+++ b/plugins/modules/strip_dict_keys.py
@@ -1,0 +1,160 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2026, Red Hat
+# GNU General Public License v3.0+ (see COPYING or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: strip_dict_keys
+short_description: Remove top-level keys from a YAML file
+
+description:
+- Reads a YAML file, removes every top-level key that appears in any of the
+  provided key-source YAML files, and writes the result back.
+
+author:
+  - Enrique Vallespi Gil (@evallesp)
+
+options:
+  src:
+    description:
+      - Path to the YAML file whose keys will be stripped.
+    required: true
+    type: str
+  keys_from:
+    description:
+      - List of paths to YAML files whose top-level keys identify
+        which keys to remove from I(src).
+    required: true
+    type: list
+    elements: str
+  dest:
+    description:
+      - Path to write the result. If omitted, I(src) is overwritten in place.
+    required: false
+    type: str
+"""
+
+EXAMPLES = r"""
+- name: Strip keys from exclusion files out of reproducer-variables
+  cifmw.general.strip_dict_keys:
+    src: /tmp/reproducer-variables.yml
+    keys_from:
+      - /home/zuul/configs/excluded_vars.yaml
+      - /home/zuul/configs/other_excluded.yaml
+
+- name: Strip keys and write to a different file
+  cifmw.general.strip_dict_keys:
+    src: /tmp/reproducer-variables.yml
+    keys_from:
+      - /home/zuul/configs/excluded_vars.yaml
+    dest: /tmp/stripped-variables.yml
+"""
+
+RETURN = r"""
+removed_keys:
+    description: The list of top-level keys that were removed.
+    type: list
+    returned: always
+    sample: ["cifmw_discovered_image_url", "cifmw_other_var"]
+src:
+    description: The source file path.
+    type: str
+    returned: always
+dest:
+    description: The destination file path.
+    type: str
+    returned: always
+"""
+
+import os
+
+import yaml
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def load_yaml(path):
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    return data if data is not None else {}
+
+
+def run_module():
+    module_args = {
+        "src": {"type": "str", "required": True},
+        "keys_from": {
+            "type": "list",
+            "elements": "str",
+            "required": True,
+            "no_log": False,
+        },
+        "dest": {"type": "str", "required": False, "default": None},
+    }
+
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+
+    src = module.params["src"]
+    keys_from = module.params["keys_from"]
+    dest = module.params["dest"] or src
+
+    if not os.path.isfile(src):
+        module.fail_json(msg=f"Source file not found: {src}")
+
+    try:
+        base = load_yaml(src)
+    except Exception as e:
+        module.fail_json(msg=f"Failed to read source file {src}: {e}")
+
+    if not isinstance(base, dict):
+        module.fail_json(
+            msg=f"{src}: root must be a YAML mapping, got {type(base).__name__}"
+        )
+
+    keys_to_remove = set()
+    for kf in keys_from:
+        if not os.path.isfile(kf):
+            module.fail_json(msg=f"Keys-from file not found: {kf}")
+        try:
+            keys_data = load_yaml(kf)
+        except Exception as e:
+            module.fail_json(msg=f"Failed to read keys-from file {kf}: {e}")
+        if isinstance(keys_data, dict):
+            keys_to_remove.update(keys_data.keys())
+
+    removed = sorted(k for k in keys_to_remove if k in base)
+    filtered = {k: v for k, v in base.items() if k not in keys_to_remove}
+    changed = len(removed) > 0
+
+    if changed and not module.check_mode:
+        try:
+            with open(dest, "w", encoding="utf-8") as f:
+                yaml.dump(
+                    filtered,
+                    f,
+                    default_flow_style=False,
+                    sort_keys=False,
+                    allow_unicode=True,
+                )
+        except Exception as e:
+            module.fail_json(msg=f"Failed to write destination file {dest}: {e}")
+
+    module.exit_json(
+        changed=changed,
+        removed_keys=removed,
+        src=src,
+        dest=dest,
+    )
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/reproducer/tasks/overwrite_zuul_vars.yml
+++ b/roles/reproducer/tasks/overwrite_zuul_vars.yml
@@ -41,6 +41,18 @@
         dest: /usr/local/bin/merge_yaml_override
         mode: "0755"
 
+    - name: Strip excluded keys from reproducer-variables
+      when:
+        - exclude_discovered_files is defined
+        - exclude_discovered_files | length > 0
+      cifmw.general.strip_dict_keys:
+        src: "{{ temp_reproducer_var_path }}"
+        keys_from: >-
+          {{ exclude_discovered_files
+             | map('regex_replace', '^(.*)$',
+                   ansible_user_dir ~ '/configs/\1')
+             | list }}
+
     - name: Execute merge script
       ansible.builtin.shell: >
         python3 /usr/local/bin/merge_yaml_override

--- a/tests/unit/modules/test_strip_dict_keys.py
+++ b/tests/unit/modules/test_strip_dict_keys.py
@@ -1,0 +1,139 @@
+# Copyright: (c) 2026, Red Hat
+
+# GNU General Public License v3.0+ (see COPYING or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+import os
+import tempfile
+
+import yaml
+
+from ansible_collections.cifmw.general.tests.unit.utils import (
+    ModuleBaseTestCase,
+    set_module_args,
+    AnsibleExitJson,
+    AnsibleFailJson,
+)
+from ansible_collections.cifmw.general.plugins.modules import strip_dict_keys
+
+
+class TestStripDictKeys(ModuleBaseTestCase):
+
+    def _write_yaml(self, data, path):
+        with open(path, "w", encoding="utf-8") as f:
+            yaml.dump(data, f)
+
+    def _read_yaml(self, path):
+        with open(path, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f)
+
+    def test_strip_single_source(self):
+        with tempfile.TemporaryDirectory() as td:
+            src = os.path.join(td, "base.yml")
+            kf = os.path.join(td, "exclude.yml")
+            self._write_yaml({"a": 1, "b": 2, "c": 3}, src)
+            self._write_yaml({"a": "x", "c": "y"}, kf)
+
+            set_module_args({"src": src, "keys_from": [kf]})
+            with self.assertRaises(AnsibleExitJson) as ctx:
+                strip_dict_keys.run_module()
+
+            result = ctx.exception.args[0]
+            self.assertTrue(result["changed"])
+            self.assertEqual(sorted(result["removed_keys"]), ["a", "c"])
+            self.assertEqual(self._read_yaml(src), {"b": 2})
+
+    def test_strip_multiple_sources(self):
+        with tempfile.TemporaryDirectory() as td:
+            src = os.path.join(td, "base.yml")
+            kf1 = os.path.join(td, "ex1.yml")
+            kf2 = os.path.join(td, "ex2.yml")
+            self._write_yaml({"a": 1, "b": 2, "c": 3, "d": 4}, src)
+            self._write_yaml({"a": "x"}, kf1)
+            self._write_yaml({"c": "y"}, kf2)
+
+            set_module_args({"src": src, "keys_from": [kf1, kf2]})
+            with self.assertRaises(AnsibleExitJson) as ctx:
+                strip_dict_keys.run_module()
+
+            result = ctx.exception.args[0]
+            self.assertTrue(result["changed"])
+            self.assertEqual(self._read_yaml(src), {"b": 2, "d": 4})
+
+    def test_no_matching_keys(self):
+        with tempfile.TemporaryDirectory() as td:
+            src = os.path.join(td, "base.yml")
+            kf = os.path.join(td, "exclude.yml")
+            self._write_yaml({"a": 1, "b": 2}, src)
+            self._write_yaml({"x": "foo"}, kf)
+
+            set_module_args({"src": src, "keys_from": [kf]})
+            with self.assertRaises(AnsibleExitJson) as ctx:
+                strip_dict_keys.run_module()
+
+            result = ctx.exception.args[0]
+            self.assertFalse(result["changed"])
+            self.assertEqual(result["removed_keys"], [])
+            self.assertEqual(self._read_yaml(src), {"a": 1, "b": 2})
+
+    def test_write_to_dest(self):
+        with tempfile.TemporaryDirectory() as td:
+            src = os.path.join(td, "base.yml")
+            dest = os.path.join(td, "out.yml")
+            kf = os.path.join(td, "exclude.yml")
+            self._write_yaml({"a": 1, "b": 2}, src)
+            self._write_yaml({"a": "x"}, kf)
+
+            set_module_args({"src": src, "keys_from": [kf], "dest": dest})
+            with self.assertRaises(AnsibleExitJson) as ctx:
+                strip_dict_keys.run_module()
+
+            result = ctx.exception.args[0]
+            self.assertTrue(result["changed"])
+            self.assertEqual(result["dest"], dest)
+            self.assertEqual(self._read_yaml(src), {"a": 1, "b": 2})
+            self.assertEqual(self._read_yaml(dest), {"b": 2})
+
+    def test_missing_src(self):
+        set_module_args({"src": "/nonexistent.yml", "keys_from": []})
+        with self.assertRaises(AnsibleFailJson) as ctx:
+            strip_dict_keys.run_module()
+        self.assertIn("not found", ctx.exception.args[0]["msg"])
+
+    def test_missing_keys_from_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            src = os.path.join(td, "base.yml")
+            self._write_yaml({"a": 1}, src)
+
+            set_module_args({"src": src, "keys_from": ["/nonexistent.yml"]})
+            with self.assertRaises(AnsibleFailJson) as ctx:
+                strip_dict_keys.run_module()
+            self.assertIn("not found", ctx.exception.args[0]["msg"])
+
+    def test_empty_keys_from_list(self):
+        with tempfile.TemporaryDirectory() as td:
+            src = os.path.join(td, "base.yml")
+            self._write_yaml({"a": 1, "b": 2}, src)
+
+            set_module_args({"src": src, "keys_from": []})
+            with self.assertRaises(AnsibleExitJson) as ctx:
+                strip_dict_keys.run_module()
+
+            result = ctx.exception.args[0]
+            self.assertFalse(result["changed"])
+            self.assertEqual(self._read_yaml(src), {"a": 1, "b": 2})
+
+    def test_empty_keys_from_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            src = os.path.join(td, "base.yml")
+            kf = os.path.join(td, "empty.yml")
+            self._write_yaml({"a": 1}, src)
+            self._write_yaml(None, kf)
+
+            set_module_args({"src": src, "keys_from": [kf]})
+            with self.assertRaises(AnsibleExitJson) as ctx:
+                strip_dict_keys.run_module()
+
+            result = ctx.exception.args[0]
+            self.assertFalse(result["changed"])


### PR DESCRIPTION
Plugin for removing top-level key that appears in a provided
key-source yamls files.

Used at overwrite_zuul_vars file for removing variables
added at: exclude_discovered_files as in premetal path
these variables were already loaded in previous premetal step.

Signed-off-by: Enrique Vallespi Gil <evallesp@redhat.com>