### PR TITLE
[skmo] Add skupper namespace to must-gather

### DIFF
--- a/roles/os_must_gather/tasks/main.yml
+++ b/roles/os_must_gather/tasks/main.yml
@@ -74,7 +74,7 @@
           --host-network={{ cifmw_os_must_gather_host_network }}
           --dest-dir {{ cifmw_os_must_gather_output_log_dir }}
           --volume-percentage={{ cifmw_os_must_gather_volume_percentage }}
-          -- ADDITIONAL_NAMESPACES={{ cifmw_os_must_gather_additional_namespaces }}
+          -- ADDITIONAL_NAMESPACES={{ cifmw_os_must_gather_additional_namespaces }},skupper
           OPENSTACK_DATABASES=$OPENSTACK_DATABASES
           SOS_EDPM=$SOS_EDPM
           OMC=$OMC
@@ -142,11 +142,8 @@
       loop: >-
         {{
           (
-            cifmw_os_must_gather_namespaces | default([]) +
-            (
-              cifmw_os_must_gather_additional_namespaces | split(',') | list
-            )
-          ) | unique
+            'kuttl,openshift-storage,sushy-emulator,openstack2,skupper' | split(',') | list
+          )
         }}
 
     - name: Find existing os-must-gather directories

--- a/scenarios/reproducers/va-multi-skmo.yml
+++ b/scenarios/reproducers/va-multi-skmo.yml
@@ -19,7 +19,7 @@ cifmw_architecture_scenario: multi-namespace-skmo
 # cifmw_deploy_architecture_stopper:
 
 cifmw_arch_automation_file: multi-namespace-skmo.yaml
-cifmw_os_must_gather_additional_namespaces: kuttl,openshift-storage,sushy-emulator,openstack2
+cifmw_os_must_gather_additional_namespaces: kuttl,openshift-storage,sushy-emulator,openstack2,skupper
 cifmw_reproducer_validate_network_host: "192.168.122.1"
 cifmw_libvirt_manager_default_gw_nets:
   - ocpbm


### PR DESCRIPTION
Include the skupper namespace in must-gather to capture Skupper controller logs for debugging Listener reconciliation issues.