### PR TITLE
[DNM] tobiko - testing s2i tobiko container image

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -67,11 +67,14 @@
               - ^CONTRIBUTING.md
               - ^docs/*
               - ^OWNERS*
-        - podified-multinode-edpm-deployment-crc: *content_provider
-        - cifmw-crc-podified-edpm-baremetal: *content_provider
-        - cifmw-crc-podified-edpm-baremetal-minor-update: *content_provider
-        - podified-multinode-hci-deployment-crc: *content_provider
-        - cifmw-multinode-tempest: *content_provider
+        # DNM: skip the default EDPM/baremetal jobs. To test tobiko
+        # with podified-multinode-edpm-deployment-crc-test-operator-tobiko-s2i job
+        # - podified-multinode-edpm-deployment-crc: *content_provider
+        # - cifmw-crc-podified-edpm-baremetal: *content_provider
+        # - cifmw-crc-podified-edpm-baremetal-minor-update: *content_provider
+        # - podified-multinode-hci-deployment-crc: *content_provider
+        # - cifmw-multinode-tempest: *content_provider
+        - podified-multinode-edpm-deployment-crc-test-operator-tobiko-s2i: *content_provider
         - cifmw-pod-zuul-files
 
 - project-template:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -15,9 +15,10 @@
       - openstack-k8s-operators-content-provider:
           vars:
             cifmw_edpm_build_images_force: true
-      - openstack-k8s-operators-content-provider-bootc:
-          vars:
-            cifmw_edpm_build_images_force: true
+      # DNM: skip bootc while testing tobiko s2i
+      # - openstack-k8s-operators-content-provider-bootc:
+      #     vars:
+      #       cifmw_edpm_build_images_force: true
       - cifmw-molecule-adoption_osp_deploy
       - cifmw-molecule-artifacts
       - cifmw-molecule-bm_sno
@@ -125,6 +126,7 @@
     name: openstack-k8s-operators/ci-framework
     templates:
     - podified-multinode-edpm-ci-framework-pipeline
-    - podified-multinode-edpm-baremetal-bootc-pipeline
+    # DNM: skip bootc jobs while testing tobiko s2i
+    # - podified-multinode-edpm-baremetal-bootc-pipeline
     - data-plane-adoption-ci-framework-pipeline
     - whitebox-neutron-tempest-plugin-podified-pipeline

--- a/zuul.d/test_operator_tobiko.yaml
+++ b/zuul.d/test_operator_tobiko.yaml
@@ -1,0 +1,29 @@
+---
+- job:
+    name: podified-multinode-edpm-deployment-crc-test-operator-tobiko-s2i
+    parent: podified-multinode-edpm-deployment-crc-test-operator
+    description: |
+      Run podified-multinode-edpm-deployment-crc-test-operator with only the
+      Tobiko stage, using a from-source image from
+      quay.io/rh-ee-fyanac/tobiko_test:tobiko-test.
+    vars:
+      cifmw_run_test_role: test_operator
+      cifmw_test_operator_stages:
+        - name: tobiko
+          type: tobiko
+      cifmw_test_operator_tobiko_registry: quay.io
+      cifmw_test_operator_tobiko_namespace: rh-ee-fyanac
+      cifmw_test_operator_tobiko_container: tobiko_test
+      cifmw_test_operator_tobiko_image_tag: tobiko-test
+      cifmw_test_operator_tobiko_workflow:
+        - stepName: 'podified-functional'
+          testenv: 'functional'
+          pytestAddopts: "tobiko/tests/functional/podified/test_topology.py"
+          numProcesses: 2
+        - stepName: 'sanity'
+          testenv: 'sanity'
+      cifmw_test_operator_tobiko_network_attachments:
+        - ctlplane
+    files:
+      - ^zuul.d/test_operator_tobiko.yaml
+      - ^roles/test_operator


### PR DESCRIPTION
tobiko - testing s2i tobiko container image
with podified-multinode-edpm-deployment-crc-test-operator-tobiko-s2i

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/4144