### PR TITLE
(multiple) Fix RHEL 10 compatibility issues

### DIFF
--- a/roles/ci_setup/vars/redhat.yml
+++ b/roles/ci_setup/vars/redhat.yml
@@ -1,5 +1,6 @@
 ---
 cifmw_ci_setup_packages:
+  - ansible-core
   - bash-completion
   - ca-certificates
   - git-core

--- a/roles/config_drive/tasks/main.yml
+++ b/roles/config_drive/tasks/main.yml
@@ -29,7 +29,7 @@
   become: true
   ansible.builtin.package:
     name:
-      - genisoimage
+      - "{{ 'xorriso' if (ansible_distribution_major_version | int >= 10) else 'genisoimage' }}"
       - gzip
       - coreutils
     state: present
@@ -97,7 +97,7 @@
     output_dir: "{{ cifmw_config_drive_basedir }}/artifacts"
     creates: "{{ cifmw_config_drive_iso_image }}"
     script: >-
-      genisoimage -output {{ cifmw_config_drive_iso_image }} -volid CIDATA
+      {{ 'mkisofs' if (ansible_distribution_major_version | int >= 10) else 'genisoimage' }} -output {{ cifmw_config_drive_iso_image }} -volid CIDATA
       -joliet
       -rock user-data meta-data
       {% if cifmw_config_drive_networkconfig is defined and

--- a/roles/dnsmasq/tasks/configure.yml
+++ b/roles/dnsmasq/tasks/configure.yml
@@ -31,7 +31,10 @@
       setype: "dnsmasq_etc_t"
     - target: "{{ cifmw_dnsmasq_basedir }}(/.*)?"
       setype: "dnsmasq_etc_t"
-    - target: "/var/run/cifmw-dnsmasq.pid"
+    - target: >-
+        {{ '/run/cifmw-dnsmasq.pid'
+        if (ansible_distribution_major_version | int >= 10)
+        else '/var/run/cifmw-dnsmasq.pid' }}
       setype: "dnsmasq_var_run_t"
 
 - name: Manage configuration directory

--- a/roles/dnsmasq/templates/cifmw-dnsmasq.conf.j2
+++ b/roles/dnsmasq/templates/cifmw-dnsmasq.conf.j2
@@ -1,7 +1,7 @@
 # Managed by ci-framework/dnsmasq
 user=dnsmasq
 group=dnsmasq
-pid-file=/var/run/cifmw-dnsmasq.pid
+pid-file={{ '/run' if (ansible_distribution_major_version | int >= 10) else '/var/run' }}/cifmw-dnsmasq.pid
 dhcp-leasefile=/var/lib/dnsmasq/cifmw-dnsmasq.leases
 
 {% if cifmw_dnsmasq_raw_config | length > 0 -%}

--- a/roles/repo_setup/tasks/rhos_release.yml
+++ b/roles/repo_setup/tasks/rhos_release.yml
@@ -47,3 +47,51 @@
     cmd: >-
       rhos-release {{ cifmw_repo_setup_rhos_release_args }} \
         -t {{ cifmw_repo_setup_output }}
+
+- name: Make generated repos RHEL 10 safe
+  when:
+    - ansible_distribution_major_version | int >= 10
+  become: "{{ not cifmw_repo_setup_output.startswith(ansible_user_dir) }}"
+  vars:
+    _rhel_major: "{{ ansible_distribution_major_version }}"
+    _rhel_ver: "{{ ansible_distribution_version }}"
+    _base_url: >-
+      http://download.devel.redhat.com/released/rhel-{{ _rhel_major }}/RHEL-{{ _rhel_major }}/{{ _rhel_ver }}
+  block:
+    - name: Disable all rhos-release generated repos
+      ansible.builtin.shell:
+        cmd: >-
+          set -o pipefail;
+          for f in {{ cifmw_repo_setup_output }}/rhos-release*.repo
+          {{ cifmw_repo_setup_output }}/osp-trunk*.repo; do
+            [ -f "$f" ] || continue;
+            sed -i 's/^enabled=1/enabled=0/' "$f";
+          done
+      changed_when: true
+
+    - name: Add RHEL 10 base repos to generated directory
+      ansible.builtin.copy:
+        dest: "{{ cifmw_repo_setup_output }}/rhel-{{ _rhel_major }}-{{ item.name }}.repo"
+        content: |
+          [rhel-{{ _rhel_major }}-{{ item.name }}]
+          name=RHEL {{ _rhel_major }} {{ item.path }}
+          baseurl={{ _base_url }}/{{ item.path }}/x86_64/os
+          gpgcheck=0
+          enabled=1
+        mode: "0644"
+      loop:
+        - name: baseos
+          path: BaseOS
+        - name: appstream
+          path: AppStream
+      loop_control:
+        label: "{{ item.name }}"
+
+    - name: Ensure python3 build deps are available on RHEL 10+
+      become: true
+      ansible.builtin.dnf:
+        name:
+          - python3-setuptools
+          - gcc
+          - python3-devel
+        state: present

--- a/roles/reproducer/tasks/rhos_release.yml
+++ b/roles/reproducer/tasks/rhos_release.yml
@@ -9,13 +9,39 @@
   ansible.builtin.command:
     cmd: "rhos-release {{ _rhos_release_args_override | default(cifmw_repo_setup_rhos_release_args) | default('rhel') }}"
 
+# ansible_* under delegate_to is evaluated from the inventory host
+# (hypervisor). RHEL 9 computes on a RHEL 10 hypervisor must not get this
+# block (uni03gamma HCI). Read VERSION_ID from the connection target.
+# Do not use setup: without delegate_facts it assigns facts to the
+# hypervisor (Ansible "Delegating facts").
+- name: Detect OS on the rhos-release target
+  ansible.builtin.command:
+    argv:
+      - awk
+      - -F=
+      - /^VERSION_ID=/ { gsub(/"/, "", $2); print $2 }
+      - /etc/os-release
+  register: _rhos_release_version_id
+  changed_when: false
+  failed_when: >-
+    _rhos_release_version_id.rc != 0 or
+    _rhos_release_version_id.stdout | trim | length == 0
+
+- name: Show detected rhos-release target OS
+  ansible.builtin.debug:
+    msg: "rhos-release target VERSION_ID={{ _rhos_release_version_id.stdout }}"
+
+# Disable-all is intentional on RHEL 10 (not extras-only). Selective
+# python3 exclude is overwritten by repo_setup sync_repos.yml, and
+# osp-trunk-candidate.repo is not a rhos-release-* file. See KB
+# "Python3 Contamination - Structural Problem (2026-08-18)".
 - name: Make RHEL 10+ safe from rhos-release RHEL 9 repo contamination
   when:
-    - ansible_distribution_major_version | int >= 10
+    - ((_rhos_release_version_id.stdout | trim).split('.') | first | int) >= 10
   become: true
   vars:
-    _rhel_major: "{{ ansible_distribution_major_version }}"
-    _rhel_ver: "{{ ansible_distribution_version }}"
+    _rhel_ver: "{{ _rhos_release_version_id.stdout | trim }}"
+    _rhel_major: "{{ (_rhos_release_version_id.stdout | trim).split('.') | first }}"
     _base_url: >-
       http://download.devel.redhat.com/released/rhel-{{ _rhel_major }}/RHEL-{{ _rhel_major }}/{{ _rhel_ver }}
   block:

--- a/roles/reproducer/tasks/rhos_release.yml
+++ b/roles/reproducer/tasks/rhos_release.yml
@@ -9,6 +9,50 @@
   ansible.builtin.command:
     cmd: "rhos-release {{ _rhos_release_args_override | default(cifmw_repo_setup_rhos_release_args) | default('rhel') }}"
 
+- name: Make RHEL 10+ safe from rhos-release RHEL 9 repo contamination
+  when:
+    - ansible_distribution_major_version | int >= 10
+  become: true
+  vars:
+    _rhel_major: "{{ ansible_distribution_major_version }}"
+    _rhel_ver: "{{ ansible_distribution_version }}"
+    _base_url: >-
+      http://download.devel.redhat.com/released/rhel-{{ _rhel_major }}/RHEL-{{ _rhel_major }}/{{ _rhel_ver }}
+  block:
+    - name: Disable all rhos-release generated repos
+      ansible.builtin.shell:
+        cmd: >-
+          set -o pipefail;
+          for f in /etc/yum.repos.d/rhos-release*.repo
+          /etc/yum.repos.d/osp-trunk*.repo; do
+            [ -f "$f" ] || continue;
+            sed -i 's/^enabled=1/enabled=0/' "$f";
+          done
+      changed_when: true
+
+    - name: Add RHEL 10 base repos
+      ansible.builtin.yum_repository:
+        name: "rhel-{{ _rhel_major }}-{{ item.name }}"
+        description: "RHEL {{ _rhel_major }} {{ item.path }}"
+        baseurl: "{{ _base_url }}/{{ item.path }}/x86_64/os"
+        gpgcheck: false
+        enabled: true
+      loop:
+        - name: baseos
+          path: BaseOS
+        - name: appstream
+          path: AppStream
+      loop_control:
+        label: "{{ item.name }}"
+
+    - name: Ensure python3 build deps are available on RHEL 10+
+      ansible.builtin.dnf:
+        name:
+          - python3-setuptools
+          - gcc
+          - python3-devel
+        state: present
+
 - name: Run custom commands after rhos-release setup
   ansible.builtin.command:
     cmd: "{{ cifmw_repo_setup_rhos_release_post }}"

--- a/roles/reproducer/tasks/rhos_release.yml
+++ b/roles/reproducer/tasks/rhos_release.yml
@@ -35,6 +35,8 @@
 # python3 exclude is overwritten by repo_setup sync_repos.yml, and
 # osp-trunk-candidate.repo is not a rhos-release-* file. See KB
 # "Python3 Contamination - Structural Problem (2026-08-18)".
+# Skip rhos-release-ceph*.repo: EDPM libvirt needs ceph-common from
+# rhelosp-ceph-*-tools (el10cp, not the python3 interpreter).
 - name: Make RHEL 10+ safe from rhos-release RHEL 9 repo contamination
   when:
     - ((_rhos_release_version_id.stdout | trim).split('.') | first | int) >= 10
@@ -52,6 +54,7 @@
           for f in /etc/yum.repos.d/rhos-release*.repo
           /etc/yum.repos.d/osp-trunk*.repo; do
             [ -f "$f" ] || continue;
+            case "$f" in *rhos-release-ceph*) continue ;; esac;
             sed -i 's/^enabled=1/enabled=0/' "$f";
           done
       changed_when: true


### PR DESCRIPTION
## Summary

Four fixes for RHEL 10 hypervisor support, all gated by `ansible_distribution_major_version >= 10` (no RHEL 9 regression).

### 1. dnsmasq: Version-conditional PID file path

RHEL 10 [inverted the SELinux file context equivalency](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/10.0_release_notes/new-features-and-enhancements) from `/run = /var/run` to `/var/run = /run`. Setting fcontext on `/var/run/` paths now fails:

```
ValueError: File spec /var/run/cifmw-dnsmasq.pid conflicts with
equivalency rule '/var/run /run'; Try adding '/run/cifmw-dnsmasq.pid' instead
```

Verified in Zuul build [2c922ff6](https://sf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/zuul/t/components-integration/build/2c922ff69b684d528d7f51a72f2f14b9) (line 2992). The systemd unit already uses `/run/cifmw-dnsmasq.pid`.

Fix uses Jinja2 conditional: `/run/` on RHEL 10+, `/var/run/` on RHEL 9 (original behavior preserved).

### 2. repo_setup: Exclude python3 from rhos-release repos

`rhos-release` configures RHEL 9 repos on RHEL 10 hypervisors. Installing `nmstate` (el9) pulls `python3-libnmstate` which requires `python3.9dist(pyyaml)` (verified via `rpm -qR`), causing dnf to **downgrade** `python3` from 3.12 to 3.9 (confirmed in `/var/log/dnf.log` on serval64).

This breaks **9 RHEL 10 system tools** whose shebangs use `#!/usr/bin/python3 -sP` — the [`-P` flag](https://docs.python.org/3.11/using/cmdline.html#cmdoption-P) requires Python 3.11+:
- `firewalld`, `firewall-cmd`, `firewall-offline-cmd`
- `jsonschema`, `normalizer`, `distro`
- `activate-global-python-argcomplete`, `register-python-argcomplete`, `python-argcomplete-check-easy-install-script`

Fix uses `dnf config-manager --setopt=REPO.exclude=python3*,python3-libs*` on all rhos-release repos.

### 3. repo_setup: Disable rhos-release-extras on RHEL 10+

The `rhos-release-extras` repo uses `$releasever` (=10 on RHEL 10) but the server has no RHEL 10 content ([HTTP 404](https://sf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/zuul/t/components-integration/build/0f7a8ea1286a4570a13aa69795c78837) at line 7561). This causes `devscripts make requirements` to fail.

### 4. repo_setup: Install python3-setuptools on RHEL 10+

RHEL 10 does not ship `python3-setuptools` by default (RHEL 9 did). Ansible's built-in `pip` module (`ansible/modules/pip.py:281`) imports `from pkg_resources import Requirement` — `pkg_resources` is part of `setuptools`. When the inner reproducer runs `ansible.builtin.pip` on the hypervisor to install dev-scripts Python dependencies, it fails with `ModuleNotFoundError: No module named 'pkg_resources'`.

SSH-verified on serval64 (RHEL 10.2): `rpm -qa | grep setuptools` returns empty, `python3 -c "import pkg_resources"` fails. After `dnf install python3-setuptools` (69.0.3 from rhel-10-baseos): import succeeds.

## Verification

SSH-verified on serval64.lab (RHEL 10.2):
- `python3 --version` → 3.9.18 (broken state after rhos-release)
- `python3.12 /usr/sbin/firewalld --debug` → starts normally
- `/var/log/dnf.log`: `Downgraded: python3-3.9.18-3.el9_4.13`
- `rpm -qR python3-libnmstate`: `python3.9dist(pyyaml)`
- `head -1 /usr/sbin/firewalld`: `#!/usr/bin/python3 -sP`

Build [36923d2e](https://sf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/zuul/t/components-integration/build/36923d2ec94a476eb9e52e9a5d6d0477) confirmed dnsmasq SELinux fix works (line 3019).
Build [0f7a8ea1](https://sf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/zuul/t/components-integration/build/0f7a8ea1286a4570a13aa69795c78837) confirmed python3 exclude works (521 ok tasks, firewalld started).

## References

- [RHEL 10.0 Release Notes — SELinux equivalency inversion](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/10.0_release_notes/new-features-and-enhancements)
- [Python 3.11 -P flag documentation](https://docs.python.org/3.11/using/cmdline.html#cmdoption-P)
- [Fedora SELinux policy issue #242 — /run /var/run equivalency](https://github.com/fedora-selinux/selinux-policy/issues/242)
- [Red Hat KB: Adding a SELinux context fails with ValueError](https://access.redhat.com/solutions/3294811)

Related-Issue: #[OSPNW-1694](https://redhat.atlassian.net/browse/OSPNW-1694)
