### PR TITLE
[edpm_build_images] Detect bootc Containerfile for downstream

### DIFF
--- a/roles/edpm_build_images/molecule/bootc_containerfile/converge.yml
+++ b/roles/edpm_build_images/molecule/bootc_containerfile/converge.yml
@@ -1,0 +1,102 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  vars:
+    cifmw_edpm_build_images_test_base: /tmp/bootc_containerfile_test
+  tasks:
+    - name: Create test repository directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0755"
+      loop:
+        - "{{ cifmw_edpm_build_images_test_base }}/centos_variant"
+        - "{{ cifmw_edpm_build_images_test_base }}/fallback"
+        - "{{ cifmw_edpm_build_images_test_base }}/rhel_variant"
+        - "{{ cifmw_edpm_build_images_test_base }}/missing"
+
+    - name: Create Containerfile fixtures
+      ansible.builtin.copy:
+        content: "FROM scratch\n"
+        dest: "{{ item }}"
+        mode: "0644"
+      loop:
+        # Variant must win when both files exist
+        - "{{ cifmw_edpm_build_images_test_base }}/centos_variant/Containerfile.centos9"
+        - "{{ cifmw_edpm_build_images_test_base }}/centos_variant/Containerfile"
+        - "{{ cifmw_edpm_build_images_test_base }}/fallback/Containerfile"
+        - "{{ cifmw_edpm_build_images_test_base }}/rhel_variant/Containerfile.rhel9"
+
+    - name: Select centos9 variant Containerfile
+      ansible.builtin.include_role:
+        name: edpm_build_images
+        tasks_from: bootc_containerfile.yml
+      vars:
+        cifmw_edpm_build_images_bootc_repo_path: "{{ cifmw_edpm_build_images_test_base }}/centos_variant"
+        cifmw_edpm_build_images_bootc_base_image: quay.io/centos-bootc/centos-bootc:stream9
+
+    - name: Assert centos9 variant selected
+      ansible.builtin.assert:
+        that:
+          - cifmw_edpm_build_images_bootc_base_variant == 'centos9'
+          - cifmw_edpm_build_images_bootc_containerfile == 'Containerfile.centos9'
+
+    - name: Fall back to plain Containerfile
+      ansible.builtin.include_role:
+        name: edpm_build_images
+        tasks_from: bootc_containerfile.yml
+      vars:
+        cifmw_edpm_build_images_bootc_repo_path: "{{ cifmw_edpm_build_images_test_base }}/fallback"
+        cifmw_edpm_build_images_bootc_base_image: quay.io/centos-bootc/centos-bootc:stream9
+
+    - name: Assert plain Containerfile fallback
+      ansible.builtin.assert:
+        that:
+          - cifmw_edpm_build_images_bootc_containerfile == 'Containerfile'
+
+    - name: Select rhel9 variant Containerfile
+      ansible.builtin.include_role:
+        name: edpm_build_images
+        tasks_from: bootc_containerfile.yml
+      vars:
+        cifmw_edpm_build_images_bootc_repo_path: "{{ cifmw_edpm_build_images_test_base }}/rhel_variant"
+        cifmw_edpm_build_images_bootc_base_image: registry.example.com/rhel-bootc/rhel:9
+
+    - name: Assert rhel9 variant selected
+      ansible.builtin.assert:
+        that:
+          - cifmw_edpm_build_images_bootc_base_variant == 'rhel9'
+          - cifmw_edpm_build_images_bootc_containerfile == 'Containerfile.rhel9'
+
+    - name: Fail when no Containerfile exists
+      block:
+        - name: Run Containerfile detection on empty repository
+          ansible.builtin.include_role:
+            name: edpm_build_images
+            tasks_from: bootc_containerfile.yml
+          vars:
+            cifmw_edpm_build_images_bootc_repo_path: "{{ cifmw_edpm_build_images_test_base }}/missing"
+            cifmw_edpm_build_images_bootc_base_image: quay.io/centos-bootc/centos-bootc:stream9
+      rescue:
+        - name: Assert failure message
+          ansible.builtin.assert:
+            that:
+              - ansible_failed_result is defined
+              - "'No bootc Containerfile found' in ansible_failed_result.msg"
+            fail_msg: "Expected Containerfile detection to fail on empty repository"

--- a/roles/edpm_build_images/molecule/bootc_containerfile/molecule.yml
+++ b/roles/edpm_build_images/molecule/bootc_containerfile/molecule.yml
@@ -1,0 +1,9 @@
+---
+# Mainly used to override the defaults set in .config/molecule/
+# By default, it uses the "config_podman.yml" - in CI, it will use
+# "config_local.yml".
+log: true
+
+provisioner:
+  name: ansible
+  log: true

--- a/roles/edpm_build_images/tasks/bootc.yml
+++ b/roles/edpm_build_images/tasks/bootc.yml
@@ -1,4 +1,7 @@
 ---
+- name: Detect bootc Containerfile
+  ansible.builtin.import_tasks: bootc_containerfile.yml
+
 - name: Ensure bootc output directories exist
   become: "{{ cifmw_edpm_build_images_via_rpm }}"
   ansible.builtin.file:
@@ -41,7 +44,7 @@
     --build-arg USER_PACKAGES={{ cifmw_edpm_build_images_bootc_user_packages }}
     --volume /etc/pki/ca-trust:/etc/pki/ca-trust:ro,Z
     --volume {{ cifmw_edpm_build_images_bootc_repo_path }}/output/yum.repos.d:/etc/yum.repos.d:rw,Z
-    -f ./Containerfile
+    -f ./{{ cifmw_edpm_build_images_bootc_containerfile }}
     -t localhost/edpm-bootc:{{ cifmw_edpm_build_images_tag }}
     . > {{ cifmw_edpm_build_images_basedir }}/logs/edpm_images/edpm_bootc_image_build.log
     2> {{ cifmw_edpm_build_images_basedir }}/logs/edpm_images/edpm_bootc_image_build_err.log

--- a/roles/edpm_build_images/tasks/bootc_containerfile.yml
+++ b/roles/edpm_build_images/tasks/bootc_containerfile.yml
@@ -1,0 +1,31 @@
+---
+- name: Set bootc base image variant
+  ansible.builtin.set_fact:
+    cifmw_edpm_build_images_bootc_base_variant: >-
+      {{ cifmw_edpm_build_images_bootc_base_image
+         | regex_search('(?P<d>centos|rhel)[^0-9]*(?P<v>\d+)', '\g<d>', '\g<v>')
+         | default([], true) | join('') }}
+
+- name: Check bootc Containerfile
+  ansible.builtin.stat:
+    path: "{{ cifmw_edpm_build_images_bootc_repo_path }}/{{ item }}"
+  loop:
+    - "Containerfile.{{ cifmw_edpm_build_images_bootc_base_variant }}"
+    - Containerfile
+  register: cifmw_edpm_build_images_bootc_containerfiles
+
+- name: Fail when bootc Containerfile missing
+  ansible.builtin.fail:
+    msg: >-
+      No bootc Containerfile found in {{ cifmw_edpm_build_images_bootc_repo_path }}.
+      The installed edpm-image-builder package does not include bootc content.
+      Update the edpm-image-builder repository.
+  when: not (cifmw_edpm_build_images_bootc_containerfiles.results
+             | selectattr('stat.exists') | list)
+
+- name: Set bootc Containerfile
+  ansible.builtin.set_fact:
+    cifmw_edpm_build_images_bootc_containerfile: >-
+      {{ cifmw_edpm_build_images_bootc_containerfiles.results
+         | selectattr('stat.exists') | map(attribute='item')
+         | list | first }}


### PR DESCRIPTION
The bootc build hardcoded `-f ./Containerfile`, which matches the upstream edpm-image-builder layout. The downstream RPM (built from the Gerrit tree) ships `bootc/Containerfile.centos9` instead, so builds with `cifmw_edpm_build_images_via_rpm: true` failed with buildah rc 125: `stat .../bootc/Containerfile: no such file or directory`.

jira: [OSPCIX-1481](https://redhat.atlassian.net/browse/OSPCIX-1481)