### PR TITLE
Switch adoption base job to use OCP 4.22

### DIFF
--- a/zuul.d/adoption.yaml
+++ b/zuul.d/adoption.yaml
@@ -7,7 +7,7 @@
     abstract: true
     timeout: 14400
     attempts: 1
-    nodeset: centos-9-rhel-9-2-crc-cloud-ocp-4-20-1-3xl
+    nodeset: centos-9-rhel-9-2-crc-cloud-ocp-4-22-1-3xl
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run:
@@ -202,7 +202,7 @@
     abstract: true
     timeout: 14400
     attempts: 1
-    nodeset: centos-9-multinode-rhel-9-2-crc-cloud-ocp-4-20-1-3xl
+    nodeset: centos-9-multinode-rhel-9-2-crc-cloud-ocp-4-22-1-3xl
     roles: &multinode-roles
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run: &multinode-prerun
@@ -413,7 +413,7 @@
     voting: false
     timeout: 14400
     attempts: 1
-    nodeset: centos-9-multinode-rhel-9-2-crc-cloud-ocp-4-20-1-3xl-novacells
+    nodeset: centos-9-multinode-rhel-9-2-crc-cloud-ocp-4-22-1-3xl-novacells
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     pre-run: *multinode-prerun


### PR DESCRIPTION
This PR switched the adoption base github-check jobs to OCP- 4.22

Jobs:
adoption base jobs

Signed-off-by: Bhagyashri Shewale bshewale@redhat.com