### PR TITLE
Fix missing is succeeded guard on Wait for NHC CR task

### DIFF
--- a/roles/cifmw_snr_nhc/tasks/main.yml
+++ b/roles/cifmw_snr_nhc/tasks/main.yml
@@ -555,7 +555,7 @@
       This is expected if cleanup was skipped due to active remediations.
 
 - name: Wait for Node Health Check CR to be created
-  when: existing_nhc_cr_check.resources | length == 0
+  when: existing_nhc_cr_check is succeeded and (existing_nhc_cr_check.resources | length == 0)
   kubernetes.core.k8s_info:
     kubeconfig: "{{ cifmw_snr_nhc_kubeconfig }}"
     api_version: remediation.medik8s.io/v1alpha1


### PR DESCRIPTION
- The previous fix (f9b046b3) added `is succeeded` guards to three of the four `NodeHealthCheck` tasks but missed the "Wait for Node Health Check CR to be created" task
- Without this guard, a transient API failure on that task causes an unhandled error instead of being skipped gracefully — inconsistent with the other three tasks in the same flow