### PR TITLE
[test_operator] Add WA for HorizonTest admin credentials

### DIFF
--- a/roles/test_operator/tasks/runners/horizontest_runner.yml
+++ b/roles/test_operator/tasks/runners/horizontest_runner.yml
@@ -1,28 +1,64 @@
 ---
-- name: Fetch admin password from osp-secret
-  no_log: true
-  ansible.builtin.command:
-    cmd: >-
-      oc get secret osp-secret
-      -n {{ cifmw_test_operator_namespace }}
-      -o jsonpath='{.data.AdminPassword}'
-  register: _horizontest_admin_password_b64
-  failed_when: false
-  changed_when: false
-
-- name: Override admin password from osp-secret
-  no_log: true
-  when:
-    - _horizontest_admin_password_b64.rc == 0
-    - _horizontest_admin_password_b64.stdout | length > 0
+# Note(kstrenko): Remove WA once the TCIB and test-operator fix reaches downstream
+- name: Check if admin credentials need fetching
   ansible.builtin.set_fact:
-    stage_vars_dict: >-
+    _horizontest_fetch_creds: >-
       {{
-        stage_vars_dict | combine({
-          'cifmw_test_operator_horizontest_admin_password':
-            _horizontest_admin_password_b64.stdout | b64decode
-        })
+        stage_vars_dict.cifmw_test_operator_horizontest_admin_username | default('') | length == 0 or
+        stage_vars_dict.cifmw_test_operator_horizontest_admin_password | default('') | length == 0
       }}
+
+- name: Fetch admin credentials from OpenStack config
+  when: _horizontest_fetch_creds | bool
+  block:
+    - name: Fetch OpenStackConfigMap
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit) }}"
+        context: "{{ cifmw_openshift_context | default(omit) }}"
+        kind: ConfigMap
+        name: openstack-config
+        namespace: "{{ stage_vars_dict.cifmw_test_operator_namespace }}"
+      register: _horizontest_configmap
+
+    - name: Fetch OpenStackConfigSecret
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+        api_key: "{{ cifmw_openshift_token | default(omit) }}"
+        context: "{{ cifmw_openshift_context | default(omit) }}"
+        kind: Secret
+        name: openstack-config-secret
+        namespace: "{{ stage_vars_dict.cifmw_test_operator_namespace }}"
+      register: _horizontest_secret
+
+    - name: Override admin credentials in stage_vars_dict
+      ansible.builtin.set_fact:
+        stage_vars_dict: >-
+          {{
+            stage_vars_dict | combine({
+              'cifmw_test_operator_horizontest_admin_username':
+                (_horizontest_configmap.resources[0].data['clouds.yaml'] | from_yaml).clouds.default.auth.username,
+              'cifmw_test_operator_horizontest_admin_password':
+                (_horizontest_secret.resources[0].data['secure.yaml'] | b64decode | from_yaml).clouds.default.auth.password | string
+            })
+          }}
+
+    - name: Patch admin credentials into horizontest config
+      ansible.builtin.set_fact:
+        stage_vars_dict: >-
+          {{
+            stage_vars_dict | combine({
+              'cifmw_test_operator_horizontest_config':
+                stage_vars_dict.cifmw_test_operator_horizontest_config | combine(
+                  {'spec': {
+                    'adminUsername': stage_vars_dict.cifmw_test_operator_horizontest_admin_username,
+                    'adminPassword': stage_vars_dict.cifmw_test_operator_horizontest_admin_password
+                  }},
+                  recursive=true
+                )
+            })
+          }}
+
 
 - name: Run horizontest job
   vars:


### PR DESCRIPTION
This WA sets the HorizonTest admin credentials from OpenStackConfigMap and OpenStackConfigSecret respectively. This will be done automatically once TCIB and test-operator fixes reach downstream. Until then, this WA is needed for running horizon tests with correct credentials.