### PR TITLE
[edpm_deploy_baremetal] Wait for ProvisionServer localImageUrl

### DIFF
--- a/roles/edpm_deploy_baremetal/tasks/main.yml
+++ b/roles/edpm_deploy_baremetal/tasks/main.yml
@@ -266,12 +266,42 @@
             name: openstack-edpm-ipam-provisionserver
             namespace: "{{ cifmw_install_yamls_defaults['NAMESPACE'] }}"
           register: cifmw_edpm_deploy_baremetal_provisionserver
-          failed_when: cifmw_edpm_deploy_baremetal_provisionserver.resources | length == 0
+          until: >-
+            cifmw_edpm_deploy_baremetal_provisionserver.resources | length > 0
+            and (
+              cifmw_edpm_deploy_baremetal_provisionserver.resources[0].status.get('localImageUrl', '')
+              | trim | length
+            ) > 0
+          retries: "{{ cifmw_edpm_deploy_baremetal_wait_provisionserver_retries }}"
+          delay: 10
           changed_when: false
+
+        - name: Set OpenStack Provision Server local image URL facts
+          ansible.builtin.set_fact:
+            cifmw_edpm_deploy_baremetal_provisionserver_local_image_url: >-
+              {{
+                cifmw_edpm_deploy_baremetal_provisionserver.resources[0].status.get('localImageUrl', '')
+              }}
+            cifmw_edpm_deploy_baremetal_provisionserver_local_image_checksum_url_effective: >-
+              {{
+                (
+                  cifmw_edpm_deploy_baremetal_provisionserver.resources[0].status.get('localImageChecksumUrl', '')
+                  | trim
+                )
+                if (
+                  cifmw_edpm_deploy_baremetal_provisionserver.resources[0].status.get('localImageChecksumUrl', '')
+                  | trim | length
+                ) > 0
+                else
+                (
+                  cifmw_edpm_deploy_baremetal_provisionserver.resources[0].status.get('localImageUrl', '')
+                  | trim
+                ) ~ '.sha256'
+              }}
 
         - name: Verify OpenStack Provision Server image is reachable
           ansible.builtin.uri:
-            url: "{{ cifmw_edpm_deploy_baremetal_provisionserver.resources[0].status.localImageUrl }}"
+            url: "{{ cifmw_edpm_deploy_baremetal_provisionserver_local_image_url }}"
             method: HEAD
             status_code: 200
           register: cifmw_edpm_deploy_baremetal_provisionserver_image_head


### PR DESCRIPTION
## Summary

- Retry fetching `OpenStackProvisionServer` until `status.localImageUrl` is set.
- Use safe `.get()` access when deriving the checksum URL fallback.
- Store the image URL in a fact for the subsequent HTTP probes.

## Problem

`cifmw-crc-podified-edpm-baremetal-bootc` failed in `edpm_deploy_baremetal`
with `'dict object' has no attribute 'localImageUrl'` even though the
Provision Server pod and deployment were ready. The operator publishes
`localImageUrl` after reconciliation, not when the Deployment becomes
Available.

## Test plan

- [ ] Re-run `cifmw-crc-podified-edpm-baremetal-bootc` on rdoproject Zuul
- [ ] `TEST_SINGLE_ROLE=edpm_deploy_baremetal make molecule` (dry-run converge)

Made with [Cursor](https://cursor.com)