### PR TITLE
edpm_baremetal_update: use the split update procedure (services only)

### DIFF
--- a/ci/playbooks/edpm_baremetal_update/update-edpm.yml
+++ b/ci/playbooks/edpm_baremetal_update/update-edpm.yml
@@ -168,22 +168,22 @@
         (        cifmw_update_containers_watcher is defined and
         cifmw_update_containers_watcher | bool)
 
-    - name: Set update step to Starting the CI update sequence
+    - name: Set update step to Starting the services update sequence
       ansible.builtin.command:
         cmd: >
           {{ cifmw_update_artifacts_basedir }}/update_event.sh
-          Starting the CI update sequence
+          Starting the services update sequence
 
-    - name: Run make openstack_update_run
+    - name: Run make update_services
       vars:
-        make_openstack_update_run_env: "{{ cifmw_minor_update_env }}"
-        make_openstack_update_run_params:
+        make_update_services_env: "{{ cifmw_minor_update_env }}"
+        make_update_services_params:
           TIMEOUT: "1200s"
           OPENSTACK_VERSION: "{{ cifmw_minor_update_target_version }}"
-        make_openstack_update_run_dryrun: false
+        make_update_services_dryrun: false
       ansible.builtin.include_role:
         name: 'install_yamls_makes'
-        tasks_from: 'make_openstack_update_run'
+        tasks_from: 'make_update_services'
 
     - name: Set update step to Verifying update completion
       ansible.builtin.command:


### PR DESCRIPTION
The monolithic update procedure is being removed. Switch the edpm_baremetal_update role to use the new split update procedure. As it looks like only the services update is relevant in the edpm_baremetal_update, we don't include the operating system update.

Assisted-by: goose+gpt
Resolves: https://redhat.atlassian.net/browse/OSPRH-36564