### PR TITLE
[devscripts] Pin repo to 9116d288 to unblock RHOSO CI

### DIFF
--- a/roles/devscripts/vars/main.yml
+++ b/roles/devscripts/vars/main.yml
@@ -29,7 +29,15 @@ cifmw_devscripts_packages:
   - buildah
 
 cifmw_devscripts_repo: "https://github.com/openshift-metal3/dev-scripts.git"
-cifmw_devscripts_repo_branch: HEAD
+# Note: Pinning devscripts at https://github.com/openshift-metal3/dev-scripts/commit/9116d288bb2885a29d3c9c9c4bf422305bef370d
+# (last known-good before regressions from):
+# - https://github.com/openshift-metal3/dev-scripts/pull/1922 broke local registry setup
+#   (connection refused during release mirror; OSPCIX-1469)
+# - https://github.com/openshift-metal3/dev-scripts/pull/1933 switched the default CI
+#   registry to quay-proxy.ci.openshift.org and breaks pull-secret login in our jobs
+#   (invalid username/password at build_installer; OSPCIX-1472)
+# We should unpin once upstream fixes are available and validated in RHOSO CI.
+cifmw_devscripts_repo_branch: 9116d288bb2885a29d3c9c9c4bf422305bef370d
 
 cifmw_devscripts_config_defaults:
   working_dir: "/home/dev-scripts"


### PR DESCRIPTION
## Summary

- Pin `cifmw_devscripts_repo_branch` to `9116d288bb2885a29d3c9c9c4bf422305bef370d` (last known-good before recent upstream regressions).
- Avoids breakage from [openshift-metal3/dev-scripts#1922](https://github.com/openshift-metal3/dev-scripts/pull/1922) (baremetal ABI / local registry setup → release mirror `connection refused`; [OSPCIX-1469](https://redhat.atlassian.net/browse/OSPCIX-1469)).
- Avoids breakage from [openshift-metal3/dev-scripts#1933](https://github.com/openshift-metal3/dev-scripts/pull/1933) (default CI registry switched to `quay-proxy.ci.openshift.org` → pull-secret login fails with invalid username/password at `build_installer`; [OSPCIX-1472](https://redhat.atlassian.net/browse/OSPCIX-1472)).

Closes: [OSPCIX-1469](https://redhat.atlassian.net/browse/OSPCIX-1469)
Closes: [OSPCIX-1472](https://redhat.atlassian.net/browse/OSPCIX-1472)

## Test plan

- [ ] Confirm `roles/devscripts/vars/main.yml` pins `cifmw_devscripts_repo_branch` to `9116d288bb2885a29d3c9c9c4bf422305bef370d`
- [ ] Smoke a uni job that uses the `devscripts` role and verify checkout uses the pinned commit
- [ ] Verify uni04delta-ipv6 (or equivalent) gets past release mirror / local registry ([OSPCIX-1469](https://redhat.atlassian.net/browse/OSPCIX-1469))
- [ ] Verify uni jobs get past `build_installer` without `quay-proxy.ci.openshift.org` login failures ([OSPCIX-1472](https://redhat.atlassian.net/browse/OSPCIX-1472))
- [ ] Track unpin once upstream fixes land and are validated in RHOSO CI


Made with [Cursor](https://cursor.com)