### PR TITLE
[scenarios] Pin DB root password for whitebox tempest compat

### DIFF
--- a/scenarios/centos-9/hci_ceph_backends.yml
+++ b/scenarios/centos-9/hci_ceph_backends.yml
@@ -15,6 +15,7 @@ cifmw_rgw_ssl_backward_compatibility: false
 cifmw_install_yamls_vars:
   BMO_SETUP: false
   INSTALL_CERT_MANAGER: false
+  DB_ROOT_PASSWORD: "12345678"
 
 cifmw_edpm_prepare_skip_crc_storage_creation: true
 

--- a/scenarios/centos-9/multinode-ci.yml
+++ b/scenarios/centos-9/multinode-ci.yml
@@ -26,6 +26,7 @@ cifmw_run_tests: true
 cifmw_install_yamls_vars:
   BMO_SETUP: false
   INSTALL_CERT_MANAGER: false
+  DB_ROOT_PASSWORD: "12345678"
 
 # Deploy EDPM in multinode scenario
 cifmw_deploy_edpm: true


### PR DESCRIPTION
install_yamls PR openstack-k8s-operators/install_yamls#1158 replaced
hardcoded passwords with dynamically generated per-service secrets.
The `whitebox_tempest_plugin` tempestconf overrides still reference the
old hardcoded `whitebox-database.password` value (`12345678`), causing
`Access Denied` errors against Galera.

As a short-term fix, pin `DB_ROOT_PASSWORD` in the `multinode-ci` and
`hci_ceph_backends` scenarios so that the deployed Galera root password
matches what whitebox tempest expects. A proper long-term fix (reading
`DbRootPassword` from `osp-secret` at runtime) is tracked in #4090.