### PR TITLE
Revert 1a41672 commit of pinning devscripts version

### DIFF
--- a/roles/devscripts/vars/main.yml
+++ b/roles/devscripts/vars/main.yml
@@ -29,15 +29,7 @@ cifmw_devscripts_packages:
   - buildah
 
 cifmw_devscripts_repo: "https://github.com/openshift-metal3/dev-scripts.git"
-# Note: Pinning devscripts at https://github.com/openshift-metal3/dev-scripts/commit/9116d288bb2885a29d3c9c9c4bf422305bef370d
-# (last known-good before regressions from):
-# - https://github.com/openshift-metal3/dev-scripts/pull/1922 broke local registry setup
-#   (connection refused during release mirror; OSPCIX-1469)
-# - https://github.com/openshift-metal3/dev-scripts/pull/1933 switched the default CI
-#   registry to quay-proxy.ci.openshift.org and breaks pull-secret login in our jobs
-#   (invalid username/password at build_installer; OSPCIX-1472)
-# We should unpin once upstream fixes are available and validated in RHOSO CI.
-cifmw_devscripts_repo_branch: 9116d288bb2885a29d3c9c9c4bf422305bef370d
+cifmw_devscripts_repo_branch: HEAD
 
 cifmw_devscripts_config_defaults:
   working_dir: "/home/dev-scripts"


### PR DESCRIPTION
This was made because:
1922 breaks local registry: fixed on devscripts commit 4559bc6
1933 switch ci registry and fails login: fixed on devscripts commit ff6edd3