### PR TITLE
Adapt install-openstack-lightspeed playbook to current operator

### DIFF
--- a/hooks/playbooks/README.md
+++ b/hooks/playbooks/README.md
@@ -25,16 +25,26 @@ on removing "import_playbook" usage in ci-framework project.
 None
 
 ## install-openstack-lightspeed.yml
-Installs OpenShift Lightspeed and OpenStack Lightspeed operators on CRC cluster.
-This hook deploys both operators sequentially, setting up required namespaces,
-operator groups, catalog sources, and subscriptions.
+Installs OpenStack Lightspeed operator and creates the OpenStackLightspeed custom resource.
+This hook deploys the operator, waits for it to be ready, then creates a CR to deploy the service.
 
 ### Input
-* `cifmw_openstack_lightspeed_namespace`: (String) Namespace for OpenStack Lightspeed operator. Defaults to `openshift-lightspeed`.
+
+**Required variables:**
+* `cifmw_openstack_lightspeed_llm_endpoint`: (String) **REQUIRED.** LLM service endpoint URL. Example: `https://your-llm-service/v1/chat/completions`
+* `cifmw_openstack_lightspeed_model_name`: (String) **REQUIRED.** LLM model name. Example: `gpt-4`, `llama3.1:8b`, `granite-3.1-8b`
+
+**Optional variables:**
+* `cifmw_openstack_lightspeed_namespace`: (String) Namespace for OpenStack Lightspeed operator. Defaults to `openstack-lightspeed`.
 * `cifmw_openstack_lightspeed_operator_group`: (String) OperatorGroup name for OpenStack Lightspeed. Defaults to `openstack-lightspeed-operator-group`.
 * `cifmw_openstack_lightspeed_catalog_image`: (String) Container image for OpenStack Lightspeed catalog source. Defaults to `quay.io/openstack-lightspeed/operator-catalog:latest`.
 * `cifmw_openstack_lightspeed_catalog_name`: (String) Name for OpenStack Lightspeed CatalogSource resource. Defaults to `openstack-lightspeed-catalog`.
-* `cifmw_openshift_kubeconfig`: (String) Path to kubeconfig file for OpenShift cluster. Defaults to `{{ ansible_env.HOME }}/.crc/machines/crc/kubeconfig`.
+* `cifmw_openstack_lightspeed_llm_endpoint_type`: (String) LLM endpoint API format. Defaults to `openai`.
+* `cifmw_openstack_lightspeed_llm_credentials`: (String) Secret name containing LLM API token. Defaults to `openstack-lightspeed-apitoken`.
+* `cifmw_openstack_lightspeed_api_token`: (String) LLM API token value. If provided, playbook creates the secret. If not provided, playbook validates secret exists.
+* `cifmw_openstack_lightspeed_tls_ca_cert_bundle`: (String) ConfigMap name containing TLS CA certificates. Defaults to `openstack-lightspeed-certs`.
+* `cifmw_openstack_lightspeed_ca_cert`: (String) TLS CA certificate content. If provided, playbook creates the ConfigMap. If not provided, playbook validates ConfigMap exists.
+* `cifmw_openstack_lightspeed_cr_name`: (String) Name for OpenStackLightspeed CR. Defaults to `openstacklightspeed-sample`.
 
 ### Output
 None

--- a/hooks/playbooks/README.md
+++ b/hooks/playbooks/README.md
@@ -43,7 +43,7 @@ This hook deploys the operator, waits for it to be ready, then creates a CR to d
 * `cifmw_openstack_lightspeed_llm_credentials`: (String) Secret name containing LLM API token. Defaults to `openstack-lightspeed-apitoken`.
 * `cifmw_openstack_lightspeed_api_token`: (String) LLM API token value. If provided, playbook creates the secret. If not provided, playbook validates secret exists.
 * `cifmw_openstack_lightspeed_tls_ca_cert_bundle`: (String) ConfigMap name containing TLS CA certificates. Defaults to `openstack-lightspeed-certs`.
-* `cifmw_openstack_lightspeed_ca_cert_url`: (String) URL to download TLS CA certificate from. If provided, playbook downloads cert from URL and creates the ConfigMap. Example: `http://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem`
+* `cifmw_openstack_lightspeed_ca_cert_url`: (String) URL to download TLS CA certificate from. If provided, playbook downloads cert from URL and creates the ConfigMap. Example: `https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem`
 * `cifmw_openstack_lightspeed_ca_cert`: (String) TLS CA certificate content. If provided (and URL not provided), playbook creates the ConfigMap from this content. If neither URL nor content provided, playbook validates ConfigMap exists.
 * `cifmw_openstack_lightspeed_cr_name`: (String) Name for OpenStackLightspeed CR. Defaults to `openstacklightspeed-sample`.
 

--- a/hooks/playbooks/README.md
+++ b/hooks/playbooks/README.md
@@ -26,7 +26,7 @@ None
 
 ## install-openstack-lightspeed.yml
 Installs OpenStack Lightspeed operator and creates the OpenStackLightspeed custom resource.
-This hook deploys the operator, waits for it to be ready, then creates a CR to deploy the service.
+This hook deploys the operator, waits for it to be ready, then creates a CR to deploy the service. The CI job calling this hook is responsible for waiting for full service health.
 
 ### Input
 
@@ -43,7 +43,8 @@ This hook deploys the operator, waits for it to be ready, then creates a CR to d
 * `cifmw_openstack_lightspeed_llm_credentials`: (String) Secret name containing LLM API token. Defaults to `openstack-lightspeed-apitoken`.
 * `cifmw_openstack_lightspeed_api_token`: (String) LLM API token value. If provided, playbook creates the secret. If not provided, playbook validates secret exists.
 * `cifmw_openstack_lightspeed_tls_ca_cert_bundle`: (String) ConfigMap name containing TLS CA certificates. Defaults to `openstack-lightspeed-certs`.
-* `cifmw_openstack_lightspeed_ca_cert`: (String) TLS CA certificate content. If provided, playbook creates the ConfigMap. If not provided, playbook validates ConfigMap exists.
+* `cifmw_openstack_lightspeed_ca_cert_url`: (String) URL to download TLS CA certificate from. If provided, playbook downloads cert from URL and creates the ConfigMap. Example: `http://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem`
+* `cifmw_openstack_lightspeed_ca_cert`: (String) TLS CA certificate content. If provided (and URL not provided), playbook creates the ConfigMap from this content. If neither URL nor content provided, playbook validates ConfigMap exists.
 * `cifmw_openstack_lightspeed_cr_name`: (String) Name for OpenStackLightspeed CR. Defaults to `openstacklightspeed-sample`.
 
 ### Output

--- a/hooks/playbooks/install-openstack-lightspeed.yml
+++ b/hooks/playbooks/install-openstack-lightspeed.yml
@@ -135,6 +135,7 @@
           stringData:
             apitoken: "{{ cifmw_openstack_lightspeed_api_token }}"
       when: cifmw_openstack_lightspeed_api_token is defined
+      no_log: true
 
     - name: Verify LLM credentials secret exists
       kubernetes.core.k8s_info:
@@ -145,7 +146,27 @@
       failed_when: secret_check.resources | length == 0
       when: cifmw_openstack_lightspeed_api_token is not defined
 
-    - name: Create TLS CA certificate bundle ConfigMap
+    - name: Download TLS CA certificate from URL
+      ansible.builtin.uri:
+        url: "{{ cifmw_openstack_lightspeed_ca_cert_url }}"
+        return_content: true
+      register: ca_cert_download
+      when: cifmw_openstack_lightspeed_ca_cert_url is defined
+
+    - name: Create TLS CA certificate bundle ConfigMap (from URL)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: "{{ cifmw_openstack_lightspeed_tls_ca_cert_bundle | default('openstack-lightspeed-certs') }}"
+            namespace: "{{ openstack_lightspeed_namespace }}"
+          data:
+            ca-bundle.crt: "{{ ca_cert_download.content }}"
+      when: cifmw_openstack_lightspeed_ca_cert_url is defined
+
+    - name: Create TLS CA certificate bundle ConfigMap (from content)
       kubernetes.core.k8s:
         state: present
         definition:
@@ -156,7 +177,9 @@
             namespace: "{{ openstack_lightspeed_namespace }}"
           data:
             ca-bundle.crt: "{{ cifmw_openstack_lightspeed_ca_cert }}"
-      when: cifmw_openstack_lightspeed_ca_cert is defined
+      when:
+        - cifmw_openstack_lightspeed_ca_cert is defined
+        - cifmw_openstack_lightspeed_ca_cert_url is not defined
 
     - name: Verify TLS certificate bundle ConfigMap exists
       kubernetes.core.k8s_info:
@@ -165,7 +188,9 @@
         namespace: "{{ openstack_lightspeed_namespace }}"
       register: cert_check
       failed_when: cert_check.resources | length == 0
-      when: cifmw_openstack_lightspeed_ca_cert is not defined
+      when:
+        - cifmw_openstack_lightspeed_ca_cert is not defined
+        - cifmw_openstack_lightspeed_ca_cert_url is not defined
 
     # STEP 4: Create OpenStackLightspeed CR to deploy the service
     # Note: Uses configurable parameters for LLM integration
@@ -189,23 +214,6 @@
             modelName: "{{ cifmw_openstack_lightspeed_model_name }}"
             llmCredentials: "{{ cifmw_openstack_lightspeed_llm_credentials | default('openstack-lightspeed-apitoken') }}"
             tlsCACertBundle: "{{ cifmw_openstack_lightspeed_tls_ca_cert_bundle | default('openstack-lightspeed-certs') }}"
-
-    - name: Wait for OpenStackLightspeed CR to be ready
-      kubernetes.core.k8s_info:
-        api_version: lightspeed.openstack.org/v1beta1
-        kind: OpenStackLightspeed
-        name: "{{ cifmw_openstack_lightspeed_cr_name | default('openstacklightspeed-sample') }}"
-        namespace: "{{ openstack_lightspeed_namespace }}"
-      register: osls_cr
-      until:
-        - osls_cr.resources is defined
-        - osls_cr.resources | length > 0
-        - osls_cr.resources[0].status is defined
-        - osls_cr.resources[0].status.conditions is defined
-        - osls_cr.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready') | selectattr('status', 'equalto', 'True') | list | length > 0
-      retries: 60
-      delay: 10
-      ignore_errors: true
 
     - name: Display deployment summary
       ansible.builtin.debug:

--- a/hooks/playbooks/install-openstack-lightspeed.yml
+++ b/hooks/playbooks/install-openstack-lightspeed.yml
@@ -145,6 +145,7 @@
       register: secret_check
       failed_when: secret_check.resources | length == 0
       when: cifmw_openstack_lightspeed_api_token is not defined
+      no_log: true 
 
     - name: Download TLS CA certificate from URL
       ansible.builtin.uri:
@@ -153,7 +154,7 @@
       register: ca_cert_download
       when: cifmw_openstack_lightspeed_ca_cert_url is defined
 
-    - name: Create TLS CA certificate bundle ConfigMap (from URL)
+    - name: Create TLS CA certificate bundle ConfigMap
       kubernetes.core.k8s:
         state: present
         definition:
@@ -163,23 +164,9 @@
             name: "{{ cifmw_openstack_lightspeed_tls_ca_cert_bundle | default('openstack-lightspeed-certs') }}"
             namespace: "{{ openstack_lightspeed_namespace }}"
           data:
-            ca-bundle.crt: "{{ ca_cert_download.content }}"
-      when: cifmw_openstack_lightspeed_ca_cert_url is defined
-
-    - name: Create TLS CA certificate bundle ConfigMap (from content)
-      kubernetes.core.k8s:
-        state: present
-        definition:
-          apiVersion: v1
-          kind: ConfigMap
-          metadata:
-            name: "{{ cifmw_openstack_lightspeed_tls_ca_cert_bundle | default('openstack-lightspeed-certs') }}"
-            namespace: "{{ openstack_lightspeed_namespace }}"
-          data:
-            ca-bundle.crt: "{{ cifmw_openstack_lightspeed_ca_cert }}"
-      when:
-        - cifmw_openstack_lightspeed_ca_cert is defined
-        - cifmw_openstack_lightspeed_ca_cert_url is not defined
+            ca-bundle.crt: >-
+              {{ ca_cert_download.content if cifmw_openstack_lightspeed_ca_cert_url is defined else cifmw_openstack_lightspeed_ca_cert }}
+      when: cifmw_openstack_lightspeed_ca_cert_url is defined or cifmw_openstack_lightspeed_ca_cert is defined
 
     - name: Verify TLS certificate bundle ConfigMap exists
       kubernetes.core.k8s_info:

--- a/hooks/playbooks/install-openstack-lightspeed.yml
+++ b/hooks/playbooks/install-openstack-lightspeed.yml
@@ -19,16 +19,16 @@
   connection: local
   vars:
     # OpenStack Lightspeed configuration
-    # Note: Installing in openshift-lightspeed namespace to ensure compatibility
-    openstack_lightspeed_namespace: "{{ cifmw_openstack_lightspeed_namespace | default('openshift-lightspeed') }}"
+    # Note: Using openstack-lightspeed namespace per operator's suggested namespace
+    openstack_lightspeed_namespace: "{{ cifmw_openstack_lightspeed_namespace | default('openstack-lightspeed') }}"
     openstack_lightspeed_operator_group: "{{ cifmw_openstack_lightspeed_operator_group | default('openstack-lightspeed-operator-group') }}"
     openstack_lightspeed_catalog_image: "{{ cifmw_openstack_lightspeed_catalog_image | default('quay.io/openstack-lightspeed/operator-catalog:latest') }}"
     openstack_lightspeed_catalog_name: "{{ cifmw_openstack_lightspeed_catalog_name | default('openstack-lightspeed-catalog') }}"
 
     # Kubeconfig path - use user-provided or default to CRC location
-    cifmw_openshift_kubeconfig: "{{ cifmw_openshift_kubeconfig | default(ansible_env.HOME ~ '/.crc/machines/crc/kubeconfig') }}"
+    kubeconfig_path: "{{ cifmw_openshift_kubeconfig | default(ansible_env.HOME ~ '/.crc/machines/crc/kubeconfig') }}"
   environment:
-    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    KUBECONFIG: "{{ kubeconfig_path }}"
 
   tasks:
     # STEP 1: Deploy OpenStack Lightspeed catalog
@@ -121,8 +121,45 @@
       retries: 30
       delay: 10
 
+    # STEP 3: Create OpenStackLightspeed CR to deploy the service
+    # Note: Uses configurable parameters for LLM integration
+
+    - name: Create OpenStackLightspeed custom resource
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: lightspeed.openstack.org/v1beta1
+          kind: OpenStackLightspeed
+          metadata:
+            name: "{{ cifmw_openstack_lightspeed_cr_name | default('openstacklightspeed-sample') }}"
+            namespace: "{{ openstack_lightspeed_namespace }}"
+          spec:
+            llmCredentials: "{{ cifmw_openstack_lightspeed_llm_credentials | default('openstack-lightspeed-apitoken') }}"
+            llmEndpoint: "{{ cifmw_openstack_lightspeed_llm_endpoint | default('http://llm-provider:11434/v1') }}"
+            llmEndpointType: "{{ cifmw_openstack_lightspeed_llm_endpoint_type | default('openai') }}"
+            modelName: "{{ cifmw_openstack_lightspeed_model_name | default('llama3.1:8b') }}"
+            tlsCACertBundle: "{{ cifmw_openstack_lightspeed_tls_ca_cert_bundle | default('openstack-lightspeed-certs') }}"
+
+    - name: Wait for OpenStackLightspeed CR to be ready
+      kubernetes.core.k8s_info:
+        api_version: lightspeed.openstack.org/v1beta1
+        kind: OpenStackLightspeed
+        name: "{{ cifmw_openstack_lightspeed_cr_name | default('openstacklightspeed-sample') }}"
+        namespace: "{{ openstack_lightspeed_namespace }}"
+      register: osls_cr
+      until:
+        - osls_cr.resources is defined
+        - osls_cr.resources | length > 0
+        - osls_cr.resources[0].status is defined
+        - osls_cr.resources[0].status.conditions is defined
+        - osls_cr.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready') | selectattr('status', 'equalto', 'True') | list | length > 0
+      retries: 60
+      delay: 10
+      ignore_errors: true
+
     - name: Display deployment summary
       ansible.builtin.debug:
         msg:
           - "✓ OpenStack Lightspeed operator deployed in namespace: {{ openstack_lightspeed_namespace }}"
+          - "✓ OpenStack Lightspeed CR created: {{ cifmw_openstack_lightspeed_cr_name | default('openstacklightspeed-sample') }}"
           - "✓ OpenShift Lightspeed operator will be automatically managed by OpenStack Lightspeed"

--- a/hooks/playbooks/install-openstack-lightspeed.yml
+++ b/hooks/playbooks/install-openstack-lightspeed.yml
@@ -135,9 +135,9 @@
             namespace: "{{ openstack_lightspeed_namespace }}"
           spec:
             llmCredentials: "{{ cifmw_openstack_lightspeed_llm_credentials | default('openstack-lightspeed-apitoken') }}"
-            llmEndpoint: "{{ cifmw_openstack_lightspeed_llm_endpoint | default('http://llm-provider:11434/v1') }}"
+            llmEndpoint: "{{ cifmw_openstack_lightspeed_llm_endpoint | default('https://api.models.corp/v1/chat/completions') }}"
             llmEndpointType: "{{ cifmw_openstack_lightspeed_llm_endpoint_type | default('openai') }}"
-            modelName: "{{ cifmw_openstack_lightspeed_model_name | default('llama3.1:8b') }}"
+            modelName: "{{ cifmw_openstack_lightspeed_model_name | default('openai/gpt-oss-20b') }}"
             tlsCACertBundle: "{{ cifmw_openstack_lightspeed_tls_ca_cert_bundle | default('openstack-lightspeed-certs') }}"
 
     - name: Wait for OpenStackLightspeed CR to be ready

--- a/hooks/playbooks/install-openstack-lightspeed.yml
+++ b/hooks/playbooks/install-openstack-lightspeed.yml
@@ -205,12 +205,8 @@
             name: "{{ cifmw_openstack_lightspeed_cr_name | default('openstacklightspeed-sample') }}"
             namespace: "{{ openstack_lightspeed_namespace }}"
           spec:
-            # REQUIRED: LLM endpoint must be provided via cifmw_openstack_lightspeed_llm_endpoint
-            # Example: https://your-llm-service/v1/chat/completions
             llmEndpoint: "{{ cifmw_openstack_lightspeed_llm_endpoint }}"
             llmEndpointType: "{{ cifmw_openstack_lightspeed_llm_endpoint_type | default('openai') }}"
-            # REQUIRED: Model name must be provided via cifmw_openstack_lightspeed_model_name
-            # Example: gpt-4, llama3.1:8b, granite-3.1-8b
             modelName: "{{ cifmw_openstack_lightspeed_model_name }}"
             llmCredentials: "{{ cifmw_openstack_lightspeed_llm_credentials | default('openstack-lightspeed-apitoken') }}"
             tlsCACertBundle: "{{ cifmw_openstack_lightspeed_tls_ca_cert_bundle | default('openstack-lightspeed-certs') }}"

--- a/hooks/playbooks/install-openstack-lightspeed.yml
+++ b/hooks/playbooks/install-openstack-lightspeed.yml
@@ -121,7 +121,53 @@
       retries: 30
       delay: 10
 
-    # STEP 3: Create OpenStackLightspeed CR to deploy the service
+    # STEP 3: Create prerequisites (secrets and certificates)
+
+    - name: Create LLM API token secret
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ cifmw_openstack_lightspeed_llm_credentials | default('openstack-lightspeed-apitoken') }}"
+            namespace: "{{ openstack_lightspeed_namespace }}"
+          stringData:
+            apitoken: "{{ cifmw_openstack_lightspeed_api_token }}"
+      when: cifmw_openstack_lightspeed_api_token is defined
+
+    - name: Verify LLM credentials secret exists
+      kubernetes.core.k8s_info:
+        kind: Secret
+        name: "{{ cifmw_openstack_lightspeed_llm_credentials | default('openstack-lightspeed-apitoken') }}"
+        namespace: "{{ openstack_lightspeed_namespace }}"
+      register: secret_check
+      failed_when: secret_check.resources | length == 0
+      when: cifmw_openstack_lightspeed_api_token is not defined
+
+    - name: Create TLS CA certificate bundle ConfigMap
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: "{{ cifmw_openstack_lightspeed_tls_ca_cert_bundle | default('openstack-lightspeed-certs') }}"
+            namespace: "{{ openstack_lightspeed_namespace }}"
+          data:
+            ca-bundle.crt: "{{ cifmw_openstack_lightspeed_ca_cert }}"
+      when: cifmw_openstack_lightspeed_ca_cert is defined
+
+    - name: Verify TLS certificate bundle ConfigMap exists
+      kubernetes.core.k8s_info:
+        kind: ConfigMap
+        name: "{{ cifmw_openstack_lightspeed_tls_ca_cert_bundle | default('openstack-lightspeed-certs') }}"
+        namespace: "{{ openstack_lightspeed_namespace }}"
+      register: cert_check
+      failed_when: cert_check.resources | length == 0
+      when: cifmw_openstack_lightspeed_ca_cert is not defined
+
+    # STEP 4: Create OpenStackLightspeed CR to deploy the service
     # Note: Uses configurable parameters for LLM integration
 
     - name: Create OpenStackLightspeed custom resource
@@ -134,10 +180,14 @@
             name: "{{ cifmw_openstack_lightspeed_cr_name | default('openstacklightspeed-sample') }}"
             namespace: "{{ openstack_lightspeed_namespace }}"
           spec:
-            llmCredentials: "{{ cifmw_openstack_lightspeed_llm_credentials | default('openstack-lightspeed-apitoken') }}"
-            llmEndpoint: "{{ cifmw_openstack_lightspeed_llm_endpoint | default('https://api.models.corp/v1/chat/completions') }}"
+            # REQUIRED: LLM endpoint must be provided via cifmw_openstack_lightspeed_llm_endpoint
+            # Example: https://your-llm-service/v1/chat/completions
+            llmEndpoint: "{{ cifmw_openstack_lightspeed_llm_endpoint }}"
             llmEndpointType: "{{ cifmw_openstack_lightspeed_llm_endpoint_type | default('openai') }}"
-            modelName: "{{ cifmw_openstack_lightspeed_model_name | default('openai/gpt-oss-20b') }}"
+            # REQUIRED: Model name must be provided via cifmw_openstack_lightspeed_model_name
+            # Example: gpt-4, llama3.1:8b, granite-3.1-8b
+            modelName: "{{ cifmw_openstack_lightspeed_model_name }}"
+            llmCredentials: "{{ cifmw_openstack_lightspeed_llm_credentials | default('openstack-lightspeed-apitoken') }}"
             tlsCACertBundle: "{{ cifmw_openstack_lightspeed_tls_ca_cert_bundle | default('openstack-lightspeed-certs') }}"
 
     - name: Wait for OpenStackLightspeed CR to be ready


### PR DESCRIPTION
Updated the playbook to work with the current OpenStack Lightspeed operator after org migration from openstack-lightspeed to openstack-k8s-operators.

Changes:
1. Namespace: Changed default from openshift-lightspeed to openstack-lightspeed to match operator's suggested namespace in csv
2. CR creation: Added STEP 3 to create OpenStackLightspeed CR
   - Deploys the actual service (not just operator)
   - Configurable LLM parameters (endpoint, credentials, model)
   - Graceful timeout with ignore_errors for test environments
3. Kubeconfig fix: Resolved variable recursion bug on line 29
   - Renamed cifmw_openshift_kubeconfig to kubeconfig_path
   - Prevents 'recursive loop detected' error

Jira ticket: [OSPRH-33342](https://redhat.atlassian.net/browse/OSPRH-33342)