### PR TITLE
[edpm_prepare] Skip manila/cinder override if explicitly set

### DIFF
--- a/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
+++ b/roles/edpm_prepare/tasks/kustomize_and_deploy.yml
@@ -165,16 +165,17 @@
           {%- for _image_name, _image_uri in (cifmw_update_containers_custom_images | default({})).items() -%}
           {%- set _ = _custom_images.append({'name': _image_name, 'full_registry': _image_uri}) -%}
           {%- endfor -%}
+          {%- set _explicit_names = (cifmw_set_containers_images | default([])) | map(attribute='name') | list -%}
           {{
             (cifmw_set_containers_images | default([])) +
             _custom_images +
             (
               [{'name': 'cinderVolumeImages', 'container_suffix': 'cinder-volume', 'backends': cifmw_edpm_prepare_cindervolumes}]
-              if cifmw_edpm_prepare_cindervolumes else []
+              if (cifmw_edpm_prepare_cindervolumes and 'cinderVolumeImages' not in _explicit_names) else []
             ) +
             (
               [{'name': 'manilaShareImages', 'container_suffix': 'manila-share', 'backends': cifmw_edpm_prepare_manilashares}]
-              if cifmw_edpm_prepare_manilashares else []
+              if (cifmw_edpm_prepare_manilashares and 'manilaShareImages' not in _explicit_names) else []
             ) +
             (
               [{'name': 'osContainerImage', 'full_registry': cifmw_update_containers_edpm_image_url}]


### PR DESCRIPTION
If cinder volume and manila share images are explicitly set as part of cifmw_set_containers_images, we shouldn't override those.

Follow up of https://github.com/openstack-k8s-operators/ci-framework/pull/4100