### PR TITLE
Fix BGP setup in reproducer deployments

### DIFF
--- a/playbooks/bgp/prepare-bgp-spines-leaves.yaml
+++ b/playbooks/bgp/prepare-bgp-spines-leaves.yaml
@@ -17,7 +17,7 @@
     fabric_list: "{{ leafs_list + spines_list + routers_list }}"
   tasks:
     - name: Start spine and leaf VMs
-      delegate_to: hypervisor
+      delegate_to: "{{ hostvars['controller-0'].cifmw_hypervisor_host }}"
       become: true
       community.libvirt.virt:
         name: "cifmw-{{ item }}"
@@ -46,7 +46,7 @@
       loop: "{{ routers_list }}"
 
     - name: Check SSH connectivity
-      delegate_to: hypervisor
+      delegate_to: "{{ hostvars['controller-0'].cifmw_hypervisor_host }}"
       ansible.builtin.wait_for:
         port: 22
         host: "{{ item }}.utility"
@@ -122,6 +122,12 @@
         sysctl_file: /etc/sysctl.d/90-network.conf
         state: present
         reload: true
+
+    - name: Install internal CA
+      vars:
+        cifmw_install_ca_url_validate_certs: false
+      ansible.builtin.include_role:
+        name: install_ca
 
     - name: Check installed packages
       ansible.builtin.package_facts:


### PR DESCRIPTION
The BGP preparation hook delegated libvirt tasks to the literal hypervisor host. Generated reproducer inventories identify that host through controller-0.cifmw_hypervisor_host, typically as hypervisor-1. This caused the hook to fail with:

  Could not resolve hostname hypervisor

Use the inventory's recorded hypervisor name for both delegated tasks.

Fabric nodes also tried to download rhos-release before trusting the Red Hat internal CA, causing:

 CERTIFICATE_VERIFY_FAILED: self-signed certificate in chain

Install the internal CA before downloading rhos-release so FRR can be installed on the leaf, spine, and router nodes.

Co-authored-by: Codex (GPT-5) <codex@openai.com>
Signed-off-by: John Fulton <fulton@redhat.com>