### PR TITLE
Bgp adoption fix nic1 2ndtry

### DIFF
--- a/hooks/playbooks/adoption_bgp_pre_overcloud.yaml
+++ b/hooks/playbooks/adoption_bgp_pre_overcloud.yaml
@@ -14,37 +14,24 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: BGP pre_undercloud hook
+- name: BGP pre_overcloud hook
   hosts: "{{ cifmw_target_host | default('localhost') }}"
   gather_facts: false
   tasks:
-    - name: Add default route to UC
+    - name: Add default route to OC nodes
       delegate_to: "{{ _vm }}"
       become: true
+      vars:
+        gw_ip: >-
+          {{
+            '192.168.122.1' if 'r0' in _vm
+            else '192.168.123.1' if 'r1' in _vm
+            else '192.168.124.1' if 'r2' in _vm
+          }}
       ansible.builtin.command:
-        cmd: ip route add default via 192.168.111.1
+        cmd: ip route replace default via {{ gw_ip }}
       loop: >-
         {{
-          _vm_groups['osp-underclouds'] | list
-        }}
-      loop_control:
-        loop_var: _vm
-
-    - name: Prefer IPv4 over IPv6 for name resolution (both UC and OC)
-      delegate_to: "{{ _vm }}"
-      become: true
-      ansible.builtin.lineinfile:
-        path: /etc/gai.conf
-        line: 'precedence ::ffff:0:0/96  100'
-        regexp: '^#?\s*precedence ::ffff:0:0/96' # Matches the line, even if commented
-        state: present
-        create: true
-        owner: root
-        group: root
-        mode: '0644'
-      loop: >-
-        {{
-          _vm_groups['osp-underclouds'] | list +
           _vm_groups['osp-r0-computes'] | list +
           _vm_groups['osp-r0-controllers'] | list +
           _vm_groups['osp-r1-computes'] | list +

--- a/roles/adoption_osp_deploy/templates/os_net_config_overcloud_bgp.yml.j2
+++ b/roles/adoption_osp_deploy/templates/os_net_config_overcloud_bgp.yml.j2
@@ -1,6 +1,9 @@
 #jinja2: trim_blocks:True, lstrip_blocks:True
 network_config:
 - type: interface
+  name: nic1
+  use_dhcp: false
+- type: interface
   name: nic2
   mtu: {{ _interface_mtu }}
 {% if 'r0' in overcloud_vm %}


### PR DESCRIPTION
fix-on-fix because [1] did not work as expected.

nic1/eth0 obtains a default route via DHCP, conflicting with the default
route obtained via BGP, which is the one that should be applied.
For that reason, nic1 needs to be included in os-net-config file, but
disabling DHCP on it, in order to avoid that conflict.

Then, the temporary default routes for the overcloud nodes need to be
added right before the overcloud deployment starts.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/4095