### PR TITLE
[ci_gen_kustomize_values] Fix non-deterministic snippet combine order

### DIFF
--- a/roles/ci_gen_kustomize_values/tasks/generate_values.yml
+++ b/roles/ci_gen_kustomize_values/tasks/generate_values.yml
@@ -72,7 +72,12 @@
         default(_cifmw_gen_kustomize_values_base_cm_content, true) |
         combine(_parsed, recursive=true)
       }}
-  loop: "{{ _snippets_content.results }}"
+  # Snippet filenames use a numeric prefix (02_ci_data.yaml, 03_..., 04_...)
+  # to control override precedence, but ansible.builtin.find does not
+  # guarantee sorted results. Without an explicit sort, combine order (and
+  # therefore which snippet wins on conflicting keys) is filesystem-order
+  # dependent instead of matching the intended numeric precedence.
+  loop: "{{ _snippets_content.results | sort(attribute='source') }}"
   loop_control:
     label: "{{ item.source | basename }}"
 


### PR DESCRIPTION
## Summary

`generate_values.yml` combines per-stage YAML snippets via a loop over `ansible.builtin.find` results. Snippet filenames use a numeric prefix (`02_ci_data.yaml`, `03_user_data_b64.yaml`, `04_user_data.yaml`) to signal intended override precedence, but `find()` does not guarantee sorted results, so combine order was filesystem-order dependent instead of matching the intended numeric precedence.

## Impact observed

On RHOSO 19 RHEL 10 uni01alpha ([OSPNW-1694](https://redhat.atlassian.net/browse/OSPNW-1694)), a user-provided `edpm_fips_mode: check` override (needed because `fips-mode-setup` was removed from RHEL 10) was silently discarded in favor of the common `edpm-nodeset-values` template's `cifmw_fips_enabled`-derived default of `enabled`, causing every EDPM bootstrap job to fail with `fips-mode-setup: No such file or directory`.

**Live verification**: on the held CI node from tp !2601 build [b5e8409](https://sf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/logs/b5e/components-integration/b5e8409379b545b081d794a2f8f5710a/), the `OpenStackDataPlaneNodeSet` spec carried `edpm_fips_mode: enabled` despite the job-var override. Patching it to `check` directly on the live NodeSet and re-running the `bootstrap` service completed cleanly (all FIPS tasks correctly skipped, `failed=0`).

## Fix

Add an explicit `sort(attribute='source')` on the combine loop so snippets are always applied in filename order, matching the numeric prefix convention already in use.

Related-Issue: #[OSPNW-1694](https://redhat.atlassian.net/browse/OSPNW-1694)
Related-Issue: #[OSPNW-1715](https://redhat.atlassian.net/browse/OSPNW-1715)