### PR TITLE
Add nodesets based on OCP 4.22.1

### DIFF
--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -637,3 +637,294 @@
     nodes:
       - name: controller
         label: centos-9-stream-crc-2-56-0-xl
+
+#
+# CRC CLOUD (OCP 4.22) (CRC 2.62.0) nodesets
+#
+
+- nodeset:
+    name: centos-9-crc-2-62-0-xxl
+    nodes:
+      - name: controller
+        label: centos-9-stream-crc-2-62-0-xxl
+
+- nodeset:
+    name: centos-9-medium-2x-centos-9-crc-cloud-ocp-4-22-1-xxl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: crc-cloud-ocp-4-22-1-xxl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-medium-2x-centos-9-crc-cloud-ocp-4-22-1-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: crc-cloud-ocp-4-22-1-3xl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-2x-centos-9-xxl-crc-cloud-ocp-4-22-1-xxl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo-xxl
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo-xxl
+      - name: crc
+        label: crc-cloud-ocp-4-22-1-xxl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-2x-centos-9-xxl-crc-cloud-ocp-4-22-1-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo-xxl
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo-xxl
+      - name: crc
+        label: crc-cloud-ocp-4-22-1-3xl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-medium-3x-centos-9-crc-cloud-ocp-4-22-1-xxl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-2
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: crc-cloud-ocp-4-22-1-xxl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+          - compute-2
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-medium-crc-cloud-ocp-4-22-1-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: crc
+        label: crc-cloud-ocp-4-22-1-3xl
+    groups:
+      - name: computes
+        nodes: []
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-rhel-9-2-crc-cloud-ocp-4-22-1-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: crc-cloud-ocp-4-22-1-3xl
+      - name: standalone
+        label: cloud-rhel-9-2-tripleo
+    groups:
+      - name: computes
+        nodes: []
+      - name: ocps
+        nodes:
+          - crc
+      - name: rh-subscription
+        nodes:
+          - standalone
+
+- nodeset:
+    name: centos-9-multinode-rhel-9-2-crc-cloud-ocp-4-22-1-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: crc-cloud-ocp-4-22-1-3xl
+      - name: undercloud
+        label: cloud-rhel-9-2-tripleo
+      - name: overcloud-controller-0
+        label: cloud-rhel-9-2-tripleo
+      - name: overcloud-controller-1
+        label: cloud-rhel-9-2-tripleo
+      - name: overcloud-controller-2
+        label: cloud-rhel-9-2-tripleo
+      - name: overcloud-novacompute-0
+        label: cloud-rhel-9-2-tripleo
+      - name: overcloud-novacompute-1
+        label: cloud-rhel-9-2-tripleo
+      - name: overcloud-novacompute-2
+        label: cloud-rhel-9-2-tripleo
+    groups:
+      - name: computes
+        nodes: []
+      - name: ocps
+        nodes:
+          - crc
+      - name: rh-subscription
+        nodes:
+          - undercloud
+          - overcloud-controller-0
+          - overcloud-controller-1
+          - overcloud-controller-2
+          - overcloud-novacompute-0
+          - overcloud-novacompute-1
+          - overcloud-novacompute-2
+      - name: tripleo_controllers
+        nodes:
+          - overcloud-controller-0
+          - overcloud-controller-1
+          - overcloud-controller-2
+      - name: tripleo_computes
+        nodes:
+          - overcloud-novacompute-0
+          - overcloud-novacompute-1
+          - overcloud-novacompute-2
+
+- nodeset:
+    name: centos-9-multinode-rhel-9-2-crc-cloud-ocp-4-22-1-3xl-novacells
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: crc-cloud-ocp-4-22-1-3xl
+      - name: undercloud
+        label: cloud-rhel-9-2-tripleo
+      - name: overcloud-controller-0
+        label: cloud-rhel-9-2-tripleo
+      - name: cell1-controller-0
+        label: cloud-rhel-9-2-tripleo
+      - name: cell1-compute-0
+        label: cloud-rhel-9-2-tripleo
+      - name: cell2-controller-compute-0
+        label: cloud-rhel-9-2-tripleo
+    groups:
+      - name: computes
+        nodes: []
+      - name: ocps
+        nodes:
+          - crc
+      - name: rh-subscription
+        nodes:
+          - undercloud
+          - overcloud-controller-0
+          - cell1-controller-0
+          - cell2-controller-compute-0
+          - cell1-compute-0
+      - name: tripleo_controllers
+        nodes:
+          - overcloud-controller-0
+          - cell1-controller-0
+          - cell2-controller-compute-0
+      - name: tripleo_computes
+        nodes:
+          - cell1-compute-0
+          - cell2-controller-compute-0
+
+- nodeset:
+    name: centos-9-medium-centos-9-crc-cloud-ocp-4-22-1-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: crc-cloud-ocp-4-22-1-3xl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-crc-2-62-0-3xl
+    nodes:
+      - name: controller
+        label: centos-9-stream-crc-2-62-0-3xl
+
+- nodeset:
+    name: centos-9-medium-3x-centos-9-crc-cloud-ocp-4-22-1-3xl
+    nodes:
+      - name: controller
+        label: cloud-centos-9-stream-tripleo-medium
+      - name: compute-0
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-1
+        label: cloud-centos-9-stream-tripleo
+      - name: compute-2
+        label: cloud-centos-9-stream-tripleo
+      - name: crc
+        label: crc-cloud-ocp-4-22-1-3xl
+    groups:
+      - name: computes
+        nodes:
+          - compute-0
+          - compute-1
+          - compute-2
+      - name: ocps
+        nodes:
+          - crc
+
+- nodeset:
+    name: centos-9-crc-2-62-0-6xlarge
+    nodes:
+      - name: controller
+        label: centos-9-stream-crc-2-62-0-6xlarge
+
+- nodeset:
+    name: centos-9-crc-2-62-0-xl
+    nodes:
+      - name: controller
+        label: centos-9-stream-crc-2-62-0-xl


### PR DESCRIPTION
The new nodesets would be using:

crc-cloud based on OCP 4.22.1
nested crc based on CRC 2.62.0 (OCP 4.22.1)

Signed-off-by: Bhagyashri Shewale <bshewale@redhat.com>