### PR TITLE
[cleanup_openstack] fix reuse_ocp workflow

### DIFF
--- a/deploy-edpm-reuse.yaml
+++ b/deploy-edpm-reuse.yaml
@@ -108,6 +108,25 @@
         name: reproducer
         tasks_from: reuse_main
 
+    - name: Find stale root-owned log files
+      delegate_to: controller-0
+      ansible.builtin.find:
+        paths: /home/zuul/ci-framework-data/logs
+        patterns: "ansible-*.log"
+        file_type: file
+      register: _stale_logs
+      failed_when: false
+
+    - name: Fix log file ownership for reuse runs
+      delegate_to: controller-0
+      become: true
+      ansible.builtin.file:
+        path: "{{ item }}"
+        owner: zuul
+        group: zuul
+      loop: "{{ _stale_logs.files | default([]) | map(attribute='path') | list }}"
+      failed_when: false
+
     - name: Run deployment if instructed to
       when:
         - cifmw_deploy_architecture | default(false) | bool

--- a/roles/cleanup_openstack/tasks/detach_bmh.yaml
+++ b/roles/cleanup_openstack/tasks/detach_bmh.yaml
@@ -35,7 +35,10 @@
       retries: 60
       delay: 10
       until:
-        - bmh_status.resources | length == 0 or bmh_status.resources[0].status.operationalStatus == 'detached'
+        - >-
+          bmh_status.resources | length == 0 or
+          bmh_status.resources[0].status is not defined or
+          bmh_status.resources[0].status.operationalStatus | default('') == 'detached'
       register: bmh_status
       loop: "{{ cifmw_deploy_bmh_bm_hosts_list }}"
       loop_control:


### PR DESCRIPTION
Fix BMH detach wait when no status exist

The until condition in detach_bmh.yaml accesses
bmh_status.resources[0].status.operationalStatus without
guarding against the case where the BareMetalHost CR exists
but has no .status subresource. This happens when the BMH
was created manually and Metal3 has not reconciled it (e.g.
pre-existing bare metal hosts in reuse_ocp workflows).
In that state, operationalStatus will never become
'detached' because Metal3 never provisioned the host.

Treat a missing .status as success: the detached annotation
is already applied by the preceding patch task, and a BMH
with no status was never Metal3-provisioned, so there is
nothing to deprovision.

Additionally chown stale root-owned log files for zuul
to access those without issue in reuse_ocp.