### PR TITLE
Use AES Ceph cipher for CentOS-9 HCI scenario

### DIFF
--- a/scenarios/centos-9/hci_ceph_backends.yml
+++ b/scenarios/centos-9/hci_ceph_backends.yml
@@ -11,6 +11,13 @@ cifmw_cephadm_version: "tentacle"
 cifmw_cephadm_prepare_host: true
 # Apply the new spec version for RGW/TLS
 cifmw_rgw_ssl_backward_compatibility: false
+# If your OpenStack service does not have Ceph client version
+# 20.2.4+ or 19.2.6+, then it cannot speak the AES256k cipher
+# which guards against CVE-2025-30156. These overrides result
+# in Ceph being deployed with support for the old AES cipher
+# and the ci-framework will create an AES OpenStack CephX key.
+cifmw_ceph_key_cipher: aes
+cifmw_cephadm_auth_allowed_ciphers: "aes,aes256k"
 
 cifmw_install_yamls_vars:
   BMO_SETUP: false


### PR DESCRIPTION
Update scenarios/centos-9/hci_ceph_backends.yml so that jobs which depend on that file use the Ceph old AES cipher and not the new AES256k cipher.