### PR TITLE
[update] Make post-reboot sanity check timeout configurable

### DIFF
--- a/roles/update/README.md
+++ b/roles/update/README.md
@@ -20,6 +20,7 @@ Role to run update
 * `cifmw_update_reboot_test`: (Boolean) Activate the reboot test after update. Default to `False`.
 * `cifmw_update_ansible_ssh_private_key_file`: (String) Define the path to the private key file used for the compute nodes.
 * `cifmw_update_wait_retries_reboot`: (Integer) Number of retries to wait for a compute node reboot. One retry is done every five seconds. Default to 60, so five minutes.
+* `cifmw_update_wait_retries_sanity`: (Integer) Number of retries to wait for compute node services (nova-compute, ovn-controller, neutron-ovn-metadata-agent) to become active after reboot. One retry is done every five seconds. Default to 30, so two and a half minutes.
 * `cifmw_update_resources_monitoring_interval`: (Integer) Interval, in seconds, between two resources monitor during update. Default to 10 seconds.
 * `cifmw_update_wait_controplane_status_change_sec`: (Integer) Time, in seconds, to wait before checking openstack control plane deployment status. Used when need to wait to allow the control plane's ready condition to transition from its initial state, preventing premature completion while the control plane is still reconciling the operator changes. Defaults to `60`.
 * `cifmw_update_openstack_update_kpatch`: (Boolean) Activate `kpatch` during update. Default to false.

--- a/roles/update/defaults/main.yml
+++ b/roles/update/defaults/main.yml
@@ -55,6 +55,7 @@ cifmw_update_reboot_test: false
 cifmw_update_ansible_ssh_private_key_file: >-
   "{{ ansible_ssh_private_key_file | default(ansible_user_dir ~ '/.ssh/id_cifw') }}"
 cifmw_update_wait_retries_reboot: 60
+cifmw_update_wait_retries_sanity: 30
 
 cifmw_update_ping_test: false
 cifmw_update_create_volume: false

--- a/roles/update/tasks/reboot_hypervisor_sanity_checks.yml
+++ b/roles/update/tasks/reboot_hypervisor_sanity_checks.yml
@@ -16,7 +16,7 @@
     | select(.Binary | contains("nova-compute")) | .State'
   register: nova_compute_status
   until: nova_compute_status.stdout == 'up'
-  retries: 30
+  retries: "{{ cifmw_update_wait_retries_sanity }}"
   delay: 5
 
 - name: Verify ovn-controller services
@@ -31,7 +31,7 @@
     | select(.Binary | contains("ovn-controller")) | .Alive'
   register: ovn_controller_status
   until: ovn_controller_status.stdout == 'true'
-  retries: 30
+  retries: "{{ cifmw_update_wait_retries_sanity }}"
   delay: 5
 
 - name: Verify networking-ovn-metadata-agent
@@ -46,5 +46,5 @@
     | select(.Binary | contains("neutron-ovn-metadata-agent")) | .Alive'
   register: networking_ovn_metadata_status
   until: networking_ovn_metadata_status.stdout == 'true'
-  retries: 30
+  retries: "{{ cifmw_update_wait_retries_sanity }}"
   delay: 5


### PR DESCRIPTION
Make the retry count for post-reboot service sanity checks configurable via `cifmw_update_wait_retries_sanity`. This allows operators to adjust wait times for nova-compute, ovn-controller, and neutron-ovn-metadata-agent services based on their environment's performance characteristics.