### PR TITLE
[edpm_prepare] Apply set_containers overrides from job vars

### DIFF
--- a/plugins/modules/set_containers.py
+++ b/plugins/modules/set_containers.py
@@ -56,6 +56,16 @@ options:
     - When C(true) and C(state=present), run C(oc apply -f dest_path).
     type: bool
     default: false
+  preserve_unlisted:
+    description:
+    - When C(true), read the current OpenStackVersion CR from the cluster
+      and keep C(spec.customContainerImages) entries that are not overridden
+      before writing/applying the manifest.
+    - Requires C(kubeconfig) when the cluster lookup is needed.
+    - A missing OpenStackVersion is treated as an empty map. Any other
+      C(oc get) failure is an error.
+    type: bool
+    default: false
   namespace:
     description:
     - Kubernetes namespace for the OpenStackVersion CR.
@@ -250,6 +260,7 @@ changed:
     returned: always
 """
 
+import json
 import os
 
 from ansible.module_utils.basic import AnsibleModule
@@ -484,6 +495,55 @@ def _run_oc(module, args, kubeconfig):
     return rc, out, err
 
 
+def _fetch_existing_custom_container_images(module, params, kubeconfig):
+    rc, out, err = _run_oc(
+        module,
+        [
+            "get",
+            "openstackversion",
+            params["metadata_name"],
+            "-n",
+            params["namespace"],
+            "-o",
+            "json",
+        ],
+        kubeconfig,
+    )
+    if rc != 0:
+        err_text = err or ""
+        if "NotFound" in err_text:
+            return {}
+        module.fail_json(
+            msg="oc get openstackversion failed",
+            rc=rc,
+            stdout=out,
+            stderr=err,
+        )
+    if not out.strip():
+        module.fail_json(
+            msg="oc get openstackversion returned empty output",
+            rc=rc,
+            stdout=out,
+            stderr=err,
+        )
+    try:
+        obj = json.loads(out)
+    except ValueError as exc:
+        module.fail_json(
+            msg=("Could not decode OpenStackVersion JSON from cluster: {}").format(exc)
+        )
+    if not isinstance(obj, dict):
+        module.fail_json(msg="OpenStackVersion from cluster is not a mapping")
+    images = (obj.get("spec") or {}).get("customContainerImages")
+    if not images:
+        return {}
+    if not isinstance(images, dict):
+        module.fail_json(
+            msg="Existing customContainerImages from cluster is not a mapping"
+        )
+    return images
+
+
 _IMAGE_ELEMENT_SPEC = dict(
     name=dict(type="str", required=True),
     full_registry=dict(type="str"),
@@ -501,6 +561,7 @@ def run_module():
     module_args = dict(
         state=dict(type="str", choices=["present", "absent"], default="present"),
         apply=dict(type="bool", default=False),
+        preserve_unlisted=dict(type="bool", default=False),
         namespace=dict(type="str", default="openstack"),
         metadata_name=dict(type="str", default="controlplane"),
         dest_path=dict(type="path", required=True),
@@ -591,6 +652,15 @@ def run_module():
             )
 
     cr = _build_cr(module.params, module)
+    if module.params["preserve_unlisted"]:
+        if not kubeconfig:
+            module.fail_json(msg="kubeconfig is required when preserve_unlisted=true")
+        existing_images = _fetch_existing_custom_container_images(
+            module, module.params, kubeconfig
+        )
+        merged_images = existing_images.copy()
+        merged_images.update(cr["spec"]["customContainerImages"])
+        cr["spec"]["customContainerImages"] = merged_images
     cr_yaml = yaml.dump(cr, default_flow_style=False, sort_keys=False)
 
     existing = None

--- a/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
+++ b/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
@@ -47,6 +47,26 @@
   ansible.builtin.include_role:
     name: update_containers
 
+- name: Apply custom OpenStackVersion container overrides
+  when:
+    - cifmw_prepare_openstackversion | bool
+    - cifmw_set_containers_images is defined
+    - cifmw_set_containers_images | length > 0
+  cifmw.general.set_containers:
+    dest_path: >-
+      {{
+        cifmw_set_containers_dest_path | default(
+          (cifmw_edpm_prepare_basedir, 'artifacts', 'manifests', 'set_containers.yml') |
+          ansible.builtin.path_join
+        )
+      }}
+    metadata_name: "{{ _ctlplane_name }}"
+    namespace: "{{ cifmw_update_containers_namespace | default('openstack') }}"
+    apply: "{{ cifmw_set_containers_apply | default(true) | bool }}"
+    preserve_unlisted: "{{ cifmw_set_containers_preserve_unlisted | default(true) | bool }}"
+    kubeconfig: "{{ cifmw_openshift_kubeconfig }}"
+    images: "{{ cifmw_set_containers_images }}"
+
 - name: Controlplane name kustomization
   ansible.builtin.set_fact:
     _ctlplane_name_kustomizations:

--- a/tests/unit/modules/test_set_containers.py
+++ b/tests/unit/modules/test_set_containers.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import json
 import unittest
 from unittest.mock import MagicMock, mock_open, patch
 
@@ -28,6 +29,20 @@ REG = "quay.io"
 ORG = "openstack-k8s-operators"
 PREFIX = "openstack"
 TAG = "current-podified"
+
+
+def _osversion_json(images=None):
+    spec = {}
+    if images is not None:
+        spec["customContainerImages"] = images
+    return json.dumps(
+        {
+            "apiVersion": "core.openstack.org/v1beta1",
+            "kind": "OpenStackVersion",
+            "metadata": {"name": "controlplane", "namespace": "openstack"},
+            "spec": spec,
+        }
+    )
 
 
 class TestBuildUrl(unittest.TestCase):
@@ -334,6 +349,117 @@ class TestRunModule(ModuleBaseTestCase):
         mock_oc.assert_called_once()
         self.assertEqual(mock_oc.call_args[0][1][0], "apply")
         self.assertTrue(cm.exception.args[0]["changed"])
+
+    def test_present_preserve_unlisted_calls_oc_get_and_apply(self):
+        set_module_args(
+            self._args(
+                apply=True,
+                preserve_unlisted=True,
+                kubeconfig="/home/zuul/.kube/config",
+                images=[
+                    dict(
+                        name="glanceAPIImage",
+                        full_registry="registry.example:5000/ns/glance:tag",
+                    )
+                ],
+            )
+        )
+        mopen = mock_open()
+        with patch(_MOD + ".os.path.exists", return_value=False), patch(
+            _MOD + ".os.makedirs"
+        ), patch("builtins.open", mopen), patch(
+            _MOD + "._run_oc",
+            side_effect=[
+                (0, _osversion_json({"keystoneAPIImage": "keep-me"}), ""),
+                (0, "", ""),
+            ],
+        ) as mock_oc:
+            with self.assertRaises(AnsibleExitJson) as cm:
+                set_containers.run_module()
+        self.assertEqual(mock_oc.call_count, 2)
+        get_args = mock_oc.call_args_list[0][0][1]
+        self.assertEqual(get_args[0], "get")
+        self.assertEqual(get_args[-2:], ["-o", "json"])
+        self.assertEqual(mock_oc.call_args_list[1][0][1][0], "apply")
+        self.assertTrue(cm.exception.args[0]["changed"])
+        written = yaml.safe_load(mopen.return_value.write.call_args[0][0])
+        images = written["spec"]["customContainerImages"]
+        self.assertEqual(images["keystoneAPIImage"], "keep-me")
+        self.assertEqual(
+            images["glanceAPIImage"], "registry.example:5000/ns/glance:tag"
+        )
+
+    def test_present_preserve_unlisted_not_found_applies_overrides_only(self):
+        set_module_args(
+            self._args(
+                apply=True,
+                preserve_unlisted=True,
+                kubeconfig="/home/zuul/.kube/config",
+                images=[
+                    dict(
+                        name="glanceAPIImage",
+                        full_registry="registry.example:5000/ns/glance:tag",
+                    )
+                ],
+            )
+        )
+        mopen = mock_open()
+        not_found = (
+            "Error from server (NotFound): openstackversions.core.openstack.org"
+            ' "controlplane" not found'
+        )
+        with patch(_MOD + ".os.path.exists", return_value=False), patch(
+            _MOD + ".os.makedirs"
+        ), patch("builtins.open", mopen), patch(
+            _MOD + "._run_oc",
+            side_effect=[(1, "", not_found), (0, "", "")],
+        ):
+            with self.assertRaises(AnsibleExitJson) as cm:
+                set_containers.run_module()
+        self.assertTrue(cm.exception.args[0]["changed"])
+        written = yaml.safe_load(mopen.return_value.write.call_args[0][0])
+        images = written["spec"]["customContainerImages"]
+        self.assertEqual(
+            images, {"glanceAPIImage": "registry.example:5000/ns/glance:tag"}
+        )
+
+    def test_present_preserve_unlisted_oc_get_failure_fails(self):
+        set_module_args(
+            self._args(
+                preserve_unlisted=True,
+                kubeconfig="/home/zuul/.kube/config",
+                images=[
+                    dict(
+                        name="glanceAPIImage",
+                        full_registry="registry.example:5000/ns/glance:tag",
+                    )
+                ],
+            )
+        )
+        with patch(_MOD + ".os.path.exists", return_value=False), patch(
+            _MOD + "._run_oc",
+            return_value=(1, "", "Error from server (Forbidden): access denied"),
+        ):
+            with self.assertRaises(AnsibleFailJson) as cm:
+                set_containers.run_module()
+        self.assertIn("oc get openstackversion failed", cm.exception.args[0]["msg"])
+
+    def test_present_preserve_unlisted_requires_kubeconfig(self):
+        set_module_args(
+            self._args(
+                preserve_unlisted=True,
+                images=[
+                    dict(
+                        name="glanceAPIImage",
+                        full_registry="registry.example:5000/ns/glance:tag",
+                    )
+                ],
+            )
+        )
+        with patch(_MOD + ".os.path.exists", return_value=False):
+            with self.assertRaises(AnsibleFailJson) as cm:
+                set_containers.run_module()
+        self.assertIn("kubeconfig is required", cm.exception.args[0]["msg"])
 
     def test_present_apply_oc_failure_fails(self):
         set_module_args(self._args(apply=True))


### PR DESCRIPTION
## Summary

- Add one small task to `edpm_prepare` that calls `cifmw.general.set_containers` when jobs provide `cifmw_set_containers_images`.
- Leave the legacy `update_containers` role untouched.
- Add `preserve_unlisted` to `set_containers` so partial override lists keep unspecified images from the current OpenStackVersion CR before apply.

## Design

### Problem

Consumer jobs (for example the s2i content provider) return a *partial*
`customContainerImages` map: only the services that were built, not the full
OpenStack image set. Those overrides must be applied during `edpm_prepare`,
before `OpenStackControlPlane` is deployed. Applying them later (for example
via a `pre_tests` hook) is too late — the control plane and dataplane may
already be running with operator-default images.

### Approach

- Jobs pass `cifmw_set_containers_images` as a list of `{name, full_registry}` entries.
- `edpm_prepare` runs one generic `set_containers` task when that list is non-empty.
- `preserve_unlisted` reads the current OpenStackVersion CR, keeps entries not
  present in the override list, overlays the new entries, writes the manifest,
  and applies it via the module's existing `oc apply -f` path.
- No s2i-specific logic lives in ci-framework; job YAML owns the translation
  from provider output to `cifmw_set_containers_images`.

### Out of scope (follow-up)

- Migrating the legacy `update_containers` role to `set_containers` for all
  EDPM and DLRN flows. The architecture deploy path already uses
  `set_containers`; this change adds a narrow override hook for EDPM jobs that
  supply explicit image lists.
- Replacing `update_containers` wholesale in this PR would duplicate the large
  parameter surface already present in `deploy_architecture.yml` and expand
  review scope beyond what consumer jobs need today.

### Alternatives considered

- **`pre_tests` hook + `oc patch`:** wrong point in the deploy timeline.
- **Inlining a full `set_containers` call in `edpm_prepare`:** rejected; job
  vars plus a thin task keeps the framework generic.
- **Migrating `update_containers` to `set_containers` in this PR:** larger
  change, separate from the partial-override use case.
- **Applying partial manifests without `preserve_unlisted`:** would replace the
  entire `customContainerImages` map and drop unspecified services.

## Test plan

- [ ] `make ansible_test` (set_containers unit tests)
- [ ] Cross-repo Zuul check with `Depends-On` from s2i-openstack-containers PR #91


Depends-on: https://github.com/openstack-k8s-operators/ci-framework/pull/4136