### PR TITLE
[multiple] Fix Ceph v20 client.openstack auth for HCI scenarios

### DIFF
--- a/hooks/playbooks/ceph.yml
+++ b/hooks/playbooks/ceph.yml
@@ -372,9 +372,19 @@
         all_addresses: ansible_all_ipv6_addresses
         cidr: 64
 
+    - name: Select cephx cipher default for Ceph release
+      ansible.builtin.set_fact:
+        _cifmw_ceph_key_cipher_default: >-
+          {{
+            'aes256k' if (
+              cifmw_cephadm_version | default('') == 'tentacle'
+              or (cifmw_cephadm_container_tag | default('v18') is match('^v(20|[2-9][0-9])'))
+            ) else 'aes'
+          }}
+
     - name: Generate a cephx key
       cephx_key:
-        cipher: "{{ cifmw_ceph_key_cipher | default('aes') }}"
+        cipher: "{{ cifmw_ceph_key_cipher | default(_cifmw_ceph_key_cipher_default) }}"
       register: cephx
       no_log: "{{ cifmw_nolog | default(true) | bool }}"
 
@@ -386,11 +396,36 @@
             mode: '0600'
             caps:
               mgr: allow *
-              mon: profile rbd
-              osd: "{{ pools | map('regex_replace', '^(.*)$',
-                                   'profile rbd pool=\\1') | join(', ') }}"
+              mon: allow r, profile rbd
+              osd: "{{ _cifmw_cephadm_osd_caps }}"
       vars:
-        pools: "{{ cifmw_cephadm_pools | map(attribute='name') | list }}"
+        _cifmw_cephadm_rbd_pools: >-
+          {{
+            cifmw_cephadm_pools
+            | selectattr('application', 'equalto', 'rbd')
+            | map(attribute='name')
+            | list
+          }}
+        _cifmw_cephadm_cephfs_pools: >-
+          {{
+            cifmw_cephadm_pools
+            | selectattr('application', 'equalto', 'cephfs')
+            | map(attribute='name')
+            | list
+          }}
+        _cifmw_cephadm_osd_caps: >-
+          {{
+            (
+              _cifmw_cephadm_rbd_pools
+              | map('regex_replace', '^(.*)$', 'profile rbd pool=\\1')
+              | list
+              + (
+                _cifmw_cephadm_cephfs_pools
+                | map('regex_replace', '^(.*)$', 'allow rw pool=\\1')
+                | list
+              )
+            ) | join(', ')
+          }}
       no_log: "{{ cifmw_nolog | default(true) | bool }}"
 
     # for deploying external ceph for 17.1 using cifmw, we need this playbook to create keyring

--- a/roles/cifmw_cephadm/README.md
+++ b/roles/cifmw_cephadm/README.md
@@ -137,6 +137,16 @@ that they do not need to be changed for a typical EDPM deployment.
    Example values are `"aes,aes256k"` or `"aes256k"` or `"aes"`.
    Defaults to `""` (unset, no command is run).
 
+* `cifmw_cephadm_auth_preferred_cipher`: (String) When set, runs
+  `ceph mon set auth_preferred_cipher <value>` during cluster configuration.
+   Use `aes256k` for Ceph Tentacle (v20+) greenfield deployments.
+   Defaults to `""` (unset, no command is run).
+
+* `cifmw_ceph_key_cipher`: (String) Cipher passed to the `cephx_key` module
+  when generating `client.openstack`. Use `aes256k` for Ceph v20/Tentacle.
+  The `ceph.yml` hook defaults to `aes256k` when `cifmw_cephadm_version` is
+  `tentacle` or `cifmw_cephadm_container_tag` matches `v20+`.
+
 Use the `cifmw_cephadm_pools` list of dictionaries to define pools for
 Nova (vms), Cinder (volumes), Cinder-backups (backups), and Glance (images).
 ```
@@ -169,7 +179,7 @@ cifmw_cephadm_keys:
     mode: '0600'
     caps:
       mgr: allow *
-      mon: profile rbd
+      mon: allow r, profile rbd
       osd: profile rbd pool=vms, profile rbd pool=volumes, profile rbd pool=backups, profile rbd pool=images
 ```
 

--- a/roles/cifmw_cephadm/defaults/main.yml
+++ b/roles/cifmw_cephadm/defaults/main.yml
@@ -54,6 +54,7 @@ cifmw_cephadm_certs: /etc/pki/tls
 cifmw_cephadm_debug: false
 cifmw_cephadm_min_compat_client: "mimic"
 cifmw_cephadm_auth_allowed_ciphers: ""
+cifmw_cephadm_auth_preferred_cipher: ""
 cifmw_cephadm_deployed_ceph: false
 cifmw_cephadm_backend: ''
 cifmw_cephadm_action: disable

--- a/roles/cifmw_cephadm/tasks/cephadm_config_set.yml
+++ b/roles/cifmw_cephadm/tasks/cephadm_config_set.yml
@@ -62,6 +62,16 @@
     {{ cifmw_cephadm_auth_allowed_ciphers }}
   changed_when: false
 
+- name: Set Ceph auth_preferred_cipher
+  become: true
+  when:
+    - cifmw_cephadm_auth_preferred_cipher is defined
+    - cifmw_cephadm_auth_preferred_cipher | length > 0
+  ansible.builtin.command: |
+    {{ cifmw_cephadm_ceph_cli }} mon set auth_preferred_cipher \
+    {{ cifmw_cephadm_auth_preferred_cipher }}
+  changed_when: false
+
 - name: Set container image base in ceph configuration
   become: true
   when:

--- a/scenarios/centos-9/hci_ceph_backends.yml
+++ b/scenarios/centos-9/hci_ceph_backends.yml
@@ -11,6 +11,10 @@ cifmw_cephadm_version: "tentacle"
 cifmw_cephadm_prepare_host: true
 # Apply the new spec version for RGW/TLS
 cifmw_rgw_ssl_backward_compatibility: false
+# Ceph Tentacle (v20) requires aes256k client keys; see Ceph auth config ref.
+cifmw_ceph_key_cipher: aes256k
+cifmw_cephadm_auth_allowed_ciphers: "aes,aes256k"
+cifmw_cephadm_auth_preferred_cipher: aes256k
 
 cifmw_install_yamls_vars:
   BMO_SETUP: false


### PR DESCRIPTION
## Summary

Fixes Glance and Manila RADOS permission denied failures on HCI Ceph backend deployments running Ceph Tentacle (v20).

- **`hooks/playbooks/ceph.yml`**: Default `client.openstack` key generation to `aes256k` on Tentacle/v20+ clusters; fix cephx caps (`mon: allow r, profile rbd`, separate RBD vs CephFS pool caps).
- **`roles/cifmw_cephadm`**: Add `cifmw_cephadm_auth_preferred_cipher` to run `ceph mon set auth_preferred_cipher` during cluster bootstrap.
- **`scenarios/centos-9/hci_ceph_backends.yml`**: Enable `aes256k` cipher settings for the Tentacle scenario.

## Problem

In recent HCI Ceph backend CI runs, hook 82 (`control_plane_kustomize_deploy`) timed out waiting for `OpenStackControlPlane` ready. Must-gather showed Glance and Manila failing with `rados.PermissionDeniedError`. Hook 80 completed successfully but imported a `client.openstack` key using legacy `aes` cipher (insecure on Ceph v20) and caps missing `mon: allow r` and proper CephFS pool permissions.

## Test plan

- [ ] Re-run `s2i-openstack-deploy-validation` or `podified-multinode-edpm-deployment-crc-test-operator` on HCI Ceph backends scenario
- [ ] Verify hook 80 imports `client.openstack` with `aes256k` key (60-char base64)
- [ ] Verify Glance and Manila pods connect to Ceph without permission denied errors
- [ ] Verify `OpenStackControlPlane` reaches Ready within timeout

Assisted-By: Claude

Made with [Cursor](https://cursor.com)