### PR TITLE
[update] Fix floating IP leak in DPDK workload cleanup

### DIFF
--- a/roles/update/templates/workload_launch.sh.j2
+++ b/roles/update/templates/workload_launch.sh.j2
@@ -219,6 +219,15 @@ function sanity_teardown {
         echo "Deleting DPDK port ${DPDK_PORT}"
         openstack port delete "${DPDK_PORT}" || echo "Warning: Failed to delete DPDK port ${DPDK_PORT}"
     fi
+    if [ -n "${INSTANCE_FIP}" ]; then
+        echo "Remove ${INSTANCE_FIP} from ${INSTANCE_NAME}"
+        openstack server remove floating ip ${INSTANCE_NAME} ${INSTANCE_FIP} || echo "Warning: Failed to remove floating IP from instance"
+        if [ -f "${INSTANCE_FILE}" ] && grep -q "${INSTANCE_FIP}" "${INSTANCE_FILE}"; then
+            rm "${INSTANCE_FILE}"
+        fi
+        echo "Delete floating ip ${INSTANCE_FIP}"
+        openstack floating ip delete ${INSTANCE_FIP} || echo "Warning: Failed to delete floating IP ${INSTANCE_FIP}"
+    fi
     {% else -%}
     if [ "${IS_IPV6}" = "True" ]; then
         # For IPv6, clean up the dedicated port


### PR DESCRIPTION
When `workload_dpdk` is true, the `sanity_teardown` function only deletes the DPDK port but does not clean up the floating IP created by `set_vm_ip`. The VM is deleted (which disassociates the FIP) but the floating IP remains allocated, leaking one IP per update run.

Over multiple runs this exhausts the access network's IP pool, causing subsequent tempest tests to fail with
`IpAddressGenerationFailure: No more IP addresses available`.

Add floating IP cleanup to the DPDK branch of `sanity_teardown`, matching the existing cleanup logic in the default (non-SRIOV, non-DPDK) branch.