### PR TITLE
[cifmw_cephadm] Allow legacy CephX while daemons use aes256k

### DIFF
--- a/hooks/playbooks/ceph.yml
+++ b/hooks/playbooks/ceph.yml
@@ -372,6 +372,10 @@
         all_addresses: ansible_all_ipv6_addresses
         cidr: 64
 
+    # OpenStack service images still ship librados that only understands
+    # CephX type aes. CVE-2025-30156: keep daemons on aes256k via
+    # auth_allowed_ciphers, but mint client.openstack as aes until those
+    # images are upgraded. Do not set auth_preferred_cipher.
     - name: Generate a cephx key
       cephx_key:
         cipher: "{{ cifmw_ceph_key_cipher | default('aes') }}"
@@ -386,11 +390,36 @@
             mode: '0600'
             caps:
               mgr: allow *
-              mon: profile rbd
-              osd: "{{ pools | map('regex_replace', '^(.*)$',
-                                   'profile rbd pool=\\1') | join(', ') }}"
+              mon: allow r, profile rbd
+              osd: "{{ _cifmw_cephadm_osd_caps }}"
       vars:
-        pools: "{{ cifmw_cephadm_pools | map(attribute='name') | list }}"
+        _cifmw_cephadm_rbd_pools: >-
+          {{
+            cifmw_cephadm_pools
+            | selectattr('application', 'equalto', 'rbd')
+            | map(attribute='name')
+            | list
+          }}
+        _cifmw_cephadm_cephfs_pools: >-
+          {{
+            cifmw_cephadm_pools
+            | selectattr('application', 'equalto', 'cephfs')
+            | map(attribute='name')
+            | list
+          }}
+        _cifmw_cephadm_osd_caps: >-
+          {{
+            (
+              _cifmw_cephadm_rbd_pools
+              | map('regex_replace', '^(.*)$', 'profile rbd pool=\\1')
+              | list
+              + (
+                _cifmw_cephadm_cephfs_pools
+                | map('regex_replace', '^(.*)$', 'allow rw pool=\\1')
+                | list
+              )
+            ) | join(', ')
+          }}
       no_log: "{{ cifmw_nolog | default(true) | bool }}"
 
     # for deploying external ceph for 17.1 using cifmw, we need this playbook to create keyring

--- a/roles/cifmw_cephadm/README.md
+++ b/roles/cifmw_cephadm/README.md
@@ -136,6 +136,16 @@ that they do not need to be changed for a typical EDPM deployment.
   `ceph mon set auth_allowed_ciphers <value>` during cluster configuration.
    Example values are `"aes,aes256k"` or `"aes256k"` or `"aes"`.
    Defaults to `""` (unset, no command is run).
+   For Tentacle (v20) HCI with older OpenStack librados, set
+   `"aes,aes256k"` so daemons can use `aes256k` while `client.openstack`
+   keys of type `aes` still authenticate (CVE-2025-30156). Do not set
+   `auth_preferred_cipher` until Glance/Cinder/Manila images understand
+   `aes256k`.
+
+* `cifmw_ceph_key_cipher`: (String) Cipher passed to the `cephx_key` module
+  when generating `client.openstack`. Defaults to `aes`. Keep `aes` for
+  OpenStack clients until service images ship librados that understands
+  `aes256k`.
 
 Use the `cifmw_cephadm_pools` list of dictionaries to define pools for
 Nova (vms), Cinder (volumes), Cinder-backups (backups), and Glance (images).
@@ -169,7 +179,7 @@ cifmw_cephadm_keys:
     mode: '0600'
     caps:
       mgr: allow *
-      mon: profile rbd
+      mon: allow r, profile rbd
       osd: profile rbd pool=vms, profile rbd pool=volumes, profile rbd pool=backups, profile rbd pool=images
 ```
 

--- a/scenarios/centos-9/hci_ceph_backends.yml
+++ b/scenarios/centos-9/hci_ceph_backends.yml
@@ -11,6 +11,12 @@ cifmw_cephadm_version: "tentacle"
 cifmw_cephadm_prepare_host: true
 # Apply the new spec version for RGW/TLS
 cifmw_rgw_ssl_backward_compatibility: false
+# CVE-2025-30156: Tentacle daemons may use aes256k, but Antelope
+# Glance/Cinder/Manila librados only understands aes. Allow both
+# types and mint client.openstack as aes. Do not set
+# auth_preferred_cipher until those service images are upgraded.
+cifmw_ceph_key_cipher: aes
+cifmw_cephadm_auth_allowed_ciphers: "aes,aes256k"
 
 cifmw_install_yamls_vars:
   BMO_SETUP: false


### PR DESCRIPTION
Ceph 20.2.4 (CVE-2025-30156) can fail the CephX handshake for OpenStack Glance, Cinder, and Manila. Those Antelope service images still ship librados that only understands key type `aes`, while Tentacle daemons may use `aes256k`.

This is a fresh cephadm cluster every CI run, so the CVE upgrade path is:

1. Keep `auth_allowed_ciphers=aes,aes256k` so daemons can use the new type and legacy `aes` clients can still authenticate.
2. Do **not** set `auth_preferred_cipher`. New keys would otherwise default to `aes256k` before OpenStack images understand that type.
3. Mint `client.openstack` as type `aes` until Glance/Cinder/Manila images ship librados that understands `aes256k`.
4. Keep the RBD vs CephFS cap split (`profile rbd` on RBD pools, `allow rw` on CephFS pools, plus `mon: allow r`). That is a separate Manila/RBD fix, not the errno 5 connect path.

HCI scenario `hci_ceph_backends.yml` sets the allow-list and `cifmw_ceph_key_cipher: aes`. The `cifmw_cephadm` role does not set `auth_preferred_cipher`.