### PR TITLE
Fail shiftstack testconfig when testing stages marked UNSTABLE

### DIFF
--- a/roles/shiftstack/tasks/test_config.yml
+++ b/roles/shiftstack/tasks/test_config.yml
@@ -72,3 +72,26 @@
           {{ cifmw_shiftstack_client_pod_name }}:{{ cifmw_shiftstack_shiftstackclient_artifacts_dir }}/
           {{ testconfig_artifacts_dir }}/
       failed_when: false
+
+    - name: Check for UNSTABLE shiftstack testing stages flag in artifacts
+      ansible.builtin.stat:
+        path: "{{ testconfig_artifacts_dir }}/test_stage_unstable_flag"
+      register: _shiftstack_test_unstable_flag
+
+    - name: Read UNSTABLE shiftstack testing stage messages from artifacts
+      ansible.builtin.set_fact:
+        _shiftstack_test_unstable_messages: >-
+          {{ lookup('ansible.builtin.file', testconfig_artifacts_dir + '/test_stage_unstable_flag')
+             | split('\n')
+             | map('trim')
+             | reject('equalto', '')
+             | list
+             | join('; ') }}
+      when: _shiftstack_test_unstable_flag.stat.exists
+
+    - name: Fail when shiftstack testing stages were marked UNSTABLE
+      ansible.builtin.fail:
+        msg: >-
+          UNSTABLE: one or more shiftstack testing stages failed:
+          {{ _shiftstack_test_unstable_messages }}
+      when: _shiftstack_test_unstable_flag.stat.exists


### PR DESCRIPTION
## Summary

- After rsyncing shiftstackclient artifacts, fail the shiftstack testconfig when `test_stage_unstable_flag` is present in the artifact tree.
- Allows the inner `ocp_testing.yaml` playbook to complete all testing stages while still failing the outer Zuul job for test regressions.

## Companion changes (required together)

1. **shiftstack-qa** — testing stages write `test_stage_unstable_flag`: https://github.com/shiftstack/shiftstack-qa/pull/36
2. **ci-framework-jobs** — `failure-message: unstable` on monolithic shiftstack jobs for yellow UI: https://gitlab.cee.redhat.com/ci-framework/ci-framework-jobs/-/merge_requests/3556

## Test plan

- [ ] Land all three PRs/MRs together
- [ ] TP check with failing openstack-test stage → Zuul job **unstable/yellow**
- [ ] Passing run → green
- [ ] Soft verification-only issues → green (no test flag)


Made with [Cursor](https://cursor.com)