### PR TITLE
[operator_build] Make tasks fails on command error

### DIFF
--- a/roles/operator_build/molecule/default/converge.yml
+++ b/roles/operator_build/molecule/default/converge.yml
@@ -37,6 +37,11 @@
       ansible.builtin.set_fact:
         latest_open_pr: "{{ pr_list.json[0] }}"
 
+    - name: Make download_tools
+      ansible.builtin.include_role:
+        name: 'install_yamls_makes'
+        tasks_from: 'make_download_tools'
+
   tasks:
     - name: Build keystone-operator
       ansible.builtin.include_role:

--- a/roles/operator_build/molecule/default/prepare.yml
+++ b/roles/operator_build/molecule/default/prepare.yml
@@ -19,3 +19,4 @@
   hosts: all
   roles:
     - role: test_deps
+    - role: install_yamls

--- a/roles/operator_build/tasks/build.yml
+++ b/roles/operator_build/tasks/build.yml
@@ -40,6 +40,7 @@
 
 - name: "{{ operator.name }} - Update the go.mod file in meta operator for provided PR_SHA"  # noqa: name[template]
   ansible.builtin.shell: |
+    set -eo pipefail
     go mod edit -replace {{ operator_api_path }}=github.com/{{ operator.pr_owner }}/{{ operator_base_module_name }}@{{ operator.pr_sha }}
     go mod tidy
     if [ -d ./apis ]; then
@@ -69,6 +70,7 @@
 
 - name: "{{ operator.name }} - Update the go.mod file using latest commit if no PR is provided"  # noqa: name[template]
   ansible.builtin.shell: |
+    set -eo pipefail
     go mod edit -replace {{ operator_api_path }}={{ operator_api_path }}@{{ pr_sha }}
     go mod tidy
     if [ -d ./apis ]; then


### PR DESCRIPTION
These task succeeds always as the last command will never fail. Make the task fail on any command error by using set -eo pipefail.