### PR TITLE
[adoption_osp_deploy] Skip nic1 configuration for bgp overcloud

### DIFF
--- a/roles/adoption_osp_deploy/templates/os_net_config_overcloud_bgp.yml.j2
+++ b/roles/adoption_osp_deploy/templates/os_net_config_overcloud_bgp.yml.j2
@@ -1,11 +1,6 @@
 #jinja2: trim_blocks:True, lstrip_blocks:True
 network_config:
 - type: interface
-  name: nic1
-  mtu: {{ _interface_mtu }}
-  use_dhcp: true
-  routes: []
-- type: interface
   name: nic2
   mtu: {{ _interface_mtu }}
 {% if 'r0' in overcloud_vm %}


### PR DESCRIPTION
nic1/eth0 is configured during the VM creation and it does not need to be included in the os-net-config configuration file. When it is included, starting network.service fails because dhclient is already running on that NIC. That is the reason why the default template (for non-BGP environments) does not include nic1.