### PR TITLE
[multiple] Log patched container images for OpenStackVersion CR

### DIFF
--- a/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
+++ b/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
@@ -210,6 +210,16 @@
               if (cifmw_update_containers_watcher | default(false) | bool) else []
             )
           }}
+      register: _cifmw_set_containers_result
+
+    - name: Read back generated OpenStackVersion CR
+      ansible.builtin.slurp:
+        src: "{{ _cifmw_set_containers_result.dest_path }}"
+      register: _cifmw_set_containers_cr
+
+    - name: Display generated OpenStackVersion CR (container images to patch)
+      ansible.builtin.debug:
+        msg: "{{ (_cifmw_set_containers_cr.content | b64decode | trim).splitlines() }}"
 
 - name: Apply the OpenStackControlPlane CR
   environment:

--- a/roles/update_containers/tasks/main.yml
+++ b/roles/update_containers/tasks/main.yml
@@ -26,6 +26,15 @@
     dest: "{{ cifmw_update_containers_dest_path }}"
     mode: "0644"
 
+- name: Read back generated OpenStackVersion CR
+  ansible.builtin.slurp:
+    src: "{{ cifmw_update_containers_dest_path }}"
+  register: cifmw_update_containers_cr
+
+- name: Display generated OpenStackVersion CR (container images to patch)
+  ansible.builtin.debug:
+    msg: "{{ (cifmw_update_containers_cr.content | b64decode | trim).splitlines() }}"
+
 - name: Update the containers
   when: cifmw_update_containers | bool
   environment:


### PR DESCRIPTION
When a job patches the `OpenStackVersion` `controlplane` CR with custom container images (e.g. s2i-built images from an operator PR), the resulting `spec.customContainerImages` is only visible by inspecting the must-gather `openstackversions.core.openstack.org/controlplane.yaml`. Jobs like `s2i-speculative-deploy-test-*` gave no in-log indication of which images were applied.

Add a debug task in both `OpenStackVersion` writers -- the `update_containers` role (template + `oc apply`) and the `set_containers` call in `edpm_prepare` -- that reads back the generated CR and prints the `customContainerImages` map, so the patched images are visible directly in the job output.

Assisted-By: Claude Opus 4.8 <noreply@anthropic.com>