### PR TITLE
[edpm_build_images] Fix bootc output directory permissions

### DIFF
--- a/roles/edpm_build_images/tasks/bootc.yml
+++ b/roles/edpm_build_images/tasks/bootc.yml
@@ -1,5 +1,6 @@
 ---
 - name: Ensure bootc output directories exist
+  become: "{{ cifmw_edpm_build_images_via_rpm }}"
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
@@ -16,7 +17,7 @@
   register: cifmw_edpm_build_images_bootc_repo_files
 
 - name: Copy repo files for bootc build
-  become: true
+  become: "{{ cifmw_edpm_build_images_via_rpm }}"
   ansible.builtin.copy:
     src: "{{ item.path }}"
     dest: "{{ cifmw_edpm_build_images_bootc_repo_path }}/output/yum.repos.d/{{ item.path | basename }}"
@@ -88,6 +89,7 @@
     mode: "0644"
 
 - name: Copy bootc qcow2 packaging helper files
+  become: "{{ cifmw_edpm_build_images_via_rpm }}"
   ansible.builtin.copy:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"


### PR DESCRIPTION
Run the bootc output directory creation task with privilege escalation so bootc builds can write under the RPM-installed edpm-image-builder path in /usr/share.