### PR TITLE
Switch to OCP 4.22 for periodic-whitebox-neutron-tempest-plugin CI jo…

### DIFF
--- a/zuul.d/whitebox_neutron_tempest_jobs.yaml
+++ b/zuul.d/whitebox_neutron_tempest_jobs.yaml
@@ -5,7 +5,7 @@
 - job:
     name: whitebox-neutron-tempest-plugin-podified-multinode-edpm-deployment-crc-2comp
     parent: podified-multinode-edpm-deployment-crc-2comp
-    nodeset: centos-9-2x-centos-9-xxl-crc-cloud-ocp-4-20-1-3xl
+    nodeset: centos-9-2x-centos-9-xxl-crc-cloud-ocp-4-22-1-3xl
     timeout: 18000
     override-checkout: main
     description: |
@@ -169,6 +169,7 @@
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_internal_dns.InternalDNSTestOvn
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_multicast.MulticastTestIPv4Common.test_flooding_when_special_groups
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_multicast.MulticastTestIPv4Common.test_igmp_snooping_same_network_and_unsubscribe
+              ^whitebox_neutron_tempest_plugin.tests.scenario.test_multicast.MulticastTestIPv4Common.test_igmp_snooping_after_openvswitch_restart
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_multicast.MulticastTestIPv4Ovn
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_multicast.MulticastTestVlanTransparency
               ^whitebox_neutron_tempest_plugin.tests.scenario.test_portsecurity.PortSecurityTest


### PR DESCRIPTION
…b- #3881

This PR switched the whitebox-neutron-tempest-plugin-podified-multinode-edpm-deployment job to OCP- 4.22

Excluded whitebox_neutron_tempest_plugin.tests.scenario.test_multicast.MulticastTestIPv4Common.test_igmp_snooping_after_openvswitch_restart test it's failing consistently.

Jobs:
whitebox-neutron-tempest-plugin-podified-multinode-edpm-deployment-crc-2comp

Signed-off-by: Bhagyashri Shewale bshewale@redhat.com