### PR TITLE
[kuttl] Honor cifmw_zuul_target_host_env in operator Make targets

### DIFF
--- a/ci/playbooks/kuttl/deploy-deps.yaml
+++ b/ci/playbooks/kuttl/deploy-deps.yaml
@@ -152,6 +152,16 @@
               {{
                 zuul.projects[project_name].src_dir
               }}
+          # cifmw_zuul_target_host_env lets a job pass extra env vars (e.g.
+          # KUTTL_SUITE) into the operator Make targets, so the prep step
+          # deploys deps for the same suite that kuttl-test-run executes.
+          environment: >-
+            {{
+              {
+                'KUBECONFIG': cifmw_openshift_kubeconfig,
+                'PATH': cifmw_path | default(ansible_env.PATH),
+              } | combine(cifmw_zuul_target_host_env | default({}))
+            }}
           ansible.builtin.command:
             cmd: make kuttl-test-prep
             chdir: "{{ ansible_user_dir }}/{{ operator_basedir }}"

--- a/ci/playbooks/kuttl/run-kuttl-from-operator-targets.yaml
+++ b/ci/playbooks/kuttl/run-kuttl-from-operator-targets.yaml
@@ -14,9 +14,16 @@
         name: run_hook
 
     - name: run kuttl test suite from operator Makefile
-      environment:
-        KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-        PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
+      # cifmw_zuul_target_host_env lets a job pass extra env vars (e.g.
+      # KUTTL_SUITE) into the operator Make targets. Merge it last so a job
+      # can override the suite selected by the operator Makefile default.
+      environment: >-
+        {{
+          {
+            'KUBECONFIG': cifmw_openshift_kubeconfig,
+            'PATH': cifmw_path | default(ansible_env.PATH),
+          } | combine(cifmw_zuul_target_host_env | default({}))
+        }}
       ansible.builtin.command:
         cmd: make kuttl-test-run
         chdir: "{{ ansible_user_dir }}/{{ operator_basedir }}"


### PR DESCRIPTION
The kuttl-from-operator jobs let a Zuul job select the kuttl suite via cifmw_zuul_target_host_env (e.g. KUTTL_SUITE), which is exported into the job parameters (zuul-params.yml) and available to the run/deps plays.

However, the tasks that invoke the operator Make targets hardcoded their `environment` to only KUBECONFIG and PATH, so cifmw_zuul_target_host_env was never applied. As a result `make kuttl-test-prep` and `make kuttl-test-run` always used the operator Makefile default (KUTTL_SUITE ?= <default>), silently ignoring the job's override.

Concretely, nova-operator's nova-operator-kuttl-placement job sets KUTTL_SUITE=placement but ran the nova suite instead, leaving the placement kuttl suite with zero CI coverage.

Merge cifmw_zuul_target_host_env into the environment of both make invocations so a job can override the suite (and any other Make env var) it needs.

Related: https://redhat.atlassian.net/browse/OSPRH-33503