### PR TITLE
[update] Allow overriding NodeSets for compute reboot

### DIFF
--- a/roles/update/tasks/reboot_hypervisor_using_cr.yml
+++ b/roles/update/tasks/reboot_hypervisor_using_cr.yml
@@ -1,5 +1,6 @@
 ---
 - name: Fetch NodeSets for the Reboot OpenStackDataPlaneDeployment
+  when: cifmw_update_node_sets is not defined
   environment:
     KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
     PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
@@ -8,8 +9,13 @@
     oc -n {{ cifmw_update_namespace }}
     get openstackdataplanenodeset -o name
     | awk -F'/' '{print $2}'
-  register: cifmw_update_node_sets
+  register: _cifmw_update_node_sets_fetch
   changed_when: false
+
+- name: Set cifmw_update_node_sets from fetch result
+  when: _cifmw_update_node_sets_fetch is not skipped
+  ansible.builtin.set_fact:
+    cifmw_update_node_sets: "{{ _cifmw_update_node_sets_fetch }}"
 
 - name: Construct the Reboot CR name
   ansible.builtin.set_fact:


### PR DESCRIPTION
Make the NodeSet fetch in reboot_hypervisor_using_cr.yml conditional on cifmw_update_node_sets being undefined. This allows callers to pre-set the variable to control which NodeSets are targeted for reboot instead of always fetching all NodeSets in the namespace.