### PR TITLE
[cifmw_cephadm] add generic ceph-config override passthrough

### DIFF
--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -54,6 +54,18 @@ cifmw_cephadm_certs: /etc/pki/tls
 cifmw_cephadm_debug: false
 cifmw_cephadm_min_compat_client: "mimic"
 cifmw_cephadm_auth_allowed_ciphers: ""
+# Extra `ceph config set` entries, applied after the built-in config so they
+# can also override earlier values. Each item maps to
+# `ceph config set <who> <key> <value>`, where `who` is the section or daemon
+# (global, mon, mgr, osd, mds, osd.0, ...) - the WHO column shown by
+# `ceph config dump`. Example - bound the MDS cap-revoke stall that wedges
+# manila-share on CephFS/NFS-Ganesha (evict a stale cap-holder before the
+# ~60s liveness kill):
+#   cifmw_cephadm_extra_config:
+#     - who: mds
+#       key: mds_cap_revoke_eviction_timeout
+#       value: "25"
+cifmw_cephadm_extra_config: []
 cifmw_cephadm_deployed_ceph: false
 cifmw_cephadm_backend: ''
 cifmw_cephadm_action: disable

--- a/roles/cifmw_cephadm/tasks/cephadm_config_set.yml
+++ b/roles/cifmw_cephadm/tasks/cephadm_config_set.yml
@@ -119,3 +119,16 @@
         {{ cifmw_cephadm_ceph_cli }} config set mgr mgr/cephadm/container_image_prometheus \
         {{ cifmw_cephadm_prometheus_container_image }}
       changed_when: false
+
+- name: Apply extra ceph config set entries
+  become: true
+  when:
+    - cifmw_cephadm_extra_config | default([]) | length > 0
+  ansible.builtin.command:
+    cmd: >-
+      {{ cifmw_cephadm_ceph_cli }} config set
+      {{ item.who }} {{ item.key }} {{ item.value }}
+  loop: "{{ cifmw_cephadm_extra_config }}"
+  loop_control:
+    label: "{{ item.who }}/{{ item.key }}={{ item.value }}"
+  changed_when: false


### PR DESCRIPTION
The role applies a fixed set of `ceph config set` commands in tasks/cephadm_config_set.yml, one task per option. A scenario that needs to tune any other cluster option currently has to patch the role. Add a generic, opt-in `cifmw_cephadm_extra_config` list so scenarios can apply arbitrary `ceph config set <who> <key> <value>` entries without a new task per option. It defaults to empty (no-op) and is applied after the built-in configuration, so it can also override earlier values.

For example, a deployment can bound the MDS cap-revoke stall that wedges a single-worker CephFS/NFS-Ganesha consumer by evicting an unresponsive cap-holder before it hits session_autoclose:

    cifmw_cephadm_extra_config:
      - who: mds
        key: mds_cap_revoke_eviction_timeout
        value: "25"

Assisted-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Luigi Toscano <ltoscano@redhat.com>