### PR TITLE
[reproducer] Fix IPv6 NDP stale cache on MAC churn

### DIFF
--- a/roles/reproducer/tasks/libvirt_layout.yml
+++ b/roles/reproducer/tasks/libvirt_layout.yml
@@ -122,3 +122,27 @@
   loop_control:
     loop_var: compute
     label: "{{ compute.key }}"
+
+# macvlan CNI assigns a new random MAC per AnsibleEE pod while
+# Whereabouts IPAM reuses the same IPv6 address. Target nodes' NDP
+# cache maps the address to the previous pod's MAC, silently dropping
+# return traffic and causing SSH timeouts.
+# Reducing base_reachable_time_ms makes stale entries expire faster
+# so the kernel re-probes on the next packet.
+- name: Reduce IPv6 NDP reachable time on nodes reachable via ctlplane
+  when:
+    - cifmw_networking_env_definition.networks.ctlplane.network_v6 is defined
+    - _ndp_host.value.networks.ctlplane is defined
+    - _ndp_host.key is not match('^(ocp|crc).*')
+  delegate_to: "{{ _ndp_host.key }}"
+  become: true
+  ansible.posix.sysctl:
+    name: net.ipv6.neigh.default.base_reachable_time_ms
+    value: "5000"
+    sysctl_set: true
+    state: present
+  loop: >-
+    {{ cifmw_networking_env_definition.instances | dict2items }}
+  loop_control:
+    loop_var: _ndp_host
+    label: "{{ _ndp_host.key }}"


### PR DESCRIPTION
macvlan CNI assigns a new random MAC per AnsibleEE pod while Whereabouts IPAM reuses the same IPv6 address from a small pool. When pods cycle rapidly (~30s between retries), target nodes' NDP cache still maps the reused address to the dead pod's MAC (REACHABLE state lasts 30s by default). Return traffic (SYN-ACK) is sent to the stale MAC and silently dropped on the `ospbr` linux bridge, causing SSH connection timeouts.

This was observed on uni04delta-ipv6-rhel9-rhoso18.0 adoption where all 4 `configure-network-networker` pod attempts failed with `UNREACHABLE` on all 3 controllers. Earlier services (bootstrap, download-cache) succeeded because they had longer gaps between retries.

Reducing `base_reachable_time_ms` from 30000 to 5000 on all non-OCP nodes with IPv6 ctlplane connectivity makes NDP entries transition to STALE after 5s, triggering kernel re-probing on the next packet. The first SYN-ACK may be lost but TCP retransmits within 1s, by which time the NDP cache is updated.

Related-Issue: #[OSPRH-34824](https://redhat.atlassian.net/browse/OSPRH-34824)