### PR TITLE
[edpm_prepare] Fix empty tag

### DIFF
--- a/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
+++ b/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
@@ -25,7 +25,7 @@
   ansible.builtin.set_fact:
     cifmw_update_containers_registry: "{{ content_provider_os_registry_url  | split('/') | first }}"
     cifmw_update_containers_org: "{{ content_provider_os_registry_url  | split('/') | last }}"
-    cifmw_update_containers_tag: "{{ content_provider_dlrn_md5_hash }}"
+    cifmw_update_containers_tag: "{{ content_provider_dlrn_md5_hash | default(cifmw_default_container_image_tag, true) }}"
     cifmw_update_containers_openstack: true
 
 - name: Controlplane name kustomization


### PR DESCRIPTION
The Prepare OpenStackVersion CR started failing recently when content_provider_dlrn_md5_hash is set to "" (empty string).

Add a guard, which sets the cifmw_update_containers_tag to cifmw_default_container_image_tag in such cases.

Assisted-By: Claude-Code claude-opus-4-6