### PR TITLE
Fix bmo01 baremetalhosts template YAML sexagesimal parsing bug

### DIFF
--- a/roles/ci_gen_kustomize_values/templates/bmo01/baremetalhost-values/values.yaml.j2
+++ b/roles/ci_gen_kustomize_values/templates/bmo01/baremetalhost-values/values.yaml.j2
@@ -9,13 +9,13 @@ data:
 {% endif %}
   {{ _host }}:
     bmc:
-      address: {{ cifmw_baremetal_hosts[host].connection }}
+      address: "{{ cifmw_baremetal_hosts[host].connection }}"
       credentialsName: bmc-secret
-    bootMACAddress: {{ cifmw_baremetal_hosts[host].nics[0].mac }}
+    bootMACAddress: "{{ cifmw_baremetal_hosts[host].nics[0].mac }}"
     labels:
       app: openstack
-      nodeset: {{ host | split('-') | first }}
-    name: {{ host }}
+      nodeset: "{{ host | split('-') | first }}"
+    name: "{{ host }}"
     rootDeviceHints:
       deviceName: /dev/sda
 {% endfor %}


### PR DESCRIPTION
Quote all dynamic values in the bmo01 baremetalhost-values template to prevent PyYAML (YAML 1.1) from misinterpreting MAC addresses as sexagesimal integers. All-numeric MACs like 52:54:05:00:23:48 match the base-60 pattern and get parsed as integers (41136121428) when the rendered template is re-parsed by from_yaml in generate_values.

Related-Issue: #[OSPRH-32298](https://redhat.atlassian.net/browse/OSPRH-32298)