### PR TITLE
[multiple] Enable Zuul auto-retry for infrastructure failures

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -6,7 +6,7 @@
     parent: base-crc-cloud
     abstract: true
     timeout: 14400
-    attempts: 1
+    attempts: 2
     nodeset: centos-9-rhel-9-2-crc-cloud-ocp-4-22-1-3xl
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
@@ -201,7 +201,7 @@
     parent: base-crc-cloud
     abstract: true
     timeout: 14400
-    attempts: 1
+    attempts: 2
     nodeset: centos-9-multinode-rhel-9-2-crc-cloud-ocp-4-22-1-3xl
     roles: &multinode-roles
       - zuul: github.com/openstack-k8s-operators/ci-framework
@@ -412,7 +412,7 @@
     abstract: true
     voting: false
     timeout: 14400
-    attempts: 1
+    attempts: 2
     nodeset: centos-9-multinode-rhel-9-2-crc-cloud-ocp-4-22-1-3xl-novacells
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
@@ -496,7 +496,7 @@
     name: cifmw-adoption-base-multinode-networker
     parent: base-crc-cloud
     abstract: true
-    attempts: 1
+    attempts: 2
     roles: *multinode-roles
     pre-run: *multinode-prerun
     post-run: *multinode-postrun

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -127,7 +127,7 @@
     name: cifmw-podified-multinode-edpm-base-crc
     parent: base-crc-cloud
     timeout: 10800
-    attempts: 1
+    pre-timeout: 3600
     nodeset: centos-9-medium-centos-9-crc-cloud-ocp-4-20-1-3xl
     irrelevant-files: *ir_files
     required-projects: &multinode_edpm_rp
@@ -215,7 +215,8 @@
     name: cifmw-podified-multinode-edpm-ci-bootstrap
     parent: base-extracted-crc-ci-bootstrap
     timeout: 10800
-    attempts: 1
+    attempts: 3
+    pre-timeout: 3600
     nodeset: centos-9-medium-centos-9-crc-cloud-ocp-4-20-1-3xl
     irrelevant-files: *ir_files
     required-projects: *multinode_edpm_rp
@@ -235,7 +236,8 @@
     name: cifmw-podified-multinode-edpm-ci-bootstrap-staging
     parent: base-extracted-crc-ci-bootstrap-staging
     timeout: 10800
-    attempts: 1
+    attempts: 3
+    pre-timeout: 3600
     nodeset: centos-9-medium-centos-9-crc-cloud-ocp-4-20-1-3xl
     irrelevant-files: *ir_files
     required-projects: *multinode_edpm_rp
@@ -257,6 +259,7 @@
     name: cifmw-base-crc
     nodeset: centos-9-crc-2-56-0-3xl
     timeout: 10800
+    attempts: 3
     abstract: true
     parent: base-simple-crc
     vars:

--- a/zuul.d/content_provider.yaml
+++ b/zuul.d/content_provider.yaml
@@ -6,6 +6,8 @@
 - job:
     name: openstack-k8s-operators-content-provider-bootc
     parent: openstack-k8s-operators-content-provider
+    timeout: 7200
+    attempts: 2
     description: |
       A zuul job to build and publish bootc qcow2 and ironic-python-agent
       content for dependent jobs.

--- a/zuul.d/molecule-base.yaml
+++ b/zuul.d/molecule-base.yaml
@@ -23,6 +23,9 @@
 - job:
     name: cifmw-molecule-base-crc
     nodeset: centos-9-crc-2-56-0-xxl
+    timeout: 3600
+    pre-timeout: 2100
+    attempts: 3
     parent: base-simple-crc
     provides:
       - cifmw-molecule

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -110,6 +110,7 @@
       jobs:
         - openstack-k8s-operators-content-provider
         - whitebox-neutron-tempest-plugin-podified-multinode-edpm-deployment-crc-2comp:
+            voting: false
             dependencies:
               - openstack-k8s-operators-content-provider
             files:


### PR DESCRIPTION
## Summary

Remove explicit `attempts: 1` overrides from Zuul base job definitions, restoring auto-retry for pre-run playbook failures and unreachable-node errors. Add `timeout` and `pre-timeout` to molecule CRC jobs and multinode base jobs to fix the root cause of CRC startup timeouts. Fix content-provider-bootc timeout and mark broken whitebox test non-voting.

## What changed

| File | Change | Effect |
|------|--------|--------|
| `zuul.d/base.yaml` | **Remove** `attempts: 1` from `cifmw-podified-multinode-edpm-base-crc` and replace with `pre-timeout: 3600` | Inherit `attempts: 3` from parent `base-crc-cloud`; cap pre-run at 60 min so CRC hang retries fast |
| `zuul.d/base.yaml` | **Remove** `attempts: 1` from 2 ci-bootstrap multinode jobs, **add** `attempts: 3` + `pre-timeout: 3600` | Override `base-extracted-crc-wo-networks` parent (`attempts: 1`); cap pre-run for CRC hang protection |
| `zuul.d/base.yaml` | **Add** `attempts: 3` to `cifmw-base-crc` | Override `base-simple-crc` parent (`attempts: 1` in RDO config) |
| `zuul.d/adoption.yaml` | **Change** `attempts: 1` to `attempts: 2` on 4 adoption base jobs | Limit retries (3 have `timeout: 14400`, 1 inherits from parent) |
| `zuul.d/molecule-base.yaml` | **Add** `timeout: 3600`, `pre-timeout: 2100`, `attempts: 3` to `cifmw-molecule-base-crc` | Fix CRC startup timeout root cause; override `base-simple-crc` parent |
| `zuul.d/content_provider.yaml` | **Add** `timeout: 7200`, `attempts: 2` to `content-provider-bootc` | Fix bootc image build timeout (parent timeout 2700 insufficient - timed out at 47 min in buildset `e2b7708f`) |
| `zuul.d/project-templates.yaml` | **Set** `voting: false` on whitebox-neutron-tempest job | 71% failure rate from broken `test_igmp_snooping_after_openvswitch_restart`; independent of PR changes |

## Why this is needed

### Root cause: CRC startup consumes the default timeout

4 CRC molecule jobs (`ci_multus`, `ci_nmstate`, `os_must_gather`, `set_openstack_containers`) inherit a ~30-minute default timeout from `base-simple-crc`. CRC startup takes ~24 minutes, leaving only ~6 minutes for tests - causing timeouts on first attempt.

**Fix**: `timeout: 3600` (60 min) gives ~36 min for tests after CRC startup. `pre-timeout: 2100` (35 min) caps pre-run so a CRC hang fails fast and retries instead of consuming the full 60 min. The 1 CRC molecule job with its own override (`install_openstack_ca: timeout: 5400`) keeps its value.

### Content-provider-bootc timeout

The bootc content provider inherits `timeout: 2700` (45 min) from its parent. Zuul `timeout` is per-playbook (each pre-run, run, and post-run playbook gets `timeout` seconds individually). Bootc image builds can exceed this per-playbook limit - timed out at 47 min in buildset `e2b7708f`. Fix: `timeout: 7200` (120 min per playbook) for headroom + `attempts: 2`.

### Multinode base and ci-bootstrap pre-timeout

`cifmw-podified-multinode-edpm-base-crc` has `timeout: 10800` (3h) and 5 child jobs. CRC startup in the pre-run phase can hang indefinitely, consuming the full 3h timeout before a retry. `pre-timeout: 3600` (60 min) caps the pre-run phase - CRC startup (~24 min) fits comfortably, but a hang fails fast and retries instead of wasting hours.

The 2 ci-bootstrap multinode jobs (`cifmw-podified-multinode-edpm-ci-bootstrap` and `-staging`) have the same CRC hang risk: their parent chain includes `base-extracted-crc-wo-networks` which runs `playbooks/crc/prepare-crc.yaml` in pre-run. That parent also pins `attempts: 1`, so removing the ci-framework-level `attempts: 1` alone would be a no-op. Explicit `attempts: 3` + `pre-timeout: 3600` overrides the parent and adds CRC hang protection.

### Whitebox non-voting

`whitebox-neutron-tempest-plugin-podified-multinode-edpm-deployment-crc-2comp` has a 71% failure rate on ci-framework PRs (5/7 recent runs) but passes 100% on its native project (neutron-tempest-plugin). The failing test (`test_igmp_snooping_after_openvswitch_restart`) is deterministically broken. The job uses `override-checkout: main` - it does not test PR changes. Marked non-voting until the test is fixed upstream.

### Retry behavior

Zuul `attempts` retries these conditions, allocating a fresh Nodepool node each time:
- **Pre-run playbook failures** (CRC startup timeout, package install failure)
- **Unreachable nodes** during any phase (SSH drops, node crashes)

**NOT retried**: run-phase failures (test exits non-zero), post-run failures, Nodepool request failures (`NODE_FAILURE` before any playbook runs).

Reference: [Zuul job.attempts documentation](https://zuul-ci.org/docs/zuul/latest/config/job.html)

## Evidence

Verified via live RDO Zuul API and upstream config repo (`components-integration-config`):

| Parent Job | `attempts` | Source |
|---|---|---|
| `base-crc-cloud` | **3** | `components-integration-config/zuul.d/_jobs-crc.yaml:183` |
| `base-extracted-crc-wo-networks` | **1** | `components-integration-config/zuul.d/_jobs-crc.yaml:79` (grandparent of ci-bootstrap jobs) |
| `base-simple-crc` | **1** | `components-integration-config/zuul.d/_jobs-crc.yaml:30` |

### CRC startup timing (from build logs, buildset `d9467e70`)

| Build | CRC startup | Total duration | Result |
|---|---|---|---|
| `cifmw-molecule-ci_multus` (1st attempt) | 24 min | 31 min (TIMED_OUT) | Test got ~6 min → timeout |
| `cifmw-molecule-ci_nmstate` (2nd attempt) | 20 min | 28 min (FAILURE) | Test ran 4 min, actual failure |
| `cifmw-molecule-install_openstack_ca` | 24 min | 40 min (SUCCESS) | Has `timeout: 5400` → enough room |

## Motivation

PR #3922 demonstrated the problem: 20+ buildsets over 6 weeks, different jobs failing each time due to infrastructure flakes. Each failure required a full manual `recheck` re-running all jobs (2-3 hours). With this change, transient failures auto-retry and molecule CRC jobs get enough timeout for CRC startup + tests.