### PR TITLE
[bgp] Optionally configure router-0 as a BGP-EVPN VTEP

### DIFF
--- a/playbooks/bgp/prepare-bgp-spines-leaves.yaml
+++ b/playbooks/bgp/prepare-bgp-spines-leaves.yaml
@@ -282,6 +282,86 @@
           ip address replace {{ router_loopback_ip }}/32 dev lo
       changed_when: true
 
+    # EVPN VTEP is IPv4-only: the Linux dataplane (VRF/bridge/VXLAN + SNAT) is
+    # built only for IPv4, so fail early instead of rendering FRR EVPN config
+    # with no matching dataplane on an IPv6 run. It also reuses router_loopback_ip
+    # as the VTEP address (already assigned to lo above), so require it to be set.
+    - name: Assert EVPN VTEP prerequisites
+      when: router_evpn_vtep | default(false)
+      ansible.builtin.assert:
+        that:
+          - _ip_version == 4
+          - (router_loopback_ip | default('') | length) > 0
+        fail_msg: >-
+          router_evpn_vtep requires IPv4 (_ip_version == 4, got {{ _ip_version }})
+          and a non-empty router_loopback_ip (got '{{ router_loopback_ip | default('') }}').
+
+    # Make router-0 an EVPN VTEP so it can reach tenant IPs advertised via
+    # BGP-EVPN Type-5 routes. Netdevs are created before FRR starts so zebra can
+    # map "vni N" to the VRF and program the L3VNI. They are not persistent, but
+    # the router is never rebooted (same rationale as the IPv6 route below).
+    # NOTE: dstport must be 4789 to match the OVN dataplane VXLAN port on EDPM
+    # nodes; the kernel FRR device default (8472/60010) is advertisement-only.
+    - name: Configure EVPN VTEP netdevs on router
+      when:
+        - _ip_version == 4
+        - router_evpn_vtep | default(false)
+      become: true
+      vars:
+        _vni: "{{ router_evpn_l3vni | default(1) }}"
+        _table: "{{ 1000 + (router_evpn_l3vni | default(1) | int) }}"
+      block:
+        - name: Create the L3VNI VRF device
+          ansible.builtin.shell:
+            cmd: |
+              set -o errexit
+              ip link show vrf-l3vni{{ _vni }} \
+                || ip link add vrf-l3vni{{ _vni }} type vrf table {{ _table }}
+              ip link set vrf-l3vni{{ _vni }} up
+            executable: /bin/bash
+          changed_when: true
+
+        - name: Create the L3VNI bridge and enslave it to the VRF
+          ansible.builtin.shell:
+            cmd: |
+              set -o errexit
+              ip link show br-l3vni{{ _vni }} \
+                || ip link add br-l3vni{{ _vni }} type bridge
+              ip link set br-l3vni{{ _vni }} master vrf-l3vni{{ _vni }}
+              ip link set br-l3vni{{ _vni }} up
+            executable: /bin/bash
+          changed_when: true
+
+        - name: Create the L3VNI VXLAN device and enslave it to the bridge
+          ansible.builtin.shell:
+            cmd: |
+              set -o errexit
+              ip link show vx-0-{{ _vni }} \
+                || ip link add vx-0-{{ _vni }} type vxlan id {{ _vni }} \
+                     local {{ router_loopback_ip }} dstport 4789 nolearning
+              ip link set vx-0-{{ _vni }} master br-l3vni{{ _vni }}
+              ip link set vx-0-{{ _vni }} up
+            executable: /bin/bash
+          changed_when: true
+      rescue:
+        - name: Collect VTEP netdev state for debugging
+          ansible.builtin.command:
+            cmd: "{{ item }}"
+          loop:
+            - ip address show dev lo
+            - ip -d link show vrf-l3vni{{ _vni }}
+            - ip -d link show br-l3vni{{ _vni }}
+            - ip -d link show vx-0-{{ _vni }}
+          register: _evpn_vtep_debug
+          changed_when: false
+          failed_when: false
+
+        - name: Fail after dumping VTEP netdev state
+          ansible.builtin.fail:
+            msg: >-
+              Failed to configure EVPN VTEP netdevs.
+              State: {{ _evpn_vtep_debug.results | map(attribute='stdout') | list }}
+
     - name: Configure FRR
       vars:
         # Prefer loopback IP as BGP router-id when set; else 1.1.1.1 (IPv4 and IPv6).
@@ -327,6 +407,29 @@
               ip6tables -t nat -A POSTROUTING -s f00d:f00d:f00d:f00d:99:99::/96 -o {{ router_ext_if }} -j MASQUERADE
               {% endif %}
           changed_when: false
+
+        # SNAT tenant-bound traffic to the loopback/VTEP IP so the return path
+        # works without leaking the worker-3 subnet into the tenant VRF: the VM
+        # sees the VTEP IP as source and replies to it, and router-0 advertises
+        # only that /32 into EVPN. The destination is the whole tempest
+        # project_network_cidr (default 10.100.0.0/16), not a single subnet,
+        # because tempest carves /28 subnets sequentially out of it.
+        # -C || -A keeps the rule idempotent across playbook re-runs.
+        - name: SNAT tenant-bound traffic to the EVPN VTEP IP
+          when:
+            - _ip_version == 4
+            - router_evpn_vtep | default(false)
+          become: true
+          vars:
+            _vni: "{{ router_evpn_l3vni | default(1) }}"
+            _tenant_cidr: "{{ router_tenant_cidr | default('10.100.0.0/16') }}"
+          ansible.builtin.shell:
+            cmd: >
+              iptables -t nat -C POSTROUTING -d {{ _tenant_cidr }}
+              -o br-l3vni{{ _vni }} -j SNAT --to-source {{ router_loopback_ip }}
+              || iptables -t nat -A POSTROUTING -d {{ _tenant_cidr }}
+              -o br-l3vni{{ _vni }} -j SNAT --to-source {{ router_loopback_ip }}
+          changed_when: true
 
     - name: Add route to RH intranet from router via HV when IPv6
       when: _ip_version == 6

--- a/playbooks/bgp/templates/router-frr.conf.j2
+++ b/playbooks/bgp/templates/router-frr.conf.j2
@@ -13,6 +13,12 @@ debug bgp neighbor-events
 debug bgp updates
 debug bgp update-groups
 
+{% if router_evpn_vtep | default(false) %}
+vrf vrf-l3vni{{ router_evpn_l3vni | default(1) }}
+  vni {{ router_evpn_l3vni | default(1) }}
+exit-vrf
+
+{% endif %}
 router bgp {{ router_asn | default(65000) }}
 {% if _router_id %}
   bgp router-id {{_router_id}}
@@ -39,6 +45,9 @@ router bgp {{ router_asn | default(65000) }}
     neighbor downlink default-originate
     neighbor downlink prefix-list only-host-prefixes in
     neighbor uplink prefix-list only-default-host-prefixes in
+{% if router_evpn_vtep | default(false) %}
+    import vrf vrf-l3vni{{ router_evpn_l3vni | default(1) }}
+{% endif %}
   exit-address-family
 
   address-family ipv6 unicast
@@ -57,6 +66,30 @@ router bgp {{ router_asn | default(65000) }}
     advertise-all-vni
   exit-address-family
 
+{% if router_evpn_vtep | default(false) %}
+{# Second BGP instance for the L3VNI VRF: imports the VTEP IP from the default
+   VRF and advertises it (only) into EVPN so SNAT'd return traffic can come
+   back. route-target must match the EDPM/OVN side (<edpm_asn>:<l3vni>). #}
+router bgp {{ router_asn | default(65000) }} vrf vrf-l3vni{{ router_evpn_l3vni | default(1) }}
+  bgp router-id {{ router_loopback_ip }}
+
+  address-family ipv4 unicast
+    import vrf route-map RM-ADV-VTEP-ONLY
+    import vrf default
+  exit-address-family
+
+  address-family l2vpn evpn
+    advertise ipv4 unicast route-map RM-ADV-VTEP-ONLY
+    route-target import {{ router_evpn_edpm_asn | default(65000) }}:{{ router_evpn_l3vni | default(1) }}
+    route-target export {{ router_evpn_edpm_asn | default(65000) }}:{{ router_evpn_l3vni | default(1) }}
+  exit-address-family
+
+ip prefix-list PL-VTEP-IP seq 5 permit {{ router_loopback_ip }}/32
+
+route-map RM-ADV-VTEP-ONLY permit 10
+  match ip address prefix-list PL-VTEP-IP
+
+{% endif %}
 ip prefix-list only-default-host-prefixes permit 0.0.0.0/0
 ip prefix-list only-default-host-prefixes permit 0.0.0.0/0 ge 32
 ip prefix-list only-host-prefixes permit 0.0.0.0/0 ge 32


### PR DESCRIPTION
The BGP-EVPN dataplane test needs the DC router (router-0) to reach tenant VM IPs advertised via BGP-EVPN Type-5 routes. Until now the router only ran `advertise-all-vni`, so the Type-5 routes propagated through the fabric but router-0 was not a VTEP and could not decapsulate or forward tenant traffic, leaving the private IPs unreachable.

Make router-0 a real EVPN VTEP, gated behind `router_evpn_vtep` (default `false`, so existing plain-BGP and non-EVPN jobs are unchanged):

- `router-frr.conf.j2`: add the L3VNI VRF (`vrf vrf-l3vniN`/`vni N`), `import vrf` into the default instance so ingress traffic on the default VRF can resolve tenant routes, and a second `router bgp <asn> vrf vrf-l3vniN` instance that imports the VTEP IP from the default VRF and advertises only the VTEP `/32` into EVPN. The VTEP address is router-0's loopback IP (`router_loopback_ip`), which is already assigned to `lo`, so there is no separate VTEP-IP knob to configure. The `route-target` matches the EDPM/OVN side (`<edpm_asn>:<vni>`).
- `prepare-bgp-spines-leaves.yaml`: create the VTEP netdevs (`vrf-l3vniN` -> `br-l3vniN` -> `vx-0-N`) before FRR starts so zebra can program the L3VNI. The VXLAN `dstport` is `4789` to match the OVN dataplane on EDPM nodes; the kernel FRR default port is advertisement-only and silently blackholes decapsulated packets.
- Add an idempotent SNAT rule that rewrites tenant-bound traffic to the VTEP IP (router-0's loopback), so the VM replies to an address router-0 advertises into EVPN and no worker subnet needs to be leaked into the tenant VRF. The destination is the whole tempest `project_network_cidr` (`router_tenant_cidr`, default `10.100.0.0/16`) because tempest carves `/28` subnets sequentially out of it -- a single `/24` route flakes once the allocator advances past `10.100.0.255`.

The worker-3 node route and the `bgpnet-worker-3` NAD route (`10.100.0.0/16 -> 100.64.10.1`) live in the `architecture` repo and are handled by a separate change.

Related-ticket: [OSPRH-34785](https://redhat.atlassian.net/browse/OSPRH-34785)
