### PR TITLE
[DNM] [cleanup_openstack] fix BMH detach wait when no status exist

### DIFF
--- a/roles/cleanup_openstack/tasks/detach_bmh.yaml
+++ b/roles/cleanup_openstack/tasks/detach_bmh.yaml
@@ -35,7 +35,10 @@
       retries: 60
       delay: 10
       until:
-        - bmh_status.resources | length == 0 or bmh_status.resources[0].status.operationalStatus == 'detached'
+        - >-
+          bmh_status.resources | length == 0 or
+          bmh_status.resources[0].status is not defined or
+          bmh_status.resources[0].status.operationalStatus | default('') == 'detached'
       register: bmh_status
       loop: "{{ cifmw_deploy_bmh_bm_hosts_list }}"
       loop_control:


### PR DESCRIPTION
The until condition in detach_bmh.yaml accesses
bmh_status.resources[0].status.operationalStatus without guarding against the case where the BareMetalHost CR exists but has no .status subresource. This happens when the BMH was created manually and Metal3 has not reconciled it (e.g. pre-existing bare metal hosts in reuse_ocp workflows). In that state, operationalStatus will never become 'detached' because Metal3 never provisioned the host.

Treat a missing .status as success: the detached annotation is already applied by the preceding patch task, and a BMH with no status was never Metal3-provisioned, so there is nothing to deprovision.