### PR TITLE
(multiple) Allow OCP cluster reuse when switching architectures

### DIFF
--- a/roles/devscripts/tasks/110_check_ocp.yml
+++ b/roles/devscripts/tasks/110_check_ocp.yml
@@ -89,7 +89,6 @@
   when:
     - _deployed_cluster.stat.exists | bool
     - _needed_base_imgs | bool
-    - _needed_volumes | bool
   ansible.builtin.set_fact:
     cifmw_devscripts_ocp_comply: true
 

--- a/roles/libvirt_manager/tasks/clean_layout.yml
+++ b/roles/libvirt_manager/tasks/clean_layout.yml
@@ -265,6 +265,20 @@
            default([])
         }}
 
+    - name: Find stale volume attachment XML files in ocp pool
+      register: _ocp_vol_xml_files
+      ansible.builtin.find:
+        paths: "{{ cifmw_libvirt_manager_ocp_pool_dir }}"
+        patterns: "*-vol-*.xml"
+
+    - name: Remove stale volume attachment XML files
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: absent
+      loop: "{{ _ocp_vol_xml_files.files }}"
+      loop_control:
+        label: "{{ item.path | basename }}"
+
     - name: Remove ocp_volumes storage pool
       when:
         - _is_deepscrub | bool

--- a/roles/reproducer/tasks/ocp_layout.yml
+++ b/roles/reproducer/tasks/ocp_layout.yml
@@ -148,6 +148,67 @@
     name: "devscripts"
     tasks_from: "110_check_ocp.yml"
 
+# devscripts cleanup (make clean) destroys all devscripts-managed
+# resources including the ocpbm/ocppr libvirt networks that were
+# already created by prepare_networking.yml. Recreate any that are
+# missing so that VBMC can reach ipmi.utility before devscripts
+# redeploys the OCP cluster.
+- name: Restore networks destroyed by devscripts cleanup
+  when:
+    - not cifmw_devscripts_ocp_comply | bool
+    - _cifmw_libvirt_manager_layout.networks is defined
+  vars:
+    _fixed_nets: >-
+      {{
+        ['ocpbm', 'ocppr'] +
+        (cifmw_libvirt_manager_fixed_networks | default([]))
+      }}
+  block:
+    - name: List existing libvirt networks after cleanup
+      register: _post_cleanup_nets
+      community.libvirt.virt_net:
+        command: list_nets
+        uri: "qemu:///system"
+
+    - name: Identify fixed networks needing restoration
+      ansible.builtin.set_fact:
+        _nets_to_restore: >-
+          {{
+            _cifmw_libvirt_manager_layout.networks |
+            dict2items |
+            selectattr('key', 'in', _fixed_nets) |
+            rejectattr('key', 'in', _post_cleanup_nets.list_nets) |
+            list
+          }}
+
+    - name: Define missing networks in libvirt
+      community.libvirt.virt_net:
+        command: define
+        name: "{{ item.key }}"
+        xml: "{{ item.value }}"
+        uri: "qemu:///system"
+      loop: "{{ _nets_to_restore }}"
+      loop_control:
+        label: "{{ item.key }}"
+
+    - name: Start missing networks
+      community.libvirt.virt_net:
+        command: create
+        name: "{{ item.key }}"
+        uri: "qemu:///system"
+      loop: "{{ _nets_to_restore }}"
+      loop_control:
+        label: "{{ item.key }}"
+
+    - name: Ensure restored networks are active with autostart
+      community.libvirt.virt_net:
+        autostart: true
+        name: "{{ item.key }}"
+        uri: "qemu:///system"
+      loop: "{{ _nets_to_restore }}"
+      loop_control:
+        label: "{{ item.key }}"
+
 - name: Bootstrap devscript using baremetal provisioning
   when:
     - not cifmw_devscripts_ocp_comply | bool


### PR DESCRIPTION
The devscripts compliance check in `110_check_ocp.yml` required an exact match of extra disk volume count to consider an existing OCP deployment reusable. When switching architectures after a non-deepscrub clean (e.g. va-multi with 3 extra disks to va-hci with 2), the volume count mismatch forced a full `make clean` followed by `make all`, triggering an hour-plus OCP rebuild that is unnecessary — the OCP boot disk images are architecture-agnostic and extra disks are blank storage volumes that `deploy_layout.yml` recreates with the correct count.

Remove `_needed_volumes` from the compliance condition so that the boot disk image count and cluster directory are sufficient to determine reusability. Clean up stale volume attachment XML files during non-deepscrub cleanup to prevent a decrease in `extra_disks_num` from leaving orphan XMLs that would cause `create_vms.yml` to attach the wrong number of disks. Add a safety-net block in `ocp_layout.yml` to restore libvirt networks destroyed by `make clean` for cases where a genuine full rebuild is still required (e.g. master count change).