### PR TITLE
[cifmw_helpers] Fix non-deterministic parameter-dir include order

### DIFF
--- a/roles/cifmw_helpers/tasks/include_dir.yml
+++ b/roles/cifmw_helpers/tasks/include_dir.yml
@@ -29,7 +29,11 @@
         included_file: "{{ _file_to_parse.path }}"
       ansible.builtin.include_tasks:
         file: include_file.yml
-      loop: "{{ _yaml_files.files }}"
+      # ansible.builtin.find does not guarantee sorted results, so without
+      # an explicit sort, include order (and therefore which file's
+      # variables win on conflicting keys) is filesystem-order dependent
+      # rather than deterministic.
+      loop: "{{ _yaml_files.files | sort(attribute='path') }}"
       loop_control:
         loop_var: _file_to_parse
       no_log: "{{ cifmw_helpers_no_log }}"


### PR DESCRIPTION
## Summary

`include_dir.yml` finds YAML files in a directory (e.g.
`artifacts/parameters`) via `ansible.builtin.find`, then loops over them
calling `include_vars`. `find()` never sorts (verified in the installed
`find.py`: `os.walk()`, no `sorted()` call), so if two files define the
same key, which wins is filesystem-order dependent.

Same defect shape as [PR #4138](https://github.com/openstack-k8s-operators/ci-framework/pull/4138)
([OSPNW-1694](https://redhat.atlassian.net/browse/OSPNW-1694)): there,
`edpm_fips_mode: check` was silently lost to a same-directory default.
That case was a live, reproduced failure. This one is preventative --
current `artifacts/parameters` writers (`openshift_login`, `cifmw_nfs`,
`install_yamls`) each use a distinct prefix, so no active collision
exists today. This closes the same latent class before a future writer
hits it. Kept as a separate PR since it's a different role/file and
#4138 has its own unresolved CI failure to isolate.

## Fix

`sort(attribute='path')` on the include loop, so order is deterministic.

## Verification

- Confirmed no `sorted()`/`.sort()` in `find.py`'s source.
- Fetched genuine pre-fix code via `git show origin/main:...` and ran it
  through real `ansible-playbook` against colliding-key fixtures --
  fix reliably makes the lexically-last file win.
- `ansible-lint` passes.
- Existing `cifmw_helpers` molecule test for `include_dir.yml` only uses
  one fixture file, so it's a no-op there (no regression, but also no
  CI coverage of the multi-file case this fixes).

Related-Issue: #[OSPNW-1694](https://redhat.atlassian.net/browse/OSPNW-1694)