### PR TITLE
Skip test_igmp_snooping_after_openvswitch_restart from whitebox job

### DIFF
--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -188,3 +188,5 @@
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_vlan_transparency.MultiPortVlanTransparencyTest
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_vlan_transparency.MultiVlanTransparencyTest
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_vrrp.VrrpTest
+              # executed on d/s:
+              ^whitebox_neutron_tempest_plugin.tests.scenario.test_multicast.MulticastTestIPv4Common.test_igmp_snooping_after_openvswitch_restart


### PR DESCRIPTION
Skip test:
^whitebox_neutron_tempest_plugin.tests.scenario.test_multicast.MulticastTestIPv4Common.test_igmp_snooping_after_openvswitch_restart

from periodic-whitebox-neutron-tempest-plugin-podified-multinode-edpm-deployment-crc-2comp job.

This test is executed on d/s

Related to: [OSPCIX-1484](https://redhat.atlassian.net/browse/OSPCIX-1484)

Signed-off-by: Fiorella Yanac <fyanac@redhat.com>
